### PR TITLE
[FIX] account: fix create with empty line_ids

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1784,7 +1784,7 @@ class AccountMove(models.Model):
 
             is_invoice = vals.get('move_type') in self.get_invoice_types(include_receipts=True)
 
-            if 'line_ids' in vals:
+            if vals.get('line_ids'):
                 vals.pop('invoice_line_ids', None)
                 new_vals_list.append(vals)
                 continue


### PR DESCRIPTION
If an empty value is given, all lines are dropped altogether.
Fine-tuning of fdc96de0e411760f84a78c36543f9157332346de
Note that although this is a forward-port of 03e87628e364f6, the original commit
does not suffer from this issue.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
