### PR TITLE
[FIX] mass_mailing: properly handle multiple bounced_partner

### DIFF
--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -57,7 +57,7 @@ class MailThread(models.AbstractModel):
         if bounced_email:
             three_months_ago = fields.Datetime.to_string(datetime.datetime.now() - datetime.timedelta(weeks=13))
             stats = self.env['mailing.trace'].search(['&', ('bounced', '>', three_months_ago), ('email', '=ilike', bounced_email)]).mapped('bounced')
-            if len(stats) >= BLACKLIST_MAX_BOUNCED_LIMIT and (not bounced_partner or bounced_partner.message_bounce >= BLACKLIST_MAX_BOUNCED_LIMIT):
+            if len(stats) >= BLACKLIST_MAX_BOUNCED_LIMIT and (not bounced_partner or any(p.message_bounce >= BLACKLIST_MAX_BOUNCED_LIMIT for p in bounced_partner)):
                 if max(stats) > min(stats) + datetime.timedelta(weeks=1):
                     blacklist_rec = self.env['mail.blacklist'].sudo()._add(bounced_email)
                     blacklist_rec._message_log(

--- a/addons/test_mass_mailing/tests/test_mail_auto_blacklist.py
+++ b/addons/test_mass_mailing/tests/test_mail_auto_blacklist.py
@@ -5,11 +5,34 @@ import datetime
 
 from odoo import tools
 from odoo.tests import common
+from odoo.addons.mass_mailing.models.mail_thread import BLACKLIST_MAX_BOUNCED_LIMIT
 
 
 class TestAutoBlacklist(common.TransactionCase):
 
     def test_mail_bounced_auto_blacklist(self):
+        bounced_partner = self.env['res.partner'].sudo()
+        self._test_mail_bounced_auto_blacklist(bounced_partner)
+
+    def test_mail_bounced_auto_blacklist_partner(self):
+        bounced_partner = self.env['res.partner'].sudo().create({
+            'name': 'test1',
+            'message_bounce': BLACKLIST_MAX_BOUNCED_LIMIT,
+        })
+        self._test_mail_bounced_auto_blacklist(bounced_partner)
+
+    def test_mail_bounced_auto_blacklist_partner_duplicates(self):
+        bounced_partner = self.env['res.partner'].sudo().create({
+            'name': 'test1',
+            'message_bounce': BLACKLIST_MAX_BOUNCED_LIMIT,
+        }) | self.env['res.partner'].sudo().create({
+            'name': 'test2',
+            'message_bounce': BLACKLIST_MAX_BOUNCED_LIMIT,
+        })
+
+        self._test_mail_bounced_auto_blacklist(bounced_partner)
+
+    def _test_mail_bounced_auto_blacklist(self, bounced_partner):
         mass_mailing_contacts = self.env['mailing.contact']
         mass_mailing = self.env['mailing.mailing']
         mail_blacklist = self.env['mail.blacklist']
@@ -20,7 +43,7 @@ class TestAutoBlacklist(common.TransactionCase):
 
         base_parsed_values = {
             'email_from': 'toto@yaourth.com', 'to': 'tata@yaourth.com', 'message_id': '<123.321@yaourth.com>',
-            'bounced_partner': self.env['res.partner'].sudo(), 'bounced_message': self.env['mail.message'].sudo()
+            'bounced_partner': bounced_partner, 'bounced_message': self.env['mail.message'].sudo()
         }
 
         # create bounced history of 4 statistics


### PR DESCRIPTION
It may be a recordset in case of partner duplicates. The variable
bounced_partner is simple search by email:

https://github.com/odoo/odoo/blob/72b5a17fc0e6f439d462647a7b55c9a26235a8df/addons/mail/models/mail_thread.py#L1349

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
