### PR TITLE
[FIX] mail: Wrong signature of function export_data

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1047,11 +1047,11 @@ class Message(models.Model):
             limit=limit, orderby=orderby, lazy=lazy,
         )
 
-    def export_data(self, fields_to_export):
+    def export_data(self, fields_to_export, raw_data=False):
         if not self.env.user._is_admin():
             raise AccessError(_("Only administrators are allowed to export mail message"))
 
-        return super(Message, self).export_data(fields_to_export)
+        return super(Message, self).export_data(fields_to_export, raw_data)
 
     #------------------------------------------------------
     # Messaging API


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to Settings > Technical > Messages
- Select some records and export it

Bug:

A traceback was raised because

PS: When exporting data, the function export_date is called from web/controllers/main.py
with the attribute raw_data

opw:2504763