### PR TITLE
[FIX] calendar: create recurrent events with rrule and end date

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -932,7 +932,7 @@ class Meeting(models.Model):
                 data = self._rrule_default_values()
                 data['recurrency'] = True
                 data.update(self._rrule_parse(meeting.rrule, data, meeting.start))
-                meeting.update(data)
+                meeting.write(data)
 
     @api.model
     def _event_tz_get(self):

--- a/addons/calendar/tests/test_calendar_recurrent_event_case2.py
+++ b/addons/calendar/tests/test_calendar_recurrent_event_case2.py
@@ -214,3 +214,17 @@ class TestRecurrentEvent(common.TransactionCase):
         meetings = self.CalendarEvent.with_context({'virtual_id': True}).search(['!', ['id', 'in', recurrent_ids[:1]]])
         excluded_meetings = (all_meetings - meetings).ids
         self.assertEqual(excluded_meetings, recurrent_ids, "Recurrent event is excluded by the domain")
+
+    def test_recurrent_meeting7(self):
+        self.CalendarEvent.create({
+            'start': '2000-04-11 12:00:00',
+            'stop': '2000-04-11 13:00:00',
+            'allday': False,
+            'name': 'SuperReccurentMeeting07',
+            'rrule': 'FREQ=DAILY;UNTIL=20000420T215959Z',
+            'duration': 1.0
+        })
+        meetings_count = self.CalendarEvent.with_context({'virtual_id': True}).search_count([
+            ('start', '>=', '2000-04-11 12:00:00'), ('stop', '<=', '2000-04-21 13:00:00')
+        ])
+        self.assertEqual(meetings_count, 10, 'Recurrent daily meetings are not created !')


### PR DESCRIPTION
When creating a recurrent event with a recurrence rule and a final date,
the creation may be incorrect.

The problem comes from the method `_inverse_rrule`. This one generates
all the fields that need to be changed. However, calling `update` is the
issue source: it writes the new value of these fields, but one by one,
and the order may be a problem.

Here is an exemple. Suppose the creation of this event:
```python
{
	'start': '2021-04-11 12:00:00',
	'stop': '2021-04-11 13:00:00',
	'allday': False,
	'name': 'SuperReccurentMeeting07',
	'rrule': 'FREQ=DAILY;UNTIL=20210420T215959Z',
	'duration': 1.0
}
```
In `_inverse_rrule`, several fields must be changed. At some point, the
code updates the field `rrule_type` with the value `'daily'`. However, the
fields `count` and `end_type` are not yet up to date (they are
respectively `1` and `'count'`, instead of `None` and `'end_date'`).
Therefore, since the values are not yet the good ones, the following
block will be executed:
https://github.com/odoo/odoo/blob/d139b509bb4e1e5b7fd64004dfadbe7633f37d64/addons/calendar/models/calendar.py#L1557-L1562
So, `final_date` will be redefined based on wrong values and the
recurrence rule won't be respected.

Note: this use case happens if the user creates such a recurrent event
on Google Calendar and then tries to sync with Odoo Calendar.

OPW-2474721