### PR TITLE
[IMP] product, website_sale: small improvements on priority field

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -143,7 +143,7 @@ class ProductTemplate(models.Model):
     priority = fields.Selection([
         ('0', 'Normal'),
         ('1', 'Favorite'),
-    ], default='0', string="Priority")
+    ], default='0', string="Favorite")
 
     def _compute_item_count(self):
         for template in self:

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -9,9 +9,7 @@
                 <field name="sale_ok" invisible="1"/>
                 <field name="currency_id" invisible="1"/>
                 <field name="cost_currency_id" invisible="1"/>
-
-                <field name="sequence" widget="handle" readonly="1"/>
-                <field name="priority" widget="priority" nolabel="1"/>
+                <field name="priority" widget="priority" optional="show" nolabel="1"/>
                 <field name="name" string="Product Name"/>
                 <field name="default_code" optional="show"/>
                 <field name="barcode" optional="hide" attrs="{'readonly': [('product_variant_count', '>', 1)]}"/>
@@ -82,15 +80,19 @@
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <div class="o_kanban_image">
+                        <div class="oe_kanban_card oe_kanban_global_click">
+                            <div class="o_kanban_image mr-1">
                                 <img t-att-src="kanban_image('product.template', 'image_128', record.id.raw_value)" alt="Product" class="o_image_64_contain"/>
                             </div>
                             <div class="oe_kanban_details">
-                                <field name="priority" widget="priority"/>
-                                <strong class="o_kanban_record_title">
-                                    <field name="name"/>
-                                </strong>
+                                <div class="o_kanban_record_top mb-0">
+                                    <div class="o_kanban_record_headings">
+                                        <strong class="o_kanban_record_title">
+                                            <field name="name"/>
+                                        </strong>
+                                    </div>
+                                    <field name="priority" widget="priority"/>
+                                </div>
                                 <t t-if="record.default_code.value">[<field name="default_code"/>]</t>
                                 <div t-if="record.product_variant_count.value &gt; 1" groups="product.group_product_variant">
                                     <strong>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -46,11 +46,26 @@
             <xpath expr="/tree" position="attributes">
               <attribute name="default_order">website_sequence</attribute>
             </xpath>
-            <field name="sequence" position="replace">
+            <field name="priority" position="before">
                 <field name="website_sequence" widget="handle"/>
             </field>
             <field name="website_id" position="after">
                 <field name="is_published" string="Is Published" optional="hide"/>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="product_template_view_kanban_website_sale">
+        <field name="name">product.template.view.kanban.website_sale</field>
+        <field name="mode">primary</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_kanban_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="/kanban" position="attributes">
+              <attribute name="default_order">website_sequence</attribute>
+            </xpath>
+            <field name="id" position="after">
+                <field name="website_sequence"/>
             </field>
         </field>
     </record>
@@ -61,7 +76,7 @@
         <field name="view_mode">tree,kanban,form,activity</field>
         <field name="view_id"/>
         <field name="search_view_id" ref="product_template_search_view_website"/>
-        <field name="context">{'search_default_published': 1, 'tree_view_ref':'website_sale.product_template_view_tree_website_sale'}</field>
+        <field name="context">{'search_default_published': 1, 'tree_view_ref':'website_sale.product_template_view_tree_website_sale', 'kanban_view_ref':'website_sale.product_template_view_kanban_website_sale'}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new product


### PR DESCRIPTION
-  Rename Priority to Favorite
- Move the priority field star icon in the kanban view
- Remove the sequence field from the list view
- (website_sale) make the favorite column optional in tree view
- (website_sale) keep same order in kanban view than in list view

task-2496758
