### PR TITLE
[FIX] web: do not use default en_US lang when loading translations fr…

### DIFF
--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -212,13 +212,16 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
         });
     },
     load_translations: function () {
+        var lang = this.user_context.lang
         /* We need to get the website lang at this level.
            The only way is to get it is to take the HTML tag lang
            Without it, we will always send undefined if there is no lang
            in the user_context. */
         var html = document.documentElement,
-            htmlLang = (html.getAttribute('lang') || 'en_US').replace('-', '_'),
-            lang = this.user_context.lang || htmlLang;
+            htmlLang = html.getAttribute('lang');
+        if (!this.user_context.lang && htmlLang) {
+            lang = htmlLang.replace('-', '_');
+        }
 
         return _t.database.load_translations(this, this.module_list, lang, this.translationURL);
     },


### PR DESCRIPTION
…om session

When loading translations from Session, if no lang is defined in context or html,
it is loading translations of en_US lang by default.
No default should be used to fallback on the language of the current user.

opw-2501708

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
