### PR TITLE
[FIX] l10n_id_efaktur: fix the “_onchange_l10n_id_tax_number” method

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
     @api.onchange('l10n_id_tax_number')
     def _onchange_l10n_id_tax_number(self):
         for record in self:
-            if record.l10n_id_tax_number and record.type not in self.get_purchase_types():
+            if record.l10n_id_tax_number and record.move_type not in self.get_purchase_types():
                 raise UserError(_("You can only change the number manually for a Vendor Bills and Credit Notes"))
 
     @api.depends('l10n_id_attachment_id')


### PR DESCRIPTION
Steps to follow to reproduce the bug:
- Create an Indonesian company
- Go to Invoicing settings / in “Fiscal Localization” / install Indonesian-Accounting “ l10n_id”
- Go to Invoicing / Vendors / bills
- Create a new bill / add a vendor / go to “other info” / add a valid Indonesian Tax Number, for example :  “0112345678912345”
- An error is triggered

Problem:
In the “_onchange_l10n_id_tax_number” method, we try to access “record.type”, but in v14 the field "type" was replaced by "move_type” in the "account.move" model.

opw-2492530

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
