### PR TITLE
[FIX] Wrong task used for recurring task

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -214,14 +214,14 @@ class ProjectTaskRecurrence(models.Model):
 
     def _create_next_task(self):
         for recurrence in self:
-            task = self.sudo().task_ids[-1]
+            task = recurrence.sudo().task_ids[-1]
             create_values = recurrence._new_task_values(task)
             new_task = self.env['project.task'].sudo().create(create_values)
             if not new_task.parent_id and task.child_ids:
                 children = []
                 # copy the subtasks of the original task
                 for child in task.child_ids:
-                    child_values = self._new_task_values(child)
+                    child_values = recurrence._new_task_values(child)
                     child_values['parent_id'] = new_task.id
                     children.append(child_values)
                 self.env['project.task'].create(children)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: If multiple recurring tasks exists, the last one created was used to create all recurring task due to `self` being used instead of `recurrence`

Current behavior before PR: Wrong recurring task used to create new recurring task

Desired behavior after PR is merged: Use the last task of the same recurring task (not all recurring tasks)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
