### PR TITLE
[FIX] web_editor: properly hide the toolbar when needed in iframe

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3000,7 +3000,7 @@ var SnippetsMenu = Widget.extend({
      * Update editor UI visibility based on the current range.
      */
     _checkEditorToolbarVisibility: function (e) {
-        const $toolbarContainer = $('#o_we_editor_toolbar_container');
+        const $toolbarContainer = this.$('#o_we_editor_toolbar_container');
         const docSelection = document.getSelection();
         const $currentSelectionTarget = docSelection && docSelection.rangeCount > 0 ? $(docSelection.getRangeAt(0).commonAncestorContainer) : $();
         // Do not  toggle visibility if the target is inside the toolbar ( eg. during link edition).
@@ -3013,7 +3013,7 @@ var SnippetsMenu = Widget.extend({
         const selection = this.options.wysiwyg.odooEditor.document.getSelection();
         const range = selection && selection.rangeCount && selection.getRangeAt(0);
         if (!range ||
-            !$(range.commonAncestorContainer).parents('#wrapwrap').length ||
+            !$(range.commonAncestorContainer).parents('#wrapwrap, .iframe-editor-wrapper .o_editable').length ||
             $(range.commonAncestorContainer).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length
         ) {
             $toolbarContainer.hide();


### PR DESCRIPTION
This fixes a bug in mass mailing, that made the toolbar still visible while the selection was not in an editable area. It was due to a jquery selector targetting the top document instead of the iframe's document.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
