### PR TITLE
[FIX]pos_cash_rounding: do not allow not rounded payment line

### DIFF
--- a/addons/pos_cash_rounding/models/pos_order.py
+++ b/addons/pos_cash_rounding/models/pos_order.py
@@ -21,8 +21,76 @@ class PosOrder(models.Model):
             vals['invoice_cash_rounding_id'] = self.config_id.rounding_method.id
         return vals
 
+    def _create_invoice(self, move_vals):
+        new_move = super(PosOrder, self)._create_invoice(move_vals)
+        if self.config_id.cash_rounding:
+            rounding_applied = float_round(self.amount_paid - self.amount_total, precision_rounding=new_move.currency_id.rounding)
+            rounding_line = new_move.line_ids.filtered(lambda line: line.is_rounding_line)
+            if rounding_applied:
+                if rounding_applied > 0.0:
+                    account_id = new_move.invoice_cash_rounding_id._get_loss_account_id().id
+                else:
+                    account_id = new_move.invoice_cash_rounding_id._get_profit_account_id().id
+                if rounding_line:
+                    if rounding_line.debit > 0:
+                        rounding_line_difference = rounding_line.debit + rounding_applied
+                    else:
+                        rounding_line_difference = -rounding_line.credit + rounding_applied
+                    if rounding_line_difference:
+                        rounding_line.with_context(check_move_validity=False).write({
+                            'debit': rounding_applied < 0.0 and -rounding_applied or 0.0,
+                            'credit': rounding_applied > 0.0 and rounding_applied or 0.0,
+                            'account_id': account_id,
+                            'price_unit': rounding_applied,
+                        })
+                        existing_terms_line = new_move.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
+                        if existing_terms_line.debit > 0:
+                            existing_terms_line_new_val = float_round(existing_terms_line.debit + rounding_line_difference, precision_rounding=new_move.currency_id.rounding)
+                        else:
+                            existing_terms_line_new_val = float_round(-existing_terms_line.credit + rounding_line_difference, precision_rounding=new_move.currency_id.rounding)
+                        existing_terms_line.write({
+                            'debit': existing_terms_line_new_val > 0.0 and existing_terms_line_new_val or 0.0,
+                            'credit': existing_terms_line_new_val < 0.0 and -existing_terms_line_new_val or 0.0,
+                        })
+
+                        new_move._recompute_payment_terms_lines()
+
+                else:
+                     self.env['account.move.line'].create({
+                         'debit': rounding_applied < 0.0 and -rounding_applied or 0.0,
+                         'credit': rounding_applied > 0.0 and rounding_applied or 0.0,
+                         'quantity': 1.0,
+                         'amount_currency': rounding_applied,
+                         'partner_id': new_move.partner_id.id,
+                         'move_id': new_move.id,
+                         'currency_id': new_move.currency_id if new_move.currency_id != new_move.company_id.currency_id else False,
+                         'company_id': new_move.company_id.id,
+                         'company_currency_id': new_move.company_id.currency_id.id,
+                         'is_rounding_line': True,
+                         'sequence': 9999,
+                         'name': new_move.invoice_cash_rounding_id.name,
+                         'account_id': account_id,
+                     })
+            else:
+                if rounding_line:
+                    rounding_line.unlink()
+        return new_move
+
     def _get_amount_receivable(self):
         if self.config_id.cash_rounding and (
                 not self.config_id.only_round_cash_method or self.payment_ids.filtered(lambda p: p.payment_method_id.is_cash_count)):
             return self.amount_paid
         return super(PosOrder, self)._get_amount_receivable()
+
+    def _is_pos_order_paid(self):
+        res = super(PosOrder, self)._is_pos_order_paid()
+        if not res and self.config_id.cash_rounding:
+            currency = self.currency_id
+            if self.config_id.rounding_method.rounding_method == "HALF-UP":
+                maxDiff = currency.round(self.config_id.rounding_method.rounding / 2)
+            else:
+                maxDiff = currency.round(self.config_id.rounding_method.rounding)
+
+            diff = currency.round(self.amount_total - self.amount_paid)
+            res = abs(diff) < maxDiff
+        return res

--- a/addons/pos_cash_rounding/static/src/js/pos_cash_rounding.js
+++ b/addons/pos_cash_rounding/static/src/js/pos_cash_rounding.js
@@ -6,6 +6,8 @@ var rpc = require('web.rpc');
 var screens = require('point_of_sale.screens');
 var utils = require('web.utils');
 
+var core    = require('web.core');
+var _t      = core._t;
 var round_pr = utils.round_precision;
 
 
