### PR TITLE
 [FIX] crm: fixed form view for leads in reporting 

### DIFF
--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -143,8 +143,10 @@
             }</field>
             <field name="view_ids"
                    eval="[(5, 0, 0),
-                          (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
-                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')})]"/>
+                          (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead'), 'sequence': 0}),
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead'), 'sequence': 1}),
+                         (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_leads'), 'sequence': 3}),
+                           (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')})]"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data found!

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -145,8 +145,8 @@
                    eval="[(5, 0, 0),
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead'), 'sequence': 0}),
                           (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead'), 'sequence': 1}),
-                         (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_leads'), 'sequence': 3}),
-                           (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')})]"/>
+                          (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_leads'), 'sequence': 3}),
+                          (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')})]"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data found!


### PR DESCRIPTION
PURPOSE 

When we go to CRM -> Reporting -> Leads, It shows the analysis of leads. We
can open the form view of every leads from the different views wise 'Graph', 
'Pivot' and  'Dashboard'  except the 'List" view and its a bit odd. We should be able 
to open form view from corresponding leads from the list view
Also Currently the view which is coming in the current 'List' view is not correct 
and should be replaced by the same view which is rendered by action 
'crm_lead_all_leads'

SPECIFICATIONS

1. Initially we have to fix the correct list view to be rendered  and that is
  'crm_case_tree_view_leads' instead of 'crm_case_tree_view_oppor'
2. Next we have added the form view  in addition to list view in view_ids of 
 the corresponding action.

This is the goal of this commit.

LINKS

PR #69174
Task 2497936