### PR TITLE
[FIX]point_of_sale: allow pos user to make payment

### DIFF
--- a/addons/point_of_sale/security/ir.model.access.csv
+++ b/addons/point_of_sale/security/ir.model.access.csv
@@ -48,6 +48,6 @@ access_pos_payment_method_user,pos.payment.method user,model_pos_payment_method,
 access_pos_payment_method_manager,pos.payment.method manager,model_pos_payment_method,group_pos_manager,1,1,1,1
 access_closing_balance_confirm_wizard,access.closing.balance.confirm.wizard,model_closing_balance_confirm_wizard,point_of_sale.group_pos_manager,1,1,1,0
 access_pos_details_wizard,access.pos.details.wizard,model_pos_details_wizard,point_of_sale.group_pos_manager,1,1,1,0
-access_pos_make_payment,access.pos.make.payment,model_pos_make_payment,point_of_sale.group_pos_manager,1,1,1,0
+access_pos_make_payment,access.pos.make.payment,model_pos_make_payment,point_of_sale.group_pos_user,1,1,1,0
 access_money_in_out_wizard,access.money.in.out.wizard,model_cash_box_out,point_of_sale.group_pos_user,1,1,1,0
 access_account_cash_rounding_pos_user,account.cash.rounding pos_user,account.model_account_cash_rounding,group_pos_user,1,0,0,0


### PR DESCRIPTION
Steps to reproduce bug:

- Point of Sale --> Orders --> Return Products
- Click on Payment Button from Point of sale user access rights (No other access rights)

Bug:
Access error
You are not allowed to access 'Point of Sale Make Payment Wizard' (pos.make.payment)
records.

Fix:
Add access rights for Group Point of Sale/User for `pos.make.payment` model.

Fixes: #69283

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
