### PR TITLE
[FIX] web_editor: added check before updateLeftPanel timeout

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2679,9 +2679,11 @@ var SnippetsMenu = Widget.extend({
         // make text tools visible only on that specific tab). Also do it with
         // a slight delay to avoid flickering doing it twice.
         clearTimeout(this._textToolsSwitchingTimeout);
-        this._textToolsSwitchingTimeout = setTimeout(() => {
-            this._updateLeftPanelContent({tab: this.tabs.OPTIONS});
-        }, 250);
+        if (!this.$('#o_scroll').hasClass('d-none')) {
+            this._textToolsSwitchingTimeout = setTimeout(() => {
+                this._updateLeftPanelContent({tab: this.tabs.OPTIONS});
+            }, 250);
+        }
     },
     /**
      * @private


### PR DESCRIPTION
Added a check to make sure that we do not set a timeout to update the option panel when said option panel is already open.
This could sometimes occur which could cause all opened select to close and could fail some tests if said events happened in the middle of selecting an option.

This fix is needed only because of a summernote event and is therefore not needed in 14.3 =<

task : 2502297
