### PR TITLE
[FIX] core: fix <act_window> deprecation warning

### DIFF
--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -333,7 +333,7 @@ form: module.record_id""" % (xml_id,)
         name = rec.get('name')
         xml_id = rec.get('id','')
         self._test_xml_id(xml_id)
-        warnings.warn("The <act_window> tag is deprecated, use a <record> for {xml_id!r}.", DeprecationWarning)
+        warnings.warn(f"The <act_window> tag is deprecated, use a <record> for {xml_id!r}.", DeprecationWarning)
         view_id = False
         if rec.get('view_id'):
             view_id = self.id_get(rec.get('view_id'))


### PR DESCRIPTION
Description of the issue/feature this PR addresses: without the f-string literal the XML ID is not printed.

Current behavior before PR: the deprecation warning message is not formatted and the actual XML ID is not printed (`{xml_id!r}` is printed instead).

Desired behavior after PR is merged: the actual XML ID is printed in the deprecation warning.

Opening a PR to `14.0` as noted by @xmo-odoo in the [original PR](https://github.com/odoo/odoo/pull/69349#issuecomment-820924551).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
