### PR TITLE
[IMP] Snailmail: Incomplete address improvements

### DIFF
--- a/addons/snailmail_account/wizard/account_invoice_send_views.xml
+++ b/addons/snailmail_account/wizard/account_invoice_send_views.xml
@@ -23,28 +23,16 @@
                                     <i class="fa fa-info-circle" role="img" aria-label="Warning" title="Make sure you have enough Stamps on your account."/>
                                 )</b>
                             </span>
-                            <span attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">
-                                <span attrs="{'invisible': [('invalid_addresses', '!=', 0)]}">
-                                    <div class="text-right text-muted d-inline-block" name="address">
-                                        <span> to: </span>
-                                        <field name="partner_id" readonly="1" force_save="1" context="{'show_address': 1, 'address_inline': 1}" options="{'always_reload': True, 'no_quick_create': True}"/>
-                                    </div>
-                                </span>
-                                <span attrs="{'invisible': [('invalid_addresses', '=', 0)]}">
-                                    <div class="text-right d-inline-block" attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">
-                                        <span class="text-danger">
-                                            The customer address is not complete.
-                                        </span>
-                                    </div>
-                                </span>
+                            <span class="text-right d-inline-block " attrs="{'invisible': ['|', ('composition_mode', '=', 'mass_mail'), ('partner_id', '=', False)]}" name="address">
+                                <span class="text-muted" attrs="{'invisible': [('invalid_addresses', '!=', 0)]}"> to: </span>
+                                <span class="text-danger" attrs="{'invisible': [('invalid_addresses', '=', 0)]}"> The customer's address is incomplete: </span>
+                                <field name="partner_id" readonly="1" force_save="1" context="{'show_address': 1, 'address_inline': 1}" options="{'always_reload': True, 'no_quick_create': True}"/>
                             </span>
-                            <span attrs="{'invisible': [('composition_mode', '!=', 'mass_mail')]}">
-                                <span attrs="{'invisible': [('invalid_addresses', '=', 0)]}">
-                                    <span class="text-danger">
-                                        Some customer addresses are not complete.
-                                    </span>
-                                    <button type="object" name="invalid_addresses_action" class="btn btn-link" role="button"><field name="invalid_addresses" readonly="1" options="{'digits':[0,0]}"/> invoices</button>
+                            <span attrs="{'invisible': ['|', ('composition_mode', '!=', 'mass_mail'), ('invalid_addresses', '=', 0)]}">
+                                <span class="text-danger">
+                                    Some customer addresses are incomplete.
                                 </span>
+                                <button type="object" name="invalid_addresses_action" class="btn btn-link" role="button"><field name="invalid_addresses" readonly="1" options="{'digits':[0,0]}"/> Contacts</button>
                             </span>
                         </span>
                     </div>


### PR DESCRIPTION
If 'send by post' is enabled AND the address is incomplete, display:
"The customer's address is incomplete:" followed by a link to the corresponding partner
'send by post' only visible in single mode, not when sending invoices in batch

Purpose:
When the user tries to send an invoice by post, the system warns him that the customer's address is incomplete.
But then, it's a dead end. The user doesn't have any tool to rectify the situation.

taskid: 2502597

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
