### PR TITLE
[FIX] account: allow to search payment name (reconciliation widget)

### DIFF
--- a/addons/account/models/reconciliation_widget.py
+++ b/addons/account/models/reconciliation_widget.py
@@ -494,6 +494,7 @@ class AccountReconciliation(models.AbstractModel):
             '|', ('account_id.code', 'ilike', search_str),
             '|', ('move_id.name', 'ilike', search_str),
             '|', ('move_id.ref', 'ilike', search_str),
+            '|', ('payment_id.name', 'ilike', search_str),
             '|', ('date_maturity', 'like', parse_date(self.env, search_str)),
             '&', ('name', '!=', '/'), ('name', 'ilike', search_str)
         ]


### PR DESCRIPTION
Create a payment
Hit on 'payment matching' button
No line will be highlighted and the payment name cannot be used to
retrieve associated move lines.

This will make the reconciliation widget difficult to use for the user
as te move line created from the payment is not immidiately visible and
would need to be manually searched for

opw-2461109

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
