### PR TITLE
[IMP] core: allow skipping field recomputitation on installation

### DIFF
--- a/odoo/addons/test_inherit/models.py
+++ b/odoo/addons/test_inherit/models.py
@@ -75,6 +75,24 @@ class res_partner(models.Model):
     # define a one2many field based on the inherited field partner_id
     daughter_ids = fields.One2many('test.inherit.daughter', 'partner_id')
 
+    # define two computed fields, one of which is initialized by _init_column()
+    test_init_computed = fields.Char(compute='_compute_test_init_computed', store=True)
+    test_init_optimized = fields.Char(compute='_compute_test_init_optimized', store=True)
+
+    def _compute_test_init_computed(self):
+        self.test_init_computed = 'computed'
+
+    def _compute_test_init_optimized(self):
+        self.test_init_optimized = 'computed'
+
+    def _init_column(self, column_name):
+        if column_name == "test_init_optimized":
+            # initialize the field and return True to avoid the field being
+            # computed with '_compute_test_init_optimized'
+            self.env.cr.execute("UPDATE res_partner p SET test_init_optimized = 'optimized'")
+            return True
+        return super()._init_column(column_name)
+
 
 # Check the overriding of property fields by non-property fields.
 # Contribution by Adrien Peiffer (ACSONE).

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -173,3 +173,13 @@ class TestXMLIDS(common.TransactionCase):
         self.assertCountEqual(xml_ids.get(baz.id), [
             'test_inherit.selection__test_new_api_selection__state__baz',
         ])
+
+
+class TestInitColumn(common.TransactionCase):
+    def test_init_column(self):
+        # the installation of this module should:
+        #  - use the compute method to initialize field 'test_init_computed'
+        #  - bypass the compute method to initialize field 'test_init_optimized'
+        partner = self.env.user.partner_id
+        self.assertEqual(partner.test_init_computed, 'computed')
+        self.assertEqual(partner.test_init_optimized, 'optimized')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -976,26 +976,9 @@ class Field(MetaField('DummyField', (object,), {})):
         # create/update the column, not null constraint; the index will be
         # managed by registry.check_indexes()
         self.update_db_column(model, column)
-        self.update_db_notnull(model, column)
+        initialized = self.update_db_notnull(model, column)
 
-        # optimization for computing simple related fields like 'foo_id.bar'
-        if (
-            not column
-            and self.related and self.related.count('.') == 1
-            and self.related_field.store and not self.related_field.compute
-            and not (self.related_field.type == 'binary' and self.related_field.attachment)
-            and self.related_field.type not in ('one2many', 'many2many')
-        ):
-            join_field = model._fields[self.related.split('.')[0]]
-            if (
-                join_field.type == 'many2one'
-                and join_field.store and not join_field.compute
-            ):
-                model.pool.post_init(self.update_db_related, model)
-                # discard the "classical" computation
-                return False
-
-        return not column
+        return not initialized
 
     def update_db_column(self, model, column):
         """ Create/update the column corresponding to ``self``.
@@ -1026,13 +1009,15 @@ class Field(MetaField('DummyField', (object,), {})):
 
             :param model: an instance of the field's model
             :param column: the column's configuration (dict) if it exists, or ``None``
+            :return: ``True`` if the column has been initialized in database
         """
+        initialized = False
         has_notnull = column and column['is_nullable'] == 'NO'
 
         if not column or (self.required and not has_notnull):
             # the column is new or it becomes required; initialize its values
             if model._table_has_rows():
-                model._init_column(self.name)
+                initialized = model._init_column(self.name)
 
         if self.required and not has_notnull:
             # _init_column may delay computations in post-init phase
@@ -1045,22 +1030,54 @@ class Field(MetaField('DummyField', (object,), {})):
         elif not self.required and has_notnull:
             sql.drop_not_null(model._cr, model._table, self.name)
 
