### PR TITLE
[FIX] purchase: Update correctly the price according to UoM

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -641,6 +641,16 @@ class PurchaseOrderLine(models.Model):
         if not seller:
             if self.product_id.seller_ids.filtered(lambda s: s.name.id == self.partner_id.id):
                 self.price_unit = 0.0
+
+            if self.product_uom:
+                price_unit = self.env['account.tax']._fix_tax_included_price_company(
+                    self.product_id.uom_id._compute_price(self.product_id.standard_price, self.product_id.uom_po_id),
+                    self.product_id.supplier_taxes_id,
+                    self.taxes_id,
+                    self.company_id,
+                )
+                self.price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom)
+
             return
 
         price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, self.product_id.supplier_taxes_id, self.taxes_id, self.company_id) if seller else 0.0


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Create Product with Purchase Vendor(s) set
    2. Create Units of Measure that are bigger than (10kg/50kg in tests)

What is currently happening ?

    If you put a vendor that is listed in product form, when changing purchase unit from kg to 10/50kg price is updated
    If you put a vendor not listed, it gives cost price which is correct, but does not update price according to unit of measure.

What are you expecting to happen ?

    Update correctly the unit of measure when the vendor is not listed

opw-2494769