### PR TITLE
[FIX] crm: fixed form view for leads in reporting

### DIFF
--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -144,7 +144,10 @@
             <field name="view_ids"
                    eval="[(5, 0, 0),
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
-                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')})]"/>
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')}),
+                          (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')}),
+                          (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_leads')}),
+                         ]"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data found!

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -82,9 +82,28 @@
            <field name="context">{'search_default_team_id': [active_id], 'search_default_filter_create_date': 1}}</field>
            <field name="domain">[]</field>
            <field name="view_mode">graph,pivot,tree,form</field>
-           <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
+           <field name="view_id" ref="crm_lead_view_graph"/>
+           <field name="search_view_id" ref="crm.view_crm_case_leads_filter"/>
            <field name="help">Leads Analysis allows you to check different CRM related information like the treatment delays or number of leads per state. You can sort out your leads analysis by different groups to get accurate grained analysis.</field>
        </record>
+        <record id="action_report_crm_lead_salesteam_view_graph" model="ir.actions.act_window.view">
+            <field name="sequence">2</field>
+            <field name="view_mode">graph</field>
+            <field name="view_id" ref="crm_lead_view_graph"/>
+            <field name="act_window_id" ref="action_report_crm_lead_salesteam"/>
+        </record>
+        <record id="action_report_crm_lead_salesteam_view_pivot" model="ir.actions.act_window.view">
+            <field name="sequence">3</field>
+            <field name="view_mode">pivot</field>
+            <field name="view_id" ref="crm_lead_view_pivot"/>
+            <field name="act_window_id" ref="action_report_crm_lead_salesteam"/>
+        </record>
+        <record id="action_report_crm_lead_salesteam_view_tree" model="ir.actions.act_window.view">
+            <field name="sequence">4</field>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="crm_case_tree_view_leads"/>
+            <field name="act_window_id" ref="action_report_crm_lead_salesteam"/>
+        </record>
 
        <record id="action_report_crm_opportunity_salesteam" model="ir.actions.act_window">
             <field name="name">Pipeline Analysis</field>


### PR DESCRIPTION
PURPOSE

When we go to CRM -> Reporting -> Leads, It shows the analysis of leads. We
can open the form view of every leads from the different views wise Graph,
'Pivot', and 'Dashboard' except the 'List' view and it's a bit odd. We should be able
to open the form view from corresponding leads in the list view.
Currently, the view which is coming in the 'List' view is not correct and should be 
replaced by the same view which is rendered by action
'crm_lead_all_leads'

SPECIFICATIONS

- Initially, we have to fix the correct list view to be rendered and that is
  'crm_case_tree_view_leads' instead of 'crm_case_tree_view_oppor'.
- Next, we have added the form view in addition to the list view in view_ids of
   the corresponding action.
This is the goal of this commit.

LINKS

PR #69575
Task 2497936