### PR TITLE
[IMP] stock, purchase: usability improvements

### DIFF
--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -115,14 +115,8 @@ tour.register('purchase_tour' , {
     position: "bottom",
     run: 'click',
 }, {
-    trigger: ".ui-sortable-handle",
+    trigger: ".o_field_widget [name=price_unit]",
     extra_trigger: ".o_purchase_order",
-    content: _t("Click here to edit or move the quotation line."),
-    position: "bottom",
-    run: 'click',
-}, {
-    trigger: ".o_form_editable input[name='price_unit']",
-    extra_trigger: ".o_form_editable input[name='price_unit']",
     content: _t("Once you get the price from the vendor, you can complete the purchase order with the right price."),
     position: "right",
     run: 'text 200.00'

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -56,7 +56,7 @@ class StockMove(models.Model):
     product_uom_qty = fields.Float(
         'Demand',
         digits='Product Unit of Measure',
-        default=0.0, required=True, states={'done': [('readonly', True)]},
+        default=1.0, required=True, states={'done': [('readonly', True)]},
         help="This is the quantity of products from an inventory "
              "point of view. For moves in the state 'done', this is the "
              "quantity of products that were actually moved. For other "

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -92,6 +92,7 @@ class StockQuant(models.Model):
     in_date = fields.Datetime('Incoming Date', readonly=True, required=True, default=fields.Datetime.now)
     tracking = fields.Selection(related='product_id.tracking', readonly=True)
     on_hand = fields.Boolean('On Hand', store=False, search='_search_on_hand')
+    product_categ_id = fields.Many2one(related='product_tmpl_id.categ_id')
 
     # Inventory Fields
     inventory_quantity = fields.Float(

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -4413,7 +4413,7 @@ class StockMove(TransactionCase):
             'product_uom': self.uom_unit.id,
         })
         self.assertEqual(move1.state, 'draft')
-        self.assertEqual(move1.product_uom_qty, 0)
+        self.assertEqual(move1.product_uom_qty, 1)
         move1.product_uom_qty = 100
         move1.product_id = self.product_serial
         move1._onchange_product_id()

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -11,6 +11,7 @@
                 <field name="location_id"/>
                 <field name="user_id"/>
                 <field name="inventory_date"/>
+                <field name="product_categ_id"/>
                 <field name="package_id" groups="stock.group_tracking_lot"/>
                 <field name="lot_id" groups="stock.group_production_lot"/>
                 <field name="owner_id" groups="stock.group_tracking_owner"/>
@@ -128,6 +129,7 @@
                 <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}"
                        readonly="context.get('single_product', False)" force_save="1"
                        options="{'no_create': True}"/>
+                <field name="product_categ_id" optional="show"/>
                 <field name="location_id" attrs="{'readonly': [('id', '!=', False)]}"
                        invisible="context.get('hide_location', False)"
                        options="{'no_create': True}"/>
@@ -351,6 +353,7 @@
                 <field name="inventory_quantity_set" invisible="1"/>
                 <field name="location_id" domain="[('usage', 'in', ['internal', 'transit'])]" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)" options="{'no_create': True}"/>
                 <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}" readonly="context.get('single_product', False)" force_save="1" options="{'no_create': True}"/>
+                <field name="product_categ_id" optional="show"/>
                 <field name="lot_id" groups="stock.group_production_lot"
                     attrs="{'readonly': ['|', ('id', '!=', False), ('tracking', 'not in', ['serial', 'lot'])]}"
                     invisible="context.get('hide_lot', False)"


### PR DESCRIPTION
1. Add product category in inventory report.
2. Default quantity when creating a transfer switched to 1 instead of 0.
3. Remove the reorganize lines step in purchase tour (there is only 1
line).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
