### PR TITLE
Gender neutral welcome

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -124,7 +124,7 @@ class ResUsers(models.Model):
             if invite_partner:
                 # notify invite user that new user is connected
                 title = _("%s connected", user.name)
-                message = _("This is his first connection. Wish him welcome")
+                message = _("This is their first connection. Wish them welcome.")
                 self.env['bus.bus'].sendone(
                     (self._cr.dbname, 'res.partner', invite_partner.id),
                     {'type': 'user_connection', 'title': title,

--- a/doc/cla/individual/geoff-bbc.md
+++ b/doc/cla/individual/geoff-bbc.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Geoff Petkus geoff-bbc@blue-bird.cloud https://github.com/geoff-bbc
+Geoff Petkus 59264352+geoff-bbc@users.noreply.github.com https://github.com/geoff-bbc

--- a/doc/cla/individual/geoff-bbc.md
+++ b/doc/cla/individual/geoff-bbc.md
@@ -1,0 +1,11 @@
+United States, 2021-04-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Geoff Petkus geoff-bbc@blue-bird.cloud https://github.com/geoff-bbc


### PR DESCRIPTION
Description of the issue/feature this PR addresses: As discussed and suggested by @mart-e in issue #67124.

Current behavior before PR: Assumption that all new users arriving in Odoo can be addressed as "him" and "his"

Desired behavior after PR is merged: The new text is gender neutral and appropriate English grammar.

I'm new at this, but I've done my best to follow the guidelines. As requested by @mart-e I am creating this PR against master.

The same male-oriented phrase exists in English in translation files such as:

- auth_signup/i18n/az.po
- auth_signup/i18n/gu.po
- and others

I don't know the process to suggest the same update to those. Help from another member would be appreciated.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
