### PR TITLE
[IMP] core: add method mapped to query object

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -150,13 +150,13 @@ class HrEmployeeBase(models.AbstractModel):
                 employee.show_leaves = False
 
     def _search_absent_employee(self, operator, value):
-        holidays = self.env['hr.leave'].sudo().search([
+        holidays = self.env['hr.leave'].sudo()._search([
             ('employee_id', '!=', False),
             ('state', 'not in', ['cancel', 'refuse']),
             ('date_from', '<=', datetime.datetime.utcnow()),
             ('date_to', '>=', datetime.datetime.utcnow())
         ])
-        return [('id', 'in', holidays.mapped('employee_id').ids)]
+        return [('id', 'in', holidays.mapped('employee_id'))]
 
     @api.model
     def create(self, values):

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -238,8 +238,8 @@ class ProductTemplate(models.Model):
                 template.product_variant_ids.standard_price = template.standard_price
 
     def _search_standard_price(self, operator, value):
-        products = self.env['product.product'].search([('standard_price', operator, value)], limit=None)
-        return [('id', 'in', products.mapped('product_tmpl_id').ids)]
+        products = self.env['product.product']._search([('standard_price', operator, value)], limit=None)
+        return [('id', 'in', products.mapped('product_tmpl_id'))]
 
     @api.depends('product_variant_ids', 'product_variant_ids.volume')
     def _compute_volume(self):

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -20,8 +20,8 @@ class MailMessage(models.Model):
             message.rating_value = mapping.get(message.id, 0.0)
 
     def _search_rating_value(self, operator, operand):
-        ratings = self.env['rating.rating'].sudo().search([
+        ratings = self.env['rating.rating'].sudo()._search([
             ('rating', operator, operand),
             ('message_id', '!=', False)
         ])
-        return [('id', 'in', ratings.mapped('message_id').ids)]
+        return [('id', 'in', ratings.mapped('message_id'))]

--- a/addons/website_slides/models/res_partner.py
+++ b/addons/website_slides/models/res_partner.py
@@ -30,11 +30,11 @@ class ResPartner(models.Model):
             ]).mapped('channel_id')
 
     def _search_slide_channel_completed_ids(self, operator, value):
-        cp_done = self.env['slide.channel.partner'].sudo().search([
+        cp_done = self.env['slide.channel.partner'].sudo()._search([
             ('channel_id', operator, value),
             ('completed', '=', True)
         ])
-        return [('id', 'in', cp_done.partner_id.ids)]
+        return [('id', 'in', cp_done.mapped('partner_id'))]
 
     @api.depends('is_company')
     def _compute_slide_channel_count(self):

--- a/odoo/osv/query.py
+++ b/odoo/osv/query.py
@@ -143,6 +143,16 @@ class Query(object):
         where_clause = " AND ".join(self._where_clauses)
         return from_clause, where_clause, params + self._where_params
 
+    def mapped(self, path):
+        assert isinstance(path, str), "Method query.mapped cannot be called with function in argument. Convert it to a string or browse result first"
+        path_parts = path.split('.')
+        assert len(path_parts) == 1, "More than 1 field is not supported yet. Browse result first."
+
+        # TODO: add support for related/inherited fields?
+        last_field = path_parts[-1]
+        alias = next(iter(self._tables))
+        return self.select('"%s"."%s"' % (alias, last_field))
+
     @lazy_property
     def _result(self):
         query_str, params = self.select()


### PR DESCRIPTION
this adds more magic to `model._search` which should speed up some searching by
computed field, because we can make a single query instead of getting ids first
and then filtering by that ids

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
