### PR TITLE
[FIX] Calendar: fix avatar preview on hover

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -739,7 +739,7 @@ return AbstractRenderer.extend({
                                 delay: {show: 300, hide: 0},
                                 content: function () {
                                     return $('<img>', {
-                                        src: `/web/image/${options.avatar_model}/${filter.value}/${options.avatar_field}}`,
+                                        src: `/web/image/${options.avatar_model}/${filter.value}/${options.avatar_field}`,
                                         class: 'mx-auto',
                                     });
                                 },


### PR DESCRIPTION
delete redundant '}' added by another developer by accident

taskid: 2504659

