### PR TITLE
[FIX] im_livechat, website: 'Visitor' translated


### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -4,7 +4,7 @@ import base64
 import random
 import re
 
-from odoo import api, fields, models, modules
+from odoo import api, fields, models, modules, _
 
 
 class ImLivechatChannel(models.Model):
@@ -231,7 +231,7 @@ class ImLivechatChannel(models.Model):
         if info['available']:
             info['options'] = self._get_channel_infos()
             info['options']['current_partner_id'] = self.env.user.partner_id.id
-            info['options']["default_username"] = username
+            info['options']["default_username"] = username if username != 'Visitor' else _('Visitor')
         return info
 
 

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -66,10 +66,10 @@ class WebsiteVisitor(models.Model):
 
     @api.depends('name')
     def name_get(self):
-        return [(
-            record.id,
-            (record.name or _('Website Visitor #%s', record.id))
-        ) for record in self]
+        res = []
+        for record in self:
+            res.append((record.id, record.name or _('Website Visitor #%s', record.id)))
+        return res
 
     @api.depends('partner_id.email_normalized', 'partner_id.mobile', 'partner_id.phone')
     def _compute_email_phone(self):

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -64,5 +64,5 @@ class WebsiteLivechat(LivechatController):
         """ Override to use visitor name instead of 'Visitor' whenever a visitor start a livechat session. """
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
-            anonymous_name = visitor_sudo.display_name
+            anonymous_name = visitor_sudo.with_context(lang=visitor_sudo.lang_id.code).display_name
         return super(WebsiteLivechat, self).get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, **kwargs)


### PR DESCRIPTION

Make translation work for "Visitor" / "Website Visitor" that were
appearing for a logged-out visitor in livechat.

opw-2504461
