### PR TITLE
[FIX] http_routing, website: prevent crash when using `fw` in url

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -11,6 +11,7 @@ import werkzeug.utils
 import werkzeug.wrappers
 
 from itertools import islice
+from werkzeug import urls
 from xml.etree import ElementTree as ET
 
 import odoo
@@ -82,10 +83,37 @@ class Website(Home):
 
         raise request.not_found()
 
-    @http.route('/website/force_website', type='json', auth="user")
-    def force_website(self, website_id):
-        request.env['website']._force_website(website_id)
-        return True
+    @http.route('/website/force/<int:website_id>', type='http', auth="user", website=True, sitemap=False, multilang=False)
+    def website_force(self, website_id, path='/', isredir=False, **kw):
+        """ To switch from a website to another, we need to force the website in
+        session, AFTER landing on that website domain (if set) as this will be a
+        different session.
+        """
+        parse = werkzeug.urls.url_parse
+        safe_path = parse(path).path
+
+        if not (request.env.user.has_group('website.group_multi_website')
+           and request.env.user.has_group('website.group_website_publisher')):
+            # The user might not be logged in on the forced website, so he won't
+            # have rights. We just redirect to the path as the user is already
+            # on the domain (basically a no-op as it won't change domain or
+            # force website).
+            # Website 1 : 127.0.0.1 (admin)
+            # Website 2 : 127.0.0.2 (not logged in)
+            # Click on "Website 2" from Website 1
+            return request.redirect(safe_path)
+
+        website = request.env['website'].browse(website_id)
+
+        if not isredir and website.domain:
+            domain_from = request.httprequest.environ.get('HTTP_HOST', '')
+            domain_to = parse(website._get_http_domain()).netloc
+            if domain_from != domain_to:
+                # redirect to correct domain for a correct routing map
+                url_to = urls.url_join(website._get_http_domain(), '/website/force/%s?isredir=1&path=%s' % (website.id, safe_path))
+                return request.redirect(url_to)
+        website._force()
+        return request.redirect(safe_path)
 
     # ------------------------------------------------------
     # Login - overwrite of the web login so that regular users are redirected to the backend

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -178,11 +178,12 @@ class Http(models.AbstractModel):
     @classmethod
     def _add_dispatch_parameters(cls, func):
 
-        # Force website with query string paramater, typically set from website selector in frontend navbar
+        # DEPRECATED for /website/force/<website_id> - remove me in master~saas-14.4
+        # Force website with query string paramater, typically set from website selector in frontend navbar and inside tests
         force_website_id = request.httprequest.args.get('fw')
-        if (force_website_id and request.session.get('force_website_id') != force_website_id and
-                request.env.user.has_group('website.group_multi_website') and
-                request.env.user.has_group('website.group_website_publisher')):
+        if (force_website_id and request.session.get('force_website_id') != force_website_id
+                and request.env.user.has_group('website.group_multi_website')
+                and request.env.user.has_group('website.group_website_publisher')):
             request.env['website']._force_website(request.httprequest.args.get('fw'))
 
         context = {}

