### PR TITLE
[FIX] survey: display right date format in datepicker

### DIFF
--- a/addons/survey/static/src/js/survey.js
+++ b/addons/survey/static/src/js/survey.js
@@ -3,8 +3,8 @@ odoo.define('survey.survey', function (require) {
 
 require('web.dom_ready');
 var core = require('web.core');
+var session = require('web.session');
 var time = require('web.time');
-var ajax = require('web.ajax');
 var field_utils = require('web.field_utils');
 var Dialog = require('web.Dialog');
 
@@ -183,15 +183,10 @@ if(!the_form.length) {
         }
     });
 
-    function load_locale(){
-        var url = "/web/webclient/locale/" + (document.documentElement.getAttribute('lang') || 'en_US').replace('-', '_');
-        return ajax.loadJS(url);
-    }
-
     // datetimepicker use moment locale to display date format according to language
     // frontend does not load moment locale at all.
     // so wait until DOM ready with locale then init datetimepicker
-    load_locale().then(function(){
+    session.load_translations().then(function(){
         _.each($('.input-group.date'), function(date_field){
             var disabledDates = [];
             var minDate, maxDate;


### PR DESCRIPTION
Issue

	- Install 'Survey' app
	- Enable "es_VE" language and activate on main website
	- Create a survey:
	- Add a question of type 'Date' then save
	- Click on "TEST" button
	- Start survey and add a date with the datepicker
	- Submit survey

	Error message / traceback.

Cause
	
	The date format is wrong because session translations
	params are not loaded before generating datepicker.

Solution

	Use 'session.load_translations()' to load session translation
	before generating datepicker.

opw-2452237