### PR TITLE
[FIX] website: allow "Search..." translation


### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -6275,6 +6275,11 @@ msgid ""
 msgstr ""
 
 #. module: website
+#: model_terms:ir.ui.view,arch_db:website.website_search_box
+msgid "Search..."
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_features
 msgid "Second Feature"
 msgstr ""

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2336,7 +2336,8 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 
 <template id="website_search_box" name="Website Searchbox">
     <div t-attf-class="input-group #{_classes}" role="search">
-        <input type="search" name="search" class="search-query form-control oe_search_box" t-att-placeholder="placeholder if placeholder else 'Search...'" t-att-value="search"/>
+        <t t-set="search_placeholder">Search...</t>
+        <input type="search" name="search" class="search-query form-control oe_search_box" t-att-placeholder="placeholder if placeholder else search_placeholder" t-att-value="search"/>
         <div class="input-group-append">
             <button type="submit" class="btn btn-primary oe_search_button" aria-label="Search" title="Search"><i class="fa fa-search"/></button>
         </div>


### PR DESCRIPTION

Strings in python expression in 't-att-placeholder' are not translated
automatically.

opw-2467404
