### PR TITLE
[IMP] survey: add background image on survey sections - alternative

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -193,8 +193,6 @@ class Survey(http.Controller):
             values['token'] = token
         if survey.scoring_type != 'no_scoring' and survey.certification:
             values['graph_data'] = json.dumps(answer._prepare_statistics()[answer])
-        if survey.background_image:
-            values['background_image_url'] = survey.background_image_url
         return values
 
     # ------------------------------------------------------------
@@ -289,7 +287,6 @@ class Survey(http.Controller):
                 'previous_page_id': new_previous_id,
                 'has_answered': answer_sudo.user_input_line_ids.filtered(lambda line: line.question_id.id == new_previous_id),
                 'can_go_back': survey_sudo._can_go_back(answer_sudo, page_or_question),
-                'background_image_url': page_or_question.background_image_url,
                 'reload_background_on_next': survey_sudo.has_conditional_questions or page_or_question.background_image_url != next_page_or_question.background_image_url
             })
             return data
@@ -312,7 +309,6 @@ class Survey(http.Controller):
                 page_or_question_key: next_page_or_question,
                 'has_answered': answer_sudo.user_input_line_ids.filtered(lambda line: line.question_id == next_page_or_question),
                 'can_go_back': survey_sudo._can_go_back(answer_sudo, next_page_or_question),
-                'background_image_url': next_page_or_question.background_image_url,
                 'reload_background_on_next': survey_sudo.has_conditional_questions or following_question.background_image_url != next_page_or_question.background_image_url
             })
             if survey_sudo.questions_layout != 'one_page':
