### PR TITLE
[FIX] account: Allow mixing 'affect base' price-included/price-exclud…

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -339,76 +339,21 @@ class AccountTax(models.Model):
         rep_lines = self.mapped(is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids')
         return rep_lines.filtered(lambda x: x.repartition_type == repartition_type).mapped('tag_ids')
 
-    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True):
-        """ Returns all information required to apply taxes (in self + their children in case of a tax group).
-            We consider the sequence of the parent for group of taxes.
-                Eg. considering letters as taxes and alphabetic order as sequence :
-                [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
+    def _compute_taxes(
+        self,
+        precision_rounding,
+        base,
+        groups_map,
+        currency,
+        price_unit,
+        quantity=1.0,
+        product=None,
+        partner=None,
+        is_refund=False,
+        handle_price_include=True,
+    ):
 
-            'handle_price_include' is used when we need to ignore all tax included in price. If False, it means the
-            amount passed to this method will be considered as the base of all computations.
-
-        RETURN: {
-            'total_excluded': 0.0,    # Total without taxes
-            'total_included': 0.0,    # Total with taxes
-            'total_void'    : 0.0,    # Total with those taxes, that don't have an account set
-            'taxes': [{               # One dict for each tax in self and their children
-                'id': int,
-                'name': str,
-                'amount': float,
-                'sequence': int,
-                'account_id': int,
-                'refund_account_id': int,
-                'analytic': boolean,
-            }],
-        } """
-        if not self:
-            company = self.env.company
-        else:
-            company = self[0].company_id
-
-        # 1) Flatten the taxes.
-        taxes, groups_map = self.flatten_taxes_hierarchy(create_map=True)
-
-        # 2) Avoid mixing taxes having price_include=False && include_base_amount=True
-        # with taxes having price_include=True. This use case is not supported as the
-        # computation of the total_excluded would be impossible.
-        base_excluded_flag = False  # price_include=False && include_base_amount=True
-        included_flag = False  # price_include=True
-        for tax in taxes:
-            if tax.price_include:
-                included_flag = True
-            elif tax.include_base_amount:
-                base_excluded_flag = True
-            if base_excluded_flag and included_flag:
-                raise UserError(_('Unable to mix any taxes being price included with taxes affecting the base amount but not included in price.'))
-
-        # 3) Deal with the rounding methods
-        if not currency:
-            currency = company.currency_id
-        # By default, for each tax, tax amount will first be computed
-        # and rounded at the 'Account' decimal precision for each
-        # PO/SO/invoice line and then these rounded amounts will be
-        # summed, leading to the total amount for that tax. But, if the
-        # company has tax_calculation_rounding_method = round_globally,
-        # we still follow the same method, but we use a much larger
-        # precision when we round the tax amount for each line (we use
-        # the 'Account' decimal precision + 5), and that way it's like
-        # rounding after the sum of the tax amounts of each line
-        prec = currency.rounding
-
-        # In some cases, it is necessary to force/prevent the rounding of the tax and the total
-        # amounts. For example, in SO/PO line, we don't want to round the price unit at the
-        # precision of the currency.
-        # The context key 'round' allows to force the standard behavior.
-        round_tax = False if company.tax_calculation_rounding_method == 'round_globally' else True
-        if 'round' in self.env.context:
-            round_tax = bool(self.env.context['round'])
-
-        if not round_tax:
-            prec *= 1e-5
-
-        # 4) Iterate the taxes in the reversed sequence order to retrieve the initial base of the computation.
+        # Iterate the taxes in the reversed sequence order to retrieve the initial base of the computation.
         #     tax  |  base  |  amount  |
         # /\ ----------------------------
         # || tax_1 |  XXXX  |          | <- we are looking for that, it's the total_excluded
@@ -431,34 +376,6 @@ class AccountTax(models.Model):
             # (145 - 15) / (1.0 + 30%) * 90% = 130 / 1.3 * 90% = 90
             return (base_amount - fixed_amount) / (1.0 + percent_amount / 100.0) * (100 - division_amount) / 100
 