-    def update_db_related(self, model):
+        return initialized
+
+    def initialize(self, model):
+        """ Possibly initialize the field, and return ``True`` if it has been
+        actually done.
+        """
+        if self.related and self.related.count('.') == 1:
+            join_field = model._fields[self.related.split('.')[0]]
+            if (
+                self.related_field.column_type
+                and self.related_field.store
+                and not self.related_field.compute
+                and join_field.type == 'many2one'
+                and join_field.store
+                and not join_field.compute
+            ):
+                model.pool.post_init(self.initialize_related, model)
+                # consider it done, to avoid the classical computation
+                return True
+
+        # get the default value; ideally, we should use default_get(), but it
+        # fails due to ir.default not being ready
+        if field.default:
+            value = field.default(self)
+            value = field.convert_to_write(value, self)
+            value = field.convert_to_column(value, self)
+        else:
+            value = None
+        # Write value if non-NULL, except for booleans for which False means
+        # the same as NULL - this saves us an expensive query on large tables.
+        necessary = (value is not None) if field.type != 'boolean' else value
+        if necessary:
+            _logger.debug("Table '%s': setting default value of new column %s to %r",
+                          self._table, column_name, value)
+            query = f'UPDATE "{self._table}" SET "{column_name}" = %s WHERE "{column_name}" IS NULL'
+            self._cr.execute(query, (value,))
+            return True
+
+    def initialize_related(self, model):
         """ Compute a stored related field directly in SQL. """
         comodel = model.env[self.related_field.model_name]
         join_field, comodel_field = self.related.split('.')
-        model.env.cr.execute("""
-            UPDATE "{model_table}" AS x
-            SET "{model_field}" = y."{comodel_field}"
-            FROM "{comodel_table}" AS y
+        model.env.cr.execute(f"""
+            UPDATE "{model._table}" AS x
+            SET "{self.name}" = y."{comodel_field}"
+            FROM "{comodel._table}" AS y
             WHERE x."{join_field}" = y.id
-        """.format(
-            model_table=model._table,
-            model_field=self.name,
-            comodel_table=comodel._table,
-            comodel_field=comodel_field,
-            join_field=join_field,
-        ))
+        """)
 
     ############################################################################
     #

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2898,24 +2898,14 @@ class BaseModel(metaclass=MetaModel):
                 tools.drop_not_null(cr, self._table, row['attname'])
 
     def _init_column(self, column_name):
-        """ Initialize the value of the given column for existing rows. """
-        # get the default value; ideally, we should use default_get(), but it
-        # fails due to ir.default not being ready
+        """ Initialize the value of the given column for existing rows.
+
+        It may be overriden for computed fields to optimize their computation on
+        existing records.  In that case, returning ``True`` skips the default
+        computation with the compute method.
+        """
         field = self._fields[column_name]
-        if field.default:
-            value = field.default(self)
-            value = field.convert_to_write(value, self)
-            value = field.convert_to_column(value, self)
-        else:
-            value = None
-        # Write value if non-NULL, except for booleans for which False means
-        # the same as NULL - this saves us an expensive query on large tables.
-        necessary = (value is not None) if field.type != 'boolean' else value
-        if necessary:
-            _logger.debug("Table '%s': setting default value of new column %s to %r",
-                          self._table, column_name, value)
-            query = f'UPDATE "{self._table}" SET "{column_name}" = %s WHERE "{column_name}" IS NULL'
-            self._cr.execute(query, (value,))
+        return field.initialize(self)
 
     @ormcache()
     def _table_has_rows(self):


### PR DESCRIPTION
When a module adds new computated field, it may take significant time to make
initial computation. Before this commit, the only way to avoid this was using
`_auto_init`. Example:

https://github.com/odoo/odoo/blob/ca0d8978b6585fe4f96100df56b8a7346468dc6c/addons/l10n_latam_invoice_document/models/account_move.py#L42-L44

https://github.com/odoo/enterprise/blob/46812d9abb3eb6e2b5ac565b4817548317c4a354/l10n_mx_edi_extended/models/account_move.py#L79-L82

But such method requires creating columns manually.

This commit allows to use `_init_column` method instead by adding return value
``skip_recomputation``

As a bonus, this allows make some cleanup in odoo/fields.py and move code
"optimization for computing simple related fields like 'foo_id.bar'" to _init_column
