### PR TITLE
[FIX] base: ensure_one in ir.sequence._get_prefix_suffix

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -213,12 +213,13 @@ class IrSequence(models.Model):
 
             return res
 
+        self.ensure_one()
         d = _interpolation_dict()
         try:
             interpolated_prefix = _interpolate(self.prefix, d)
             interpolated_suffix = _interpolate(self.suffix, d)
         except ValueError:
-            raise UserError(_('Invalid prefix or suffix for sequence \'%s\'') % (self.get('name')))
+            raise UserError(_('Invalid prefix or suffix for sequence \'%s\'') % self.name)
         return interpolated_prefix, interpolated_suffix
 
     def get_next_char(self, number_next):


### PR DESCRIPTION
The try/except is there to check that the string can be interpolated, so
it is catching a ValueError. But if there is a singleton error (when the
length of `self` is bigger than 1), it will raise a ValueError too.
The UserError raised in the except is then weird/wrong.


Was detected with this bugfix https://github.com/odoo/enterprise/pull/17817



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
