### PR TITLE
[FIX] point_of_sale: take into account fiscal position in order list

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -13,7 +13,7 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
     class OrderManagementScreen extends ControlButtonsMixin(IndependentToOrderScreen) {
         constructor() {
             super(...arguments);
-            useListener('close-screen', this.close);
+            useListener('close-screen', this._close);
             useListener('set-numpad-mode', this._setNumpadMode);
             useListener('click-order', this._onClickOrder);
             useListener('next-page', this._onNextPage);
@@ -78,6 +78,16 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
         _onClickOrder({ detail: clickedOrder }) {
             if (!clickedOrder || clickedOrder.locked) {
                 this.orderManagementContext.selectedOrder = clickedOrder;
+                let currentPOSOrder = this.env.pos.get_order();
+                if (clickedOrder.attributes.client){
+                    currentPOSOrder.set_client(clickedOrder.attributes.client);
+                }
+                if (clickedOrder.fiscal_position){
+                    currentPOSOrder.fiscal_position = clickedOrder.fiscal_position;
+                }
+                if (clickedOrder.pricelist){
+                    currentPOSOrder.set_pricelist(clickedOrder.pricelist);
+                }
             } else {
                 this._setOrder(clickedOrder);
             }
@@ -90,6 +100,15 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             if (order === this.env.pos.get_order()) {
                 this.close();
             }
+        }
+        _close() {
+            let currentOrder = this.env.pos.get_order();
+            if (currentOrder){
+                currentOrder.set_client(false);
+                currentOrder.fiscal_position = false;
+                currentOrder.set_pricelist(this.env.pos.default_pricelist);
+            }
+            this.close();
         }
     }
     OrderManagementScreen.template = 'OrderManagementScreen';


### PR DESCRIPTION
- Create Tax Exempt fiscal position
- Create Customer with Tax Exempt in fiscal position
- Enable Tax Exempt fiscal position in POS settings
- In POS, set customer to one with Tax Exempt
- Create a sale, apply, payment, validate, and click New Order
- Click magnifying glass to reprint receipt
- Default tax is automatically applied to all past orders/receipts

This occur because:
- in Pos OrderList the total is based on the amount total, and not the
actual amount paid
- the fiscal position object is not present when retrieving the order
via `selectedOrder`

opw-2485178

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
