### PR TITLE
[IMP] base: improve ir.module.module tree view

### DIFF
--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -143,7 +143,7 @@
             <field name="name">ir.module.module.tree</field>
             <field name="model">ir.module.module</field>
             <field name="arch" type="xml">
-                <tree decoration-info="state=='to upgrade' or state=='to install'" decoration-danger="state=='uninstalled'" decoration-muted="state=='uninstallable'" create="false" string="Apps">
+                <tree create="false" string="Apps">
                     <header>
                         <button name="button_immediate_install" type="object" string="Install"/>
                     </header>
@@ -152,7 +152,11 @@
                     <field name="author"/>
                     <field name="website"/>
                     <field name="installed_version"/>
-                    <field name="state"/>
+                    <field name="state" widget="badge"
+                        decoration-muted="state == 'uninstallable'"
+                        decoration-info="state in ['to upgrade', 'to install']"
+                        decoration-success="state == 'installed'"
+                        decoration-danger="state == 'uninstalled'"/>
                     <field name="category_id" invisible="1"/>
                 </tree>
             </field>


### PR DESCRIPTION
This commit simply improves the modules tree view by removing the tree
"decorators" and replacing it by a badge widget with associated decorators on
the 'state' field.

Indeed, the previous implementation could make the tree view look a bit "scary"
at first opening because it would color a lot of lines in red (modules were
not installed), giving it a feeling or "error" where there was none.

Now the color is directly shown on the state field, making it clear it's
related to that information.

Task-2507703

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
