### PR TITLE
[FIX] hr_timesheet: prevent creation of tasks without project_id

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -25,7 +25,7 @@
                     <field name="date"/>
                     <field name="employee_id" invisible="1"/>
                     <field name="project_id" required="1" options="{'no_create_edit': True}"/>
-                    <field name="task_id" optional="show" options="{'no_create_edit': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
+                    <field name="task_id" optional="show" options="{'no_create': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
                     <field name="name" optional="show" required="0"/>
                     <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" decoration-danger="unit_amount &gt; 24"/>
                     <field name="company_id" invisible="1"/>


### PR DESCRIPTION
This PR main purpose is to prevent the creation of tasks without project_id.
It has been identified that this was still possible in the Timesheet app.

* Prior to this commit:

        It was possible to create a new task in the list view thanks to the create feature of the
	M2O widget as the option was only set to `no_create_edit: True` and that the value passed
	in the context is the project_id which can potentially still be blank when creating the task
	through the M2O widget.

* After this commit:

        It will no more be possible to create a new task from the M2O widget from the
        list view.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
