### PR TITLE
[IMP] Event: Exhibitor - Dynamic search for exhibitor

### DIFF
--- a/addons/website_event_exhibitor/__manifest__.py
+++ b/addons/website_event_exhibitor/__manifest__.py
@@ -36,6 +36,7 @@
         'web.assets_frontend': [
             'website_event_exhibitor/static/src/scss/event_templates_sponsor.scss',
             'website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss',
+            'website_event_exhibitor/static/src/js/event_exhibitor.js',
             'website_event_exhibitor/static/src/js/event_exhibitor_connect.js',
         ],
     }

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -26,7 +26,7 @@ class Sponsor(models.Model):
     ]
 
     event_id = fields.Many2one('event.event', 'Event', required=True)
-    sponsor_type_id = fields.Many2one('event.sponsor.type', 'Sponsoring Level', required=True)
+    sponsor_type_id = fields.Many2one('event.sponsor.type', 'Sponsoring Level', required=True, auto_join=True)
     url = fields.Char('Sponsor Website', compute='_compute_url', readonly=False, store=True)
     sequence = fields.Integer('Sequence')
     active = fields.Boolean(default=True)

--- a/addons/website_event_exhibitor/static/src/js/event_exhibitor.js
+++ b/addons/website_event_exhibitor/static/src/js/event_exhibitor.js
@@ -1,0 +1,208 @@
+odoo.define('website_event_exhibitor.event_exhibitor', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+publicWidget.registry.eventExhibitor = publicWidget.Widget.extend({
+    selector: '.o_wesponsor_index',
+    events: {
+        'click .dropdown-menu a': '_onAddFilter',
+        'click .o_wesponsor_search_tag a': '_onRemoveFilter',
+        'input .o_wesearch_bar': '_onSearch',
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        this.$container = this.$el.find('.o_wesponsor_active_search_tags');
+        this.term = ''
+        this.activeTags = new Map([
+            ['country', []],
+            ['level', []]
+        ]);
+        return this._super.apply(this, arguments);
+    },
+
+    /**
+     * 
+     * @param {OdooEvent} event
+     */
+    _onSearch: function (event) {
+        event.preventDefault();
+        this.term = $(event.target).val();
+        this.applyFilter();
+    },
+
+    /**
+     * 
+     * @param {OdooEvent} event
+     */
+    _onAddFilter: function (event) {
+        event.preventDefault();
+        const $link = $(event.target);
+        const group = $link.closest('.dropdown-menu').data('group');
+        const value = $link.data('value');
+        if (this.addFilter(group, value)) {
+            const $tag = this.renderTag(group, value);
+            this.$container.append($tag);
+        }
+    },
+
+    /**
+     * @param {String} group
+     * @param {String} value
+     * @returns {boolean}
+     */
+    addFilter: function (group, value) {
+        if (!this.activeTags.has(group)) {
+            return false;
+        }
+        const values = this.activeTags.get(group);
+        if (values.includes(value)) {
+            return false;
+        }
+        this.activeTags.set(group, [...values, value]);
+        this.applyFilter();
+        return true;
+    },
+
+    applyFilter: function () {
+        this.$el.find('.o_wesponsor_card').each((index, card) => {
+            const $card = $(card);
+            if (this.matchWithTags($card) && this.matchWithTerms($card)) {
+                $card.parent().show();
+            } else {
+                $card.parent().hide();
+            }
+        });
+    },
+
+    /**
+     * Returns true if the card matches with the selected tags. Otherwise returns false.
+     * @param {Object} predicates
+     * @returns {Function}
+     */
+    matchWithTags: function ($card) {
+        const data = this.extractData($card);
+        for (let [group, tags] of this.activeTags) {
+            if (tags.length === 0) {
+                continue;
+            }
+            if (!tags.includes(data[group])) {
+                return false;
+            }
+        }
+        return true;
+    },
+
+    /**
+     * @param {OdooEvent} event
+     */
+    _onRemoveFilter: function (event) {
+        event.preventDefault();
+        const $tag = $(event.target).parent();
+        const data = $tag.data();
+        if (this.removeFilter(data.group, data.value)) {
+            $tag.remove();
+        }
+    },
+
+    // Helpers:
+
+    /**
+     * @param {jQuery} $card
+     */
+    extractData: function ($card) {
+        const $image = $card.find('img');
+        const $group = $card.closest('.o_wesponsor_category');
+        return {
+            country: $image.attr('alt').trim() || '',
+            level: $group.find('h2').text().trim() || ''
+        }
+    },
+
+    /**
+     * @param {String} group
+     * @param {String} value
+     */
+    removeFilter: function (group, value) {
+        if (!this.activeTags.has(group)) {
+            return false;
+        }
+        const values = this.activeTags.get(group);
+        this.activeTags.set(group, values.filter(elem => elem !== value));
+        this.applyFilter();
+        return true;
+    },
+
+    /**
+     * @param {String} group Group
+     * @param {String} value Value
+     */
+    renderTag: function (group, value) {
+        return $(
+            '<span ' +
+                'data-group="' + group + '" ' +
+                'data-value="' + value + '" ' +
+                'class="o_wesponsor_search_tag align-items-baseline border d-inline-flex pl-2 mt-3 rounded ml16 mb-2 bg-white">' +
+                '<i class="fa fa-tag mr-2 text-muted"/>' +
+                value +
+                '<a href="#" class="btn border-0 py-1">&#215;</a>' +
+            '</span>'
+        );
+    },
+
+    /**
+     * Returns true if the card matches with the provided term. Otherwise, returns false.
+     * @param {jQuery} $card
+     * @returns {boolean}
+     */
+    matchWithTerms: function ($card) {
+        let active = false
+        active = this.highlight($card.find('.card-title > span:first')) || active;
+        active = this.highlight($card.find('.card-body > span:first')) || active;
+        const term = this.term.trim().toLowerCase();
+        if (term.length > 0) {
+            $.each(this.extractData($card), (key, str) => {
+                active = (str.toLowerCase().indexOf(term) >= 0) || active;
+            });
+        }
+        return active;
+    },
+
+    /**
+     * Returns true of the element has been highlighted, false otherwise.
+     * @param {jQuery} $elem
+     * @returns {boolean}
+     */
+    highlight: function ($elem) {
+        const text = $elem.text();
+        if (this.term.length === 0) {
+            $elem.empty();
+            $elem.append(text);
+            return true;
+        }
+        const pattern = new RegExp('(' + this.escape(this.term) + ')', 'gi');
+        if (!pattern.test(text)) {
+            $elem.empty();
+            $elem.append(text);
+            return false;
+        }
+        $elem.empty();
+        $elem.append(text.replaceAll(pattern, '<mark>$1</mark>'));
+        return true;
+    },
+
+    /**
+     * Escapes regular expression special characters.
+     * @param {String} string
+     */
+    escape: function (string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    },
+});
+
+return {
+    eventExhibitor: publicWidget.registry.eventExhibitor,
+};
+});

