### PR TITLE
[FIX] web: js_transpiler accepts object exports containing comments

### DIFF
--- a/doc/reference/javascript_reference.rst
+++ b/doc/reference/javascript_reference.rst
@@ -766,6 +766,33 @@ parser to transform native modules. There are, therefore, a number of limitation
       import X ...
     */
 
+- when you ``export`` an object, it can't contain a comment
+
+.. code-block:: javascript
+
+    // supported
+    export {
+      a as b,
+      c,
+      d,
+    }
+
+    export {
+      a
+    } from "./file_a"
+
+
+    // not supported
+    export {
+      a as b, // this is a comment
+      c,
+      d,
+    }
+
+    export {
+      a /* this is a comment */
+    } from "./file_a"
+
 - Odoo needs a way to determine if a module is described by a path (like ``./views/form_view``) or a name (like
   ``web.FormView``). It has to use a heuristic to do just that: if there is a ``/`` in the name, it is considered
   a path.  This means that Odoo does not really support anymore module names with a ``/``.


### PR DESCRIPTION
Before this commit, the js_transpiler did not convert object exports
containing a comment.

This commit will modify the regex EXPORT_OBJECT_RE and EXPORT_FROM_RE
so that they match all characters between { and }.

Example:
```js
export {
    a // this is a comment
}

export {
    a // this is a comment
}
```

Output before this commit (no modification is applied)
```js
export {
    a // this is a comment
}

export {
    a // this is a comment
} from "@addon/path"
```

Output after this commit

```js
Object.assign(__exports, {
        a // this is a comment
        })

{const {
        a // this is a comment
        } = require("@addon/path");Object.assign(__exports, {
        a // this is a comment
        })};
```

Limitation:
It is still impossible to have a comment containing `}` inside
an exported object. The js_tranpiler will generate wrong code
if this happens.

Example:
```js
export {
    a // this is a comment with }
}
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
