### PR TITLE
[FIX] web: chrome 89 event delegation


### DIFF
--- a/addons/web/static/lib/jquery/jquery.js
+++ b/addons/web/static/lib/jquery/jquery.js
@@ -4666,8 +4666,11 @@ jQuery.event = {
 
                 // Find delegate handlers
                 // Black-hole SVG <use> instance trees (#13180)
-                // Avoid non-left-click bubbling in Firefox (#3861)
-                if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
+                // ODOO CHANGE: cherry-picking https://github.com/jquery/jquery/commit/c82a6685bb9
+                // Support: Firefox<=42+
+                // Avoid non-left-click in FF but don't block IE radio events (#3861, gh-2343)
+                if ( delegateCount && cur.nodeType &&
+                        ( event.type !== "click" || isNaN( event.button ) || event.button < 1 ) ) {
 
                         /* jshint eqeqeq: false */
                         for ( ; cur != this; cur = cur.parentNode || this ) {


### PR DESCRIPTION
In windows chrome 89 (seemed ok at version 89.0.4389.90 (13 march 2021)
and broken at version 89.0.4389.114 (29 march 2021)), clicking on a
select option doesn't trigger jQuery events if they are delegated.

For example this happen when selecting a field for custom group or
custom filter in the search view and when selecting a field the dropdown
closes.

This happens because:

- chrome now sends MouseEvent.button[^1] with value -1 instead of
  previousvalue of 0.

- jquery in odoo 12 and under is version 1.11.1 and only executes the
  delegated event if the button value is 0

Reproduction case of the issue [^2]: clicking to choose an option only
logs "non-delegated click".

So for version 12.0 and only 12.0, this commit is cherry-picking
jquery's commit that is fixing the issue:

jquery/jquery@c82a668

[^1]: https://developer.mozilla.org/docs/Web/API/MouseEvent/button
[^2]: http://jsfiddle.net/cox4gzae

opw-2497859
opw-2499415
opw-2499305
opw-2466991
opw-2506676

fixes #66848