### PR TITLE
[FIX] account_batch_payment: Payment method on payment not availalbe

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -344,7 +344,9 @@ class AccountPayment(models.Model):
                 available_payment_methods = pay.journal_id.outbound_payment_method_ids
 
             # Select the first available one by default.
-            if available_payment_methods:
+            if pay.payment_method_id in available_payment_methods:
+                pay.payment_method_id = pay.payment_method_id
+            elif available_payment_methods:
                 pay.payment_method_id = available_payment_methods[0]._origin
             else:
                 pay.payment_method_id = False


### PR DESCRIPTION
Steps to reproduce the bug:

    - Let's consider a journal J with inbound payment methods PM1 and PM2
    - Create an inbound batch payment with Bank = J
    - The default payment method will be PM2, change it to PM1
    - Create a payment P in the batch content (payment_ids)
    - Save

Bug:

    A UserError was raised: The batch must have the same type as the payments it contains.
    because when setting a partner on P the function _compute_payment_method_id defined in module account_check_printing
    was triggered and the first available payment method was set.

opw:2495487