### PR TITLE
[FIX] website: show domain in settings even if no multi-website

### DIFF
--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -95,7 +95,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="domain_settings" groups="website.group_multi_website">
+                            <div class="col-12 col-lg-6 o_setting_box" id="domain_settings">
                                 <div class="o_setting_right_pane">
                                     <label string="Domain" for="website_domain"/>
                                     <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>


### PR DESCRIPTION
Without this commit, a database with only one website would not see the domain
field in the res settings.
But the domain field is useful to set even if there is only one website.

For instance, if no domain is specified, the web.base.url ICP will be used
instead to generate links, but it might be the wrong url as it is the last
domain used to login as the admin (unless web.base.url.freeze is set).

Also, one might want to unset the `localhost` domain that was set by default
in xml data (now removed with 1f0edacdf)
