### PR TITLE
[MERGE] website_event_*: improve Online Events feeling and organization

### DIFF
--- a/addons/website_event_exhibitor/static/src/scss/event_templates_sponsor.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_templates_sponsor.scss
@@ -55,6 +55,7 @@
     border: 1px solid $gray-200;
     background-color: $white;
     margin: 0 -1px -1px 0;
+    cursor: pointer;
 
     .ribbon-wrapper {
         width: 50px;

--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -6,17 +6,18 @@
         <div class="container mt32 mb16 d-none d-md-block d-print-none" t-if="event.sponsor_ids">
             <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(event.sponsor_ids) > 10) else 'justify-content-md-center'}">
                 <t t-foreach="event.sponsor_ids.sorted(lambda sponsor: not sponsor.website_published)" t-as="sponsor">
-                    <t t-if="sponsor.url">
-                        <a class="o_wevent_sponsor o_wevent_sponsor_card h-100 text-decoration-none" target="_blank" t-att-href="sponsor.url"
-                            t-att-data-publish="'on' if sponsor.website_published else 'off'">
-                            <t t-call="website_event_exhibitor.event_sponsor_thumb_details"/>
-                        </a>
-                    </t>
-                    <t t-if="not sponsor.url">
-                        <div class="o_wevent_sponsor o_wevent_sponsor_card h-100" t-att-data-publish="'on' if sponsor.website_published else 'off'">
-                            <t t-call="website_event_exhibitor.event_sponsor_thumb_details"/>
+                    <t t-set="popover_content">
+                        <div t-field="sponsor.name" class="h5"/>
+                        <div t-if="sponsor.url" class="d-flex align-items-baseline">
+                            <i class="fa fa-home mr-2"/><a t-att-href="sponsor.url" t-field="sponsor.url" class="text-truncate"/>
                         </div>
                     </t>
+                    <a class="o_wevent_sponsor o_wevent_sponsor_card h-100" tabindex="0" role="button"
+                        t-att-data-publish="'on' if sponsor.website_published else 'off'"
+                        t-att-data-content="popover_content"
+                        data-html="true" data-trigger="focus" data-toggle="popover" data-placement="bottom">
+                        <t t-call="website_event_exhibitor.event_sponsor_thumb_details"/>
+                    </a>
                 </t>
             </div>
         </div>

--- a/addons/website_event_track/data/event_track_data.xml
+++ b/addons/website_event_track/data/event_track_data.xml
@@ -16,14 +16,14 @@
             <field name="name">Announced</field>
             <field name="sequence">3</field>
             <field name="color">3</field>
-            <field name="is_accepted" eval="True"/>
+            <field name="is_visible_in_agenda" eval="True"/>
         </record>
         <record id="event_track_stage3" model="event.track.stage">
             <field name="name">Published</field>
             <field name="sequence">4</field>
             <field name="color">4</field>
-            <field name="is_accepted" eval="True"/>
-            <field name="is_done" eval="True"/>
+            <field name="is_visible_in_agenda" eval="True"/>
+            <field name="is_fully_accessible" eval="True"/>
         </record>
         <record id="event_track_stage4" model="event.track.stage">
             <field name="name">Refused</field>

--- a/addons/website_event_track/data/event_track_demo.xml
+++ b/addons/website_event_track/data/event_track_demo.xml
@@ -48,7 +48,7 @@
     </record>
     <record id="event_track5" model="event.track">
         <field name="name">The new way to promote your creations</field>
-        <field name="is_published" eval="True"/>
+        <field name="is_published" eval="False"/>
         <field name="event_id" ref="event.event_0"/>
         <field name="date" eval="(DateTime.now() + timedelta(days=1, hours=4, minutes=5)).strftime('%Y-%m-%d %H:%M:%S')"></field>
         <field name="location_id" ref="website_event_track.event_track_location6"/>
@@ -59,7 +59,7 @@
     </record>
     <record id="event_track6" model="event.track">
         <field name="name">Detailed roadmap of our new products</field>
-        <field name="is_published" eval="True"/>
+        <field name="is_published" eval="False"/>
         <field name="event_id" ref="event.event_0"/>
         <field name="date" eval="(DateTime.now() + timedelta(days=1, hours=7, minutes=5)).strftime('%Y-%m-%d %H:%M:%S')"></field>
         <field name="location_id" ref="website_event_track.event_track_location6"/>

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -41,7 +41,6 @@ class Track(models.Model):
         index=True, copy=False, default=_get_default_stage_id,
         group_expand='_read_group_stage_ids',
         required=True, tracking=True)
-    is_accepted = fields.Boolean('Is Accepted', related='stage_id.is_accepted', readonly=True)
     legend_blocked = fields.Char(related='stage_id.legend_blocked',
         string='Kanban Blocked Explanation', readonly=True)
     legend_done = fields.Char(related='stage_id.legend_done',
@@ -442,7 +441,7 @@ class Track(models.Model):
         return stages.search([], order=order)
 
     def _synchronize_with_stage(self, stage):
-        if stage.is_done:
+        if stage.is_fully_accessible:
             self.is_published = True
         elif stage.is_cancel:
             self.is_published = False

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -42,15 +42,24 @@ class Track(models.Model):
         group_expand='_read_group_stage_ids',
         required=True, tracking=True)
     is_accepted = fields.Boolean('Is Accepted', related='stage_id.is_accepted', readonly=True)
+    legend_blocked = fields.Char(related='stage_id.legend_blocked',
+        string='Kanban Blocked Explanation', readonly=True)
+    legend_done = fields.Char(related='stage_id.legend_done',
+        string='Kanban Valid Explanation', readonly=True)
+    legend_normal = fields.Char(related='stage_id.legend_normal',
+        string='Kanban Ongoing Explanation', readonly=True)
     kanban_state = fields.Selection([
         ('normal', 'Grey'),
         ('done', 'Green'),
         ('blocked', 'Red')], string='Kanban State',
-        copy=False, default='normal', required=True, tracking=True,
+        copy=False, default='normal', required=True,
         help="A track's kanban state indicates special situations affecting it:\n"
              " * Grey is the default situation\n"
              " * Red indicates something is preventing the progress of this track\n"
              " * Green indicates the track is ready to be pulled to the next stage")
