### PR TITLE
[FIX] sale_coupon: Allow coupons to correctly allow several free products

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -95,7 +95,7 @@ class SaleOrder(models.Model):
                 order_total = sum(order_lines.mapped('price_total')) - (program.reward_product_quantity * program.reward_product_id.lst_price)
                 reward_product_qty = min(reward_product_qty, order_total // program.rule_minimum_amount)
         else:
-            reward_product_qty = min(max_product_qty, total_qty)
+            reward_product_qty = program.reward_product_quantity
 
         reward_qty = min(int(int(max_product_qty / program.rule_min_quantity) * program.reward_product_quantity), reward_product_qty)
         # Take the default taxes on the reward product, mapped with the fiscal position


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Add a coupon program with the following condition sale_ok == True & name == 'Large Desk'
    2. Add 'Buy 1 get 2 free' 'Large Cabinet'
    3. Create a quotation with 1 Large Desk and 2 Large Cabinet
    4. Add the coupon code

What is currently happening ?

    Promotion will only remove one * Large Cabinet price instead of 2

What are you expecting to happen ?

    Promotion remove two * Large Cabinet price

Why is this happening ?

    The products quantity was mixed with the reward products quantity

How to fix the bug ?

    Remove this first filter

opw-2496940