### PR TITLE
[IMP] website, website_blog: use general options for page layout & covers

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -8290,9 +8290,9 @@ registry.BackgroundShape = SnippetOptionWidget.extend({
 });
 
 /**
- * Handles the edition of snippets' background image position.
+ * Mixin handling background image positioning.
  */
-registry.BackgroundPosition = SnippetOptionWidget.extend({
+const BackgroundPositionMixin = {
     /**
      * @override
      */
@@ -8319,16 +8319,6 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
     // Options
     //--------------------------------------------------------------------------
 
-    /**
-     * Sets the background type (cover/repeat pattern).
-     *
-     * @see this.selectClass for params
-     */
-    backgroundType: function (previewMode, widgetValue, params) {
-        this.$target.toggleClass('o_bg_img_opt_repeat', widgetValue === 'repeat-pattern');
-        this.$target.css('background-position', '');
-        this.$target.css('background-size', widgetValue !== 'repeat-pattern' ? '' : '100px');
-    },
     /**
      * Saves current background position and enables overlay.
      *
@@ -8368,37 +8358,19 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         }
         this._toggleBgOverlay(true);
     },
-    /**
-     * @override
-     */
-    selectStyle: function (previewMode, widgetValue, params) {
-        if (params.cssProperty === 'background-size'
-                && !this.$target.hasClass('o_bg_img_opt_repeat')) {
-            // Disable the option when the image is in cover mode, otherwise
-            // the background-size: auto style may be forced.
-            return;
-        }
-        this._super(...arguments);
-    },
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
     /**
-     * @override
+     * Applies the new position
+     *
+     * @private
+     * @param position as obtained from CSS "background-position"
      */
-    _computeVisibility: function () {
-        return this._super(...arguments) && !!getBgImageURL(this.$target[0]);
-    },
-    /**
-     * @override
-     */
-    _computeWidgetState: function (methodName, params) {
-        if (methodName === 'backgroundType') {
-            return this.$target.css('background-repeat') === 'repeat' ? 'repeat-pattern' : 'cover';
-        }
-        return this._super(...arguments);
+    _applyPosition: async function (position) {
+        this.$target[0].style.backgroundPosition = position;
     },
     /**
      * Initializes the overlay, binds events to the buttons, inserts it in
@@ -8411,8 +8383,8 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         this.$overlayContent = this.$backgroundOverlay.find('.o_we_overlay_content');
         this.$overlayBackground = this.$overlayContent.find('.o_overlay_background');
 
-        this.$backgroundOverlay.on('click', '.o_btn_apply', () => {
-            this.$target.css('background-position', this.$bgDragger.css('background-position'));
+        this.$backgroundOverlay[0].querySelector(".o_btn_apply").addEventListener("click", async () => {
+            await this._applyPosition(window.getComputedStyle(this.$bgDragger[0]).backgroundPosition);
             this._toggleBgOverlay(false);
         });
         this.$backgroundOverlay.on('click', '.o_btn_discard', () => {
@@ -8431,14 +8403,11 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         if (!this.$backgroundOverlay.is('.oe_active')) {
             return;
         }
-        // TODO: change #wrapwrap after web_editor rework.
-        const $wrapwrap = $(this.ownerDocument.body).find("#wrapwrap");
         const targetOffset = this.$target.offset();
 
-        this.$backgroundOverlay.css({
-            width: $wrapwrap.innerWidth(),
-            height: $wrapwrap.innerHeight(),
-        });
+        const overlaySize = this._getOverlaySize();
+        this.$backgroundOverlay[0].style.width = overlaySize.width;
+        this.$backgroundOverlay[0].style.height = overlaySize.height;
 
         this.$overlayContent.offset(targetOffset);
 
@@ -8449,6 +8418,21 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
 
         const topPos = Math.max(0, $(window).scrollTop() - this.$target.offset().top);
         this.$overlayContent.find('.o_we_overlay_buttons').css('top', `${topPos}px`);
+    },
+    /**
+     * Returns the overlay size.
+     *
+     * @private
+     * @returns {Object} width and height of overlay
+     */
+    _getOverlaySize() {
+        // TODO: change #wrapwrap after web_editor rework.
+        const wrapwrapEl = this.ownerDocument.body.querySelector("#wrapwrap");
+        const style = getComputedStyle(wrapwrapEl);
+        return {
+            width: parseInt(style.width) + parseInt(style.paddingLeft) + parseInt(style.paddingRight),
+            height: parseInt(style.height) + parseInt(style.paddingTop) + parseInt(style.paddingBottom),
+        };
     },
     /**
      * Toggles the overlay's display and renders a background clone inside of it.
@@ -8480,16 +8464,25 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         });
         this.trigger_up('block_preview_overlays');
 
-        // Create empty clone of $target with same display size, make it draggable and give it a tooltip.
+        // Create empty clone of $t with same display size, make it draggable and give it a tooltip.
         this.$bgDragger = this.$target.clone().empty();
         // Prevent clone from being seen as editor if target is editor (eg. background on root tag)
         this.$bgDragger.removeClass('o_editable');
         // Some CSS child selector rules will not be applied since the clone has a different container from $target.
         // The background-attachment property should be the same in both $target & $bgDragger, this will keep the
         // preview more "wysiwyg" instead of getting different result when bg position saved (e.g. parallax snippet)
-        // TODO: improve this to copy all style from $target and override it with overlay related style (copying all
-        // css into $bgDragger will not work since it will change overlay content style too).
-        this.$bgDragger.css('background-attachment', this.$target.css('background-attachment'));
+        // The other background properties must be copied because the CSS is not available outside the iframe.
+        const targetStyle = window.getComputedStyle(this.$target[0]);
+        const draggerStyle = window.getComputedStyle(this.$bgDragger[0]);
+        ["background-attachment", "background-image", "background-position", "background-size", "background-repeat", "width", "height"].forEach(
+            cssProperty => this.$bgDragger[0].style[cssProperty] = targetStyle[cssProperty]
+        );
+        if (draggerStyle.backgroundRepeat === "no-repeat") {
+            this.$bgDragger[0].style.backgroundSize = "cover";
+        }
+        if (this.data["draggerTransparent"]) {
+            this.$bgDragger[0].style.opacity = 0.8;
+        }
         this.$bgDragger.on('mousedown', this._onDragBackgroundStart.bind(this));
         this.$bgDragger.tooltip({
             title: 'Click and drag the background to adjust its position!',
@@ -8600,6 +8593,62 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         if (!$(ev.target).closest('.o_we_background_position_overlay').length) {
             this._toggleBgOverlay(false);
         }
+    },
+};
+
+/**
+ * Handles the edition of snippets' background image position.
+ */
+registry.BackgroundPosition = SnippetOptionWidget.extend(BackgroundPositionMixin, {
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Sets the background type (cover/repeat pattern).
+     *
+     * @see this.selectClass for params
+     */
+    backgroundType(previewMode, widgetValue, params) {
+        if (widgetValue === "pattern") {
+            this.$target[0].classList.add("o_bg_img_opt_repeat");
+        } else {
+            this.$target[0].classList.remove("o_bg_img_opt_repeat");
+        }
+        this.$target[0].style.backgroundPosition = "";
+        this.$target[0].style.backgroundSize = "";
+        this.$target[0].style.backgroundRepeat = widgetValue === "pattern" ? "repeat" : "no-repeat";
+    },
+    /**
+     * @override
+     */
+    selectStyle(previewMode, widgetValue, params) {
+        if (params.cssProperty === "background-size"
+                && getComputedStyle(this.$target[0]).backgroundRepeat !== 'repeat') {
+            // Disable the option when the image is in cover mode, otherwise
+            // the background-size: auto style may be forced.
+            return;
+        }
+        this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _computeWidgetState(methodName, params) {
+        if (methodName === "backgroundType") {
+            if (getBgImageURL(this.$target[0])) {
+                const targetStyle = window.getComputedStyle(this.$target[0]);
+                return targetStyle.backgroundRepeat === "repeat" ? "pattern" : "image";
+            }
+            return "";
+        }
+        return this._super(...arguments);
     },
 });
 
@@ -9281,6 +9330,7 @@ export default {
     UserValueWidget: UserValueWidget,
     userValueWidgetsRegistry: userValueWidgetsRegistry,
     UnitUserValueWidget: UnitUserValueWidget,
+    BackgroundPositionMixin: BackgroundPositionMixin,
 
     addTitleAndAllowedAttributes: _addTitleAndAllowedAttributes,
     buildElement: _buildElement,

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3895,6 +3895,13 @@ const SnippetOptionWidget = Widget.extend({
             el.querySelector('.o_we_collapse_toggler').classList.toggle('d-none', hasNoVisibleElInCollapseMenu);
         }
     },
+    /**
+     * Called after an option was used.
+     * @see _select.
+     */
+    onOptionUsed(previewMode, widget) {
+        // To be overridden by options that need specific behavior.
+    },
 
     //--------------------------------------------------------------------------
     // Private
@@ -4295,6 +4302,8 @@ const SnippetOptionWidget = Widget.extend({
                 await this[methodName](previewMode, widgetValue, params);
             }
         }
+
+        this.onOptionUsed(previewMode, widget);
 
         if (previewMode === 'reset' || previewMode === false) {
             this.options.wysiwyg.odooEditor.automaticStepActive('preview_option');

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -783,7 +783,20 @@ const ButtonUserValueWidget = UserValueWidget.extend({
         if (this.options && this.options.childNodes) {
             this.options.childNodes.forEach(node => this.containerEl.appendChild(node));
         }
-
+        if (this.illustrationEl) {
+            this.el.classList.add("o_we_icon_button");
+            const svgEl = this.el.querySelector("svg");
+            if (svgEl) {
+                svgEl.style.visibility = "hidden";
+            }
+            const text = this.el.innerText.replace(/\u200B+/g, "").trim();
+            if (svgEl) {
+                svgEl.style.visibility = "";
+            }
+            if (text) {
+                this.illustrationEl.classList.add("o_we_img_with_text");
+            }
+        }
         return this._super(...arguments);
     },
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1813,6 +1813,10 @@
                 svg {
                     margin: 0 auto;
                 }
+                .o_we_img_with_text {
+                    // Not only SVG.
+                    margin-inline-end: $o-we-sidebar-content-field-spacing;
+                }
             }
 
             &:not(.o_we_fw) {

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -47,6 +47,44 @@
     </div>
 </template>
 
+<template id="snippet_options_image_selection_widgets">
+    <we-row string="Image" class="o_we_sublevel_1">
+        <we-imagepicker title="Edit image"
+                        data-background=""
+                        data-name="bg_image_opt"
+                        data-dependencies="bg_image_opt"/>
+    </we-row>
+    <we-row string="Main Color" class="o_we_sublevel_2" title="Main Color" data-name="main_color_opt">
+        <we-colorpicker data-dynamic-color="true" data-color-name="c1"/>
+        <we-colorpicker data-dynamic-color="true" data-color-name="c2"/>
+        <we-colorpicker data-dynamic-color="true" data-color-name="c3"/>
+        <we-colorpicker data-dynamic-color="true" data-color-name="c4"/>
+        <we-colorpicker data-dynamic-color="true" data-color-name="c5"/>
+    </we-row>
+</template>
+
+<template id="snippet_options_image_position_widgets">
+    <t t-set="bg_image_dependencies" t-value="bg_image_dependencies or None"/>
+    <t t-set="type_method" t-value="type_method or 'data-background-type'"/>
+    <t t-set="type_method_value_quote" t-value="type_method_value_quote or ''"/>
+    <t t-set="type_param" t-value="type_param"/>
+    <t t-set="type_param_value" t-value="type_param_value"/>
+    <t t-set="size_method" t-value="size_method or 'data-select-style'"/>
+    <t t-set="size_param" t-value="size_param or 'data-css-property'"/>
+    <t t-set="size_param_value" t-value="size_param_value or 'background-size'"/>
+    <we-row string="Position" class="o_we_sublevel_2">
+        <we-select data-no-preview="true" t-att-data-dependencies="bg_image_dependencies" t-att="type_param and {type_param: type_param_value}">
+            <we-button t-att="{type_method: type_method_value_quote + 'image' + type_method_value_quote}">Cover</we-button>
+            <we-button t-att="{type_method: type_method_value_quote + 'pattern' + type_method_value_quote}" data-name="background_repeat_opt">Repeat pattern</we-button>
+        </we-select>
+        <we-button class="fa fa-fw fa-crosshairs" title="Background Position" data-background-position-overlay="true" t-att-data-dependencies="bg_image_dependencies" data-no-preview="true"/>
+    </we-row>
+    <we-multi data-dependencies="background_repeat_opt" t-att="{size_param: size_param_value}">
+        <we-input string="Width" class="o_we_sublevel_3" placeholder="auto" data-unit="px" t-att="{size_method: 'auto'}"/>
+        <we-input string="Height" class="o_we_sublevel_3" placeholder="auto" data-unit="px" t-att="{size_method: 'auto'}"/>
+    </we-multi>
+</template>
+
 <template id="snippet_options_image_optimization_widgets">
     <t t-set="filter_label">Filter</t>
     <we-select t-att-string="filter_label" t-att-class="indent and 'o_we_sublevel_2'">
@@ -170,36 +208,16 @@
              t-att-data-selector="selector"
              t-att-data-exclude="exclude"
              t-att-data-target="target">
-            <we-row string="Image" class="o_we_sublevel_1">
-                <we-imagepicker title="Edit image"
-                                data-background=""
-                                data-name="bg_image_opt"
-                                data-dependencies="bg_image_opt"/>
-            </we-row>
-            <we-row string="Main Color" class="o_we_sublevel_2" title="Main Color" data-name="main_color_opt">
-                <we-colorpicker data-dynamic-color="true" data-color-name="c1"/>
-                <we-colorpicker data-dynamic-color="true" data-color-name="c2"/>
-                <we-colorpicker data-dynamic-color="true" data-color-name="c3"/>
-                <we-colorpicker data-dynamic-color="true" data-color-name="c4"/>
-                <we-colorpicker data-dynamic-color="true" data-color-name="c5"/>
-            </we-row>
+            <t t-call="web_editor.snippet_options_image_selection_widgets"/>
         </div>
 
         <div data-js="BackgroundPosition"
              t-att-data-selector="selector"
              t-att-data-exclude="exclude"
              t-att-data-target="target">
-            <we-row string="Position" class="o_we_sublevel_2">
-                <we-select data-no-preview="true">
-                    <we-button data-background-type="cover">Cover</we-button>
-                    <we-button data-background-type="repeat-pattern" data-name="background_repeat_opt">Repeat pattern</we-button>
-                </we-select>
-                <we-button class="fa fa-fw fa-crosshairs" title="Background Position" data-background-position-overlay="true" data-no-preview="true"/>
-            </we-row>
-            <we-multi data-css-property="background-size" data-dependencies="background_repeat_opt">
-                <we-input string="Width" class="o_we_sublevel_3" data-select-style="auto" placeholder="auto" data-unit="px"/>
-                <we-input string="Height" class="o_we_sublevel_3" data-select-style="auto" placeholder="auto" data-unit="px"/>
-            </we-multi>
+            <t t-call="web_editor.snippet_options_image_position_widgets">
+                <t t-set="bg_image_dependencies" t-valuef="bg_image_toggle_opt"/>
+            </t>
         </div>
 
         <div data-js="BackgroundOptimize"

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -836,9 +836,13 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         }
         this.__savedCovers[resModel].push(resID);
 
-        var cssBgImage = $(el.querySelector('.o_record_cover_image')).css('background-image');
-        var coverProps = {
+        const bgImageEl = el.querySelector(".o_record_cover_image");
+        const cssBgImage = window.getComputedStyle(bgImageEl).backgroundImage;
+        const coverProps = {
             'background-image': cssBgImage.replace(/"/g, '').replace(window.location.protocol + "//" + window.location.host, ''),
+            'background-position': bgImageEl.style.backgroundPosition,
+            'background-repeat': bgImageEl.style.backgroundRepeat,
+            'background-size': bgImageEl.style.backgroundSize,
             'background_color_class': el.dataset.bgColorClass,
             'background_color_style': el.dataset.bgColorStyle,
             'opacity': el.dataset.filterValue,

--- a/addons/website/static/src/img/snippets_options/page_layout_boxed.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_boxed.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-341.08" y1="513.78" x2="-341.08" y2="511.93" gradientTransform="matrix(44, 0, 0, -17, 15050.29, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="12.04" y1="5.66" x2="73.26" y2="5.66" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="47.27" y="20.68" width="19.23" height="12.63" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="47.27" y="20.68" width="19.53" height="12.9" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-338.14" y1="514.3" x2="-338.27" y2="514.34" gradientTransform="matrix(32.81, 0, 0, -17.65, 11162.9, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="47.27" y="20.68" width="19.23" height="12.76" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-342.8" y1="519.42" x2="-343" y2="519.4" gradientTransform="matrix(61.88, 0, 0, -25.41, 21267.5, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g id="Boxed">
+    <g>
+      <rect x="12.04" y="11.33" width="61.21" height="31.31" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+      <g>
+        <g>
+          <rect id="path-2" x="18.42" y="22.03" width="22.11" height="1.88"/>
+          <rect id="path-2-2" data-name="path-2" x="18.42" y="22.03" width="22.11" height="1.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-3" data-name="path-2" x="18.42" y="25.8" width="19.24" height="0.88" fill="#fff"/>
+          <rect id="path-2-4" data-name="path-2" x="18.42" y="25.8" width="19.24" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-5" data-name="path-2" x="18.42" y="28.43" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-6" data-name="path-2" x="18.42" y="28.43" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-7" data-name="path-2" x="18.42" y="31.06" width="19.24" height="0.88" fill="#fff"/>
+          <rect id="path-2-8" data-name="path-2" x="18.42" y="31.06" width="19.24" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g id="Group">
+        <rect id="Rectangle" x="12.04" width="61.21" height="11.33" fill="url(#linear-gradient-2)"/>
+      </g>
+      <g id="Group-4" opacity="0.8">
+        <g id="Group-2" data-name="Group">
+          <path id="Rectangle-2" data-name="Rectangle" d="M61.57,4.92V6.41H29.4V4.92Z" fill="#fff"/>
+        </g>
+      </g>
+      <path id="Rectangle-3" data-name="Rectangle" d="M66,4.36h2.85A1.24,1.24,0,0,1,70,5.66h0A1.24,1.24,0,0,1,68.84,7H66a1.24,1.24,0,0,1-1.17-1.3h0A1.25,1.25,0,0,1,66,4.36Z" fill="#fff"/>
+      <path id="Rectangle-4" data-name="Rectangle" d="M16.27,4.36h8.87a1,1,0,0,1,1,1.1v.41a1,1,0,0,1-1,1.09H16.27a1,1,0,0,1-1-1.09V5.46A1,1,0,0,1,16.27,4.36Z" fill="#fff"/>
+      <g>
+        <rect x="46.9" y="20.28" width="19.99" height="13.42" fill="#fff"/>
+        <g>
+          <rect id="path-1-4" data-name="path-1" x="47.27" y="20.68" width="19.23" height="12.63" fill="#79d1f2"/>
+          <g mask="url(#mask)">
+            <ellipse cx="63.68" cy="23.91" rx="2.07" ry="2.11" fill="#f3ec60"/>
+          </g>
+          <g mask="url(#mask-2-2)">
+            <path d="M66.6,33.39c0-.21.51-3.63-.09-3.64h-.19c-4,0-7.44,1.5-8.51,3.56C57.58,33.74,66.6,33.57,66.6,33.39Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+          </g>
+          <g mask="url(#mask-3)">
+            <path d="M47.27,33.31c3.21,0,13.41.25,13.36,0-.71-3.24-5.77-5.76-13.36-6.18Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+          </g>
+        </g>
+        <path d="M66.88,20.28V33.7h-20V20.28Zm-.37.4H47.27V33.31H66.51Z" fill="#fff" fill-rule="evenodd"/>
+      </g>
+      <rect x="12.04" y="42.64" width="61.21" height="19.31" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+      <g>
+        <circle cx="54.66" cy="52.29" r="1.39" fill="#fff"/>
+        <circle cx="60" cy="52.29" r="1.39" fill="#fff"/>
+        <circle cx="65.49" cy="52.29" r="1.39" fill="#fff"/>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-9" data-name="path-2" x="35.84" y="49.22" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-10" data-name="path-2" x="35.84" y="49.22" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-11" data-name="path-2" x="35.84" y="51.85" width="9.41" height="0.88" fill="#fff"/>
+          <rect id="path-2-12" data-name="path-2" x="35.84" y="51.85" width="9.41" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-13" data-name="path-2" x="35.84" y="54.49" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-14" data-name="path-2" x="35.84" y="54.49" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-15" data-name="path-2" x="18.42" y="49.21" width="8.28" height="0.88" fill="#fff"/>
+          <rect id="path-2-16" data-name="path-2" x="18.42" y="49.21" width="8.28" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-17" data-name="path-2" x="18.42" y="51.84" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-18" data-name="path-2" x="18.42" y="51.84" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-19" data-name="path-2" x="18.42" y="54.47" width="11.05" height="0.88" fill="#fff"/>
+          <rect id="path-2-20" data-name="path-2" x="18.42" y="54.47" width="11.05" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_framed.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_framed.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-437.08" y1="513.44" x2="-437.08" y2="511.93" gradientTransform="matrix(44, 0, 0, -17, 19274.28, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="12.05" y1="11.33" x2="73.27" y2="11.33" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="48.25" y="24.13" width="17.31" height="11.37" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="48.25" y="24.13" width="17.57" height="11.61" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-433.41" y1="514.17" x2="-433.53" y2="514.2" gradientTransform="matrix(32.81, 0, 0, -17.65, 14287.87, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="48.25" y="24.13" width="17.31" height="11.48" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-439.44" y1="519.33" x2="-439.62" y2="519.3" gradientTransform="matrix(61.88, 0, 0, -25.41, 27247.69, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g id="Framed">
+    <g>
+      <rect x="12.05" y="16.99" width="61.21" height="25.65" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+      <g>
+        <g>
+          <rect id="path-2" x="19.53" y="25.35" width="19.9" height="1.7"/>
+          <rect id="path-2-2" data-name="path-2" x="19.53" y="25.35" width="19.9" height="1.7" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-3" data-name="path-2" x="19.53" y="28.74" width="17.31" height="0.79" fill="#fff"/>
+          <rect id="path-2-4" data-name="path-2" x="19.53" y="28.74" width="17.31" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-5" data-name="path-2" x="19.53" y="31.11" width="14.74" height="0.79" fill="#fff"/>
+          <rect id="path-2-6" data-name="path-2" x="19.53" y="31.11" width="14.74" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-7" data-name="path-2" x="19.53" y="33.48" width="17.31" height="0.79" fill="#fff"/>
+          <rect id="path-2-8" data-name="path-2" x="19.53" y="33.48" width="17.31" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g id="Group">
+        <rect id="Rectangle" x="12.05" y="5.66" width="61.21" height="11.33" fill="url(#linear-gradient-2)"/>
+      </g>
+      <g id="Group-4" opacity="0.8">
+        <g id="Group-2" data-name="Group">
+          <path id="Rectangle-2" data-name="Rectangle" d="M61.58,10.58v1.5H29.42v-1.5Z" fill="#fff"/>
+        </g>
+      </g>
+      <path id="Rectangle-3" data-name="Rectangle" d="M66,10h2.85A1.24,1.24,0,0,1,70,11.33h0a1.24,1.24,0,0,1-1.17,1.3H66a1.24,1.24,0,0,1-1.16-1.3h0A1.24,1.24,0,0,1,66,10Z" fill="#fff"/>
+      <path id="Rectangle-4" data-name="Rectangle" d="M16.29,10h8.86a1,1,0,0,1,1,1.09v.41a1,1,0,0,1-1,1.1H16.29a1,1,0,0,1-1-1.1v-.41A1,1,0,0,1,16.29,10Z" fill="#fff"/>
+      <g>
+        <rect x="47.91" y="23.78" width="17.99" height="12.08" fill="#fff"/>
+        <g>
+          <rect id="path-1-4" data-name="path-1" x="48.25" y="24.13" width="17.31" height="11.37" fill="#79d1f2"/>
+          <g mask="url(#mask)">
+            <ellipse cx="63.01" cy="27.04" rx="1.87" ry="1.9" fill="#f3ec60"/>
+          </g>
+          <g mask="url(#mask-2-2)">
+            <path d="M65.64,35.57c0-.19.46-3.26-.08-3.27h-.17c-3.63,0-6.7,1.35-7.66,3.2C57.52,35.89,65.64,35.74,65.64,35.57Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+          </g>
+          <g mask="url(#mask-3)">
+            <path d="M48.25,35.5c2.88,0,12.07.23,12,0-.64-2.91-5.2-5.18-12-5.56Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+          </g>
+        </g>
+        <path d="M65.9,23.78V35.85h-18V23.78Zm-.34.35H48.25V35.5H65.56Z" fill="#fff" fill-rule="evenodd"/>
+      </g>
+      <rect x="12.05" y="42.64" width="61.22" height="13.65" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+      <g>
+        <circle cx="53.41" cy="49.46" r="1.25" fill="#fff"/>
+        <circle cx="58.21" cy="49.46" r="1.25" fill="#fff"/>
+        <circle cx="63.16" cy="49.46" r="1.25" fill="#fff"/>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-9" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-10" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-11" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff"/>
+          <rect id="path-2-12" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-13" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-14" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-15" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff"/>
+          <rect id="path-2-16" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-17" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-18" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-19" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff"/>
+          <rect id="path-2-20" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_full.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_full.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-247.54" y1="513.78" x2="-247.54" y2="511.93" gradientTransform="matrix(44, 0, 0, -17, 10934.29, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="0" y1="5.67" x2="85.27" y2="5.67" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="49.01" y="19.22" width="23.75" height="15.61" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="49.01" y="19.22" width="24.11" height="15.95" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-245.13" y1="514.22" x2="-245.29" y2="514.27" gradientTransform="matrix(32.81, 0, 0, -17.65, 8117.83, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="49.01" y="19.22" width="23.75" height="15.77" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-248.56" y1="519.39" x2="-248.81" y2="519.36" gradientTransform="matrix(61.88, 0, 0, -25.41, 15440.22, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g id="Full">
+    <g>
+      <rect y="11.34" width="85.26" height="31.36" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+      <g>
+        <g>
+          <rect id="path-2" x="12.05" y="22.06" width="22.81" height="1.89"/>
+          <rect id="path-2-2" data-name="path-2" x="12.05" y="22.06" width="22.81" height="1.89" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-3" data-name="path-2" x="12.05" y="25.84" width="19.84" height="0.88" fill="#fff"/>
+          <rect id="path-2-4" data-name="path-2" x="12.05" y="25.84" width="19.84" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-5" data-name="path-2" x="12.05" y="28.47" width="16.9" height="0.88" fill="#fff"/>
+          <rect id="path-2-6" data-name="path-2" x="12.05" y="28.47" width="16.9" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-7" data-name="path-2" x="12.05" y="31.11" width="19.84" height="0.88" fill="#fff"/>
+          <rect id="path-2-8" data-name="path-2" x="12.05" y="31.11" width="19.84" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g id="Group">
+        <rect id="Rectangle" width="85.27" height="11.34" fill="url(#linear-gradient-2)"/>
+      </g>
+      <g id="Group-4" opacity="0.8">
+        <g id="Group-2" data-name="Group">
+          <path id="Rectangle-2" data-name="Rectangle" d="M69,5.24V7H24.2V5.24Z" fill="#fff"/>
+        </g>
+      </g>
+      <path id="Rectangle-3" data-name="Rectangle" d="M75.13,3.87h4a1.83,1.83,0,0,1,1.62,2h0a1.83,1.83,0,0,1-1.62,2h-4a1.83,1.83,0,0,1-1.62-2h0A1.83,1.83,0,0,1,75.13,3.87Z" fill="#fff"/>
+      <path id="Rectangle-4" data-name="Rectangle" d="M6,3.87H18.29a1.54,1.54,0,0,1,1.37,1.67v.63a1.54,1.54,0,0,1-1.37,1.67H6A1.54,1.54,0,0,1,4.6,6.17V5.54A1.54,1.54,0,0,1,6,3.87Z" fill="#fff"/>
+      <g>
+        <rect x="48.54" y="18.74" width="24.68" height="16.59" fill="#fff"/>
+        <g>
+          <rect id="path-1-4" data-name="path-1" x="49.01" y="19.22" width="23.75" height="15.61" fill="#79d1f2"/>
+          <g mask="url(#mask)">
+            <ellipse cx="69.26" cy="23.22" rx="2.56" ry="2.61" fill="#f3ec60"/>
+          </g>
+          <g mask="url(#mask-2-2)">
+            <path d="M72.86,34.94c0-.26.64-4.48-.11-4.49h-.23c-5,0-9.18,1.85-10.51,4.39C61.73,35.38,72.86,35.16,72.86,34.94Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+          </g>
+          <g mask="url(#mask-3)">
+            <path d="M49,34.84c4,.07,16.55.32,16.48,0-.87-4-7.12-7.11-16.48-7.64Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+          </g>
+        </g>
+        <path d="M73.22,18.74V35.33H48.54V18.74Zm-.47.48H49V34.84H72.75Z" fill="#fff" fill-rule="evenodd"/>
+      </g>
+      <rect y="42.7" width="85.27" height="19.25" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+      <g>
+        <circle cx="58.83" cy="52.37" r="1.55" fill="#fff"/>
+        <circle cx="65.02" cy="52.37" r="1.55" fill="#fff"/>
+        <circle cx="71.2" cy="52.37" r="1.55" fill="#fff"/>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-9" data-name="path-2" x="33.24" y="49.28" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-10" data-name="path-2" x="33.24" y="49.28" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-11" data-name="path-2" x="33.24" y="51.92" width="13.95" height="0.88" fill="#fff"/>
+          <rect id="path-2-12" data-name="path-2" x="33.24" y="51.92" width="13.95" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-13" data-name="path-2" x="33.24" y="54.55" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-14" data-name="path-2" x="33.24" y="54.55" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+      <g>
+        <g opacity="0.6">
+          <rect id="path-2-15" data-name="path-2" x="11.94" y="49.28" width="12.26" height="0.88" fill="#fff"/>
+          <rect id="path-2-16" data-name="path-2" x="11.94" y="49.28" width="12.26" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-17" data-name="path-2" x="11.94" y="51.92" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-18" data-name="path-2" x="11.94" y="51.92" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+        <g opacity="0.6">
+          <rect id="path-2-19" data-name="path-2" x="11.94" y="54.55" width="16.38" height="0.88" fill="#fff"/>
+          <rect id="path-2-20" data-name="path-2" x="11.94" y="54.55" width="16.38" height="0.88" fill="#fff" fill-opacity="0.95"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_postcard.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_postcard.svg
@@ -1,0 +1,113 @@
+<svg id="Postcard" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 85.26 61.95">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-535.26" y1="513.44" x2="-535.26" y2="512.27" gradientTransform="matrix(44, 0, 0, -17, 23594.27, 8745.52)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a09d"/>
+      <stop offset="1" stop-color="#00e2ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="12.05" y1="5.66" x2="73.27" y2="5.66" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linear-gradient"/>
+    <mask id="mask" x="46.82" y="21.3" width="17.31" height="11.37" maskUnits="userSpaceOnUse">
+      <g id="mask-2">
+        <rect id="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <mask id="mask-2-2" x="46.82" y="21.3" width="17.57" height="11.61" maskUnits="userSpaceOnUse">
+      <g id="mask-2-3" data-name="mask-2">
+        <rect id="path-1-2" data-name="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-3" x1="-530.86" y1="514.33" x2="-530.97" y2="514.36" gradientTransform="matrix(32.81, 0, 0, -17.65, 17483.86, 9108.82)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#008374"/>
+      <stop offset="1" stop-color="#006a59"/>
+    </linearGradient>
+    <mask id="mask-3" x="46.82" y="21.3" width="17.31" height="11.48" maskUnits="userSpaceOnUse">
+      <g id="mask-2-4" data-name="mask-2">
+        <rect id="path-1-3" data-name="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#fff"/>
+      </g>
+    </mask>
+    <linearGradient id="linear-gradient-4" x1="-538.3" y1="519.44" x2="-538.48" y2="519.41" gradientTransform="matrix(61.88, 0, 0, -25.41, 33363.79, 13229.75)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00aa89"/>
+      <stop offset="1" stop-color="#009989"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="12.05" y="16.99" width="61.21" height="19.99" fill-opacity="0.4" fill="url(#linear-gradient)"/>
+    <g>
+      <g>
+        <rect id="path-2" x="20.85" y="22.52" width="18.92" height="1.7"/>
+        <rect id="path-2-2" data-name="path-2" x="20.85" y="22.52" width="18.92" height="1.7" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-3" data-name="path-2" x="20.85" y="25.91" width="16.46" height="0.79" fill="#fff"/>
+        <rect id="path-2-4" data-name="path-2" x="20.85" y="25.91" width="16.46" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-5" data-name="path-2" x="20.85" y="28.28" width="14.02" height="0.79" fill="#fff"/>
+        <rect id="path-2-6" data-name="path-2" x="20.85" y="28.28" width="14.02" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-7" data-name="path-2" x="20.85" y="30.65" width="16.46" height="0.79" fill="#fff"/>
+        <rect id="path-2-8" data-name="path-2" x="20.85" y="30.65" width="16.46" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+    </g>
+    <g id="Group">
+      <rect id="Rectangle" x="12.05" width="61.21" height="11.33" fill="url(#linear-gradient-2)"/>
+    </g>
+    <g id="Group-4" opacity="0.8">
+      <g id="Group-2" data-name="Group">
+        <path id="Rectangle-2" data-name="Rectangle" d="M61.58,4.92V6.41H29.42V4.92Z" fill="#fff"/>
+      </g>
+    </g>
+    <path id="Rectangle-3" data-name="Rectangle" d="M66,4.36h2.85A1.25,1.25,0,0,1,70,5.66h0A1.24,1.24,0,0,1,68.85,7H66a1.24,1.24,0,0,1-1.16-1.3h0A1.24,1.24,0,0,1,66,4.36Z" fill="#fff"/>
+    <path id="Rectangle-4" data-name="Rectangle" d="M16.29,4.36h8.86a1,1,0,0,1,1,1.1v.41a1,1,0,0,1-1,1.09H16.29a1,1,0,0,1-1-1.09V5.46A1,1,0,0,1,16.29,4.36Z" fill="#fff"/>
+    <g>
+      <rect x="46.48" y="20.95" width="17.99" height="12.08" fill="#fff"/>
+      <g>
+        <rect id="path-1-4" data-name="path-1" x="46.82" y="21.3" width="17.31" height="11.37" fill="#79d1f2"/>
+        <g mask="url(#mask)">
+          <ellipse cx="61.59" cy="24.21" rx="1.87" ry="1.9" fill="#f3ec60"/>
+        </g>
+        <g mask="url(#mask-2-2)">
+          <path d="M64.21,32.74c0-.19.47-3.26-.08-3.27H64c-3.63,0-6.69,1.35-7.66,3.2C56.1,33.06,64.21,32.91,64.21,32.74Z" fill-rule="evenodd" fill="url(#linear-gradient-3)"/>
+        </g>
+        <g mask="url(#mask-3)">
+          <path d="M46.82,32.67c2.89,0,12.07.23,12,0-.64-2.91-5.19-5.18-12-5.56Z" fill-rule="evenodd" fill="url(#linear-gradient-4)"/>
+        </g>
+      </g>
+      <path d="M64.47,21V33h-18V21Zm-.34.35H46.82V32.67H64.13Z" fill="#fff" fill-rule="evenodd"/>
+    </g>
+    <rect x="12.04" y="42.64" width="61.21" height="13.65" fill="#d8d8d8" opacity="0.26" style="isolation: isolate"/>
+    <g>
+      <circle cx="53.41" cy="49.46" r="1.25" fill="#fff"/>
+      <circle cx="58.21" cy="49.46" r="1.25" fill="#fff"/>
+      <circle cx="63.16" cy="49.46" r="1.25" fill="#fff"/>
+    </g>
+    <g>
+      <g opacity="0.6">
+        <rect id="path-2-9" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-10" data-name="path-2" x="36.52" y="46.7" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-11" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff"/>
+        <rect id="path-2-12" data-name="path-2" x="36.52" y="49.07" width="8.47" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-13" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-14" data-name="path-2" x="36.52" y="51.44" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+    </g>
+    <g>
+      <g opacity="0.6">
+        <rect id="path-2-15" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff"/>
+        <rect id="path-2-16" data-name="path-2" x="20.84" y="46.69" width="7.45" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-17" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-18" data-name="path-2" x="20.84" y="49.06" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+      <g opacity="0.6">
+        <rect id="path-2-19" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff"/>
+        <rect id="path-2-20" data-name="path-2" x="20.84" y="51.43" width="9.95" height="0.79" fill="#fff" fill-opacity="0.95"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3031,20 +3031,16 @@ options.registry.CoverProperties = options.Class.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Handles a background change.
+     * Toggles background image on or off.
      *
      * @see this.selectClass for parameters
      */
-    background: async function (previewMode, widgetValue, params) {
-        if (widgetValue === '') {
+    toggleBgImage: async function (previewMode, widgetValue, params) {
+        if (widgetValue) {
+            this._requestUserValueWidgets("bg_image_opt")[0].enable();
+        } else {
             this.$image.css('background-image', '');
             this.$target.removeClass('o_record_has_cover');
-        } else {
-            this.$image.css('background-image', `url('${widgetValue}')`);
-            this.$target.addClass('o_record_has_cover');
-            const $defaultSizeBtn = this.$el.find('.o_record_cover_opt_size_default');
-            $defaultSizeBtn.click();
-            $defaultSizeBtn.closest('we-select').click();
         }
 
         if (!previewMode) {
@@ -3095,12 +3091,9 @@ options.registry.CoverProperties = options.Class.extend({
             case 'filterValue': {
                 return parseFloat(this.$filter.css('opacity')).toFixed(1);
             }
-            case 'background': {
-                const background = this.$image.css('background-image');
-                if (background && background !== 'none') {
-                    return background.match(/^url\(["']?(.+?)["']?\)$/)[1];
-                }
-                return '';
+            case "toggleBgImage": {
+                const background = this.$image[0].style.backgroundImage;
+                return background && background !== "none";
             }
         }
         return this._super(...arguments);

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -658,7 +658,12 @@ options.Class.include({
     custom_events: Object.assign({}, options.Class.prototype.custom_events || {}, {
         'google_fonts_custo_request': '_onGoogleFontsCustoRequest',
     }),
-    specialCheckAndReloadMethodsNames: ['customizeWebsiteViews', 'customizeWebsiteVariable', 'customizeWebsiteColor'],
+    specialCheckAndReloadMethodsNames: [
+        "customizeWebsiteViews",
+        "customizeWebsiteVariable",
+        "customizeWebsiteColor",
+        "customizeWebsiteColorOrGradient",
+    ],
 
     /**
      * @override
@@ -711,6 +716,12 @@ options.Class.include({
      */
     async customizeWebsiteAssets(previewMode, widgetValue, params) {
         await this._customizeWebsite(previewMode, widgetValue, params, 'assets');
+    },
+    /**
+     * @see this.selectClass for parameters
+     */
+    async customizeWebsiteColorOrGradient(previewMode, widgetValue, params) {
+        await this._customizeWebsite(previewMode, widgetValue, params, "colorOrGradient");
     },
 
     //--------------------------------------------------------------------------
@@ -784,6 +795,16 @@ options.Class.include({
             case 'customizeWebsiteAssets': {
                 return this._getEnabledCustomizeValues(params.possibleValues, false);
             }
+            case "customizeWebsiteColorOrGradient": {
+                let gradientValue = weUtils.getCSSVariableValue(params.colorGradient);
+                if (gradientValue) {
+                    if (gradientValue.startsWith("'") && gradientValue.endsWith("'")) {
+                        gradientValue = gradientValue.substring(1, gradientValue.length - 1);
+                    }
+                    return gradientValue;
+                }
+                return weUtils.getCSSVariableValue(params.color);
+            }
         }
         return this._super(...arguments);
     },
@@ -818,6 +839,11 @@ options.Class.include({
                 break;
             case 'assets':
                 await this._customizeWebsiteData(widgetValue, params, false);
+                break;
+            case "colorOrGradient":
+                await this._customizeWebsiteColorOrGradient(widgetValue, params);
+                break;
+            case "reloadOnly":
                 break;
             default:
                 if (params.customCustomization) {
@@ -857,6 +883,18 @@ options.Class.include({
     /**
      * @private
      */
+    async _customizeWebsiteColorOrGradient(color, params) {
+        if (weUtils.isColorGradient(color)) {
+            await this._customizeWebsiteVariable(color, {variable: params.colorGradient});
+            await this._customizeWebsiteColors({[params.color]: ""}, params);
+        } else {
+            await this._customizeWebsiteColors({[params.color]: color}, params);
+            await this._customizeWebsiteVariable(null, {variable: params.colorGradient});
+        }
+    },
+    /**
+     * @private
+     */
      async _customizeWebsiteColors(colors, params) {
         colors = colors || {};
 
@@ -890,9 +928,9 @@ options.Class.include({
      *
      * @private
      * @param {Object} values: value per key variable
-     * @param {string} nullValue: string that represent null
+     * @param {string} nullValue: string that represents null
      */
-    _customizeWebsiteVariables: async function (values, nullValue) {
+    async _customizeWebsiteVariables(values, nullValue) {
         await this._makeSCSSCusto('/website/static/src/scss/options/user_values.scss', values, nullValue);
         await this._refreshBundles();
     },
@@ -1266,7 +1304,13 @@ options.registry.BackgroundVideo = options.Class.extend({
     },
 });
 
-options.registry.OptionsTab = options.Class.extend({
+options.registry.OptionsTab = options.Class.extend(options.BackgroundPositionMixin, {
+    specialCheckAndReloadMethodsNames: options.Class.prototype.specialCheckAndReloadMethodsNames
+        .concat([
+            "customizeBodyBg",
+            "toggleBodyBgImage",
+        ]),
+
     GRAY_PARAMS: {EXTRA_SATURATION: "gray-extra-saturation", HUE: "gray-hue"},
 
     /**
@@ -1277,6 +1321,7 @@ options.registry.OptionsTab = options.Class.extend({
         this.grayParams = {};
         this.grays = {};
         this.orm = this.bindService("orm");
+        this.$target = $(this.ownerDocument.body).find("#wrapwrap");
     },
 
     //--------------------------------------------------------------------------
@@ -1399,26 +1444,32 @@ options.registry.OptionsTab = options.Class.extend({
         });
     },
     /**
-     * @see this.selectClass for parameters
-     */
-    async customizeBodyBgType(previewMode, widgetValue, params) {
-        if (widgetValue === 'NONE') {
-            this.bodyImageType = 'image';
-            return this.customizeBodyBg(previewMode, '', params);
-        }
-        // TODO improve: hack to click on external image picker
-        this.bodyImageType = widgetValue;
-        const widget = this._requestUserValueWidgets(params.imagepicker)[0];
-        widget.enable();
-    },
-    /**
      * @override
      */
     async customizeBodyBg(previewMode, widgetValue, params) {
+        if (previewMode) {
+            return;
+        }
+        // Customize several variables at the same time.
         await this._customizeWebsiteVariables({
-            'body-image-type': this.bodyImageType,
+            "body-image-type": "image",
+            "body-image-repeat-size": null,
+            "body-image-position": null,
             'body-image': widgetValue ? `'${widgetValue}'` : '',
         }, params.nullValue);
+        await this._customizeWebsite(previewMode, widgetValue, params, "reloadOnly");
+    },
+    /**
+     * Toggles background image on or off.
+     *
+     * @see this.selectClass for parameters
+     */
+    async toggleBodyBgImage(previewMode, widgetValue, params) {
+        if (widgetValue) {
+            this._requestUserValueWidgets("body_bg_image_opt")[0].enable();
+        } else {
+            await this.customizeBodyBg(previewMode, "", {});
+        }
     },
     async openCustomCodeDialog(previewMode, widgetValue, params) {
         return new Promise(resolve => {
@@ -1552,12 +1603,9 @@ options.registry.OptionsTab = options.Class.extend({
      * @override
      */
     async _computeWidgetState(methodName, params) {
-        if (methodName === 'customizeBodyBgType') {
-            const bgImage = getComputedStyle(this.ownerDocument.querySelector('#wrapwrap'))['background-image'];
-            if (bgImage === 'none') {
-                return "NONE";
-            }
-            return weUtils.getCSSVariableValue('body-image-type');
+        if (methodName === "toggleBodyBgImage") {
+            const bgImageParts = weUtils.backgroundImageCssToParts(getComputedStyle(this.$target[0])["background-image"]);
+            return !!bgImageParts.url;
         }
         if (methodName === 'customizeGray') {
             // See updateUI override
@@ -1574,9 +1622,6 @@ options.registry.OptionsTab = options.Class.extend({
      * @override
      */
     async _computeWidgetVisibility(widgetName, params) {
-        if (widgetName === 'body_bg_image_opt') {
-            return false;
-        }
         if (params.param === this.GRAY_PARAMS.HUE) {
             return this.grayHueIsDefined;
         }
@@ -1587,6 +1632,32 @@ options.registry.OptionsTab = options.Class.extend({
             return !!font;
         }
         return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    async _applyPosition(position) {
+        await options.BackgroundPositionMixin._applyPosition.apply(this, arguments);
+        await this.customizeWebsiteVariable(false, position, {variable: "body-image-position"});
+    },
+    /**
+     * @override
+     */
+    _getOverlaySize() {
+        const style = getComputedStyle(this.$target[0]);
+        return {
+            width: parseInt(style.width) + parseInt(style.paddingLeft) + parseInt(style.paddingRight),
+            height: parseInt(style.height) + parseInt(style.paddingTop) + parseInt(style.paddingBottom),
+        };
+    },
+    /**
+     * @override
+     */
+    _toggleBgOverlay(activate) {
+        options.BackgroundPositionMixin._toggleBgOverlay.apply(this, arguments);
+        if (activate) {
+            this.$bgDragger[0].style.backgroundAttachment = "scroll";
+        }
     },
 });
 

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -1983,8 +1983,11 @@ $o-base-website-values-palette: (
     'google-fonts': null,
     'google-local-fonts': null,
 
+    'body-gradient': null,
     'body-image': null,
     'body-image-type': 'image', // 'image' or 'pattern'
+    'body-image-position': null,
+    'body-image-repeat-size': null,
 
     'layout': 'full', // 'full' / 'boxed'
     'color-palettes-name': null, // Default to the individual variables for each color palette type

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -179,16 +179,22 @@ $-seen-urls: ();
 
 #wrapwrap {
     @if o-website-value('body-image') {
-        background-image: url("/#{str-slice(o-website-value('body-image'), 2)}");
-        background-position: center;
+        @if o-website-value('body-gradient') and o-website-value('layout') != 'full' {
+            background-image: url("/#{str-slice(o-website-value('body-image'), 2)}"), o-website-value('body-gradient');
+        } @else {
+            background-image: url("/#{str-slice(o-website-value('body-image'), 2)}");
+        }
+        background-position: o-website-value('body-image-position') or center;
         background-attachment: fixed;
         @if o-website-value('body-image-type') == 'pattern' {
-            background-size: auto;
+            background-size: o-website-value('body-image-repeat-size') or auto;
             background-repeat: repeat;
         } @else {
             background-size: cover;
             background-repeat: no-repeat;
         }
+    } @else if o-website-value('body-gradient') and o-website-value('layout') != 'full' {
+        background-image: o-website-value('body-gradient');
     }
 
     @if o-website-value('layout') != 'full' {

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -98,8 +98,7 @@ wTourUtils.goToTheme(),
 wTourUtils.goToTheme(),
 {
     content: "Click on the Background Image selection",
-    trigger: '[data-customize-body-bg-type="\'image\'"]:not(.active)',
-    extra_trigger: '[data-customize-body-bg-type="NONE"].active',
+    trigger: '[data-name="bg_image_toggle_opt"]',
 }, {
     content: "The media dialog should open",
     trigger: '.o_select_media_dialog',

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1332,11 +1332,11 @@
                     data-toggle-bg-image="true" data-no-preview="true"/>
         </we-row>
     </div>
-    <div data-js="BackgroundImage" data-selector=".o_record_cover_container"
+    <div data-js="CoverBackgroundImage" data-selector=".o_record_cover_container"
             data-target=".o_record_cover_image" data-no-check="true">
         <t t-call="web_editor.snippet_options_image_selection_widgets"/>
     </div>
-    <div data-js="BackgroundPosition" data-selector=".o_record_cover_container"
+    <div data-js="CoverBackgroundPosition" data-selector=".o_record_cover_container"
             data-target=".o_record_cover_image" data-no-check="true">
         <t t-call="web_editor.snippet_options_image_position_widgets">
             <t t-set="bg_image_dependencies" t-valuef="bg_image_toggle_opt"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1738,10 +1738,14 @@
             <we-button data-add-language="" data-no-preview="true" class="o_we_bg_brand_primary">Add a Language</we-button>
         </we-row>
         <we-select string="Page Layout" data-variable="layout">
-            <we-button data-customize-website-variable="'full'" data-name="layout_full_opt">Full</we-button>
-            <we-button data-customize-website-variable="'boxed'">Boxed</we-button>
-            <we-button data-customize-website-variable="'framed'">Framed</we-button>
-            <we-button data-customize-website-variable="'postcard'">Postcard</we-button>
+            <t t-set="page_layout_full_label">Full</t>
+            <t t-set="page_layout_boxed_label">Boxed</t>
+            <t t-set="page_layout_framed_label">Framed</t>
+            <t t-set="page_layout_postcard_label">Postcard</t>
+            <we-button t-att-data-select-label="page_layout_full_label" data-customize-website-variable="'full'" data-name="layout_full_opt" data-img="/website/static/src/img/snippets_options/page_layout_full.svg">Full</we-button>
+            <we-button t-att-data-select-label="page_layout_boxed_label" data-customize-website-variable="'boxed'" data-img="/website/static/src/img/snippets_options/page_layout_boxed.svg">Boxed</we-button>
+            <we-button t-att-data-select-label="page_layout_framed_label" data-customize-website-variable="'framed'" data-img="/website/static/src/img/snippets_options/page_layout_framed.svg">Framed</we-button>
+            <we-button t-att-data-select-label="page_layout_postcard_label" data-customize-website-variable="'postcard'" data-img="/website/static/src/img/snippets_options/page_layout_postcard.svg">Postcard</we-button>
         </we-select>
         <we-row string="Background" class="o_we_sublevel_1" data-no-preview="true">
             <we-colorpicker data-dependencies="!layout_full_opt"

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1730,7 +1730,7 @@
         <we-collapse class="o_we_theme_presets_collapse" string="Color Presets">
         </we-collapse>
     </div>
-    <div data-js="OptionsTab" data-selector="website-settings" data-no-check="true">
+    <div data-js="OptionsTab" data-selector="website-settings" data-dragger-transparent="true" data-no-check="true">
         <we-row string="Theme">
             <we-button data-switch-theme="" data-no-preview="true" class="o_we_bg_brand_primary">Switch Theme</we-button>
         </we-row>
@@ -1747,22 +1747,26 @@
             <we-button t-att-data-select-label="page_layout_framed_label" data-customize-website-variable="'framed'" data-img="/website/static/src/img/snippets_options/page_layout_framed.svg">Framed</we-button>
             <we-button t-att-data-select-label="page_layout_postcard_label" data-customize-website-variable="'postcard'" data-img="/website/static/src/img/snippets_options/page_layout_postcard.svg">Postcard</we-button>
         </we-select>
-        <we-row string="Background" class="o_we_sublevel_1" data-no-preview="true">
+        <we-row string="Background" class="o_we_sublevel_1 o_we_full_row" data-no-preview="true">
             <we-colorpicker data-dependencies="!layout_full_opt"
-                            data-customize-website-color=""
-                            data-color="body"/>
-            <we-button-group data-imagepicker="body_bg_image_opt">
-                <we-button title="Image" class="fa fa-fw fa-camera"
-                           data-customize-body-bg-type="'image'"/>
-                <we-button title="Pattern" class="fa fa-fw fa-th"
-                           data-customize-body-bg-type="'pattern'"/>
-                <we-button title="None" class="fa fa-fw fa-ban"
-                           data-customize-body-bg-type="NONE"/>
-            </we-button-group>
-            <!-- Hidden imagepicker enabled by above button-group -->
-            <we-imagepicker data-name="body_bg_image_opt"
-                            data-customize-body-bg=""/>
+                    data-with-gradients="True" data-color-gradient="body-gradient"
+                    data-customize-website-color-or-gradient="" data-color="body"/>
+            <we-button title="Image" class="ms-auto fa fa-fw fa-camera" data-name="bg_image_toggle_opt"
+                    data-toggle-body-bg-image="true" data-no-preview="true"/>
         </we-row>
+        <we-row string="Image" class="o_we_sublevel_2">
+            <we-imagepicker title="Edit image" data-dependencies="bg_image_toggle_opt" data-name="body_bg_image_opt" data-customize-body-bg=""/>
+        </we-row>
+        <t t-call="web_editor.snippet_options_image_position_widgets">
+            <t t-set="bg_image_dependencies" t-valuef="bg_image_toggle_opt"/>
+            <t t-set="type_method" t-valuef="data-customize-website-variable"/>
+            <t t-set="type_method_value_quote" t-valuef="'"/>
+            <t t-set="type_param" t-valuef="data-variable"/>
+            <t t-set="type_param_value" t-valuef="body-image-type"/>
+            <t t-set="size_method" t-valuef="data-customize-website-variable"/>
+            <t t-set="size_param" t-valuef="data-variable"/>
+            <t t-set="size_param_value" t-valuef="body-image-repeat-size"/>
+        </t>
     </div>
     <div data-js="OptionsTab" data-selector="theme-paragraph" data-no-check="true">
         <we-collapse>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1328,12 +1328,21 @@
                 <t t-set="with_color_combinations" t-value="True"/>
                 <t t-set="with_gradients" t-value="True"/>
             </t>
-            <we-button-group class="ms-auto">
-                <we-imagepicker title="Image" data-background="" data-button-style="true"/>
-                <we-button class="fa fa-fw fa-ban" title="None" data-background="">
-                </we-button>
-            </we-button-group>
+            <we-button title="Image" class="ms-auto fa fa-fw fa-camera" data-name="bg_image_toggle_opt"
+                    data-toggle-bg-image="true" data-no-preview="true"/>
         </we-row>
+    </div>
+    <div data-js="BackgroundImage" data-selector=".o_record_cover_container"
+            data-target=".o_record_cover_image" data-no-check="true">
+        <t t-call="web_editor.snippet_options_image_selection_widgets"/>
+    </div>
+    <div data-js="BackgroundPosition" data-selector=".o_record_cover_container"
+            data-target=".o_record_cover_image" data-no-check="true">
+        <t t-call="web_editor.snippet_options_image_position_widgets">
+            <t t-set="bg_image_dependencies" t-valuef="bg_image_toggle_opt"/>
+        </t>
+    </div>
+    <div data-js="CoverProperties" data-selector=".o_record_cover_container" data-no-check="true">
         <we-select string="Size" data-name="size_opt" data-cover-opt-name="size">
             <we-button data-select-class="o_full_screen_height">Full Screen</we-button>
             <we-button class="o_record_cover_opt_size_default" data-select-class="o_half_screen_height">Half Screen</we-button>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2227,7 +2227,7 @@
          t-att-data-res-model="_name"
          t-att-data-res-id="_id"
          t-attf-class="o_record_cover_container d-flex flex-column h-100 o_colored_level o_cc #{_cp.get('background_color_class')} #{use_size and _cp.get('resize_class')} #{use_text_align and _cp.get('text_align_class')} #{additionnal_classes}">
-        <div t-attf-class="o_record_cover_component o_record_cover_image #{snippet_autofocus and 'o_we_snippet_autofocus'}" t-attf-style="background-image: #{_bg};"/>
+        <div t-attf-class="o_record_cover_component o_record_cover_image #{snippet_autofocus and 'o_we_snippet_autofocus'}" t-attf-style="background-image: #{_bg}; background-position: #{_cp.get('background-position', '')}; background-repeat: #{_cp.get('background-repeat', 'no-repeat')}; background-size: #{_cp.get('background-size', '')};"/>
         <div t-if="use_filters" t-attf-class="o_record_cover_component o_record_cover_filter oe_black" t-attf-style="opacity: #{_cp.get('opacity', 0.0)};"/>
         <t t-out="0"/>
     </div>

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -50,10 +50,10 @@
         consumeEvent: 'mouseup',
         run: "text",
     }, {
-        trigger: "we-button[data-background]:nth(1)",
+        trigger: "we-button[data-toggle-bg-image]",
         extra_trigger: "iframe #wrap h1[data-oe-expression=\"blog_post.name\"]:not(:containsExact(\"\"))",
         content: markup(_t("Set a blog post <b>cover</b>.")),
-        position: "top",
+        position: "left",
     }, {
         trigger: ".o_select_media_dialog .o_we_search",
         content: _t("Search for an image. (eg: type \"business\")"),


### PR DESCRIPTION
Before this commit the background options were specific for the page
layout and cover properties.

After this commit the background options for the page layout and cover properties are the
same as for a section.
Also added images in the page layout dropdown to illustrate what each layout is about.

task-2359250
