### PR TITLE
do not throw error when wrong value entered in daterange

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -632,7 +632,12 @@ var FieldDateRange = InputField.extend({
      * @returns {Moment|false}
      */
     _getValue: function () {
-        return field_utils.parse[this.formatType](this.$input.val(), this.field, { timezone: true });
+        try {
+            return field_utils.parse[this.formatType](this.$input.val(), this.field, { timezone: true });
+        } catch (err) {
+            this.$input[0].value = "";
+            return false;
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -3099,6 +3099,36 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('Datetime field manually input invalid value should clear input value', async function (assert) {
+        assert.expect(2);
+
+        this.data.partner.fields.datetime_end = { string: 'Datetime End', type: 'datetime' };
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="datetime" widget="daterange" options="{'related_end_date': 'datetime_end'}"/>
+                    <field name="datetime_end" widget="daterange" options="{'related_start_date': 'datetime'}"/>
+                </form>`,
+        });
+
+        await testUtils.nextTick();
+        // Enter invalid date in input
+        await testUtils.fields.editAndTrigger(form.$('.o_field_date_range:first'), 'blabla', ['input', 'change']);
+
+        assert.strictEqual(form.$('.o_field_date_range:first').text(), '',
+            "the start date should be clear when invalid date entered");
+
+        await testUtils.fields.editAndTrigger(form.$('.o_field_date_range:last'), 'blabla', ['input', 'change']);
+        assert.strictEqual(form.$('.o_field_date_range:last').text(), '',
+            "the end date should be clear when invalid date entered");
+
+        form.destroy();
+    });
+
     QUnit.module('FieldDate');
 
     QUnit.test('date field: toggle datepicker [REQUIRE FOCUS]', async function (assert) {


### PR DESCRIPTION
PURPOSE
The date widget gracefully fails when garbage value is entered. 

SPEC
The date range widget, however, does not. It throws a javascript error. We want it to behave just like the date field for unvalid values. 

TASK 2492797