### PR TITLE
[FIX] l10n_it_edi: only send e-invoice in IT companies

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -260,7 +260,7 @@ class AccountMove(models.Model):
         # OVERRIDE
         posted = super()._post(soft=soft)
 
-        for move in posted.filtered(lambda m: m.l10n_it_send_state == 'to_send' and m.move_type == 'out_invoice'):
+        for move in posted.filtered(lambda m: m.l10n_it_send_state == 'to_send' and m.move_type == 'out_invoice' and m.company_id.country_id.code == 'IT'):
             move.send_pec_mail()
 
         return posted


### PR DESCRIPTION
Have 2 companies, one in FR (with l10n_fr), one in IT (with l10n_it_edi)
From the French company create an invoice for a french customer.
Confirm.

The message ' E-Invoice check failed. You can modify the
invoice, and resend it.' related to italian e-invoicing will appear

opw-2481035

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
