### PR TITLE
[FIX] web: find scrollingElement despite rounding


### DIFF
--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -171,7 +171,7 @@ $.fn.extend({
             // Search for a body child which is at least as tall as the body
             // and which has the ability to scroll if enough content in it. If
             // found, suppose this is the top scrolling element.
-            if (bodyHeight - el.scrollHeight > 1) {
+            if (bodyHeight - el.scrollHeight > 1.5) {
                 continue;
             }
             const $el = $(el);


### PR DESCRIPTION

In mass mailing edition, in some configuration of:

- being in a modal or not
- size of window
- zoom level

we might get an error when getting the scrolling element.

For example when editing a mass mailing, if I set my viewport to 595
pixels height and have a 90% zoom, the editor is broken.

This is because in SnippetsMenu.starts  `$().getScrollingElement()`
doesn't find an element that has the height of body. In my use case body
height is 329.111 pixels, and scroll height is 328 pixels.

Testing different zoom level and viewport height, the maximum difference
I was able to get was 1.25 so this commit increase to 1.5 the maxmimum
difference.

opw-2455727
opw-2469174
