### PR TITLE
[FIX] web_editor, website: ensure editor toolbar doesn't hide dropdowns

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2040,6 +2040,7 @@ var SnippetsMenu = Widget.extend({
 
         this.$el.addClass('o_loaded');
         this.trigger_up('snippets_loaded', self.$el);
+        $(this.el.ownerDocument.body).addClass('editor_has_snippets');
     },
     /**
      * Creates a snippet editor to associated to the given snippet. If the given

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -34,7 +34,6 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
     background-color: $o-we-bg;
     color: $o-we-color;
     font-family: $o-we-font-family;
-    z-index: 1051; // Bootstrap sets .modal z-index at 1050. Ensure toolbar is visible in modals.
 
     &.noarrow::before {
         display: none;
@@ -128,6 +127,13 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
     .o_image_alt {
         @include o-text-overflow();
         max-width: 150px;
+    }
+}
+body:not(.editor_has_snippets) {
+    .oe-toolbar {
+        // Bootstrap sets .modal z-index at 1050. Ensure toolbar is visible in
+        // modals. Only apply this to the toolbar if it's not in a snippets menu.
+        z-index: 1051;
     }
 }
 @media only screen and (max-width: 767px) {

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -31,7 +31,6 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         request_save: '_onSnippetRequestSave',
         request_cancel: '_onSnippetRequestCancel',
         get_clean_html: '_onGetCleanHTML',
-        snippets_loaded: '_onSnippetLoaded',
     }),
 
     /**
@@ -522,15 +521,6 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
     _onSnippetRequestCancel: function (ev) {
         ev.stopPropagation();
         this.cancel();
-    },
-    /**
-     * Add class that inform the SnippetMenu biend loaded.
-     *
-     * @private
-     * @param {OdooEvent} ev
-     */
-    _onSnippetLoaded: function (ev) {
-        $('body.editor_enable').addClass('editor_has_snippets');
     },
 });
 


### PR DESCRIPTION
A colorpicker in an option positioned above the toolbar in a snippets menu would be hidden by the toolbar because of the toolbar's z-index.
That z-index is only needed when the editor is in a modal.
The bug this commit fixes only arises when the toolbar is in a snippets menu.
This applies the z-index only when there is a snippets menu in the page. To accomplish that we need the "editor_has_snippets" class that the website module applied to the body. For the sake of harmony within Odoo, that class is now applied by snippets.editor so that no matter the module, if there is a snippets bar, the class is on the body of its document.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
