### PR TITLE
[FIX] crm: fixed form view for leads in reporting

### DIFF
--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -138,7 +138,9 @@
             <field name="view_ids"
                    eval="[(5, 0, 0),
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
-                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')})]"/>
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')}),
+                          (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_leads')}),
+                          (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')})]"/>
             <field name="help">This report analyses the source of your leads.</field>
         </record>
 


### PR DESCRIPTION
PURPOSE

When we go to CRM -> Reporting -> Leads, It shows the analysis of leads. We
can open the form view of every leads from the different views wise Dashboard,
'Graph', and  'Pivot' except the 'List' view and it's a bit odd. We should be able
to open the form view from corresponding leads in the list view.
Also, Currently the view which is coming in the 'List' view is not correct
and should be replaced by the same view which is rendered by action
'crm_lead_all_leads'

SPECIFICATIONS

- Initially, we have to fix the correct list view to be rendered and that is
  'crm_case_tree_view_leads' instead of 'crm_case_tree_view_oppor'
- Next we have added the form view in addition to the list view in view_ids of
   the corresponding action.

This is the goal of this commit.

LINKS

PR #69232
Task 2497936