### PR TITLE
[IMP] mail_plugin: return the "is_company" field

### DIFF
--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -267,7 +267,7 @@ class MailPluginController(http.Controller):
 
     def _get_partner_data(self, partner):
 
-        fields_list = ['id', 'name', 'email', 'phone', 'mobile']
+        fields_list = ['id', 'name', 'email', 'phone', 'mobile', 'is_company']
 
         partner_values = dict((fname, partner[fname]) for fname in fields_list)
         partner_values['image'] = partner.image_128


### PR DESCRIPTION
Purpose
=======
Return the "is_company" field for the <res.partner>, so when the partner
has no image, we can display the appropriate placeholder image
(person for non-company and buildings image for company).

Task 2496443
