### PR TITLE
[IMP] mail: make admin read all the emails

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -382,7 +382,7 @@ class Message(models.Model):
                     model_record_ids.setdefault(vals['model'], set()).add(vals['res_id'])
             return model_record_ids
 
-        if self.env.is_superuser():
+        if self.env.is_admin():
             return
         # Non employees see only messages with a subtype (aka, not internal logs)
         if not self.env['res.users'].has_group('base.group_user'):


### PR DESCRIPTION
PURPOSE
Let the admins access any email as they may be trying to debug it. This is especially 
useful to debug emails and see what went wrong (see the failure reason, check if there
is a correct "from" and "to", try to resend, ...)

CURRENT
Admin not able to access any emails in debug mode. thus admin not decides what went wrong in email.

TO BE
As admin, user can access all the content of mail/message when he trying to debug it.

**TaskID - 2464212**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
