### PR TITLE
[FIX] website: fix top position of modal

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -87,11 +87,6 @@ $-seen-urls: ();
 }
 
 #wrapwrap {
-    // When the modal is in #wrapwrap, position top should be size of the navbar
-    .modal:not(.s_popup_bottom) {
-        top: $o-navbar-height;
-    }
-
     @if o-website-value('body-image') {
         background-image: url("/#{str-slice(o-website-value('body-image'), 2)}");
         background-position: center;
@@ -178,6 +173,13 @@ $-seen-urls: ();
                 }
             }
         }
+    }
+}
+
+#oe_main_menu_navbar:not(.o_hidden) + #wrapwrap {
+    .o_header_affixed, .modal:not(.s_popup_bottom) {
+        // For these elements, in #wrapwrap, position top should be size of the navbar
+        top: $o-navbar-height;
     }
 }
 
@@ -769,9 +771,6 @@ $-transition-duration: 200ms;
             }
         }
     }
-}
-#oe_main_menu_navbar + #wrapwrap .o_header_affixed {
-    top: $o-navbar-height;
 }
 
 // Navbar


### PR DESCRIPTION
Before this commit, the top position of a modal in website was always
the height of the main menu navbar. Even if the main menu navbar was
not displayed when the user is not logged. (see below)
That bug was introduced in 6ef6227

![FireShot Capture 963 - Customizable Desk - My Website - 7199745-master-all runbot29 odoo com](https://user-images.githubusercontent.com/52911687/114989199-7c719180-9e97-11eb-9b82-02cc9b7325c6.jpg)

After this commit, the top position of a modal is the height of the
main menu navbar but only if that navbar is displayed.

task-2507949

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