--- a/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
@@ -59,6 +59,11 @@
             }
         }
 
+        mark {
+            padding: 0 !important;
+            background-color: $warning;
+        }
+
         @include media-breakpoint-up(md) {
             :hover .o_wesponsor_connect_button {
                 cursor: pointer;

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -37,11 +37,7 @@
             <div class="d-flex flex-column flex-sm-row justify-content-between w-100">
                 <ul class="o_wesponsor_topbar_filters o_wevent_index_topbar_filters nav"/>
                 <div class="d-flex align-items-center flex-wrap pl-sm-3 pr-0">
-                    <t t-call="website_event.events_search_box">
-                        <t t-set="_searches" t-value="searches"/>
-                        <t t-set="action" t-value="'/event/%s/exhibitors' % (slug(event))"/>
-                        <t t-set="_placeholder" t-value="'Search an exhibitor ...'"/>
-                    </t>
+                    <t t-call="website_event_exhibitor.exhibitor_search_bar"/>
                 </div>
             </div>
         </div>
@@ -60,17 +56,11 @@
                 <i class="fa fa-folder-open"/>
                 By Country
             </a>
-            <div class="dropdown-menu">
-                <a t-att-href="'/event/%s/exhibitors?%s' % (slug(event), keep_query('*', countries=''))"
-                    t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if not search_countries else ''}">
-                    All Countries
-                </a>
+            <div class="dropdown-menu" data-group="country">
                 <t t-foreach="sponsor_countries" t-as="sponsor_country">
-                    <a t-att-href="'/event/%s/exhibitors?%s' % (
-                            slug(event),
-                            keep_query('*', countries=str((search_countries - sponsor_country).ids if sponsor_country in search_countries else (sponsor_country | search_countries).ids))
-                        )"
-                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if sponsor_country in search_countries else ''}">
+                    <a href="#"
+                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between"
+                        t-att-data-value="sponsor_country.name">
                         <t t-esc="sponsor_country.name"/>
                     </a>
                 </t>
