### PR TITLE
[FIX] hr_timesheet: only create task in timesheet views if project set

### DIFF
--- a/addons/hr_timesheet/static/src/js/task_with_hours.js
+++ b/addons/hr_timesheet/static/src/js/task_with_hours.js
@@ -1,23 +1,37 @@
-odoo.define('hr_timesheet.task_with_hours', function (require) {
-"use strict";
+/** @odoo-module alias=hr_timesheet.task_with_hours **/
 
-var field_registry = require('web.field_registry');
-var relational_fields = require('web.relational_fields');
-var FieldMany2One = relational_fields.FieldMany2One;
+import field_registry from 'web.field_registry';
+import { FieldMany2One } from 'web.relational_fields';
 
-var TaskWithHours = FieldMany2One.extend({
+const TaskWithHours = FieldMany2One.extend({
     /**
      * @override
      */
     init: function () {
         this._super.apply(this, arguments);
         this.additionalContext.hr_timesheet_display_remaining_hours = true;
+        // By default, we keep the no_quick_create value or we set to false.
+        this.nodeOptions.no_quick_create = this.nodeOptions.no_quick_create || false;
     },
     /**
      * @override
      */
     _getDisplayNameWithoutHours: function (value) {
         return value.split(' ‒ ')[0];
+    },
+    /**
+     * @override
+     * @private
+     */
+    _onInputClick: function () {
+        const context = Object.assign(
+            this.record.getContext(this.recordParams),
+            this.additionalContext
+        );
+        // We don't want to quick create if no project is set in the timesheet
+        this.nodeOptions.no_quick_create =
+            this.nodeOptions.no_quick_create || (!('default_project_id' in context) || !context.default_project_id);
+        this._super.apply(this, arguments);
     },
     /**
      * @override
@@ -31,6 +45,4 @@ var TaskWithHours = FieldMany2One.extend({
 
 field_registry.add('task_with_hours', TaskWithHours);
 
-return TaskWithHours;
-
-});
+export default TaskWithHours;


### PR DESCRIPTION
Before this commit, when the user wants to create a timesheet in the
list or form view of this model, the user can quick create a project and
a task if he wishes. The problem is when the user wants to quick create
a task without defining a project in the form view of timesheet, because
the default_project_id of the task will be false and a task without
project will be created.

This commit checks when the user clicks on the task_id field if the
default_project_id exists in the context and if the default_project_id
is not false, then we allow to the user to quick create a task for this
timesheet, otherwise he can just select a task.

Moreover, the js file is updated to fit with the new syntax.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
