### PR TITLE
[FIX] sale: display correct order line value

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -485,6 +485,7 @@
                                     <field name="product_uom_qty"/>
                                     <field name="product_uom" groups="uom.group_uom"/>
                                     <field name="price_subtotal"/>
+                                    <field name="price_total"/>
                                     <field name="price_tax" invisible="1"/>
                                     <field name="price_total" invisible="1"/>
                                     <field name="price_unit"/>
@@ -505,7 +506,9 @@
                                                         <div class="col-4">
                                                             <strong>
                                                                 <span class="float-right text-right">
-                                                                    <t t-esc="record.price_subtotal.value"/>
+                                                                    <t t-set="line_price" t-value="record.price_subtotal.value" groups="account.group_show_line_subtotals_tax_excluded"/>
+                                                                    <t t-set="line_price" t-value="record.price_total.value" groups="account.group_show_line_subtotals_tax_included"/>
+                                                                    <t t-esc="line_price"/>
                                                                 </span>
                                                             </strong>
                                                         </div>


### PR DESCRIPTION
To reproduce the error:
(Need sale_management)
1. In Settings:
    - Line Subtotals Tax Display: Tax-Included
2. Create a tax T:
    - Included in Price: True
3. Create and save a SO
    - Add a line with T
4. Switch to mobile view

Error: The amount of the order line is incorrect, it does not consider
the option from step 1.

OPW-2484646