### PR TITLE
[FIX] repair: Invoice lines are not added for Repair

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -329,7 +329,6 @@ class Repair(models.Model):
                     'narration': narration,
                     'invoice_origin': repair.name,
                     'repair_ids': [(4, repair.id)],
-                    'invoice_line_ids': [],
                     'fiscal_position_id': fp_id
                 }
                 if partner_invoice.property_payment_term_id:


### PR DESCRIPTION
Steps to reproduce the bug:

- In Repair: create a new repair order
- add some product to "Add' and operation.
- Select option for Invoice Method: Before/After Repair.
- Confirm Repair, finish repair and create invoice.

Bug:

No line was created in the invoice

PS: the invoice_line_ids were popped from function _move_autocomplete_invoice_lines_create

opw:2491405