### PR TITLE
[IMP] Update google analytics to use gtags

### DIFF
--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -30,6 +30,7 @@ class ResConfigSettings(models.TransientModel):
     website_cookies_bar = fields.Boolean(related='website_id.cookies_bar', readonly=False)
 
     google_analytics_key = fields.Char('Google Analytics Key', related='website_id.google_analytics_key', readonly=False)
+    google_analytics_anonymize = fields.Boolean('Google Analytics Anonymization', related='website_id.google_analytics_anonymize', readonly=False)
     google_management_client_id = fields.Char('Google Client ID', related='website_id.google_management_client_id', readonly=False)
     google_management_client_secret = fields.Char('Google Client Secret', related='website_id.google_management_client_secret', readonly=False)
     google_search_console = fields.Char('Google Search Console', related='website_id.google_search_console', readonly=False)

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -103,6 +103,7 @@ class Website(models.Model):
     has_social_default_image = fields.Boolean(compute='_compute_has_social_default_image', store=True)
 
     google_analytics_key = fields.Char('Google Analytics Key')
+    google_analytics_anonymize = fields.Boolean('Google Analytics Anonymization', default=True)
     google_management_client_id = fields.Char('Google Client ID')
     google_management_client_secret = fields.Char('Google Client Secret')
     google_search_console = fields.Char(help='Google key, or Enable to access first reply')

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -284,6 +284,8 @@
                                     </div>
                                     <div class="content-group" attrs="{'invisible': [('has_google_analytics', '=', False)]}">
                                         <div class="row mt16">
+                                            <label class="col-lg-3 o_light_label" for="google_analytics_anonymize" string="Anonymization"/>
+                                            <field name="google_analytics_anonymize"/>
                                             <label class="col-lg-3 o_light_label" string="Tracking ID" for="google_analytics_key"/>
                                             <field name="google_analytics_key" placeholder="UA-XXXXXXXX-Y"
                                                 attrs="{'required': [('has_google_analytics', '=', True)]}"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -141,15 +141,19 @@
     </xpath>
 
     <xpath expr="//div[@id='wrapwrap']" position="after">
-        <script id='tracking_code' t-if="website and website.google_analytics_key and not editable">
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        <t t-if="website and website.google_analytics_key and not editable">
+            <script id="tracking_code" async="1" t-attf-src="https://www.googletagmanager.com/gtag/js?id={{ website.google_analytics_key }}"></script>
+            <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
 
-            ga('create', '<t t-esc="website.google_analytics_key"/>'.trim(), 'auto');
-            ga('send','pageview');
-        </script>
+                gtag('config', '<t t-esc="website.google_analytics_key"/>', {
+                    <t t-if="website.google_analytics_anonymize">'anonymize_ip': true,</t>
+                    <t t-else="">'anonymize_ip': false,</t>
+                });
+            </script>
+        </t>
     </xpath>
 
     <!-- Page options -->

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1065,8 +1065,7 @@ class WebsiteSale(http.Controller):
         for line in order_lines:
             product = line.product_id
             ret.append({
-                'id': line.order_id.id,
-                'sku': product.barcode or product.id,
+                'id': product.barcode or product.id,
                 'name': product.name or '-',
                 'category': product.categ_id.name or '-',
                 'price': line.price_unit,
@@ -1077,14 +1076,12 @@ class WebsiteSale(http.Controller):
     def order_2_return_dict(self, order):
         """ Returns the tracking_cart dict of the order for Google analytics basically defined to be inherited """
         return {
-            'transaction': {
-                'id': order.id,
-                'affiliation': order.company_id.name,
-                'revenue': order.amount_total,
-                'tax': order.amount_tax,
-                'currency': order.currency_id.name
-            },
-            'lines': self.order_lines_2_google_api(order.order_line)
+            'transaction_id': order.id,
+            'affiliation': order.company_id.name,
+            'value': order.amount_total,
+            'tax': order.amount_tax,
+            'currency': order.currency_id.name,
+            'items': self.order_lines_2_google_api(order.order_line)
         }
 
     @http.route(['/shop/country_infos/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)

--- a/addons/website_sale/static/src/js/website_sale_tracking.js
+++ b/addons/website_sale/static/src/js/website_sale_tracking.js
@@ -26,23 +26,13 @@ publicWidget.registry.websiteSaleTracking = publicWidget.Widget.extend({
 
         // ...
         if (this.$('div.oe_website_sale_tx_status').length) {
-            this._trackGA('require', 'ecommerce');
-
             var orderID = this.$('div.oe_website_sale_tx_status').data('order-id');
             this._vpv('/stats/ecom/order_confirmed/' + orderID);
 
             this._rpc({
                 route: '/shop/tracking_last_order/',
             }).then(function (o) {
-                self._trackGA('ecommerce:clear');
-
-                if (o.transaction && o.lines) {
-                    self._trackGA('ecommerce:addTransaction', o.transaction);
-                    _.forEach(o.lines, function (line) {
-                        self._trackGA('ecommerce:addItem', line);
-                    });
-                }
-                self._trackGA('ecommerce:send');
+                self._trackGA('event', 'purchase', o);
             });
         }
 
@@ -57,16 +47,15 @@ publicWidget.registry.websiteSaleTracking = publicWidget.Widget.extend({
      * @private
      */
     _trackGA: function () {
-        var websiteGA = window.ga || function () {};
+        var websiteGA = window.gtag || function () {};
         websiteGA.apply(this, arguments);
     },
     /**
      * @private
      */
     _vpv: function (page) { //virtual page view
-        this._trackGA('send', 'pageview', {
-          'page': page,
-          'title': document.title,
+        this._trackGA('event', 'page_view', {
+            'page_path': page,
         });
     },
 

--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -77,9 +77,7 @@ class WebsiteSaleDelivery(WebsiteSale):
     def order_2_return_dict(self, order):
         """ Returns the tracking_cart dict of the order for Google analytics """
         ret = super(WebsiteSaleDelivery, self).order_2_return_dict(order)
-        for line in order.order_line:
-            if line.is_delivery:
-                ret['transaction']['shipping'] = line.price_unit
+        ret['shipping'] = sum(order.order_line.filtered('is_delivery').mapped('price_unit'))
         return ret
 
     def _get_shop_payment_values(self, order, **kwargs):

--- a/doc/_extensions/odoo_ext/layout.html
+++ b/doc/_extensions/odoo_ext/layout.html
@@ -26,14 +26,13 @@
 
 {%- block footer -%}
   {%- if google_analytics_key -%}
+    <script id="tracking_code" async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics_key }}"></script>
     <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    ga('create', '{{ google_analytics_key }}', 'auto');
-    ga('send','pageview');
+      gtag('config', '{{ google_analytics_key }}');
     </script>
   {%- endif -%}
 {%- endblock -%}


### PR DESCRIPTION
The old analytics snippet (isogram) is replaced by the newer gtags snippet. Virtual page views and e-commerce transactions are now tracked using gtags.

An anonymization option is addes to the website settings. Activating
this option (default) will enable IP anonymization in gtags.