### PR TITLE
[FIX] sale: avoid re-invoicing invoiced SO lines

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -50,6 +50,8 @@ class AccountMoveLine(models.Model):
             For Vendor Bill flow, if the product has a 'erinvoice policy' and is a cost, then we will find the SO on which reinvoice the AAL
         """
         self.ensure_one()
+        if self.sale_line_ids:
+            return False
         uom_precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         return float_compare(self.credit or 0.0, self.debit or 0.0, precision_digits=uom_precision_digits) != 1 and self.product_id.expense_policy not in [False, 'no']
 


### PR DESCRIPTION
- Create a product:
  * Invoicing Policy: Delivered quantities
  * Re-invoice Expenses: At cost
- Create a SO with the created product in Order Lines
- Make sure the subtotal of the SO line is equal to 0, by setting an Unit Price to 0
  or by applying a 100% discount
- Confirm SO and create an invoice (Regular invoice)
- Post the invoice
A new line with the same product and the same delivered quantity is added to the SO.

It is not possible to invoice a SO line with a product having an expense policy and
a subtotal equal to 0, without having it reinvoiced to the SO.

This fix will prevent account move lines linked to a SO line from being reinvoiced.

opw-2479560

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
