### PR TITLE
[IMP] website: configurator changes and adaptations to iap module

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -223,7 +223,7 @@ class Website(Home):
         }
         return request.render('website.website_info', values)
 
-    @http.route(['/website/configurator/<int:step>'], type='http', auth="user", website=True)
+    @http.route(['/website/configurator', '/website/configurator/<int:step>'], type='http', auth="user", website=True, multilang=False)
     def website_configurator(self, step=1, **kwargs):
         if not request.env.user.has_group('website.group_website_designer'):
             raise werkzeug.exceptions.NotFound()

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -272,15 +272,14 @@ class Website(models.Model):
         return r
 
     @api.model
-    def configurator_recommended_themes(self, industry_name, palette):
+    def configurator_recommended_themes(self, industry_id, palette):
         domain = [('name', '=like', 'theme%'), ('name', 'not in', ['theme_default', 'theme_common'])]
         client_themes = request.env['ir.module.module'].search(domain).mapped('name')
         params = {
-            'industry_name': industry_name,
             'palette': palette,
             'client_themes': client_themes,
         }
-        return self._website_api_rpc('/api/website/1/configurator/recommended_themes', params)
+        return self._website_api_rpc('/api/website/1/configurator/recommended_themes/%s' % industry_id, params)
 
     @api.model
     def configurator_skip(self):
@@ -362,12 +361,13 @@ class Website(models.Model):
         pages_views = set_features(kwargs.get('selected_features'))
 
         # Load suggestion from iap for selected pages
+        requested_pages = list(pages_views.keys())
+        requested_pages.append('homepage')
         params = {
             'theme': kwargs.get('theme_name'),
-            'industry': kwargs.get('industry'),
-            'pages': list(pages_views.keys()),
+            'pages': requested_pages,
         }
-        custom_resources = self._website_api_rpc('/api/website/1/configurator/custom_resources', params)
+        custom_resources = self._website_api_rpc('/api/website/1/configurator/custom_resources/%s' % kwargs.get('industry_id'), params)
 
         # Update pages
         pages = custom_resources.get('pages', {})

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -84,7 +84,7 @@ class DescriptionScreen extends Component {
         super(...arguments);
         this.industrySelection = useRef('industrySelection');
         this.state = useStore((state) => state);
-        this.labelToName = {};
+        this.labelToId = {};
         this.getters = useGetters();
         this.dispatch = useDispatch();
     }
@@ -111,7 +111,7 @@ class DescriptionScreen extends Component {
             return val.label.startsWith(lcTerm);
         });
         let results = matches.slice(0, limit);
-        this.labelToName = {};
+        this.labelToId = {};
         let labels = results.map((val) => val.label);
         if (labels.length < limit) {
             let relaxedMatches = this.state.industries.filter((val) => {
@@ -122,20 +122,20 @@ class DescriptionScreen extends Component {
             labels = results.map((val) => val.label);
         }
         results.forEach((r) => {
-            this.labelToName[r.label] = r.name;
+            this.labelToId[r.label] = r.id;
         });
         response(labels);
     }
 
     selectIndustry(_, ui) {
-        this.dispatch('selectIndustry', this.labelToName[ui.item.label]);
+        this.dispatch('selectIndustry', this.labelToId[ui.item.label]);
         this.checkDescriptionCompletion();
     }
 
     blurIndustrySelection(ev) {
-        const name = this.labelToName[ev.target.outerText];
-        this.dispatch('selectIndustry', name);
-        if (name === undefined) {
+        const id = this.labelToId[ev.target.outerText];
+        this.dispatch('selectIndustry', id);
+        if (id === undefined) {
             this.industrySelection.el.textContent = '';
         } else {
             this.checkDescriptionCompletion();
@@ -143,7 +143,7 @@ class DescriptionScreen extends Component {
     }
 
     inputIndustrySelection(ev) {
-        this.dispatch('selectIndustry', this.labelToName[ev.target.outerText]);
+        this.dispatch('selectIndustry', this.labelToId[ev.target.outerText]);
     }
 
     selectWebsiteType(ev) {
@@ -233,13 +233,13 @@ class FeaturesSelectionScreen extends Component {
     }
 
     async buildWebsite() {
-        const industryName = this.state.selectedIndustry;
-        if (!industryName) {
+        const industryId = this.state.selectedIndustry;
+        if (!industryId) {
             this.env.router.navigate({to: 'CONFIGURATOR_DESCRIPTION_SCREEN'});
             return;
         }
         const params = {
-            industry_name: industryName,
+            industry_id: industryId,
             palette: this.state.selectedPalette
         };
         const themes = await rpc.query({
@@ -295,12 +295,11 @@ Object.assign(App, {
 //---------------------------------------------------------
 
 const ROUTES = [
-    {name: 'CONFIGURATOR_WELCOME_SCREEN', path: '/website/configurator/1', component: WelcomeScreen},
+    {name: 'CONFIGURATOR_WELCOME_SCREEN', path: '/website/configurator', component: WelcomeScreen},
     {name: 'CONFIGURATOR_DESCRIPTION_SCREEN', path: '/website/configurator/2', component: DescriptionScreen},
     {name: 'CONFIGURATOR_PALETTE_SELECTION_SCREEN', path: '/website/configurator/3', component: PaletteSelectionScreen},
     {name: 'CONFIGURATOR_FEATURES_SELECTION_SCREEN', path: '/website/configurator/4', component: FeaturesSelectionScreen},
     {name: 'CONFIGURATOR_THEME_SELECTION_SCREEN', path: '/website/configurator/5', component: ThemeSelectionScreen},
-    {name: 'CONFIGURATOR_WELCOME_SCREEN_LANG', path: '/{{lang}}/website/configurator/1', component: WelcomeScreen},
 ];
 
 //---------------------------------------------------------
@@ -347,8 +346,8 @@ const actions = {
     selectWebsitePurpose({state}, id) {
         state.selectedPurpose = id;
     },
-    selectIndustry({state}, name) {
-        state.selectedIndustry = name;
+    selectIndustry({state}, id) {
+        state.selectedIndustry = id;
     },
     changeLogo({state}, data) {
         state.logo = data;
@@ -471,7 +470,7 @@ async function applyConfigurator(self, themeName) {
         const data = {
             selected_features: selectedFeatures,
             logo: self.state.logo,
-            industry: self.state.selectedIndustry,
+            industry_id: self.state.selectedIndustry,
             selected_palette: self.state.selectedPalette.id,
             theme_name: themeName,
         };

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -549,7 +549,7 @@
         <!-- Configurator actions -->
         <record id="start_configurator_act_url" model="ir.actions.act_url">
             <field name="name">Website Configurator</field>
-            <field name="url">/website/configurator/1</field>
+            <field name="url">/website/configurator</field>
             <field name="target">self</field>
         </record>
 


### PR DESCRIPTION
The following two points are necessary adaptations for
the correct functioning of the configurator with the
module deployed on iap-services.

- The routes of the api_website module deployed on
iap-services.odoo.com use model converters to retrieve
the industry selected by the user. The configurator
has been updated accordingly. We now use industry id
instead of industry name. Using id instead of name make
record retrieval faster and model converters handle
exception if the record doesn't exist.

- 'homepage' is now added to the requested pages by
the client. Previously, this page was added by the iap
module to the requested pages.

The following two points are changes to the configurator
route handling:

- multilang=False has been added to the route rendering
the configurator in order to avoid having the lang in
the url.

- If no step is specified in the url, the implicit step
is 1. Therefore /website/configurator/1 has been changed
to /website/configurator.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
