### PR TITLE
[IMP] account, l10n_latam_invoice_document: compute method invoice_taxes_by_group

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1509,50 +1509,53 @@ class AccountMove(models.Model):
             else:
                 move.invoice_payments_widget = json.dumps(False)
 
+    def _compute_move_taxes_by_group(self, tax_lines):
+        lang_env = self.with_context(lang=self.partner_id.lang).env
+        tax_balance_multiplicator = -1 if self.is_inbound(True) else 1
+        res = {}
+        # There are as many tax line as there are repartition lines
+        done_taxes = set()
+        for line in tax_lines:
+            res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
+            res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
+            tax_key_add_base = tuple(self._get_tax_key_for_group_add_base(line))
+            if tax_key_add_base not in done_taxes:
+                if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
+                    amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.context_today(self))
+                else:
+                    amount = line.tax_base_amount
+                res[line.tax_line_id.tax_group_id]['base'] += amount
+                # The base should be added ONCE
+                done_taxes.add(tax_key_add_base)
+
+        # At this point we only want to keep the taxes with a zero amount since they do not
+        # generate a tax line.
+        zero_taxes = set()
+        for line in self.line_ids:
+            for tax in line.tax_ids.flatten_taxes_hierarchy():
+                if tax.tax_group_id not in res or tax.tax_group_id in zero_taxes:
+                    res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
+                    res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
+                    zero_taxes.add(tax.tax_group_id)
+
+        res = sorted(res.items(), key=lambda l: l[0].sequence)
+        self.amount_by_group = [(
+            group.name, amounts['amount'],
+            amounts['base'],
+            formatLang(lang_env, amounts['amount'], currency_obj=self.currency_id),
+            formatLang(lang_env, amounts['base'], currency_obj=self.currency_id),
+            len(res),
+            group.id
+        ) for group, amounts in res]
+
     @api.depends('line_ids.price_subtotal', 'line_ids.tax_base_amount', 'line_ids.tax_line_id', 'partner_id', 'currency_id')
     def _compute_invoice_taxes_by_group(self):
         ''' Helper to get the taxes grouped according their account.tax.group.
         This method is only used when printing the invoice.
         '''
         for move in self:
-            lang_env = move.with_context(lang=move.partner_id.lang).env
             tax_lines = move.line_ids.filtered(lambda line: line.tax_line_id)
-            tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
-            res = {}
-            # There are as many tax line as there are repartition lines
-            done_taxes = set()
-            for line in tax_lines:
-                res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                tax_key_add_base = tuple(move._get_tax_key_for_group_add_base(line))
-                if tax_key_add_base not in done_taxes:
-                    if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
-                        amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.context_today(self))
-                    else:
-                        amount = line.tax_base_amount
-                    res[line.tax_line_id.tax_group_id]['base'] += amount
-                    # The base should be added ONCE
-                    done_taxes.add(tax_key_add_base)
-
-            # At this point we only want to keep the taxes with a zero amount since they do not
-            # generate a tax line.
-            zero_taxes = set()
-            for line in move.line_ids:
-                for tax in line.tax_ids.flatten_taxes_hierarchy():
-                    if tax.tax_group_id not in res or tax.tax_group_id in zero_taxes:
-                        res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                        res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                        zero_taxes.add(tax.tax_group_id)
-
-            res = sorted(res.items(), key=lambda l: l[0].sequence)
-            move.amount_by_group = [(
-                group.name, amounts['amount'],
-                amounts['base'],
-                formatLang(lang_env, amounts['amount'], currency_obj=move.currency_id),
-                formatLang(lang_env, amounts['base'], currency_obj=move.currency_id),
-                len(res),
-                group.id
-            ) for group, amounts in res]
+            move._compute_move_taxes_by_group(tax_lines)
 
     @api.model
     def _get_tax_key_for_group_add_base(self, line):

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -227,44 +227,8 @@ class AccountMove(models.Model):
 
         move_with_doc_type = self.filtered('l10n_latam_document_type_id')
         for move in move_with_doc_type:
-            lang_env = move.with_context(lang=move.partner_id.lang).env
             tax_lines = move.l10n_latam_tax_ids
-            tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
-            res = {}
-            # There are as many tax line as there are repartition lines
-            done_taxes = set()
-            for line in tax_lines:
-                res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                tax_key_add_base = tuple(move._get_tax_key_for_group_add_base(line))
-                if tax_key_add_base not in done_taxes:
-                    if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
-                        amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.today())
-                    else:
-                        amount = line.tax_base_amount
-                    res[line.tax_line_id.tax_group_id]['base'] += amount
-                    # The base should be added ONCE
-                    done_taxes.add(tax_key_add_base)
-
-            # At this point we only want to keep the taxes with a zero amount since they do not
-            # generate a tax line.
-            zero_taxes = set()
-            for line in move.line_ids:
-                for tax in line.l10n_latam_tax_ids.flatten_taxes_hierarchy():
-                    if tax.tax_group_id not in res or tax.id in zero_taxes:
-                        res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                        res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                        zero_taxes.add(tax.id)
-
-            res = sorted(res.items(), key=lambda l: l[0].sequence)
-            move.amount_by_group = [(
-                group.name, amounts['amount'],
-                amounts['base'],
-                formatLang(lang_env, amounts['amount'], currency_obj=move.currency_id),
-                formatLang(lang_env, amounts['base'], currency_obj=move.currency_id),
-                len(res),
-                group.id
-            ) for group, amounts in res]
+            move._compute_move_taxes_by_group(tax_lines)
         super(AccountMove, self - move_with_doc_type)._compute_invoice_taxes_by_group()
 
     @api.constrains('name', 'partner_id', 'company_id', 'posted_before')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

1. Separate the method invoice_taxes_by_group in two, in order to enable localizations to inherit it and pass their own tax lines.
2. Adapt Latam localizations to inherit it properly passing their own tax lines.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
