### PR TITLE
[FIX] web: fix bouncing edit button prevention

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -480,8 +480,7 @@ var FormController = BasicController.extend({
     _shouldBounceOnClick(element) {
         return this.mode === 'readonly' &&
             !!element.closest('.oe_title, .o_inner_group') &&
-            !element.classList.contains("o_form_label") &&
-            !element.classList.contains("o_quick_editable");
+            this.quickEditTimeout === undefined;
     },
 
     //--------------------------------------------------------------------------
@@ -709,6 +708,7 @@ var FormController = BasicController.extend({
                         await this._setEditMode();
                         this.renderer.quickEdit(ev.data);
                     }
+                    this.quickEditTimeout = undefined;
                 }, this.multiClickTime);
             } else {
                 await this._setEditMode();

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -11118,8 +11118,33 @@ QUnit.module('Views', {
         form.destroy();
     });
 
-    QUnit.test('Quick Edition: do not bounce edit button when click on field or label', async function (assert) {
-        assert.expect(2);
+    QUnit.test('Quick Edition: do not bounce edit button when click on label', async function (assert) {
+        assert.expect(1);
+
+        const MULTI_CLICK_TIME = 50;
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <group>
+                        <field name="display_name"/>
+                    </group>
+                </form>`,
+            formMultiClickTime: MULTI_CLICK_TIME,
+            res_id: 1,
+        });
+
+        await testUtils.dom.click(form.$('.o_form_label'));
+        assert.containsNone(form, 'button.o_catch_attention:visible');
+
+        form.destroy();
+    });
+
+    QUnit.test('Quick Edition: do not bounce edit button when click on field char', async function (assert) {
+        assert.expect(1);
 
         const MULTI_CLICK_TIME = 50;
 
@@ -11139,13 +11164,31 @@ QUnit.module('Views', {
 
         await testUtils.dom.click(form.$('.o_field_widget'));
         assert.containsNone(form, 'button.o_catch_attention:visible');
-        await concurrency.delay(MULTI_CLICK_TIME);
 
-        await testUtils.form.clickDiscard(form);
+        form.destroy();
+    });
 
-        await testUtils.dom.click(form.$('.o_form_label'));
+    QUnit.test('Quick Edition: do not bounce edit button when click on field boolean', async function (assert) {
+        assert.expect(1);
+
+        const MULTI_CLICK_TIME = 50;
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <group>
+                        <field name="bar"/>
+                    </group>
+                </form>`,
+            formMultiClickTime: MULTI_CLICK_TIME,
+            res_id: 1,
+        });
+
+        await testUtils.dom.click(form.$('.o_field_widget'));
         assert.containsNone(form, 'button.o_catch_attention:visible');
-        await concurrency.delay(MULTI_CLICK_TIME);
 
         form.destroy();
     });


### PR DESCRIPTION
The PR https://github.com/odoo/odoo/pull/68799 tried to prevent the
form's edit button to bounce when quick editing.
The fix was wrong and some field continued to bounce the button.

This commit prevents the edit button to bounce when clicking on
any field by checking if we are quick editing.