### PR TITLE
[FIX] stock: make warehouse list scrollable

### DIFF
--- a/addons/stock/static/src/xml/report_stock_forecasted.xml
+++ b/addons/stock/static/src/xml/report_stock_forecasted.xml
@@ -14,7 +14,7 @@
             data-toggle="dropdown">
             <span class="fa fa-home"/> Warehouse: <t t-esc="active_warehouse['name']"/>
         </button>
-        <div class="dropdown-menu o_filter_menu" role="menu">
+        <div class="dropdown-menu o_dropdown_menu o_filter_menu" role="menu">
             <t t-foreach="warehouses" t-as="wh">
                 <a role="menuitem" class="dropdown-item warehouse_filter"
                     data-filter="warehouses" t-att-data-warehouse-id="wh['id']"


### PR DESCRIPTION
On a product's Forecasted Report page, if the company has a lot of
warehouses, when the user opens the drop-down list to select another
warehouse, the list will exceeds the window height and won't be
scrollable. The user will have to zoom out to see the rest of the list.

`o_dropdown_menu` class is used to add required attributes:
https://github.com/odoo/odoo/blob/a622936ab09497086f43715e546a1b33418d0ee3/addons/web/static/src/scss/dropdown_menu.scss#L7-L8

OPW-2480784