### PR TITLE
[MERGE] test_{mass_mailing, mail, mail_full}: improve mail marketing tests

### DIFF
--- a/addons/link_tracker/tests/common.py
+++ b/addons/link_tracker/tests/common.py
@@ -22,7 +22,8 @@ class MockLinkTracker(common.BaseCase):
         self.addCleanup(link_tracker_title_patch.stop)
 
     def _get_href_from_anchor_id(self, body, anchor_id):
-        html = etree.fromstring(body)
+        """ Parse en html body to find the href of an element given its ID. """
+        html = etree.fromstring(body, parser=etree.HTMLParser())
         return html.xpath("//*[@id='%s']" % anchor_id)[0].attrib.get('href')
 
     def _get_tracker_from_short_url(self, short_url):
@@ -41,7 +42,7 @@ class MockLinkTracker(common.BaseCase):
         )
         """
         (anchor_id, url, is_shortened) = link_info
-        anchor_href = self._get_href_from_anchor_id("<div>%s</div>" % body, anchor_id)
+        anchor_href = self._get_href_from_anchor_id(body, anchor_id)
         if is_shortened:
             self.assertTrue('/r/' in anchor_href, '%s should be shortened: %s' % (anchor_id, anchor_href))
             link_tracker = self._get_tracker_from_short_url(anchor_href)

--- a/addons/link_tracker/tests/common.py
+++ b/addons/link_tracker/tests/common.py
@@ -52,6 +52,25 @@ class MockLinkTracker(common.BaseCase):
             self.assertTrue('/r/' not in anchor_href, '%s should not be shortened: %s' % (anchor_id, anchor_href))
             self.assertEqual(anchor_href, url)
 
+    def assertLinkShortenedText(self, body, link_info, link_params=None):
+        """ Find shortened links in an text content. Usage :
+
+        self.assertLinkShortenedText(
+            message.body,
+            ('http://www.odoo.com',  True),
+            {'utm_campaign': self.utm_c.name, 'utm_medium': self.utm_m.name}
+        )
+        """
+        (url, is_shortened) = link_info
+        link_tracker = self.env['link.tracker'].search([('url', '=', url)])
+        if is_shortened:
+            self.assertEqual(len(link_tracker), 1)
+            self.assertIn(link_tracker.short_url, body, '%s should be shortened' % (url))
+            self.assertLinkParams(url, link_tracker, link_params=link_params)
+        else:
+            self.assertEqual(len(link_tracker), 0)
+            self.assertIn(url, body)
+
     def assertLinkParams(self, url, link_tracker, link_params=None):
         """ Usage
 

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -125,6 +125,10 @@ class MockEmail(common.BaseCase):
         return self.env[target_model].search([(target_field, '=', subject)])
 
     def gateway_reply_wrecord(self, template, record, use_in_reply_to=True):
+        """ Deprecated, remove in 14.4 """
+        return self.gateway_mail_reply_wrecord(template, record, use_in_reply_to=use_in_reply_to)
+
+    def gateway_mail_reply_wrecord(self, template, record, use_in_reply_to=True):
         """ Simulate a reply through the mail gateway. Usage: giving a record,
         find an email sent to him and use its message-ID to simulate a reply.
 
@@ -176,7 +180,11 @@ class MockEmail(common.BaseCase):
         """ Find a sent email with a given list of recipients. Email should match
         exactly the recipients.
 
-        :return email: a dictionary mapping values given to ``build_email``;
+        :param email-to: a list of emails that will be compared to email_to
+          of sent emails (also a list of emails);
+
+        :return email: an email which is a dictionary mapping values given to
+          ``build_email``;
         """
         for sent_email in self._mails:
             if set(sent_email['email_to']) == set([email_to]):
@@ -184,6 +192,20 @@ class MockEmail(common.BaseCase):
         else:
             raise AssertionError('sent mail not found for email_to %s' % (email_to))
         return sent_email
+
+    def _find_mail_mail_wid(self, mail_id):
+        """ Find a ``mail.mail`` record based on a given ID (used notably when having
+        mail ID in mailing traces).
+
+        :return mail: a ``mail.mail`` record generated during the mock and matching
+          given ID;
+        """
+        for mail in self._new_mails:
+            if mail.id == mail_id:
+                break
+        else:
+            raise AssertionError('mail.mail not found for ID %s' % (mail_id))
+        return mail
 
     def _find_mail_mail_wpartners(self, recipients, status, mail_message=None, author=None):
         """ Find a mail.mail record based on various parameters, notably a list
@@ -271,7 +293,7 @@ class MockEmail(common.BaseCase):
         :param status: mail.mail state used to filter mails. If ``sent`` this method
           also check that emails have been sent trough gateway;
         :param mail_message: see ``_find_mail_mail_wpartners``;
-        :param author: see ``_find_mail_mail_wpartners``;;
+        :param author: see ``_find_mail_mail_wpartners``;
         :param content: if given, check it is contained within mail html body;
         :param fields_values: if given, should be a dictionary of field names /
           values allowing to check ``mail.mail`` additional values (subject,
@@ -329,7 +351,33 @@ class MockEmail(common.BaseCase):
             for email_to in emails:
                 self.assertSentEmail(email_values['email_from'] if email_values and email_values.get('email_from') else author, [email_to], **(email_values or {}))
 
+    def assertMailMailWId(self, mail_id, status,
+                          content=None, fields_values=None):
+        """ Assert mail.mail records are created and maybe sent as emails. Allow
+        asserting their content. Records to check are the one generated when
+        using mock (mail.mail and outgoing emails). This method takes partners
+        as source of record fetch and assert.
+
+        :param mail_id: a ``mail.mail`` DB ID. See ``_find_mail_mail_wid``;
+        :param status: mail.mail state to check upon found mail;
+        :param content: if given, check it is contained within mail html body;
+        :param fields_values: if given, should be a dictionary of field names /
+          values allowing to check ``mail.mail`` additional values (subject,
+          reply_to, ...);
+        """
+        found_mail = self._find_mail_mail_wid(mail_id)
+        self.assertTrue(bool(found_mail))
+        if status:
+            self.assertEqual(found_mail.state, status)
+        if content:
+            self.assertIn(content, found_mail.body_html)
+        for fname, fvalue in (fields_values or {}).items():
+            self.assertEqual(
+                found_mail[fname], fvalue,
+                'Mail: expected %s for %s, got %s' % (fvalue, fname, found_mail[fname]))
+
     def assertNoMail(self, recipients, mail_message=None, author=None):
+        """ Check no mail.mail and email was generated during gateway mock. """
         try:
             self._find_mail_mail_wpartners(recipients, False, mail_message=mail_message, author=author)
         except AssertionError:
@@ -340,6 +388,7 @@ class MockEmail(common.BaseCase):
             self.assertNotSentEmail()
 
     def assertNotSentEmail(self):
+        """ Check no email was generated during gateway mock. """
         self.assertEqual(len(self._mails), 0)
 
     def assertSentEmail(self, author, recipients, **values):

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -202,7 +202,7 @@ class MassMailing(models.Model):
                 m.id
         """, (tuple(self.ids), ))
         for row in self.env.cr.dictfetchall():
-            total = row['expected'] = (row['expected'] - row['ignored']) or 1
+            total = (row['expected'] - row['ignored']) or 1
             row['received_ratio'] = 100.0 * row['delivered'] / total
             row['opened_ratio'] = 100.0 * row['opened'] / total
             row['replied_ratio'] = 100.0 * row['replied'] / total

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -176,6 +176,8 @@ class MassMailing(models.Model):
             self[key] = False
         if not self.ids:
             return
+        # ensure traces are sent to db
+        self.flush()
         self.env.cr.execute("""
             SELECT
                 m.id as mailing_id,

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -1,32 +1,78 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import datetime
+import random
+import re
+import werkzeug
+
 from odoo.addons.link_tracker.tests.common import MockLinkTracker
 from odoo.addons.mail.tests.common import MailCase, MailCommon, mail_new_test_user
-
+from odoo import tools
 
 class MassMailCase(MailCase, MockLinkTracker):
 
+    # ------------------------------------------------------------
+    # ASSERTS
+    # ------------------------------------------------------------
+
+    def assertMailingStatistics(self, mailing, **kwargs):
+        """ Helper to assert mailing statistics fields. As we have many of them
+        it helps lessening test asserts. """
+        if not kwargs.get('expected'):
+            kwargs['expected'] = len(mailing.mailing_trace_ids)
+        if not kwargs.get('delivered'):
+            kwargs['delivered'] = len(mailing.mailing_trace_ids)
+        for fname in ['scheduled', 'expected', 'sent', 'delivered',
+                      'opened', 'replied', 'clicked',
+                      'ignored', 'failed', 'bounced']:
+            self.assertEqual(
+                mailing[fname], kwargs.get(fname, 0),
+                'Mailing %s statistics failed: got %s instead of %s' % (fname, mailing[fname], kwargs.get(fname, 0))
+            )
+
     def assertMailTraces(self, recipients_info, mailing, records,
-                         check_mail=True, author=None):
-        """ Check content of traces.
+                         check_mail=True, sent_unlink=False, author=None,
+                         mail_links_info=None):
+        """ Check content of traces. Traces are fetched based on a given mailing
+        and records. Their content is compared to recipients_info structure that
+        holds expected information. Links content may be checked, notably to
+        assert shortening or unsubscribe links. Mail.mail records may optionally
+        be checked.
 
         :param recipients_info: list[{
+            # TRACE
             'partner': res.partner record (may be empty),
             'email': email used when sending email (may be empty, computed based on partner),
-            'state': outgoing / sent / open / reply / error / cancel (sent by default),
+            'state': outgoing / sent / ignored / bounced / exception / opened (sent by default),
             'record: linked record,
-            'content': UDPATE ME
-            'failure_type': optional: UPDATE ME
+            # MAIL.MAIL
+            'content': optional content that should be present in mail.mail body_html;
+            'failure_type': optional failure reason;
             }, { ... }]
+
+        :param mailing: a mailing.mailing record from which traces have been
+          generated;
+        :param records: records given to mailing that generated traces. It is
+          used notably to find traces using their IDs;
+        :param check_mail: if True, also check mail.mail records that should be
+          linked to traces;
+        :param sent_unlink: it True, sent mail.mail are deleted and we check gateway
+          output result instead of actual mail.mail records;
+        :param mail_links_info: if given, should follow order of ``recipients_info``
+          and give details about links. See ``assertLinkShortenedHtml`` helper for
+          more details about content to give;
+        :param author: author of sent mail.mail;
         """
         # map trace state to email state
         state_mapping = {
             'sent': 'sent',
-            'replied': 'sent',  # replied imply something has been sent
+            'opened': 'sent',  # opened implies something has been sent
+            'replied': 'sent',  # replied implies something has been sent
             'ignored': 'cancel',
             'exception': 'exception',
-            'canceled': 'canceled',
+            'canceled': 'cancel',
+            'bounced': 'cancel',
         }
 
         traces = self.env['mailing.trace'].search([
@@ -39,11 +85,13 @@ class MassMailCase(MailCase, MockLinkTracker):
         self.assertEqual(set(s.res_id for s in traces), set(records.ids))
 
         # check each traces
-        for recipient_info in recipients_info:
+        if not mail_links_info:
+            mail_links_info = [None] * len(recipients_info)
+        for recipient_info, link_info, record in zip(recipients_info, mail_links_info, records):
             partner = recipient_info.get('partner', self.env['res.partner'])
             email = recipient_info.get('email')
             state = recipient_info.get('state', 'sent')
-            record = recipient_info.get('record')
+            record = record or recipient_info.get('record')
             content = recipient_info.get('content')
             if email is None and partner:
                 email = partner.email_normalized
@@ -55,6 +103,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                 len(recipient_trace) == 1,
                 'MailTrace: email %s (recipient %s, state: %s, record: %s): found %s records (1 expected)' % (email, partner, state, record, len(recipient_trace))
             )
+            self.assertTrue(bool(recipient_trace.mail_mail_id_int))
 
             if check_mail:
                 if author is None:
@@ -64,10 +113,102 @@ class MassMailCase(MailCase, MockLinkTracker):
                 if 'failure_type' in recipient_info:
                     fields_values['failure_type'] = recipient_info['failure_type']
 
+                # specific for partner: email_formatted is used
                 if partner:
-                    self.assertMailMail(partner, state_mapping[state], author=author, content=content, fields_values=fields_values)
+                    if state == 'sent' and sent_unlink:
+                        self.assertSentEmail(author, [partner])
+                    else:
+                        self.assertMailMail(partner, state_mapping[state], author=author, content=content, fields_values=fields_values)
+                # specific if email is False -> could have troubles finding it if several falsy traces
+                elif not email and state in ('ignored', 'canceled', 'bounced'):
+                    self.assertMailMailWId(recipient_trace.mail_mail_id_int, state_mapping[state], content=content, fields_values=fields_values)
                 else:
                     self.assertMailMailWEmails([email], state_mapping[state], author=author, content=content, fields_values=fields_values)
+
+            if link_info:
+                trace_mail = self._find_mail_mail_wrecord(record)
+                for (anchor_id, url, is_shortened, add_link_params) in link_info:
+                    link_params = {'utm_medium': 'Email', 'utm_source': mailing.name}
+                    if add_link_params:
+                        link_params.update(**add_link_params)
+                    self.assertLinkShortenedHtml(
+                        trace_mail.body_html,
+                        (anchor_id, url, is_shortened),
+                        link_params=link_params,
+                    )
+
+    # ------------------------------------------------------------
+    # TOOLS
+    # ------------------------------------------------------------
+
+    def gateway_mail_bounce(self, mailing, record, bounce_base_values=None):
+        """ Generate a bounce at mailgateway level.
+
+        :param mailing: a ``mailing.mailing`` record on which we find a trace
+          to bounce;
+        :param record: record which should bounce;
+        :param bounce_base_values: optional values given to routing;
+        """
+        trace = mailing.mailing_trace_ids.filtered(lambda t: t.model == record._name and t.res_id == record.id)
+
+        parsed_bounce_values = {
+            'email_from': 'some.email@external.example.com',  # TDE check: email_from -> trace email ?
+            'to': 'bounce@test.example.com',  # TDE check: bounce alias ?
+            'message_id': tools.generate_tracking_message_id('MailTest'),
+            'bounced_partner': self.env['res.partner'].sudo(),
+            'bounced_message': self.env['mail.message'].sudo()
+        }
+        if bounce_base_values:
+            parsed_bounce_values.update(bounce_base_values)
+        parsed_bounce_values.update({
+            'bounced_email': trace.email,
+            'bounced_msg_id': [trace.message_id],
+        })
+        self.env['mail.thread']._routing_handle_bounce(False, parsed_bounce_values)
+
+    def gateway_mail_click(self, mailing, record, click_label):
+        """ Simulate a click on a sent email. """
+        trace = mailing.mailing_trace_ids.filtered(lambda t: t.model == record._name and t.res_id == record.id)
+        email = self._find_sent_mail_wemail(trace.email)
+        self.assertTrue(bool(email))
+        for (_url_href, link_url, _dummy, label) in re.findall(tools.HTML_TAG_URL_REGEX, email['body']):
+            if label == click_label and '/r/' in link_url:  # shortened link, like 'http://localhost:8069/r/LBG/m/53'
+                parsed_url = werkzeug.urls.url_parse(link_url)
+                path_items = parsed_url.path.split('/')
+                code, trace_id = path_items[2], int(path_items[4])
+                self.assertEqual(trace.id, trace_id)
+
+                self.env['link.tracker.click'].sudo().add_click(
+                    code,
+                    ip='100.200.300.%3f' % random.random(),
+                    country_code='BE',
+                    mailing_trace_id=trace.id
+                )
+                break
+        else:
+            raise AssertionError('url %s not found in mailing %s for record %s' % (click_label, mailing, record))
+
+    @classmethod
+    def _create_bounce_trace(cls, mailing, record, dt=None):
+        if 'email_normalized' in record:
+            trace_email = record.email_normalized
+        elif 'email_from' in record:
+            trace_email = record.email_from
+        else:
+            trace_email = record.email
+        if dt is None:
+            dt = datetime.datetime.now() - datetime.timedelta(days=1)
+        randomized = random.random()
+        trace = cls.env['mailing.trace'].create({
+            'mass_mailing_id': mailing.id,
+            'model': record._name,
+            'res_id': record.id,
+            'bounced': dt,
+            # TDE FIXME: improve this with a mail-enabled heuristics
+            'email': trace_email,
+            'message_id': '<%5f@gilbert.boitempomils>' % randomized,
+        })
+        return trace
 
 
 class MassMailCommon(MailCommon, MassMailCase):

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -202,7 +202,7 @@ class TestMassMailFeatures(MassMailCommon):
         self.assertMailTraces(
             [{'partner': partner_a},
              {'partner': partner_b, 'state': 'ignored'}],
-            mailing, partner_a | partner_b, check_mail=True
+            mailing, partner_a + partner_b, check_mail=True
         )
 
     @users('user_marketing')

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -74,7 +74,8 @@ class MailComposeMessage(models.TransientModel):
                     'model': self.model,
                     'res_id': res_id,
                     'mass_mailing_id': mass_mailing.id,
-                    'email': mail_to,
+                    # if mail_to is void, keep falsy values to allow searching / debugging traces
+                    'email': mail_to or mail_values.get('email_to'),
                 }
                 if mail_values.get('body_html') and mass_mail_layout:
                     mail_values['body_html'] = mass_mail_layout._render({'body': mail_values['body_html']}, engine='ir.qweb', minimal_qcontext=True)

--- a/addons/mass_mailing_sms/tests/common.py
+++ b/addons/mass_mailing_sms/tests/common.py
@@ -11,14 +11,134 @@ from odoo.addons.sms.tests.common import SMSCase, SMSCommon
 class MassSMSCase(SMSCase):
 
     # ------------------------------------------------------------
+    # ASSERTS
+    # ------------------------------------------------------------
+
+    def assertSMSStatistics(self, recipients_info, mailing, records, check_sms=True):
+        """ Deprecated, remove in 14.4 """
+        return self.assertSMSTraces(recipients_info, mailing, records, check_sms=check_sms)
+
+    def assertSMSTraces(self, recipients_info, mailing, records,
+                        check_sms=True, sent_unlink=False,
+                        sms_links_info=None):
+        """ Check content of traces. Traces are fetched based on a given mailing
+        and records. Their content is compared to recipients_info structure that
+        holds expected information. Links content may be checked, notably to
+        assert shortening or unsubscribe links. Sms.sms records may optionally
+        be checked.
+
+        :param recipients_info: list[{
+          # TRACE
+          'partner': res.partner record (may be empty),
+          'number': number used for notification (may be empty, computed based on partner),
+          'state': outgoing / sent / ignored / bounced / exception / opened (outgoing by default),
+          'record: linked record,
+          # SMS.SMS
+          'content': optional: if set, check content of sent SMS;
+          'failure_type': error code linked to sms failure (see ``error_code``
+            field on ``sms.sms`` model);
+          },
+          { ... }];
+        :param mailing: a mailing.mailing record from which traces have been
+          generated;
+        :param records: records given to mailing that generated traces. It is
+          used notably to find traces using their IDs;
+        :param check_sms: if set, check sms.sms records that should be linked to traces;
+        :param sent_unlink: it True, sent sms.sms are deleted and we check gateway
+          output result instead of actual sms.sms records;
+        :param sms_links_info: if given, should follow order of ``recipients_info``
+          and give details about links. See ``assertLinkShortenedHtml`` helper for
+          more details about content to give;
+        ]
+        """
+        # map trace state to sms state
+        state_mapping = {
+            'sent': 'sent',
+            'outgoing': 'outgoing',
+            'exception': 'error',
+            'ignored': 'canceled',
+            'bounced': 'error',
+        }
+        traces = self.env['mailing.trace'].search([
+            ('mass_mailing_id', 'in', mailing.ids),
+            ('res_id', 'in', records.ids)
+        ])
+
+        self.assertTrue(all(s.model == records._name for s in traces))
+        # self.assertTrue(all(s.utm_campaign_id == mailing.campaign_id for s in traces))
+        self.assertEqual(set(s.res_id for s in traces), set(records.ids))
+
+        # check each trace
+        if not sms_links_info:
+            sms_links_info = [None] * len(recipients_info)
+        for recipient_info, link_info, record in zip(recipients_info, sms_links_info, records):
+            partner = recipient_info.get('partner', self.env['res.partner'])
+            number = recipient_info.get('number')
+            state = recipient_info.get('state', 'outgoing')
+            content = recipient_info.get('content', None)
+            if number is None and partner:
+                number = partner._sms_get_recipients_info()[partner.id]['sanitized']
+
+            trace = traces.filtered(
+                lambda t: t.sms_number == number and t.state == state and (t.res_id == record.id if record else True)
+            )
+            self.assertTrue(len(trace) == 1,
+                            'SMS: found %s notification for number %s, (state: %s) (1 expected)' % (len(trace), number, state))
+            self.assertTrue(bool(trace.sms_sms_id_int))
+
+            if check_sms:
+                if state == 'sent':
+                    if sent_unlink:
+                        self.assertSMSIapSent([number], content=content)
+                    else:
+                        self.assertSMS(partner, number, 'sent', content=content)
+                elif state in state_mapping:
+                    sms_state = state_mapping[state]
+                    error_code = recipient_info['failure_type'] if state in ('exception', 'ignored', 'bounced') else None
+                    self.assertSMS(partner, number, sms_state, error_code=error_code, content=content)
+                else:
+                    raise NotImplementedError()
+
+            if link_info:
+                # shortened links are directly included in sms.sms record as well as
+                # in sent sms (not like mails who are post-processed)
+                sms_sent = self._find_sms_sent(partner, number)
+                sms_sms = self._find_sms_sms(partner, number, state_mapping[state])
+                for (url, is_shortened, add_link_params) in link_info:
+                    if url == 'unsubscribe':
+                        url = '%s/sms/%d/%s' % (mailing.get_base_url(), mailing.id, trace.sms_code)
+                    link_params = {'utm_medium': 'SMS', 'utm_source': mailing.name}
+                    if add_link_params:
+                        link_params.update(**add_link_params)
+                    self.assertLinkShortenedText(
+                        sms_sms.body,
+                        (url, is_shortened),
+                        link_params=link_params,
+                    )
+                    self.assertLinkShortenedText(
+                        sms_sent['body'],
+                        (url, is_shortened),
+                        link_params=link_params,
+                    )
+
+    # ------------------------------------------------------------
     # GATEWAY TOOLS
     # ------------------------------------------------------------
 
-    def gateway_sms_click(self, sent_sms):
+    def gateway_sms_click(self, mailing, record):
         """ Simulate a click on a sent SMS. Usage: giving a partner and/or
         a number, find an SMS sent to him, find shortened links in its body
         and call add_click to simulate a click. """
-        for url in re.findall(tools.TEXT_URL_REGEX, sent_sms['body']):
+        trace = mailing.mailing_trace_ids.filtered(lambda t: t.model == record._name and t.res_id == record.id)
+        sms_sent = self._find_sms_sent(self.env['res.partner'], trace.sms_number)
+        self.assertTrue(bool(sms_sent))
+        return self.gateway_sms_sent_click(sms_sent)
+
+    def gateway_sms_sent_click(self, sms_sent):
+        """ When clicking on a link in a SMS we actually don't have any
+        easy information in body, only body. We currently click on all found
+        shortened links. """
+        for url in re.findall(tools.TEXT_URL_REGEX, sms_sent['body']):
             if '/r/' in url:  # shortened link, like 'http://localhost:8069/r/LBG/s/53'
                 parsed_url = werkzeug.urls.url_parse(url)
                 path_items = parsed_url.path.split('/')
@@ -31,74 +151,6 @@ class MassSMSCase(SMSCase):
                     country_code='BE',
                     mailing_trace_id=trace_id
                 )
-
-
-    # ------------------------------------------------------------
-    # ASSERTS
-    # ------------------------------------------------------------
-
-    def assertSMSOutgoingStatistics(self, partners, numbers, records, mailing):
-        found_sms = self.env['sms.sms'].sudo().search([
-            '|', ('partner_id', 'in', partners.ids), ('number', 'in', numbers),
-            ('state', '=', 'outgoing')
-        ])
-        self.assertEqual(found_sms.filtered(lambda s: s.partner_id).mapped('partner_id'), partners)
-        self.assertEqual(set(found_sms.filtered(lambda s: not s.partner_id).mapped('number')), set(numbers))
-
-        found_traces = self.env['mailing.trace'].sudo().search([
-            ('sms_sms_id_int', 'in', found_sms.ids),
-        ])
-        self.assertEqual(len(found_sms), len(found_traces))
-        self.assertTrue(all(s.state == 'outgoing' for s in found_traces))
-        self.assertTrue(all(s.res_model == records._name for s in found_traces))
-        self.assertEqual(set(found_traces.mapped('res_id')), set(records.ids))
-        self.assertTrue(all(s.mass_mailing_id == mailing for s in found_traces))
-
-    def assertSMSStatistics(self, recipients_info, mailing, records, check_sms=True):
-        """ Check content of notifications.
-
-        :param recipients_info: list[{
-          'partner': res.partner record (may be empty),
-          'number': number used for notification (may be empty, computed based on partner),
-          'state': outgoing / sent / ignored / exception / opened (sent by default),
-          'record: linked record,
-          'content': optional: if set, check content of sent SMS
-          'failure_type': optional: sms_number_missing / sms_number_format / sms_credit / sms_server
-          },
-          { ... }
-        ]
-        """
-        traces = self.env['mailing.trace'].search([
-            ('mass_mailing_id', 'in', mailing.ids),
-            ('res_id', 'in', records.ids)
-        ])
-
-        self.assertTrue(all(s.model == records._name for s in traces))
-        # self.assertTrue(all(s.utm_campaign_id == mailing.campaign_id for s in traces))
-        self.assertEqual(set(s.res_id for s in traces), set(records.ids))
-
-        for recipient_info in recipients_info:
-            partner = recipient_info.get('partner', self.env['res.partner'])
-            number = recipient_info.get('number')
-            state = recipient_info.get('state', 'outgoing')
-            content = recipient_info.get('content', None)
-            if number is None and partner:
-                number = partner._sms_get_recipients_info()[partner.id]['sanitized']
-
-            notif = traces.filtered(lambda s: s.sms_number == number and s.state == state)
-            self.assertTrue(notif, 'SMS: not found notification for number %s, (state: %s)' % (number, state))
-
-            if check_sms:
-                if state == 'sent':
-                    self.assertSMSSent([number], content)
-                elif state == 'outgoing':
-                    self.assertSMSOutgoing(partner, number, content)
-                elif state == 'exception':
-                    self.assertSMSFailed(partner, number, recipient_info.get('failure_type'), content)
-                elif state == 'ignored':
-                    self.assertSMSCanceled(partner, number, recipient_info.get('failure_type', False), content)
-                else:
-                    raise NotImplementedError()
 
 
 class MassSMSCommon(MassMailCommon, SMSCommon, MassSMSCase):

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -63,11 +63,8 @@ class TestMassMailing(TestMailFullCommon):
                 recipient_info['state'] = 'ignored'
             # falsy: ignored (cancel mail)
             elif recipient == recipient_falsy_1:
-                # TDE FIXME: currently setting False as email
-                # recipient_info['state'] = 'ignored'
-                # recipient_info['email'] = recipient.email_from  # normalized is False but email should be falsymail
                 recipient_info['state'] = 'ignored'
-                recipient_info['email'] = False
+                recipient_info['email'] = recipient.email_from  # normalized is False but email should be falsymail
             else:
                 email = self._find_sent_mail_wemail(recipient.email_normalized)
                 # preview correctly integrated rendered jinja

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -119,4 +119,4 @@ class TestMassMailing(TestMailFullCommon):
                 check_mail=True,)
 
         # sent: 13, 2 bl, 2 opt-out, 3 invalid -> 6 remaining
-        self.assertMailingStatistics(mailing, expected=6, delivered=6, sent=6, ignored=7)
+        self.assertMailingStatistics(mailing, expected=13, delivered=6, sent=6, ignored=7)

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import werkzeug
+
 from odoo.addons.test_mail_full.tests.common import TestMailFullCommon
 from odoo.tests.common import users
-from odoo.tools import config, mute_logger
+from odoo.tools import mute_logger
 from odoo.tests import tagged
 
 
@@ -17,49 +19,55 @@ class TestMassMailing(TestMailFullCommon):
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_mailing_w_blacklist_opt_out(self):
-        # TDE FIXME: better URLs check for unsubscribe / view (res_id + email + correct parse of url)
-        mailing = self.mailing_bl.with_user(self.env.user)
+        mailing = self.env['mailing.mailing'].browse(self.mailing_bl.ids)
 
-        jinja_html = '''
-<div>
-    <p>Hello <span class="text-muted">${object.name}</span></p>
-    <p>
-        Here are your personal links
-        <a href="http://www.example.com">External link</a>
-        <a href="/event/dummy-event-0">Internal link</a>
-        <a role="button" href="/unsubscribe_from_list" class="btn btn-link">Unsubscribe link</a>
-        <a href="/view">
-            View link
-        </a>
-    </p>
-</div>'''
-
-        mailing.write({
-            'preview': 'Hi ${object.name} :)',
-            'body_html': jinja_html,
-            'mailing_model_id': self.env['ir.model']._get('mailing.test.optout').id,
-        })
-        recipients = self._create_test_blacklist_records(model='mailing.test.optout', count=10)
+        mailing.write({'mailing_model_id': self.env['ir.model']._get('mailing.test.optout').id})
+        recipients = self._create_mailing_test_records(model='mailing.test.optout', count=10)
 
         # optout records 1 and 2
         (recipients[1] | recipients[2]).write({'opt_out': True})
         # blacklist records 3 and 4
         self.env['mail.blacklist'].create({'email': recipients[3].email_normalized})
         self.env['mail.blacklist'].create({'email': recipients[4].email_normalized})
+        # have a duplicate email for 9
+        recipient_dup_1 = recipients[9].copy()
+        # have a void mail
+        recipient_void_1 = self.env['mailing.test.optout'].create({'name': 'TestRecord_void_1'})
+        # have a falsy mail
+        recipient_falsy_1 = self.env['mailing.test.optout'].create({
+            'name': 'TestRecord_falsy_1',
+            'email_from': 'falsymail'
+        })
+        recipients_all = recipients + recipient_dup_1 + recipient_void_1 + recipient_falsy_1
 
-        mailing.write({'mailing_domain': [('id', 'in', recipients.ids)]})
+        mailing.write({'mailing_domain': [('id', 'in', recipients_all.ids)]})
         mailing.action_put_in_queue()
         with self.mock_mail_gateway(mail_unlink_sent=False):
             mailing._process_mass_mailing_queue()
 
-        for recipient in recipients:
+        for recipient in recipients_all:
             recipient_info = {
                 'email': recipient.email_normalized,
-                'content': 'Hello <span class="text-muted">%s</span' % recipient.name}
+                'content': 'Hello %s' % recipient.name}
+            # opt-out: ignored (cancel mail)
             if recipient in recipients[1] | recipients[2]:
                 recipient_info['state'] = 'ignored'
+            # blacklisted: ignored (cancel mail)
             elif recipient in recipients[3] | recipients[4]:
                 recipient_info['state'] = 'ignored'
+            # duplicates: ignored (cancel mail)
+            elif recipient == recipient_dup_1:
+                recipient_info['state'] = 'ignored'
+            # void: ignored (cancel mail)
+            elif recipient == recipient_void_1:
+                recipient_info['state'] = 'ignored'
+            # falsy: ignored (cancel mail)
+            elif recipient == recipient_falsy_1:
+                # TDE FIXME: currently setting False as email
+                # recipient_info['state'] = 'ignored'
+                # recipient_info['email'] = recipient.email_from  # normalized is False but email should be falsymail
+                recipient_info['state'] = 'ignored'
+                recipient_info['email'] = False
             else:
                 email = self._find_sent_mail_wemail(recipient.email_normalized)
                 # preview correctly integrated rendered jinja
@@ -68,13 +76,47 @@ class TestMassMailing(TestMailFullCommon):
                     email['body'])
                 # rendered unsubscribe
                 self.assertIn(
-                    'http://localhost:%s/mail/mailing/%s/unsubscribe' % (config['http_port'], mailing.id),
+                    '%s/mail/mailing/%s/unsubscribe' % (mailing.get_base_url(), mailing.id),
                     email['body'])
+                unsubscribe_href = self._get_href_from_anchor_id(email['body'], "url6")
+                unsubscribe_url = werkzeug.urls.url_parse(unsubscribe_href)
+                unsubscribe_params = unsubscribe_url.decode_query().to_dict(flat=True)
+                self.assertEqual(int(unsubscribe_params['res_id']), recipient.id)
+                self.assertEqual(unsubscribe_params['email'], recipient.email_normalized)
+                self.assertEqual(
+                    mailing._unsubscribe_token(unsubscribe_params['res_id'], (unsubscribe_params['email'])),
+                    unsubscribe_params['token']
+                )
                 # rendered view
                 self.assertIn(
-                    'http://localhost:%s/mailing/%s/view' % (config['http_port'], mailing.id),
+                    '%s/mailing/%s/view' % (mailing.get_base_url(), mailing.id),
                     email['body'])
+                view_href = self._get_href_from_anchor_id(email['body'], "url6")
+                view_url = werkzeug.urls.url_parse(view_href)
+                view_params = view_url.decode_query().to_dict(flat=True)
+                self.assertEqual(int(view_params['res_id']), recipient.id)
+                self.assertEqual(view_params['email'], recipient.email_normalized)
+                self.assertEqual(
+                    mailing._unsubscribe_token(view_params['res_id'], (view_params['email'])),
+                    view_params['token']
+                )
 
-            self.assertMailTraces([recipient_info], mailing, recipient, check_mail=True, author=self.env.user.partner_id)
+            self.assertMailTraces(
+                [recipient_info], mailing, recipient,
+                mail_links_info=[[
+                    ('url0', 'https://www.odoo.tz/my/%s' % recipient.name, True, {}),
+                    ('url1', 'https://www.odoo.be', True, {}),
+                    ('url2', 'https://www.odoo.com', True, {}),
+                    ('url3', 'https://www.odoo.eu', True, {}),
+                    ('url4', 'https://www.example.com/foo/bar?baz=qux', True, {'baz': 'qux'}),
+                    ('url5', '%s/event/dummy-event-0' % mailing.get_base_url(), True, {}),
+                    # view is not shortened and parsed at sending
+                    ('url6', '%s/view' % mailing.get_base_url(), False, {}),
+                    ('url7', 'mailto:test@odoo.com', False, {}),
+                    # unsubscribe is not shortened and parsed at sending
+                    ('url8', '%s/unsubscribe_from_list' % mailing.get_base_url(), False, {}),
+                ]],
+                check_mail=True,)
 
-        self.assertEqual(mailing.ignored, 4)
+        # sent: 13, 2 bl, 2 opt-out, 3 invalid -> 6 remaining
+        self.assertMailingStatistics(mailing, expected=6, delivered=6, sent=6, ignored=7)

--- a/addons/test_mail_full/tests/test_sms_performance.py
+++ b/addons/test_mail_full/tests/test_sms_performance.py
@@ -51,14 +51,14 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.mockSMSGateway(), self.assertQueryCount(employee=23):  # test_mail_enterprise: 25
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=23):  # test_mail_enterprise: 25
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
             )
 
         self.assertEqual(record.message_ids[0].body, '<p>Performance Test</p>')
-        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages)
+        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages, sent_unlink=True)
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
     @users('employee')
@@ -66,27 +66,27 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_10_partners(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.partners.ids
-        with self.mockSMSGateway(), self.assertQueryCount(employee=41):  # test_mail_enterprise: 43
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=41):  # test_mail_enterprise: 43
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
             )
 
         self.assertEqual(record.message_ids[0].body, '<p>Performance Test</p>')
-        self.assertSMSNotification([{'partner': partner} for partner in self.partners], 'Performance Test', messages)
+        self.assertSMSNotification([{'partner': partner} for partner in self.partners], 'Performance Test', messages, sent_unlink=True)
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
     @users('employee')
     @warmup
     def test_message_sms_record_default(self):
         record = self.test_record.with_user(self.env.user)
-        with self.mockSMSGateway(), self.assertQueryCount(employee=26):  # test_mail_enterprise: 28
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=26):  # test_mail_enterprise: 28
             messages = record._message_sms(
                 body='Performance Test',
             )
 
         self.assertEqual(record.message_ids[0].body, '<p>Performance Test</p>')
-        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages)
+        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages, sent_unlink=True)
 
 
 @tagged('mail_performance')
@@ -142,7 +142,7 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': False,
         })
 
-        with self.mockSMSGateway(), self.assertQueryCount(employee=106):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=106):
                 composer.action_send_sms()
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
@@ -159,5 +159,5 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': True,
         })
 
-        with self.mockSMSGateway(), self.assertQueryCount(employee=157):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=157):
             composer.action_send_sms()

--- a/addons/test_mail_full/tests/test_sms_post.py
+++ b/addons/test_mail_full/tests/test_sms_post.py
@@ -390,7 +390,7 @@ class TestSMSApi(TestMailFullCommon):
                 self.env['mail.test.sms'].browse(self.records.ids)._message_sms_schedule_mass(body=self._test_body, mass_keep_log=False)
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, self._test_body)
+            self.assertSMSOutgoing(record.customer_id, None, content=self._test_body)
 
     def test_message_schedule_sms_w_log(self):
         with self.with_user('employee'):
@@ -398,7 +398,7 @@ class TestSMSApi(TestMailFullCommon):
                 self.env['mail.test.sms'].browse(self.records.ids)._message_sms_schedule_mass(body=self._test_body, mass_keep_log=True)
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, self._test_body)
+            self.assertSMSOutgoing(record.customer_id, None, content=self._test_body)
             self.assertSMSLogged(record, self._test_body)
 
     def test_message_schedule_sms_w_template(self):
@@ -407,7 +407,7 @@ class TestSMSApi(TestMailFullCommon):
                 self.env['mail.test.sms'].browse(self.records.ids)._message_sms_schedule_mass(template=self.sms_template, mass_keep_log=False)
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, 'Dear %s this is an SMS.' % record.display_name)
+            self.assertSMSOutgoing(record.customer_id, None, content='Dear %s this is an SMS.' % record.display_name)
 
     def test_message_schedule_sms_w_template_and_log(self):
         with self.with_user('employee'):
@@ -415,5 +415,5 @@ class TestSMSApi(TestMailFullCommon):
                 self.env['mail.test.sms'].browse(self.records.ids)._message_sms_schedule_mass(template=self.sms_template, mass_keep_log=True)
 
         for record in self.records:
-            self.assertSMSOutgoing(record.customer_id, None, 'Dear %s this is an SMS.' % record.display_name)
+            self.assertSMSOutgoing(record.customer_id, None, content='Dear %s this is an SMS.' % record.display_name)
             self.assertSMSLogged(record, 'Dear %s this is an SMS.' % record.display_name)

--- a/addons/test_mail_full/tests/test_sms_server_actions.py
+++ b/addons/test_mail_full/tests/test_sms_server_actions.py
@@ -37,8 +37,8 @@ class TestServerAction(TestMailFullCommon, TestRecipients):
         with self.with_user('employee'), self.mockSMSGateway():
             self.action.with_user(self.env.user).with_context(**context).run()
 
-        self.assertSMSOutgoing(self.test_record.customer_id, None, 'Dear %s this is an SMS.' % self.test_record.display_name)
-        self.assertSMSOutgoing(self.env['res.partner'], self.test_numbers_san[0], 'Dear %s this is an SMS.' % self.test_record_2.display_name)
+        self.assertSMSOutgoing(self.test_record.customer_id, None, content='Dear %s this is an SMS.' % self.test_record.display_name)
+        self.assertSMSOutgoing(self.env['res.partner'], self.test_numbers_san[0], content='Dear %s this is an SMS.' % self.test_record_2.display_name)
 
     def test_action_sms_single(self):
         context = {
@@ -48,7 +48,7 @@ class TestServerAction(TestMailFullCommon, TestRecipients):
 
         with self.with_user('employee'), self.mockSMSGateway():
             self.action.with_user(self.env.user).with_context(**context).run()
-        self.assertSMSOutgoing(self.test_record.customer_id, None, 'Dear %s this is an SMS.' % self.test_record.display_name)
+        self.assertSMSOutgoing(self.test_record.customer_id, None, content='Dear %s this is an SMS.' % self.test_record.display_name)
 
     def test_action_sms_w_log(self):
         self.action.sms_mass_keep_log = True
@@ -60,8 +60,8 @@ class TestServerAction(TestMailFullCommon, TestRecipients):
         with self.with_user('employee'), self.mockSMSGateway():
             self.action.with_user(self.env.user).with_context(**context).run()
 
-        self.assertSMSOutgoing(self.test_record.customer_id, None, 'Dear %s this is an SMS.' % self.test_record.display_name)
+        self.assertSMSOutgoing(self.test_record.customer_id, None, content='Dear %s this is an SMS.' % self.test_record.display_name)
         self.assertSMSLogged(self.test_record, 'Dear %s this is an SMS.' % self.test_record.display_name)
 
-        self.assertSMSOutgoing(self.env['res.partner'], self.test_numbers_san[0], 'Dear %s this is an SMS.' % self.test_record_2.display_name)
+        self.assertSMSOutgoing(self.env['res.partner'], self.test_numbers_san[0], content='Dear %s this is an SMS.' % self.test_record_2.display_name)
         self.assertSMSLogged(self.test_record_2, 'Dear %s this is an SMS.' % self.test_record_2.display_name)

--- a/addons/test_mail_full/tests/test_sms_sms.py
+++ b/addons/test_mail_full/tests/test_sms_sms.py
@@ -146,7 +146,7 @@ class TestSMSPost(TestMailFullCommon, LinkTrackerMock):
             self.env['sms.sms'].with_user(self.user_employee).browse(self.sms_all.ids).send()
 
     def test_sms_send_delete_all(self):
-        with self.mockSMSGateway(sim_error='jsonrpc_exception'):
+        with self.mockSMSGateway(sms_allow_unlink=True, sim_error='jsonrpc_exception'):
             self.env['sms.sms'].browse(self.sms_all.ids).send(delete_all=True, raise_exception=False)
         self.assertFalse(len(self.sms_all.exists()))
 

--- a/addons/test_mass_mailing/tests/common.py
+++ b/addons/test_mass_mailing/tests/common.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import datetime
-import random
-
 from odoo.addons.mass_mailing.tests.common import MassMailCommon
 from odoo.addons.test_mail.tests.common import TestMailCommon
 
@@ -19,40 +16,45 @@ class TestMassMailCommon(MassMailCommon, TestMailCommon):
         cls.mailing_bl = cls.env['mailing.mailing'].with_user(cls.user_marketing).create({
             'name': 'SourceName',
             'subject': 'MailingSubject',
-            'body_html': '<p>Hello ${object.name}</p>',
+            'preview': 'Hi ${object.name} :)',
+            'body_html': """<div><p>Hello ${object.name}</p>,
+% set url = "www.odoo.com"
+% set httpurl = "https://www.odoo.eu"
+<span>Website0: <a id="url0" href="https://www.odoo.tz/my/${object.name}">https://www.odoo.tz/my/${object.name}</a></span>
+<span>Website1: <a id="url1" href="https://www.odoo.be">https://www.odoo.be</a></span>
+<span>Website2: <a id="url2" href="https://${url}">https://${url}</a></span>
+<span>Website3: <a id="url3" href="${httpurl}">${httpurl}</a></span>
+<span>External1: <a id="url4" href="https://www.example.com/foo/bar?baz=qux">Youpie</a></span>
+<span>Internal1: <a id="url5" href="/event/dummy-event-0">Internal link</a></span>
+<span>Internal2: <a id="url6" href="/view"/>View link</a></span>
+<span>Email: <a id="url7" href="mailto:test@odoo.com">test@odoo.com</a></span>
+<p>Stop spam ? <a id="url8" role="button" href="/unsubscribe_from_list">Ok</a></p>
+</div>""",
             'mailing_type': 'mail',
             'mailing_model_id': cls.env['ir.model']._get('mailing.test.blacklist').id,
         })
 
     @classmethod
     def _create_test_blacklist_records(cls, model='mailing.test.blacklist', count=1):
+        """ Deprecated, remove in 14.4 """
+        return cls.__create_mailing_test_records(model=model, count=count)
+
+    @classmethod
+    def _create_mailing_test_records(cls, model='mailing.test.blacklist', partners=None, count=1):
         """ Helper to create data. Currently simple, to be improved. """
         Model = cls.env[model]
         email_field = 'email' if 'email' in Model else 'email_from'
+        partner_field = 'customer_id' if 'customer_id' in Model else 'partner_id'
 
-        records = cls.env[model].create([{
-            'name': 'TestRecord_%02d' % x,
-            email_field: '"TestCustomer %02d" <test.record.%02d@test.example.com>' % (x, x),
-        } for x in range(0, count)])
-        return records
+        vals_list = []
+        for x in range(0, count):
+            vals = {
+                'name': 'TestRecord_%02d' % x,
+                email_field: '"TestCustomer %02d" <test.record.%02d@test.example.com>' % (x, x),
+            }
+            if partners:
+                vals[partner_field] = partners[x % len(partners)]
 
-    @classmethod
-    def _create_bounce_trace(cls, record, dt=None):
-        if dt is None:
-            dt = datetime.datetime.now() - datetime.timedelta(days=1)
-        randomized = random.random()
-        if 'email_normalized' in record:
-            trace_email = record.email_normalized
-        elif 'email_from' in record:
-            trace_email = record.email_from
-        else:
-            trace_email = record.email
-        trace = cls.env['mailing.trace'].create({
-            'model': record._name,
-            'res_id': record.id,
-            'bounced': dt,
-            # TDE FIXME: improve this with a mail-enabled heuristics
-            'email': trace_email,
-            'message_id': '<%5f@gilbert.boitempomils>' % randomized,
-        })
-        return trace
+            vals_list.append(vals)
+
+        return cls.env[model].create(vals_list)

--- a/addons/test_mass_mailing/tests/test_blacklist_behavior.py
+++ b/addons/test_mass_mailing/tests/test_blacklist_behavior.py
@@ -11,24 +11,17 @@ class TestAutoBlacklist(common.TestMassMailCommon):
 
     @users('user_marketing')
     def test_mailing_bounce_w_auto_bl(self):
-        mailing = self.mailing_bl.with_user(self.env.user)
-        base_parsed_values = {
-            'email_from': 'toto@yaourth.com', 'to': 'tata@yaourth.com', 'message_id': '<123.321@yaourth.com>',
-            'bounced_partner': self.env['res.partner'].sudo(), 'bounced_message': self.env['mail.message'].sudo()
-        }
+        mailing = self.env['mailing.mailing'].browse(self.mailing_bl.ids)
+        target = self._create_mailing_test_records()[0]
+        mailing.write({'mailing_domain': [('id', 'in', target.ids)]})
 
-        target = self._create_test_blacklist_records()[0]
         # create bounced history of 4 statistics
         for idx in range(4):
-            trace = self._create_bounce_trace(target, dt=datetime.datetime.now() - datetime.timedelta(weeks=idx+2))
-            base_parsed_values.update({
-                'bounced_email': target.email_normalized,
-                'bounced_msg_id': [trace.message_id],
-            })
-            self.env['mail.thread']._routing_handle_bounce(False, base_parsed_values)
+            new_mailing = mailing.copy()
+            self._create_bounce_trace(new_mailing, target, dt=datetime.datetime.now() - datetime.timedelta(weeks=idx+2))
+            self.gateway_mail_bounce(new_mailing, target)
 
         # mass mail record: ok, not blacklisted yet
-        mailing.write({'mailing_domain': [('id', 'in', target.ids)]})
         mailing.action_put_in_queue()
         with self.mock_mail_gateway(mail_unlink_sent=False):
             mailing._process_mass_mailing_queue()
@@ -40,12 +33,7 @@ class TestAutoBlacklist(common.TestMassMailCommon):
         )
 
         # call bounced
-        trace = self._create_bounce_trace(target, dt=datetime.datetime.now())
-        base_parsed_values.update({
-            'bounced_email': target.email_normalized,
-            'bounced_msg_id': [trace.message_id],
-        })
-        self.env['mail.thread']._routing_handle_bounce(False, base_parsed_values)
+        self.gateway_mail_bounce(mailing, target)
 
         # check blacklist
         blacklist_record = self.env['mail.blacklist'].sudo().search([('email', '=', target.email_normalized)])

--- a/addons/test_mass_mailing/tests/test_mailing_internals.py
+++ b/addons/test_mass_mailing/tests/test_mailing_internals.py
@@ -45,7 +45,7 @@ class TestMailingInternals(TestMassMailCommon):
         # Test if bad jinja in the subject raises an error
         mailing.write({'subject': 'Subject ${object.name_id.id}'})
         with self.mock_mail_gateway(), self.assertRaises(Exception):
-                mailing_test.send_mail_test()
+            mailing_test.send_mail_test()
 
         # Test if bad jinja in the body raises an error
         mailing.write({
@@ -53,15 +53,15 @@ class TestMailingInternals(TestMassMailCommon):
             'body_html': '<p>Hello ${object.name_id.id}</p>',
         })
         with self.mock_mail_gateway(), self.assertRaises(Exception):
-                mailing_test.send_mail_test()
-        
+            mailing_test.send_mail_test()
+
         # Test if bad jinja in the preview raises an error
         mailing.write({
             'body_html': '<p>Hello ${object.name}</p>',
             'preview': 'Preview ${object.name_id.id}',
         })
         with self.mock_mail_gateway(), self.assertRaises(Exception):
-                mailing_test.send_mail_test()
+            mailing_test.send_mail_test()
 
     def test_mailing_trace_update(self):
         customers = self.env['res.partner']
@@ -85,8 +85,8 @@ class TestMailingInternals(TestMassMailCommon):
         with self.mock_mail_gateway(mail_unlink_sent=False):
             mailing.action_send_mail()
 
-        self.gateway_reply_wrecord(MAIL_TEMPLATE, customers[0], use_in_reply_to=True)
-        self.gateway_reply_wrecord(MAIL_TEMPLATE, customers[1], use_in_reply_to=False)
+        self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, customers[0], use_in_reply_to=True)
+        self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, customers[1], use_in_reply_to=False)
 
         # customer2 looses headers
         mail_mail = self._find_mail_mail_wrecord(customers[2])
@@ -152,8 +152,8 @@ class TestMailingInternals(TestMassMailCommon):
         self.assertEqual(len(traces), 3)
 
         # simulate response to mailing
-        self.gateway_reply_wrecord(MAIL_TEMPLATE, self.mailing_list_1.contact_ids[0], use_in_reply_to=True)
-        self.gateway_reply_wrecord(MAIL_TEMPLATE, self.mailing_list_1.contact_ids[1], use_in_reply_to=False)
+        self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, self.mailing_list_1.contact_ids[0], use_in_reply_to=True)
+        self.gateway_mail_reply_wrecord(MAIL_TEMPLATE, self.mailing_list_1.contact_ids[1], use_in_reply_to=False)
 
         mailing_test_utms = self.env['mailing.test.utm'].search([('name', '=', 'Re: %s' % subject)])
         self.assertEqual(len(mailing_test_utms), 2)


### PR DESCRIPTION
PURPOSE

Purpose is to have more tests when sending mail mailings, notably about
canceled or failed mails or sms as well as jinja and links rendering.

SPECIFICATIONS

In this commit we improve Email/SMS Marketing mailing tests. We notably

  * add tests for void and invalid emails and numbers. It allows to check they
    correctly update their trace status;
  * add tests for unsubscribe and view links embedded in mass mailing emails
    and sms;
  * add tests to simulate a click on links sent through mass mailing and
    ensure click statistics are effectively updated;
  * add tests to simulate bounce emails coming back to the mail gateway;

Default content of mailings used in test is updated to ensure jinja is
correctly rendered, including links and some corner cases. This will also
helps ensuring behavior is kept when converting to QWeb. Both text- and
html-based jinja rendering for links is now tested.

Various docstrings are added to helpers and custom asserts. Various helpers
are improved or cleaned, with some old methods kept for backward compatibility.

LINKS

Task ID-2508643
Followup of #68874 (improve mail tests)
Prepares Task ID-27033 (support QWeb in templates)
Prepares Task ID-2377974 (clean trace and status management in mass mailing)