### PR TITLE
[FIX]sale_stock: add missing access rights for scrap model

### DIFF
--- a/addons/sale_stock/security/ir.model.access.csv
+++ b/addons/sale_stock/security/ir.model.access.csv
@@ -16,3 +16,4 @@ access_account_journal,account.journal,account.model_account_journal,stock.group
 access_stock_location_sale_manager,stock.location sale manager,stock.model_stock_location,sales_team.group_sale_manager,1,0,0,0
 access_stock_rule_salemanager,stock_rule salemanager,stock.model_stock_rule,sales_team.group_sale_manager,1,1,1,1
 access_stock_rule,stock.rule.flow,stock.model_stock_rule,sales_team.group_sale_salesman,1,0,0,0
+access_stock_scrap_salesman,stock.scrap.salesman,stock.model_stock_scrap,sales_team.group_sale_salesman,1,1,1,0


### PR DESCRIPTION
Steps to reproduce bug:
- Click on Delivery Button from Sales user access rights (No other access rights)

Bug:
Access error
You are not allowed to access 'Scrap' (stock.scrap) records.

Fix:
Add access rights for Group `Sales/User: Own Documents Only` for
`Scrap` model


Fixes: #69432

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
