### PR TITLE
[FIX] sale: reposition tooltip to avoid resize flicker


### DIFF
--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -38,7 +38,7 @@ tour.register("sale_tour", {
     trigger: "button[name='document_layout_save']",
     extra_trigger: ".o_sale_order",
     content: _t("Good job, let's continue."),
-    position: "bottom",
+    position: "top", // dot NOT move to bottom, it would cause a resize flicker
 }, {
     trigger: 'a.o_onboarding_step_action.btn[data-method=action_open_sale_onboarding_payment_acquirer]',
     extra_trigger: ".o_sale_order",


### PR DESCRIPTION
Same reason that cdb7a8ad7647649ad8f595454aa9dc0464117568

The tour bubble animation might cause the page to flicker since the
scrollbar might appear disappear depending on size of modal / browser.

opw-2469248