### PR TITLE
[FIX] mail: sanitize dots in generated mail alias

### DIFF
--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -148,6 +148,7 @@ class Alias(models.Model):
         name already exists an UserError is raised. """
         sanitized_name = remove_accents(name).lower().split('@')[0]
         sanitized_name = re.sub(r'[^\w+.]+', '-', sanitized_name)
+        sanitized_name = re.sub(r'^\.+|\.+$|\.+(?=\.)', '', sanitized_name)
         sanitized_name = sanitized_name.encode('ascii', errors='replace').decode()
 
         catchall_alias = self.env['ir.config_parameter'].sudo().get_param('mail.catchall.alias')


### PR DESCRIPTION
Create a company whoose name ends with a dot like "Bidule Inc.", change
the company of the user to that new company, head to the Accouning
module and create a new journal of type purchase. Traceback because the
generated mail alias for that journal uses the company name and that the
local-part of an email cannot ends with a dot.

From the RFC standpoint, the local-part of an email address (the part
before the @, `john` in `"John Doe" <john@example.com>`), cannot begins
with, ends with or contain following dots.

The email sanitizing function have been updated so it takes care of the
above requirement.

See also #61811
opw-2448692

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
