### PR TITLE
[FIX] mail: remove internal communication banner when no Reply-To

### DIFF
--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -73,7 +73,7 @@
     <td colspan="2" style="text-align:center;">
         <hr width="100%"
             style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin:4px 0 12px 0;"/>
-        <p t-if="subtype.internal" style="background-color: #f2dede; padding: 5px; margin-bottom: 16px;">
+        <p t-if="subtype.internal and message.reply_to != message.email_from" style="background-color: #f2dede; padding: 5px; margin-bottom: 16px;">
             <strong>Internal communication</strong>: Replying will post an internal note. Followers won't receive any email notification.
         </p>
     </td>


### PR DESCRIPTION
Steps:
- Install Projects
- Go to Settings / General Settings
- Make sure External Email Servers / Alias Domain is not filled in
- Go to a project's task and mention someone in the chatter as a note

Bug:
The internal communication banner is displayed but replying to the email
won't be treated as a note and won't go through the system.

Explanation:
When no Alias Domain are added, the `Reply-To` email header is the same
as the `From` header.
Replying to this email will be treated as a normal email and this email
will be sent directly to the recipient, bypassing the system.

This commit removes the "Internal communication" banner in this case
since this can be misleading. In fact, someone could directly be
replying to a customer thinking the reply would have been an internal
note.

opw:2447524