+    kanban_state_label = fields.Char(
+        string='Kanban State Label', compute='_compute_kanban_state_label', store=True,
+        tracking=True)
     partner_id = fields.Many2one('res.partner', 'Contact', help="Contact of the track, may be different from speaker.")
     # speaker information
     partner_name = fields.Char(
@@ -158,6 +167,18 @@ class Track(models.Model):
         for track in self:
             if track.id:
                 track.website_url = '/event/%s/track/%s' % (slug(track.event_id), slug(track))
+
+    # STAGES
+
+    @api.depends('stage_id', 'kanban_state')
+    def _compute_kanban_state_label(self):
+        for track in self:
+            if track.kanban_state == 'normal':
+                track.kanban_state_label = track.stage_id.legend_normal
+            elif track.kanban_state == 'blocked':
+                track.kanban_state_label = track.stage_id.legend_blocked
+            else:
+                track.kanban_state_label = track.stage_id.legend_done
 
     # SPEAKER
 

--- a/addons/website_event_track/models/event_track_stage.py
+++ b/addons/website_event_track/models/event_track_stage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class TrackStage(models.Model):
@@ -15,6 +15,13 @@ class TrackStage(models.Model):
         'mail.template', string='Email Template',
         domain=[('model', '=', 'event.track')],
         help="If set an email will be sent to the customer when the track reaches this step.")
+    # legends
+    color = fields.Integer(string='Color')
+    description = fields.Text(string='Description', translate=True)
+    legend_blocked = fields.Char('Red Kanban Label', default=lambda s: _('Blocked'), translate=True)
+    legend_done = fields.Char('Green Kanban Label', default=lambda s: _('Ready for Next Stage'), translate=True)
+    legend_normal = fields.Char('Grey Kanban Label', default=lambda s: _('In Progress'), translate=True)
+    # pipe
     fold = fields.Boolean(
         string='Folded in Kanban',
         help='This stage is folded in the kanban view when there are no records in that stage to display.')
@@ -26,4 +33,3 @@ class TrackStage(models.Model):
         help='Done tracks are automatically published so that they are available in frontend.')
     is_cancel = fields.Boolean(string='Canceled Stage')
     is_done = fields.Boolean()
-    color = fields.Integer(string='Color')

--- a/addons/website_event_track/static/src/js/website_event_track.js
+++ b/addons/website_event_track/static/src/js/website_event_track.js
@@ -14,6 +14,15 @@ publicWidget.registry.websiteEventTrack = publicWidget.Widget.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * @override
+     */
+    start: function () {
+        this._super.apply(this, arguments).then(() => {
+            this.$el.find('[data-toggle="popover"]').popover()
+        })
+    },
+
+    /**
      * @private
      * @param {Event} ev
      */

--- a/addons/website_event_track/views/event_track_stage_views.xml
+++ b/addons/website_event_track/views/event_track_stage_views.xml
@@ -22,13 +22,12 @@
                         <group>
                             <field name="name"/>
                             <field name="mail_template_id"/>
-                            <field name="sequence" groups="base.group_no_one"/>
+                            <field name="is_visible_in_agenda" attrs="{'readonly': [('is_cancel', '=', True)]}"/>
+                            <field name="is_fully_accessible" attrs="{'readonly': [('is_cancel', '=', True)]}"/>
+                            <field name="is_cancel"/>
                         </group>
                         <group>
                             <field name="fold"/>
-                            <field name="is_accepted"/>
-                            <field name="is_done"/>
-                            <field name="is_cancel"/>
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>
@@ -65,8 +64,8 @@
             <tree string="Track Stage">
                 <field name="sequence" widget="handle" groups="event.group_event_manager"/>
                 <field name="name"/>
-                <field name="is_accepted"/>
-                <field name="is_done"/>
+                <field name="is_visible_in_agenda"/>
+                <field name="is_fully_accessible"/>
                 <field name="is_cancel"/>
                 <field name="fold"/>
             </tree>

--- a/addons/website_event_track/views/event_track_stage_views.xml
+++ b/addons/website_event_track/views/event_track_stage_views.xml
@@ -32,6 +32,27 @@
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>
+                    <group string="Stage Description and Tooltips">
+                        <p class="text-muted" colspan="2">
+                            Define labels explaining kanban state management.
+                        </p>
+                        <label for="legend_normal" string=" " class="o_status"
+                            title="Task in progress. Click to block or set as done."
+                            aria-label="Task in progress. Click to block or set as done." role="img"/>
+                        <field name="legend_normal" nolabel="1"/>
+                        <label for="legend_blocked" string=" " class="o_status o_status_red"
+                            title="Task is blocked. Click to unblock or set as done."
+                            aria-label="Task is blocked. Click to unblock or set as done." role="img"/>
+                        <field name="legend_blocked" nolabel="1"/>
+                        <label for="legend_done" string=" " class="o_status o_status_green"
+                            title="This step is done. Click to block or set in progress."
+                            aria-label="This step is done. Click to block or set in progress." role="img"/>
+                        <field name="legend_done" nolabel="1"/>
+                        <p class="text-muted" colspan="2">
+                            Add a description to help your coworkers understand the meaning and purpose of the stage.
+                        </p>
+                        <field name="description" placeholder="Add a description..." nolabel="1" colspan="2"/>
+                    </group>
                 </sheet>
             </form>
         </field>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -164,8 +164,6 @@
             <small t-if="not track.website_published and is_event_user"
                    title="Unpublished"
                    class="ml-1 mt-1 mt-md-0 badge badge-danger o_wevent_online_badge_unpublished">Unpublished</small>
