### PR TITLE
[MERGE] core, web, crm: add a forecast feature and use it for crm leads

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -71,9 +71,13 @@
     'application': True,
     'auto_install': False,
     'assets': {
+        'web.assets_qweb': [
+            'crm/static/src/xml/forecast_kanban.xml',
+        ],
         'web.assets_backend': [
             'crm/static/src/js/crm_form.js',
             'crm/static/src/js/crm_kanban.js',
+            'crm/static/src/js/forecast/*',
             'crm/static/src/js/systray_activity_menu.js',
             'crm/static/src/js/tours/crm.js',
             'crm/static/src/scss/crm.scss',
@@ -84,6 +88,7 @@
         ],
         'web.qunit_suite_tests': [
             'crm/static/tests/mock_server.js',
+            'crm/static/tests/forecast_kanban_tests.js',
             'crm/static/tests/crm_rainbowman_tests.js',
         ],
     }

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -33,6 +33,7 @@
         'data/crm_stage_data.xml',
         'data/crm_team_data.xml',
         'data/digest_data.xml',
+        'data/ir_action_data.xml',
         'data/ir_cron_data.xml',
         'data/mail_data.xml',
         'data/crm_recurring_plan_data.xml',

--- a/addons/crm/data/crm_lead_demo.xml
+++ b/addons/crm/data/crm_lead_demo.xml
@@ -353,7 +353,7 @@ Andrew</p>]]></field>
             <field name="street">Kensington Road 189</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor1')])]"/>
             <field name="priority">1</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=4)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="stage_id" ref="crm.stage_lead1"/>
@@ -379,7 +379,7 @@ Andrew</p>]]></field>
             <field name="phone">+32 10 588 558</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor2')])]"/>
             <field name="priority">2</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.crm_team_1"/>
             <field name="user_id" ref="base.user_demo"/>
             <field name="stage_id" ref="crm.stage_lead1"/>
@@ -402,7 +402,7 @@ Andrew</p>]]></field>
             <field name="phone">+32 10 588 558</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor1')])]"/>
             <field name="priority">1</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=1)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="stage_id" ref="crm.stage_lead2"/>
@@ -495,7 +495,7 @@ Andrew</p>]]></field>
             <field name="street">Union Road</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor5')])]"/>
             <field name="priority">2</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=1)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="DateTime.today().strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="stage_id" ref="crm.stage_lead2"/>
@@ -520,7 +520,7 @@ Andrew</p>]]></field>
             <field name="street">Rue des Palais 51, bte 33</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor3'),ref('sales_team.categ_oppor4')])]"/>
             <field name="priority">1</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=3)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.crm_team_1"/>
             <field name="user_id" ref="base.user_demo"/>
             <field name="stage_id" ref="crm.stage_lead2"/>
@@ -553,7 +553,7 @@ Andrew</p>]]></field>
             <field name="partner_id" ref="base.res_partner_4"/>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor4'),ref('sales_team.categ_oppor6')])]"/>
             <field name="priority">1</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=3)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.crm_team_1"/>
             <field name="user_id" ref="base.user_demo"/>
             <field name="stage_id" ref="crm.stage_lead2"/>
@@ -628,6 +628,7 @@ Andrew</p>]]></field>
             <field name="phone">+1 312 349 2324</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor4'),ref('sales_team.categ_oppor8')])]"/>
             <field name="priority">2</field>
+            <field name="date_deadline" eval="DateTime.today().strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="stage_id" ref="crm.stage_lead3"/>
@@ -684,6 +685,7 @@ Andrew</p>]]></field>
             <field name="partner_id" ref="base.res_partner_18"/>
             <field name="priority">0</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor3')])]"/>
+            <field name="date_deadline" eval="DateTime.today().strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.crm_team_1"/>
             <field name="user_id" ref="base.user_demo"/>
             <field name="stage_id" ref="crm.stage_lead3"/>
@@ -702,6 +704,7 @@ Andrew</p>]]></field>
             <field name="country_id" ref="base.pe"/>
             <field name="city">Lima</field>
             <field name="priority">0</field>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor7')])]"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
@@ -750,7 +753,6 @@ Andrew</p>]]></field>
             <field name="zip">1300</field>
             <field name="priority">2</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor2')])]"/>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=6)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.crm_team_1"/>
             <field name="user_id" ref="base.user_demo"/>
             <field name="stage_id" ref="crm.stage_lead3"/>
@@ -774,7 +776,7 @@ Andrew</p>]]></field>
             <field name="street">Rue de Namur 69</field>
             <field name="priority">2</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor2')])]"/>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=6)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="DateTime.today().strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.crm_team_1"/>
             <field name="user_id" ref="base.user_demo"/>
             <field name="stage_id" ref="crm.stage_lead3"/>
@@ -865,7 +867,7 @@ Andrew</p>]]></field>
             <field name="street">1920 Del Dew Drive</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor1')])]"/>
             <field name="priority">1</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="stage_id" ref="crm.stage_lead1"/>
@@ -887,7 +889,7 @@ Andrew</p>]]></field>
             <field name="street">1920 Del Dew Drive</field>
             <field name="tag_ids" eval="[(6, 0, [ref('sales_team.categ_oppor1')])]"/>
             <field name="priority">1</field>
