### PR TITLE
[FIX] purchase: Update correctly the price according to UoM

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1058,6 +1058,10 @@ class PurchaseOrderLine(models.Model):
                     self.order_id.company_id,
                     self.date_order or fields.Date.today(),
                 )
+
+            if self.product_uom:
+                price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom)
+
             self.price_unit = price_unit
             return
 


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Create Product with Purchase Vendor(s) set
    2. Create Units of Measure that are bigger than (10kg/50kg in tests)

What is currently happening ?

    If you put a vendor that is listed in product form, when changing purchase unit from kg to 10/50kg price is updated
    If you put a vendor not listed, it gives cost price which is correct, but does not update price according to unit of measure.

What are you expecting to happen ?

    Update correctly the unit of measure when the vendor is not listed

opw-2494769