### PR TITLE
[IMP] website_slides: replace error by log in page, always show invit…

### DIFF
--- a/addons/website_slides/data/mail_templates.xml
+++ b/addons/website_slides/data/mail_templates.xml
@@ -29,7 +29,7 @@
         <td style="min-width: 590px;">
             <t t-raw="message.body"/>
             <div style="margin: 32px 0px 32px 0px; text-align: center;">
-                <a t-att-href="record.channel_id.website_url"
+                <a t-att-href="'%s/slides/%s/invite' % (record.channel_id.get_base_url(), record.channel_id.id)"
                     style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                     Click here to start the course
                 </a>

--- a/addons/website_slides/static/src/js/slides_course_unsubscribe.js
+++ b/addons/website_slides/static/src/js/slides_course_unsubscribe.js
@@ -98,8 +98,12 @@ var SlideUnsubscribeDialog = Dialog.extend({
         this._rpc({
             route: '/slides/channel/leave',
             params: {channel_id: this.channelID},
-        }).then(function () {
-            window.location.reload();
+        }).then(function (isChannelPublic) {
+            if (!isChannelPublic) {
+                window.location.replace(window.location.origin + '/slides');
+            } else {
+                window.location.reload();
+            }
         });
     },
 

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Channels">
                     <header>
-                        <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight"  attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
+                        <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">


### PR DESCRIPTION
…e button.

Ease the invitiations to a course by always showing the invite button, whatever
the enroll policy.

Also, when a not-logged user receives an invitation email, it will lead to an
error 403 page if the visibility of the course is set to members only. It is now
replaced with the error page by the login page, redirecting to the course.

Introduces a new route that acts as a dispatcher to either course (channel) or
the login page (if not logged). This route does not include model as ACL would
raise 403 error immediately.

Therefore, change the invitation mail template to include this new route as
hyperlink instead of the old one, that included channel model.

-- Links --
Task-Id 2481522


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
