### PR TITLE
[IMP] iap: Add TTL option for IAP transaction

### DIFF
--- a/addons/iap/models/iap.py
+++ b/addons/iap/models/iap.py
@@ -80,13 +80,14 @@ class IapTransaction(object):
     def __init__(self):
         self.credit = None
 
-def authorize(env, key, account_token, credit, dbuuid=False, description=None, credit_template=None):
+def authorize(env, key, account_token, credit, dbuuid=False, description=None, credit_template=None, ttl=4320):
     endpoint = get_endpoint(env)
     params = {
         'account_token': account_token,
         'credit': credit,
         'key': key,
         'description': description,
+        'ttl': ttl
     }
     if dbuuid:
         params.update({'dbuuid': dbuuid})


### PR DESCRIPTION
New optional 'ttl' parameter for the authorize function. It will allow to specify how much time the credits will be reserved.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
