### PR TITLE
[FIX] account: change partner keep previous lines


### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -235,6 +235,7 @@ var StatementModel = BasicModel.extend({
         var line = this.getLine(handle);
         line.st_line.partner_id = partner && partner.id;
         line.st_line.partner_name = partner && partner.display_name || '';
+        line.mv_lines_match = [];
         line.mv_lines_match_rp = [];
         line.mv_lines_match_other = [];
         return Promise.resolve(partner && this._changePartner(handle, partner.id))


### PR DESCRIPTION

When we change partner in reconciliation, current lines are excluded
from the search and kept. So if we eg. have partner "Azure Interior":

[no partner shown] line 1
[no partner shown] line 2

then search "Deco Addict" that find a line 4, we would have this result:

Azure Interior line 1
Azure Interior line 2
line 4

That might make things messy to find the right line.

opw-2504501
