### PR TITLE
[FIX] mrp: optimize _compute_used_in_bom_count

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -28,7 +28,7 @@ class ProductTemplate(models.Model):
     def _compute_used_in_bom_count(self):
         for template in self:
             template.used_in_bom_count = self.env['mrp.bom'].search_count(
-                [('bom_line_ids.product_id', 'in', template.product_variant_ids.ids)])
+                [('bom_line_ids.product_tmpl_id', '=', template.id)])
 
     def write(self, values):
         if 'active' in values:
@@ -40,7 +40,7 @@ class ProductTemplate(models.Model):
     def action_used_in_bom(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_form_action")
-        action['domain'] = [('bom_line_ids.product_id', 'in', self.product_variant_ids.ids)]
+        action['domain'] = [('bom_line_ids.product_tmpl_id', '=', self.id)]
         return action
 
     def _compute_mrp_product_qty(self):


### PR DESCRIPTION
previous implementation works slowly for products with many variants.

Performance Test
================

* ~5 K product.template
* ~14 K product.variants
* ~12 K mrp.bom
* ~414 K mrp.bom.line

Reading time for the field on a product with ~1000 variants

* Before 9,5 sec
* After 1,5 sec

---

opw-2494423