### PR TITLE
[FIX] account: Traceback on multiple auto-validation candidates

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -890,6 +890,11 @@ class AccountReconcileModel(models.Model):
         the most prioritary are kept.
         """
         candidates_by_priority = self._sort_reconciliation_candidates_by_priority(candidates, aml_ids_to_exclude, reconciled_amls_ids)
+
+        # This can happen if the candidates were already reconciled at this point
+        if not candidates_by_priority:
+            return [], set()
+
         max_priority = min(candidates_by_priority.keys())
 
         filtered_candidates = candidates_by_priority[max_priority]


### PR DESCRIPTION
When an auto-validating reconciliation model is defined for matching
bank statement lines to invoices, it was possible to get a traceback
when the bank statement lines were in a certain order and matched in a
certain way.

In particular, if the first bank statement line is priority 3
(communication_flag True) and the amount is an exact match with the
invoice, it will be instantly reconciled. If there's a second line
that's a priority 5 match, it crashed because _filter_candidates didn't
take into account that candidates_by_priority could be empty if the
candidates were already reconciled.

Instead we just return an empty list of candidates and priorities when
this happens.

Ticket: 2507189