### PR TITLE
[IMP] base, hr: language setting access

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -16,6 +16,7 @@ HR_READABLE_FIELDS = [
     'last_activity',
     'last_activity_time',
     'can_edit',
+    'is_system',
 ]
 
 HR_WRITABLE_FIELDS = [
@@ -132,6 +133,11 @@ class User(models.Model):
     employee_type = fields.Selection(related='employee_id.employee_type', readonly=False, related_sudo=False)
 
     can_edit = fields.Boolean(compute='_compute_can_edit')
+    is_system = fields.Boolean(compute="_compute_is_system")
+
+    @api.depends_context('uid')
+    def _compute_is_system(self):
+        self.write({'is_system': self.env.user._is_system()})
 
     def _compute_can_edit(self):
         can_edit = self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit') or self.env.user.has_group('hr.group_hr_user')

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -29,6 +29,12 @@
                 <field name="tz" position="attributes">
                     <attribute name="required">1</attribute>
                 </field>
+                <field name="tz" position="after">
+                    <field name="is_system" invisible="1"/>
+                </field>
+                <xpath expr="//button[@name='%(base.res_lang_act_window)d']" position="attributes">
+                    <attribute name="attrs">{'invisible': [('is_system', '=', False)]}</attribute>
+                </xpath>
             </field>
         </record>
 

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -257,6 +257,10 @@ class Lang(models.Model):
         langs = self.with_context(active_test=True).search([])
         return sorted([(lang.code, lang.name) for lang in langs], key=itemgetter(1))
 
+    def action_archive(self):
+        self.ensure_one()
+        self.active = False
+
     def toggle_active(self):
         super().toggle_active()
         # Automatically load translation

--- a/odoo/addons/base/views/res_lang_views.xml
+++ b/odoo/addons/base/views/res_lang_views.xml
@@ -13,9 +13,20 @@
                     <field name="direction" groups="base.group_no_one"/>
                     <field name="active"/>
                     <button name="%(base.action_view_base_language_install)d"
-                        string="Activate / Update"
+                        string="Activate"
                         type="action"
-                        icon="fa-refresh"/>
+                        icon="fa-check"
+                        attrs="{'invisible': [('active', '=', True)]}"/>
+                    <button name="%(base.action_view_base_language_install)d"
+                        string="Update"
+                        type="action"
+                        icon="fa-refresh"
+                        attrs="{'invisible': [('active', '!=', True)]}"/>
+                    <button name="action_archive"
+                        string="Disable"
+                        type="object"
+                        icon="fa-times"
+                        attrs="{'invisible': [('active', '!=', True)]}"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Currently, in My Profile all the users have access to language settings
even when the user does not have the rights to activate/deactivate
languages. Also, the language setting list is not user friendly which
needs to be imporved.

The purpose of this commit is to hide "More Languages" button in My Profile,
for users that does not have the rights. And the language settings list is
improved by adding seperate buttons to "activate", "disable" and "update" a
language.

TaskId: 2466771
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
