### PR TITLE
[FIX] gamification: filter badge owner info based on user companies

### DIFF
--- a/addons/gamification/models/badge.py
+++ b/addons/gamification/models/badge.py
@@ -138,14 +138,25 @@ class GamificationBadge(models.Model):
             the total number of time this badge was granted
             the total number of users this badge was granted to
         """
-        self.env.cr.execute("""
-            SELECT badge_id, count(user_id) as stat_count,
-                count(distinct(user_id)) as stat_count_distinct,
-                array_agg(distinct(user_id)) as unique_owner_ids
-            FROM gamification_badge_user
-            WHERE badge_id in %s
-            GROUP BY badge_id
-            """, [tuple(self.ids)])
+        Users = self.env["res.users"]
+        query = Users._where_calc([])
+        Users._apply_ir_rules(query)
+        query.add_join(("res_users", "gamification_badge_user", "id", "user_id", "badges"))
+
+        tables, where_clauses, where_params = query.get_sql()
+
+        self.env.cr.execute(
+            f"""
+              SELECT res_users__badges.badge_id, count(res_users.id) as stat_count,
+                     count(distinct(res_users.id)) as stat_count_distinct,
+                     array_agg(distinct(res_users.id)) as unique_owner_ids
+                FROM {tables}
+               WHERE {where_clauses}
+                 AND res_users__badges.badge_id in %s
+            GROUP BY res_users__badges.badge_id
+            """,
+            [*where_params, tuple(self.ids)]
+        )
 
         defaults = {
             'stat_count': 0,


### PR DESCRIPTION
When retrieving the list of badge owners in `_get_owners_info()`, we should apply `res.users` ir rules to be sure to respect multi-company rules.

upg-7081

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
