### PR TITLE
[IMP] website: change configurator palette selection

### DIFF
--- a/addons/web/static/src/js/widgets/colorpicker.js
+++ b/addons/web/static/src/js/widgets/colorpicker.js
@@ -654,6 +654,25 @@ ColorpickerWidget.isCSSColor = function (cssColor) {
     return ColorpickerWidget.convertCSSColorToRgba(cssColor) !== false;
 };
 
+/**
+ * Mixes two colors by applying a weighted average of their red, green and blue
+ * components.
+ *
+ * @static
+ * @param {string} cssColor1 - hexadecimal code or rgb() or rgba()
+ * @param {string} cssColor2 - hexadecimal code or rgb() or rgba()
+ * @param {number} weight - a number between 0 and 1
+ * @returns {string} - mixed color in hexadecimal format
+ */
+ColorpickerWidget.mixCssColors = function (cssColor1, cssColor2, weight) {
+    const rgba1 = ColorpickerWidget.convertCSSColorToRgba(cssColor1);
+    const rgba2 = ColorpickerWidget.convertCSSColorToRgba(cssColor2);
+    const rgb1 = [rgba1.red, rgba1.green, rgba1.blue];
+    const rgb2 = [rgba2.red, rgba2.green, rgba2.blue];
+    const [r, g, b] = rgb1.map((_, idx) => Math.round(rgb2[idx] + (rgb1[idx] - rgb2[idx]) * weight));
+    return ColorpickerWidget.convertRgbaToCSSColor(r, g, b);
+};
+
 const ColorpickerDialog = Dialog.extend({
     /**
      * @override

--- a/addons/website/static/src/components/configurator/configurator.xml
+++ b/addons/website/static/src/components/configurator/configurator.xml
@@ -97,7 +97,7 @@
                 <div class="w-100 w-lg-25 order-lg-3 my-4 my-md-0 d-flex flex-column">
                     <div class="h4 text-center">
                         <b>Detect</b> from Logo</div>
-                    <div class="d-flex flex-column flex-grow-1">
+                    <div class="d-flex flex-column flex-grow-1 py-4">
                         <a href="#" t-on-click="uploadLogo" t-attf-class="o_configurator_logo_upload position-relative btn-link rounded bg-100 overflow-hidden d-flex flex-grow-1 justify-content-center align-items-center text-decoration-none {{state.logo? 'h-50' : ''}}">
                             <input type="file" class="logo_selection_input" t-on-change="changeLogo" style="display:none" name="logo_selection" t-ref="logoSelectionInput" accept="image/*"/>
                             <div class="o_configurator_logo_button text-center">
@@ -111,10 +111,11 @@
                         </a>
                         <div t-if="state.recommendedPalette" class="w-75 mx-auto px-2 pt-3" style="max-width: 184px;">
                             <h6 class="text-center text-success d-block badge mb-0 mt-n2">Detected Colors</h6>
-                            <div t-attf-class="palette_card rounded-pill overflow-hidden d-flex" t-on-click="selectPalette(state.recommendedPalette.id)" t-attf-style="background-color: {{state.recommendedPalette.color3}}">
-                                <div class="color_sample w-100 first" t-attf-style="background-color: {{state.recommendedPalette.color1}}"/>
-                                <div class="color_sample w-100 second" t-attf-style="background-color: {{state.recommendedPalette.color2}}"/>
-                                <div class="color_sample w-100 third" t-attf-style="background-color: {{state.recommendedPalette.color3}}"/>
+                            <div t-attf-class="palette_card rounded-pill overflow-hidden d-flex {{getters.getSelectedPaletteName() == 'recommendedPalette' ? 'selected' : ''}}"
+                                 t-on-click="selectPalette('recommendedPalette')" t-attf-style="background-color: {{state.recommendedPalette.color3}}">
+                                <div class="color_sample w-100" t-attf-style="background-color: {{state.recommendedPalette.color1}}"/>
+                                <div class="color_sample w-100" t-attf-style="background-color: {{state.recommendedPalette.color3}}"/>
+                                <div class="color_sample w-100" t-attf-style="background-color: {{state.recommendedPalette.color2}}"/>
                             </div>
                         </div>
                     </div>
@@ -130,10 +131,11 @@
                     <div class="d-flex flex-wrap align-items-end">
                         <t t-foreach="getters.getPalettes()" t-as="palette" t-key="palette_index">
                             <div class="w-50 w-md-25 px-2 pt-3">
-                                <div t-attf-class="palette_card rounded-pill overflow-hidden d-flex" t-on-click="selectPalette(palette.id)" t-attf-style="background-color: {{palette.color3}}">
-                                    <div class="color_sample w-100 first" t-attf-style="background-color: {{palette.color1}}"/>
-                                    <div class="color_sample w-100 second" t-attf-style="background-color: {{palette.color2}}"/>
-                                    <div class="color_sample w-100 third" t-attf-style="background-color: {{palette.color3}}"/>
+                                <div t-attf-class="palette_card rounded-pill overflow-hidden d-flex {{getters.getSelectedPaletteName() == palette.name ? 'selected' : ''}}"
+                                     t-on-click="selectPalette(palette.name)" t-attf-style="background-color: {{palette.color3}}">
+                                    <div class="color_sample w-100" t-attf-style="background-color: {{palette.color1}}"/>
+                                    <div class="color_sample w-100" t-attf-style="background-color: {{palette.color3}}"/>
+                                    <div class="color_sample w-100" t-attf-style="background-color: {{palette.color2}}"/>
                                 </div>
                             </div>
                         </t>

--- a/addons/website/static/src/scss/configurator.scss
+++ b/addons/website/static/src/scss/configurator.scss
@@ -193,7 +193,7 @@
                     padding-top: 30%;
                 }
 
-                &:hover {
+                &:hover, &.selected {
                     box-shadow: 0 0 0 1px #FFF, 0 0 0 3px theme-color("primary")
                 }
             }


### PR DESCRIPTION
This commit brings some functionnal changes to the
palette selection screen:

- The list of proposed palettes doesn't depend on the
uploaded logo anymore. It is now a fixed list of 20
palettes manually chosen among the existing ones.

- The recommended palette is not chosen among the existing
palettes based on the logo's extracted colors anymore.
The recommended palette is now a fully custom palette
generated based on the two colors extracted from the logo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
