### PR TITLE
[FIX] web_editor: properly load iframe wysiwyg without defining it twice

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -101,7 +101,9 @@ Wysiwyg.include({
                 var $iframeTarget = self.$iframe.contents().find('#iframe_target');
                 // copy the html in itself to have the node prototypes relative
                 // to this window rather than the iframe window.
-                $iframeTarget.html($iframeTarget.html());
+                const $targetClone = $iframeTarget.clone();
+                $targetClone.find('script').remove();
+                $iframeTarget.html($targetClone.html());
                 self.$iframeBody = $iframeTarget;
                 $iframeTarget.attr("isMobile", config.device.isMobile);
                 const $utilsZone = $('<div class="iframe-utils-zone">');


### PR DESCRIPTION
Template `wysiwyg.iframeContent`'s `#iframe_target` includes a `script` element that defines an odoo module (`web_editor.wysiwyg.iniframe`). `wysiwyg_iframe.js` resets the html of that target so that the node prototypes are defined relative to the top window rather than the iframe window. Resetting that html had as a side effect that the script was run a second time while that is unnecessary given that the module has already been defined. This resulted in an error, which is here fixed by removing the `script` element from the html when resetting it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
