### PR TITLE
[IMP] account: error message when no country can be inferred for taxes when installing the CoA

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -8830,6 +8830,12 @@ msgid "Please define a payment method on your payment."
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/chart_template.py:0
+#, python-format
+msgid "Please first define a fiscal country for company %s."
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_bank_statement.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1022,6 +1022,11 @@ class AccountTaxTemplate(models.Model):
 
                     if self.chart_template_id.country_id:
                         vals['country_id'] = self.chart_template_id.country_id.id
+                    elif company.account_fiscal_country_id:
+                        vals['country_id'] = company.account_fiscal_country_id.id
+                    else:
+                        # Will happen for generic CoAs such as syscohada (they are available for multiple countries, and don't have any country_id)
+                        raise UserError(_("Please first define a fiscal country for company %s.", company.name))
 
                     tax_template_vals.append((template, vals))
                 else:


### PR DESCRIPTION
Generic chart of accounts such as Syscohada don't have any country_id set. When installing them on a company without any account_fiscal_country_id, no country could be assigned to the account.tax being created, hence crashing, as country_id is required on account.tax. We now prevent that by raising a more comprehensive error.
