### PR TITLE
[FIX] l10n_fr_pos_cert: reset session start date

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -32,7 +32,9 @@ class pos_session(models.Model):
         return True
 
     def open_frontend_cb(self):
-        for session in self.filtered(lambda s: s.config_id.company_id._is_accounting_unalterable()):
+        sessions_to_check = self.filtered(lambda s: s.config_id.company_id._is_accounting_unalterable())
+        sessions_to_check.filtered(lambda s: s.state == 'opening_control').start_at = fields.Datetime.now()
+        for session in sessions_to_check:
             session._check_session_timing()
         return super(pos_session, self).open_frontend_cb()
 


### PR DESCRIPTION
When resuming a POS session, if the latter has been opened in the past
and if its state is 'Opening Control', a incorrect UserError is raised
and prevents the session to be started.

To reproduce the error:
1. Use a French company
2. Create a POS
    - Enable "Advanced Cash Control"
3. Start a new session
4. Close it
5. Set the computer's date in the future
5. Open the POS session > Continue Selling

Error: A UserError is raised ("This session has been opened another day.
To comply with the French law, [...]"), but the user does not have the
possibility to close the session. Moreover, since its state is "Opening
Control", no sales have been made yet.

This fix suggests to reset the start date in such a situation.

OPW-2488952