### PR TITLE
[REF] hr_*,product,stock: use _search on searching computed fields

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -303,8 +303,8 @@ class HolidaysRequest(models.Model):
         if not is_officer:
             domain = expression.AND([domain, [('user_id', '=', self.env.user.id)]])
 
-        leaves = self.search(domain)
-        return [('id', 'in', leaves.ids)]
+        leaves = self._search(domain)
+        return [('id', 'in', leaves)]
 
     @api.depends('holiday_status_id')
     def _compute_state(self):

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -247,8 +247,8 @@ class HolidaysAllocation(models.Model):
         if not is_officer:
             domain = expression.AND([domain, [('employee_id.user_id', '=', self.env.user.id)]])
 
-        allocations = self.sudo().search(domain)
-        return [('id', 'in', allocations.ids)]
+        allocations = self.sudo()._search(domain)
+        return [('id', 'in', allocations)]
 
     @api.depends('employee_id', 'holiday_status_id')
     def _compute_leaves(self):

--- a/addons/hr_recruitment/models/hr_employee.py
+++ b/addons/hr_recruitment/models/hr_employee.py
@@ -18,10 +18,10 @@ class HrEmployee(models.Model):
             employee.newly_hired_employee = bool(employee.create_date > (now - timedelta(days=90)))
 
     def _search_newly_hired_employee(self, operator, value):
-        employees = self.env['hr.employee'].search([
+        employees = self.env['hr.employee']._search([
             ('create_date', '>', fields.Datetime.now() - timedelta(days=90))
         ])
-        return [('id', 'in', employees.ids)]
+        return [('id', 'in', employees)]
 
     @api.model
     def create(self, vals):

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -273,8 +273,8 @@ class ProductTemplate(models.Model):
                 template.barcode = template.product_variant_ids.barcode
 
     def _search_barcode(self, operator, value):
-        templates = self.with_context(active_test=False).search([('product_variant_ids.barcode', operator, value)])
-        return [('id', 'in', templates.ids)]
+        templates = self.with_context(active_test=False)._search([('product_variant_ids.barcode', operator, value)])
+        return [('id', 'in', templates)]
 
     def _set_barcode(self):
         if len(self.product_variant_ids) == 1:

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -129,7 +129,7 @@ class StockQuant(models.Model):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise UserError(_('Operation not supported'))
         domain_loc = self.env['product.product']._get_domain_locations()[0]
-        quant_ids = [l['id'] for l in self.env['stock.quant'].search_read(domain_loc, ['id'])]
+        quant_ids = self.env['stock.quant']._search(domain_loc)
         if (operator == '!=' and value is True) or (operator == '=' and value is False):
             domain_operator = 'not in'
         else:


### PR DESCRIPTION
`model._search` return query object which can be considered as simple list of
ids [1], but because it's still query, it allows make subselect query and hence
make a better postgres plan, that just quering ``WHERE id
in (1,2,3,...,100333)``. That's why it's preferable than ``search([...]).ids``.

[1] https://github.com/odoo/odoo/blob/86cf231bf1a4c80f4c7bccdae406287ac90d9916/odoo/osv/query.py#L146-L162

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
