### PR TITLE
[FIX] l10n_ch: Add padding in qr report title (for bigger headers that hide it)

### DIFF
--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -10,7 +10,7 @@ body.l10n_ch_qr {
     .swissqr_title {
         position: absolute;
         padding: 15px;
-        padding-top: 150px;
+        padding-top: 175px;
     }
 
     .swissqr_content {

--- a/doc/cla/individual/SimoneVagile.md
+++ b/doc/cla/individual/SimoneVagile.md
@@ -1,0 +1,11 @@
+Italy, 2021-04-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Simone Vanin simone.vanin@agilebg.com https://github.com/SimoneVagile


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add padding in qr report title (for bigger headers that hide it)

Current behavior before PR:
Some headers may hide Qr-bill title.

Desired behavior after PR is merged:
Qr-bill title is visible with any headers



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
