### PR TITLE
[FIX] point_of_sale: invoice line description

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -185,12 +185,20 @@ class PosOrder(models.Model):
             order.add_payment(return_payment_vals)
 
     def _prepare_invoice_line(self, order_line):
+
+        product = order_line.product_id
+        values = []
+        if product.partner_ref:
+            values.append(product.partner_ref)
+        if product.description_sale:
+            values.append(product.description_sale)
+        name = '\n'.join(values)
         return {
             'product_id': order_line.product_id.id,
             'quantity': order_line.qty if self.amount_total >= 0 else -order_line.qty,
             'discount': order_line.discount,
             'price_unit': order_line.price_unit,
-            'name': order_line.product_id.display_name,
+            'name': name,
             'tax_ids': [(6, 0, order_line.tax_ids_after_fiscal_position.ids)],
             'product_uom_id': order_line.product_uom_id.id,
         }


### PR DESCRIPTION
When an invoice is generated from the point of sale, the sale
description of the product is not set on the invoice line.

So we are now taking it into account, by using a similar method than the
one set on the onchange of the invoice line to fill the name.

OPW-2457450