### PR TITLE
[FIX] website{,_livechat}: 'Website Visitor' translate

### DIFF
--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -65,10 +65,13 @@ class WebsiteVisitor(models.Model):
 
     @api.depends('name')
     def name_get(self):
-        return [(
-            record.id,
-            (record.name or _('Website Visitor #%s') % record.id)
-        ) for record in self]
+        res = []
+        for record in self:
+            res.append((
+                record.id,
+                record.name or _('Website Visitor #%s') % record.id
+            ))
+        return res
 
     @api.depends('partner_id.email_normalized', 'partner_id.mobile', 'partner_id.phone')
     def _compute_email_phone(self):

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -63,7 +63,7 @@ class WebsiteLivechat(LivechatController):
         """ Override to use visitor name instead of 'Visitor' whenever a visitor start a livechat session. """
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
-            anonymous_name = visitor_sudo.display_name
+            anonymous_name = visitor_sudo.with_context(lang=visitor_sudo.lang_id.code).display_name
         return super(WebsiteLivechat, self).get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, **kwargs)
 
     @http.route('/im_livechat/visitor_leave_session', type='json', auth="public")


### PR DESCRIPTION
Make translation works for "Website Visitor" that was appearing when a
logged-out user open a livechat session.

note: list comprehension has to be removed since translation only search
language in direct calling method closure.

opw-2504461
