### PR TITLE
[FW][IMP] l10n_ar: show payment terms

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Argentina - Accounting',
-    'version': "3.2",
+    'version': "3.3",
     'description': """
 Functional
 ----------

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -159,9 +159,6 @@
             <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
         </span>
 
-        <!-- remove payment term, this is added on information section -->
-        <p name="payment_term" position="replace"/>
-
         <!-- remove payment reference that is not used in Argentina -->
         <xpath expr="//span[@t-field='o.payment_reference']/../.." position="replace"/>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In the Argentinean invoices report view, we were removing the Payment
Terms and we were only showing the Payment Term name in the header.
Now we add it back following the Odoo approach but we also keep the name
of the terms on the header.
We made this modification in the invoice report with and without payment.
Example: [FA-A.00001-00000386.pdf](https://github.com/odoo/odoo/files/6337477/FA-A.00001-00000386.pdf)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
