### PR TITLE
[IMP] base: add modules in _reflect_fields warning message

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1018,10 +1018,11 @@ class IrModelFields(models.Model):
             by_label = {}
             for field in model._fields.values():
                 if field.string in by_label:
-                    _logger.warning('Two fields (%s, %s) of %s have the same label: %s.',
-                                    field.name, by_label[field.string], model, field.string)
+                    other = by_label[field.string]
+                    _logger.warning('Two fields (%s, %s) of %s have the same label: %s. [Modules: %s and %s]',
+                                    field.name, other.name, model, field.string, field._module, other._module)
                 else:
-                    by_label[field.string] = field.name
+                    by_label[field.string] = field
 
         # determine expected and existing rows
         rows = []


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**  A warning message shows two fields that have same string, in order for a developer to fix one of them. The problem is that sometimes (without using queries) finding those fields is a pain, because there are a lot of modules.

**Current behavior before PR:** Show two fields, without knowing in which modules are declared.

**Desired behavior after PR is merged:** Add module names in a warning message.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr