### PR TITLE
[IMP] account: notify sales rep when their invoices are validated

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2418,6 +2418,15 @@ class AccountMove(models.Model):
             result.append((move.id, name))
         return result
 
+    def _message_auto_subscribe_followers(self, updated_values, subtype_ids):
+        res = super(AccountMove, self)._message_auto_subscribe_followers(updated_values, subtype_ids)
+        if updated_values.get('invoice_user_id'):
+            subtype_ids.append(self.env.ref('account.mt_invoice_validated').id)
+            sale_person = self.env['res.users'].browse(updated_values['invoice_user_id'])
+            if sale_person:
+                res.append((sale_person.partner_id.id, subtype_ids, False))
+        return res
+
     # -------------------------------------------------------------------------
     # RECONCILIATION METHODS
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Purpose of this task is to allow sales rep(who don't have any billing right) to
be aware when invoices related to their SO have been approved by accounting so
that they can send them to their customer.

So in this commit, 'validated' is subscribed by default on the user so whenever
one of their colleagues approved created invoice then they are notified.

Task-ID: 2418033

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
