### PR TITLE
[FIX] account: Analytic lines must belong to Journal Items' Company

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4727,7 +4727,7 @@ class AccountMoveLine(models.Model):
                 'move_id': move_line.id,
                 'user_id': move_line.move_id.invoice_user_id.id or self._uid,
                 'partner_id': move_line.partner_id.id,
-                'company_id': move_line.analytic_account_id.company_id.id or self.env.company.id,
+                'company_id': move_line.company_id.id,
             })
         return result
 
@@ -4753,7 +4753,7 @@ class AccountMoveLine(models.Model):
             'ref': self.ref,
             'move_id': self.id,
             'user_id': self.move_id.invoice_user_id.id or self._uid,
-            'company_id': distribution.account_id.company_id.id or self.env.company.id,
+            'company_id': self.company_id.id,
         }
 
     @api.model


### PR DESCRIPTION

Main
-

When creating Journal Items/Entries from other service than the front-end 
this bug could lead to the Journal Analytic Items being created with a company other than the
Journal Item/Entry.

Following query shall yield none results on created Analytic Lines
```
SELECT aal.id
FROM account_analytic_line aal
INNER JOIN account_move_line aml ON aml.id = aal.move_id
WHERE aal.company_id != aml.company_id;
```

migration script is currently yielding results on that query.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
