### PR TITLE
[FIX] web_editor: prevent traceback on select image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -78,6 +78,9 @@ $.fn.extend({
         return this;
     },
     selectContent: function () {
+        if (this.length && !this[0].hasChildNodes()) {
+            return this.selectElement();
+        }
         if (this.length) {
             const selection = document.getSelection();
             selection.removeAllRanges();


### PR DESCRIPTION
Trying to select the contents of a content-less element should select the element itself instead.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
