### PR TITLE
[FIX] l10n_ar_website_sale: fix demo data

### DIFF
--- a/addons/l10n_ar_website_sale/demo/website_demo.xml
+++ b/addons/l10n_ar_website_sale/demo/website_demo.xml
@@ -12,12 +12,12 @@
         <value eval="{'company_id': ref('l10n_ar.company_ri'), 'state': 'enabled'}"/>
     </function>
     <function model="product.pricelist" name="write">
-        <value model="product.pricelist" eval="obj().search([('currency_id', '=', ref('base.ARS'))]).id"/>
+        <value model="product.pricelist" eval="obj().search([('currency_id', '=', ref('base.ARS'))], limit=1).id"/>
         <value model="website" eval="{'sequence': 1, 'website_id': ref('l10n_ar_website_sale.default_website_ri')}"/>
     </function>
     <function model="product.product" name="write">
         <value model="product.product" eval="obj().search([('taxes_id', '=', False)]).ids"/>
-        <value model="account.tax" eval="{'taxes_id': (4, obj().search([('type_tax_use', '=', 'sale'), ('tax_group_id', '=', 'VAT 21%')]).id )}"/>
+        <value model="account.tax" eval="{'taxes_id': [(4, obj().search([('type_tax_use', '=', 'sale'), ('tax_group_id', '=', ref('l10n_ar.tax_group_iva_21')), ('company_id', '=', ref('l10n_ar.company_ri'))]).id)]}"/>
     </function>
 
 </odoo>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fix the demo data to install with the module.
We create a new website and associate a pricelist with currency ARS and the tax IVA 21% associated with the RI company.

**Current behavior before PR:**
At install the module with demo data it returns a traceback error if there is more than one pricelist with currency 'ARS'

**Desired behavior after PR is merged:**
Choose the most priority pricelist with currency 'ARS' to associate to the demo Argentinean website 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