-        # The first/last base must absolutely be rounded to work in round globally.
-        # Indeed, the sum of all taxes ('taxes' key in the result dictionary) must be strictly equals to
-        # 'price_included' - 'price_excluded' whatever the rounding method.
-        #
-        # Example using the global rounding without any decimals:
-        # Suppose two invoice lines: 27000 and 10920, both having a 19% price included tax.
-        #
-        #                   Line 1                      Line 2
-        # -----------------------------------------------------------------------
-        # total_included:   27000                       10920
-        # tax:              27000 / 1.19 = 4310.924     10920 / 1.19 = 1743.529
-        # total_excluded:   22689.076                   9176.471
-        #
-        # If the rounding of the total_excluded isn't made at the end, it could lead to some rounding issues
-        # when summing the tax amounts, e.g. on invoices.
-        # In that case:
-        #  - amount_untaxed will be 22689 + 9176 = 31865
-        #  - amount_tax will be 4310.924 + 1743.529 = 6054.453 ~ 6054
-        #  - amount_total will be 31865 + 6054 = 37919 != 37920 = 27000 + 10920
-        #
-        # By performing a rounding at the end to compute the price_excluded amount, the amount_tax will be strictly
-        # equals to 'price_included' - 'price_excluded' after rounding and then:
-        #   Line 1: sum(taxes) = 27000 - 22689 = 4311
-        #   Line 2: sum(taxes) = 10920 - 2176 = 8744
-        #   amount_tax = 4311 + 8744 = 13055
-        #   amount_total = 31865 + 13055 = 37920
-        base = currency.round(price_unit * quantity)
-
         # For the computation of move lines, we could have a negative base value.
         # In this case, compute all with positive values and negate them at the end.
         sign = 1
@@ -471,14 +388,14 @@ class AccountTax(models.Model):
 
         # Store the totals to reach when using price_include taxes (only the last price included in row)
         total_included_checkpoints = {}
-        i = len(taxes) - 1
+        i = len(self) - 1
         store_included_tax_total = True
         # Keep track of the accumulated included fixed/percent amount.
         incl_fixed_amount = incl_percent_amount = incl_division_amount = 0
         # Store the tax amounts we compute while searching for the total_excluded
         cached_tax_amounts = {}
         if handle_price_include:
-            for tax in reversed(taxes):
+            for tax in reversed(self):
                 tax_repartition_lines = (
                     is_refund
                     and tax.refund_repartition_line_ids
@@ -522,7 +439,7 @@ class AccountTax(models.Model):
         taxes_vals = []
         i = 0
         cumulated_tax_included_amount = 0
-        for tax in taxes:
+        for tax in self:
             tax_repartition_lines = (is_refund and tax.refund_repartition_line_ids or tax.invoice_repartition_line_ids).filtered(lambda x: x.repartition_type == 'tax')
             sum_repartition_factor = sum(tax_repartition_lines.mapped('factor'))
 
@@ -538,8 +455,8 @@ class AccountTax(models.Model):
                     base, sign * price_unit, quantity, product, partner)
 
             # Round the tax_amount multiplied by the computed repartition lines factor.
-            tax_amount = round(tax_amount, precision_rounding=prec)
-            factorized_tax_amount = round(tax_amount * sum_repartition_factor, precision_rounding=prec)
+            tax_amount = round(tax_amount, precision_rounding=precision_rounding)
+            factorized_tax_amount = round(tax_amount * sum_repartition_factor, precision_rounding=precision_rounding)
 
             if price_include and not total_included_checkpoints.get(i):
                 cumulated_tax_included_amount += factorized_tax_amount
@@ -550,7 +467,7 @@ class AccountTax(models.Model):
             subsequent_taxes = self.env['account.tax']
             subsequent_tags = self.env['account.account.tag']
             if tax.include_base_amount:
-                subsequent_taxes = taxes[i+1:]
+                subsequent_taxes = self[i+1:]
                 subsequent_tags = subsequent_taxes.get_tax_tags(is_refund, 'base')
 
             # Compute the tax line amounts by multiplying each factor with the tax amount.
@@ -561,10 +478,19 @@ class AccountTax(models.Model):
             # The factorized_tax_amount will be 0.06 (200% x 0.03). However, each line taken independently will compute
             # 50% * 0.03 = 0.01 with rounding. It means there is 0.06 - 0.04 = 0.02 as total_rounding_error to dispatch
             # in lines as 2 x 0.01.
-            repartition_line_amounts = [round(tax_amount * line.factor, precision_rounding=prec) for line in tax_repartition_lines]
-            total_rounding_error = round(factorized_tax_amount - sum(repartition_line_amounts), precision_rounding=prec)
+            repartition_line_amounts = [
+                round(tax_amount * line.factor, precision_rounding=precision_rounding)
+                for line in tax_repartition_lines
+            ]
+            total_rounding_error = round(
+                factorized_tax_amount - sum(repartition_line_amounts),
+                precision_rounding=precision_rounding,
+            )
             nber_rounding_steps = int(abs(total_rounding_error / currency.rounding))
