### PR TITLE
[IMP] models: add default name for action

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1677,6 +1677,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         return {
             'type': 'ir.actions.act_window',
             'res_model': self._name,
+            'name': self.env['ir.model']._get(self._name).name,
             'view_type': 'form',
             'view_mode': 'form',
             'views': [(view_id, 'form')],


### PR DESCRIPTION
Before this commit, Returning action by calling this
method will display `Unnamed` on the view.

Now we are using model's name as default.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
