### PR TITLE
[IMP]auth_totp: 2FA Trusted Devices

### DIFF
--- a/addons/auth_totp/views/templates.xml
+++ b/addons/auth_totp/views/templates.xml
@@ -1,5 +1,10 @@
 <odoo>
-    <template id="auth_totp_form">
+    <template id="assets_tests" inherit_id="web.assets_tests">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/auth_totp/static/tests/totp_flow.js"></script>
+        </xpath>
+    </template>
+    <template id="auth_totp_form" name="Two-Factor Authentication">
         <t t-call="web.login_layout">
             <t t-set="disable_footer">1</t>
             <div class="oe_login_form">
@@ -15,6 +20,10 @@
                     <p class="alert alert-danger" t-if="error" role="alert">
                         <t t-esc="error"/>
                     </p>
+                    <div class="mb-2 mt-2 text-muted">
+                        <input type="checkbox" name="remember" id="switch-remember" checked="checked"/>
+                        <label for="switch-remember">Remember this Device</label>
+                    </div>
                     <div t-attf-class="clearfix oe_login_buttons text-center mb-1">
                         <button type="submit" class="btn btn-primary btn-block">
                             Verify


### PR DESCRIPTION
+ Added the 'Trusted Devices' feature
+ Added 'Remember this Device' checkbox on /web/login/totp
+ Added trusted device's OS / browser on Profile > Account Security

Added '2FA Trusted Devices' feature to allow users to remember their device to bypass the 2FA for the next connections. The trusted devices are displayed in a 'Trusted Devices' One2Many under the 'Developer API Keys'. It is possible to revoke all the trusted devices at once with a special button. It is also possible to revoke one at a time on the desired one.
