### PR TITLE
[FIX] snailmail_account: send letter to valid partners

### DIFF
--- a/addons/snailmail_account/wizard/account_invoice_send.py
+++ b/addons/snailmail_account/wizard/account_invoice_send.py
@@ -38,7 +38,7 @@ class AccountInvoiceSend(models.TransientModel):
     def snailmail_print_action(self):
         self.ensure_one()
         letters = self.env['snailmail.letter']
-        for invoice in self.invoice_ids:
+        for invoice in self.invoice_ids.filtered(lambda i: i.partner_id):
             letter = self.env['snailmail.letter'].create({
                 'partner_id': invoice.partner_id.id,
                 'model': 'account.move',
@@ -49,7 +49,7 @@ class AccountInvoiceSend(models.TransientModel):
             })
             letters |= letter
 
-        self.invoice_ids.filtered(lambda inv: not inv.invoice_sent).write({'invoice_sent': True})
+        self.invoice_ids.filtered(lambda inv: inv.partner_id and not inv.invoice_sent).write({'invoice_sent': True})
         if len(self.invoice_ids) == 1:
             letters._snailmail_print()
         else:


### PR DESCRIPTION
Before this commit, It was sending letters for all Invoices
which might be failed if invoice has no `partner_id` since
`partner_id` is required field on `snailmail.letter`

Now, we are sending letters to Valid Invoices only.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
