### PR TITLE
[FIX] mrp: print bom structure per variants

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -14,7 +14,8 @@ class ReportBomStructure(models.AbstractModel):
         docs = []
         for bom_id in docids:
             bom = self.env['mrp.bom'].browse(bom_id)
-            candidates = bom.product_id or bom.product_tmpl_id.product_variant_ids
+            variant = data.get('variant')
+            candidates = variant and self.env['product.product'].browse(variant) or bom.product_id or bom.product_tmpl_id.product_variant_ids
             quantity = float(data.get('quantity', 1))
             for product_variant_id in candidates.ids:
                 if data and data.get('childs'):

--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -30,6 +30,9 @@ var MrpBomReport = stock_report_generic.extend({
             })
             .then(function (result) {
                 self.data = result;
+                if (! self.given_context.searchVariant) {
+                    self.given_context.searchVariant = result.is_variant_applied && Object.keys(result.variants)[0];
+                }
             });
     },
     set_html: function() {
@@ -107,8 +110,9 @@ var MrpBomReport = stock_report_generic.extend({
         return this.updateControlPanel(status);
     },
     renderSearch: function () {
-        this.$buttonPrint = $(QWeb.render('mrp.button'));
+        this.$buttonPrint = $(QWeb.render('mrp.button', {'is_variant_applied': this.data.is_variant_applied}));
         this.$buttonPrint.find('.o_mrp_bom_print').on('click', this._onClickPrint.bind(this));
+        this.$buttonPrint.find('.o_mrp_bom_print_all_variants').on('click', this._onClickPrint.bind(this));
         this.$buttonPrint.find('.o_mrp_bom_print_unfolded').on('click', this._onClickPrint.bind(this));
         this.$searchView = $(QWeb.render('mrp.report_bom_search', _.omit(this.data, 'lines')));
         this.$searchView.find('.o_mrp_bom_report_qty').on('change', this._onChangeQty.bind(this));
@@ -126,7 +130,9 @@ var MrpBomReport = stock_report_generic.extend({
         if (! $(ev.currentTarget).hasClass('o_mrp_bom_print_unfolded')) {
             reportname += '&childs=' + JSON.stringify(childBomIDs);
         }
-        if (this.given_context.searchVariant) {
+        if ($(ev.currentTarget).hasClass('o_mrp_bom_print_all_variants')) {
+            reportname += '&all_variants=' + 1;
+        } else if (this.given_context.searchVariant) {
             reportname += '&variant=' + this.given_context.searchVariant;
         }
         var action = {

--- a/addons/mrp/static/src/xml/mrp.xml
+++ b/addons/mrp/static/src/xml/mrp.xml
@@ -3,6 +3,9 @@
     <t t-name="mrp.button">
         <div class="o_list_buttons o_mrp_bom_report_buttons">
             <button type="button" class="btn btn-primary o_mrp_bom_print">Print</button>
+            <t t-if="is_variant_applied">
+                <button type="button" class="btn btn-primary o_mrp_bom_print_all_variants">Print All Variants</button>
+            </t>
             <button type="button" class="btn btn-primary o_mrp_bom_print_unfolded">Print Unfolded</button>
         </div>
     </t>


### PR DESCRIPTION
Commit 044c5c2c81d0b3dd8b4abb8df34f6b1cb0a6e122 removed the context key
`variant` of the bom structure report. This implies to always print
every variant in case a BoM has no product_id.
This commit fix this issue to print only the variant selected in the
report. It also adds a new button to print the report with all variants
in case for some customers this behavior was "not a bug but a feature".

Task : 2504524

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
