### PR TITLE
[IMP] account: check non reconcilable accounts for configured journals

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -11515,6 +11515,14 @@ msgstr ""
 #: code:addons/account/models/account_account.py:0
 #, python-format
 msgid ""
+"This account is configured in %(journal_names)s journal(s) (ids %(journal_ids)s) as payment debit or credit account. "
+"This means that this account's type should be reconcilable."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_account.py:0
+#, python-format
+msgid ""
 "The account is already in use in a 'sale' or 'purchase' journal. This means "
 "that the account's type couldn't be 'receivable' or 'payable'."
 msgstr ""

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -188,6 +188,32 @@ class AccountAccount(models.Model):
         if self._cr.fetchone():
             raise ValidationError(_("The account is already in use in a 'sale' or 'purchase' journal. This means that the account's type couldn't be 'receivable' or 'payable'."))
 
+    @api.constrains('reconcile')
+    def _check_used_as_journal_default_debit_credit_account(self):
+        accounts = self.filtered(lambda a: not a.reconcile)
+        if not accounts:
+            return
+
+        self.flush(['reconcile'])
+        self._cr.execute('''
+            SELECT journal.id
+            FROM account_journal journal
+            WHERE journal.payment_credit_account_id in %(credit_account)s
+            OR journal.payment_debit_account_id in %(debit_account)s ;
+        ''', {
+            'credit_account': tuple(accounts.ids),
+            'debit_account': tuple(accounts.ids)
+        })
+
+        rows = self._cr.fetchall()
+        if rows:
+            journals = self.env['account.journal'].browse([r[0] for r in rows])
+            raise ValidationError(_(
+                "This account is configured in %(journal_names)s journal(s) (ids %(journal_ids)s) as payment debit or credit account. This means that this account's type should be reconcilable.",
+                journal_names=journals.mapped('display_name'),
+                journal_ids=journals.ids
+            ))
+
     @api.depends('code')
     def _compute_account_root(self):
         # this computes the first 2 digits of the account.

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 @tagged('post_install', '-at_install')
@@ -126,3 +126,12 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         # Try to set the account as a not-reconcile one.
         with self.assertRaises(UserError), self.cr.savepoint():
             account.reconcile = False
+
+    def test_toggle_reconcile_outstanding_account(self):
+        ''' Test the feature when the user sets an account as not reconcilable when a journal
+        is configured with this account as the payment credit or debit account.
+        Since such an account should be reconcilable by nature, a ValidationError is raised.'''
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            self.company_data['default_journal_bank'].payment_debit_account_id.reconcile = False
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            self.company_data['default_journal_bank'].payment_credit_account_id.reconcile = False

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -153,6 +153,7 @@
                         <field name="id" invisible="1"/>
                         <field name="is_move_sent" invisible="1"/>
                         <field name="is_reconciled" invisible="1"/>
+                        <field name="is_matched" invisible="1"/>
                         <field name="payment_method_code" invisible="1"/>
                         <field name="show_partner_bank_account" invisible="1"/>
                         <field name="require_partner_bank_account" invisible="1"/>


### PR DESCRIPTION
… journals

Beforehand, users could configure an account as non reconcilable
even when it was configured as a payment credit or debit account
in a journal. This prevented journal items to be reconciled

Now, when a user tries to set an account as non reconcilable,
we check if there is no journal with a payment credit or debit account
set to this particular account. If there is at least one journal,
then we display an error message stating the journals names and ids
that the user would have to modify before changing the account
configuration.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
