### PR TITLE
[FIX] point_of_sale: allow unreconciliation of POS invoices

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -19,9 +19,9 @@ class AccountMove(models.Model):
 
     def _compute_amount(self):
         super(AccountMove, self)._compute_amount()
-        pos_invoices = self.filtered(lambda i: i.type in ['out_invoice', 'out_refund'] and i.pos_order_ids)
-        for invoice in pos_invoices:
-            invoice.invoice_payment_state = 'paid'
+        for inv in self:
+            if inv.type in ['out_invoice', 'out_refund'] and inv.pos_order_ids and any(s != 'closed' for s in inv.pos_order_ids.mapped('session_id.state')):
+                inv.invoice_payment_state = 'paid'
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'


### PR DESCRIPTION
- Open POS session
- Make an order to a customer, generating the invoice.
- Close POS session and go to the invoice
- Unreconcile the payment.

User is now stuck because the invoice is still marked as paid and is no
longer possible to record a payment or add an outstanding amount as
payment

opw-2349727

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
