### PR TITLE
[FIX] l10n_ar: Number format for doc 99

### DIFF
--- a/addons/l10n_ar/models/l10n_latam_document_type.py
+++ b/addons/l10n_ar/models/l10n_latam_document_type.py
@@ -68,7 +68,11 @@ class L10nLatamDocumentType(models.Model):
 
         msg = "'%s' " + _("is not a valid value for") + " '%s'.<br/>%s"
 
-        if not self.code:
+
+        # This two represent documents used only in vendor bills: "Importation Invoices" and "(99) Otros Documentos.."
+        # documents, thouse two documents not need to have the regular invoice document format, the user can enter any
+        # value
+        if not self.code or self.code == '99':
             return document_number
 
         # Import Dispatch Number Validator


### PR DESCRIPTION
task 529
---

### Description of the issue/feature this PR addresses:

We were forcing that the "(99) OTROS COMPROBANTES.." document type has the number format as all regular invoices, but this is not true, the number related to this document does not have to match any format.

### Current behavior before PR:

Before this PR the users were not able to register vendor bills for document 99 because of a raise about the number format, with this change they are able to add it without problems.

NOTE: Doc 99 can only be created from vendor bills so this does not affect the regular format we use when validating customer invoices.

### Desired behavior after PR is merged:

Now can create doc 99 vendor bills with any document number

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
