### PR TITLE
[IMP] mail: improve external server wording

### DIFF
--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -36,9 +36,10 @@
                                     Configure your own email servers
                                 </div>
                                 <div class="content-group"  attrs="{'invisible': [('external_email_server_default', '=', False)]}">
-                                    <div class="row mt16" id="mail_alias_domain">
-                                        <label for="alias_domain" class="col-lg-3 o_light_label"/>
-                                        <field name="alias_domain" placeholder="mycompany.odoo.com"/>
+                                    <div class="mt16" id="mail_alias_domain">
+                                        <label for="alias_domain" class="o_light_label"/>
+                                        <span>@</span>
+                                        <field name="alias_domain" placeholder='e.g. "mycompany.com"'/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
improve external server wording in settings by:

- adding a @ to the domain so that users won't add it themselves
- removing the .odoo since it's an external server domain
- making Alias Domain not take more then a single line

Task-2507856

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
