### PR TITLE
[FIX] l10n_in: Set automatically GST Treatment on invoice creation

### DIFF
--- a/addons/l10n_in_sale/wizard/sale_make_invoice_advance.py
+++ b/addons/l10n_in_sale/wizard/sale_make_invoice_advance.py
@@ -11,4 +11,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
         res = super()._prepare_invoice_values(order, name, amount, so_line)
         if order.l10n_in_journal_id:
             res['journal_id'] = order.l10n_in_journal_id.id
+        if order.l10n_in_company_country_code == 'IN':
+            res['l10n_in_gst_treatment'] = order.l10n_in_gst_treatment
+        if order.l10n_in_reseller_partner_id:
+            res['l10n_in_reseller_partner_id'] = order.l10n_in_reseller_partner_id
         return res


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Create a contact and set 'VAT' to "20AAACT2803M2ZO". The 'GST Treatment' will be automatically set correctly.
    2. Create a sale order for this new contact. GST Treatment is automatically filled in correctly.
    3.  Confirm the order.
    4. Create an invoice.

What is currently happening ?

    The related invoice does not fetch the 'GST Treatment' automatically

What are you expecting to happen ?

    The related invoice must set the 'GST Treatment' automatically.

opw-2499503