### PR TITLE
[FIX] website_slides: close fullscreen mode when opening web editor

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -707,11 +707,32 @@ odoo.define('website_slides.fullscreen', function (require) {
         selector: '.o_wslides_fs_main',
         xmlDependencies: ['/website_slides/static/src/xml/website_slides_fullscreen.xml', '/website_slides/static/src/xml/website_slides_share.xml'],
         start: function (){
+            var self = this;
             var proms = [this._super.apply(this, arguments)];
             var fullscreen = new Fullscreen(this, this._getSlides(), this._getCurrentSlideID(), this._extractChannelData());
             proms.push(fullscreen.attachTo(".o_wslides_fs_main"));
-            return Promise.all(proms);
+            return Promise.all(proms).then(function () {
+                $('#edit-page-menu a[data-action="edit"]').on('click', self._onWebEditorClick.bind(self));
+            });
         },
+
+        /**
+         * The web editor does not work well with the e-learning fullscreen view.
+         * It actually completely closes the fullscreen view and opens the edition on a blank page.
+         *
+         * To avoid this, we intercept the click on the 'edit' button and redirect to the
+         * non-fullscreen view of this slide with the editor enabled, which is more suited to edit
+         * in-place anyway.
+         *
+         * @param {MouseEvent} e
+         */
+        _onWebEditorClick: function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            window.location = `${window.location.pathname}?fullscreen=0&enable_editor=1`;
+        },
+
         _extractChannelData: function (){
             return this.$el.data();
         },

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -50,6 +50,20 @@ class TestUi(tests.HttpCase):
             'odoo.__DEBUG__.services["web_tour.tour"].tours.course_member.ready',
             login=user_portal.login)
 
+    def test_full_screen_edition_website_publisher(self):
+        # group_website_designer
+        user_demo = self.env.ref('base.user_demo')
+        user_demo.flush()
+        user_demo.write({
+            'groups_id': [(5, 0), (4, self.env.ref('base.group_user').id), (4, self.env.ref('website.group_website_publisher').id)]
+        })
+
+        self.phantom_js(
+            '/slides',
+            'odoo.__DEBUG__.services["web_tour.tour"].run("full_screen_web_editor")',
+            'odoo.__DEBUG__.services["web_tour.tour"].tours.full_screen_web_editor.ready',
+            login=user_demo.login)
+
 
 @tests.common.tagged('external', '-standard')
 class TestUiYoutube(tests.HttpCase):

--- a/addons/website_slides/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/tests/tours/slides_full_screen_web_editor.js
@@ -1,0 +1,39 @@
+odoo.define('website_slides.tour.fullscreen.edition.publisher', function (require) {
+'use strict';
+
+var tour = require('web_tour.tour');
+
+/**
+ * Global use case:
+ * - a user (website publisher) lands on the fullscreen view of a course ;
+ * - he clicks on the website editor "Edit" button ;
+ * - he is redirected to the non-fullscreen view with the editor opened.
+ *
+ * This tour tests a fix made when editing a course in fullscreen view.
+ * See "Fullscreen#_onWebEditorClick" for more information.
+ *
+ */
+tour.register('full_screen_web_editor', {
+    url: '/slides',
+    test: true
+}, [{
+    // open to the course
+    trigger: 'a:contains("Basics of Gardening")'
+}, {
+    // click on a slide to open the fullscreen view
+    trigger: 'a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")'
+}, {
+    trigger: '.o_wslides_fs_main',
+    run: function () {} // check we land on the fullscreen view
+}, {
+    // click on the main "Edit" button to open the web editor
+    trigger: '#edit-page-menu a[data-action="edit"]',
+}, {
+    trigger: '.o_wslides_lesson_main',
+    run: function () {} // check we are redirected on the detailed view
+}, {
+    trigger: 'body.editor_enable',
+    run: function () {} // check the editor is automatically opened on the detailed view
+}]);
+
+});

--- a/addons/website_slides/views/assets.xml
+++ b/addons/website_slides/views/assets.xml
@@ -38,6 +38,7 @@
                 <script type="text/javascript" src="/website_slides/tests/tours/slides_course_member.js"/>
                 <script type="text/javascript" src="/website_slides/tests/tours/slides_course_member_yt.js"/>
                 <script type="text/javascript" src="/website_slides/tests/tours/slides_course_publisher.js"/>
+                <script type="text/javascript" src="/website_slides/tests/tours/slides_full_screen_web_editor.js"/>
             </xpath>
         </template>
 


### PR DESCRIPTION
The web editor does not work well with the e-learning fullscreen view.
It actually completely closes the fullscreen view and opens the edition on a
blank page.

To avoid this, we intercept the click on the 'edit' button and redirect to the
non-fullscreen view of this slide with the editor enabled, whose layout is more
suited to edit in-place anyway.

A small testing tour was added to ensure this behavior is kept.

Task-2507179

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
