### PR TITLE
[IMP] mail_plugin: support translation for the Gmail addon

### DIFF
--- a/addons/crm_mail_plugin/static/src/to_translate/translations_gmail.xml
+++ b/addons/crm_mail_plugin/static/src/to_translate/translations_gmail.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Terms to translate for the Gmail plugin
+-->
+<ressources>
+    <string>Log the email on the lead</string>
+    <string>Email already logged on the lead</string>
+    <string>Could not create the lead</string>
+    <string>Opportunities (%s)</string>
+    <string>%(expected_revenue)s at %(probability)s%</string>
+    <string>%(expected_revenue)s + %(recurring_revenue)s %(recurring_plan)s at %(probability)s%</string>
+    <string>Save Contact to create new Opportunities.</string>
+</ressources>

--- a/addons/mail_plugin/static/src/to_translate/translations_gmail.xml
+++ b/addons/mail_plugin/static/src/to_translate/translations_gmail.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Terms to translate for the Gmail plugin.
+    Named string format is supported (e.g: %(param)s)
+    as well as standard string format (%s).
+-->
+<resources>
+    <string>Login</string>
+    <string>Logout</string>
+    <string>Debug</string>
+    <string>Close</string>
+    <string>Refresh</string>
+    <string>Create</string>
+    <string>Search</string>
+    <string>Search contact</string>
+    <string>No contact found.</string>
+    <string>Company</string>
+    <string>Description</string>
+    <string>Address</string>
+    <string>Phones</string>
+    <string>Website</string>
+    <string>Industry</string>
+    <string>Employees</string>
+    <string>employees</string>
+    <string>Founded Year</string>
+    <string>Keywords</string>
+    <string>Company Type</string>
+    <string>Annual Revenue</string>
+    <string>Create a company</string>
+    <string>Contact</string>
+    <string>Email already logged on the contact</string>
+    <string>This contact does not exist in the Odoo database.</string>
+    <string>Can not save the contact</string>
+    <string>Save in Odoo</string>
+    <string>Log email</string>
+    <string>Buy new credits</string>
+    <string>Could not connect to database. Try to log out and in.</string>
+    <string>You don't have enough credit to enrich.</string>
+    <string>Company Created.</string>
+    <string>Our IAP server is down, please come back later.</string>
+    <string>Oops, looks like you have exhausted your free enrichment requests. Please log in to try again.</string>
+    <string>No data found for this email address.</string>
+    <string>Something bad happened. Please, try again later.</string>
+    <string>Invalid URL</string>
+    <string>No company attached to this contact.</string>
+    <string>Debug Zone</string>
+    <string>Debug zone for development purpose.</string>
+    <string>Odoo Server URL</string>
+    <string>Odoo Access Token</string>
+    <string>Clear Translations Cache</string>
+</resources>


### PR DESCRIPTION
Purpose
=======
This commit allow the users to translate their Gmail Addon.

The language of the addon will be the language the user set on his
preference, on his Odoo database.

The translations will be downloaded from Odoo and stored in the cache,
so translator can use the existing system to translate the addon.

Task 2502261
See odoo/mail-client-extensions/pull/8
See /pull/69288
See odoo/enterprise/pull/17711