@@ -32,6 +34,13 @@ models.Order = models.Order.extend({
       due += this.get_rounding_applied();
       return round_pr(due, this.pos.currency.rounding);
     },
+    add_paymentline: function(payment_method){
+        _super_order.add_paymentline.apply(this, arguments);
+        if(this.pos.config.cash_rounding && (!payment_method.is_cash_count || this.pos.config.iface_precompute_cash)){
+          this.selected_paymentline.set_amount(0);
+          this.selected_paymentline.set_amount(this.get_due());
+        }
+    },
     get_change_value: function(paymentline) {
       var change  = _super_order.get_change_value.apply(this, arguments);
       change -= this.get_rounding_applied();
@@ -40,12 +49,13 @@ models.Order = models.Order.extend({
     get_rounding_applied: function() {
         if(this.pos.config.cash_rounding) {
             const only_cash = this.pos.config.only_round_cash_method;
-            const has_cash = _.some(this.get_paymentlines(), function(pl) { return pl.payment_method.is_cash_count == true;});
+            const has_cash = this.selected_paymentline ? this.selected_paymentline.payment_method.is_cash_count == true: false;
             if (!only_cash || (only_cash && has_cash)) {
-                var total = round_pr(this.get_total_with_tax(), this.pos.cash_rounding[0].rounding);
+                var remaining = this.get_total_with_tax() - this.get_total_paid();
+                var total = round_pr(remaining, this.pos.cash_rounding[0].rounding);
                 var sign = total > 0 ? 1.0 : -1.0;
 
-                var rounding_applied = total - this.get_total_with_tax();
+                var rounding_applied = total - remaining;
                 rounding_applied *= sign;
                 // because floor and ceil doesn't include decimals in calculation, we reuse the value of the half-up and adapt it.
                 if (utils.float_is_zero(rounding_applied, this.pos.currency.decimals)){
@@ -65,8 +75,43 @@ models.Order = models.Order.extend({
         }
         return 0;
     },
+    check_paymentlines_rounding: function() {
+        if(this.pos.config.cash_rounding) {
+            var cash_rounding = this.pos.cash_rounding[0].rounding;
+            var default_rounding = this.pos.currency.rounding;
+            for(var id in this.get_paymentlines()) {
+                var line = this.get_paymentlines()[id];
+                var diff = round_pr(round_pr(line.amount, cash_rounding) - round_pr(line.amount, default_rounding), default_rounding);
+                if(diff && line.payment_method.is_cash_count) {
+                    return false;
+                } else if(!this.pos.config.only_round_cash_method && diff) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return true;
+    },
     get_total_balance: function() {
         return this.get_total_with_tax() - this.get_total_paid() + this.get_rounding_applied();
     },
+    is_paid: function() {
+        var is_paid = _super_order.is_paid.apply(this, arguments);
+        return is_paid && this.check_paymentlines_rounding();
+    }
 });
+    screens.PaymentScreenWidget.include({
+        validate_order: function(force_validation) {
+            if(this.pos.config.cash_rounding) {
+                if(!this.pos.get_order().check_paymentlines_rounding()) {
+                    this.pos.gui.show_popup('error', {
+                        'title': _t("Rounding error in payment lines"),
+                        'body': _t("The amount of your payment lines must be rounded to validate the transaction."),
+                    });
+                    return;
+                }
+            }
+            this._super(event);
+        },
+    });
 });

--- a/addons/pos_cash_rounding/static/src/xml/pos.xml
+++ b/addons/pos_cash_rounding/static/src/xml/pos.xml
@@ -4,7 +4,11 @@
         <t t-jquery='.pos-receipt-amount:first' t-operation='after'>
           <t t-if="receipt.total_rounded != receipt.total_with_tax">
               <div class="pos-receipt-amount">
-                  ROUNDED
+                  Rounding
+                  <span t-esc='widget.format_currency(receipt.rounding_applied)' class="pos-receipt-right-align"/>
+              </div>
+              <div class="pos-receipt-amount">
+                  To Pay
                   <span t-esc='widget.format_currency(receipt.total_rounded)' class="pos-receipt-right-align"/>
               </div>
           </t>
@@ -13,7 +17,7 @@
     <t t-extend="PaymentScreen-Paymentlines">
         <t t-jquery='.paymentlines-empty > .total' t-operation='replace'>
             <div class='total'>
-                <t t-esc="widget.format_currency(order.get_total_with_tax() + order.get_rounding_applied())"/>
+                <t t-esc="widget.format_currency(order.get_total_with_tax())"/>
             </div>
         </t>
     </t>


### PR DESCRIPTION
Because of the law, the rounding must depend mostly of the last line.
ex: I must pay 12.13
If only 1 payment method:
  - Cash: Must be rounding to 12.15
  - Bank: I can pay 12.13 or 12.15 depending of the pos config

If multiples:
  - 10 bank and rest is cash:
	- Bank: 10
	- Cash: 2.15

  - 9.99 bank rest is cash:
	- Bank: 9.99(Can be rounded. Depend of the pos config)
	- Cash: 2.15

We also modify the end of the receipt for the main information when using cash rounding.
ex:
Total : 1.11€
Rouding : -0.01€
To pay : 1.10€

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
