### PR TITLE
[FIX] point_of_sale: fix pricelist discount display

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/OrderReceipt.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/OrderReceipt.js
@@ -34,7 +34,7 @@ odoo.define('point_of_sale.OrderReceipt', function(require) {
                 line.quantity === 1 &&
                 !(
                     line.display_discount_policy == 'without_discount' &&
-                    line.price != line.price_lst
+                    line.price < line.price_lst
                 )
             );
         }

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -37,7 +37,7 @@
                         <span> </span><t t-esc="props.line.get_unit().name" />
                         at
                         <t t-if="props.line.display_discount_policy() == 'without_discount' and
-                            props.line.get_unit_display_price() != props.line.get_lst_price()">
+                            props.line.get_unit_display_price() &lt; props.line.get_lst_price()">
                             <s>
                                 <t t-esc="env.pos.format_currency(props.line.get_fixed_lst_price(),'Product Price')" />
                             </s>


### PR DESCRIPTION
When a pricelist is set to display a discount, it also display the price
difference when the price is increased for a reason.

To avoid such an anoying behavior, that'll show that the price of a
product as been increased by aplying a discount, we only show the old
price when it has been decreased.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
