### PR TITLE
[FIX] mrp: remove workorder_ids on removing bom_id

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -712,6 +712,8 @@ class MrpProduction(models.Model):
     def _onchange_workorder_ids(self):
         if self.bom_id:
             self._create_workorder()
+        else:
+            self.workorder_ids = False
 
     def write(self, vals):
         if 'workorder_ids' in self:


### PR DESCRIPTION
Method `_onchange_workorder_ids` will create workorder_ids
for the the selected bom but it was not re-setting it on removing
BoM.
It was causing issue on `_action_confirm` as Bom for the selected
WO will not be found.

Fixes: #68261

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
