### PR TITLE
[FIX] website_sale_comparison: allow inherit ProductComparison

### DIFF
--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -287,4 +287,5 @@ publicWidget.registry.ProductComparison = publicWidget.Widget.extend({
         $target.find('.fa-chevron-circle-down, .fa-chevron-circle-right').toggleClass('fa-chevron-circle-down fa-chevron-circle-right');
     },
 });
+return ProductComparison;
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
@JKE-be before this PR it is not possible to inherit ProductComparison correctly.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
