### PR TITLE
[FIX] portal: display discounts on quotation pdf for portal user

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -377,7 +377,7 @@ class CustomerPortal(Controller):
         if report_type not in ('html', 'pdf', 'text'):
             raise UserError(_("Invalid report type: %s") % report_type)
 
-        report_sudo = request.env.ref(report_ref).sudo()
+        report_sudo = request.env.ref(report_ref).with_user(SUPERUSER_ID)
 
         if not isinstance(report_sudo, type(request.env['ir.actions.report'])):
             raise UserError(_("%s is not the reference of a report") % report_ref)


### PR DESCRIPTION
Issue

	- Install "Sale" app
	- Activate "Discounts" feature in settings
	- Create a quotation to a portal user (ex: Joel Willis)
	- Add a product with a discount then send
	- Logout then login as 'Joel Willis'
	- Go to 'My account' then 'Quotations'
	- Select the quotation just created and print it

	Discount not display in pdf file.

Cause

	The current env.user when rendering pdf is the portal user.
	To display discount, current env.user must have group
	'product.group_discount_per_so_line' who is not the case
	even when using sudo() on report template.

Solution

	Since Odoo 13.0, the sudo() function does not return the
	superuser by default but instead the current user
	with a bypass on access rights.
	Therefore, must add `.with_user(SUPERUSER_ID)` on report.

opw-2501337