### PR TITLE
[FIX] website_sale: Display discounted price with included tax

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -292,13 +292,13 @@ class SaleOrder(models.Model):
                     'pricelist': order.pricelist_id.id,
                     'force_company': order.company_id.id,
                 })
-                product = self.env['product.product'].with_context(product_context).browse(product_id)
-                values['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(
-                    order_line._get_display_price(product),
-                    order_line.product_id.taxes_id,
-                    order_line.tax_id,
-                    self.company_id
-                )
+            product = self.env['product.product'].with_context(product_context).browse(product_id)
+            values['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(
+                order_line._get_display_price(product),
+                order_line.product_id.taxes_id,
+                order_line.tax_id,
+                self.company_id
+            )
 
             order_line.write(values)
 

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -3,6 +3,7 @@
 
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueSetup
 from odoo.tests import tagged
+from odoo.addons.website.tools import MockRequest
 
 
 @tagged('post_install', '-at_install')
@@ -129,3 +130,59 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueSe
         combination_info = test_product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")
         self.assertEqual(round(combination_info['list_price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")
+
+    def test_cart_update_with_fpos(self):
+        # We will test that the mapping of an 10% included tax by a 0% by a fiscal position is taken into account when updating the cart 
+        self.env.user.partner_id.country_id = False
+        current_website = self.env['website'].get_current_website()
+        pricelist = current_website.get_current_pricelist()
+        (self.env['product.pricelist'].search([]) - pricelist).write({'active': False})
+        # Add 10% tax on product
+        tax10 = self.env['account.tax'].create({'name': "Test tax 10", 'amount': 10, 'price_include': True, 'amount_type': 'percent'})
+        tax0 = self.env['account.tax'].create({'name': "Test tax 0", 'amount': 0, 'price_include': True, 'amount_type': 'percent'})
+
+        test_product = self.env['product.template'].create({
+            'name': 'Test Product',
+            'price': 110,
+            'taxes_id': [(6, 0, [tax10.id])],
+        }).with_context(website_id=current_website.id)
+
+        # Add discout of 50% for pricelist
+        pricelist.item_ids = self.env['product.pricelist.item'].create({
+            'applied_on': "1_product",
+            'base': "list_price",
+            'compute_price': "percentage",
+            'percent_price': 50,
+            'product_tmpl_id': test_product.id,
+        })
+
+        pricelist.discount_policy = 'without_discount'
+
+        # Create fiscal position mapping taxes 10% -> 0%
+        fpos = self.env['account.fiscal.position'].create({
+            'name': 'test',
+        })
+        self.env['account.fiscal.position.tax'].create({
+            'position_id': fpos.id,
+            'tax_src_id': tax10.id,
+            'tax_dest_id': tax0.id,
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+        })
+        sol = self.env['sale.order.line'].create({
+            'name': test_product.name,
+            'product_id': test_product.product_variant_id.id,
+            'product_uom_qty': 1,
+            'product_uom': test_product.uom_id.id,
+            'price_unit': test_product.list_price,
+            'order_id': so.id,
+            'tax_id': [(6, 0, [tax10.id])],
+        })
+        self.assertEqual(round(so.amount_total), 110.0, "110$ with 10% included tax")
+        so.pricelist_id = pricelist
+        so.fiscal_position_id = fpos
+        sol.product_id_change()
+        with MockRequest(self.env, website=current_website, sale_order_id=so.id):
+            so._cart_update(product_id=test_product.product_variant_id.id, line_id=sol.id, set_qty=1)
+        self.assertEqual(round(so.amount_total), 50, "100$ with 50% discount + 0% tax (mapped from fp 10% -> 0%)")

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -858,7 +858,7 @@
                         </td>
                         <td class="text-center td-price" name="price">
                             <t t-set="combination" t-value="line.product_id.product_template_attribute_value_ids + line.product_no_variant_attribute_value_ids"/>
-                            <t t-set="combination_info" t-value="line.product_id.product_tmpl_id._get_combination_info(combination)"/>
+                            <t t-set="combination_info" t-value="line.product_id.product_tmpl_id._get_combination_info(combination, pricelist=website_sale_order.pricelist_id)"/>
 
                             <t t-set="list_price_converted" t-value="website.currency_id._convert(combination_info['list_price'], website_sale_order.currency_id, website_sale_order.company_id, date)"/>
                             <t groups="account.group_show_line_subtotals_tax_excluded" t-if="(website_sale_order.pricelist_id.discount_policy == 'without_discount' and website_sale_order.currency_id.compare_amounts(list_price_converted, line.price_reduce_taxexcl) == 1) or website_sale_order.currency_id.compare_amounts(line.price_unit, line.price_reduce) == 1" name="order_line_discount">


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a company in €
- Let's consider two sales taxes T1 (10% included) and T2 (0%)
- Define a fiscal position FP that maps T1 to T2
- Define a product P with T1, price = 11€ and available in the shop
- Define a pricelist PL in $ such as 1€ = 1$, show discount to customer and discount P with 50%
- Define a portal user PU with FP and PL
- Log with PU
- Add P in the cart

Bug:

The unit price of P was 2,75$ instead of 2,5$

PS: Before adding P in the cart, the correct unit price was displayed.

opw:2472528