### PR TITLE
[FIX] website_form: fix duplicate id on duplicate field

### DIFF
--- a/addons/website_form/static/src/snippets/s_website_form/options.js
+++ b/addons/website_form/static/src/snippets/s_website_form/options.js
@@ -53,6 +53,15 @@ const FormEditor = options.Class.extend({
         return field.records;
     },
     /**
+     * Generates a new ID.
+     *
+     * @private
+     * @returns {string} The new ID
+     */
+    _generateUniqueID() {
+        return Math.random().toString(36).substring(2, 15);
+    },
+    /**
      * Returns a field object
      *
      * @private
@@ -119,10 +128,10 @@ const FormEditor = options.Class.extend({
     /**
      * @private
      * @param {Object} field
-     * @returns {Promise<HTMLElement>}
+     * @returns {HTMLElement}
      */
     _renderField: function (field) {
-        field.id = Math.random().toString(36).substring(2, 15); // Big unique ID
+        field.id = this._generateUniqueID();
         const template = document.createElement('template');
         template.innerHTML = qweb.render("website_form.field_" + field.type, {field: field}).trim();
         return template.content.firstElementChild;
@@ -426,10 +435,10 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
             field.formatInfo.requiredMark = this._isRequiredMark();
             field.formatInfo.optionalMark = this._isOptionalMark();
             field.formatInfo.mark = this._getMark();
-            const htmlField = this._renderField(field);
-            data.$target.after(htmlField);
+            const fieldEl = this._renderField(field);
+            data.$target.after(fieldEl);
             this.trigger_up('activate_snippet', {
-                $snippet: $(htmlField),
+                $snippet: $(fieldEl),
             });
         }
     },
@@ -821,6 +830,19 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         // We need to reload the existing type list.
         this.rerender = true;
     },
+    /**
+     * Rerenders the clone to avoid id duplicates.
+     * Rendering the list before replacing the field is needed
+     * for selects, in order to build this.listTable.
+     *
+     * @override
+     */
+    onClone() {
+        this._renderList();
+        const field = this._getActiveField();
+        const fieldEl = this._renderField(field);
+        this._replaceFieldElement(fieldEl);
+    },
 
     //----------------------------------------------------------------------
     // Options
@@ -978,7 +1000,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         }
     },
     /**
-     * Replace the target content with the field provided
+     * Replaces the target content with the field provided.
      *
      * @private
      * @param {Object} field
@@ -986,11 +1008,20 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      */
     _replaceField: async function (field) {
         await this._fetchFieldRecords(field);
-        const htmlField = this._renderField(field);
+        const fieldEl = this._renderField(field);
+        this._replaceFieldElement(fieldEl);
+    },
+    /**
+     * Replaces the target with provided field.
+     *
+     * @private
+     * @param {HTMLElement} fieldEl
+     */
+    _replaceFieldElement(fieldEl) {
         [...this.$target[0].childNodes].forEach(node => node.remove());
-        [...htmlField.childNodes].forEach(node => this.$target[0].appendChild(node));
-        [...htmlField.attributes].forEach(el => this.$target[0].removeAttribute(el.nodeName));
-        [...htmlField.attributes].forEach(el => this.$target[0].setAttribute(el.nodeName, el.nodeValue));
+        [...fieldEl.childNodes].forEach(node => this.$target[0].appendChild(node));
+        [...fieldEl.attributes].forEach(el => this.$target[0].removeAttribute(el.nodeName));
+        [...fieldEl.attributes].forEach(el => this.$target[0].setAttribute(el.nodeName, el.nodeValue));
     },
 
     /**
@@ -1153,7 +1184,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             const params = {
                 field: {
                     name: name,
-                    id: Math.random().toString(36).substring(2, 15), // Big unique ID
+                    id: this._generateUniqueID(),
                     required: isRequiredField,
                     formatInfo: {
                         multiPosition: multiInputsWrap.dataset.display,
@@ -1270,10 +1301,10 @@ options.registry.AddFieldForm = FormEditor.extend({
     addField: async function (previewMode, value, params) {
         const field = this._getCustomField('char', 'Custom Text');
         field.formatInfo = this._getDefaultFormat();
-        const htmlField = this._renderField(field);
-        this.$target.find('.s_website_form_submit, .s_website_form_recaptcha').first().before(htmlField);
+        const fieldEl = this._renderField(field);
+        this.$target.find('.s_website_form_submit, .s_website_form_recaptcha').first().before(fieldEl);
         this.trigger_up('activate_snippet', {
-            $snippet: $(htmlField),
+            $snippet: $(fieldEl),
         });
     },
 });


### PR DESCRIPTION
When a user creates a form, he can duplicate a field.
As long as he hasn't modified this field, both fields (the original and the copy have the same ID)
This PR solves this problem

**Task #2485093**




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
