### PR TITLE
[FIX] web: centered event name while dragging in month mode

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -512,6 +512,7 @@ return AbstractRenderer.extend({
                 $(self.calendarElement).find(_.str.sprintf('[data-event-id=%s]', mouseLeaveInfo.event.id)).removeClass('o_cw_custom_hover');
             },
             eventDragStart: function (mouseDragInfo) {
+                mouseDragInfo.el.classList.add(mouseDragInfo.view.type);
                 $(self.calendarElement).find(_.str.sprintf('[data-event-id=%s]', mouseDragInfo.event.id)).addClass('o_cw_custom_hover');
                 self._unselectEvent();
             },

--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -37,6 +37,11 @@ $o-cw-filter-avatar-size: 20px;
             color: $body-color;
         }
 
+        &.fc-dragging.fc-day-grid-event.dayGridMonth .fc-content {
+            @include text-truncate();
+            margin: 4px 4px 3px;
+        }
+
         .fc-bg {
             background-color: mix(theme-color('primary'), white); // Used for placeholder events only (on creation)
             @include size(101%); // Compensate border

--- a/addons/web/static/tests/views/calendar_tests.js
+++ b/addons/web/static/tests/views/calendar_tests.js
@@ -2878,7 +2878,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test("drag and drop on month mode", async function (assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         const calendar = await createCalendarView({
             arch:
@@ -2902,6 +2902,14 @@ QUnit.module('Views', {
         await testUtils.fields.editInput($input, "An event");
         await testUtils.dom.click($('.modal button.btn-primary'));
         await testUtils.nextTick();
+
+        await testUtils.dragAndDrop(
+            calendar.$('.fc-event:contains("event 1")'),
+            calendar.$('.fc-day-grid .fc-row:eq(3) .fc-day-top:eq(1)'),
+            { disableDrop: true },
+        );
+        assert.hasClass(calendar.$('.o_calendar_widget > [data-event-id="1"]'), 'dayGridMonth',
+            "should have dayGridMonth class");
 
         // Move event to another day (on 19 december)
         await testUtils.dragAndDrop(


### PR DESCRIPTION
before this commit, the name of the event and hour is not
correctly centered while dragging the pill in month mode.

This commit fixes the issue by adding the CSS property.
after this commit, the name of the event and hour should be
correctly centered while dragging the pill in month mode.

TaskID-2506060