--- a/addons/website/static/src/js/backend/dashboard.js
+++ b/addons/website/static/src/js/backend/dashboard.js
@@ -137,7 +137,7 @@ var Dashboard = AbstractAction.extend({
     on_go_to_website: function (ev) {
         ev.preventDefault();
         var website = _.findWhere(this.websites, {selected: true});
-        window.location.href = $.param.querystring(website.domain + '/', {'fw': website.id});
+        window.location.href = `/website/force/${website.id}`;
     },
 
     on_save_ga_client_id: function(ga_client_id, ga_analytics_key) {

--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -169,12 +169,12 @@ var WebsiteRoot = publicRootData.PublicRoot.extend({
     _onWebsiteSwitch: function (ev) {
         var websiteId = ev.currentTarget.getAttribute('website-id');
         var websiteDomain = ev.currentTarget.getAttribute('domain');
-        var url = window.location.href;
+        let url = `/website/force/${websiteId}`;
         if (websiteDomain && window.location.hostname !== websiteDomain) {
-            var path = window.location.pathname + window.location.search + window.location.hash;
-            url = websiteDomain + path;
+            url = websiteDomain + url;
         }
-        window.location.href = $.param.querystring(url, {'fw': websiteId});
+        const path = window.location.pathname + window.location.search + window.location.hash;
+        window.location.href = $.param.querystring(url, {'path': path});
     },
     /**
      * @private

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -139,8 +139,8 @@ class TestUi(odoo.tests.HttpCase):
                 </xpath>
             """,
         })
-        self.start_tour("/?fw=%s" % website_default.id, "generic_website_editor", login='admin')
-        self.start_tour("/?fw=%s" % new_website.id, "specific_website_editor", login='admin')
+        self.start_tour("/website/force/%s" % website_default.id, "generic_website_editor", login='admin')
+        self.start_tour("/website/force/%s" % new_website.id, "specific_website_editor", login='admin')
 
     def test_06_public_user_editor(self):
         website_default = self.env['website'].search([], limit=1)

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1133,9 +1133,7 @@ class Crawler(HttpCase):
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
 
         # Simulate website 2 (that use only generic views)
-        url = base_url + '/website/force_website'
-        json = {'params': {'website_id': website_2.id}}
-        self.opener.post(url=url, json=json)
+        self.url_open(base_url + '/website/force/%s' % website_2.id)
 
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
@@ -1173,9 +1171,7 @@ class Crawler(HttpCase):
         #       | Filter By Country
 
         # Simulate website 1 (that has specific views)
-        url = base_url + '/website/force_website'
-        json = {'params': {'website_id': website_1.id}}
-        self.opener.post(url=url, json=json)
+        self.url_open(base_url + '/website/force/%s' % website_1.id)
 
         # Test controller
         url = base_url + '/website/get_switchable_related_views'

--- a/addons/website_theme_install/tests/test_views.py
+++ b/addons/website_theme_install/tests/test_views.py
@@ -194,9 +194,7 @@ class Crawler(HttpCase):
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
 
         # Simulate website 2
-        url = base_url + '/website/force_website'
-        json = {'params': {'website_id': website_2.id}}
-        self.opener.post(url=url, json=json)
+        self.url_open(base_url + '/website/force/%s' % website_2.id)
 
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
@@ -207,9 +205,7 @@ class Crawler(HttpCase):
         self.assertEqual(response.json()['result'][0]['key'], '_theme_kea_sale.products', "Only '_theme_kea_sale.products' should be returned")
 
         # Simulate website 1
-        url = base_url + '/website/force_website'
-        json = {'params': {'website_id': website_1.id}}
-        self.opener.post(url=url, json=json)
+        self.url_open(base_url + '/website/force/%s' % website_1.id)
 
         # Test controller
         url = base_url + '/website/get_switchable_related_views'


### PR DESCRIPTION
Before this commit, the routing map generated and used would be the one from
the website the request is performed, instead of the one from the `fw` website
ID which will be the one we redirect the user.

This issue was introduced with the routing map by website, be8fc2296b38 and is
restricted to a single case: a publisher using the website switcher, and it
won't happen on next page naviguation/refresh as the `fw` website id will be
the same as the current website's ID.

---------------------------------------------
**Technical analysis:**

_website/models/ir_http.py_
```python
_dispatch
  request.website_routing = request.env['website'].get_current_website().id
  response = super(Http, cls)._dispatch()
  return response

_add_dispatch_parameters
  if mw + publisher + fw in url:
    request.env['website']._force_website(request.httprequest.args.get('fw'))
  super(Http, cls)._add_dispatch_parameters(func)

_match
  key = key or (request and request.website_routing)
  return super(Http, cls)._match(path_info, key=key)

_generate_routing_rules
  website_id = request.website_routing
  logger.debug("_generate_routing_rules for website: %s", website_id)
```
_http_routing/models/ir_http.py_
```python
_dispatch
  rule, arguments = cls._match(request.httprequest.path)
  cls._authenticate(func.routing['auth'])
  cls._add_dispatch_parameters(func)
```
_base/models/ir_http.py_
```python
_match
  return cls.routing_map(key=key).bind('').match(
    return_rule=True,
    method=request.httprequest.method,
    path_info=path_info
  )

routing_map
  for url, endpoint, routing in cls._generate_routing_rules(mods, converters=cls._get_converters()):
```

Current flow when accessing /?fw=1 depuis le website 2
1. website_routing is set to get_current_website -> 2 in _dispatch
2. _match is called in _dispatch
3. _match is calling routing_map with key = website_routing (set to 2 in step 1.)
4. routing_map is calling _generate_routing_rules which generate it based on website_routing (set to 2 in step 1.)

5. user is retrieved/authenticated in _dispatch by calling _authenticate
6. in _dispatch, _add_dispatch_parameter is called, where fw in url is forced in session and so get_current_website now return correct website_id -> 1

**Fix**: move step 6 before step 1 -> force fw in session before setting website_routing to the wrong website id
**Problem**: we need the user to be authenticated to use env.user.has_group(designer + mw) to allow fw to be forced
**Suggested** solution: force fw before user is authenticated and store the fact we did it, then when authenticating, if not the rights, redirect to previous website