@@ -325,15 +321,16 @@ class Survey(http.Controller):
         elif survey_sudo.background_image:
             # If survey start, add background if any
             data.update({
-                'background_image_url': survey_sudo.background_image_url,
-                'reload_background_on_next' : survey_sudo.has_conditional_questions or survey_sudo.background_image_url != next_page_or_question.background_image_url
+                'reload_background_on_next': survey_sudo.has_conditional_questions or survey_sudo.background_image_url != next_page_or_question.background_image_url
             })
 
         return data
 
     def _prepare_question_html(self, survey_sudo, answer_sudo, **post):
         """ Survey page navigation is done in AJAX. This function prepare the 'next page' to display in html
-        and send back this html to the survey_form widget that will inject it into the page."""
+        and send back this html to the survey_form widget that will inject it into the page.
+        Background url must be given to the caller in order to process its refresh as we don't have the next question
+        object at frontend side."""
         survey_data = self._prepare_survey_data(survey_sudo, answer_sudo, **post)
 
         if answer_sudo.state == 'done':

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -245,7 +245,9 @@ class Survey(http.Controller):
                 'title': page.title,
             } for page in survey_sudo.page_ids],
             'format_datetime': lambda dt: format_datetime(request.env, dt, dt_format=False),
-            'format_date': lambda date: format_date(request.env, date)
+            'format_date': lambda date: format_date(request.env, date),
+            'reload_background_on_next': False,
+            'survey_last': False,  # Is it the last question/screen of the survey ?
         }
         if survey_sudo.questions_layout != 'page_per_question':
             triggering_answer_by_question, triggered_questions_by_answer, selected_answers = answer_sudo._get_conditional_values()

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -197,9 +197,8 @@ class UserInputSession(http.Controller):
     def _prepare_manage_session_values(self, survey):
         is_first_question, is_last_question = False, False
         if survey.question_ids:
-            most_voted_answers = survey._get_session_most_voted_answers()
             is_first_question = survey._is_first_page_or_question(survey.session_question_id)
-            is_last_question = survey._is_last_page_or_question(most_voted_answers, survey.session_question_id)
+            is_last_question = survey.session_question_id == survey.question_ids[-1]
 
         values = {
             'survey': survey,

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -53,7 +53,8 @@ class Survey(models.Model):
     description_done = fields.Html(
         "End Message", translate=True,
         help="This message will be displayed when survey is completed")
-    background_image = fields.Binary("Background Image")
+    background_image = fields.Image("Background Image")
+    background_image_url = fields.Char('Background Url', compute="_compute_background_image_url")
     active = fields.Boolean("Active", default=True)
     user_id = fields.Many2one('res.users', string='Responsible', tracking=True, default=lambda self: self.env.user)
     # questions
@@ -165,6 +166,12 @@ class Survey(models.Model):
             'The attempts limit needs to be a positive number if the survey has a limited number of attempts.'),
         ('badge_uniq', 'unique (certification_badge_id)', "The badge for each survey should be unique!"),
     ]
+
+    @api.depends('background_image', 'access_token')
+    def _compute_background_image_url(self):
+        base_bg_url = "/survey/get_background_image/%s"
+        for survey in self:
+            survey.background_image_url = base_bg_url % survey.access_token if survey.background_image else False
 
     def _compute_users_can_signup(self):
         signup_allowed = self.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -14,6 +14,18 @@ nav#oe_main_menu_navbar {
 /**********************************************************
                         Common Style
  **********************************************************/
+.o_survey_background {
+    height: 100%;
+    overflow: auto;
+    transition: box-shadow 0.3s ease-in-out;
+    box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7);
+    background: no-repeat fixed center;
+    background-size: cover;
+    &.o_survey_background_transition {
+        box-shadow: inset 0 0 0 10000px rgba(255,255,255,1);
+    }
+}
+
 .o_survey_wrap {
     min-height: 100%;
 }

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -13,6 +13,7 @@
                 <field name="sequence" invisible="1"/>
                 <field name="scoring_type" invisible="1"/>
                 <sheet>
+                    <field name="background_image" widget="image" class="oe_avatar" attrs="{'invisible': [('is_page', '=', False)]}"/>
                     <div class="oe_title" style="width: 100%;">
                         <label for="title" string="Section" attrs="{'invisible': [('is_page', '=', False)]}"/>
                         <label for="title" string="Question" attrs="{'invisible': [('is_page', '=', True)]}"/>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -68,6 +68,7 @@
                                 <tree decoration-bf="is_page" editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="title" widget="survey_description_page"/>
+                                    <field name="background_image" invisible="1"/>
                                     <field name="question_type" />
                                     <field name="is_page" invisible="1"/>
                                     <field name="questions_selection" invisible="1"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -9,8 +9,11 @@
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
             <attribute name="t-att-style"
-                       add="(('background-image: url(' + background_image_url + ');')
-                             if background_image_url else '')"/>
+                       add="(('background-image: url(' + question.background_image_url + ');')
+                             if question else ('background-image: url(' + page.background_image_url + ');')
+                             if page else ('background-image: url(' + survey.background_image_url + ');')
+                             if survey.background_image_url
+                             else '')"/>
             <attribute name="t-att-class" add="'o_survey_background'"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
@@ -87,6 +90,11 @@
 
     <template id="survey_fill_form" name="Survey: main page content">
         <t t-set="survey_form_readonly" t-value="answer.state == 'done'"/>
+        <t t-set="background_image_url"
+           t-value="question.background_image_url
+                    if question else page.background_image_url
+                    if page else survey.background_image_url
+                    if survey.background_image_url else False"/>
         <form role="form" method="post" t-att-name="survey.id"
                 class="d-flex flex-grow-1 align-items-center"
                 t-att-data-answer-token="answer.access_token"

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -8,7 +8,10 @@
             <t t-set="no_livechat" t-value="True"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-att-style" add="(('height: 100%; overflow: auto; background: url(' + '/survey/get_background_image/%s/%s' % (survey.access_token, answer.access_token) + ') no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;') if survey and survey.background_image and answer else 'height: 100%; overflow: auto;')"/>
+            <attribute name="t-att-style"
+                       add="(('background-image: url(' + background_image_url + ');')
+                             if background_image_url else '')"/>
+            <attribute name="t-att-class" add="'o_survey_background'"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -96,7 +99,9 @@
                 t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
                 t-att-data-questions-layout="survey.questions_layout"
                 t-att-data-triggered-questions-by-answer="json.dumps(triggered_questions_by_answer)"
-                t-att-data-selected-answers="json.dumps(selected_answers)">
+                t-att-data-selected-answers="json.dumps(selected_answers)"
+                t-att-data-background-image-url="background_image_url"
+                t-att-data-reload-background-on-next="reload_background_on_next">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
             <input type="hidden" name="token" t-att-value="answer.access_token" />
             <div class="o_survey_error alert alert-danger d-none" role="alert">

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -7,7 +7,10 @@
             <t t-set="no_livechat" t-value="True"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-att-style" add="('height: 100%; overflow: auto; background: url(' + '/web/image/survey.survey/%s/background_image' % survey.id + ') no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;') if survey and survey.background_image else 'height: 100%; overflow: auto;'"/>
+            <attribute name="t-att-style"
+                       add="(('background-image: url(' + background_image_url + ');')
+                             if background_image_url else '')"/>
+            <attribute name="t-att-class" add="'o_survey_background'"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -76,7 +79,9 @@
             t-att-data-is-last-question="is_last_question"
             t-att-data-current-screen="'question' if is_scored_question else 'userInputs'"
             t-att-data-show-bar-chart="show_bar_chart"
-            t-att-data-show-text-answers="show_text_answers">
+            t-att-data-show-text-answers="show_text_answers"
+            t-att-data-background-image-url="background_image_url"
+            t-att-data-reload-background-on-next="bool(reload_background_on_next)">
             <div class="o_survey_question_header flex-wrap px-3 w-100 d-flex justify-content-between align-items-center position-absolute">
                 <h3>
                     <span>Go to <a t-att-href="survey.session_link" t-esc="survey.session_link" target="_blank" /></span>


### PR DESCRIPTION
This merge adds the background per section feature.
If the section to display has a background image configured, the background
will be refreshed using that section background image.
If the section has no background, the survey background is used.
The background is refreshed only if the previous and the next sections are
different. The background is refreshed at the same time that the next question
is loaded.

To ease technical maintenance and to keep it simple, the background is always
faded out on back or if survey has conditional questions. This is to avoid to
load all the survey structure and to copy the get_next_question logic in the
frontend. When loading the next question, we check that the question that will
follow afterwards has the same background. If not, we force the background fade
out when user goes to the next question (refresh_background_on_next).
Otherwize, we only fade out the question and not the background to keep a
smooth transition between questions and/or sections.

Note: The next section to display depends on free text (section with
description) configuration and on conditional questions.
The next section to display can be the next question's section or directly
the next question itself (if the question is a section).

Task ID: 2225393