### PR TITLE
13.0 website event track fix method not allowed mub

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -302,9 +302,13 @@ class WebsiteEventController(http.Controller):
             Attendees += Attendees.sudo().create(
                 Attendees._prepare_attendee_values(registration))
 
+        return request.redirect('/event/%s/registration/%s/success' % (event.id, Attendees.sudo().id))
+
+    @http.route(['/event/<model("event.event"):event>/registration/<model("event.registration"):registration>/success'], type='http', auth="public", website=True)
+    def event_registration_success(self, registration, event):
         urls = event._get_event_resource_urls()
         return request.render("website_event.registration_complete", {
-            'attendees': Attendees.sudo(),
+            'attendees': registration.sudo(),
             'event': event,
             'google_url': urls.get('google_url'),
             'iCal_url': urls.get('iCal_url')

--- a/addons/website_event_track/controllers/main.py
+++ b/addons/website_event_track/controllers/main.py
@@ -159,4 +159,11 @@ class WebsiteEventTrackController(http.Controller):
             partner = request.env['res.partner'].sudo().search([('email', '=', post['email_from'])])
             if partner:
                 track.sudo().message_subscribe(partner_ids=partner.ids)
+        return request.redirect('/event/%s/track_proposal/%s/success' % (event.id, track.id))
+
+    @http.route(['/event/<model("event.event"):event>/track_proposal/<model("event.track"):track>/success'], type='http', auth="public", website=True)
+    def event_track_proposal_success(self, track, event):
+        if not event.can_access_from_current_website():
+            raise NotFound()
+
         return request.render("website_event_track.event_track_proposal_success", {'track': track, 'event': event})


### PR DESCRIPTION
PURPOSE

If the user go to and event and submit the track proposal
and go to event and register event after reload the page
it gave the error message "Method not Allowed".

SPECIFICATION

so for this we use two methods first is POST and second is GET
if user fill up the register form at that time use post method 
and after successful register/track_proposal and post method is 
empty than we use GET mothod.

Task Id: 2500573

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
