### PR TITLE
[FIX] account_edi_ubl: payment_reference not available in efff format

### DIFF
--- a/addons/account_edi_ubl/data/ubl_templates.xml
+++ b/addons/account_edi_ubl/data/ubl_templates.xml
@@ -123,6 +123,7 @@
                 </cac:AccountingCustomerParty>
                 <cac:PaymentMeans>
                     <cbc:PaymentMeansCode listID="UN/ECE 4461" t-esc="payment_means_code"/>
+                    <cbc:InstructionID t-esc="invoice.payment_reference"/>
                     <cbc:PaymentDueDate t-esc="invoice.invoice_date_due"/>
                     <cac:PayeeFinancialAccount t-if="invoice.journal_id.bank_account_id">
                         <cbc:ID schemeName="IBAN" t-esc="invoice.journal_id.bank_account_id.acc_number"/>


### PR DESCRIPTION
Inspired from http://www.datypic.com/sc/ubl21/e-cac_PaymentMeans.html

opw:2468492