### PR TITLE
[FIX] payment: fix ecommerce blinking "Pay now" button


### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -296,6 +296,7 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
                             _t("We are not able to redirect you to the payment form. ") +
                                 error.message.data.arguments[0]
                         );
+                        self.enableButton(button);
                     });
                 }
                 else {


### PR DESCRIPTION

Missing line in forward-port of 12.0 #41860 (88b37c2b1).

If a server error happen when we try to pay (eg. there is not enoug
quantity of a product), the page is forever freezed and the user only
option is to refresh which is not user friendly.

opw-2438379
