### PR TITLE
[FIX] web_editor: fix traceback for some CTRL+A cases in mass_mailing

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -860,13 +860,21 @@ const Wysiwyg = Widget.extend({
         if (e && e.key === 'a' && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             const selection = this.odooEditor.document.getSelection();
-            const deepestParent =
+            const containerSelector = '#wrap>*, [contenteditable], .oe_structure>*';
+            let $deepestParent =
                 selection ?
-                    $(selection.anchorNode).parentsUntil('#wrap>*, [contenteditable], .oe_structure>*').last() :
-                    [];
-            if(deepestParent.length) {
+                    $(selection.anchorNode).parentsUntil(containerSelector).last() :
+                    $();
+
+            if ($deepestParent.is('html')) {
+                // In case we didn't find a suitable container
+                // we need to restrict the selection inside to the editable area.
+                $deepestParent = this.$editable.find(containerSelector);
+            }
+
+            if ($deepestParent.length) {
                 const range = document.createRange();
-                range.selectNodeContents(deepestParent.parent()[0]);
+                range.selectNodeContents($deepestParent.parent()[0]);
                 selection.removeAllRanges();
                 selection.addRange(range);
             }


### PR DESCRIPTION
Bug report : 
9.5.2021[SAR]
In Google slides, if i press ctl+a twice , traceback occurs- See here- https://youtu.be/m10NFYWIrWU
Note- It happens when there is a image in a block.

See Odoo task : https://www.odoo.com/web#active_id=2497783&cids=1&id=2497783&model=project.task&menu_id=



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