@@ -91,23 +81,24 @@
                 <i class="fa fa-folder-open"/>
                 By Level
             </a>
-            <div class="dropdown-menu">
-                <a t-att-href="'/event/%s/exhibitors?%s' % (slug(event), keep_query('*', sponsorships=''))"
-                    t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if not search_sponsorships else ''}">
-                    All Levels
-                </a>
+            <div class="dropdown-menu" data-group="level">
                 <t t-foreach="sponsor_types" t-as="sponsor_type">
-                    <a t-att-href="'/event/%s/exhibitors?%s' % (
-                            slug(event),
-                            keep_query('*', sponsorships=str((search_sponsorships - sponsor_type).ids if sponsor_type in search_sponsorships else (sponsor_type | search_sponsorships).ids))
-                        )"
-                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if sponsor_type in search_sponsorships else ''}">
+                    <a href="#"
+                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between"
+                        t-att-data-value="sponsor_type.name">
                         <t t-esc="sponsor_type.name"/>
                     </a>
                 </t>
             </div>
         </li>
     </xpath>
+</template>
+
+<!-- Search Bar -->
+<template id="exhibitor_search_bar" name="Exhibitors: Search Bar">
+    <input type="text"
+        class="o_wesearch_bar form-control"
+        placeholder="Search an exhibitor"/>
 </template>
 
 <!-- ============================================================ -->
@@ -120,12 +111,6 @@
     <t t-if="not sponsor_categories">
         <div class="col-12">
             <div class="h2 mb-3">No exhibitor found.</div>
-            <div t-if="search_key" class="alert alert-info text-center">
-                <p class="m-0">We did not find any exhibitor matching your <strong t-esc="search_key"/> search.</p>
-            </div>
-            <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
-                <p class="m-0">Add some exhibitors to get started !</p>
-            </div>
         </div>
     </t>
     <!-- Cards -->
@@ -134,7 +119,7 @@
 
 <!-- Exhibitors: Cards-based display -->
 <template id="exhibitors_display_cards" name="Exhibitors Cards">
-    <div t-foreach="sponsor_categories" t-as="sponsor_category" class="row mb-3">
+    <div t-foreach="sponsor_categories" t-as="sponsor_category" class="o_wesponsor_category row mb-3">
         <div class="col-12">
             <h2 class="m-0" t-esc="sponsor_category['sponsorship'].name"/>
             <hr class="mt-2 pb-1 mb-1"/>
@@ -218,28 +203,7 @@
 
 <!-- Searched terms -->
 <template id="exhibitors_search" name="Exhibitors: search terms">
-    <div class="d-flex align-items-center mb-3">
-        <t t-foreach="search_countries" t-as="country">
-            <span class="align-items-baseline border d-inline-flex pl-2 mt-3 rounded ml16 mb-2 bg-white">
-                <i class="fa fa-tag mr-2 text-muted"/>
-                <t t-esc="country.display_name"/>
-                <a t-att-href="'/event/%s/exhibitors?%s' % (
-                    slug(event),
-                    keep_query('*', countries=str((search_countries - country).ids)))"
-                    class="btn border-0 py-1">&#215;</a>
-            </span>
-        </t>
-        <t t-foreach="search_sponsorships" t-as="sponsorship">
-            <span class="align-items-baseline border d-inline-flex pl-2 mt-3 rounded ml16 mb-2 bg-white">
-                <i class="fa fa-tag mr-2 text-muted"/>
-                <t t-esc="sponsorship.display_name"/>
-                <a t-att-href="'/event/%s/exhibitors?%s' % (
-                    slug(event),
-                    keep_query('*', sponsorships=str((search_sponsorships - sponsorship).ids)))"
-                    class="btn border-0 py-1">&#215;</a>
-            </span>
-        </t>
-    </div>
+    <div class="o_wesponsor_active_search_tags d-flex align-items-center mb-3"></div>
 </template>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

It has been reported that the page showing the exhibitors is slow because of the partner table used behind the scene. It turns out that the page can generate many links for the filters which can trick the crawlers to explore them all. As the page is slow, the crawlers can put a high pressure on the server by exploring those links.

Current behavior before PR:
The filters are applied server side. The user will have to reload the page to apply the filters.

Desired behavior after PR is merged:
The filter is applied client side. The user do not have to reload the page to apply the filters.

Task id: 2347597
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