-            <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(months=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="stage_id" ref="crm.stage_lead2"/>

--- a/addons/crm/data/ir_action_data.xml
+++ b/addons/crm/data/ir_action_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="action_opportunity_forecast" model="ir.actions.server">
+        <field name="name">Crm: Forecast</field>
+        <field name="model_id" ref="crm.model_crm_team"/>
+        <field name="state">code</field>
+        <field name="groups_id"  eval="[(4, ref('base.group_user'))]"/>
+        <field name="code">action = model.action_opportunity_forecast()</field>
+    </record>
+
+</odoo>

--- a/addons/crm/data/ir_action_data.xml
+++ b/addons/crm/data/ir_action_data.xml
@@ -1,6 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!--
+        'Mark as Lost' in action dropdown
+    -->
+    <record id="action_mark_as_lost" model="ir.actions.server">
+        <field name="name">Mark as lost</field>
+        <field name="model_id" ref="model_crm_lead"/>
+        <field name="binding_model_id" ref="crm.model_crm_lead"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+if record:
+    action_values = env.ref('crm.crm_lead_lost_action').sudo().read()[0]
+    action_values.update({'context': env.context})
+    action = action_values
+        </field>
+    </record>
+
+    <record id="action_your_pipeline" model="ir.actions.server">
+        <field name="name">Crm: My Pipeline</field>
+        <field name="model_id" ref="crm.model_crm_team"/>
+        <field name="state">code</field>
+        <field name="groups_id"  eval="[(4, ref('base.group_user'))]"/>
+        <field name="code">action = model.action_your_pipeline()</field>
+    </record>
+
     <record id="action_opportunity_forecast" model="ir.actions.server">
         <field name="name">Crm: Forecast</field>
         <field name="model_id" ref="crm.model_crm_team"/>

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -587,6 +587,15 @@ class Team(models.Model):
     @api.model
     def action_your_pipeline(self):
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_action_pipeline")
+        return self._action_update_to_pipeline(action)
+
+    @api.model
+    def action_opportunity_forecast(self):
+        action = self.env['ir.actions.actions']._for_xml_id('crm.crm_lead_action_forecast')
+        return self._action_update_to_pipeline(action)
+
+    @api.model
+    def _action_update_to_pipeline(self, action):
         user_team_id = self.env.user.sale_team_id.id
         if user_team_id:
             # To ensure that the team is readable in multi company

--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -104,7 +104,7 @@
             name="Activities"
             parent="crm_menu_report"
             action="crm_activity_report_action"
-            sequence="3"/>
+            sequence="4"/>
 
         <record id="crm_activity_report_action_team" model="ir.actions.act_window">
             <field name="name">Pipeline Activities</field>

--- a/addons/crm/static/src/js/forecast/fill_temporal_service.js
+++ b/addons/crm/static/src/js/forecast/fill_temporal_service.js
@@ -1,0 +1,318 @@
+/** @odoo-module */
+import AbstractService from 'web.AbstractService';
+import core from 'web.core';
+
+/**
+ * Configuration depending on the granularity:
+ * @param {function} startOf function to get the start moment of the period from a moment
+ * @param {int} cycle amount of 'granularity' periods constituting a cycle. The cycle duration
+ *                    is arbitrary for each granularity:
+ * cycle    ---    granularity
+ * ___________________________
+ * 1 day           hour
+ * 1 week          day
+ * 1 week          week    # there is no greater time period that takes an integer amount of weeks
+ * 1 year          month
+ * 1 year          quarter
+ * 1 year          year    # we are not using a greater time period in Odoo (yet)
+ * @param {int} cyclePos function to get the position (index) in the cycle from a moment.
+ *                       {1} is the first index. {+1} is used for functions which have an index
+ *                       starting from 0, to standardize between granularities.
+ */
+const GRANULARITY_TABLE = {
+    hour: {
+        startOf: x => x.startOf('hour'),
+        cycle: 24,
+        cyclePos: x => x.hour() + 1,
+    },
+    day: {
+        startOf: x => x.startOf('day'),
+        cycle: 7,
+        cyclePos: x => x.isoWeekday(),
+    },
+    week: {
+        startOf: x => x.startOf('isoWeek'),
+        cycle: 1,
+        cyclePos: x => 1,
+    },
+    month: {
+        startOf: x => x.startOf('month'),
+        cycle: 12,
+        cyclePos: x => x.month() + 1,
+    },
+    quarter: {
+        startOf: x => x.startOf('quarter'),
+        cycle: 4,
+        cyclePos: x => x.quarter(),
+    },
+    year: {
+        startOf: x => x.startOf('year'),
+        cycle: 1,
+        cyclePos: x => 1,
+    },
+};
+
+/**
+ * configuration depending on the time type:
+ * @param {string} format moment format to display this type as a string
+ * @param {string} minGranularity granularity of the smallest time interval used in Odoo for this
+ *                                type
+ */
+const FIELD_TYPE_TABLE = {
+    date: {
+        format: "YYYY-MM-DD",
+        minGranularity: "day",
+    },
+    datetime: {
+        format: "YYYY-MM-DD HH:mm:ss",
+        minGranularity: "second",
+    }
+};
+
+/**
+ * fill_temporal period:
+ *   Represents a specific date/time range for a specific model, field and granularity.
+ *
+ * It is used to add new domain and context constraints related to a specific date/time
+ * field, in order to configure the _read_group_fill_temporal (see core models.py)
+ * method. It will be used when we want to get continuous groups in chronological
+ * order in a specific date/time range.
+ */
+class FillTemporalPeriod {
+    /**
+     * This constructor is meant to be used only by the FillTemporalService (see below)
+     *
+     * @param {string} modelName directly taken from model.loadParams.modelName.
+     *                           this is the `res_model` from the action (i.e. `crm.lead`)
+     * @param {Object} field a dictionary with keys "name" and "type".
+    *                        name: Name of the field on which the fill_temporal should apply
+    *                              (i.e. 'date_deadline')
+    *                        type: 'date' or 'datetime'
+     * @param {string} granularity can either be : hour, day, week, month, quarter, year
+     * @param {integer} minGroups minimum amount of groups to display, regardless of other
+     *                            constraints
+     */
+    constructor(modelName, field, granularity, minGroups) {
+        this.modelName = modelName;
+        this.field = field;
+        this.granularity = granularity || "month";
+        this.setMinGroups(minGroups);
+
+        this._computeStart();
+        this._computeEnd();
+    }
+    /**
+     * Compute the moment for the start of the period containing "now"
+     *
+     * @private
+     */
+    _computeStart() {
+        this.start = GRANULARITY_TABLE[this.granularity].startOf(moment());
+    }
+    /**
+     * Compute the moment for the end of the fill_temporal period. This bound is exclusive.
+     * The fill_temporal period is the number of [granularity] from [start] to the end of the
+     * [cycle] reached after adding [minGroups]
+     * i.e. we are in october 2020 :
+     *      [start] = 2020-10-01
+     *      [granularity] = 'month',
+     *      [cycle] = 12
+     *      [minGroups] = 4,
+     *      => fillTemporalPeriod = 15 months (until end of december 2021)
+     *
+     * @private
+     */
+    _computeEnd() {
+        const cycle = GRANULARITY_TABLE[this.granularity].cycle;
+        const cyclePos = GRANULARITY_TABLE[this.granularity].cyclePos(this.start);
+        /**
+         * fillTemporalPeriod formula explanation :
+         * We want to know how many steps need to be taken from the current position until the end
+         * of the cycle reached after guaranteeing minGroups positions. Let's call this cycle (C).
+         *
+         * (1) compute the steps needed to reach the last position of the current cycle, from the
+         *     current position:
+         *     {cycle - cyclePos}
+         *
+         * (2) ignore {minGroups - 1} steps from the position reached in (1). Now, the current
+         *     position is somewhere in (C). One step from minGroups is reserved to reach the first
+         *     position after (C), hence {-1}
+         *
+         * (3) compute the additional steps needed to reach the last position of (C), from the
+         *     position reached in (2):
+         *     {cycle - (minGroups - 1) % cycle}
+         *
+         * (4) combine (1) and (3), the sum should not be greater than a full cycle (-> truncate):
+         *     {(2 * cycle - (minGroups - 1) % cycle - cyclePos) % cycle}
+         *
+         * (5) add minGroups!
+         */
+        const fillTemporalPeriod = (2 * cycle - (this.minGroups - 1) % cycle - cyclePos) % cycle + this.minGroups;
+        this.end = moment(this.start).add(fillTemporalPeriod, `${this.granularity}s`);
+        this.computedEnd = true;
+    }
+    /**
+     * The server needs a date/time in UTC, but we don't want a day shift in case
+     * of dates, even if the date is not in UTC
+     *
+     * @param {moment} bound the moment to be formatted (this.start or this.end)
+     */
+    _getFormattedServerDate(bound) {
+        if (bound.isUTC() || this.field.type === "date") {
+            return bound.format(FIELD_TYPE_TABLE[this.field.type].format);
+        } else {
+            return moment.utc(bound).format(FIELD_TYPE_TABLE[this.field.type].format);
+        }
+    }
+    /**
+     * @param {Object} configuration
+     * @param {Array[]} [domain]
+     * @param {boolean} [forceStartBound=true] whether this.start moment must be used as a domain
+     *                                         constraint to limit read_group results or not
+     * @param {boolean} [forceEndBound=true] whether this.end moment must be used as a domain
+     *                                       constraint to limit read_group results or not
+     * @returns {Array[]} new domain
+     */
+    getDomain({domain, forceStartBound=true, forceEndBound=true}) {
+        if (!forceEndBound && !forceStartBound) {
+            return domain;
+        }
+        const originalDomain = domain.length ? ['&', ...domain] : [];
+        const defaultDomain = ['|', [this.field.name, '=', false]];
+        const linkDomain = forceStartBound && forceEndBound ? ['&'] : [];
+        const startDomain = !forceStartBound ? [] : [
+            [this.field.name, '>=', this._getFormattedServerDate(this.start)]];
+        const endDomain = !forceEndBound ? [] : [
+            [this.field.name, '<', this._getFormattedServerDate(this.end)]];
+        return [...originalDomain, ...defaultDomain, ...linkDomain, ...startDomain, ...endDomain];
+    }
+    /**
+     * The default value of forceFillingTo is false when this.end is the
+     * computed one, and true when it is manually set. This is because the default value of
+     * this.end is computed without any knowledge of the existing data, and as such, we only
+     * want to get continuous groups until the last group with data (no need to force until
+     * this.end). On the contrary, when we set this.end, this means that we want groups until
+     * that date.
+     *
+     * @param {Object} configuration
+     * @param {Object} [context]
+     * @param {boolean} [forceFillingFrom=true] fill_temporal must apply from:
+     *                                          true: this.start
+     *                                          false: the first group with at least one record
+     * @param {boolean} [forceFillingTo=!this.computedEnd] fill_temporal must apply until:
+     *                                          true: this.end
+     *                                          false: the last group with at least one record
+     * @returns {Object} new context
+     */
+    getContext({context, forceFillingFrom=true, forceFillingTo=!this.computedEnd}) {
+        const fillTemporal = {
+            min_groups: this.minGroups,
+        };
+        if (forceFillingFrom) {
+            fillTemporal.fill_from = this._getFormattedServerDate(this.start);
+        }
+        if (forceFillingTo) {
+            fillTemporal.fill_to = this._getFormattedServerDate(
+                moment(this.end).subtract(1, FIELD_TYPE_TABLE[this.field.type].minGranularity)
+            );
+        }
+        context = {...context, fill_temporal: fillTemporal};
+        return context;
+    }
+    /**
+     * @param {integer} minGroups minimum amount of groups to display, regardless of other
+     *                            constraints
+     */
+    setMinGroups(minGroups) {
+        this.minGroups = minGroups || 1;
+    }
+    /**
+     * sets the end of the period to the desired moment. It must be greater
+     * than start. Changes the default behavior of getContext forceFillingTo
+     * (becomes true instead of false)
+     *
+     * @param {moment} end
+     */
+    setEnd(end) {
+        this.end = moment.max(this.start, end);
+        this.computedEnd = false;
+    }
+    /**
+     * sets the start of the period to the desired moment. It must be smaller than end
+     *
+     * @param {moment} start
+     */
+    setStart(start) {
+        this.start = moment.min(this.end, start);
+    }
+    /**
+     * Adds one "granularity" period to [this.end], to expand the current fill_temporal period
+     */
+    expand() {
+        this.setEnd(this.end.add(1, `${this.granularity}s`));
+    }
+}
+
+/**
+ * fill_temporal Service
+ *
+ * This service will be used to generate or retrieve fill_temporal periods
+ *
+ * A specific fill_temporal period configuration will always refer to the same instance
+ * unless forceRecompute is true
+ */
+ const FillTemporalService = AbstractService.extend({
+    /**
+     * @override
+     */
+    start() {
+        this._super.apply(...arguments);
+        this._fillTemporalPeriods = {};
+    },
+    /**
+     * Get a fill_temporal period according to the configuration.
+     * The default initial fill_temporal period is the number of [granularity] from [start]
+     * to the end of the [cycle] reached after adding [minGroups]
+     * i.e. we are in october 2020 :
+     *      [start] = 2020-10-01
+     *      [granularity] = 'month',
+     *      [cycle] = 12 (one year)
+     *      [minGroups] = 4,
+     *      => fillTemporalPeriod = 15 months (until the end of december 2021)
+     * Once created, a fill_temporal period for a specific configuration will be stored
+     * until requested again. This allows to manipulate the period and store the changes
+     * to it. This also allows to keep the configuration when switching to another view
+     *
+     * @param {Object} configuration
+     * @param {string} [modelName] directly taken from model.loadParams.modelName.
+     *                             this is the `res_model` from the action (i.e. `crm.lead`)
+     * @param {Object} [field] a dictionary with keys "name" and "type".
+     * @param {string} [field.name] name of the field on which the fill_temporal should apply
+     *                              (i.e. 'date_deadline')
+     * @param {string} [field.type] date field type: 'date' or 'datetime'
+     * @param {string} [granularity] can either be : hour, day, week, month, quarter, year
+     * @param {integer} [minGroups=4] optional minimal amount of desired groups
+     * @param {boolean} [forceRecompute=false] optional whether the fill_temporal period should be
+     *                                         reinstancied
+     * @returns {FillTemporalPeriod}
+     */
+    getFillTemporalPeriod({modelName, field, granularity, minGroups=4, forceRecompute=false}) {
+        if (!(modelName in this._fillTemporalPeriods)) {
+            this._fillTemporalPeriods[modelName] = {};
+        }
+        if (!(field.name in this._fillTemporalPeriods[modelName])) {
+            this._fillTemporalPeriods[modelName][field.name] = {};
+        }
+        if (!(granularity in this._fillTemporalPeriods[modelName][field.name]) || forceRecompute) {
+            this._fillTemporalPeriods[modelName][field.name][granularity] =
+                new FillTemporalPeriod(modelName, field, granularity, minGroups);
+        } else if (this._fillTemporalPeriods[modelName][field.name][granularity].minGroups != minGroups) {
+            this._fillTemporalPeriods[modelName][field.name][granularity].setMinGroups(minGroups);
+        }
+        return this._fillTemporalPeriods[modelName][field.name][granularity];
+    }
+});
+
+core.serviceRegistry.add('fillTemporalService', FillTemporalService);
+
+export default FillTemporalService;

--- a/addons/crm/static/src/js/forecast/forecast_controllers.js
+++ b/addons/crm/static/src/js/forecast/forecast_controllers.js
@@ -1,0 +1,35 @@
+/** @odoo-module */
+import KanbanController from 'web.KanbanController';
+
+const ForecastKanbanController = KanbanController.extend({
+    custom_events: _.extend({}, KanbanController.prototype.custom_events, {
+        forecast_kanban_add_column: '_onAddColumnForecast',
+    }),
+
+    /**
+     * Expand the fill_temporal period after the ForecastColumnQuickCreate has been used, then
+     * reload the view to refetch updated data
+     *
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onAddColumnForecast(ev) {
+        ev.stopPropagation();
+        this.call('fillTemporalService', 'getFillTemporalPeriod', {
+            modelName: this.model.loadParams.modelName,
+            field: {
+                name: this.model.forecast_field,
+                type: this.model.loadParams.fields[this.model.forecast_field].type,
+            },
+            granularity: this.model.granularity,
+        }).expand();
+        this.mutex.exec(() => this.update(
+            { groupBy: [`${this.model.forecast_field}:${this.model.granularity}`] },
+            { reload: true }
+        ));
+    },
+});
+
+export {
+    ForecastKanbanController,
+};

--- a/addons/crm/static/src/js/forecast/forecast_kanban_column_quick_create.js
+++ b/addons/crm/static/src/js/forecast/forecast_kanban_column_quick_create.js
@@ -1,0 +1,48 @@
+/** @odoo-module */
+import Widget from 'web.Widget';
+import { _t } from 'web.core';
+
+/**
+ * Widget to handle events related to the Add button in
+ * ForecastKanban views. The view is supposed to automatically add
+ * the next column (chronological order), and use the
+ * FillTemporalService which will handle the covered fill_temporal period
+ * to know which column to add.
+ */
+const ForecastColumnQuickCreate = Widget.extend({
+    template: 'KanbanView.ForecastColumnQuickCreate',
+    events: {
+        'click .o_quick_create_folded': '_onAddColumnClicked',
+    },
+
+    /**
+     * @override
+     * @param {Object} options
+     * @param {string} [options.addColumnLabel] displayed label
+     *        (should be the granularity of a date/datetime groupBy)
+     */
+    init: function (parent, options) {
+        this._super.apply(this, arguments);
+        this.addColumnLabel = _.str.sprintf(_t('Add next %s'), options.addColumnLabel);
+    },
+
+    /**
+     * Notify the environment to add a column
+     *
+     * @private
+     */
+    _addColumn: function () {
+        this.trigger_up('forecast_kanban_add_column', {});
+    },
+
+    /**
+     * @private
+     * @param {MouseEvent} event
+     */
+    _onAddColumnClicked: function (event) {
+        event.stopPropagation();
+        this._addColumn();
+    },
+});
+
+export default ForecastColumnQuickCreate;

--- a/addons/crm/static/src/js/forecast/forecast_model_extension.js
+++ b/addons/crm/static/src/js/forecast/forecast_model_extension.js
@@ -1,0 +1,116 @@
+/** @odoo-module */
+import ActionModel from 'web.ActionModel';
+
+/**
+ * This file contains the logic behind a special "Forecast" filter.
+ * Any such filter should set the context key {forecast_filter: 1}
+ * Another context key must also be set for the view using this model extension:
+ * {forecast_field: "date_field_name"}, which represents the date/time field on which
+ * the forecast should be applied
+ *
+ * The main purpose is to be able to modify the domain depending on the groupby granularity
+ * when the field is a `date/time` field and is the `forecast_field`. The domain should filter
+ * records from the period (granularity) containing "now", or those where the forecast_field
+ * is not set.
+ * example:
+ *  today:          2021-04-21
+ *  granularity:    month
+ *  field name:     date_field
+ *  -> the domain would be: ['&', ['date_field', '=', false], ['date_field', '>=', '2021-04-01']]
+ */
+const DATE_FORMAT = {
+    datetime: "YYYY-MM-DD HH:mm:ss",
+    date: "YYYY-MM-DD",
+};
+class ForecastModelExtension extends ActionModel.Extension {
+    /**
+     * @override
+     * @returns {any}
+     */
+    get(property) {
+        switch (property) {
+            case "domain": return this.getDomain();
+            default: return super.get(...arguments);
+        }
+    }
+
+    /**
+     * @override
+     */
+    prepareState() {
+        super.prepareState(...arguments);
+        Object.assign(this.state, {
+            forecastField: null,  // {string} forecast_field from the context (name)
+            forecastFieldType: null,  // {string} forecast_field type (date or datetime)
+            forecastFilter: null,  // {boolean} if the "Forecast" filter is active
+            forecastStart: null,  // {string} limiting bound of the filter (if active)
+                                  // -> starting date before which records are filtered out
+        });
+    }
+
+    /**
+     * The state needs to be recomputed each time the parent model initiates a load action.
+     *
+     * @override
+     * @returns {Promise}
+     */
+    callLoad() {
+        this._computeState();
+        return super.callLoad(...arguments);
+    }
+
+    /**
+     * Adds a domain constraint to only get records from the start of the period containing "now",
+     * only if the "Forecast" filter is active
+     *
+     * @returns {Array[]}
+     */
+    getDomain() {
+        return !this.state.forecastFilter ? null :
+            ['|', [this.state.forecastField, '=', false],
+             [this.state.forecastField, '>=', this.state.forecastStart]
+            ];
+    }
+
+    /**
+     * The state is mostly dependent on 2 context keys :
+     * forecast_field -> is a prerequisite for this extension to work
+     * forecast_filter -> a filter which applies this context key should be present and active in
+     * order to get the modified domain
+     * If the forecast_field is present in the groupby, the related granularity is used
+     * If no granularity is specified, or if there is no groupby, the default is "month"
+     * If there is a groupby, but not the forecast_field, "day" is used (the filter will get data
+     * from 00:00:00 today, browser time)
+     *
+     * @private
+     */
+    _computeState() {
+        this.prepareState();
+        if (!this.config.context.forecast_field) { return; }
+        this.state.forecastField = this.config.context.forecast_field;
+        const format = DATE_FORMAT[this.config.fields[this.state.forecastField].type];
+        const filters = this.config.get('filters').flat();
+        this.state.forecastFilter = !!filters.filter(f => f.isActive && f.context &&
+            f.context.forecast_filter).length;
+        const groupBy = this.config.get('groupBy').flat();
+        const forecastGroupBys = groupBy.filter(gb => gb.includes(this.state.forecastField));
+        let granularity = "month";
+        if (forecastGroupBys.length > 0) {
+            [this.state.forecastField, granularity] = [...forecastGroupBys[0].split(":"), granularity];
+        } else if (groupBy.length) {
+            // there is a groupBy, but it is not the forecast_field
+            granularity = "day";
+        }
+        let startMoment = moment().startOf(granularity);
+        // The server needs a date/time in UTC, but to avoid a day shift in case
+        // of date, we only need to consider it for datetime fields
+        if (this.config.fields[this.state.forecastField].type === "datetime") {
+            startMoment = moment.utc(startMoment);
+        }
+        this.state.forecastStart = startMoment.format(format);
+    }
+}
+
+ActionModel.registry.add("Forecast", ForecastModelExtension, 20);
+
+export default ForecastModelExtension;

--- a/addons/crm/static/src/js/forecast/forecast_models.js
+++ b/addons/crm/static/src/js/forecast/forecast_models.js
@@ -1,0 +1,170 @@
+/** @odoo-module */
+import KanbanModel from 'web.KanbanModel';
+
+const ForecastKanbanModel = KanbanModel.extend({
+    /**
+     * Checks whether to apply the forecast logic to a load or a reload, depending on the groupby
+     * and the forecast_field. Sets the current granularity if the forecast applies
+     *
+     * @private
+     * @param {Object} element what to load (params) / reload (localData from id)
+     * @param {Object} params optional reload params
+     * @returns {boolean}
+     */
+    _isForecast(element, params={}) {
+        let groupby, granularity;
+        if (!element) {
+            return false;
+        }
+        if ("groupBy" in params) {
+            [groupby, granularity] = params.groupBy[0].split(':');
+        } else if (element.groupedBy.length != 0) {
+            [groupby, granularity] = element.groupedBy[0].split(':');
+        } else if (element.groupBy.length != 0) {
+            [groupby, granularity] = element.groupBy[0].split(':');
+        }
+        granularity = granularity || "month";
+        if (!this.forecast_field || groupby != this.forecast_field) {
+            return false;
+        }
+        this.granularity = granularity;
+        return true;
+    },
+
+    /**
+     * At every __load/__reload, we have to check the range of the last group received from the
+     * read_group, and update the fillTemporalPeriod from the FillTemporalService accordingly
+     *
+     * @private
+     */
+    _updateFillTemporalPeriodEnd(fillTemporalPeriod) {
+        let lastGroup = this.get(this.handle).data.filter(group => group.value).slice(-1)[0];
+        if (lastGroup) {
+            lastGroup = this.localData[lastGroup.id];
+            fillTemporalPeriod.setEnd(moment.utc(lastGroup.range[this.forecast_field].to));
+        }
+    },
+
+    /**
+     * Applies the forecast logic to the domain and context if needed before the read_group.
+     * After the read_group, checks the end date of the last displayed group in order to be able to
+     * add the next group with the ForecastColumnQuickCreate widget
+     *
+     * @private
+     * @override
+     */
+    async __load(params) {
+        this.loadDomain = params.domain;
+        this.loadContext = params.context;
+        this.forecast_field = params.context.forecast_field;
+        if (!this._isForecast(params)) {
+            return this._super(...arguments);
+        }
+        this.minGroups =
+            params.context.fill_temporal && params.context.fill_temporal.min_groups || undefined;
+        const fillTemporalPeriod = this.call('fillTemporalService', 'getFillTemporalPeriod', {
+            modelName: params.modelName,
+            field: {
+                name: this.forecast_field,
+                type: params.fields[this.forecast_field].type,
+            },
+            granularity: this.granularity,
+            minGroups: this.minGroups,
+            forceRecompute: true,
+        });
+        params.domain = fillTemporalPeriod.getDomain({
+            domain: this.loadDomain,
+            forceStartBound: false
+        });
+        params.context = fillTemporalPeriod.getContext({ context: this.loadContext });
+        this.handle = await this._super(...arguments);
+        this._updateFillTemporalPeriodEnd(fillTemporalPeriod);
+        return this.handle;
+    },
+
+    /**
+     * In order to display the sample data, the context and domain need to be the same as before a
+     * reload. If the user switches to another view (list, pivot, ...) and comes back without
+     * adding any record or modifying the search bar, we still want to display the sample data, but
+     * the actual domain and context won't be the same because load and reload are modifying them.
+     *
+     * As such, we will only compare the original domain and context (without the use of the
+     * FillTemporalService) to determine whether the sample data should be enabled or not.
+     *
+     * The behavior for timeRanges and groupBy is unchanged from the original
+     *
+     * @private
+     * @override
+     * @param {Object} [params={}]
+     * @param {Object} [params.context]
+     * @param {Array[]} [params.domain]
+     * @param {Object} [params.timeRanges]
+     * @param {string[]} [params.groupBy]
+     * @returns {boolean}
+     */
+    _haveParamsChanged(params = {}) {
+        const originalParams = [this.loadContext, this.loadDomain];
+        const currentParams = [this.reloadContext, this.reloadDomain];
+        if (JSON.stringify(originalParams) !== JSON.stringify(currentParams)) {
+            return true;
+        }
+        if ('timeRanges' in params) {
+            const diff = JSON.stringify(params.timeRanges) !== JSON.stringify(this.loadParams.timeRanges);
+            if (diff) {
+                return true;
+            }
+        }
+        if (this.useSampleModel && 'groupBy' in params) {
+            return JSON.stringify(params.groupBy) !== JSON.stringify(this.loadParams.groupedBy);
+        }
+    },
+
+    /**
+     * Applies the forecast logic to the domain and context if needed before the read_group.
+     * After the read_group, checks the end date of the last displayed group in order to be able to
+     * add the next group with the ForecastColumnQuickCreate widget
+     *
+     * @private
+     * @override
+     */
+    async __reload(id, params) {
+        if (this.handle !== id || this.isSampleModel) {
+            // the forecast logic should only apply when the whole view is reloading on real data
+            return this._super(...arguments);
+        }
+        if ("domain" in params) {
+            this.reloadDomain = params.domain;
+        }
+        if ("context" in params) {
+            this.reloadContext = params.context;
+            this.forecast_field = params.context.forecast_field;
+            this.minGroups =
+                params.context.fill_temporal && params.context.fill_temporal.min_groups || this.minGroups;
+        }
+        const element = this.localData[id];
+        if (!this._isForecast(element, params)) {
+            return this._super(...arguments);
+        }
+        const fillTemporalPeriod = this.call('fillTemporalService', 'getFillTemporalPeriod', {
+            modelName: this.loadParams.modelName,
+            field: {
+                name: this.forecast_field,
+                type: this.loadParams.fields[this.forecast_field].type,
+            },
+            granularity: this.granularity,
+            minGroups: this.minGroups,
+        });
+        params.domain = fillTemporalPeriod.getDomain({
+            domain: this.reloadDomain || this.loadDomain,
+            forceStartBound: false
+        });
+        params.context = fillTemporalPeriod.getContext({ context: this.reloadContext || this.loadContext });
+        const reload = await this._super(...arguments);
+        this._updateFillTemporalPeriodEnd(fillTemporalPeriod);
+        return reload;
+    },
+});
+
+export {
+    ForecastKanbanModel,
+};

--- a/addons/crm/static/src/js/forecast/forecast_renderers.js
+++ b/addons/crm/static/src/js/forecast/forecast_renderers.js
@@ -1,0 +1,31 @@
+/** @odoo-module */
+import ForecastColumnQuickCreate from './forecast_kanban_column_quick_create';
+import KanbanRenderer from 'web.KanbanRenderer';
+
+const ForecastKanbanRenderer = KanbanRenderer.extend({
+    /**
+     * Adds the widget ForecastColumnQuickCreate if there is a forecast_field and the current
+     * groupby targets it. It will be used to automatically add the next group for a date/datetime
+     * field
+     *
+     * @private
+     * @override
+     * @param {DocumentFragment} fragment
+     */
+    _renderGrouped(fragment) {
+        this._super(...arguments);
+        let [groupby, granularity] = this.state.groupedBy[0].split(":");
+        const forecast_field = this.state.context.forecast_field;
+        if (forecast_field && groupby === forecast_field) {
+            granularity = granularity || "month";
+            this.forecastColumnQuickCreate = new ForecastColumnQuickCreate(this, {
+                addColumnLabel: granularity,
+            });
+            this.defs.push(this.forecastColumnQuickCreate.appendTo(fragment));
+        }
+    },
+});
+
+export {
+    ForecastKanbanRenderer,
+};

--- a/addons/crm/static/src/js/forecast/forecast_views.js
+++ b/addons/crm/static/src/js/forecast/forecast_views.js
@@ -1,0 +1,96 @@
+/** @odoo-module */
+import { ForecastKanbanController } from './forecast_controllers';
+import { ForecastKanbanModel } from './forecast_models';
+import { ForecastKanbanRenderer } from './forecast_renderers';
+import GraphView from 'web.GraphView';
+import KanbanView from 'web.KanbanView';
+import ListView from 'web.ListView';
+import PivotView from 'web.PivotView';
+import viewRegistry from 'web.view_registry';
+
+/**
+ * Graph view to be used for a Forecast @see ForecastModelExtension
+ * requires:
+ * - context key `forecast_field` on a date/datetime field
+ * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ */
+const ForecastGraphView = GraphView.extend({
+    /**
+     * @private
+     * @override
+     */
+    _createSearchModel(params, extraExtensions = {}) {
+        Object.assign(extraExtensions, { Forecast: {} });
+        return this._super(params, extraExtensions);
+    },
+});
+viewRegistry.add('forecast_graph', ForecastGraphView);
+
+/**
+ * Kanban view to be used for a Forecast
+ * @see ForecastModelExtension
+ * @see FillTemporalService
+ * @see ForecastKanbanColumnQuickCreate
+ * requires:
+ * - context key `forecast_field` on a date/datetime field
+ * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ */
+const ForecastKanbanView = KanbanView.extend({
+    config: _.extend({}, KanbanView.prototype.config, {
+        Renderer: ForecastKanbanRenderer,
+        Model: ForecastKanbanModel,
+        Controller: ForecastKanbanController,
+    }),
+    /**
+     * @private
+     * @override
+     */
+    _createSearchModel(params, extraExtensions={}) {
+        Object.assign(extraExtensions, { Forecast: {} });
+        return this._super(params, extraExtensions);
+    },
+});
+viewRegistry.add('forecast_kanban', ForecastKanbanView);
+
+/**
+ * List view to be used for a Forecast @see ForecastModelExtension
+ * requires:
+ * - context key `forecast_field` on a date/datetime field
+ * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ */
+const ForecastListView = ListView.extend({
+    /**
+     * @private
+     * @override
+     */
+    _createSearchModel(params, extraExtensions = {}) {
+        Object.assign(extraExtensions, { Forecast: {} });
+        return this._super(params, extraExtensions);
+    },
+});
+viewRegistry.add('forecast_list', ForecastListView);
+
+/**
+ * Pivot view to be used for a Forecast @see ForecastModelExtension
+ * requires:
+ * - context key `forecast_field` on a date/datetime field
+ * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ */
+const ForecastPivotView = PivotView.extend({
+    /**
+     * @private
+     * @override
+     */
+    _createSearchModel(params, extraExtensions = {}) {
+        Object.assign(extraExtensions, { Forecast: {} });
+        return this._super(params, extraExtensions);
+    },
+});
+viewRegistry.add('forecast_pivot', ForecastPivotView);
+
+export {
+    ForecastGraphView,
+    ForecastKanbanView,
+    ForecastListView,
+    ForecastPivotView,
+};

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -21,7 +21,7 @@
         }
     }
 
-    .oe_kanban_card_lost_ribbon {
+    .oe_kanban_card_ribbon {
         min-height: 105px;
         .o_kanban_record_title {
             max-width: calc(100% - 65px);

--- a/addons/crm/static/src/xml/forecast_kanban.xml
+++ b/addons/crm/static/src/xml/forecast_kanban.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template>
+
+<t t-name="KanbanView.ForecastColumnQuickCreate">
+    <div class="o_column_quick_create">
+        <div class="o_quick_create_folded">
+            <span class="o_kanban_add_column"><i class="fa fa-plus" role="img" t-att-aria-label="widget.addColumnLabel" t-att-title="widget.addColumnLabel"/></span>
+            <span class="o_kanban_title"><t t-esc="widget.addColumnLabel"/></span>
+        </div>
+    </div>
+</t>
+</template>

--- a/addons/crm/static/tests/forecast_kanban_tests.js
+++ b/addons/crm/static/tests/forecast_kanban_tests.js
@@ -1,0 +1,258 @@
+/** @odoo-module */
+import FillTemporalService from '../src/js/forecast/fill_temporal_service';
+import { ForecastKanbanView } from '../src/js/forecast/forecast_views';
+import testUtils from 'web.test_utils';
+
+QUnit.module('Crm Forecast Model Extension', {
+    beforeEach: async function () {
+        this.testKanbanView = {
+            arch: `
+                <kanban js_class="forecast_kanban">
+                    <field name="date_deadline"/>
+                    <field name="date_closed"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="name"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            archs: {
+                "crm.lead,false,search": `
+                    <search>
+                        <filter name="forecast" string="Forecast" context="{'forecast_filter':1}"/>
+                        <filter name='groupby_date_deadline' context="{'group_by':'date_deadline'}"/>
+                        <filter name='groupby_date_closed' context="{'group_by':'date_closed'}"/>
+                    </search>`
+            },
+            data: {
+                'crm.lead': {
+                    fields: {
+                        name: {string: 'Name', type: 'char'},
+                        date_deadline: {string: "Expected closing", type: 'date'},
+                        date_closed: {string: "Closed Date", type: 'datetime'},
+                    },
+                    records: [
+                        {id: 1, name: 'Lead 1', date_deadline: '2021-01-01', date_closed: '2021-01-01 00:00:00'},
+                        {id: 2, name: 'Lead 2', date_deadline: '2021-01-20', date_closed: '2021-01-20 00:00:00'},
+                        {id: 3, name: 'Lead 3', date_deadline: '2021-02-01', date_closed: '2021-02-01 00:00:00'},
+                        {id: 4, name: 'Lead 4', date_deadline: '2021-02-20', date_closed: '2021-02-20 00:00:00'},
+                        {id: 5, name: 'Lead 5', date_deadline: '2021-03-01', date_closed: '2021-03-01 00:00:00'},
+                        {id: 6, name: 'Lead 6', date_deadline: '2021-03-20', date_closed: '2021-03-20 00:00:00'},
+                    ],
+                },
+            },
+            services: { 'fillTemporalService': FillTemporalService },
+            model: 'crm.lead',
+            View: ForecastKanbanView,
+            viewOptions: {
+                context: {
+                    search_default_forecast: true,
+                    search_default_groupby_date_deadline: true,
+                    forecast_field: 'date_deadline',
+                },
+            },
+            groupBy: ['date_deadline'],
+            
+        };
+        this.unPatchDate = testUtils.mock.patchDate(2021, 1, 10, 0, 0, 0);
+    },
+    afterEach: async function () {
+        this.unPatchDate();
+    },
+
+}, function () {
+    QUnit.test("filter out every records before the start of the current month with forecast_filter for a date field", async function (assert) {
+        // the filter is used by the forecast model extension, and applies the forecast_filter context key,
+        // which adds a domain constraint on the field marked in the other context key forecast_field
+        assert.expect(7);
+
+        const kanban = await testUtils.createView(this.testKanbanView);
+
+        // the filter is active
+        assert.containsN(kanban, '.o_kanban_group', 2, "There should be 2 columns");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(1) .o_kanban_record', 2,
+                        "1st column February should contain 2 record");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(2) .o_kanban_record', 2,
+                        "2nd column March should contain 2 records");
+
+        // remove the filter
+        await testUtils.dom.click($('.o_searchview_facet:contains("Forecast") .o_facet_remove'));
+
+        assert.containsN(kanban, '.o_kanban_group', 3, "There should be 3 columns");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(1) .o_kanban_record', 2,
+                        "1st column January should contain 2 record");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(2) .o_kanban_record', 2,
+                        "2nd column February should contain 2 records");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(3) .o_kanban_record', 2,
+                        "3nd column March should contain 2 records");
+        kanban.destroy();
+    });
+
+    QUnit.test("filter out every records before the start of the current month with forecast_filter for a datetime field", async function (assert) {
+        // same tests as for the date field
+        assert.expect(7);
+
+        this.testKanbanView.viewOptions.context = {
+            search_default_forecast: true,
+            search_default_groupby_date_closed: true,
+            forecast_field: 'date_closed',
+        };
+        this.testKanbanView.groupBy = ['date_closed'];
+        const kanban = await testUtils.createView(this.testKanbanView);
+
+        // with the filter
+        assert.containsN(kanban, '.o_kanban_group', 2, "There should be 2 columns");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(1) .o_kanban_record', 2,
+                        "1st column February should contain 2 record");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(2) .o_kanban_record', 2,
+                        "2nd column March should contain 2 records");
+
+        // remove the filter
+        await testUtils.dom.click($('.o_searchview_facet:contains("Forecast") .o_facet_remove'));
+
+        assert.containsN(kanban, '.o_kanban_group', 3, "There should be 3 columns");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(1) .o_kanban_record', 2,
+                        "1st column January should contain 2 record");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(2) .o_kanban_record', 2,
+                        "2nd column February should contain 2 records");
+        assert.containsN(kanban, '.o_kanban_group:nth-child(3) .o_kanban_record', 2,
+                        "3nd column March should contain 2 records");
+        kanban.destroy();
+    });
+});
+
+QUnit.module('Crm Fill Temporal Service', {
+    /**
+     * Remark: -> the filter with the groupBy is needed for the model_extension to access the groupby
+     * when created with testUtils.createView. Not needed in production.
+     *         -> testKanbanView.groupBy is still needed to apply the groupby on the view
+     */
+    beforeEach: async function () {
+        this.testKanbanView = {
+            arch: `
+                <kanban js_class="forecast_kanban">
+                    <field name="date_deadline"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="name"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            archs: {
+                "crm.lead,false,search": `
+                    <search>
+                        <filter name="forecast" string="Forecast" context="{'forecast_filter':1}"/>
+                        <filter name='groupby_date_deadline' context="{'group_by':'date_deadline'}"/>
+                    </search>`
+            },
+            data: {
+                'crm.lead': {
+                    fields: {
+                        name: {string: 'Name', type: 'char'},
+                        date_deadline: {string: "Expected Closing", type: 'date'},
+                    },
+                },
+            },
+            services: { 'fillTemporalService': FillTemporalService },
+            model: 'crm.lead',
+            View: ForecastKanbanView,
+            viewOptions: {
+                context: {
+                    search_default_forecast: true,
+                    search_default_groupby_date_deadline: true,
+                    forecast_field: 'date_deadline',
+                },
+            },
+            groupBy: ['date_deadline'],
+        };
+        this.unPatchDate = testUtils.mock.patchDate(2021, 9, 10, 0, 0, 0);
+    },
+    afterEach: async function () {
+        this.unPatchDate();
+    },
+
+}, function () {
+    /**
+     * Since mock_server does not support fill_temporal, 
+     * we only check the domain and the context sent to the read_group, as well
+     * as the end value of the FillTemporal Service after the read_group (which should have been updated in the model)
+     */
+    QUnit.test("Forecast on months, until the end of the year of the latest data", async function (assert) {
+        assert.expect(3);
+
+        this.testKanbanView.data['crm.lead'].records = [
+            {id: 1, name: 'Lead 1', date_deadline: '2021-01-01'},
+            {id: 2, name: 'Lead 2', date_deadline: '2021-02-01'},
+            {id: 3, name: 'Lead 3', date_deadline: '2021-11-01'},
+            {id: 4, name: 'Lead 4', date_deadline: '2022-01-01'},
+        ];
+        this.testKanbanView.mockRPC = function (route, args) {
+            if (route === '/web/dataset/call_kw/crm.lead/web_read_group') {
+                assert.deepEqual(args.kwargs.context.fill_temporal, {
+                    fill_from: "2021-10-01",
+                    min_groups: 4,
+                });
+                assert.deepEqual(args.kwargs.domain, [
+                    "&", "|",
+                        ["date_deadline", "=", false], ["date_deadline", ">=", "2021-10-01"],
+                    "|",
+                        ["date_deadline", "=", false], ["date_deadline", "<", "2023-01-01"],
+                ]);
+            }
+            return this._super.apply(this, arguments);
+        };
+        const kanban = await testUtils.createView(this.testKanbanView);
+        assert.strictEqual(kanban.call('fillTemporalService', 'getFillTemporalPeriod', {
+            modelName: 'crm.lead',
+            field: {
+                name: 'date_deadline',
+                type: 'date',
+            },
+            granularity: 'month',
+        }).end.format('YYYY-MM-DD'), '2022-02-01');
+        kanban.destroy();
+    });
+
+    /**
+     * Since mock_server does not support fill_temporal, 
+     * we only check the domain and the context sent to the read_group, as well
+     * as the end value of the FillTemporal Service after the read_group (which should have been updated in the model)
+     */
+    QUnit.test("Forecast on years, until the end of the year of the latest data", async function (assert) {
+        assert.expect(3);
+
+        this.testKanbanView.data['crm.lead'].records = [
+            {id: 1, name: 'Lead 1', date_deadline: '2021-01-01'},
+            {id: 2, name: 'Lead 2', date_deadline: '2022-02-01'},
+            {id: 3, name: 'Lead 3', date_deadline: '2027-11-01'},
+        ];
+        this.testKanbanView.groupBy = ['date_deadline:year'];
+        this.testKanbanView.archs["crm.lead,false,search"] = 
+            this.testKanbanView.archs["crm.lead,false,search"].replace("'date_deadline'", "'date_deadline:year'");
+        this.testKanbanView.mockRPC = function (route, args) {
+            if (route === '/web/dataset/call_kw/crm.lead/web_read_group') {
+                assert.deepEqual(args.kwargs.context.fill_temporal, {
+                    fill_from: "2021-01-01",
+                    min_groups: 4,
+                });
+                assert.deepEqual(args.kwargs.domain, [
+                    "&", "|",
+                        ["date_deadline", "=", false], ["date_deadline", ">=", "2021-01-01"],
+                    "|",
+                        ["date_deadline", "=",  false], ["date_deadline", "<", "2025-01-01"],
+                ]);
+            }
+            return this._super.apply(this, arguments);
+        };
+        const kanban = await testUtils.createView(this.testKanbanView);
+        assert.strictEqual(kanban.call('fillTemporalService', 'getFillTemporalPeriod', {
+            modelName: 'crm.lead',
+            field: {
+                name: 'date_deadline',
+                type: 'date',
+            },
+            granularity: 'year',
+        }).end.format('YYYY-MM-DD'), '2023-01-01');
+        kanban.destroy();
+    });
+});

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -1,0 +1,98 @@
+/** @odoo-module */
+import tour from 'web_tour.tour';
+const today = moment();
+
+tour.register('crm_forecast', {
+    test: true,
+    url: "/web",
+}, [
+    tour.stepUtils.showAppsMenuItem(),
+    {
+        trigger: ".o_app[data-menu-xmlid='crm.crm_menu_root']",
+        content: "open crm app",
+    }, {
+        trigger: '.o_dropdown_toggler[data-menu-xmlid="crm.crm_menu_report"]',
+        content: 'Open Reporting menu',
+        run: 'click',
+    }, {
+        trigger: '.o_dropdown_item[data-menu-xmlid="crm.crm_menu_forecast"]',
+        content: 'Open Forecast menu',
+        run: 'click',
+    }, {
+        trigger: '.o_column_quick_create:contains(Add next month)',
+        content: 'Wait page loading'
+    }, {
+        trigger: ".o-kanban-button-new",
+        content: "click create",
+        run: 'click',
+    }, {
+        trigger: "input[name=name]",
+        content: "complete name",
+        run: "text Test Opportunity 1",
+    }, {
+        trigger: "div[name=expected_revenue] > input",
+        content: "complete expected revenue",
+        run: "text 999999",
+    }, {
+        trigger: "button.o_kanban_edit",
+        content: "edit lead",
+    }, {
+        trigger: "input[name=date_deadline]",
+        content: "complete expected closing",
+        run: `text ${today.format("MM/DD/YYYY")}`,
+    }, {
+        trigger: "input[name=date_deadline]",
+        content: "click to make the datepicker disappear",
+        run: "click"
+    }, {
+        trigger: "body:not(:has(div.bootstrap-datetimepicker-widget))",
+        content: "wait for date_picker to disappear",
+        run: function () {},
+    }, {
+        trigger: '.o_back_button',
+        content: 'navigate back to the kanban view',
+        position: "bottom",
+        run: "click"
+    }, {
+        trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Opportunity 1')",
+        content: "move to the next month",
+        run: function (actions) {
+            const undefined_groups = $('.o_column_title:contains("Undefined")').length;
+            actions.drag_and_drop(` .o_opportunity_kanban .o_kanban_group:eq(${1 + undefined_groups})`, this.$anchor);
+        }
+    }, {
+        trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Opportunity 1')",
+        content: "edit lead",
+        run: "click"
+    }, {
+        trigger: `span[name=date_deadline]:contains("${moment(today).add(2, 'months').startOf('month').subtract(1, 'days').format("MM/DD/YYYY")}")`,
+        content: "edit datetime",
+        position: "bottom",
+        run: "click"
+    }, {
+        trigger: "input[name=date_deadline]",
+        content: "complete expected closing",
+        run: `text ${moment(today).add(5, 'months').startOf('month').subtract(1, 'days').format("MM/DD/YYYY")}`
+    }, {
+        trigger: "body:not(:has(div.bootstrap-datetimepicker-widget))",
+        content: "wait for date_picker to disappear",
+        run: function () {},
+    }, {
+        trigger: "input[name=probability]",
+        content: "max out probability",
+        run: "text 100"
+    }, {
+        trigger: '.o_back_button',
+        content: 'navigate back to the kanban view',
+        position: "bottom",
+        run: "click"
+    }, {
+        trigger: '.o_kanban_add_column',
+        content: "add next month",
+        run: "click"
+    }, {
+        trigger: ".o_kanban_record:contains('Test Opportunity 1'):contains('Won')",
+        content: "assert that the opportunity has the Won banner",
+        run: function () {},
+    }
+]);

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -25,6 +25,8 @@ class TestUi(HttpCase):
         })
         self.start_tour("/web", 'crm_rainbowman', login="temp_crm_user")
 
+    def test_03_crm_tour_forecast(self):
+        self.start_tour("/web", 'crm_forecast', login="admin")
 
 class TestCRMLeadMisc(TestCrmCommon):
 

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -535,7 +535,7 @@
                     <templates>
                         <t t-name="kanban-box">
                             <t t-set="lost_ribbon" t-value="!record.active.raw_value and record.probability and record.probability.raw_value == 0"/>
-                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} #{lost_ribbon ? 'oe_kanban_card_lost_ribbon' : ''} oe_kanban_global_click oe_kanban_card d-flex flex-column">
+                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} #{lost_ribbon ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click oe_kanban_card d-flex flex-column">
                                 <div class="ribbon ribbon-top-right"
                                     attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}">
                                     <span class="bg-danger">Lost</span>