-            <small t-if="not track.stage_id.is_accepted" title="Not Accepted"
-                   class="ml-1 mt-1 mt-md-0 badge badge-danger o_wevent_online_badge_unpublished">Not Accepted</small>
             <span t-if="option_track_wishlist">
                 <t t-call="website_event_track.track_widget_reminder">
                     <t t-set="reminder_light" t-value="True"/>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -143,18 +143,18 @@
             <h5 class="m-0 text-danger">Live Now</h5>
             <hr class="mt-2 pb-1 mb-1"/>
         </div>
-        <div t-foreach="tracks_live" t-as="track" class="col-md-6 col-lg-3 mb-4">
-            <t t-call="website_event_track.tracks_cards_track"/>
-        </div>
+        <t t-call="website_event_track.track_cards_section">
+            <t t-set="tracks" t-value="tracks_live"/>
+        </t>
     </div>
     <div class="row mb-3" t-if="tracks_soon">
         <div class="col-12">
             <h5 class="m-0 text-danger">Coming soon ...</h5>
             <hr class="mt-2 pb-1 mb-1"/>
         </div>
-        <div t-foreach="tracks_soon" t-as="track" class="col-md-6 col-lg-3 mb-4">
-            <t t-call="website_event_track.tracks_cards_track"/>
-        </div>
+        <t t-call="website_event_track.track_cards_section">
+            <t t-set="tracks" t-value="tracks_soon"/>
+        </t>
     </div>
 </template>
 
@@ -221,7 +221,7 @@
                                     </t>
                                 </div>
                                 <span class="h5 mb0">
-                                    <a t-if="track.is_published or is_event_user"
+                                    <a t-if="track.website_published or is_event_user"
                                         class="mr-2"
                                         t-att-href="track.website_url">
                                         <span t-field="track.name"/>
@@ -229,7 +229,7 @@
                                     <t t-else="">
                                         <span class="mr-2" t-field="track.name"/>
                                     </t>
-                                    <span t-if="not track.is_published and is_event_user"
+                                    <span t-if="not track.website_published and is_event_user"
                                         class="badge badge-danger o_wevent_online_badge_unpublished">
                                         Unpublished
                                     </span>
@@ -302,71 +302,82 @@
 <!-- TOOL TEMPLATES -->
 <!-- ============================================================ -->
 
-<template id="tracks_cards_track" name="Track Card">
-    <a t-att-href="'/event/%s/track/%s' % (slug(track.event_id), slug(track))" class="text-decoration-none">
-        <article t-att-class="'h-100 card rounded-0 border-0 shadow-sm o_wesession_track_card %s' % ('o_wesession_track_card_unpublished' if not track.is_published else '')"
-            itemscope="itemscope" itemtype="http://schema.org/Event">
-            <div class="h-100 row no-gutters">
-                <header class="overflow-hidden bg-secondary col-12">
-                    <small t-if="not track.is_published" class="o_wesession_track_card_header_badge bg-danger">
-                        <i class="fa fa-ban mr-2"/>Unpublished
-                    </small>
+<template id="track_cards_section" name="Track Cards">
+    <div t-foreach="tracks" t-as="track" class="col-md-6 col-lg-3 mb-4">
+        <t t-if="track.website_published or is_event_user">
+            <a t-att-href="'/event/%s/track/%s' % (slug(track.event_id), slug(track))" class="text-decoration-none">
+                <t t-call="website_event_track.track_card"/>
+            </a>
+        </t>
+        <t t-else="">
+            <t t-call="website_event_track.track_card"/>
+        </t>
+    </div>
+</template>
 
-                    <div t-if="track.website_image_url" class="card-img-top"
-                        t-attf-style="padding-top: 50%; background-image: url(#{track.website_image_url}); background-size: cover; background-position:center">
-                        <span t-if="option_track_wishlist and not track.is_track_live" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
-                            <t t-call="website_event_track.track_widget_reminder">
-                                <t t-set="reminder_light" t-value="True"/>
-                                <t t-set="light_theme" t-value="True"/>
-                            </t>
-                        </span>
-                    </div>
-                    <div t-else="" class="o_wesession_gradient card-img-top position-relative"
-                        style="padding-top: 50%;">
-                        <span t-if="option_track_wishlist" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
-                            <t t-call="website_event_track.track_widget_reminder">
-                                <t t-set="reminder_light" t-value="True"/>
-                            </t>
-                        </span>
-                        <i class="fa fa-glass fa-2x mx-2 mb-3 position-absolute text-white-75" style="right:0; bottom: 0;"/>
-                    </div>
-                </header>
-                <div class="col-12">
-                    <main class="card-body">
-                        <!-- Title -->
-                        <h5 class="card-title mt-0 mb-0 text-truncate">
-                            <span t-field="track.name" itemprop="name"/>
-                        </h5>
-                        <!-- Tags> -->
-                        <div>
-                            <t t-foreach="track.tag_ids" t-as="tag">
-                                <t t-if="tag.color" t-call="website_event_track.track_tag_badge_info"/>
-                            </t>
-                        </div>
-                    </main>
+<template id="track_card" name="Track Card">
+    <article t-att-class="'h-100 card rounded-0 border-0 shadow-sm o_wesession_track_card %s' % ('o_wesession_track_card_unpublished' if (not track.website_published and is_event_user) else '')"
+        itemscope="itemscope" itemtype="http://schema.org/Event">
+        <div class="h-100 row no-gutters">
+            <header class="overflow-hidden bg-secondary col-12">
+                <small t-if="not track.website_published and is_event_user" class="o_wesession_track_card_header_badge bg-danger">
+                    <i class="fa fa-ban mr-2"/>Unpublished
+                </small>
+
+                <div t-if="track.website_image_url" class="card-img-top"
+                    t-attf-style="padding-top: 50%; background-image: url(#{track.website_image_url}); background-size: cover; background-position:center">
+                    <span t-if="option_track_wishlist and not track.is_track_live" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
+                        <t t-call="website_event_track.track_widget_reminder">
+                            <t t-set="reminder_light" t-value="True"/>
+                            <t t-set="light_theme" t-value="True"/>
+                        </t>
+                    </span>
                 </div>
