### PR TITLE
[FIX] website: better helper for domain in settings

### DIFF
--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -90,7 +90,7 @@
                                         Display this website when users visit this domain
                                     </div>
                                     <div class="mt8">
-                                        <field name="website_domain" placeholder="www.odoo.com"/>
+                                        <field name="website_domain" placeholder="https://www.odoo.com"/>
                                     </div>
                                     <div class="mt8 text-muted" title="You can have 2 websites with same domain AND a condition on country group to select wich website use.">
                                         Once the selection of available websites by domain is done, you can filter by country group.


### PR DESCRIPTION
If the user type his website URL as suggested by the helper, and he redirects
his `http` to `https` (nginx, cloudflare..), then his canonical url won't ever
be reachable.
Most critical issue will be that we won't display the `alternate/hreflang` tag,
which basically tells the search engines what and where is our translated
content.

opw-2486918