@@ -588,6 +588,59 @@
                         </t>
                     </templates>
                 </kanban>
+            </field>
+        </record>
+
+        <record id="crm_lead_view_kanban_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.kanban.forecast</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_case_kanban_view_leads"/>
+            <field name="mode">primary</field>
+            <field name="priority">32</field>
+            <field name="arch" type="xml">
+                <xpath expr="//kanban" position="attributes">
+                    <attribute name="default_group_by">date_deadline</attribute>
+                    <attribute name="js_class">forecast_kanban</attribute>
+                </xpath>
+                <xpath expr="//kanban" position="inside">
+                    <field name="date_deadline" allow_group_range_value="true"/>
+                </xpath>
+                <xpath expr="//field[@name='expected_revenue']" position="replace">
+                    <field name="prorated_revenue"/>
+                </xpath>
+                <xpath expr="//progressbar" position="attributes">
+                    <attribute name="sum_field">prorated_revenue</attribute>
+                </xpath>
+                <xpath expr="//t[@t-set='lost_ribbon']" position="after">
+                    <t t-set="won_ribbon" t-value="record.active.raw_value and record.probability and record.probability.raw_value == 100"/>
+                </xpath>
+                <xpath expr="//div[contains(@t-attf-class, 'oe_kanban_card')]" position="attributes">
+                    <attribute name="t-attf-class">
+                        #{!selection_mode ? kanban_color(record.color.raw_value) : ''}
+                        #{lost_ribbon || won_ribbon ? 'oe_kanban_card_ribbon' : ''}
+                        oe_kanban_global_click oe_kanban_card d-flex flex-column
+                    </attribute>
+                </xpath>
+                <xpath expr="//div[hasclass('ribbon')]" position="replace">
+                    <div class="ribbon ribbon-top-right"
+                        attrs="{'invisible': ['&amp;', '|', ('probability', '&gt;', 0), ('active', '=', True),
+                            '|', ('probability', '&lt;', 100), ('active', '=', False)]}">
+                        <span t-if="won_ribbon" class="bg-success">Won</span>
+                        <span t-elif="lost_ribbon" class="bg-danger">Lost</span>
+                    </div>
+                </xpath>
+                <xpath expr="//div[hasclass('o_kanban_record_subtitle')]" position="replace">
+                    <div class="o_kanban_record_subtitle">
+                        <t t-if="record.prorated_revenue.raw_value">
+                            <field name="prorated_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                            <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value"> + </span>
+                        </t>
+                        <t t-if="record.recurring_revenue and record.recurring_revenue.raw_value">
+                            <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                            <field name="recurring_plan"/>
+                        </t>
+                    </div>
+                </xpath>
             </field>
         </record>
 
