### PR TITLE
[FIX] base: Fix wrong wording for error when archiving a contact with a user still linked to it

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -22669,7 +22669,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/res_partner.py:509
 #, python-format
-msgid "You cannot archive a contact linked to an internal user."
+msgid "You cannot archive a contact linked to a portal or internal user."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -536,7 +536,7 @@ class Partner(models.Model):
         if vals.get('active') is False:
             for partner in self:
                 if partner.active and partner.user_ids:
-                    raise ValidationError(_('You cannot archive a contact linked to an internal user.'))
+                    raise ValidationError(_('You cannot archive a contact linked to a portal or internal user.'))
         # res.partner must only allow to set the company_id of a partner if it
         # is the same as the company of all users that inherit from this partner
         # (this is to allow the code from res_users to write to the partner!) or


### PR DESCRIPTION
**Description of the issue/feature this PR addresses and current behavior before PR:**
There is a discrepancy in the wording of the error message provided when trying to archive a contact and a portal user is still linked to it. The error reads that an 'internal user' is linked but really, it should say a 'portal user.'.

**Desired behavior after PR is merged:**
The wording of the error is clearer, and it now says 'portal user' instead of 'internal user'.

OPW: 2498139

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
