### PR TITLE
[FIX] account: generate safe email aliases

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -7,7 +7,7 @@ import logging
 
 from odoo.osv import expression
 from odoo.tools.float_utils import float_round as round
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, remove_accents
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, remove_accents, localpartify
 from odoo.exceptions import UserError, ValidationError
 from odoo import api, fields, models, _
 
@@ -610,7 +610,7 @@ class AccountJournal(models.Model):
         return {
             'alias_defaults': {'type': 'in_invoice', 'company_id': self.company_id.id},
             'alias_parent_thread_id': self.id,
-            'alias_name': re.sub(r'[^\w]+', '-', alias_name)
+            'alias_name': localpartify(alias_name)
         }
 
     @api.multi

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from odoo.tests.common import BaseCase
 from odoo.tests.common import SavepointCase
-from odoo.tools import html_sanitize, append_content_to_html, plaintext2html, email_split, misc, decode_smtp_header
+from odoo.tools import html_sanitize, append_content_to_html, plaintext2html, email_split, misc, decode_smtp_header, localpartify
 
 from . import test_mail_examples
 
@@ -328,6 +328,10 @@ class TestHtmlTools(BaseCase):
 
 class TestEmailTools(BaseCase):
     """ Test some of our generic utility functions for emails """
+
+    def test_email_localpartify(self):
+        self.assertEqual(localpartify('john.doe, MyCompany Inc.'), 'john.doe-MyCompany-Inc')
+        self.assertRaises(UnicodeEncodeError, localpartify, 'joé')
 
     def test_email_split(self):
         cases = [


### PR DESCRIPTION
Create an account journal in a company whose name ends with a dot, the
creation fails for a ValidationError("email alias must me ascii"). The
validation error is valid, there was an invalid email generated while
creating an account journal.

When you create a journal, an email alias is created for that journal,
by default it uses the company name. There are some validations to make
the email valid but until now nobody cared to make sure all generated
email were valid, now it is.

opw-2448692




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
