### PR TITLE
[FIX] mail: chatter composer adding scroll with newline

### DIFF
--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -185,7 +185,18 @@ class ComposerTextInput extends Component {
      */
     _updateHeight() {
         this._mirroredTextareaRef.el.value = this.composer.textInputContent;
-        this._textareaRef.el.style.height = (this._mirroredTextareaRef.el.scrollHeight) + "px";
+        // Fill the first line of the composer completely and hit "enter"
+        // the scrollbar will appear (before we reach max-height), specifically in firefox, ubuntu
+        var scrollHeight = this._mirroredTextareaRef.el.scrollHeight;
+        if (
+            this.composer.thread &&
+            this.composer.thread.model !== 'mail.channel' &&
+            navigator.userAgent.indexOf("Firefox") != -1 &&
+            navigator.userAgent.indexOf("Linux") != -1
+        ) {
+            scrollHeight += 20;
+        }
+        this._textareaRef.el.style.height = scrollHeight + "px";
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
**PURPOSE**
Reproduction Steps (It is reproducing in Firefox only):
    - In Chatter
    - Type text in the first line of the composer to fill it completely
    - Then press "Enter"
    - A scrollbar will appear (before we reach max-height),
      even though we are supposed to have auto-height adjust.

**SPECIFICATION**
We are now assigning the height as 0px first to the textarea and then
it will reassigned based on the content height resolves the issue.

Task : 2463635