### PR TITLE
[FIX] base_iban: Costa Rica IBAN template

### DIFF
--- a/addons/base_iban/models/res_partner_bank.py
+++ b/addons/base_iban/models/res_partner_bank.py
@@ -109,7 +109,7 @@ _map_iban_template = {
     'br': 'BRkk BBBB BBBB SSSS SCCC CCCC CCCT N',  # Brazil
     'by': 'BYkk BBBB AAAA CCCC CCCC CCCC CCCC',  # Belarus
     'ch': 'CHkk BBBB BCCC CCCC CCCC C',  # Switzerland
-    'cr': 'CRkk BBBC CCCC CCCC CCCC C',  # Costa Rica
+    'cr': 'CRkk BBBC CCCC CCCC CCCC CC',  # Costa Rica
     'cy': 'CYkk BBBS SSSS CCCC CCCC CCCC CCCC',  # Cyprus
     'cz': 'CZkk BBBB SSSS SSCC CCCC CCCC',  # Czech Republic
     'de': 'DEkk BBBB BBBB CCCC CCCC CC',  # Germany


### PR DESCRIPTION
The IBAN template of Costa Rica is incorrect
Backport of #66730

OPW-2477541