### PR TITLE
[FIX]account: process one record to set debit/credit

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -352,10 +352,12 @@ class AccountAccount(models.Model):
             record.opening_credit = opening_credit
 
     def _set_opening_debit(self):
-        self._set_opening_debit_credit(self.opening_debit, 'debit')
+        for record in self:
+            record._set_opening_debit_credit(record.opening_debit, 'debit')
 
     def _set_opening_credit(self):
-        self._set_opening_debit_credit(self.opening_credit, 'credit')
+        for record in self:
+            record._set_opening_debit_credit(record.opening_credit, 'credit')
 
     def _set_opening_debit_credit(self, amount, field):
         """ Generic function called by both opening_debit and opening_credit's


### PR DESCRIPTION
Before this commit, There would be Expected singleton error
on changing Credit/Debit for multile account in single call.

Now, We are proocess one record to set `_set_opening_debit_credit`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
