### PR TITLE
[FIX] mrp: optimize _compute_used_in_bom_count

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -288,7 +288,7 @@ class MrpBomLine(models.Model):
         return self.env['uom.uom'].search([], limit=1, order='id').id
 
     product_id = fields.Many2one('product.product', 'Component', required=True, check_company=True)
-    product_tmpl_id = fields.Many2one('product.template', 'Product Template', related='product_id.product_tmpl_id')
+    product_tmpl_id = fields.Many2one('product.template', 'Product Template', related='product_id.product_tmpl_id', store=True, index=True)
     company_id = fields.Many2one(
         related='bom_id.company_id', store=True, index=True, readonly=True)
     product_qty = fields.Float(

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -28,7 +28,7 @@ class ProductTemplate(models.Model):
     def _compute_used_in_bom_count(self):
         for template in self:
             template.used_in_bom_count = self.env['mrp.bom'].search_count(
-                [('bom_line_ids.product_id', 'in', template.product_variant_ids.ids)])
+                [('bom_line_ids.product_tmpl_id', '=', template.id)])
 
     def write(self, values):
         if 'active' in values:


### PR DESCRIPTION
previous implementation works slowly for products with many variants.

Performance Test
================

* ~5 K product.template
* ~14 K product.variants
* ~12 K mrp.bom
* ~414 K mrp.bom.line

Reading time for the field on a product with ~1000 variants

Measuring total request time:
* Before 9,5 sec
* After:
** without module upgrade 1,5 sec
** with module upgrade 0,3 sec

Measuring query execution in psql:
* Before 7,2 sec
* After:
** without module upgrade 0,7 sec
** with module upgrade 0,001 sec

---

opw-2494423

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
