### PR TITLE
[FIX] Allow to login with OpenID providers using the OAuth2 addon

### DIFF
--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -99,6 +99,10 @@ class ResUsers(models.Model):
             # Workaround: facebook does not send 'user_id' in Open Graph Api
             if validation.get('id'):
                 validation['user_id'] = validation['id']
+                
+            # Workaround: OIDC conformant providers like Auht0 do not send 'user_id'
+            elif  validation.get('sub'):
+                validation['user_id'] = validation['sub']
             else:
                 raise AccessDenied()
 

--- a/doc/cla/individual/pepjo.md
+++ b/doc/cla/individual/pepjo.md
@@ -1,0 +1,11 @@
+United Kingdom, 20th of April 2020
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pep Rodeja pep@rodeja.me https://github.com/pepjo


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Allows Odoo to use the `sub` field from the OpenID specification, which does not specify `user_id` nor `id`

Current behaviour before PR:
Odoo only checks the `user_id` and `id` from the `tokeninfo`/`userinfo` endpoints

Desired behaviour after PR is merged:
If neither `user_id` nor `id` are present in the information, but `sub` is present, the later will be used to identify the user.

--
This PR does not change any existing functionality but it allows to use a much broader set of providers who support OpenID: like Auth0, Okta, etc


--
I will now sign the CLA and read the PR guidelines at www.odoo.com/submit-pr
