### PR TITLE
[FIX] stock: keep quants on sync when changing reserved stocks

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -470,8 +470,6 @@ class StockQuant(models.Model):
         elif float_compare(quantity, 0, precision_rounding=rounding) < 0:
             # if we want to unreserve
             available_quantity = sum(quants.mapped('reserved_quantity'))
-            if float_compare(abs(quantity), available_quantity, precision_rounding=rounding) > 0:
-                raise UserError(_('It is not possible to unreserve more products of %s than you have in stock.', product_id.display_name))
         else:
             return reserved_quants
 


### PR DESCRIPTION
- Have a MO with a product component [DEMO] untracked,
with a quantity in stock (i.e. 18)
- Confirm MO, check availability
- Edit MO, raise Quantity to produce to 99, and quantity of [DEMO] to
consume to 20
- Save, check availability
- Edit MO, lower Quantity to produce to 9, and quantity of [DEMO] to
consume to 2
- Save, check availability
- Edit MO, lower Quantity to produce to 2, and raise quantity of [DEMO]
to consume to 4
- Save, check availability

Last action will be blocked by a UserError

opw-2484710

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
