### PR TITLE
[FIX] web_editor: have transcoder apply text-decoration


### DIFF
--- a/addons/web_editor/static/src/js/editor/transcoder.js
+++ b/addons/web_editor/static/src/js/editor/transcoder.js
@@ -161,6 +161,7 @@ function getMatchedCSSRules(a) {
         delete style['text-decoration-line'];
         delete style['text-decoration-color'];
         delete style['text-decoration-style'];
+        delete style['text-decoration-thickness'];
     }
 
     // text-align inheritance does not seem to get past <td> elements on some


### PR DESCRIPTION
The transcoder (transforming CSS rules into inline CSS for mail clients)
was not working for text-decoration property because it would transform
text-decoration values in:

{'text-decoration-thickness': 'normal', 'text-decoration': none}

And the regex that ensures we don't add duplicates check if there is:

"(^|;)\s*text-decoration"

so if there is text-decoration-thickness, text-decoration is not added.

The regexp could be changed to:

"(^|;)\s*text-decoration[^\w-]"

but we already have special case for other text-decoration-* properties.

With this change we should get text-decoration applied in:

- edit mode (was already the case)
- readonly mode (new)
- mail client (only if mail client does not override it)

As a side note: text-decoration-thickness seems to be rather new[^1] so
at one point in time there was probably no issue.

[^1]: https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness

opw-2496490