### PR TITLE
[FIX] web_editor: ensure editor's floating toolbar is visible in modals

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -34,6 +34,7 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
     background-color: $o-we-bg;
     color: $o-we-color;
     font-family: $o-we-font-family;
+    z-index: 1051; // Bootstrap sets .modal z-index at 1050. Ensure toolbar is visible in modals.
 
     &.noarrow::before {
         display: none;


### PR DESCRIPTION
Bootstrap sets a z-index of 1050 for modals while the editor's floating toolbar has no set z-index and is therefore invisible in modals. This ensures the visibility of the toolbar in bootstrap modals.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
