### PR TITLE
[FIX] purchase_product_matrix: Allow to change PO lines order

### DIFF
--- a/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
+++ b/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
@@ -99,7 +99,7 @@ var MatrixConfiguratorWidget = relationalFields.FieldMany2One.extend({
      */
     reset: async function (record, ev) {
         await this._super(...arguments);
-        if (ev && ev.data.changes && ev.data.changes.product_template_id && record.data.product_template_id.data.id) {
+        if (ev && ev.target === this && ev.data.changes && ev.data.changes.product_template_id && record.data.product_template_id.data.id) {
             this._onTemplateChange(record.data.product_template_id.data.id, ev.data.dataPointID);
         }
     },

--- a/addons/purchase_product_matrix/static/tests/section_and_note_widget_tests.js
+++ b/addons/purchase_product_matrix/static/tests/section_and_note_widget_tests.js
@@ -207,5 +207,54 @@ QUnit.module('section_and_note: purchase_product_matrix', {
 
         form.destroy();
     });
+
+    QUnit.test('drag and drop rows containing matrix_configurator many2one', async function (assert) {
+        assert.expect(4);
+
+        this.data.order_line.fields.sequence = {string: "Sequence", type: 'number'};
+        this.data.order_line.fields.order_id.relation = 'purchase_order';
+        this.data.purchase_order.records = [
+            {id: 1, order_line_ids: [1, 2]}
+        ];
+        this.data.order_line.records = [
+            {id: 1, sequence: 4, product_template_id: 1, order_id: 1},
+            {id: 2, sequence: 14, product_template_id: 2, order_id: 1},
+        ];
+        this.data.product.records.push(
+            {id: 1, name: "Chair"},
+            {id: 2, name: "Table"}
+        );
+
+        const form = await createView({
+            View: FormView,
+            model: 'purchase_order',
+            data: this.data,
+            arch: `<form>
+                    <field name="order_line_ids" widget="section_and_note_one2many">
+                        <tree editable="bottom">
+                            <field name="sequence" widget="handle"/>
+                            <field name="product_template_id" widget="matrix_configurator"/>
+                        </tree>
+                    </field>
+                </form>`,
+            res_id: 1,
+            viewOptions: {
+                mode: 'edit',
+            },
+        });
+
+        assert.containsN(form, '.o_data_row', 2);
+        assert.strictEqual(form.$('.o_data_row').text(), 'ChairTable');
+        assert.containsN(form, '.o_data_row .o_row_handle', 2);
+
+        // move first row below second
+        const $firstHandle = form.$('.o_data_row:nth(0) .o_row_handle');
+        const $secondHandle = form.$('.o_data_row:nth(1) .o_row_handle');
+        await testUtils.dom.dragAndDrop($firstHandle, $secondHandle);
+
+        assert.strictEqual(form.$('.o_data_row').text(), 'TableChair');
+
+        form.destroy();
+    });
 });
 });


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install 'purchase_product_matrix'
    2. try to edit a PO with more than one line
    3. try to change the order of a product line

What is currently happening ?

    Traceback: TypeError: Cannot read property 'data' of undefined

What are you expecting to happen ?

    Change order lines without traceback

Why is this happening ?

There is a function `reset` that checkes if `ev` exists:
https://github.com/odoo/odoo/blob/e0af10ccc92cb3b07f0eea6fa44ebf5a1bdc86aa/addons/sale/static/src/js/product_configurator_widget.js#L117-L130

And in `purchase_product_matrix` there is a override of this same function that calls it
and then tries to use an `ev` attribute without checking it before
https://github.com/odoo/odoo/blob/a87f1706997eda1a72054c195fc63685d7a05c35/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js#L100-L105

How to fix the bug ?

    Check 'ev' before accessing it

opw-2513061