### PR TITLE
[FIX] crm : action and partner_id is not auto set

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -7,6 +7,7 @@
             <form string="Convert to Opportunity">
                 <group name="name">
                     <field name="name" widget="radio"/>
+                    <field name="lead_id" invisible="1"/>
                 </group>
                 <group string="Assign this opportunity to">
                     <field name="user_id" domain="[('share', '=', False)]"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Go to runbot
- install CRM with lead
- create a partner "ODOO SA"
- create a lead "ODOO SA"
- click on "Convert to Opportunity"
--> Issue `action` should be `exist `and `partner _id` should be set

This behavior exist in V12.

@tde-banana-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
