### PR TITLE
[FIX] delivery: allow sales user to add shipping

### DIFF
--- a/addons/delivery/security/ir.model.access.csv
+++ b/addons/delivery/security/ir.model.access.csv
@@ -8,4 +8,4 @@ access_delivery_carrier_stock_user,delivery.carrier stock_user,model_delivery_ca
 access_delivery_carrier_stock_manager,delivery.carrier,model_delivery_carrier,stock.group_stock_manager,1,1,1,1
 access_delivery_price_rule_stock_manager,delivery.price.rule,model_delivery_price_rule,stock.group_stock_manager,1,1,1,1
 access_choose_delivery_package,access.choose.delivery.package,model_choose_delivery_package,stock.group_stock_user,1,1,1,0
-access_choose_delivery_carrier,access.choose.delivery.carrier,model_choose_delivery_carrier,stock.group_stock_user,1,1,1,0
+access_choose_delivery_carrier,access.choose.delivery.carrier,model_choose_delivery_carrier,sales_team.group_sale_salesman,1,1,1,0


### PR DESCRIPTION
Steps to Reproduce Bug:
- Try to Add Shipping using Sales user access rights (No other access rights)

Bug:
Access error of model `Delivery Carrier Selection Wizard`

Fix:
Allow Sales users to access `Delivery Carrier Selection Wizard` model.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
