### PR TITLE
[MERGE][IMP] website_slides: refactor content management + vimeo support

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -141,6 +141,8 @@ class SaleOrder(models.Model):
             """, (list(value),))
             so_ids = self.env.cr.fetchone()[0] or []
             return [('id', 'in', so_ids)]
+        if operator == '=' and not value:
+            return [('order_line.invoice_lines', '=', False)]
         return ['&', ('order_line.invoice_lines.move_id.move_type', 'in', ('out_invoice', 'out_refund')), ('order_line.invoice_lines.move_id', operator, value)]
 
     name = fields.Char(string='Order Reference', required=True, copy=False, readonly=True, states={'draft': [('readonly', False)]}, index=True, default=lambda self: _('New'))

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'eLearning',
-    'version': '2.3',
+    'version': '2.4',
     'sequence': 125,
     'summary': 'Manage and publish an eLearning platform',
     'website': 'https://www.odoo.com/page/slides',

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1079,7 +1079,7 @@ class WebsiteSlides(WebsiteProfile):
 
             if not slide.video_source_type:
                 slide.unlink()
-                return {'error': _('Please enter valid YouTube or Google Drive URL')}
+                return {'error': _('Please enter valid YouTube, Vimeo or Google Drive URL')}
 
             if slide.video_source_type == 'youtube':
                 identical_video = existing_videos.filtered(
@@ -1087,6 +1087,9 @@ class WebsiteSlides(WebsiteProfile):
             elif slide.video_source_type == 'google_drive':
                 identical_video = existing_videos.filtered(
                     lambda existing_video: slide.video_google_drive_id == existing_video.video_google_drive_id)
+            elif slide.video_source_type == 'vimeo':
+                identical_video = existing_videos.filtered(
+                    lambda existing_video: slide.video_vimeo_id == existing_video.video_vimeo_id)
             if identical_video:
                 identical_video_name = identical_video[0].name
                 slide.unlink()

--- a/addons/website_slides/data/slide_slide_demo.xml
+++ b/addons/website_slides/data/slide_slide_demo.xml
@@ -8,7 +8,7 @@
         <field name="sequence">1</field>
         <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_type">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -205,9 +205,8 @@
     <record id="slide_slide_demo_1_3" model="slide.slide">
         <field name="name">How to plant a potted tree</field>
         <field name="sequence">5</field>
-        <field name="url">https://www.youtube.com/watch?v=QYmgrw0PgLU</field>
+        <field name="video_url">https://www.youtube.com/watch?v=QYmgrw0PgLU</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_QYmgrw0PgLU.jpg"/>
-        <field name="document_id">QYmgrw0PgLU</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
@@ -323,7 +322,7 @@
         <field name="sequence">6</field>
         <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_type">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -336,9 +335,8 @@
     <record id="slide_slide_demo_1_6" model="slide.slide">
         <field name="name">How to Grow and Harvest The Best Strawberries | Gardening Tips and Tricks</field>
         <field name="sequence">7</field>
-        <field name="url">https://www.youtube.com/watch?v=l0JZ25VvbwE</field>
+        <field name="video_url">https://www.youtube.com/watch?v=l0JZ25VvbwE</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_l0JZ25VvbwE.jpg"/>
-        <field name="document_id">l0JZ25VvbwE</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
@@ -374,7 +372,7 @@
         <field name="sequence">1</field>
         <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_2.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_type">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -501,9 +499,8 @@
     <record id="slide_slide_demo_2_2" model="slide.slide">
         <field name="name">Tree planting in hanging bottles on wall</field>
         <field name="sequence">3</field>
-        <field name="url">https://www.youtube.com/watch?v=ebBez6bcSEc</field>
+        <field name="video_url">https://www.youtube.com/watch?v=ebBez6bcSEc</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_ebBez6bcSEc.jpg"/>
-        <field name="document_id">ebBez6bcSEc</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
@@ -520,7 +517,7 @@
         <field name="sequence">5</field>
         <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-documentation-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_type">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -566,8 +563,7 @@
         <field name="name">Wood Bending With Steam Box</field>
         <field name="sequence">3</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_PYr1rK8pS30.jpg"/>
-        <field name="url">https://www.youtube.com/watch?v=PYr1rK8pS30</field>
-        <field name="document_id">PYr1rK8pS30</field>
+        <field name="video_url">https://www.youtube.com/watch?v=PYr1rK8pS30</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_3_furn0"/>
         <field name="is_published" eval="True"/>
@@ -645,8 +641,7 @@
         <field name="name">Wood Types</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_bvSe6r5BpaY.jpg"/>
-        <field name="url">https://www.youtube.com/watch?v=bvSe6r5BpaY</field>
-        <field name="document_id">bvSe6r5BpaY</field>
+        <field name="video_url">https://www.youtube.com/watch?v=bvSe6r5BpaY</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="is_published" eval="True"/>
@@ -732,7 +727,7 @@
         <field name="sequence">1</field>
         <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_type">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -756,8 +751,7 @@
         <field name="name">How to find quality wood</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_5WMqwTnZ-qs.jpg"/>
-        <field name="url">https://www.youtube.com/watch?v=5WMqwTnZ-qs</field>
-        <field name="document_id">5WMqwTnZ-qs</field>
+        <field name="video_url">https://www.youtube.com/watch?v=5WMqwTnZ-qs</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
@@ -771,8 +765,7 @@
         <field name="name">How to create your own piece of furniture</field>
         <field name="sequence">4</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_ptjeDDoURL8.jpg"/>
-        <field name="url">https://www.youtube.com/watch?v=ptjeDDoURL8</field>
-        <field name="document_id">ptjeDDoURL8</field>
+        <field name="video_url">https://www.youtube.com/watch?v=ptjeDDoURL8</field>
         <field name="slide_type">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -177,7 +177,6 @@ class Channel(models.Model):
              ' * None : No slides will be shown.\n')
     promoted_slide_id = fields.Many2one('slide.slide', string='Promoted Slide')
     access_token = fields.Char("Security Token", copy=False, default=_default_access_token)
-    nbr_presentation = fields.Integer('Presentations', compute='_compute_slides_statistics', store=True)
     nbr_document = fields.Integer('Documents', compute='_compute_slides_statistics', store=True)
     nbr_video = fields.Integer('Videos', compute='_compute_slides_statistics', store=True)
     nbr_infographic = fields.Integer('Infographics', compute='_compute_slides_statistics', store=True)

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -129,6 +129,7 @@ class Slide(models.Model):
 
     YOUTUBE_VIDEO_ID_REGEX = r'^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*'
     GOOGLE_DRIVE_DOCUMENT_ID_REGEX = r'(^https:\/\/docs.google.com|^https:\/\/drive.google.com).*\/d\/([^\/]*)'
+    VIMEO_VIDEO_ID_REGEX = r'\/\/(player.)?vimeo.com\/([a-z]*\/)*([0-9]{6,11})[?]?.*'
 
     # description
     name = fields.Char('Title', required=True, translate=True)
@@ -195,13 +196,15 @@ class Slide(models.Model):
     document_data_pdf = fields.Binary('PDF Content', related='datas', readonly=False,
         help="Used to filter file input to PDF only")
     # content - videos
-    video_url = fields.Char('Video URL', help="URL of the video (we support YouTube and Google Drive as sources)")
+    video_url = fields.Char('Video URL', help="URL of the video (we support YouTube, Google Drive and Vimeo as sources)")
     video_source_type = fields.Selection([
         ('youtube', 'YouTube'),
-        ('google_drive', 'Google Drive')],
+        ('google_drive', 'Google Drive'),
+        ('vimeo', 'Vimeo')],
         string='Video Source', compute="_compute_video_source_type")
     video_youtube_id = fields.Char('Video YouTube ID', compute='_compute_video_youtube_id')
     video_google_drive_id = fields.Char('Video Google Drive ID', compute='_compute_google_drive_id')
+    video_vimeo_id = fields.Char('Video Vimeo ID', compute='_compute_video_vimeo_id')
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
     date_published = fields.Datetime('Publish Date', readonly=True, tracking=1)
@@ -373,6 +376,11 @@ class Slide(models.Model):
                     embed_code = '<iframe src="//www.youtube-nocookie.com/embed/%s?%s" allowFullScreen="true" frameborder="0"></iframe>' % (slide.video_youtube_id, query_params)
                 elif slide.video_source_type == 'google_drive':
                     embed_code = '<iframe src="//drive.google.com/file/d/%s/preview" allowFullScreen="true" frameborder="0"></iframe>' % (slide.video_google_drive_id)
+                elif slide.video_source_type == 'vimeo':
+                    embed_code = """
+                        <iframe src="https://player.vimeo.com/video/%s?badge=0&amp;autopause=0&amp;player_id=0"
+                            frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen
+                            title="sample video several minutes.mp4"></iframe>""" % (slide.video_vimeo_id)
             elif slide.slide_type in ['infographic', 'document'] and slide.source_type == 'external' and slide.document_google_drive_id:
                 embed_code = '<iframe src="//drive.google.com/file/d/%s/preview" allowFullScreen="true" frameborder="0"></iframe>' % (slide.document_google_drive_id)
             elif slide.slide_type == 'document' and slide.source_type == 'local_file':
@@ -391,6 +399,9 @@ class Slide(models.Model):
                     video_source_type = 'youtube'
             if slide.video_url and not video_source_type and re.match(self.GOOGLE_DRIVE_DOCUMENT_ID_REGEX, slide.video_url):
                 video_source_type = 'google_drive'
+            vimeo_match = re.search(self.VIMEO_VIDEO_ID_REGEX, slide.video_url) if slide.video_url else False
+            if not video_source_type and vimeo_match and len(vimeo_match.groups()) == 3:
+                video_source_type = 'vimeo'
 
             slide.video_source_type = video_source_type
 
@@ -405,6 +416,16 @@ class Slide(models.Model):
                     slide.video_youtube_id = False
             else:
                 slide.video_youtube_id = False
+
+    @api.depends('video_url', 'video_source_type')
+    def _compute_video_vimeo_id(self):
+        for slide in self:
+            if slide.video_url and slide.video_source_type == 'vimeo':
+                match = re.search(self.VIMEO_VIDEO_ID_REGEX, slide.video_url)
+                if match and len(match.groups()) == 3:
+                    slide.video_vimeo_id = match.group(3)
+            else:
+                slide.video_vimeo_id = False
 
     @api.depends('slide_type', 'document_url', 'video_url', 'video_source_type')
     def _compute_google_drive_id(self):
@@ -826,6 +847,8 @@ class Slide(models.Model):
             slide_metadata = self._fetch_youtube_metadata(fetch_image)
         elif self.slide_type == 'video' and self.video_source_type == 'google_drive':
             slide_metadata = self._fetch_google_drive_metadata(fetch_image)
+        elif self.slide_type == 'video' and self.video_source_type == 'vimeo':
+            slide_metadata = self._fetch_vimeo_metadata(fetch_image)
         elif self.slide_type in ['document', 'infographic'] and self.source_type == 'external':
             # external documents & google drive videos share the same method currently
             slide_metadata = self._fetch_google_drive_metadata(fetch_image)
@@ -1034,6 +1057,73 @@ class Slide(models.Model):
                 ) / (60 * 60 * 1000)  # millis to hours conversion
             if completion_time:
                 slide_metadata['completion_time'] = completion_time
+
+        return slide_metadata
+
+    def _fetch_vimeo_metadata(self, fetch_image=True, raise_if_error=False):
+        """ Fetches video metadata from the Vimeo API.
+        See https://developer.vimeo.com/api/oembed/showcases for more information.
+
+        Returns a dict containing video metadata with the following keys (matching slide.slide fields):
+        - 'name' matching the video title
+        - 'description' matching the video description
+        - 'image_1920' binary data of the video thumbnail
+          OR 'image_url' containing an external link to the thumbnail when 'fetch_image' param is False
+        - 'completion_time' matching the video duration
+
+        :param fetch_image: if False, will return 'image_url' instead of binary data
+          Typically used when displaying a slide preview to the end user.
+        :param raise_if_error: is True, will raise a UserError in case metadata cannot be retrieved """
+
+        self.ensure_one()
+        error_message = False
+        try:
+            response = requests.get(
+                f'https://vimeo.com/api/oembed.json?url=http%3A//vimeo.com/{self.video_vimeo_id}',
+                timeout=3
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            error_message = e.response.content
+        except requests.exceptions.ConnectionError as e:
+            error_message = str(e)
+
+        if not error_message:
+            response = response.json()
+            if response.get('error'):
+                error_message = response.get('error', {}).get('errors', [{}])[0].get('reason')
+
+            if not response:
+                error_message = _('Please enter a valid Vimeo video URL')
+
+        if error_message:
+            if raise_if_error:
+                raise UserError(_('Could not fetch Vimeo metadata: %s', error_message))
+            else:
+                _logger.warning('Could not fetch Vimeo metadata: %s', error_message)
+                return {}
+
+        vimeo_values = response
+        slide_metadata = {}
+
+        if vimeo_values.get('title'):
+            slide_metadata['name'] = vimeo_values.get('title')
+
+        if vimeo_values.get('description'):
+            slide_metadata['description'] = vimeo_values.get('description')
+
+        if vimeo_values.get('duration'):
+            # seconds to hours conversion
+            slide_metadata['completion_time'] = vimeo_values.get('duration') / (60 * 60)
+
+        thumbnail_url = vimeo_values.get('thumbnail_url')
+        if thumbnail_url:
+            if fetch_image:
+                slide_metadata['image_1920'] = base64.b64encode(
+                    requests.get(thumbnail_url, timeout=3).content
+                )
+            else:
+                slide_metadata['image_url'] = thumbnail_url
 
         return slide_metadata
 

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -50,8 +50,8 @@ tour.register('slides_tour', {
     content: _t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create a web page or link a video."),
     position: 'bottom',
 }, {
-    trigger: 'a[data-slide-type="presentation"]',
-    content: _t("First, let's add a <b>Presentation</b>. It can be a .pdf or an image."),
+    trigger: 'a[data-slide-type="document"]',
+    content: _t("First, let's add a <b>Document</b>. It has to be a .pdf file."),
     position: 'bottom',
 }, {
     trigger: 'input#upload',

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -503,6 +503,25 @@ $o-wslides-fs-side-width: 300px;
 // Modals
 // **************************************************
 
+.o_w_slide_upload_modal_container {
+    .o_slide_preview {
+        display: flex; // not using d-flex because it messes with d-none
+    }
+
+    .form-check {
+        line-height: 1.5rem; // necessary to align label correctly with radio button
+
+    }
+
+    .was-validated .form-check .form-check-label {
+        @include o-w-preserve-base; // avoid ugly green when form is marked as 'was-validated'
+    }
+}
+
+.o_wslides_slide_upload_loading {
+    background-color: rgba(0, 0, 0, .3);
+}
+
 .o_wslides_quiz_modal {
     @include media-breakpoint-up (sm) {
         .modal-body {

--- a/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
@@ -13,9 +13,21 @@
         </t>
     </t>
 
-    <t t-name="website.slides.fullscreen.video">
+    <t t-name="website.slides.fullscreen.video.google_drive">
+        <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
+            <iframe t-att-src="widget.get('slide').embedUrl" allowFullScreen="true" frameborder="0" autoplay="1" allow="autoplay"></iframe>
+        </div>
+    </t>
+
+    <t t-name="website.slides.fullscreen.video.youtube">
         <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
             <iframe t-att-id="'youtube-player' + widget.slide.id" t-att-src="widget.slide.embedUrl" allowFullScreen="true" frameborder="0" enablejsapi="1" autoplay="1" allow="autoplay"></iframe>
+        </div>
+    </t>
+
+    <t t-name="website.slides.fullscreen.video.vimeo">
+        <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
+            <t t-raw="widget.slide.embedCode"/>
         </div>
     </t>
 

--- a/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="website.slides.fullscreen.content">
-        <t t-if="_.contains(['document', 'presentation'], widget.get('slide').type)">
+        <t t-if="widget.get('slide').type === 'document'">
             <div class="embed-responsive h-100">
                 <iframe t-att-src="widget.get('slide').embedUrl" class="o_wslides_iframe_viewer" allowFullScreen="true" frameborder="0"/>
             </div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -239,7 +239,7 @@
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
                             <label for="video_url" class="col-form-label">Video Link</label>
-                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube or Google Drive URL" required="required"/>
+                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube, Vimeo or Google Drive URL" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -252,6 +252,14 @@
                                 <div>First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
                                 <div>What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
                                 <div><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <br/>
+                                <div class="h6">On Vimeo</div>
+                                <div>
+                                    <span>First, upload your videos on Vimeo and mark them as <strong>Private</strong>. This way, they will be secured.</span><br/>
+                                    <span>What does <strong>Private</strong> mean? The Vimeo "Private" privacy setting means it is a video which can be viewed only by the users with the link to it.
+                                    Your video will never come up in the search results nor on your channel.</span><br/>
+                                    <span><a href="https://vimeo.zendesk.com/hc/en-us/articles/224819527-Changing-the-privacy-settings-of-your-videos" target="_blank" >Change video privacy settings</a></span>
+                                </div>
                                 <br/>
                                 <div class="h6">On Google Drive</div>
                                 <div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -84,14 +84,33 @@
     <!--
         Slide Type templates
     -->
-    <t t-name="website.slide.upload.modal.presentation">
+    <t t-name="website.slide.upload.modal.document">
         <div>
             <form class="clearfix">
                 <div class="row">
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
-                            <label for="upload" class="col-form-label">Choose a PDF or an Image</label>
-                            <input id="upload" name="file" class="form-control h-100" accept="image/*,application/pdf" type="file" required="required"/>
+                            <label for="source_type" class="col-form-label">Document Source</label><br/>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_local_file" data-value="local_file" checked="checked"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_local_file">
+                                    Local File
+                                </label>
+                            </div>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_external" data-value="external"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_external">
+                                    External
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_local_file">
+                            <label for="upload" class="col-form-label">Choose a PDF</label>
+                            <input id="upload" name="file" class="form-control h-100" accept="application/pdf" type="file" required="required"/>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_external d-none">
+                            <label for="document_url" class="col-form-label">Document URL</label>
+                            <input id="document_url" name="document_url" class="form-control h-100"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -99,15 +118,91 @@
                     <div id="o_wslides_js_slide_upload_preview_column" class="col-md-6">
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
-                                <div class="h5">How to upload your PowerPoint Presentations or Word Documents?</div>
-                                <div class="mx-3 my-4">Save your presentations or documents as PDF files and upload them.</div>
-                                <div class="alert alert-warning" role="alert">
-                                    <i class="fa fa-info-circle pr-2"/>
-                                    Only JPG, PNG, PDF, files types are supported
+                                <div class="h5">How do I add new content?</div>
+                                <div>
+                                    <span>You can either choose a local file from your computer or insert a valid Google Drive link.</span><br/>
+                                </div>
+                                <div class="o_wslides_js_slide_upload_local_file">
+                                    <div class="h5 mt-3">What types of documents do we support?</div>
+                                    <div>
+                                        <span>When using local files, we only support PDF files.</span><br/>
+                                        <span>If you want to use other types of files, you may want to use an external source (Google Drive) instead.</span>
+                                    </div>
+                                    <div class="h5 mt-3">How to upload your PowerPoint Presentations or Word Documents?</div>
+                                    <div>
+                                        <span>Save your presentations or documents as PDF files and upload them.</span>
+                                    </div>
+                                </div>
+                                <div class="o_wslides_js_slide_upload_external d-none">
+                                    <div class="h5 mt-3">What types of documents do we support?</div>
+                                    <div>
+                                        Through Google Drive, we support most common types of documents.
+                                        Including regular documents (Google Doc, .docx), Sheets (Google Sheet, .xlsx), PowerPoints, ...
+                                    </div>
+                                    <div class="h5 mt-3">How to use Google Drive?</div>
+                                    <div>
+                                        <span>First, upload the file on your Google Drive account.</span><br/>
+                                        <span>Then, go into the file permissions and set it as "Anyone with the link".</span><br/>
+                                        <span>The Google Drive link to use here can be obtained by clicking the "Share" button in the Google interface.</span><br/>
+                                        <span>It should look similar to
+                                        <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="o_slide_preview d-none">
-                                <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                            <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
+                                <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </t>
+
+    <t t-name="website.slide.upload.modal.infographic">
+        <div>
+            <form class="clearfix">
+                <div class="row">
+                    <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
+                        <div class="form-group">
+                            <label for="source_type" class="col-form-label">Image Source</label><br/>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_local_file" data-value="local_file" checked="checked"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_local_file">
+                                    Local File
+                                </label>
+                            </div>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_external" data-value="external"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_external">
+                                    External
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_local_file">
+                            <label for="upload" class="col-form-label">Choose an Image</label>
+                            <input id="upload" name="file" class="form-control h-100" accept="image/*" type="file" required="required"/>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_external d-none">
+                            <label for="document_url" class="col-form-label">Image URL</label>
+                            <input id="document_url" name="document_url" class="form-control h-100"/>
+                        </div>
+                        <canvas id="data_canvas" class="d-none"></canvas>
+                        <t t-call="website.slide.upload.modal.common"/>
+                    </div>
+                    <div id="o_wslides_js_slide_upload_preview_column" class="col-md-6">
+                        <div class="img-thumbnail h-100">
+                            <div class="o_slide_tutorial p-3">
+                                <div class="h5">How do I add new content?</div>
+                                <div>
+                                    <span>You can either choose a local file from your computer or insert a valid Google Drive link.</span><br/>
+                                    <span>The Google Drive link can be obtained by using the 'share' button in the Google interface.</span><br/>
+                                    <span>It should look similar to
+                                    <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
+                                </div>
+                            </div>
+                            <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
+                                <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
@@ -128,7 +223,7 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How to create a Lesson as a Web Page?</div>
-                                <div class="mx-3 my-4">First, create your lesson, then edit it with the website builder. You'll be able to drop building blocks on your page and edit them.</div>
+                                <div>First, create your lesson, then edit it with the website builder. You'll be able to drop building blocks on your page and edit them.</div>
                             </div>
                         </div>
                     </div>
@@ -143,8 +238,8 @@
                 <div class="row">
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
-                            <label for="url" class="col-form-label">Youtube Link</label>
-                            <input id="url" name="url" class="form-control" placeholder="Youtube Video URL" required="required"/>
+                            <label for="video_url" class="col-form-label">Video Link</label>
+                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube or Google Drive URL" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -153,12 +248,20 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How to upload your videos ?</div>
-                                <div class="mx-3 my-4">First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
-                                <div class="mx-3 my-4">What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
-                                <div class="mx-3 my-4"><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <div class="h6">On YouTube</div>
+                                <div>First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
+                                <div>What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
+                                <div><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <br/>
+                                <div class="h6">On Google Drive</div>
+                                <div>
+                                    <span>The Google Drive link can be obtained by using the 'share' button in the Google interface.</span><br/>
+                                    <span>It should look similar to
+                                    <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
+                                </div>
                             </div>
-                            <div class="o_slide_preview d-none">
-                                <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                            <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
+                                <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
@@ -179,13 +282,23 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">Test your students with small Quizzes</div>
-                                <div class="mx-3 my-4">With Quizzes you can keep your students focused and motivated by answering some questions and gaining some karma points</div>
+                                <div>With Quizzes you can keep your students focused and motivated by answering some questions and gaining some karma points</div>
                                 <img src="/website_slides/static/src/img/onboarding-quiz.png" title="Quiz Demo Data" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
                 </div>
             </form>
+        </div>
+    </t>
+
+    <!-- Misc -->
+    <t t-name="website.slide.upload.modal.loading">
+        <div class="o_wslides_slide_upload_loading position-absolute h-100 w-100 text-center d-flex flex-column justify-content-center">
+            <h2 class="text-white">
+                <span class="fa fa-spinner fa-pulse"></span>
+                <span>Loading slide information...</span>
+            </h2>
         </div>
     </t>
 </templates>

--- a/addons/website_slides/tests/common.py
+++ b/addons/website_slides/tests/common.py
@@ -55,7 +55,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook Humans',
             'channel_id': cls.channel.id,
-            'slide_type': 'presentation',
+            'slide_type': 'document',
             'is_published': True,
             'completion_time': 2.0,
             'sequence': 1,
@@ -70,7 +70,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide_2 = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook For Humans',
             'channel_id': cls.channel.id,
-            'slide_type': 'presentation',
+            'slide_type': 'document',
             'is_published': True,
             'completion_time': 3.0,
             'sequence': 3,

--- a/addons/website_slides/tests/test_karma.py
+++ b/addons/website_slides/tests/test_karma.py
@@ -28,14 +28,14 @@ class TestKarmaGain(common.SlidesCase):
         self.slide_2_0 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'How to travel through space and time',
             'channel_id': self.channel_2.id,
-            'slide_type': 'presentation',
+            'slide_type': 'document',
             'is_published': True,
             'completion_time': 2.0,
         })
         self.slide_2_1 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'How to duplicate yourself',
             'channel_id': self.channel_2.id,
-            'slide_type': 'presentation',
+            'slide_type': 'document',
             'is_published': True,
             'completion_time': 2.0,
         })

--- a/addons/website_slides/tests/test_slide_utils.py
+++ b/addons/website_slides/tests/test_slide_utils.py
@@ -212,3 +212,23 @@ class TestFromURL(slides_common.SlidesCase):
         })
         self.assertEqual('google_drive', slide.video_source_type)
         self.assertEqual('1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR', slide.video_google_drive_id)
+
+        # test URL from Vimeo
+        slide = Slide.create({
+            'name': 'dummy',
+            'channel_id': self.channel.id,
+            'video_url': 'https://vimeo.com/545859999',
+            'slide_type': 'video'
+        })
+        self.assertEqual('vimeo', slide.video_source_type)
+        self.assertEqual('545859999', slide.video_vimeo_id)
+
+        # test channel URL from Vimeo
+        slide = Slide.create({
+            'name': 'dummy',
+            'channel_id': self.channel.id,
+            'video_url': 'https://vimeo.com/channels/staffpicks/551979139',
+            'slide_type': 'video'
+        })
+        self.assertEqual('vimeo', slide.video_source_type)
+        self.assertEqual('551979139', slide.video_vimeo_id)

--- a/addons/website_slides/tests/test_slide_utils.py
+++ b/addons/website_slides/tests/test_slide_utils.py
@@ -168,8 +168,8 @@ class TestSequencing(slides_common.SlidesCase):
 
 
 class TestFromURL(slides_common.SlidesCase):
-    def test_youtube_urls(self):
-        urls = {
+    def test_video_urls(self):
+        youtube_urls = {
             'W0JQcpGLSFw': [
                 'https://youtu.be/W0JQcpGLSFw',
                 'https://www.youtube.com/watch?v=W0JQcpGLSFw',
@@ -188,9 +188,27 @@ class TestFromURL(slides_common.SlidesCase):
             ],
         }
 
-        for id, urls in urls.items():
+        Slide = self.env['slide.slide'].with_context(website_slides_fetch_metadata=False)
+
+        # test various YouTube URL formats
+        for youtube_id, urls in youtube_urls.items():
             for url in urls:
-                with self.subTest(url=url, id=id):
-                    document = self.env['slide.slide']._find_document_data_from_url(url)
-                    self.assertEqual(document[0], 'youtube')
-                    self.assertEqual(document[1], id)
+                with self.subTest(url=url, id=youtube_id):
+                    slide = Slide.create({
+                        'name': 'dummy',
+                        'channel_id': self.channel.id,
+                        'video_url': url,
+                        'slide_type': 'video'
+                    })
+                    self.assertEqual('youtube', slide.video_source_type)
+                    self.assertEqual(youtube_id, slide.video_youtube_id)
+
+        # test URL from Google Drive when user hits the "share" button (main use case)
+        slide = Slide.create({
+            'name': 'dummy',
+            'channel_id': self.channel.id,
+            'video_url': 'https://drive.google.com/file/d/1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR/view?usp=sharing',
+            'slide_type': 'video'
+        })
+        self.assertEqual('google_drive', slide.video_source_type)
+        self.assertEqual('1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR', slide.video_google_drive_id)

--- a/addons/website_slides/tests/test_statistics.py
+++ b/addons/website_slides/tests/test_statistics.py
@@ -42,7 +42,6 @@ class TestChannelStatistics(common.SlidesCase):
         # slide type computation
         self.assertEqual(channel_publisher.total_slides, len(channel_publisher.slide_content_ids))
         self.assertEqual(channel_publisher.nbr_infographic, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'infographic')))
-        self.assertEqual(channel_publisher.nbr_presentation, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'presentation')))
         self.assertEqual(channel_publisher.nbr_document, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'document')))
         self.assertEqual(channel_publisher.nbr_video, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'video')))
         # slide statistics computation
@@ -158,9 +157,6 @@ class TestSlideStatistics(common.SlidesCase):
     @users('user_officer')
     def test_slide_statistics_types(self):
         category = self.category.with_user(self.env.user)
-        self.assertEqual(
-            category.nbr_presentation,
-            len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_type == 'presentation')))
         self.assertEqual(
             category.nbr_document,
             len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_type == 'document')))

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -34,7 +34,7 @@ class TestUICommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
                     'name': 'Gardening: The Know-How',
                     'sequence': 1,
                     'datas': pdf_content,
-                    'slide_type': 'presentation',
+                    'slide_type': 'document',
                     'is_published': True,
                     'is_preview': True,
                 }), (0, 0, {

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -64,13 +64,19 @@
                                         <field name="active" invisible="1"/>
                                         <field name="channel_id"/>
                                         <field name="slide_type"/>
-                                        <field name="url" attrs="{
-                                            'required': [('slide_type', 'in', ('video'))],
-                                            'invisible': [('slide_type', 'not in', ('video'))]}" />
-                                        <field name="document_id" invisible="1"/>
-                                        <field name="mime_type" force_save="1" readonly="1" groups="base.group_no_one"/>
-                                        <field name="datas" string="Attachment"
-                                            attrs="{'invisible': [('slide_type', 'not in', ('document', 'presentation'))]}"/>
+                                        <field name="source_type" widget="radio" attrs="{
+                                            'invisible': [('slide_type', 'not in', ['infographic', 'document'])]}" />
+                                        <field name="video_url" attrs="{
+                                            'required': [('slide_type', '=', 'video')],
+                                            'invisible': [('slide_type', '!=', 'video')]}"
+                                            widget="url"/>
+                                        <field name="document_url" attrs="{
+                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_type', 'not in', ['infographic', 'document'])]}"
+                                            widget="url"/>
+                                        <field name="document_data_pdf" string="PDF Attachment" options="{'accepted_file_extensions': '.pdf'}"
+                                            attrs="{'invisible': ['|', ('source_type', '=', 'external'), ('slide_type', '!=', 'document')]}"/>
+                                        <field name="image_data" string="Image Attachment" options="{'accepted_file_extensions': 'image/*'}"
+                                            attrs="{'invisible': ['|', ('source_type', '=', 'external'), ('slide_type', '!=', 'infographic')]}"/>
                                     </group>
                                     <group name="related_details">
                                         <field name="user_id"/>
@@ -80,7 +86,7 @@
                                             <span> hours</span>
                                         </div>
                                         <field name="is_preview"/>
-                                        <field name="slide_resource_downloadable" attrs="{'invisible': [('slide_type', 'not in', ['presentation', 'document'])]}"/>
+                                        <field name="slide_resource_downloadable" attrs="{'invisible': ['|', ('slide_type', '!=', 'document'), ('source_type', '!=', 'local_file')]}"/>
                                         <field name="date_published" string="Published Date" attrs="{'invisible': [('date_published', '=', False)]}" groups="base.group_no_one"/>
                                     </group>
                                 </group>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -365,7 +365,7 @@
                             <a  t-if="channel.can_upload"
                                 class="o_text_link o_wslides_js_slide_upload px-3 py-2"
                                 role="button"
-                                aria-label="Upload Presentation"
+                                aria-label="Upload Document"
                                 href="#"
                                 t-att-data-modules-to-install="modules_to_install"
                                 t-att-data-channel-id="channel.id"
@@ -391,7 +391,7 @@
         <div t-if="channel.can_upload" class="o_wslides_content_actions btn-group">
             <a  class="o_wslides_js_slide_upload mr-1 border btn btn-primary"
                 role="button"
-                aria-label="Upload Presentation"
+                aria-label="Upload Document"
                 href="#"
                 t-att-data-open-modal="enable_slide_upload"
                 t-att-data-modules-to-install="modules_to_install"
@@ -676,8 +676,8 @@
 
             <div t-if="channel.can_upload" class="text-right pb-2 col-auto">
                 <a class="btn btn-primary py-1 o_wslides_js_slide_upload"
-                    title="Upload Presentation" role="button"
-                    aria-label="Upload Presentation" href="#"
+                    title="Upload Document" role="button"
+                    aria-label="Upload Document" href="#"
                     t-att-data-channel-id="channel.id"
                     t-att-data-can-upload="channel.can_upload"
                     t-att-data-can-publish="channel.can_publish">
@@ -792,7 +792,7 @@
                     </span>
                 </div>
                 <t t-if="channel.is_member and channel_progress[slide.id].get('completed')">
-                    <span class="badge badge-pill badge-success"><i class="fa fa-check"/> Completed</span>
+                    <span class="badge badge-pill badge-success"><i class="fa fa-check"/> Done</span>
                 </t>
             </div>
         </div>
@@ -801,10 +801,22 @@
 
 <template id="slide_icon">
     <t t-set="icon_class" t-value="icon_class if icon_class else 'mr-2 text-muted'"/>
-    <i t-if="slide.slide_type == 'document'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'presentation'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'infographic'" t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'document' and slide.source_type == 'local_file'"
+        t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'document' and slide.source_type == 'external' and slide.document_type == 'pdf'"
+        t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'document' and slide.source_type == 'external' and slide.document_type == 'sheet'"
+        t-att-class="'fa fa-file-excel-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'document' and slide.source_type == 'external' and slide.document_type == 'doc'"
+        t-att-class="'fa fa-file-word-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'document' and slide.source_type == 'external' and slide.document_type == 'slides'"
+        t-att-class="'fa fa-file-powerpoint-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'document' and slide.source_type == 'external' and not slide.document_type"
+        t-att-class="'fa fa-file-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'infographic' or (slide.slide_type == 'document' and slide.source_type == 'external' and slide.document_type == 'image')"
+        t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'video' or (slide.slide_type == 'document' and slide.source_type == 'external' and slide.document_type == 'video')"
+        t-att-class="'fa fa-play-circle %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'link'" t-att-class="'fa fa-file-code-o %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -144,17 +144,15 @@
                 <t t-set="can_access" t-value="aside_slide.is_preview or is_member or slide.channel_id.can_publish"/>
                 <li class="p-0 pb-1">
                     <a t-att-href="'/slides/slide/%s' % (slug(aside_slide)) if can_access else '#'"
-                        t-att-class="'o_wslides_lesson_aside_list_link d-flex align-items-top px-2 pt-1 text-decoration-none %s%s' % (('bg-100 py-1 active' if aside_slide == slide else ''), 'text-muted' if not can_access else '')">
-                        <div t-if="is_member" >
-                            <i t-att-id="'o_wslides_lesson_aside_slide_check_%s' % (aside_slide.id)"
-                                t-att-class="'mr-1 fa fa-fw %s' % ('text-success fa-check-circle' if channel_progress[aside_slide.id].get('completed') else 'text-600 fa-circle')">
-                            </i>
-                        </div>
-                        <div class="o_wslides_lesson_link_name">
-                            <t t-call="website_slides.slide_icon">
-                                <t t-set="slide" t-value="aside_slide"/>
-                            </t>
-                            <span t-esc="aside_slide.name" class="mr-2"/>
+                        t-att-class="'o_wslides_lesson_aside_list_link d-flex align-items-center px-2 py-1 text-decoration-none %s%s' % (('bg-100 active' if aside_slide == slide else ''), 'text-muted' if not can_access else '')">
+                        <i t-if="is_member" t-att-id="'o_wslides_lesson_aside_slide_check_%s' % (aside_slide.id)"
+                            t-att-class="'mr-2 fa text-left %s' % ('text-success fa-check-circle' if channel_progress[aside_slide.id].get('completed') else 'text-600 fa-circle')">
+                        </i>
+                        <t t-call="website_slides.slide_icon">
+                            <t t-set="slide" t-value="aside_slide"/>
+                        </t>
+                        <div class="o_wslides_lesson_link_name text-truncate" t-att-title="aside_slide.name">
+                            <span t-esc="aside_slide.name" class="mr-2 text-truncate"/>
                         </div>
                         <div class="ml-auto" t-if="aside_slide.question_ids">
                             <span t-att-class="'badge badge-pill %s' % ('badge-success' if channel_progress[aside_slide.id].get('completed') else 'badge-light text-600')">
@@ -231,7 +229,7 @@
                     t-att-href="'/slides/slide/%s' % (slug(previous_slide)) if previous_slide else '#'">
                     <i class="fa fa-chevron-left mr-2"></i> <span class="d-none d-sm-inline-block">Prev</span>
                 </a>
-                <t t-set="allow_done_btn" t-value="slide.slide_type in ['infographic', 'presentation', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
+                <t t-set="allow_done_btn" t-value="slide.slide_type in ['infographic', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
                 <a t-att-class="'btn btn-primary border text-white %s' % ('disabled' if not allow_done_btn else '')"
                     role="button" t-att-aria-disabled="'true' if not allow_done_btn else None"
                     t-att-href="'/slides/slide/%s/set_completed?%s' % (slide.id, 'next_slide_id=%s' % (next_slide.id) if next_slide else '') if allow_done_btn else '#'">
@@ -257,10 +255,10 @@
     <div class="o_wslides_lesson_content_type">
         <img t-if="slide.slide_type == 'infographic'"
             t-att-src="website.image_url(slide, 'image_1024')" class="img-fluid" style="width:100%" t-att-alt="slide.name"/>
-        <div t-if="slide.slide_type in ('presentation', 'document')" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
+        <div t-if="slide.slide_type == 'document'" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
             <t t-esc="slide.embed_code"/>
         </div>
-        <div t-if="slide.slide_type == 'video' and slide.document_id" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
+        <div t-if="slide.slide_type == 'video'" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
             <t t-esc="slide.embed_code"/>
         </div>
         <div t-if="slide.slide_type == 'webpage'" class="bg-white p-3">
@@ -550,7 +548,7 @@
         <div class="form-group">
             <textarea class="form-control slide_embed_code" readonly="readonly" onClick="this.select();"><t t-esc="slide.embed_code"/></textarea>
         </div>
-        <div class="form-group d-flex" t-if="slide.slide_type in ('presentation', 'document')">
+        <div class="form-group d-flex" t-if="slide.slide_type == 'document'">
             <div class="form-text p-0 col-xs-5 col-sm-5 col-md-5 col-lg-5">Select page to start with</div>
             <div class="input-group col-xs-3 col-sm-2 col-md-2 col-lg-3">
                 <input type="number" value="1" class="form-control"/>

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -76,7 +76,7 @@
                                     </t>
                                 </div>
                             </div>
-                            <t t-if="slide.slide_type in ('presentation', 'document')">
+                            <t t-if="slide.slide_type == 'document'">
                                 <div id="PDFViewerLoader" class="oe_slides_loader mt-3 mx-2 w-100">
                                     <div class="toast show mx-auto">
                                         <div class="toast-header">
@@ -94,7 +94,7 @@
                             </t>
                         </div>
                         <!-- Fixed bottom navbar -->
-                        <div id="PDFViewerNav" class="pt-2 pb-2 bg-light text-white" role="navigation" t-if="slide.slide_type in ('presentation', 'document')">
+                        <div id="PDFViewerNav" class="pt-2 pb-2 bg-light text-white" role="navigation" t-if="slide.slide_type == 'document'">
                             <div class="container-fluid oe_slides_panel_footer">
                                 <div class="row align-items-center">
                                     <div class="col-3 d-flex align-items-center">

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -93,11 +93,12 @@
                     t-att-data-can-access="can_access"
                     t-att-data-name="slide.name"
                     t-att-data-type="slide.slide_type"
+                    t-att-data-video-source-type="slide.video_source_type"
                     t-att-data-slug="slug(slide)"
                     t-att-data-has-question="1 if slide.question_ids else 0"
                     t-att-data-is-quiz="0"
                     t-att-data-completed="1 if slide_completed else 0"
-                    t-att-data-embed-code="slide.embed_code if slide.slide_type in ['video', 'document', 'presentation', 'infographic'] else False"
+                    t-att-data-embed-code="slide.embed_code if slide.slide_type in ['video', 'document', 'infographic'] else False"
                     t-att-data-is-member="is_member"
                     t-att-data-session-answers="session_answers">
                     <span class="ml-3">
@@ -143,6 +144,7 @@
                             <li class="o_wslides_fs_sidebar_list_item pl-0 mb-1" t-if="slide.question_ids and not slide.slide_type == 'quiz'"
                                 t-att-data-id="slide.id"
                                 t-att-data-can-access="can_access"
+                                t-att-data-video-source-type="slide.video_source_type"
                                 t-att-data-name="slide.name"
                                 t-att-data-type="slide.slide_type"
                                 t-att-data-slug="slug(slide)"


### PR DESCRIPTION
This merge commit has two purposes:

1. Completely refactor the way we handle external content in the course slides.

This includes both technical (new fields, ...) and functional (forms) changes.
With these changes, we aim to make it much clearer for the end user on how to
introduce new content to its course, both for local files and external links.

2. Introduce support for Vimeo

Vimeo is a platform for professionals that manage video content, similarly to
YouTube.
The changes include allowing to introduce Vimeo links in your slides, correctly
embed the video, automatically set it as completed in the last 30 seconds,
fetch video metadata to autocomplete fields when URL is input, ...

See underlying commits for detailed information about both points.

LINKS

Task-2510174
UPG PR odoo/upgrade#2439