### PR TITLE
[FIX]website: fix scrolling effect when header is sidebar

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -255,7 +255,7 @@ publicWidget.registry.StandardAffixedHeader = BaseAnimatedHeader.extend({
 });
 
 publicWidget.registry.FixedHeader = BaseAnimatedHeader.extend({
-    selector: 'header.o_header_fixed',
+    selector: 'header.o_header_fixed:not(.o_header_sidebar)',
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -367,7 +367,7 @@ const BaseDisappearingHeader = publicWidget.registry.FixedHeader.extend({
 });
 
 publicWidget.registry.DisappearingHeader = BaseDisappearingHeader.extend({
-    selector: 'header.o_header_disappears',
+    selector: 'header.o_header_disappears:not(.o_header_sidebar)',
 
     //--------------------------------------------------------------------------
     // Private
@@ -390,7 +390,7 @@ publicWidget.registry.DisappearingHeader = BaseDisappearingHeader.extend({
 });
 
 publicWidget.registry.FadeOutHeader = BaseDisappearingHeader.extend({
-    selector: 'header.o_header_fade_out',
+    selector: 'header.o_header_fade_out:not(.o_header_sidebar)',
 
     //--------------------------------------------------------------------------
     // Private


### PR DESCRIPTION
Edit website
select header and set scrolling effect as fixed.
save. set header template as 'sidebar'
scroll website.
Website doesn't scroll properly .

In this commit,
fixed scrolling effect by setting the standard scrolling when
scrolling type is fixed and header set as sidebar.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
