### PR TITLE
[FIX] account: Access error in multi companies

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2819,7 +2819,8 @@ class AccountMove(models.Model):
         }
         for line in preview_vals['items_vals']:
             if 'partner_id' in line[2]:
-                line[2]['partner_id'] = self.env['res.partner'].browse(line[2]['partner_id']).display_name
+                # sudo is needed to compute display_name in a multi companies environment
+                line[2]['partner_id'] = self.env['res.partner'].browse(line[2]['partner_id']).sudo().display_name
             line[2]['account_id'] = self.env['account.account'].browse(line[2]['account_id']).display_name or _('Destination Account')
             line[2]['debit'] = currency_id and formatLang(self.env, line[2]['debit'], currency_obj=currency_id) or line[2]['debit']
             line[2]['credit'] = currency_id and formatLang(self.env, line[2]['credit'], currency_obj=currency_id) or line[2]['debit']


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two companies C1, C2 and a partner P in C2
- Let's consider an customner invoice I in C1 with P as customer
- Go to Accounting > Accounting > Partner Ledger and select I
- Click on Reconcie

Bug:

An access error was raised due to the ir.rule res.partner company

opw:2446242