-                <!-- Footer -->
-                <footer class="small align-self-end w-100 card-footer">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <!-- Speaker -->
-                        <span class="text-muted text-truncate" t-field="track.partner_name" itemprop="performer"/>
-                        <!-- Starts -->
-                        <span class="text-muted ml-auto">
-                            <t t-if="track.is_track_upcoming &gt; 0">In
-                                <span class="text-muted ml-auto" t-field="track.track_start_remaining" itemprop="duration"
-                                    t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
-                            </t>
-                            <t t-else="">
-                                <span class="text-muted ml-auto" t-field="track.track_start_relative" itemprop="duration"
-                                    t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
-                                ago
-                            </t>
-                        </span>
+                <div t-else="" class="o_wesession_gradient card-img-top position-relative"
+                    style="padding-top: 50%;">
+                    <span t-if="option_track_wishlist" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
+                        <t t-call="website_event_track.track_widget_reminder">
+                            <t t-set="reminder_light" t-value="True"/>
+                        </t>
+                    </span>
+                    <i class="fa fa-glass fa-2x mx-2 mb-3 position-absolute text-white-75" style="right:0; bottom: 0;"/>
+                </div>
+            </header>
+            <div class="col-12">
+                <main class="card-body">
+                    <!-- Title -->
+                    <h5 class="card-title mt-0 mb-0 text-truncate">
+                        <span t-field="track.name" itemprop="name"/>
+                    </h5>
+                    <!-- Tags> -->
+                    <div>
+                        <t t-foreach="track.tag_ids" t-as="tag">
+                            <t t-if="tag.color" t-call="website_event_track.track_tag_badge_info"/>
+                        </t>
                     </div>
-                </footer>
+                </main>
             </div>
-        </article>
-    </a>
+            <!-- Footer -->
+            <footer class="small align-self-end w-100 card-footer">
+                <div class="d-flex justify-content-between align-items-center">
+                    <!-- Speaker -->
+                    <span class="text-muted text-truncate" t-field="track.partner_name" itemprop="performer"/>
+                    <!-- Starts -->
+                    <span class="text-muted ml-auto">
+                        <t t-if="track.is_track_upcoming &gt; 0">In
+                            <span class="text-muted ml-auto" t-field="track.track_start_remaining" itemprop="duration"
+                                t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
+                        </t>
+                        <t t-else="">
+                            <span class="text-muted ml-auto" t-field="track.track_start_relative" itemprop="duration"
+                                t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
+                            ago
+                        </t>
+                    </span>
+                </div>
+            </footer>
+        </div>
+    </article>
 </template>
 
 <!-- Searched tags -->

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -17,13 +17,16 @@
         <field name="model">event.track</field>
         <field name="arch" type="xml">
             <kanban default_group_by="stage_id">
+                <field name="color"/>
+                <field name="partner_id"/>
+                <field name="stage_id" options='{"group_by_tooltip": {"description": "Description"}}'/>
+                <field name="website_url"/>
+                <field name="activity_ids"/>
+                <field name="activity_state"/>
+                <field name="legend_blocked"/>
+                <field name="legend_normal"/>
+                <field name="legend_done"/>
                 <templates>
-                    <field name="color"/>
-                    <field name="partner_id"/>
-                    <field name="stage_id"/>
-                    <field name="website_url"/>
-                    <field name="activity_ids"/>
-                    <field name="activity_state"/>
                     <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
                     <t t-name="kanban-box">
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
@@ -87,6 +90,7 @@
         <field name="arch" type="xml">
             <search string="Event Tracks">
                 <field name="name"/>
+                <field name="tag_ids"/>
                 <field name="event_id"/>
                 <field name="location_id"/>
                 <field name="stage_id"/>
@@ -139,6 +143,9 @@
                         </button>
                         <field name="is_published" widget="website_redirect_button"/>
                     </div>
+                    <field name="legend_blocked" invisible="1"/>
+                    <field name="legend_normal" invisible="1"/>
+                    <field name="legend_done" invisible="1"/>
                     <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="kanban_state" widget="state_selection" class="ml-3 float-right"/>
                     <field name="website_image" widget="image" class="oe_avatar"/>

--- a/addons/website_event_track_live/controllers/track_live.py
+++ b/addons/website_event_track_live/controllers/track_live.py
@@ -4,7 +4,7 @@
 from odoo import http
 
 from odoo.addons.website_event_track.controllers.event_track import EventTrackController
-
+from odoo.osv import expression
 
 class EventTrackLiveController(EventTrackController):
 
@@ -12,8 +12,10 @@ class EventTrackLiveController(EventTrackController):
     def get_next_track_suggestion(self, track_id):
         track = self._fetch_track(track_id)
         track_suggestion = track._get_track_suggestions(
-            restrict_domain=[('youtube_video_url', '!=', False), ('is_published', '=', True)],
-            limit=1)
+            restrict_domain=expression.AND([
+                self._get_event_tracks_domain(track.event_id),
+                [('youtube_video_url', '!=', False)]
+            ]), limit=1)
         if not track_suggestion:
             return False
         track_suggestion_sudo = track_suggestion.sudo()

--- a/addons/website_event_track_quiz/controllers/event_track_quiz.py
+++ b/addons/website_event_track_quiz/controllers/event_track_quiz.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from werkzeug.exceptions import Forbidden
+
 from odoo import http
 from odoo.addons.website_event_track.controllers.event_track import EventTrackController
 from odoo.http import request
@@ -14,13 +16,15 @@ class WebsiteEventTrackQuiz(EventTrackController):
     @http.route('/event_track/quiz/submit', type="json", auth="public", website=True)
     def event_track_quiz_submit(self, event_id, track_id, answer_ids):
         track = self._fetch_track(track_id)
