### PR TITLE
[FIX] web: web_translation route lang required


### DIFF
--- a/addons/web/static/src/js/core/translation.js
+++ b/addons/web/static/src/js/core/translation.js
@@ -70,9 +70,7 @@ var TranslationDataBase = Class.extend(/** @lends instance.TranslationDataBase# 
         if (modules) {
             paramsGet.modules = modules.join(',');
         }
-        if (lang) {
-            paramsGet.lang = lang;
-        }
+        paramsGet.lang = lang || null;
         return $.get(url, paramsGet).then(function (trans) {
             self.set_bundle(trans);
         });


### PR DESCRIPTION

The /web/webclient/translations route's `lang` argument has had some
changes in the last year:

- before june 2020 (a9a756cf): very often it was set to null

- after june 2020 (a9a756cf): it was more often correctly set or had
  en_US as fallback so never null

- after 31 march 2021 (8cc06617) in saas-14.3: lang is not sent to
  server if it is null (which should never happen)

- after 15 april 2021 (a93a0a3): en_US fallback is removed to prevent
  overriding server language if another language is better

But the fix in 31 march and 15 april are not compatible because the
route /web/webclient/translations require a lang argument.

With this changeset, lang argument is always sent to the server.
