### PR TITLE
[FIX] web_editor: fix impossible to duplicate form field

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -596,6 +596,7 @@ var SnippetEditor = Widget.extend({
         this.trigger_up('snippet_cloned', {$target: $clone, $origin: this.$target});
 
         $clone.trigger('content_changed');
+        this.options.wysiwyg.odooEditor.unbreakableStepUnactive();
         this.options.wysiwyg.odooEditor.historyStep();
     },
 


### PR DESCRIPTION
Since Odoo 14.3, field duplication in forms does not work correctly anymore.
This bug makes that in the Website editor, when you duplicate a field of a form that had just been created, nothing happens.



**Task #2501647**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr