### PR TITLE
[FIX] calendar: extend month_day SQL constraint

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -118,7 +118,13 @@ class RecurrenceRule(models.Model):
     until = fields.Date('Repeat Until')
 
     _sql_constraints = [
-        ('month_day', "CHECK (rrule_type != 'monthly' OR month_by != 'day' OR day >= 1 AND day <= 31)", "The day must be between 1 and 31"),
+        ('month_day',
+         "CHECK (rrule_type != 'monthly' "
+                "OR month_by != 'day' "
+                "OR day >= 1 AND day <= 31 "
+                "OR weekday in %s AND byday in %s)"
+                % (tuple(wd[0] for wd in WEEKDAY_SELECTION), tuple(bd[0] for bd in BYDAY_SELECTION)),
+         "The day must be between 1 and 31"),
     ]
 
     @api.depends('rrule')


### PR DESCRIPTION
When creating a recurrent event, an SQL contraint requires the field
`day` to be correcly defined. However, if the recurrence rule is like
"every last Monday of the month", the field becomes useless and may be
undefined. As a result, the SQL constraint will prevent the creation of
such a recurrent event.

For example, the situation will happen when the user creates this
recurrent event on Microsoft Calendar and then tries to sync with Odoo.
The recurrent event data will contain:
```python
{
    'rrule_type': 'monthly',
    'day': 0,
    'byday': '2',
    'month_by': 'day',
    'weekday': 'TU',
    # ...
}
```

OPW-2439814