### PR TITLE
[IMP] base_import: fix field dropdown list return values

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -755,14 +755,13 @@ var DataImport = AbstractAction.extend({
             if (!_.isEmpty(suggested)) {
                 basic = basic.concat({ text: _t("Suggested Fields"), children: suggested });
             }
-            basic = basic.concat([
+            return basic.concat([
                 { text: !_.isEmpty(suggested) ? _t("Additional Fields") : _t("Standard Fields"), children: regulars },
                 { text: _t("Relation Fields"), children: o2m },
             ]);
         } else {
-            basic.concat(suggested, regulars, o2m);
+            return basic.concat(suggested, regulars, o2m);
         }
-        return basic;
     },
     render_fields_matches: function (result, $fields) {
         if (_(result.matches).isEmpty()) { return; }


### PR DESCRIPTION
When generating field completion, if there are no o2m or suggested fields,
the method was returning the list of values without adding the regulars fields.

This commit returns correctly the complete set of values.

Task ID: 2508902