### PR TITLE
Document the supported `position` values of the `xpath` elements

### DIFF
--- a/doc/cla/individual/Rami-Sabbagh.md
+++ b/doc/cla/individual/Rami-Sabbagh.md
@@ -1,0 +1,11 @@
+Syria, 2021-04-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rami Sabbagh ramilego4game@gmail.com https://github.com/Rami-Sabbagh

--- a/doc/reference/qweb.rst
+++ b/doc/reference/qweb.rst
@@ -501,8 +501,13 @@ The ``XPath`` element takes a ``position`` attribute with the following supporte
     the node's body is inserted right before the context node
 ``after``
     the node's body is inserted right after the context node
+``replace``
+    the node's body is used to replace the context node itself
 ``attributes``
-    allows modifying the context node's attributes, example::
+    the nodes's body should be any number of ``attribute`` elements,
+    each with a ``name`` attribute and some textual content, the named
+    attribute of the context node will be set to the specified value
+    (either replaced if it already existed or added if not), example:
 
         <t t-inherit="base.template" t-inherit-mode="extension">
             <xpath expr="button[@disabled]" position="attributes">

--- a/doc/reference/qweb.rst
+++ b/doc/reference/qweb.rst
@@ -492,6 +492,24 @@ Extension inheritance (in-place transformation)::
         </xpath>
     </t>
 
+The ``XPath`` element takes a ``position`` attribute with the following supported values:
+
+``inside`` (default)
+    the node's body is appended at the end of the context node (after the
+    context node's last child)
+``before``
+    the node's body is inserted right before the context node
+``after``
+    the node's body is inserted right after the context node
+``attributes``
+    allows modifying the context node's attributes, example::
+
+        <t t-inherit="base.template" t-inherit-mode="extension">
+            <xpath expr="button[@disabled]" position="attributes">
+                <attribute name="disabled">false</attribute>
+            </xpath>
+        </t>
+
 Old inheritance mechanism (deprecated)
 ''''''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
The `position` attribute of the `xpath` element is not part of the XPath documentation, it's actually a feature provided by Odoo itself.

I attempted some basic search for it's documentation, but there were no results containing official documentation.

After some more search, I've found the following old post on a forum, listing the supported values:
http://findnerd.com/list/view/Different-position-values-used-in-xpath/12634/

And the following page on ReadTheDocs describing the `attributes` mode:
https://odoo-development.readthedocs.io/en/latest/dev/xml/xpath.html

So I've added this information in the documentation in the hope it'll save other coming developers time!

## Added information

The XPath element takes a position attribute with the following supported values:

- `inside` (default)
    the node's body is appended at the end of the context node (after the context node's last child)
- `before`
    the node's body is inserted right before the context node
- `after`
    the node's body is inserted right after the context node
- `replace`
    the node's body is used to replace the context node itself
- `attributes`
    the nodes's body should be any number of ``attribute`` elements,
    each with a ``name`` attribute and some textual content, the named
    attribute of the context node will be set to the specified value
    (either replaced if it already existed or added if not), example:

```xml
        <t t-inherit="base.template" t-inherit-mode="extension">
            <xpath expr="button[@disabled]" position="attributes">
                <attribute name="disabled">false</attribute>
            </xpath>
        </t>
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
