### PR TITLE
[IMP] mail: change strategy for onchange_on_keydown from throttle to …

### DIFF
--- a/addons/mail/static/src/js/field_char.js
+++ b/addons/mail/static/src/js/field_char.js
@@ -9,13 +9,13 @@ FieldChar.include({
     //-------------------------------------------------------------------------
 
     /**
-     * Support a key-based onchange in text field. In order to avoid too much
-     * rpc to the server _triggerOnchange is throttled (once every second max)
+     * Support a key-based onchange in text field.
+     * The _triggerOnchange method is debounced to run 2 seconds after typing ends.
      *
      */
     init: function () {
         this._super.apply(this, arguments);
-        this._triggerOnchange = _.throttle(this._triggerOnchange, 1000, {leading: false});
+        this._triggerOnchange = _.debounce(this._triggerOnchange, 2000);
     },
 
 
@@ -43,8 +43,9 @@ FieldChar.include({
     //--------------------------------------------------------------------------
 
     /**
-     * Triggers the 'change' event to refresh the value. Throttled at init to
-     * avoid spaming server.
+     * Triggers the 'change' event to refresh the value.
+     * This method is debounced to run 2 seconds after typing ends.
+     * (to avoid spamming the server while the user is typing his message)
      *
      * @private
      */

--- a/addons/mail/static/src/js/field_emojis_common.js
+++ b/addons/mail/static/src/js/field_emojis_common.js
@@ -19,7 +19,7 @@ var FieldEmojiCommon = {
      */
     init: function () {
         this._super.apply(this, arguments);
-        this._triggerOnchange = _.throttle(this._triggerOnchange, 1000, {leading: false});
+        this._triggerOnchange = _.debounce(this._triggerOnchange, 2000);
         this.emojis = emojis;
     },
 
@@ -91,7 +91,7 @@ var FieldEmojiCommon = {
 
     /**
      * Triggers the 'change' event to refresh the value.
-     * This method is throttled to run at most once every second.
+     * This method is debounced to run 2 seconds after typing ends.
      * (to avoid spamming the server while the user is typing his message)
      *
      * @private


### PR DESCRIPTION
…debounce

The FieldChar and the "Emoji" fields support a "onchange_on_keydown" attribute
that allow triggering the onchange event when the user types into the field.
(Instead of having to wait for a blur event).

This is especially useful, for example, in the social module to refresh the
post preview when the user is typing his message.

The current strategy to avoid spamming this onchange event was to throttle the
method to trigger it at most once every second.
However, triggering it every second could still be problematic in terms of
performances and could cause loading issues (e.g: if you have a large GIF in
your post preview)

To try to mitigate this issue, we changed the strategy from throttle to
debounce.
Meaning the onchange will be triggered one second after the user is done
typing, which still gives a nice "live update" effect without triggering the
onchange too much.

Task-2500821

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
