### PR TITLE
[IMP] mail_plugin, crm_mail_plugin: add translation support for email plugins

### DIFF
--- a/addons/crm_mail_plugin/__manifest__.py
+++ b/addons/crm_mail_plugin/__manifest__.py
@@ -17,6 +17,9 @@
         'views/crm_mail_plugin_lead.xml',
         'views/crm_lead_views.xml'
     ],
+    'web.assets_backend': [
+        'crm_mail_plugin/static/src/to_translate/**/*',
+    ],
     'installable': True,
     'application': False,
     'auto_install': True

--- a/addons/crm_mail_plugin/controllers/mail_plugin.py
+++ b/addons/crm_mail_plugin/controllers/mail_plugin.py
@@ -61,3 +61,6 @@ class MailPluginController(mail_plugin.MailPluginController):
 
     def _mail_content_logging_models_whitelist(self):
         return super(MailPluginController, self)._mail_content_logging_models_whitelist() + ['crm.lead']
+
+    def _translation_modules_whitelist(self):
+        return super(MailPluginController, self)._translation_modules_whitelist() + ['crm_mail_plugin']

--- a/addons/crm_mail_plugin/static/src/to_translate/translations_outlook.xml
+++ b/addons/crm_mail_plugin/static/src/to_translate/translations_outlook.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Terms to translate for the outlook plugin -->
+<ressources>
+    <string>Log Email Into Lead</string>
+    <string>Opportunities</string>
+    <string>Opportunities (%(count)s)</string>
+    <string>%(expected_revenue)s at %(probability)s%</string>
+    <string>%(expected_revenue)s + %(recurring_revenue)s %(recurring_plan)s at %(probability)s%</string>
+    <string>Save Contact to create new Opportunities.</string>
+    <string>No opportunities found for this contact.</string>
+</ressources>

--- a/addons/mail_plugin/__manifest__.py
+++ b/addons/mail_plugin/__manifest__.py
@@ -13,6 +13,9 @@
         'contacts',
         'iap'
     ],
+    'web.assets_backend': [
+        'mail_plugin/static/src/to_translate/**/*',
+    ],
     'data': [
         'views/mail_plugin_login.xml',
         'views/res_partner_iap_views.xml',

--- a/addons/mail_plugin/static/src/to_translate/translations_outlook.xml
+++ b/addons/mail_plugin/static/src/to_translate/translations_outlook.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Terms to translate for the outlook plugin.
+    Only named string params e.g: %(param)s are supported by the plugins,
+    unnamed params like %s are not supported.-->
+<resources>
+    <string>Logout</string>
+    <string>Company created</string>
+    <string>Company Insights</string>
+    <string>Revenues</string>
+    <string>Company Type</string>
+    <string>Keywords</string>
+    <string>Year founded</string>
+    <string>Employees</string>
+    <string>Industry</string>
+    <string>Website</string>
+    <string>Phone</string>
+    <string>Address</string>
+    <string>Contact created</string>
+    <string>Buy More</string>
+    <string>Search In Odoo</string>
+    <string>Search In Database</string>
+    <string>Contacts Found (%(count)s)</string>
+    <string>Search contact in Odoo...</string>
+    <string>Refresh Contact</string>
+    <string>Add Contact To Database</string>
+    <string>Contact Details</string>
+    <string>Log Email Into Contact</string>
+    <string>This contact has no email address, no company could be enriched</string>
+    <string>No company attached to this contact</string>
+    <string>Create a Company</string>
+    <string>No company linked to this contact could be enriched</string>
+    <string>No company linked to this contact could be enriched or found in Odoo</string>
+    <string>No data found for this email address.</string>
+    <string>You don't have enough credit to enrich.</string>
+    <string>Something bad happened. Please, try again later.</string>
+    <string>Could not autocomplete the company. Internal error. Try again later...</string>
+    <string>There was a problem contacting the service, please try again later.</string>
+    <string>An error has occurred when trying to fetch translations.</string>
+</resources>


### PR DESCRIPTION
In mail_plugin module, add a method to return translations for mail plugins,
this method will be overridden in the other modules to add their specific
translations, it will be used by mail plugins in order to display information
in the user's language.

This implementation will allow having translations handled by Odoo, which has
several advantages:
- existing system, nothing to develop
- it will use transifex and the terms will be translated by the community
- forces that mail_client implementations to have the same logic (consistency)

The method has a "plugin "param that allows it to distinguish between each
plugin's specific translations, this is done to make it easier to modify/delete
each plugin's translations, so that, for example, when having to delete
translations for a specific plugin, we won't have to check if these translations
exist in the other plugins.

The ir.http model has been updated to assign the language of the request to the
user's language as this will allow to translate the strings to the connected
user's language and not to the language put in the url.

Task-2480075

ENT-PR: odoo/enterprise#17626
PLUGIN-PR: odoo/mail-client-extensions#6



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
