### PR TITLE
[IMP] account_edi: improve how we handle the attachments in mail template

### DIFF
--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -6,6 +6,13 @@ from odoo import api, models
 class MailTemplate(models.Model):
     _inherit = "mail.template"
 
+    def _get_edi_attachments(self, attachment_id, record_data):
+        if not attachment_id:
+            return record_data
+        record_data.setdefault('attachments', [])
+        record_data['attachments'].append((attachment_id.name, attachment_id.datas))
+        return record_data
+
     def generate_email(self, res_ids, fields):
         res = super().generate_email(res_ids, fields)
 
@@ -26,10 +33,6 @@ class MailTemplate(models.Model):
                 # wizard.
                 if doc.edi_format_id._is_embedding_to_invoice_pdf_needed():
                     continue
-
-                attachment = doc.attachment_id
-                if attachment:
-                    record_data.setdefault('attachments', [])
-                    record_data['attachments'].append((attachment.name, attachment.datas))
+                record_data = self._get_edi_attachments(doc, record_data)
 
         return res


### PR DESCRIPTION
Functionally:

There is a zip with the 2 XML we need so we are unziping them and inside the CDR there is a response
that contains a base64 zip, so, we are decoding-unziping-reading that data and attaching it to the
email we are going to send as XML.

The reason we need this is because in Peruvian market even if internally the electronic invoice is managed by a Zip file, it is used to send the actual XML for the response and the invoice unzipped in the mail to be processed by the market standards.

PR related
https://github.com/odoo/enterprise/pull/17840


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