@@ -738,6 +791,25 @@
             </field>
         </record>
 
+        <record id="crm_lead_view_tree_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.tree.forecast</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_case_tree_view_oppor"/>
+            <field name="mode">primary</field>
+            <field name="priority">32</field>
+            <field name="arch" type="xml">
+                <xpath expr="//tree" position="attributes">
+                    <attribute name="js_class">forecast_list</attribute>
+                </xpath>
+                <xpath expr="//field[@name='expected_revenue']" position="attributes">
+                    <attribute name="optional">hide</attribute>
+                </xpath>
+                <xpath expr="//field[@name='expected_revenue']" position="after">
+                    <field name="prorated_revenue" sum="Prorated Revenues" optional="show" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="crm_lead_view_list_activities" model="ir.ui.view">
             <field name="name">crm.lead.list.activities</field>
             <field name="model">crm.lead</field>
@@ -797,6 +869,24 @@
             </field>
         </record>
 
+        <record id="crm_lead_view_graph_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.graph.forecast</field>
+            <field name="model">crm.lead</field>
+            <field name="priority">32</field>
+            <field name="arch" type="xml">
+                <graph string="Opportunities Forecast" sample="1" js_class="forecast_graph">
+                    <field name="date_deadline" type="row"/>
+                    <field name="prorated_revenue" type="measure"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="color" invisible="1"/>
+                    <field name="day_open" invisible="1"/>
+                    <field name="day_close" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
+                </graph>
+            </field>
+        </record>
+
         <record id="crm_lead_view_pivot" model="ir.ui.view">
             <field name="name">crm.lead.view.pivot</field>
             <field name="model">crm.lead</field>
