### PR TITLE
[FIX] account: recompute fields depending on invoice_date on copy

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1776,6 +1776,15 @@ class AccountMove(models.Model):
             move.line_ids.unlink()
         return super(AccountMove, self).unlink()
 
+    @api.returns('self', lambda value: value.id)
+    def copy(self, default=None):
+        rec = super().copy(default)
+        # invoice_date is not copied but is the basis for currency rates and payment terms
+        if rec.invoice_date != self.invoice_date:
+            rec.with_context(check_move_validity=False)._onchange_invoice_date()
+            rec._check_balanced()
+        return rec
+
     @api.depends('name', 'state')
     def name_get(self):
         result = []


### PR DESCRIPTION
Because the invoice date is not copied, it gets a new default value.
But other values depending on the invoice date are copied, like the
payment terms and the conversion rates; making some incoherence.

task-[2493033](https://www.odoo.com/web#cids=1&id=2493033&menu_id=&model=project.task&view_type=form)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
