### PR TITLE
[FIX] payment_stripe: load Stripe's library on the payment form

### DIFF
--- a/addons/payment_stripe/__manifest__.py
+++ b/addons/payment_stripe/__manifest__.py
@@ -10,6 +10,7 @@
     'depends': ['payment'],
     'data': [
         'views/payment_views.xml',
+        'views/payment_templates.xml',
         'data/payment_acquirer_data.xml',
     ],
     'application': True,
@@ -17,7 +18,6 @@
     'uninstall_hook': 'uninstall_hook',
     'assets': {
         'web.assets_frontend': [
-            'https://js.stripe.com/v3/',
             'payment_stripe/static/src/js/payment_form.js',
         ],
     }

--- a/addons/payment_stripe/views/payment_templates.xml
+++ b/addons/payment_stripe/views/payment_templates.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="checkout" inherit_id="payment.checkout">
+        <xpath expr="." position="inside">
+            <!-- As the following link does not end with '.js', it's not loaded when
+                 placed in __manifest__.py. The following declaration fix this problem -->
+            <script type="text/javascript" src="https://js.stripe.com/v3/"></script>
+        </xpath>
+    </template>
+
+    <template id="manage" inherit_id="payment.manage">
+        <xpath expr="." position="inside">
+            <!-- As the following link does not end with '.js', it's not loaded when
+                 placed in __manifest__.py. The following declaration fix this problem -->
+            <script type="text/javascript" src="https://js.stripe.com/v3/"></script>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
When the refactor of assets was done, the link to the stripe javascript framework was moved to __manifest__.py
As the link does not end with '.js', the ORM just ignore it, the script is not send to the frontend and
prevents the partner using any functionnality implementing stripe.

See PR #60632

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
