### PR TITLE
[FIX] mrp_account: not compute price if no BoM

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -50,7 +50,7 @@ class ProductProduct(models.Model):
     def _compute_bom_price(self, bom, boms_to_recompute=False):
         self.ensure_one()
         if not bom:
-            return 0
+            return self.standard_price
         if not boms_to_recompute:
             boms_to_recompute = []
         total = 0


### PR DESCRIPTION
When using "Compute Price from BoM" on a product without any BoM, its
price is reset to zero.

To reproduce the error:
(Use demo data)
1. Go to Inventory > Master Data > Product Variants
2. In list view, select Bolt
    - Its price is 0.50
3. Action > Compute Price from BoM

Error: Price becomes zero, but the product Bolt has no BoM, so its price
should not change.

OPW-2478495