### PR TITLE
[FIX] website_slides_survey: Add constraints for certifications without scoring

### DIFF
--- a/addons/website_slides_survey/i18n/website_slides_survey.pot
+++ b/addons/website_slides_survey/i18n/website_slides_survey.pot
@@ -393,6 +393,25 @@ msgid "What type of wood is the best for furniture?"
 msgstr ""
 
 #. module: website_slides_survey
+#: code:addons/website_slides_survey/models/survey_survey.py:0
+#, python-format
+msgid ""
+"You cannot remove the certificate status of a survey that is still "
+"referenced by a course as its certification. Please reactivate the "
+"certificate status or remove the survey as a certification for the courses:"
+msgstr ""
+
+#. module: website_slides_survey
+#: code:addons/website_slides_survey/models/slide_slide.py:0
+#, python-format
+msgid ""
+"You cannot set as certification a survey that is not set as a certification."
+" Please activate a scoring method and the certification option on the "
+"selected survey."
+msgstr ""
+
+
+#. module: website_slides_survey
 #: model:mail.template,subject:website_slides_survey.mail_template_user_input_certification_failed
 msgid "You have failed the course: ${object.slide_partner_id.channel_id.name}"
 msgstr ""

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class SlidePartnerRelation(models.Model):
@@ -46,6 +47,12 @@ class Slide(models.Model):
         ('check_survey_id', "CHECK(slide_type != 'certification' OR survey_id IS NOT NULL)", "A slide of type 'certification' requires a certification."),
         ('check_certification_preview', "CHECK(slide_type != 'certification' OR is_preview = False)", "A slide of type certification cannot be previewed."),
     ]
+
+    @api.constrains('survey_id')
+    def _check_survey_is_certification(self):
+        if self.slide_type == 'certification' and self.survey_id and not self.survey_id.certificate:
+            raise ValidationError(_('You cannot set as certification a survey that is not set as a certification.'
+                                  ' Please activate a scoring method and the certification option on the selected survey.'))
 
     @api.onchange('survey_id')
     def _on_change_survey_id(self):

--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -1,11 +1,22 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import models, api, _
+from odoo.exceptions import ValidationError
 
 
 class Survey(models.Model):
     _inherit = 'survey.survey'
+
+    @api.constrains('certificate')
+    def _check_if_referenced_by_certification_slides(self):
+        for record in self:
+            if not record.certificate:
+                matched_slides = record.env['slide.slide'].search([('slide_type', '=', 'certification'), ('survey_id', '=', record.id)])
+                if matched_slides:
+                    raise ValidationError(_('You cannot remove the certificate status of a survey that is still referenced by a course as its certification. '
+                                            'Please reactivate the certificate status or remove the survey as a certification for the courses:') +
+                                          f' {", ".join([slide.name for slide in matched_slides])}.')
 
     def _check_answer_creation(self, user, partner, email, test_entry=False, check_attempts=True, invite_token=False):
         """ Overridden to allow website_publisher to test certifications. """


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Certification type slides created by the user were able to reference non-certification surveys and led to displaying and configuration errors.

**Current behavior before PR:**
The user was able to assign non-certification type surveys to certification slides (through create&edit or directly editing a survey and removing its certification status).

**Desired behavior after PR is merged:**
The user can no longer assign non-certification type surveys to certification slides thanks to constraints in slide_slide and website_slide_survey/survey_survey.

**OPW: 2487124**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr