### PR TITLE
[FIX] pricelist report: active_ids condition error

### DIFF
--- a/addons/product/static/src/js/product_pricelist_report.js
+++ b/addons/product/static/src/js/product_pricelist_report.js
@@ -91,7 +91,7 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
         StandaloneFieldManagerMixin.init.call(this);
         this.context = params.context;
         // in case the window got refreshed
-        if (params.params && params.params.active_ids && typeof(params.params.active_ids === 'string')) {
+        if (params.params && params.params.active_ids && typeof params.params.active_ids === 'string') {
             try {
                 this.context.active_ids = params.params.active_ids.split(',').map(id => parseInt(id));
                 this.context.active_model = params.params.active_model;


### PR DESCRIPTION
Sentence typeof(params.params.active_ids === 'string') always returns 'boolean', fixed this little error

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
