### PR TITLE
payment: allow dynamically overriding the redirect form HTTP method 

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -290,7 +290,7 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
                         if (result) {
                             // if the server sent us the html form, we create a form element
                             var newForm = document.createElement('form');
-                            newForm.setAttribute("method", self._get_redirect_form_method());
+                            newForm.setAttribute("method", self._get_redirect_form_method(newForm));
                             newForm.setAttribute("provider", checked_radio.dataset.provider);
                             newForm.hidden = true; // hide it
                             newForm.innerHTML = result; // put the html sent by the server inside the form
@@ -349,7 +349,11 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
      * @private
      * @return {string} The HTTP method, "post" by default
      */
-    _get_redirect_form_method: function () {
+    _get_redirect_form_method: function (newForm) {
+        var action_method = $(newForm).find('input[name="data_set"]').data('actionMethod');
+        if (typeof action_method !== typeof undefined && action_method !== false) {
+            return action_method; // set it to custom method
+        }
         return "post";
     },
     /**


### PR DESCRIPTION
It should be possible to dynamically modify payment transaction submit (POST/GET) form details when such modification is required as per payment provider API specification.

Currently, such extension is not possible and with this PR we want to solve that issue.

Just add attribute: t-att-data-action-method="form_method" to payment template, for example:
```
<input type="hidden" name="data_set" t-att-data-action-url="tx_url" t-att-data-action-method="form_method" data-remove-me=""/>
```
for function "def ..._form_generate_values(self, values)" add parameter:
```
'form_method': 'get'
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
