### PR TITLE
[FIX] 12.0 13.0 14.0  webclient causing request storm on /longpolling/poll

### DIFF
--- a/addons/bus/static/src/js/crosstab_bus.js
+++ b/addons/bus/static/src/js/crosstab_bus.js
@@ -328,8 +328,19 @@ var CrossTabBus = Longpolling.extend({
         // update channels
         else if (key === this._generateKey('channels')) {
             var channels = value;
-            _.each(_.difference(this._channels, channels), this.deleteChannel.bind(this));
-            _.each(_.difference(channels, this._channels), this.addChannel.bind(this));
+            /* if the channels have not changed, do nothing
+               else, sync the local attribute, and call restart polling
+               (the method does take care of synchronising the channels in both ways,
+               depending on if we are master or not) */
+            if (_.difference(this._channels, channels).length > 0 || _.difference(channels, this._channels).length > 0) {
+                this._channels = value;
+                if (this._pollRpc) {
+                    this._pollRpc.abort();
+                } else {
+                    this.startPolling();
+                }
+            }
+
         }
         // update options
         else if (key === this._generateKey('options')) {
@@ -362,4 +373,3 @@ var CrossTabBus = Longpolling.extend({
 return CrossTabBus;
 
 });
-


### PR DESCRIPTION
Affected versions: 13.0 (for sure), other persons mention 12.0 and 14.0

It can happen that the web client will go wild and start calling poll()
repeatedly. This can have very bad side effects on the load of the
server, including exhaustion of the postgresql connection pool on the
process which serves the longpolling requests. 

The issue seems browser dependent, with Firefox not being affected, 
but Chrome / Chromium being able to trigger it (I tested with chromium 89 
on GNU/Linux, the customer involved uses Chrome on Windows). 

Our analysis of the issue is that when multiple tabs are open and not
all are subscribed to the same channels, when one tab changes its
channel subscription, we can have a race condition between the local
storage updates and the updates of the channels in the various tabs of
the browser, because the _onStorage notification will call addChannel /
deleteChannel which will in turn trigger _onStorage in a loop, which
causes a heavy load on the client. Additionally, for the master
tab, add/deleteChannel cause an abort of the current call to poll()
followed by a new poll() (and this is the cause of the storm on the
server side which raised the issue to our attention).

This patches fixes the issue by not calling add/deleteChannel in
_onStorage, but instead

1. synchronize the local variable from local storage
2. stop any ongoing poll (should only happen in the master tab)
3. call _startPolling

These 3 steps are performed IFF the _channels have changed (to avoid
looping). The _startPolling method takes care of only polling in the
master tab.

Issue not fixed by the patch:

* if two tabs are subscribed to the same channel, calling removeChannel
in one tab will unsubscribe both tabs. This was already the case in the
previous implementation.
* we still have a race condition if 2 tabs update their channels
simultaneously

Contributors:
@jbaudoux
@simahawk
@sebalix

OPW: 2502799

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