@@ -807,6 +897,25 @@
                     <field name="expected_revenue" type="measure"/>
                     <field name="recurring_revenue_monthly" type="measure"/>
                     <field name="color" invisible="1"/>
+                </pivot>
+            </field>
+        </record>
+
+        <record id="crm_lead_view_pivot_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.pivot.forecast</field>
+            <field name="model">crm.lead</field>
+            <field name="priority">32</field>
+            <field name="arch" type="xml">
+                <pivot string="Forecast Analysis" sample="1" js_class="forecast_pivot">
+                    <field name="date_deadline" interval="month" type="row"/>
+                    <field name="stage_id" type="col"/>
+                    <field name="prorated_revenue" type="measure"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="color" invisible="1"/>
+                    <field name="day_open" invisible="1"/>
+                    <field name="day_close" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
                 </pivot>
             </field>
         </record>
@@ -884,6 +993,24 @@
                         <filter string="Closed Date" name="date_closed" context="{'group_by':'date_closed'}"/>
                     </group>
                 </search>
+            </field>
+        </record>
+
+        <record id="crm_lead_view_search_forecast" model="ir.ui.view">
+            <field name="name">crm.lead.view.search.forecast</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.view_crm_case_opportunities_filter"/>
+            <field name="mode">primary</field>
+            <field name="priority">32</field>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='assigned_to_me']" position="before">
+                    <filter name="forecast" string="Upcoming Closings" context="{'forecast_filter':1}"/>
+                    <separator/>
+                </xpath>
+                <xpath expr="//filter[@name='date_deadline']" position="replace"/>
+                <filter name="month" position="before">
+                    <filter string="Expected Closing" name="date_deadline" context="{'group_by':'date_deadline:month'}"/>
+                </filter>
             </field>
         </record>
 
@@ -1095,8 +1222,61 @@ if record:
             <field name="act_window_id" ref="crm_lead_action_pipeline"/>
         </record>
 
+        <record id="crm_lead_action_forecast" model="ir.actions.act_window">
+            <field name="name">Forecast</field>
+            <field name="res_model">crm.lead</field>
+            <field name="view_mode">kanban,graph,pivot,tree,form</field>
+            <field name="domain">[('type', '=', 'opportunity')]</field>
+            <field name="context">{
+                'default_type': 'opportunity',
+                'search_default_assigned_to_me': 1,
+                'search_default_forecast': 1,
+                'search_default_date_deadline': 1,
+                'forecast_field': 'date_deadline'
+            }</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No opportunity to display!
+                </p><p>
+                    Easily set expected closing dates and overview your revenue streams.
+                </p>
+            </field>
+            <field name="search_view_id" ref="crm.crm_lead_view_search_forecast"/>
+        </record>
+
+        <record id="crm_lead_action_forecast_view_kanban" model="ir.actions.act_window.view">
+            <field name="sequence" eval="0"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="crm_lead_view_kanban_forecast"/>
+            <field name="act_window_id" ref="crm_lead_action_forecast"/>
+        </record>
+
+        <record id="crm_lead_action_forecast_view_graph" model="ir.actions.act_window.view">
+            <field name="sequence" eval="1"/>
+            <field name="view_mode">graph</field>
+            <field name="view_id" ref="crm_lead_view_graph_forecast"/>
+            <field name="act_window_id" ref="crm_lead_action_forecast"/>
+        </record>
+
+        <record id="crm_lead_action_forecast_view_pivot" model="ir.actions.act_window.view">
+            <field name="sequence" eval="2"/>
+            <field name="view_mode">pivot</field>
+            <field name="view_id" ref="crm_lead_view_pivot_forecast"/>
+            <field name="act_window_id" ref="crm_lead_action_forecast"/>
+        </record>
+
+        <record id="crm_lead_action_forecast_view_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="3"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="crm_lead_view_tree_forecast"/>
+            <field name="act_window_id" ref="crm_lead_action_forecast"/>
+        </record>
+
         <record id="menu_crm_opportunities" model="ir.ui.menu">
             <field name="action" ref="crm.action_your_pipeline"/>
+        </record>
+        <record id="crm_menu_forecast" model="ir.ui.menu">
+            <field name="action" ref="crm.action_opportunity_forecast"/>
         </record>
         <record id="crm_menu_root" model="ir.ui.menu">
             <field name="action" ref="crm.action_your_pipeline"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1014,23 +1014,6 @@
             </field>
         </record>
 
-        <!--
-            'Mark as Lost' in action dropdown
-        -->
-        <record id="action_mark_as_lost" model="ir.actions.server">
-            <field name="name">Mark as lost</field>
-            <field name="model_id" ref="model_crm_lead"/>
-            <field name="binding_model_id" ref="crm.model_crm_lead"/>
-            <field name="binding_view_types">list</field>
-            <field name="state">code</field>
-            <field name="code">
-if record:
-    action_values = env.ref('crm.crm_lead_lost_action').sudo().read()[0]
-    action_values.update({'context': env.context})
-    action = action_values
-            </field>
-        </record>
-
         <!-- Lead Menu -->
         <record model="ir.actions.act_window" id="crm_lead_all_leads">
             <field name="name">Leads</field>
@@ -1165,14 +1148,6 @@ if record:
             <field name="view_mode">calendar</field>
             <field name="view_id" ref="crm_case_calendar_view_leads"/>
             <field name="act_window_id" ref="crm_lead_opportunities"/>
