### PR TITLE
[IMP] mail: allow to force the FROM headers of the outgoing mail server

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -17,7 +17,7 @@ import html2text
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import except_orm, UserError
-from odoo.tools import ustr, pycompat, formataddr
+from odoo.tools import ustr, pycompat, formataddr, encapsulate_email, email_domain_extract
 
 _logger = logging.getLogger(__name__)
 _test_logger = logging.getLogger('odoo.tests')
@@ -328,8 +328,14 @@ class IrMailServer(models.Model):
         msg['Message-Id'] = encode_header(message_id)
         if references:
             msg['references'] = encode_header(references)
+
+        email_from = encode_rfc2822_address_header(email_from)
+        email_from, return_path = self._get_email_from(email_from)
+        msg['From'] = email_from
+        if return_path:
+            headers.setdefault('Return-Path', return_path)
+
         msg['Subject'] = encode_header(subject)
-        msg['From'] = encode_rfc2822_address_header(email_from)
         del msg['Reply-To']
         if reply_to:
             msg['Reply-To'] = encode_rfc2822_address_header(reply_to)
@@ -381,6 +387,35 @@ class IrMailServer(models.Model):
                 encoders.encode_base64(part)
                 msg.attach(part)
         return msg
+
+    def _get_email_from(self, email_from):
+        """Logic which determines which email to use when sending the email.
+
+        - If the system parameter `mail.force.smtp.from` is set we encapsulate all
+          outgoing email from
+        - If the previous system parameter is not set and if both `mail.dynamic.smtp.from`
+          and `mail.catchall.domain` are set, we encapsulate the FROM only if the domain
+          of the email is not the same as the domain of the catchall parameter
+        - Otherwise we do not encapsulate the email and given email_from is used as is
+
+        :param email_from: The initial FROM headers
+        :return: The FROM to used in the headers and optionally the Return-Path
+        """
+        force_smtp_from = self.env['ir.config_parameter'].sudo().get_param('mail.force.smtp.from')
+        dynamic_smtp_from = self.env['ir.config_parameter'].sudo().get_param('mail.dynamic.smtp.from')
+        catchall_domain = self.env['ir.config_parameter'].sudo().get_param('mail.catchall.domain')
+
+        if force_smtp_from:
+            rfc2822_force_smtp_from = extract_rfc2822_addresses(force_smtp_from)
+            rfc2822_force_smtp_from = rfc2822_force_smtp_from[0] if rfc2822_force_smtp_from else None
+            return encapsulate_email(email_from, force_smtp_from), rfc2822_force_smtp_from
+
+        elif dynamic_smtp_from and catchall_domain and email_domain_extract(email_from) != catchall_domain:
+            rfc2822_dynamic_smtp_from = extract_rfc2822_addresses(dynamic_smtp_from)
+            rfc2822_dynamic_smtp_from = rfc2822_dynamic_smtp_from[0] if rfc2822_dynamic_smtp_from else None
+            return encapsulate_email(email_from, dynamic_smtp_from), rfc2822_dynamic_smtp_from
+
+        return email_from, None
 
     @api.model
     def _get_default_bounce_address(self):

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 
+from email.mime.multipart import MIMEMultipart
 from unittest.mock import patch
 
 from odoo.tests.common import BaseCase
@@ -394,3 +395,73 @@ class EmailConfigCase(SavepointCase):
             "The body of an email",
         )
         self.assertEqual(message["From"], "settings@example.com")
