### PR TITLE
[FIX] base: User with "Administration /Access Right" can't View "Groups"

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -93,7 +93,7 @@
                             <field name="menu_access"/>
                         </page>
                         <page string="Views" name="views">
-                            <field name="view_access"/>
+                            <field name="view_access" groups="base.group_system"/>
                         </page>
                         <page string="Access Rights" name="access_rights">
                             <field name="model_access">


### PR DESCRIPTION
1. Create a new user with only "Administration / Access Right"
2. Login as the user
3. Turn on debug mode (via plugin or by editing url)
4. Go to "Settings -> Users and Companies -> Groups"
5. Open any group form / Press "Create" button.

Bug:

Error "You are not allowed to access 'View' (ir.ui.view) records."

A user who is managing "Access Right" must be able to create/edit groups

opw:2492803

Co-authored-by: mart-e <mat@odoo.com>