### PR TITLE
[13.0][IMP] base: allow Authorization header in cors pre-flight request

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -768,7 +768,7 @@ class HttpRequest(WebRequest):
         if request.httprequest.method == 'OPTIONS' and request.endpoint and request.endpoint.routing.get('cors'):
             headers = {
                 'Access-Control-Max-Age': 60 * 60 * 24,
-                'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept'
+                'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
             }
             return Response(status=200, headers=headers)
 


### PR DESCRIPTION
Accepting the `Authorization` header is necessary to create API endpoints that can be called from browser applications served from another domain.

This is a partial backport of c317232223460ba659feb27e9d48a60d3f5ffc25



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
