### PR TITLE
[FIX] fetchmail: Prevent onchange for erasing server name

### DIFF
--- a/addons/fetchmail/models/fetchmail.py
+++ b/addons/fetchmail/models/fetchmail.py
@@ -62,8 +62,6 @@ class FetchmailServer(models.Model):
             self.port = self.is_ssl and 995 or 110
         elif self.type == 'imap':
             self.port = self.is_ssl and 993 or 143
-        else:
-            self.server = ''
 
         conf = {
             'dbname': self.env.cr.dbname,


### PR DESCRIPTION
PURPOSE

currently, in fetchmail while create an incoming
mail server, Set a server name while being in POP
or IMAP server type and Switch to "Local" server type
the server name is erased.

SPECIFICATION

for this we are removing server name field 
from the onchange_server_type method.

with this commit, the value of the server name
should not be erase with onchange.

TaskId: 2258523

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
