### PR TITLE
[FIX] web_editor: ensure dropdown menus in toolbar are fully visible

### DIFF
--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -9,7 +9,7 @@
         <div id="toolbar" class="oe-toolbar">
             <div id="style" class="btn-group dropdown">
                 <button type="button" class="btn dropdown-toggle"
-                    data-toggle="dropdown" title="" tabindex="-1"
+                    data-toggle="dropdown" title="" tabindex="-1" data-display="static"
                     data-original-title="Style" aria-expanded="false">
                     <i class="fa fa-paragraph"></i>
                 </button>
@@ -78,7 +78,7 @@
 
             <div id="font-size" class="btn-group dropdown">
                 <button type="button" class="btn dropdown-toggle"
-                    data-toggle="dropdown" title="" tabindex="-1"
+                    data-toggle="dropdown" title="" tabindex="-1" data-display="static"
                     data-original-title="Font Size" aria-expanded="false">
                     <span id="fontSizeCurrentValue"></span>
                 </button>


### PR DESCRIPTION
Dropdown menus (eg.: font-size) had their contents cropped if space was lacking underneath the toolbar. With this the user can scroll down to see the rest of it if needed.

More info: twbs/bootstrap#23378

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr