### PR TITLE
[FIX] account_payment: remove double country_code field in account_payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -142,7 +142,6 @@ class AccountPayment(models.Model):
         compute='_compute_show_require_partner_bank',
         help="Technical field used to know whether the field `partner_bank_id` needs to be required or not in the payments form views")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
-    country_code = fields.Char(related='company_id.country_id.code')
     amount_signed = fields.Monetary(
         currency_field='currency_id', compute='_compute_amount_signed',
         help='Negative value of amount field if payment_type is outbound')


### PR DESCRIPTION

There were 2 country_code fieldss in account_payment. Probably the result of
faulty rebase.