### PR TITLE
[FIX] sale, website_sale: use correct url as T&C url

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -107,11 +107,14 @@ class SaleOrder(models.Model):
         return super(SaleOrder, self).get_empty_list_help(help)
 
     @api.model
+    def _default_note_url(self):
+        return self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+
+    @api.model
     def _default_note(self):
         use_invoice_terms = self.env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms')
         if use_invoice_terms and self.env.company.terms_type == "html":
-            baseurl = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
-            return _('Terms & Conditions: %s/terms', baseurl)
+            return _('Terms & Conditions: %s/terms', self._default_note_url())
         return use_invoice_terms and self.env.company.invoice_terms or ''
 
     @api.model

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -29,6 +29,13 @@ class SaleOrder(models.Model):
     website_id = fields.Many2one('website', string='Website', readonly=True,
                                  help='Website through which this order was placed.')
 
+    @api.model
+    def _default_note_url(self):
+        website = self.env['website'].get_current_website()
+        if website:
+            return website.get_base_url()
+        return super()._default_note_url()
+
     @api.depends('order_line')
     def _compute_website_order_line(self):
         for order in self:


### PR DESCRIPTION
Without this commit, the link to the T&C is always the web.base.url one instead
of the website one if created in frontend (eshop).

Steps to reproduce:
  - Add a domain on the website, eg www.odoo.com
  - Activate Terms & Conditions (settings) and select 'as Web page'
  - Create an order from eshop
  - The order contains a note with a link to the terms with the wrong url

Related to #68201
