### PR TITLE
[IMP] sale: Send coupons by SMS

### DIFF
--- a/addons/coupon_sms/__init__.py
+++ b/addons/coupon_sms/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/coupon_sms/__manifest__.py
+++ b/addons/coupon_sms/__manifest__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Coupon - SMS",
+    'summary': 'Add SMS capabilities to Coupon',
+    'description': 'Add SMS capabilities to Coupon',
+    'category': 'Hidden',
+    'version': '1.0',
+    'depends': ['coupon', 'sms'],
+    'data': [
+        'data/sms_data.xml',
+        'views/coupon_views.xml',
+    ],
+    'application': False,
+    'auto_install': True,
+}

--- a/addons/coupon_sms/data/sms_data.xml
+++ b/addons/coupon_sms/data/sms_data.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <record id="sms_template_data_coupon" model="sms.template">
+        <field name="name">Coupon: send coupon to customers</field>
+        <field name="model_id" ref="coupon.model_coupon_coupon"/>
+        <field name="body">
+            % if object.partner_id.name:
+                Congratulations ${object.partner_id.name},
+            % endif
+            Here is your reward from ${object.program_id.company_id.name}.
+            % if object.program_id.reward_type == 'discount':
+                % if object.program_id.discount_type == 'fixed_amount':
+                    ${object.program_id.discount_fixed_amount} ${object.program_id.currency_id.symbol} off on your next order
+                %else:
+                    ${object.program_id.discount_percentage}%
+                    % if object.program_id.discount_apply_on == 'specific_products':
+                        % if object.program_id.discount_apply_on == 'on_order':
+                            on some products*
+                        % else:
+                            % for products in object.program_id.discount_specific_product_ids:
+                                ${products.name},
+                            % endfor
+                        % endif
+                    % elif object.program_id.discount_apply_on == 'cheapest_product':
+                        off on the cheapest product
+                    % else:
+                        off on your next order
+                    % endif
+                % endif
+            % elif object.program_id.reward_type == 'product':
+                ${object.program_id.reward_product_quantity} ${object.program_id.reward_product_id.name} on your next order
+            % elif object.program_id.reward_type == 'free_shipping':
+                get free shipping on your next order
+            % endif
+            Use this promo code ${object.code}
+            % if object.expiration_date:
+                before ${object.expiration_date}
+            % endif
+            % if object.program_id.rule_min_quantity not in [0, 1]:
+                Minimum purchase of ${object.program_id.rule_min_quantity} products
+            % endif
+            % if object.program_id.rule_minimum_amount != 0.00:
+                Valid for purchase above ${object.program_id.company_id.currency_id.symbol}${object.program_id.rule_minimum_amount}
+            % endif
+            % if object.program_id.discount_apply_on == 'specific_products':
+                *Valid for following products:
+                % for products in object.program_id.discount_specific_product_ids:
+                    ${products.name},
+                % endfor
+            % endif
+            Thank you,
+            % if object.order_id.user_id.signature:
+                ${object.order_id.user_id.signature}
+            % endif
+        </field>
+    </record>
+
+</odoo>

--- a/addons/coupon_sms/models/__init__.py
+++ b/addons/coupon_sms/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import coupon

--- a/addons/coupon_sms/models/coupon.py
+++ b/addons/coupon_sms/models/coupon.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.from odoo import models
+
+from odoo import models
+
+
+class Coupon(models.Model):
+    _inherit = 'coupon.coupon'
+
+    def action_send_sms(self):
+        self.ensure_one()
+        template = self.env.ref('coupon_sms.sms_template_data_coupon')
+        temp_body = template._render_field('body', self.ids)[self.id]
+        ctx = dict(
+            default_res_model='res.partner',
+            default_res_id=self.partner_id.id,
+            default_body=temp_body,
+        )
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'sms.composer',
+            'view_mode': 'form',
+            'composition_mode': 'comment',
+            'target': 'new',
+            'context': ctx,
+        }

--- a/addons/coupon_sms/views/coupon_views.xml
+++ b/addons/coupon_sms/views/coupon_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="coupon_view_form_inherit_coupon" model="ir.ui.view">
+        <field name="name">coupon.coupon.form.coupon.sms</field>
+        <field name="model">coupon.coupon</field>
+        <field name="inherit_id" ref="coupon.coupon_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_coupon_sent']" position="after">
+                <button name="action_send_sms" type="object" string="Send By SMS" class="oe_highlight" attrs="{'invisible': ['|',('state', 'not in', ['new', 'sent']), ('partner_id', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+    
+</odoo>


### PR DESCRIPTION
Currently, coupons can be sent by only email and there is no way we can send those
coupons by SMS. So We have made a button through which we can send those coupons
through SMS.

**Task-Id : 2467466**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
