### PR TITLE
[FIX] website_event_track: fix new track notifications by email

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -121,7 +121,8 @@ class Track(models.Model):
     def create(self, vals):
         track = super(Track, self).create(vals)
 
-        track.event_id.message_post_with_view(
+        user = self.env.user if self.env.user.email else self.env.ref('base.user_root')
+        track.event_id.with_user(user).message_post_with_view(
             'website_event_track.event_track_template_new',
             values={'track': track},
             subject=track.name,


### PR DESCRIPTION
Bug
===
1. Create an event which allows track proposal
2. Follow it and subscribe to "New Track"
3. Log in in incognito and submit a proposal

The email is not sent, because it's sent as the public user, which has
no email address set. And so it the 2 system parameters
<mail.catchall.domain> and <mail.default.from> are not set, we can not
know which email address used to send the email.

Note that this bug also occurs if you create a track with a user without
an email address set. 

Task 2510181