### PR TITLE
[FIX] mass_mailing: fix untranslated text on unsubscribe page

### DIFF
--- a/addons/mass_mailing/static/src/js/unsubscribe.js
+++ b/addons/mass_mailing/static/src/js/unsubscribe.js
@@ -1,6 +1,7 @@
 odoo.define('mass_mailing.unsubscribe', function (require) {
     'use strict';
 
+    var session = require('web.session');
     var ajax = require('web.ajax');
     var core = require('web.core');
     require('web.dom_ready');
@@ -15,45 +16,47 @@ odoo.define('mass_mailing.unsubscribe', function (require) {
     if (!$('.o_unsubscribe_form').length) {
         return $.Deferred().reject("DOM doesn't contain '.o_unsubscribe_form'");
     }
-    if (email != '' && email != undefined){
-        ajax.jsonRpc('/mailing/blacklist/check', 'call', {'email': email, 'mailing_id': mailing_id, 'res_id': res_id, 'token': token})
-            .then(function (result) {
-                if (result == 'unauthorized'){
-                    $('#button_add_blacklist').hide();
-                    $('#button_remove_blacklist').hide();
-                }
-                else if (result == true) {
-                    $('#button_remove_blacklist').show();
-                    toggle_opt_out_section(false);
-                }
-                else if (result == false) {
-                    $('#button_add_blacklist').show();
-                    toggle_opt_out_section(true);
-                }
-                else {
+    session.load_translations().then(function () {
+        if (email != '' && email != undefined){
+            ajax.jsonRpc('/mailing/blacklist/check', 'call', {'email': email, 'mailing_id': mailing_id, 'res_id': res_id, 'token': token})
+                .then(function (result) {
+                    if (result == 'unauthorized'){
+                        $('#button_add_blacklist').hide();
+                        $('#button_remove_blacklist').hide();
+                    }
+                    else if (result == true) {
+                        $('#button_remove_blacklist').show();
+                        toggle_opt_out_section(false);
+                    }
+                    else if (result == false) {
+                        $('#button_add_blacklist').show();
+                        toggle_opt_out_section(true);
+                    }
+                    else {
+                        $('#subscription_info').text(_t('An error occured. Please try again later or contact us.'));
+                        $('#info_state').removeClass('alert-success').removeClass('alert-info').removeClass('alert-warning').addClass('alert-error');
+                    }
+                })
+                .fail(function () {
                     $('#subscription_info').html(_t('An error occured. Please try again later or contact us.'));
                     $('#info_state').removeClass('alert-success').removeClass('alert-info').removeClass('alert-warning').addClass('alert-error');
-                }
-            })
-            .fail(function () {
-                $('#subscription_info').html(_t('An error occured. Please try again later or contact us.'));
-                $('#info_state').removeClass('alert-success').removeClass('alert-info').removeClass('alert-warning').addClass('alert-error');
-            });
-    }
-    else {
-        $('#div_blacklist').hide();
-    }
+                });
+        }
+        else {
+            $('#div_blacklist').hide();
+        }
 
-    var unsubscribed_list = $("input[name='unsubscribed_list']").val();
-    if (unsubscribed_list){
-        $('#subscription_info').html(_.str.sprintf(
-            _t("You have been <strong>successfully unsubscribed from %s</strong>."),
-            _.escape(unsubscribed_list)
-        ));
-    }
-    else{
-        $('#subscription_info').html(_t('You have been <strong>successfully unsubscribed</strong>.'));
-    }
+        var unsubscribed_list = $("input[name='unsubscribed_list']").val();
+        if (unsubscribed_list){
+            $('#subscription_info').html(_.str.sprintf(
+                _t("You have been <strong>successfully unsubscribed from %s</strong>."),
+                _.escape(unsubscribed_list)
+            ));
+        }
+        else{
+            $('#subscription_info').html(_t('You have been <strong>successfully unsubscribed</strong>.'));
+        }
+    });
 
     $('#unsubscribe_form').on('submit', function (e) {
         e.preventDefault();


### PR DESCRIPTION
This is a cherry-pick of commit: https://github.com/odoo/odoo/commit/72a5e2b273e5faeccf49c0ef3fbb9f470e1a1c71

- Install Website and Email Marketing
- Go to Settings
- Click on "Manage Languages" and activate French
- Click on "Activate and Translate" and check the websites to translate
- Go to Preferences and set user language to "French"
- Go to Website > Configuration > Settings and make sure that French is in the languages list
  and that it is default
- Go to Email Marketing
- Create a new mailing
- Make sure that current user is in the Recipients list
- Send the mailing (it will be scheduled)
- In debug mode, go to Settings > Technical > Scheduled actions to run the action manually
- Check the received mail and click on the "unsubscribe" link
On the unsubscribe page there is text that is not translated.

Some of the translations on this page is done in JS.
But the translations are not available at that moment.

The translations have to be loaded manually before letting the JS doing its work.

opw-2501708

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
