### PR TITLE
[FIX] web_editor: always allow to properly see all the text tools

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -45,12 +45,11 @@ body.editor_enable.editor_has_snippets {
     $-text-tools-gap: 3px;
     $-text-tools-header-height: 35px;
 
-    padding: $-text-tools-header-height $o-we-sidebar-content-padding-base 0 $o-we-sidebar-content-indent;
-    margin-bottom: $o-we-sidebar-content-padding-base;
-    box-shadow: $o-we-item-standup-top rgba($o-we-item-standup-color-light, .2);
     z-index: $o-we-zindex;
+    flex: 1 0 auto;
     display: flex;
-    flex: 1;
+    padding: $-text-tools-header-height $o-we-sidebar-content-padding-base ($o-we-sidebar-content-padding-base * 3) $o-we-sidebar-content-indent;
+    box-shadow: $o-we-item-standup-top rgba($o-we-item-standup-color-light, .2);
     overflow-y: auto;
 
     .popover {
@@ -1410,7 +1409,7 @@ body.editor_enable.editor_has_snippets {
                     }
                 }
             }
-        }   
+        }
 
         .o_we_color_btn, .o_we_color_combination_btn {
             float: left;


### PR DESCRIPTION
Commit [1] fixed visual bugs which occurred using the text tools but
missed the fact that the tools were shrunk to a very small height when
the editor panel was filled with a lot of snippet options.

[1]: https://github.com/odoo/odoo/commit/a99ed0f4a261fba44b31e3fe7a5840d81727b6d0

Fixes https://github.com/odoo/odoo/issues/69097
