### PR TITLE
[IMP] stock: revamp putaway rules screen

### DIFF
--- a/addons/stock/views/product_strategy_views.xml
+++ b/addons/stock/views/product_strategy_views.xml
@@ -22,14 +22,17 @@
                        force_save="1"/>
                 <field name="package_type_ids" string="Package type"
                        options="{'no_create': True, 'no_open': True}"
-                       groups="stock.group_tracking_lot" widget="many2many_tags"/>
-                <field name="location_out_id" string="Store to"
+                       groups="stock.group_tracking_lot" widget="many2many_tags"
+                       optional="show"/>
+                <field name="location_out_id"
                        attrs="{'readonly': [('location_in_id', '=', False)]}"
-                       options="{'no_create': True}"/>
-                <field name="storage_category_id" string="Storage Category"
+                       options="{'no_create': True}"
+                       optional="show"/>
+                <field name="storage_category_id" string="Having Category"
                        groups="stock.group_stock_storage_categories"
-                       options="{'no_create': True}"/>
-                <field name="company_id" groups="stock.group_stock_multi_locations" force_save="1" readonly="context.get('fixed_location', False)" options="{'no_create': True}"/>
+                       options="{'no_create': True}"
+                       optional="show"/>
+                <field name="company_id" groups="stock.group_stock_multi_locations" force_save="1" readonly="context.get('fixed_location', False)" options="{'no_create': True}" optional="show"/>
             </tree>
         </field>
     </record>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -111,6 +111,14 @@
         </field>
     </record>
 
+    <record model="ir.actions.act_window" id="action_storage_category_locations">
+        <field name="name">Locations</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.location</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('storage_category_id', '=', active_id)]</field>
+    </record>
+
     <record id="action_location_form" model="ir.actions.act_window">
         <field name="name">Locations</field>
         <field name="res_model">stock.location</field>

--- a/addons/stock/views/stock_storage_category_views.xml
+++ b/addons/stock/views/stock_storage_category_views.xml
@@ -6,6 +6,9 @@
         <field name="arch" type="xml">
             <form string="Storage Category">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(action_storage_category_locations)d" string="Locations" type="action" class="oe_stat_button" icon="fa-arrows-v"/>
+                    </div>
                     <group>
                         <group>
                             <field name="name"/>
@@ -21,17 +24,7 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Product Capacity" name="product_capacity">
-                            <field name="product_capacity_ids" context="{'default_storage_category_id': id}">
-                                <tree editable="bottom">
-                                    <field name="product_id" required="1"/>
-                                    <field name="quantity"/>
-                                    <field name="product_uom_id" options="{'no_create': True, 'no_open': True}"/>
-                                    <field name="company_id" invisible="1"/>
-                                </tree>
-                            </field>
-                        </page>
-                        <page string="Package Capacity" name="package_capacity" groups="stock.group_tracking_lot">
+                        <page string="Capacity by Package" name="package_capacity" groups="stock.group_tracking_lot">
                             <field name="package_capacity_ids" context="{'default_storage_category_id': id}">
                                 <tree editable="bottom">
                                     <field name="package_type_id" required="1"/>
@@ -40,10 +33,13 @@
                                 </tree>
                             </field>
                         </page>
-                        <page string="Locations" name="locations">
-                            <field name="location_ids">
-                                <tree create="false" delete="false">
-                                    <field name="complete_name" string="Location"/>
+                        <page string="Capacity by Product" name="product_capacity">
+                            <field name="product_capacity_ids" context="{'default_storage_category_id': id}">
+                                <tree editable="bottom">
+                                    <field name="product_id" required="1"/>
+                                    <field name="quantity"/>
+                                    <field name="product_uom_id" options="{'no_create': True, 'no_open': True}"/>
+                                    <field name="company_id" invisible="1"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
1. When creating a putway rule, default location_in_id is receipt
destination location (in case of single warehouse).
2. When changing location_in_id, copy value to location_out_id.
3. Allow to hide some fields and change of some labels.
4. Move location tab to a smart button.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
