### PR TITLE
[IMP] website_form: allow reuse of form_builder_send widget

### DIFF
--- a/addons/website_form/static/src/js/website_form.js
+++ b/addons/website_form/static/src/js/website_form.js
@@ -141,6 +141,11 @@ odoo.define('website_form.animation', function (require) {
             }
 
             // Post form and handle result
+            self.post_form(form_values)
+        },
+
+        post_form: function(form_values) {
+            var self = this;
             ajax.post(this.$target.attr('action') + (this.$target.data('force_action')||this.$target.data('model_name')), form_values)
             .then(function (result_data) {
                 result_data = JSON.parse(result_data);
@@ -274,4 +279,6 @@ odoo.define('website_form.animation', function (require) {
             });
         },
     });
+
+    return publicWidget.registry.form_builder_send
 });


### PR DESCRIPTION
This commit allows the `form_builder_send` widget to be reused.
Moreover, the creation of `post_form` allows other modules to specify
how post the form to the server

(Linked to OPW-2473001)