+
+    def test_email_from_rewrite(self):
+        get_email_from = self.env['ir.mail_server']._get_email_from
+        set_param = self.env['ir.config_parameter'].set_param
+
+        # Standard case, no setting
+        set_param('mail.force.smtp.from', False)
+        set_param('mail.dynamic.smtp.from', False)
+        set_param('mail.catchall.domain', 'odoo.example.com')
+
+        email_from, return_path = get_email_from('admin@test.example.com')
+        self.assertEqual(email_from, 'admin@test.example.com')
+        self.assertFalse(return_path)
+
+        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
+        self.assertEqual(email_from, '"Admin" <admin@test.example.com>')
+        self.assertFalse(return_path)
+
+        # We always force the email FROM
+        set_param('mail.force.smtp.from', 'email_force@domain.com')
+        set_param('mail.dynamic.smtp.from', False)
+        set_param('mail.catchall.domain', 'odoo.example.com')
+
+        email_from, return_path = get_email_from('admin@test.example.com')
+        self.assertEqual(email_from, '"admin@test.example.com" <email_force@domain.com>')
+        self.assertEqual(return_path, 'email_force@domain.com')
+
+        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
+        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <email_force@domain.com>')
+        self.assertEqual(return_path, 'email_force@domain.com')
+
+        # We always force the email FROM (notification email contains a name part)
+        set_param('mail.force.smtp.from', '"Your notification bot" <email_force@domain.com>')
+        set_param('mail.dynamic.smtp.from', False)
+        set_param('mail.catchall.domain', 'odoo.example.com')
+
+        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
+        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <email_force@domain.com>',
+                         msg='Should drop the name part of the forced email')
+        self.assertEqual(return_path, 'email_force@domain.com')
+
+        # We dynamically force the email FROM
+        set_param('mail.force.smtp.from', False)
+        set_param('mail.dynamic.smtp.from', 'notification@odoo.example.com')
+        set_param('mail.catchall.domain', 'odoo.example.com')
+
+        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
+        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <notification@odoo.example.com>',
+                         msg='Domain is not the same as the catchall domain, we should force the email FROM')
+        self.assertEqual(return_path, 'notification@odoo.example.com')
+
+        email_from, return_path = get_email_from('"Admin" <admin@odoo.example.com>')
+        self.assertEqual(email_from, '"Admin" <admin@odoo.example.com>',
+                         msg='Domain is the same as the catchall domain, we should not force the email FROM')
+        self.assertFalse(return_path)
+
+        # We dynamically force the email FROM (notification email contains a name part)
+        set_param('mail.force.smtp.from', False)
+        set_param('mail.dynamic.smtp.from', '"Your notification bot" <notification@odoo.example.com>')
+        set_param('mail.catchall.domain', 'odoo.example.com')
+
+        email_from, return_path = get_email_from('"Admin" <admin@test.example.com>')
+        self.assertEqual(email_from, '"Admin (admin@test.example.com)" <notification@odoo.example.com>',
+                         msg='Domain is not the same as the catchall domain, we should force the email FROM')
+        self.assertEqual(return_path, 'notification@odoo.example.com')
+
+        email_from, return_path = get_email_from('"Admin" <admin@odoo.example.com>')
+        self.assertEqual(email_from, '"Admin" <admin@odoo.example.com>',
+                         msg='Domain is the same as the catchall domain, we should not force the email FROM')
+        self.assertFalse(return_path)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -533,6 +533,19 @@ def email_references(references):
             is_private = True
     return (ref_match, model, thread_id, hostname, is_private)
 
+
+def email_domain_extract(email):
+    """Return the domain of the given email."""
+    if not email:
+        return
+
+    email_split = getaddresses([email])
+    if not email_split or not email_split[0]:
+        return
+
+    _, _, domain = email_split[0][1].rpartition('@')
+    return domain
+
 # was mail_message.decode()
 def decode_smtp_header(smtp_header, quoted=False):
     """Returns unicode() string conversion of the given encoded smtp header
@@ -595,3 +608,30 @@ def formataddr(pair, charset='utf-8'):
                 name=email_addr_escapes_re.sub(r'\\\g<0>', name),
                 addr=address)
     return address
+
+
+def encapsulate_email(old_email, new_email):
+    """Change the FROM of the message and use the old one as name.
+
+    e.g.
+    * Old From: "Admin" <admin@gmail.com>
+    * New From: notifications@odoo.com
+    * Output:   "Admin (admin@gmail.com)" <notifications@odoo.com>
+    """
+    old_email_split = getaddresses([old_email])
+    if not old_email_split or not old_email_split[0]:
+        return old_email
+
+    new_email_split = getaddresses([new_email])
+    if not new_email_split or not new_email_split[0]:
+        return
+
+    if old_email_split[0][0]:
+        name_part = '%s (%s)' % old_email_split[0]
+    else:
+        name_part = old_email_split[0][1]
+
+    return formataddr((
+        name_part,
+        new_email_split[0][1],
+    ))


### PR DESCRIPTION
Purpose
=======
We want to be able to force the FROM headers when we sent email in
SMTP. So we can avoid the emails to be considered as spam.

Note that it will be done in a smarter way in master. In stable the FROM
will always be overridden if the system parameter is set. In master we
will override the FROM only if no mail server are found for the given
email address.

Task 2367946
See odoo/odoo/pull/61853