### PR TITLE
[FIX] account: digest email revenu values correction

### DIFF
--- a/addons/account/models/digest.py
+++ b/addons/account/models/digest.py
@@ -17,12 +17,13 @@ class Digest(models.Model):
         for record in self:
             start, end, company = record._get_kpi_compute_parameters()
             self._cr.execute('''
-                SELECT SUM(line.debit)
+                SELECT -sum(balance)
                 FROM account_move_line line
                 JOIN account_move move ON move.id = line.move_id
-                JOIN account_journal journal ON journal.id = move.journal_id
+                JOIN account_account account ON account.id = line.account_id
                 WHERE line.company_id = %s AND line.date >= %s AND line.date < %s
-                AND journal.type = 'sale'
+                AND account.internal_group = 'income'
+                AND move.state = 'posted'
             ''', [company.id, start, end])
             query_res = self._cr.fetchone()
             record.kpi_account_total_revenue_value = query_res and query_res[0] or 0.0


### PR DESCRIPTION
The value taken into account in the SQL for the calculation were wrong:
- Not based on the state of the invoices (cancelled and draft
were taken into account)
- Had the tax included

opw-2464004
feedback-2478356