### PR TITLE
display sequence field as non editable

### DIFF
--- a/addons/web/static/src/scss/list_view.scss
+++ b/addons/web/static/src/scss/list_view.scss
@@ -261,7 +261,9 @@
 
         .o_data_row.o_selected_row > .o_data_cell:not(.o_readonly_modifier):not(.o_invisible_modifier) {
             position: relative; // for o_field_translate
-            background-color: white;
+            &:not(.o_handle_cell) {
+                background-color: white;
+            }
             .o_input {
                 border: none;
                 padding: 0;


### PR DESCRIPTION
PURPOSE
When editable listview has sequence field with handle widget and user edits row it is displayed with white background, while user can not change it in edit mode so it should be displayed with grey background

SPEC
The sequence field should be displayed with grey background in editable listview in edit mode.

TASK 2507971



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
