### PR TITLE
[FIX] l10n_be: fix tax report check

### DIFF
--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -84,6 +84,7 @@
 
     <record id="tax_report_line_46L" model="account.tax.report.line">
         <field name="name">46L - Livraisons biens intra-communautaires exemptées</field>
+        <field name="code">c46L</field>
         <field name="tag_name">46L</field>
         <field name="report_id" ref="tax_report_vat"/>
         <field name="parent_id" ref="tax_report_title_operations_sortie_46"/>
@@ -92,6 +93,7 @@
 
     <record id="tax_report_line_46T" model="account.tax.report.line">
         <field name="name">46T - Livraisons biens intra-communautaire exemptées</field>
+        <field name="code">c46T</field>
         <field name="tag_name">46T</field>
         <field name="report_id" ref="tax_report_vat"/>
         <field name="parent_id" ref="tax_report_title_operations_sortie_46"/>
@@ -117,6 +119,7 @@
 
     <record id="tax_report_line_48s44" model="account.tax.report.line">
         <field name="name">48s44 - Notes de crédit aux opérations grilles [44]</field>
+        <field name="code">c48s44</field>
         <field name="tag_name">48s44</field>
         <field name="report_id" ref="tax_report_vat"/>
         <field name="parent_id" ref="tax_report_title_operations_sortie_48"/>
@@ -125,6 +128,7 @@
 
     <record id="tax_report_line_48s46L" model="account.tax.report.line">
         <field name="name">48s46L - Notes de crédit aux opérations grilles [46L]</field>
+        <field name="code">c48s46L</field>
         <field name="tag_name">48s46L</field>
         <field name="report_id" ref="tax_report_vat"/>
         <field name="parent_id" ref="tax_report_title_operations_sortie_48"/>
@@ -133,6 +137,7 @@
 
     <record id="tax_report_line_48s46T" model="account.tax.report.line">
         <field name="name">48s46T - Notes de crédit aux opérations grilles [46T]</field>
+        <field name="code">c48s46T</field>
         <field name="tag_name">48s46T</field>
         <field name="report_id" ref="tax_report_vat"/>
         <field name="parent_id" ref="tax_report_title_operations_sortie_48"/>


### PR DESCRIPTION
The tax report check made in enterprise required some codes on tax report lines that weren't present.

