### PR TITLE
[FIX] account: remove the duplicate field account_code

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -142,7 +142,6 @@ class AccountPayment(models.Model):
         compute='_compute_show_require_partner_bank',
         help="Technical field used to know whether the field `partner_bank_id` needs to be required or not in the payments form views")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
-    country_code = fields.Char(related='company_id.country_id.code')
     amount_signed = fields.Monetary(
         currency_field='currency_id', compute='_compute_amount_signed',
         help='Negative value of amount field if payment_type is outbound')


### PR DESCRIPTION
Two PR merged at around the same time both added the account_code
related field to the account.payment model.

This will remove that duplicated field.