-            rounding_error = round(nber_rounding_steps and total_rounding_error / nber_rounding_steps or 0.0, precision_rounding=prec)
+            rounding_error = round(
+                total_rounding_error / nber_rounding_steps if nber_rounding_steps else 0.0,
+                precision_rounding=precision_rounding,
+            )
 
             for repartition_line, line_amount in zip(tax_repartition_lines, repartition_line_amounts):
 
@@ -576,7 +502,7 @@ class AccountTax(models.Model):
                     'id': tax.id,
                     'name': partner and tax.with_context(lang=partner.lang).name or tax.name,
                     'amount': sign * line_amount,
-                    'base': round(sign * base, precision_rounding=prec),
+                    'base': round(sign * base, precision_rounding=precision_rounding),
                     'sequence': tax.sequence,
                     'account_id': tax.cash_basis_transition_account_id.id if tax.tax_exigibility == 'on_payment' else repartition_line.account_id.id,
                     'analytic': tax.analytic,
@@ -599,12 +525,146 @@ class AccountTax(models.Model):
             i += 1
 
         return {
-            'base_tags': taxes.mapped(is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids').filtered(lambda x: x.repartition_type == 'base').mapped('tag_ids').ids,
+            'base_tags': self.mapped(is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids').filtered(lambda x: x.repartition_type == 'base').mapped('tag_ids').ids,
             'taxes': taxes_vals,
             'total_excluded': sign * total_excluded,
             'total_included': sign * currency.round(total_included),
             'total_void': sign * currency.round(total_void),
+            'next_base': base,
         }
+
+    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True):
+        """ Returns all information required to apply taxes (in self + their children in case of a tax group).
+            We consider the sequence of the parent for group of taxes.
+                Eg. considering letters as taxes and alphabetic order as sequence :
+                [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
+
+            'handle_price_include' is used when we need to ignore all tax included in price. If False, it means the
+            amount passed to this method will be considered as the base of all computations.
+
+        RETURN: {
+            'total_excluded': 0.0,    # Total without taxes
+            'total_included': 0.0,    # Total with taxes
+            'total_void'    : 0.0,    # Total with those taxes, that don't have an account set
+            'taxes': [{               # One dict for each tax in self and their children
+                'id': int,
+                'name': str,
+                'amount': float,
+                'sequence': int,
+                'account_id': int,
+                'refund_account_id': int,
+                'analytic': boolean,
+            }],
+        } """
+        if not self:
+            company = self.env.company
+        else:
+            company = self[0].company_id
+
+        # Flatten the taxes.
+        taxes, groups_map = self.flatten_taxes_hierarchy(create_map=True)
+
+        # Deal with the rounding methods
+        if not currency:
+            currency = company.currency_id
+
+        # By default, for each tax, tax amount will first be computed
+        # and rounded at the 'Account' decimal precision for each
+        # PO/SO/invoice line and then these rounded amounts will be
+        # summed, leading to the total amount for that tax. But, if the
+        # company has tax_calculation_rounding_method = round_globally,
+        # we still follow the same method, but we use a much larger
+        # precision when we round the tax amount for each line (we use
+        # the 'Account' decimal precision + 5), and that way it's like
+        # rounding after the sum of the tax amounts of each line
+        precision_rounding = currency.rounding
+
+        # In some cases, it is necessary to force/prevent the rounding of the tax and the total
+        # amounts. For example, in SO/PO line, we don't want to round the price unit at the
+        # precision of the currency.
+        # The context key 'round' allows to force the standard behavior.
+        round_tax = False if company.tax_calculation_rounding_method == 'round_globally' else True
+        if 'round' in self.env.context:
+            round_tax = bool(self.env.context['round'])
+
+        if not round_tax:
+            precision_rounding *= 1e-5
+
+        # The first/last base must absolutely be rounded to work in round globally.
+        # Indeed, the sum of all taxes ('taxes' key in the result dictionary) must be strictly equals to
+        # 'price_included' - 'price_excluded' whatever the rounding method.
+        #
+        # Example using the global rounding without any decimals:
+        # Suppose two invoice lines: 27000 and 10920, both having a 19% price included tax.
+        #
+        #                   Line 1                      Line 2
+        # -----------------------------------------------------------------------
+        # total_included:   27000                       10920
+        # tax:              27000 / 1.19 = 4310.924     10920 / 1.19 = 1743.529
+        # total_excluded:   22689.076                   9176.471
+        #
+        # If the rounding of the total_excluded isn't made at the end, it could lead to some rounding issues
+        # when summing the tax amounts, e.g. on invoices.
+        # In that case:
+        #  - amount_untaxed will be 22689 + 9176 = 31865
+        #  - amount_tax will be 4310.924 + 1743.529 = 6054.453 ~ 6054
+        #  - amount_total will be 31865 + 6054 = 37919 != 37920 = 27000 + 10920
+        #
+        # By performing a rounding at the end to compute the price_excluded amount, the amount_tax will be strictly
+        # equals to 'price_included' - 'price_excluded' after rounding and then:
+        #   Line 1: sum(taxes) = 27000 - 22689 = 4311
+        #   Line 2: sum(taxes) = 10920 - 2176 = 8744
+        #   amount_tax = 4311 + 8744 = 13055
+        #   amount_total = 31865 + 13055 = 37920
+        base = currency.round(price_unit * quantity)
+
+        # Split taxes into groups to manage 'include_base_amount' price-included taxes mixed with 'include_base_amount'
+        # price-excluded ones.
+        groups = []
+        current_group = self.env['account.tax']
+        is_last_group_price_include = None
+        for tax in taxes:
+            if tax.include_base_amount:
+                if is_last_group_price_include is not None and is_last_group_price_include != tax.price_include:
+                    groups.append(current_group)
+                    current_group = self.env['account.tax']
+                is_last_group_price_include = tax.price_include
+            current_group |= tax
+        if current_group:
+            groups.append(current_group)
+
+        # Compute taxes for each group and aggregate them.
+        base_tag_ids = set()
+        res = {
+            'taxes': [],
+            'total_excluded': base,
+            'total_included': base,
+            'total_void': 0.0,
+        }
+
+        for taxes in groups:
+            taxes_res = taxes._compute_taxes(
+                precision_rounding,
+                base,
+                groups_map,
+                currency,
+                price_unit,
+                quantity=quantity,
+                product=product,
+                partner=partner,
+                is_refund=is_refund,
+                handle_price_include=handle_price_include,
+            )
+            for tag_id in taxes_res['base_tags']:
+                base_tag_ids.add(tag_id)
+            res['taxes'] += taxes_res['taxes']
+            res['total_excluded'] = taxes_res['total_excluded']
+            res['total_included'] = taxes_res['total_included']
+            res['total_void'] += taxes_res['total_void']
+            base = taxes_res['next_base']
+
+        res['base_tags'] = list(base_tag_ids)
+        return res
 
     @api.model
     def _fix_tax_included_price(self, price, prod_taxes, line_taxes):

--- a/addons/account_tax_python/tests/test_tax.py
+++ b/addons/account_tax_python/tests/test_tax.py
@@ -33,6 +33,9 @@ class TestTaxPython(TestTaxCommon):
 
     def test_tax_python_price_include(self):
         self.python_tax.price_include = True
+
+        python_tax2 = self.python_tax.copy()[0]
+
         res = self.python_tax.compute_all(130.0)
         self._check_compute_all_results(
             130,    # 'total_included'
@@ -46,7 +49,7 @@ class TestTaxPython(TestTaxCommon):
             res
         )
 
-        res = (self.python_tax + self.python_tax).compute_all(130.0)
+        res = (python_tax2 + self.python_tax).compute_all(130.0)
         self._check_compute_all_results(
             130,    # 'total_included'
             116.07, # 'total_excluded'


### PR DESCRIPTION
…ed taxes

Before this commit, such configuration wasn't allowed.
However, in some countries, this is mandatory, when dealing with eco-tax for example:

Suppose t1, t2 being taxes where:
- t1 is include_base_amount, price_excluded, fixed tax of 10 (eco-tax)
- t2 is include_base_amount, price_included, percent of 21%

Applying t1, then t2 on 1200:
t1: 1200 + 10 = 1210 (tax amount: 10)
t2: 1210 / 1.21 = 1000 (tax amount: 1210 - 1000 = 210)

/!\ NEED TO ADAPT POS AS WELL WHEN VALIDATED

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