+        track_sudo = track.sudo()
 
         event_track_visitor = track._get_event_track_visitors(force_create=True)
         visitor_sudo = event_track_visitor.visitor_id
         if event_track_visitor.quiz_completed:
             return {'error': 'track_quiz_done'}
 
-        answers_details = self._get_quiz_answers_details(track, answer_ids)
+        # fetch as sudo because questions / answers may not be freely available to public
+        answers_details = self._get_quiz_answers_details(track_sudo, answer_ids)
         if answers_details.get('error'):
             return answers_details
 
@@ -32,6 +36,8 @@ class WebsiteEventTrackQuiz(EventTrackController):
         result = {
             'answers': {
                 answer.question_id.id: {
+                    'awarded_points': answer.awarded_points,
+                    'correct_answer': answer.question_id.correct_answer_id.text_value,
                     'is_correct': answer.is_correct,
                     'comment': answer.comment
                 } for answer in answers_details['user_answers']
@@ -43,9 +49,15 @@ class WebsiteEventTrackQuiz(EventTrackController):
             result['visitor_uuid'] = visitor_sudo.access_token
         return result
 
-    @http.route('/event_track/quiz/reset', type="json", auth="user", website=True)
+    @http.route('/event_track/quiz/reset', type="json", auth="public", website=True)
     def quiz_reset(self, event_id, track_id):
         track = self._fetch_track(track_id)
+        # When the 'unlimited tries' option is disabled and the user is not
+        # identifed as an event manager, we do not allow the user to reset
+        # the quiz. The event managers will always be able to reset the quiz
+        # even if the option is disabled (for testing purposes).
+        if not request.env.user.has_group('event.group_event_manager') and not track.sudo().quiz_id.repeatable:
+            raise Forbidden()
 
         event_track_visitor = track._get_event_track_visitors(force_create=True)
         event_track_visitor.write({
@@ -54,8 +66,7 @@ class WebsiteEventTrackQuiz(EventTrackController):
         })
 
     def _get_quiz_answers_details(self, track, answer_ids):
-        # TDE FIXME: lost sudo
-        questions_count = request.env['event.quiz.question'].sudo().search_count([('quiz_id', '=', track.sudo().quiz_id.id)])
+        questions_count = len(track.quiz_ids)
         user_answers = request.env['event.quiz.answer'].sudo().search([('id', 'in', answer_ids)])
 
         if len(user_answers.mapped('question_id')) != questions_count:
@@ -65,6 +76,6 @@ class WebsiteEventTrackQuiz(EventTrackController):
             'user_answers': user_answers,
             'points': sum([
                 answer.awarded_points
-                for answer in user_answers.filtered(lambda answer: answer.is_correct)
+                for answer in user_answers
             ])
         }

--- a/addons/website_event_track_quiz/data/quiz_demo.xml
+++ b/addons/website_event_track_quiz/data/quiz_demo.xml
@@ -15,19 +15,20 @@
         <field name="text_value">Wood</field>
         <field name="sequence">1</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct ! You're really smart !</field>
+        <field name="is_correct" eval="True"/>
+        <field name="comment">You're really smart !</field>
         <field name="question_id" ref="event_7_track_1_question_0"/>
     </record>
     <record id="event_7_track_1_question_0_1" model="event.quiz.answer">
         <field name="text_value">Music</field>
         <field name="sequence">2</field>
-        <field name="comment">Incorrect ! Even if there will be some.</field>
+        <field name="comment">Even if there will be some.</field>
         <field name="question_id" ref="event_7_track_1_question_0"/>
     </record>
     <record id="event_7_track_1_question_0_2" model="event.quiz.answer">
         <field name="text_value">Open Source Apps</field>
         <field name="sequence">3</field>
-        <field name="comment">Incorrect ! OpenWood is not an Open Source congres about Apps.</field>
+        <field name="comment">OpenWood is not an Open Source congres about Apps.</field>
         <field name="question_id" ref="event_7_track_1_question_0"/>
     </record>
     <record id="event_7_track_1_question_1" model="event.quiz.question">
@@ -39,13 +40,13 @@
         <field name="text_value">Trees !</field>
         <field name="sequence">1</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct !</field>
+        <field name="is_correct" eval="True"/>
         <field name="question_id" ref="event_7_track_1_question_1"/>
     </record>
     <record id="event_7_track_1_question_1_1" model="event.quiz.answer">
         <field name="text_value">Stores !</field>
         <field name="sequence">2</field>
-        <field name="comment">Incorrect ! Lumbers need first to be cut from trees!</field>
+        <field name="comment">Lumbers need first to be cut from trees!</field>
         <field name="question_id" ref="event_7_track_1_question_1"/>
     </record>
 
@@ -62,14 +63,15 @@
     <record id="event_7_track_5_question_0_0" model="event.quiz.answer">
         <field name="text_value">Yes</field>
         <field name="sequence">1</field>
-        <field name="comment">Incorrect! In order to avoid accident, you need to secure any product of this kind during transportation!</field>
+        <field name="comment">In order to avoid accident, you need to secure any product of this kind during transportation!</field>
         <field name="question_id" ref="event_7_track_5_question_0"/>
     </record>
     <record id="event_7_track_5_question_0_1" model="event.quiz.answer">
         <field name="text_value">No</field>
         <field name="sequence">2</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct! Even if you have a big trunk, some long products need to be secured.</field>
+        <field name="is_correct" eval="True"/>
+        <field name="comment">Even if you have a big trunk, some long products need to be secured.</field>
         <field name="question_id" ref="event_7_track_5_question_0"/>
     </record>
     <record id="event_7_track_5_question_1" model="event.quiz.question">
@@ -80,20 +82,20 @@
     <record id="event_7_track_5_question_1_0" model="event.quiz.answer">
         <field name="text_value">Hammer</field>
         <field name="sequence">1</field>
-        <field name="comment">Incorrect! Hammer won't be of any help here!</field>
+        <field name="comment">Hammer won't be of any help here!</field>
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
     <record id="event_7_track_5_question_1_1" model="event.quiz.answer">
         <field name="text_value">Tie-down straps and other wooden blocks</field>
         <field name="sequence">2</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct!</field>
+        <field name="is_correct" eval="True"/>
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
         <record id="event_7_track_5_question_1_2" model="event.quiz.answer">
         <field name="text_value">Scotch tape</field>
         <field name="sequence">3</field>
-        <field name="comment">Incorrect! Well, it could work but you will need a lot of tape!</field>
+        <field name="comment">Well, it could work but you will need a lot of tape!</field>
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
 
@@ -111,19 +113,17 @@
         <field name="text_value">Concrete Blocks Wall</field>
         <field name="sequence">1</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct!</field>
+        <field name="is_correct" eval="True"/>
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
     <record id="event_7_track_13_question_0_1" model="event.quiz.answer">
         <field name="text_value">Steel Wall</field>
         <field name="sequence">2</field>
-        <field name="comment">Incorrect!</field>
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
     <record id="event_7_track_13_question_0_2" model="event.quiz.answer">
         <field name="text_value">Mud Wall</field>
         <field name="sequence">3</field>
-        <field name="comment">Incorrect!</field>
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
 

--- a/addons/website_event_track_quiz/models/event_quiz.py
+++ b/addons/website_event_track_quiz/models/event_quiz.py
@@ -15,6 +15,8 @@ class Quiz(models.Model):
     event_id = fields.Many2one(
         'event.event', related='event_track_id.event_id',
         readonly=True, store=True)
+    repeatable = fields.Boolean('Unlimited Tries',
+        help='Let attendees reset the quiz and try again.')
 
 
 class QuizQuestion(models.Model):
@@ -25,6 +27,7 @@ class QuizQuestion(models.Model):
     name = fields.Char("Question", required=True, translate=True)
     sequence = fields.Integer("Sequence")
     quiz_id = fields.Many2one("event.quiz", "Quiz", required=True, ondelete='cascade')
+    correct_answer_id = fields.One2many('event.quiz.answer', compute='_compute_correct_answer_id')
     awarded_points = fields.Integer("Number of Points", compute='_compute_awarded_points')
     answer_ids = fields.One2many('event.quiz.answer', 'question_id', string="Answer")
 
@@ -33,13 +36,18 @@ class QuizQuestion(models.Model):
         for question in self:
             question.awarded_points = sum(question.answer_ids.mapped('awarded_points'))
 
+    @api.depends('answer_ids.is_correct')
+    def _compute_correct_answer_id(self):
+        for question in self:
+            question.correct_answer_id = question.answer_ids.filtered(lambda e: e.is_correct)
+
     @api.constrains('answer_ids')
     def _check_answers_integrity(self):
         for question in self:
-            if len(question.answer_ids.filtered(lambda answer: answer.awarded_points)) != 1:
-                raise ValidationError(_('Question "%s" must have 1 correct answer', question.name))
+            if len(question.correct_answer_id) != 1:
+                raise ValidationError(_('Question "%s" must have 1 correct answer to be valid.', question.name))
             if len(question.answer_ids) < 2:
-                raise ValidationError(_('Question "%s" must have 1 correct answer and at least 1 incorrect answer', question.name))
+                raise ValidationError(_('Question "%s" must have 1 correct answer and at least 1 incorrect answer to be valid.', question.name))
 
 
 class QuizAnswer(models.Model):
@@ -51,13 +59,9 @@ class QuizAnswer(models.Model):
     sequence = fields.Integer("Sequence")
     question_id = fields.Many2one('event.quiz.question', string="Question", required=True, ondelete='cascade')
     text_value = fields.Char("Answer", required=True, translate=True)
-    is_correct = fields.Boolean("Is correct answer", compute='_compute_is_correct')
-    comment = fields.Text("Comment", translate=True,
+    is_correct = fields.Boolean('Correct', default=False)
+    comment = fields.Text(
+        'Extra Comment', translate=True,
         help='''This comment will be displayed to the user if he selects this answer, after submitting the quiz.
                 It is used as a small informational text helping to understand why this answer is correct / incorrect.''')
-    awarded_points = fields.Integer('Number of Points')
-
-    @api.depends('awarded_points')
-    def _compute_is_correct(self):
-        for answer in self:
-            answer.is_correct = bool(answer.awarded_points)
+    awarded_points = fields.Integer('Points', default=0)

--- a/addons/website_event_track_quiz/static/src/js/event_quiz.js
+++ b/addons/website_event_track_quiz/static/src/js/event_quiz.js
@@ -41,7 +41,8 @@ var Quiz = publicWidget.Widget.extend({
             completed: false,
             isMember: false,
             progressBar: false,
-            isEventUser: false
+            isEventUser: false,
+            repeatable: false
         });
         this.quiz = quizData || false;
         if (this.quiz) {
@@ -99,6 +100,24 @@ var Quiz = publicWidget.Widget.extend({
     },
 
     /**
+     * @private
+     * Decorate the answers according to state
+     */
+    _disableAnswers: function () {
+        this.$('.o_quiz_js_quiz_question').addClass('completed-disabled');
+        this.$('input[type=radio]').prop('disabled', true);
+    },
+
+    /**
+     * @private
+     * Decorate the answers according to state
+     */
+    _enableAnswers: function() {
+        this.$('.o_quiz_js_quiz_question').removeClass('completed-disabled');
+        this.$('input[type=radio]').prop('disabled', false);
+    },
+
+    /**
      * Get all the questions ID from the displayed Quiz
      * @returns {Array}
      * @private
@@ -110,15 +129,14 @@ var Quiz = publicWidget.Widget.extend({
     },
 
     /**
+     * Get the quiz answers filled in by the User
+     *
      * @private
-     * Decorate the answers according to state
      */
-    _disableAnswers: function () {
-        var self = this;
-        this.$('.o_quiz_js_quiz_question').addClass('completed-disabled');
-        this.$('input[type=radio]').each(function () {
-            $(this).prop('disabled', self.track.completed);
-        });
+    _getQuizAnswers: function () {
+        return this.$('input[type=radio]:checked').map(function (index, element) {
+            return parseInt($(element).val());
+        }).get();
     },
 
     /**
@@ -132,29 +150,28 @@ var Quiz = publicWidget.Widget.extend({
         this.$('.o_quiz_js_quiz_question').each(function () {
             var $question = $(this);
             var questionId = $question.data('questionId');
-            var isCorrect = self.quiz.answers[questionId].is_correct;
+            var answer = self.quiz.answers[questionId];
             $question.find('a.o_quiz_quiz_answer').each(function () {
                 var $answer = $(this);
                 $answer.find('i.fa').addClass('d-none');
-                if ($answer.find('input[type=radio]')[0].checked) {
-                    if (isCorrect) {
-                        $answer.removeClass('list-group-item-danger').addClass('list-group-item-success');
+                if ($answer.find('input[type=radio]').is(':checked')) {
+                    if (answer.is_correct) {
                         $answer.find('i.fa-check-circle').removeClass('d-none');
                     } else {
-                        $answer.removeClass('list-group-item-success').addClass('list-group-item-danger');
-                        $answer.find('i.fa-times-circle').removeClass('d-none');
                         $answer.find('label input').prop('checked', false);
+                        $answer.find('i.fa-times-circle').removeClass('d-none');
+                    }
+                    if (answer.awarded_points > 0) {
+                        var $badge = QWeb.render('quiz.badge', {'answer': answer});
+                        $answer.append($badge);
                     }
                 } else {
-                    $answer.removeClass('list-group-item-danger list-group-item-success');
                     $answer.find('i.fa-circle').removeClass('d-none');
                 }
             });
-            var comment = self.quiz.answers[questionId].comment;
-            if (comment) {
-                $question.find('.o_quiz_quiz_answer_info').removeClass('d-none');
-                $question.find('.o_quiz_quiz_answer_comment').text(comment);
-            }
+            var $list = $question.find('.list-group');
+            var $comment = QWeb.render('quiz.comment', {'answer': answer});
+            $list.append($comment);
         });
     },
 
@@ -170,14 +187,24 @@ var Quiz = publicWidget.Widget.extend({
     },
 
     /**
-     * Get the quiz answers filled in by the User
-     *
-     * @private
+     * Remove the answer decorators
      */
-    _getQuizAnswers: function () {
-        return this.$('input[type=radio]:checked').map(function (index, element) {
-            return parseInt($(element).val());
-        }).get();
+     _resetQuiz: function () {
+        this.$('.o_quiz_js_quiz_question').each(function () {
+            var $question = $(this);
+            $question.find('a.o_quiz_quiz_answer').each(function () {
+                var $answer = $(this);
+                $answer.find('i.fa').addClass('d-none');
+                $answer.find('i.fa-circle').removeClass('d-none');
+                $answer.find('span.badge').remove();
+                $answer.find('input[type=radio]').prop('checked', false);
+            });
+            var $info = $question.find('.o_quiz_quiz_answer_info');
+            $info.remove();
+        });
+        this.track.completed = false;
+        this._enableAnswers();
+        this._renderValidationInfo();
     },
 
     /**
@@ -247,9 +274,7 @@ var Quiz = publicWidget.Widget.extend({
                 event_id: this.track.eventId,
                 track_id: this.track.id
             }
-        }).then(function () {
-            window.location.reload();
-        });
+        }).then(this._resetQuiz.bind(this));
     },
 
 });

--- a/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
+++ b/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
@@ -27,39 +27,66 @@
                                 <span t-esc="answer.text_value"/>
                             </a>
                         </t>
-                        <div class="o_quiz_quiz_answer_info list-group-item list-group-item-info d-none">
-                            <i class="fa fa-info-circle"/>
-                            <span class="o_quiz_quiz_answer_comment"/>
-                        </div>
                     </div>
-                </div>
-                <div t-if="!widget.track.completed" class="o_quiz_js_quiz_validation border-top pt-3"/>
-                <div t-else="" class="row">
-                    <div class="o_quiz_js_quiz_validation col py-2 bg-100 mb-2 border-bottom"/>
                 </div>
             </div>
         </div>
     </t>
 
+    <t t-name="quiz.badge">
+        <span class="badge badge-warning ml-2">
+            <span>+ <t t-esc="answer.awarded_points"/></span>
+            <span t-if="answer.awarded_points == 1">Point</span>
+            <span t-else="">Points</span>
+        </span>
+    </t>
+
+    <t t-name="quiz.comment">
+        <t t-if="answer.is_correct">
+            <div class="o_quiz_quiz_answer_info list-group-item list-group-item-success">
+                <i class="fa fa-info-circle"/>
+                Correct.
+                <t t-if="answer.comment">
+                    <br/>
+                    <t t-esc="answer.comment"/>
+                </t>
+            </div>
+        </t>
+        <t t-else="">
+            <div class="o_quiz_quiz_answer_info list-group-item list-group-item-danger">
+                <i class="fa fa-info-circle"/>
+                Incorrect. <t t-if="answer.correct_answer">The correct answer was: <t t-esc="answer.correct_answer"/></t>
+                <t t-if="answer.comment">
+                    <br/>
+                    <t t-esc="answer.comment"/>
+                </t>
+            </div>
+        </t>
+    </t>
+
     <t t-name="quiz.validation">
-        <div id="validation">
-            <div class="d-flex align-items-center justify-content-between">
-                <div t-att-class="'d-flex align-items-center' + (widget.track.completed ? ' alert alert-success my-0 py-1 px-3' : '')">
-                    <button t-if="!widget.track.completed" role="button" title="Check answers" aria-label="Check answers"
-                        class="btn btn-primary text-uppercase font-weight-bold o_quiz_js_quiz_submit">Check your answers</button>
-                    <b t-else="" class="my-0 h5">Done !</b>
-                    <span class="my-0 h5" style="line-height: 1">
-                        <span t-if="widget.track.completed" role="button" title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge badge-pill badge-warning text-white font-weight-bold ml-3 px-2">
-                            + <t t-esc="widget.quiz.quizPointsGained || 0"/> Points
-                        </span>
-                    </span>
-                </div>
-                <div class="flex-grow-1 text-right">
-                    <button t-if="widget.track.isEventUser"
-                       class="d-none d-md-inline-block btn btn-light border o_quiz_js_quiz_reset">
-                        Reset
-                    </button>
-                </div>
+        <div id="validation" class="d-md-flex">
+            <div class="flex-grow-1">
+                <button t-if="!widget.track.completed" role="button" title="Check answers" aria-label="Check answers"
+                    class="btn btn-primary text-uppercase font-weight-bold o_quiz_js_quiz_submit">
+                    Check your answers
+                </button>
+                <t t-else="">
+                    <div t-if="widget.quiz.quizPointsGained > 0" class="alert alert-warning mr-md-3">
+                        Congratulations, you scored a total of <span t-esc="widget.quiz.quizPointsGained" class="font-weight-bold"/>
+                        <span t-if="widget.quiz.quizPointsGained == 1">point!</span>
+                        <span t-else="">points!</span>
+                    </div>
+                    <div t-else="" class="alert alert-warning mr-md-3">
+                        Oopsie, you did not score any point on this quiz.
+                    </div>
+                </t>
+            </div>
+            <div class="o_quiz_js_quiz_actions mt-3 mt-md-0">
+                <button t-if="widget.track.isEventUser or widget.track.repeatable"
+                    class="btn border o_quiz_js_quiz_reset">
+                    Reset
+                </button>
             </div>
         </div>
     </t>

--- a/addons/website_event_track_quiz/views/event_quiz_question_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_question_views.xml
@@ -46,7 +46,7 @@
                 <sheet>
                     <h1>
                         <field name="name" default_focus="1"
-                            placeholder="e.g. According to Douglas, what should you pay most attention to?"/>
+                            placeholder="e.g. What is Joe's favorite motto?"/>
                     </h1>
                     <group>
                         <field name="quiz_id"/>
@@ -57,6 +57,7 @@
                             <tree editable="bottom" create="true" delete="true">
                                 <field name="sequence" widget="handle"/>
                                 <field name="text_value"/>
+                                <field name="is_correct"/>
                                 <field name="awarded_points"/>
                                 <field name="comment"/>
                             </tree>

--- a/addons/website_event_track_quiz/views/event_quiz_templates.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_templates.xml
@@ -9,7 +9,8 @@
             t-att-data-completed="1 if quiz_completed else 0"
             t-att-data-quiz-attempts-count="quiz_attempts_count or 0"
             t-att-data-quiz-points-gained="quiz_points"
-            t-att-data-is-event-user="is_event_user or 0">
+            t-att-data-is-event-user="is_event_user or 0"
+            t-att-data-repeatable="track.quiz_id.repeatable">
             <t t-foreach="track.quiz_id.question_ids" t-as="question">
                 <t t-call="website_event_track_quiz.quiz_question"/>
             </t>
@@ -28,8 +29,8 @@
             <div class="list-group">
                 <t t-foreach="question['answer_ids']" t-as="answer">
                     <a t-att-data-answer-id="answer['id']" href="#"
-                        t-att-data-text="answer['text_value']" t-att-data-is-correct="answer['is_correct']" t-att-data-comment="answer['comment']"
-                        t-att-class="'o_quiz_quiz_answer list-group-item list-group-item-action d-flex align-items-center %s' % ('list-group-item-success' if slid_completed and answer['is_correct'] else '')">
+                        t-att-data-text="answer['text_value']"
+                        class="o_quiz_quiz_answer list-group-item list-group-item-action d-flex align-items-center">
                         <label class="my-0 d-flex align-items-center justify-content-center mr-2">
                             <input type="radio"
                                 t-att-name="question['id']"
@@ -43,10 +44,6 @@
                         <span t-esc="answer['text_value']"/>
                     </a>
                 </t>
-                <div class="o_quiz_quiz_answer_info list-group-item list-group-item-info d-none">
-                    <i class="fa fa-info-circle"/>
-                    <span class="o_quiz_quiz_answer_comment"/>
-                </div>
             </div>
         </div>
     </template>

--- a/addons/website_event_track_quiz/views/event_quiz_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_views.xml
@@ -40,9 +40,10 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="event_id"/>
+                            <field name="repeatable" string="Allow multiple tries"/>
                         </group>
                         <group>
+                            <field name="event_id"/>
                             <field name="event_track_id"/>
                         </group>
                     </group>


### PR DESCRIPTION
PURPOSE

Improve Online Events feeling, user experience and management for
event users.

SPECIFICATIONS

Allow multiple tries & improve layouts of track quizzed. Purpose is to add
feedback and allow to repeat quizzes, making them more fun to use.

Add a popover on the exhibitor cards giving their information. Purpose
is to improve they way exhibitors are displayed and ease their dicovery.

Improve track management through stage legend, like what is done in
project for example. Add customizable legends on stage kanban state,
track it on tracks records.

Update the track stage visibility logic. Rules are now

  * a published track is always displayed in agenda, tracks list and page
    view, whatever its state;
  * a track in a 'is_visible_in_agenda' stage (replacing 'is_accepted') is
    always displayed in agenda and tracks list. Its page view access is based
    on ACLs: aka: published = everyone, unpublished = for event users only;
  * a track in a 'is_fully_accessible' stage (replacing 'is_done') is
    automatically published when entering this stage, allowing its full
    display

Page view still relies on ACLs, and therefore on published flag automatically
set when entering "fully accessible" stage.

See sub commits for more details and explanations.

Task-2504216