### PR TITLE
[FIX] website: fix image display in a text block snippet

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -147,7 +147,7 @@ li > p {
     @extend %o-double-container-no-padding;
 }
 #wrap {
-    > .container, > .container-fluid {
+    .container, .container-fluid {
         // BS3 used to do this on all containers so that margins and floats are
         // cleared inside containers. As lots of current odoo layouts may rely
         // on this for some alignments, this is restored (at least for a while)


### PR DESCRIPTION
The container size of a text block snippet (and every snippet without
rows) was not correct when an image was displayed with right or left
alignment.

The css property clear was added at the end of the containers so that
floating elements from the section do not float over the next section.

task-2469516


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
