### PR TITLE
[FIX] mrp_subcontracting: create Quality Checks for product subcontracting

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -134,8 +134,8 @@ class StockMove(models.Model):
             picking._subcontracted_produce(subcontract_details)
 
         # We avoid merging move due to complication with stock.rule.
-        super(StockMove, move_to_not_merge)._action_confirm(merge=False)
-        res = super(StockMove, self - move_to_not_merge)._action_confirm(merge=merge, merge_into=merge_into)
+        res = super(StockMove, move_to_not_merge)._action_confirm(merge=False)
+        res |= super(StockMove, self - move_to_not_merge)._action_confirm(merge=merge, merge_into=merge_into)
         if subcontract_details_per_picking:
             self.env['stock.picking'].concat(*list(subcontract_details_per_picking.keys())).action_assign()
         return res


### PR DESCRIPTION
Before this commit, if a product has Quality Points, the Quality Checks weren't created if the product was subcontracted.

How to reproduce:
  - Create a product with a BOM of "Subcontracting" type and set a subcontractor;
  - Create a Quality Point for this product, for the receipt;
  - Create a RFQ for this product with the subcontractor as vendor;
  - Confirm the RFQ and receive the product -> There is no Quality Check to perform.