### PR TITLE
[FIX] sale_coupon: Allow coupons to correctly allow several free products

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -80,7 +80,7 @@ class SaleOrder(models.Model):
     def _get_reward_values_product(self, program):
         price_unit = self.order_line.filtered(lambda line: program.reward_product_id == line.product_id)[0].price_reduce
 
-        order_lines = (self.order_line - self._get_reward_lines()).filtered(lambda x: program._get_valid_products(x.product_id))
+        order_lines = (self.order_line - self._get_reward_lines())
         max_product_qty = sum(order_lines.mapped('product_uom_qty')) or 1
         total_qty = sum(self.order_line.filtered(lambda x: x.product_id == program.reward_product_id).mapped('product_uom_qty'))
         # Remove needed quantity from reward quantity if same reward and rule product


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Add a coupon program with the following condition sale_ok == True & name == 'Large Desk'
    2. Add 'Buy 1 get 2 free' 'Large Cabinet'
    3. Create a quotation with 1 Large Desk and 2 Large Cabinet
    4. Add the coupon code

What is currently happening ?

    Promotion will only remove one * Large Cabinet price instead of 2

What are you expecting to happen ?

    Promotion remove two * Large Cabinet price

Why is this happening ?

    Because there is a filter that applies before the calculation of the number of free articles obtained is done.
    This filter only keeps the products that match the condition of the coupon: the product that must be purchased in order to benefit two free items.
    In our example this filter just keeps Large Desk, which is the item you have to buy to get 2 Large Cabinet.
    The calculation is not done correctly because it only has 1 Large Desk,
    and will apply the promotion for 1 Large Cabinet

How to fix the bug ?

    Remove this first filter

opw-2496940