### PR TITLE
[14.0][DOC] remove old mail widget references

### DIFF
--- a/doc/reference/mixins.rst
+++ b/doc/reference/mixins.rst
@@ -57,8 +57,8 @@ widgets) to your form view will get you up and running in no time.
                     ...
                     Then comes chatter integration -->
                     <div class="oe_chatter">
-                        <field name="message_follower_ids" widget="mail_followers"/>
-                        <field name="message_ids" widget="mail_thread"/>
+                        <field name="message_follower_ids"/>
+                        <field name="message_ids"/>
                     </div>
                 </form>
             </field>
@@ -767,9 +767,9 @@ widgets, respectively).
                 <form string="Business Trip">
                     <!-- Your usual form view goes here -->
                     <div class="oe_chatter">
-                        <field name="message_follower_ids" widget="mail_followers"/>
-                        <field name="activity_ids" widget="mail_activity"/>
-                        <field name="message_ids" widget="mail_thread"/>
+                        <field name="message_follower_ids"/>
+                        <field name="activity_ids"/>
+                        <field name="message_ids"/>
                     </div>
                 </form>
             </field>


### PR DESCRIPTION
These widgets were removed in https://github.com/odoo/odoo/commit/3fea5b2136627c1d7e83b2a5e111952fe3eb10a1. Using them results in warnings in the JS console:
```
Missing widget:  mail_followers  for field message_follower_ids of type one2many
Missing widget:  mail_activity  for field activity_ids of type one2many
Missing widget:  mail_thread  for field message_ids of type one2many
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