-        </record>
-
-        <record id="action_your_pipeline" model="ir.actions.server">
-            <field name="name">Crm: My Pipeline</field>
-            <field name="model_id" ref="crm.model_crm_team"/>
-            <field name="state">code</field>
-            <field name="groups_id"  eval="[(4, ref('base.group_user'))]"/>
-            <field name="code">action = model.action_your_pipeline()</field>
         </record>
 
         <record model="ir.actions.act_window" id="crm_lead_action_pipeline">

--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -61,16 +61,21 @@
         sequence="20"
         groups="sales_team.group_sale_salesman"/>
     <menuitem
+        id="crm_menu_forecast"
+        name="Forecast"
+        parent="crm_menu_report"
+        sequence="1"/>
+    <menuitem
         id="crm_opportunity_report_menu_lead"
         name="Leads"
         parent="crm_menu_report"
         groups="crm.group_use_lead"
-        sequence="1"/>
+        sequence="2"/>
     <menuitem
         id="crm_opportunity_report_menu" 
         name="Pipeline"
         parent="crm_menu_report" 
-        sequence="2"/>
+        sequence="3"/>
 
     <!-- CONFIGURATION -->
     <menuitem

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -652,6 +652,7 @@ var BasicModel = AbstractModel.extend({
             res_ids: element.res_ids.slice(0),
             type: 'list',
             value: element.value,
+            range: element.range,
             viewType: element.viewType,
         };
         if (element.fieldsInfo) {
@@ -4053,6 +4054,9 @@ var BasicModel = AbstractModel.extend({
      * @param {boolean} [params.static=false]
      * @param {string} [params.type='record'|'list']
      * @param {[type]} [params.value]
+     * @param {Object} [params.range] only for datapoints representing groups coming from a groupBy on a
+     *   date(time) field @see _readGroup format: {[fieldName]: {from: string, to: string}}, where
+     *   'from' (inclusive) and 'to' (exclusive) are the group bounds under the respective date format
      * @param {string} [params.viewType] the type of the view, e.g. 'list' or 'form'
      * @returns {Object} the resource created
      */
@@ -4119,6 +4123,7 @@ var BasicModel = AbstractModel.extend({
             static: params.static || false,
             type: type,  // 'record' | 'list'
             value: value,
+            range: params.range,
             viewType: params.viewType,
         };
 
@@ -4731,6 +4736,7 @@ var BasicModel = AbstractModel.extend({
                         fields: list.fields,
                         fieldsInfo: list.fieldsInfo,
                         value: value,
+                        range: group.__range,
                         aggregateValues: aggregateValues,
                         groupedBy: list.groupedBy.slice(1),
                         orderedBy: list.orderedBy,

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
@@ -208,7 +208,8 @@ var KanbanColumn = Widget.extend({
         }
         this.trigger_up('close_quick_create'); // close other quick create widgets
         var context = this.data.getContext();
-        context['default_' + this.groupedBy] = viewUtils.getGroupValue(this.data, this.groupedBy);
+        var groupByField = viewUtils.getGroupByField(this.groupedBy);
+        context['default_' + groupByField] = viewUtils.getGroupValue(this.data, groupByField);
         this.quickCreateWidget = new RecordQuickCreate(this, {
             context: context,
             formViewRef: this.quickCreateView,

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column_progressbar.js
@@ -35,6 +35,7 @@ var KanbanColumnProgressBar = Widget.extend({
             __false: 'muted', // color to use for false value
         });
         this.sumField = columnState.progressBarValues.sum_field;
+        this.sumFieldLabel = this.sumField ? columnState.fields[this.sumField].string : false;
 
         // Previous progressBar state
         var state = options.progressBarStates[this.columnID];

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_controller.js
@@ -438,8 +438,8 @@ var KanbanController = BasicController.extend({
                 var columnState = self.model.get(column.db_id, {raw: true});
                 var context = columnState.getContext();
                 var state = self.model.get(self.handle, {raw: true});
-                var groupedBy = state.groupedBy[0];
-                context['default_' + groupedBy] = viewUtils.getGroupValue(columnState, groupedBy);
+                var groupByField = viewUtils.getGroupByField(state.groupedBy[0]);
+                context['default_' + groupByField] = viewUtils.getGroupValue(columnState, groupByField);
                 new view_dialogs.FormViewDialog(self, {
                     res_model: state.model,
                     context: _.extend({default_name: values.name || values.display_name}, context),

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_model.js
@@ -113,8 +113,8 @@ var KanbanModel = BasicModel.extend({
         var group = this.localData[groupID];
         var context = this._getContext(group);
         var parent = this.localData[group.parentID];
-        var groupedBy = parent.groupedBy;
-        context['default_' + groupedBy] = viewUtils.getGroupValue(group, groupedBy);
+        var groupByField = viewUtils.getGroupByField(parent.groupedBy[0]);
+        context['default_' + groupByField] = viewUtils.getGroupValue(group, groupByField);
         var def;
         if (Object.keys(values).length === 1 && 'display_name' in values) {
             // only 'display_name is given, perform a 'name_create'
@@ -234,9 +234,12 @@ var KanbanModel = BasicModel.extend({
         var parent = this.localData[parentID];
         var new_group = this.localData[groupID];
         var changes = {};
-        var groupedFieldName = parent.groupedBy[0];
+        var groupedFieldName = viewUtils.getGroupByField(parent.groupedBy[0]);
         var groupedField = parent.fields[groupedFieldName];
-        if (groupedField.type === 'many2one') {
+        // for a date/datetime field, we take the last moment of the group as the group value
+        if (['date', 'datetime'].includes(groupedField.type)) {
+            changes[groupedFieldName] = viewUtils.getGroupValue(new_group, groupedFieldName);
+        } else if (groupedField.type === 'many2one') {
             changes[groupedFieldName] = {
                 id: new_group.res_id,
                 display_name: new_group.value,

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
@@ -494,27 +494,34 @@ var KanbanRenderer = BasicRenderer.extend({
         this._super(...arguments);
 
         var groupByField = this.state.groupedBy[0];
-        var cleanGroupByField = this._cleanGroupByField(groupByField);
+        var cleanGroupByField = viewUtils.getGroupByField(groupByField);
         var groupByFieldAttrs = this.state.fields[cleanGroupByField];
         var groupByFieldInfo = this.state.fieldsInfo.kanban[cleanGroupByField];
-        // Deactivate the drag'n'drop if the groupedBy field:
-        // - is a date or datetime since we group by month or
-        // - is readonly (on the field attrs or in the view)
+        // Deactivate the drag'n'drop:
+        // - if the groupedBy field is readonly (on the field attrs or in the view)
+        // - for date and datetime if :
+        //   - allowGroupRangeValue is not true
+        var readonly = false;
         var draggable = true;
         var grouped_by_date = false;
         if (groupByFieldAttrs) {
             if (groupByFieldAttrs.type === "date" || groupByFieldAttrs.type === "datetime") {
                 draggable = false;
                 grouped_by_date = true;
-            } else if (groupByFieldAttrs.readonly !== undefined) {
-                draggable = !(groupByFieldAttrs.readonly);
+            }
+            if (groupByFieldAttrs.readonly !== undefined) {
+                readonly = groupByFieldAttrs.readonly;
             }
         }
         if (groupByFieldInfo) {
-            if (draggable && groupByFieldInfo.readonly !== undefined) {
-                draggable = !(groupByFieldInfo.readonly);
+            if (grouped_by_date) {
+                draggable = groupByFieldInfo.allowGroupRangeValue;
+            }
+            if (!readonly && groupByFieldInfo.readonly !== undefined) {
+                readonly = groupByFieldInfo.readonly;
             }
         }
+        draggable = !readonly && draggable;
         this.groupedByM2O = groupByFieldAttrs && (groupByFieldAttrs.type === 'many2one');
         var relation = this.groupedByM2O && groupByFieldAttrs.relation;
         var groupByTooltip = groupByFieldInfo && groupByFieldInfo.options.group_by_tooltip;
@@ -528,22 +535,6 @@ var KanbanRenderer = BasicRenderer.extend({
             quick_create: this.quickCreateEnabled && viewUtils.isQuickCreateEnabled(this.state),
         });
         this.createColumnEnabled = this.groupedByM2O && this.columnOptions.group_creatable;
-    },
-    /**
-     * Remove date/datetime magic grouping info to get proper field attrs/info from state
-     * ex: sent_date:month will become sent_date
-     *
-     * @private
-     * @param {string} groupByField
-     * @returns {string}
-     */
-    _cleanGroupByField: function (groupByField) {
-        var cleanGroupByField = groupByField;
-        if (cleanGroupByField && cleanGroupByField.indexOf(':') > -1) {
-            cleanGroupByField = cleanGroupByField.substring(0, cleanGroupByField.indexOf(':'));
-        }
-
-        return cleanGroupByField;
     },
     /**
      * Moves the focus on the first card of the next column in a given direction

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_view.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_view.js
@@ -103,6 +103,23 @@ var KanbanView = BasicView.extend({
         return true;
     },
     /**
+     * Handles the <field> attribute allow_group_range_value,
+     * used to configure, for a date(time) field, whether we want to use the front-end
+     * logic to get the group value. (i.e. with drag&drop and quickCreate features)
+     * if false, those features will be disabled for the current field.
+     * Only handles the following types: date / datetime
+     * if undefined the default is false
+     *
+     * @override
+     */
+    _processField(viewType, field, attrs) {
+        if (['date', 'datetime'].includes(field.type) && 'allow_group_range_value' in attrs) {
+            attrs.allowGroupRangeValue = !!JSON.parse(attrs.allow_group_range_value);
+            delete attrs.allow_group_range_value;
+        }
+        return this._super(...arguments);
+    },
+    /**
      * Detect <img t-att-src="kanban_image(...)"/> nodes to automatically add the
      * '__last_update' field in the fieldsInfo to ensure that the images is
      * properly reloaded when necessary.

--- a/addons/web/static/src/legacy/xml/kanban.xml
+++ b/addons/web/static/src/legacy/xml/kanban.xml
@@ -117,7 +117,7 @@
                     t-attf-style="width: #{count ? (count * 100 / widget.groupCount) : 0}%;"/>
             </t>
         </div>
-        <div class="o_kanban_counter_side"><b><t t-esc="widget.totalCounterValue || 0"/></b></div>
+        <div class="o_kanban_counter_side" t-att-title="widget.sumFieldLabel || ''"><b><t t-esc="widget.totalCounterValue || 0"/></b></div>
     </div>
 </t>
 

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -209,6 +209,7 @@
             <rng:ref name="overload"/>
             <rng:ref name="access_rights"/>
             <rng:ref name="modifiable"/>
+            <rng:optional><rng:attribute name="allow_group_range_value"/></rng:optional>
             <rng:optional><rng:attribute name="domain_filter"/></rng:optional>
             <rng:optional><rng:attribute name="attrs"/></rng:optional>
             <rng:optional><rng:attribute name="class"/></rng:optional>

--- a/odoo/addons/test_read_group/tests/test_empty.py
+++ b/odoo/addons/test_read_group/tests/test_empty.py
@@ -20,6 +20,7 @@ class TestEmptyDate(common.TransactionCase):
         self.assertEqual(gb, [{
             '__count': 3,
             '__domain': [('date', '=', False)],
+            '__range': {'date': False},
             'date': False,
             'value': 6
         }])
@@ -34,6 +35,7 @@ class TestEmptyDate(common.TransactionCase):
         self.assertEqual(gb, [{
             '__count': 3,
             '__domain': [('date', '=', False)],
+            '__range': {'date': False},
             'date:quarter': False,
             'value': 6
         }])
@@ -49,11 +51,13 @@ class TestEmptyDate(common.TransactionCase):
         self.assertSequenceEqual(sorted(gb, key=lambda r: r['date'] or ''), [{
             '__count': 2,
             '__domain': [('date', '=', False)],
+            '__range': {'date': False},
             'date': False,
             'value': 3,
         }, {
             '__count': 2,
             '__domain': ['&', ('date', '>=', '1916-12-01'), ('date', '<', '1917-01-01')],
+            '__range': {'date': {'from': '1916-12-01', 'to': '1917-01-01'}},
             'date': 'December 1916',
             'value': 7,
         }])

--- a/odoo/addons/test_read_group/tests/test_fill_temporal.py
+++ b/odoo/addons/test_read_group/tests/test_fill_temporal.py
@@ -26,26 +26,31 @@ class TestFillTemporal(common.TransactionCase):
 
         expected = [{
             '__domain': ['&', ('date', '>=', '1916-08-01'), ('date', '<', '1916-09-01')],
+            '__range': {'date': {'from': '1916-08-01', 'to': '1916-09-01'}},
             'date': 'August 1916',
             'date_count': 1,
             'value': 2
         }, {
             '__domain': ['&', ('date', '>=', '1916-09-01'), ('date', '<', '1916-10-01')],
+            '__range': {'date': {'from': '1916-09-01', 'to': '1916-10-01'}},
             'date': 'September 1916',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1916-10-01'), ('date', '<', '1916-11-01')],
+            '__range': {'date': {'from': '1916-10-01', 'to': '1916-11-01'}},
             'date': 'October 1916',
             'date_count': 1,
             'value': 3
         }, {
             '__domain': ['&', ('date', '>=', '1916-11-01'), ('date', '<', '1916-12-01')],
+            '__range': {'date': {'from': '1916-11-01', 'to': '1916-12-01'}},
             'date': 'November 1916',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1916-12-01'), ('date', '<', '1917-01-01')],
+            '__range': {'date': {'from': '1916-12-01', 'to': '1917-01-01'}},
             'date': 'December 1916',
             'date_count': 1,
             'value': 5
@@ -76,66 +81,79 @@ class TestFillTemporal(common.TransactionCase):
 
         expected = [{
             '__domain': ['&', ('date', '>=', '1915-01-01'), ('date', '<', '1915-02-01')],
+            '__range': {'date': {'from': '1915-01-01', 'to': '1915-02-01'}},
             'date': 'January 1915',
             'date_count': 1,
             'value': 3
         }, {
             '__domain': ['&', ('date', '>=', '1915-02-01'), ('date', '<', '1915-03-01')],
+            '__range': {'date': {'from': '1915-02-01', 'to': '1915-03-01'}},
             'date': 'February 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-03-01'), ('date', '<', '1915-04-01')],
+            '__range': {'date': {'from': '1915-03-01', 'to': '1915-04-01'}},
             'date': 'March 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-04-01'), ('date', '<', '1915-05-01')],
+            '__range': {'date': {'from': '1915-04-01', 'to': '1915-05-01'}},
             'date': 'April 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-05-01'), ('date', '<', '1915-06-01')],
+            '__range': {'date': {'from': '1915-05-01', 'to': '1915-06-01'}},
             'date': 'May 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-06-01'), ('date', '<', '1915-07-01')],
+            '__range': {'date': {'from': '1915-06-01', 'to': '1915-07-01'}},
             'date': 'June 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-07-01'), ('date', '<', '1915-08-01')],
+            '__range': {'date': {'from': '1915-07-01', 'to': '1915-08-01'}},
             'date': 'July 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-08-01'), ('date', '<', '1915-09-01')],
+            '__range': {'date': {'from': '1915-08-01', 'to': '1915-09-01'}},
             'date': 'August 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-09-01'), ('date', '<', '1915-10-01')],
+            '__range': {'date': {'from': '1915-09-01', 'to': '1915-10-01'}},
             'date': 'September 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-10-01'), ('date', '<', '1915-11-01')],
+            '__range': {'date': {'from': '1915-10-01', 'to': '1915-11-01'}},
             'date': 'October 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-11-01'), ('date', '<', '1915-12-01')],
+            '__range': {'date': {'from': '1915-11-01', 'to': '1915-12-01'}},
             'date': 'November 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1915-12-01'), ('date', '<', '1916-01-01')],
+            '__range': {'date': {'from': '1915-12-01', 'to': '1916-01-01'}},
             'date': 'December 1915',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1916-01-01'), ('date', '<', '1916-02-01')],
+            '__range': {'date': {'from': '1916-01-01', 'to': '1916-02-01'}},
             'date': 'January 1916',
             'date_count': 1,
             'value': 5
@@ -158,6 +176,7 @@ class TestFillTemporal(common.TransactionCase):
         self.Model.create({'date': False, 'value': 17})
 
         expected = [{'__domain': [('date', '=', False)],
+                     '__range': {'date': False},
                      'date_count': 3,
                      'value': 41,
                      'date': False}]
@@ -180,21 +199,25 @@ class TestFillTemporal(common.TransactionCase):
 
         expected = [{
             '__domain': ['&', ('date', '>=', '1916-08-01'), ('date', '<', '1916-09-01')],
+            '__range': {'date': {'from': '1916-08-01', 'to': '1916-09-01'}},
             'date': 'August 1916',
             'date_count': 2,
             'value': 7
         }, {
             '__domain': ['&', ('date', '>=', '1916-09-01'), ('date', '<', '1916-10-01')],
+            '__range': {'date': {'from': '1916-09-01', 'to': '1916-10-01'}},
             'date': 'September 1916',
             'date_count': 0,
             'value': 0
         }, {
             '__domain': ['&', ('date', '>=', '1916-10-01'), ('date', '<', '1916-11-01')],
+            '__range': {'date': {'from': '1916-10-01', 'to': '1916-11-01'}},
             'date': 'October 1916',
             'date_count': 2,
             'value': 9
         }, {
             '__domain': [('date', '=', False)],
+            '__range': {'date': False},
             'date': False,
             'date_count': 2,
             'value': 24
@@ -219,16 +242,19 @@ class TestFillTemporal(common.TransactionCase):
 
         expected = [{
             '__domain': ['&', ('date', '>=', '1916-08-01'), ('date', '<', '1916-09-01')],
+            '__range': {'date': {'from': '1916-08-01', 'to': '1916-09-01'}},
             'date': 'August 1916',
             'date_count': 2,
             'value': 7
         }, {
             '__domain': ['&', ('date', '>=', '1916-09-01'), ('date', '<', '1916-10-01')],
+            '__range': {'date': {'from': '1916-09-01', 'to': '1916-10-01'}},
             'date': 'September 1916',
             'date_count': 0,
             'value': False
         }, {
             '__domain': ['&', ('date', '>=', '1916-10-01'), ('date', '<', '1916-11-01')],
+            '__range': {'date': {'from': '1916-10-01', 'to': '1916-11-01'}},
             'date': 'October 1916',
             'date_count': 2,
             'value': 9
@@ -259,6 +285,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                       ('datetime', '>=', '1916-08-01 00:00:00'),
                       ('datetime', '<', '1916-09-01 00:00:00')],
+            '__range': {'datetime': {'from': '1916-08-01 00:00:00', 'to': '1916-09-01 00:00:00'}},
             'datetime': 'August 1916',
             'datetime_count': 2,
             'value': 10
@@ -266,6 +293,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                       ('datetime', '>=', '1916-09-01 00:00:00'),
                       ('datetime', '<', '1916-10-01 00:00:00')],
+            '__range': {'datetime': {'from': '1916-09-01 00:00:00', 'to': '1916-10-01 00:00:00'}},
             'datetime': 'September 1916',
             'datetime_count': 0,
             'value': False
@@ -273,11 +301,13 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                       ('datetime', '>=', '1916-10-01 00:00:00'),
                       ('datetime', '<', '1916-11-01 00:00:00')],
+            '__range': {'datetime': {'from': '1916-10-01 00:00:00', 'to': '1916-11-01 00:00:00'}},
             'datetime': 'October 1916',
             'datetime_count': 3,
             'value': 26
         }, {
             '__domain': [('datetime', '=', False)],
+            '__range': {'datetime': False},
             'datetime': False,
             'datetime_count': 2,
             'value': 24
@@ -308,6 +338,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 01:00:00'),
                          ('datetime', '<', '1916-01-01 02:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 01:00:00', 'to': '1916-01-01 02:00:00'}},
             'datetime:hour': '01:00 01 Jan',
             'datetime_count': 2,
             'value': 10
@@ -315,6 +346,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 02:00:00'),
                          ('datetime', '<', '1916-01-01 03:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 02:00:00', 'to': '1916-01-01 03:00:00'}},
             'datetime:hour': '02:00 01 Jan',
             'datetime_count': 1,
             'value': 3
@@ -322,6 +354,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 03:00:00'),
                          ('datetime', '<', '1916-01-01 04:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 03:00:00', 'to': '1916-01-01 04:00:00'}},
             'datetime:hour': '03:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -329,6 +362,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 04:00:00'),
                          ('datetime', '<', '1916-01-01 05:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 04:00:00', 'to': '1916-01-01 05:00:00'}},
             'datetime:hour': '04:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -336,6 +370,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 05:00:00'),
                          ('datetime', '<', '1916-01-01 06:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 05:00:00', 'to': '1916-01-01 06:00:00'}},
             'datetime:hour': '05:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -343,6 +378,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 06:00:00'),
                          ('datetime', '<', '1916-01-01 07:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 06:00:00', 'to': '1916-01-01 07:00:00'}},
             'datetime:hour': '06:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -350,6 +386,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 07:00:00'),
                          ('datetime', '<', '1916-01-01 08:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 07:00:00', 'to': '1916-01-01 08:00:00'}},
             'datetime:hour': '07:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -357,6 +394,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 08:00:00'),
                          ('datetime', '<', '1916-01-01 09:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 08:00:00', 'to': '1916-01-01 09:00:00'}},
             'datetime:hour': '08:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -364,6 +402,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 09:00:00'),
                          ('datetime', '<', '1916-01-01 10:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 09:00:00', 'to': '1916-01-01 10:00:00'}},
             'datetime:hour': '09:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -371,6 +410,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 10:00:00'),
                          ('datetime', '<', '1916-01-01 11:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 10:00:00', 'to': '1916-01-01 11:00:00'}},
             'datetime:hour': '10:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -378,6 +418,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 11:00:00'),
                          ('datetime', '<', '1916-01-01 12:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 11:00:00', 'to': '1916-01-01 12:00:00'}},
             'datetime:hour': '11:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -385,6 +426,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 12:00:00'),
                          ('datetime', '<', '1916-01-01 13:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 12:00:00', 'to': '1916-01-01 13:00:00'}},
             'datetime:hour': '12:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -392,6 +434,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 13:00:00'),
                          ('datetime', '<', '1916-01-01 14:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 13:00:00', 'to': '1916-01-01 14:00:00'}},
             'datetime:hour': '01:00 01 Jan',
             'datetime_count': 1,
             'value': 5
@@ -399,6 +442,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 14:00:00'),
                          ('datetime', '<', '1916-01-01 15:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 14:00:00', 'to': '1916-01-01 15:00:00'}},
             'datetime:hour': '02:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -406,6 +450,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 15:00:00'),
                          ('datetime', '<', '1916-01-01 16:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 15:00:00', 'to': '1916-01-01 16:00:00'}},
             'datetime:hour': '03:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -413,6 +458,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 16:00:00'),
                          ('datetime', '<', '1916-01-01 17:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 16:00:00', 'to': '1916-01-01 17:00:00'}},
             'datetime:hour': '04:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -420,6 +466,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 17:00:00'),
                          ('datetime', '<', '1916-01-01 18:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 17:00:00', 'to': '1916-01-01 18:00:00'}},
             'datetime:hour': '05:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -427,6 +474,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 18:00:00'),
                          ('datetime', '<', '1916-01-01 19:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 18:00:00', 'to': '1916-01-01 19:00:00'}},
             'datetime:hour': '06:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -434,6 +482,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 19:00:00'),
                          ('datetime', '<', '1916-01-01 20:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 19:00:00', 'to': '1916-01-01 20:00:00'}},
             'datetime:hour': '07:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -441,6 +490,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 20:00:00'),
                          ('datetime', '<', '1916-01-01 21:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 20:00:00', 'to': '1916-01-01 21:00:00'}},
             'datetime:hour': '08:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -448,6 +498,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 21:00:00'),
                          ('datetime', '<', '1916-01-01 22:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 21:00:00', 'to': '1916-01-01 22:00:00'}},
             'datetime:hour': '09:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -455,6 +506,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 22:00:00'),
                          ('datetime', '<', '1916-01-01 23:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 22:00:00', 'to': '1916-01-01 23:00:00'}},
             'datetime:hour': '10:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -462,6 +514,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 23:00:00'),
                          ('datetime', '<', '1916-01-02 00:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 23:00:00', 'to': '1916-01-02 00:00:00'}},
             'datetime:hour': '11:00 01 Jan',
             'datetime_count': 1,
             'value': 7
@@ -485,6 +538,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1915-12-31 22:00:00'),
                          ('datetime', '<', '1915-12-31 23:00:00')],
+            '__range': {'datetime': {'from': '1915-12-31 22:00:00', 'to': '1915-12-31 23:00:00'}},
             'datetime:hour': '04:00 01 Jan',
             'datetime_count': 1,
             'value': 2
@@ -492,6 +546,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1915-12-31 23:00:00'),
                          ('datetime', '<', '1916-01-01 00:00:00')],
+            '__range': {'datetime': {'from': '1915-12-31 23:00:00', 'to': '1916-01-01 00:00:00'}},
             'datetime:hour': '05:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -499,6 +554,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 00:00:00'),
                          ('datetime', '<', '1916-01-01 01:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 00:00:00', 'to': '1916-01-01 01:00:00'}},
             'datetime:hour': '06:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -506,6 +562,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 01:00:00'),
                          ('datetime', '<', '1916-01-01 02:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 01:00:00', 'to': '1916-01-01 02:00:00'}},
             'datetime:hour': '07:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -513,6 +570,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 02:00:00'),
                          ('datetime', '<', '1916-01-01 03:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 02:00:00', 'to': '1916-01-01 03:00:00'}},
             'datetime:hour': '08:00 01 Jan',
             'datetime_count': 0,
             'value': False
@@ -520,6 +578,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '1916-01-01 03:00:00'),
                          ('datetime', '<', '1916-01-01 04:00:00')],
+            '__range': {'datetime': {'from': '1916-01-01 03:00:00', 'to': '1916-01-01 04:00:00'}},
             'datetime:hour': '09:00 01 Jan',
             'datetime_count': 1,
             'value': 3
@@ -543,6 +602,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                 ('datetime', '>=', '2015-12-31 17:00:00'),
                 ('datetime', '<', '2016-03-31 16:00:00')],
+            '__range': {'datetime': {'from': '2015-12-31 17:00:00', 'to': '2016-03-31 16:00:00'}},
             'datetime:quarter': 'Q1 2016',
             'datetime_count': 1,
             'value': 2
@@ -550,6 +610,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                        ('datetime', '>=', '2016-03-31 16:00:00'),
                        ('datetime', '<', '2016-06-30 16:00:00')],
+            '__range': {'datetime': {'from': '2016-03-31 16:00:00', 'to': '2016-06-30 16:00:00'}},
             'datetime:quarter': 'Q2 2016',
             'datetime_count': 0,
             'value': False
@@ -557,6 +618,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                        ('datetime', '>=', '2016-06-30 16:00:00'),
                        ('datetime', '<', '2016-09-30 17:00:00')],
+            '__range': {'datetime': {'from': '2016-06-30 16:00:00', 'to': '2016-09-30 17:00:00'}},
             'datetime:quarter': 'Q3 2016',
             'datetime_count': 0,
             'value': False
@@ -564,6 +626,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                        ('datetime', '>=', '2016-09-30 17:00:00'),
                        ('datetime', '<', '2016-12-31 17:00:00')],
+            '__range': {'datetime': {'from': '2016-09-30 17:00:00', 'to': '2016-12-31 17:00:00'}},
             'datetime:quarter': 'Q4 2016',
             'datetime_count': 1,
             'value': 3
@@ -575,7 +638,7 @@ class TestFillTemporal(common.TransactionCase):
 
         self.assertEqual(groups, expected)
 
-    def test_egde_fx_tz(self):
+    def test_edge_fx_tz(self):
         """We test if different edge effect by using a different timezone from the user context
 
         Suppose a user resident near Hovd, a city in Mongolia. he sells a product
@@ -594,6 +657,7 @@ class TestFillTemporal(common.TransactionCase):
             '__domain': ['&',
                          ('datetime', '>=', '2017-12-31 17:00:00'),
                          ('datetime', '<', '2018-01-31 17:00:00')],
+            '__range': {'datetime': {'from': '2017-12-31 17:00:00', 'to': '2018-01-31 17:00:00'}},
             'datetime': 'January 2018',
             'datetime_count': 1,
             'value': 42

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2048,58 +2048,133 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     def _read_group_fill_temporal(self, data, groupby, aggregated_fields, annotated_groupbys,
-                                  interval=dateutil.relativedelta.relativedelta(months=1)):
+                                  fill_from=False, fill_to=False, min_groups=False):
         """Helper method for filling date/datetime 'holes' in a result set.
 
         We are in a use case where data are grouped by a date field (typically
         months but it could be any other interval) and displayed in a chart.
 
-        Assume we group records by month, and we only have data for August,
+        Assume we group records by month, and we only have data for June,
         September and December. By default, plotting the result gives something
         like:
                                                 ___
                                       ___      |   |
-                                     |   |     |   |
                                      |   | ___ |   |
-                                     |   ||   ||   |
                                      |___||___||___|
-                                      Aug  Sep  Dec
+                                      Jun  Sep  Dec
 
-        The problem is that December data follows immediately September data,
-        which is misleading for the user. Adding explicit zeroes for missing data
-        gives something like:
+        The problem is that December data immediately follow September data,
+        which is misleading for the user. Adding explicit zeroes for missing
+        data gives something like:
+                                                           ___
+                             ___                          |   |
+                            |   |           ___           |   |
+                            |___| ___  ___ |___| ___  ___ |___|
+                             Jun  Jul  Aug  Sep  Oct  Nov  Dec
+
+        To customize this output, the context key "fill_temporal" can be used
+        under its dictionary format, which has 3 attributes : fill_from,
+        fill_to, min_groups (see params of this function)
+
+        Fill between bounds:
+        Using either `fill_from` and/or `fill_to` attributes, we can further
+        specify that at least a certain date range should be returned as
+        contiguous groups. Any group outside those bounds will not be removed,
+        but the filling will only occur between the specified bounds. When not
+        specified, existing groups will be used as bounds, if applicable.
+        By specifying such bounds, we can get empty groups before/after any
+        group with data.
+
+        If we want to fill groups only between August (fill_from)
+        and October (fill_to):
                                                      ___
                                  ___                |   |
-                                |   |               |   |
-                                |   | ___           |   |
-                                |   ||   |          |   |
-                                |___||___| ___  ___ |___|
-                                 Aug  Sep  Oct  Nov  Dec
+                                |   |      ___      |   |
+                                |___| ___ |___| ___ |___|
+                                 Jun  Aug  Sep  Oct  Dec
+
+        We still get June and December. To filter them out, we should match
+        `fill_from` and `fill_to` with the domain e.g. ['&',
+            ('date_field', '>=', 'YYYY-08-01'),
+            ('date_field', '<', 'YYYY-11-01')]:
+                                         ___
+                                    ___ |___| ___
+                                    Aug  Sep  Oct
+
+        Minimal filling amount:
+        Using `min_groups`, we can specify that we want at least that amount of
+        contiguous groups. This amount is guaranteed to be provided from
+        `fill_from` if specified, or from the lowest existing group otherwise.
+        This amount is not restricted by `fill_to`. If there is an existing
+        group before `fill_from`, `fill_from` is still used as the starting
+        group for min_groups, because the filling does not apply on that
+        existing group. If neither `fill_from` nor `fill_to` is specified, and
+        there is no existing group, no group will be returned.
+
+        If we set min_groups = 4:
+                                         ___
+                                    ___ |___| ___ ___
+                                    Aug  Sep  Oct Nov
 
         :param list data: the data containing groups
         :param list groupby: name of the first group by
         :param list aggregated_fields: list of aggregated fields in the query
-        :param relativedelta interval: interval between two temporal groups
-                expressed as a relativedelta month by default
+        :param str fill_from: (inclusive) string representation of a
+            date/datetime, start bound of the fill_temporal range
+            formats: date -> %Y-%m-%d, datetime -> %Y-%m-%d %H:%M:%S
+        :param str fill_to: (inclusive) string representation of a
+            date/datetime, end bound of the fill_temporal range
+            formats: date -> %Y-%m-%d, datetime -> %Y-%m-%d %H:%M:%S
+        :param int min_groups: minimal amount of required groups for the
+            fill_temporal range (should be >= 1)
         :rtype: list
         :return: list
         """
         first_a_gby = annotated_groupbys[0]
-        if not data:
-            return data
         if first_a_gby['type'] not in ('date', 'datetime'):
             return data
         interval = first_a_gby['interval']
+        granularity = first_a_gby['granularity']
+        tz = pytz.timezone(self._context['tz']) if first_a_gby["tz_convert"] else False
         groupby_name = groupby[0]
 
         # existing non null datetimes
-        existing = [d[groupby_name] for d in data if d[groupby_name]]
+        existing = [d[groupby_name] for d in data if d[groupby_name]] or [None]
+        # assumption: existing data is sorted by field 'groupby_name'
+        existing_from, existing_to = existing[0], existing[-1]
 
-        if len(existing) < 2:
+        if fill_from:
+            fill_from = date_utils.start_of(odoo.fields.Datetime.to_datetime(fill_from), granularity)
+            if tz:
+                fill_from = tz.localize(fill_from)
+        elif existing_from:
+            fill_from = existing_from
+        if fill_to:
+            fill_to = date_utils.start_of(odoo.fields.Datetime.to_datetime(fill_to), granularity)
+            if tz:
+                fill_to = tz.localize(fill_to)
+        elif existing_to:
+            fill_to = existing_to
+
+        if not fill_to and fill_from:
+            fill_to = fill_from
+        if not fill_from and fill_to:
+            fill_from = fill_to
+        if not fill_from and not fill_to:
             return data
 
-        # assumption: existing data is sorted by field 'groupby_name'
-        first, last = existing[0], existing[-1]
+        if min_groups > 0:
+            fill_to = max(fill_to, fill_from + (min_groups - 1) * interval)
+
+        if fill_to < fill_from:
+            return data
+
+        required_dates = date_utils.date_range(fill_from, fill_to, interval)
+
+        if existing[0] is None:
+            existing = list(required_dates)
+        else:
+            existing = sorted(set().union(existing, required_dates))
 
         empty_item = {'id': False, (groupby_name.split(':')[0] + '_count'): 0}
         empty_item.update({key: False for key in aggregated_fields})
@@ -2110,8 +2185,7 @@ class BaseModel(metaclass=MetaModel):
             grouped_data[d[groupby_name]].append(d)
 
         result = []
-
-        for dt in date_utils.date_range(first, last, interval):
+        for dt in existing:
             result.extend(grouped_data[dt] or [dict(empty_item, **{groupby_name: dt})])
 
         if False in grouped_data:
@@ -2223,6 +2297,7 @@ class BaseModel(metaclass=MetaModel):
             'type': field_type,
             'display_format': display_formats[gb_function or 'month'] if temporal else None,
             'interval': time_intervals[gb_function or 'month'] if temporal else None,
+            'granularity': gb_function or 'month' if temporal else None,
             'tz_convert': tz_convert,
             'qualified_field': qualified_field,
         }
@@ -2503,9 +2578,15 @@ class BaseModel(metaclass=MetaModel):
 
         data = [{k: self._read_group_prepare_data(k, v, groupby_dict) for k, v in r.items()} for r in fetched_data]
 
-        if self.env.context.get('fill_temporal') and data:
+        fill_temporal = self.env.context.get('fill_temporal')
+        if (data and fill_temporal) or isinstance(fill_temporal, dict):
+            # fill_temporal = {} is equivalent to fill_temporal = True
+            # if fill_temporal is a dictionary and there is no data, there is a chance that we
+            # want to display empty columns anyway, so we should apply the fill_temporal logic
+            if not isinstance(fill_temporal, dict):
+                fill_temporal = {}
             data = self._read_group_fill_temporal(data, groupby, aggregated_fields,
-                                                  annotated_groupbys)
+                                                  annotated_groupbys, **fill_temporal)
 
         result = [self._read_group_format_result(d, annotated_groupbys, groupby, domain) for d in data]
 


### PR DESCRIPTION
RATIONALE

Make it easier for users to both build and see a forecast of their sales.

PURPOSE

Introduce forecasting by notably improving kanban view on crm.leads record.
It should be possible to group by date, add / remove columns dynamically
based on a given granularity (day, month, ...) and move / quick create
records.

Objective is to show the short term forecast for opportunities (crm_lead)
based on their expected closing (date_deadline) and have an overview of the
prorated revenues for each period (defaults to month).

MAIN CONTENT

[IMP] `core`, `web`: add a range for date(time) read_group

Add a way to get the date range of a group for a date(time) field in frontend.
As long as we are using Babel 2.6.0, it is not reliable to reverse-compute the
label to a range with moment.js (and will probably never be, since these are 2
different libraries)

Add a new `<field>` xml attribute `allow_group_range_value` for the kanban view
in order to enable/disable field by field the drag&drop and quickCreate
features.

[IMP] `core`: add a new dictionary format for fill_temporal

Add a dictionary format and optional keys to `fill_temporal` context key
for more flexibility with the `_read_group_fill_temporal` method from `models.py`.
Previously, we could only fill empty groups between groups containing records.
With the new format, it is possible to specify custom bounds or a minimum
amount of groups.

[IMP] `crm`: add a forecast feature (kanban, pivot, graph, list)

`fill_temporal_service.js`
The forecast will display records classified by a date/time field. A special
rule will be applied to show only the closest records (short term forecast)

`forecast_model_extension.js`
A special filter will be applied to show only future records, from the start
of the "groupBy" period containing "today"

[IMP] `crm`: implement the forecast feature for opportunities

Add a new submenu "Forecast" in "Reporting" for CRM. Forecast shows 4 views:

  1. Kanban
  2. Graph
  3. Pivot
  4. List

[MOV] `crm`: move server actions from lead views to a dedicated file

Taking advantage of the new action_opportunity_forecast for crm leads to
create a dedicated ir_actions.xml file to store all server/client actions.

[IMP] `web`: add hover description for kanban progressbar sum field

This commit adds a sum field description when hovering the quantity at the end
of a progressbar. The description is the label (translated string
representation) of the field used for the sum.

LINKS

Task ID-2243913
DOC PR odoo/documentation#1049