### PR TITLE
[FIX] mail: handle server error in the front-end part


### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -5654,6 +5654,13 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/js/attachment_box.js:132
+#, python-format
+msgid "You are not allowed to upload an attachment here."
+msgstr ""
+
+#. module: mail
+#. openerp-web
 #: code:addons/mail/static/src/js/discuss.js:338
 #, python-format
 msgid "You are the administrator of this channel. Are you sure you want to unsubscribe?"

--- a/addons/mail/static/src/js/attachment_box.js
+++ b/addons/mail/static/src/js/attachment_box.js
@@ -127,8 +127,12 @@ var AttachmentBox = Widget.extend({
     /**
      * @private
      */
-    _onUploaded: function() {
-        this.trigger_up('reload_attachment_box');
+    _onUploaded: function(ev, response) {
+        if (response.error) {
+            this.do_warn(_t("Error"), _t("You are not allowed to upload an attachment here."));
+        } else {
+            this.trigger_up('reload_attachment_box');
+        }
     },
 });
 


### PR DESCRIPTION

Issue

    - Install Time Off
    - Marc Demo > Create leave request
    - Admin > Validate the leave request
    - Marc Demo > Add an attachment

    Nothing happens

Cause

    There is a access right issue that is not handled in the
    JS.

Solution

    Handle it by doing a do_warn.

OPW-2171791

12.0 backport of #43464

note: backport for 12.0

opw-2500564
