### PR TITLE
[IMP] website: add data-snippet attribute on rendered snippets

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -9,6 +9,7 @@ import requests
 import re
 
 
+from lxml import html
 from werkzeug import urls
 from werkzeug.datastructures import OrderedMultiDict
 from werkzeug.exceptions import NotFound
@@ -321,6 +322,9 @@ class Website(models.Model):
                     view_id = self.env['website'].with_context(website_id=website.id).viewref(snippet)
                     if view_id:
                         rendered_snippet = pycompat.to_text(view_id._render())
+                        el = html.fragment_fromstring(rendered_snippet)
+                        el.attrib['data-snippet'] = snippet.split('.', 1)[-1]
+                        rendered_snippet = pycompat.to_text(html.tostring(el))
                         rendered_snippets.append(rendered_snippet)
                 except ValueError as e:
                     logger.warning(e)


### PR DESCRIPTION
Add the 'data-snippet' attribute on each snippet rendered
by the configurator when building website pages.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
