### PR TITLE
Fix a thimblefull of JS tests broken under FF

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -881,6 +881,7 @@ var FieldDate = InputField.extend({
      */
     activate: function () {
         if (this.isFocusable() && this.datewidget) {
+            this.datewidget.$input.focus();
             this.datewidget.$input.select();
             return true;
         }

--- a/addons/web/static/tests/core/util_tests.js
+++ b/addons/web/static/tests/core/util_tests.js
@@ -231,7 +231,7 @@ QUnit.module('core', {}, function () {
         );
         assert.throws(
             () => sortBy([Symbol('b'), Symbol('a')]),
-            new TypeError(`Cannot convert a Symbol value to a number`)
+            TypeError
         );
         assert.throws(
             () => sortBy(ints, true),

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4314,7 +4314,7 @@ QUnit.module('basic_fields', {
     });
 
     QUnit.test('field date should select its content onclick when there is one', async function (assert) {
-        assert.expect(2);
+        assert.expect(3);
         var done = assert.async();
 
         var form = await createView({
@@ -4332,7 +4332,10 @@ QUnit.module('basic_fields', {
             'show.datetimepicker': function () {
                 assert.ok($('.bootstrap-datetimepicker-widget').is(':visible'),
                     'bootstrap-datetimepicker is visible');
-                assert.strictEqual(window.getSelection().toString(), "02/03/2017",
+                const active = document.activeElement;
+                assert.equal(active.tagName, 'INPUT', "The datepicker input should be focused");
+                const sel = active.value.slice(active.selectionStart, active.selectionEnd);
+                assert.strictEqual(sel, "02/03/2017",
                     'The whole input of the date field should have been selected');
                 done();
             }

--- a/addons/web/static/tests/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/helpers/test_utils_dom.js
@@ -169,6 +169,9 @@ odoo.define('web.test_utils_dom', function (require) {
         if (validMatches.length === 0 && matches.length > 0) {
             throw new Error(`Element to click on is not visible ${selectorMsg}`);
         }
+        if (target.disabled) {
+            return;
+        }
 
         return triggerEvent(target, 'click');
     }


### PR DESCRIPTION
This fixes 3 tests which currently don't work in Firefox.

* One is an overspecified check (which seems entirely unnecessary but...).
* One is coding to Chrome's behaviour instead of spec.
* The last is half/half between an FF bug and coding to an implementation: the FF behaviour is arguably stupid but apparently not out-of-spec.