### PR TITLE
web many2many grouping

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -46,6 +46,7 @@
                         <filter string="Assigned to" name="user" context="{'group_by': 'user_id'}"/>
                         <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
                         <filter string="Creation Date" name="group_create_date" context="{'group_by': 'create_date'}"/>
+                        <filter string="Tags" name="group_tags" context="{'group_by': 'tag_ids'}"/>
                     </group>
                 </search>
             </field>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -919,7 +919,7 @@
                                             <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                                             <a name="%(portal.portal_share_action)d" role="menuitem" type="action" class="dropdown-item">Share</a>
                                             <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">Edit</a>
-                                            <a t-if="widget.editable" role="menuitem" class="dropdown-item" name="toggle_active" type="object">
+                                            <a t-if="widget.archivable" role="menuitem" class="dropdown-item" name="toggle_active" type="object">
                                                 <t t-if="record.active.raw_value">Archive</t>
                                                 <t t-if="!record.active.raw_value">Restore</t>
                                             </a>

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -181,6 +181,9 @@ class Base(models.AbstractModel):
             if type(group_by_value) == tuple:
                 group_by_value = group_by_value[1] # FIXME should use technical value (0)
 
+            if field_type == 'many2many' and isinstance(group_by_value, list):
+                group_by_value = str(tuple(group_by_value)) or False
+
             if group_by_value not in data:
                 data[group_by_value] = {}
                 for key in progress_bar['colors']:

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1183,7 +1183,7 @@ var BasicModel = AbstractModel.extend({
 
                             self.unfreezeOrder(record.id);
 
-                            // TODO: MSH: also reload and update other records with same res_id when editing signle record(not multi edit)
+                            self.updateSameResIdRecords(record, _changes);
                             // Update the data directly or reload them
                             if (shouldReload) {
                                 self._fetchRecord(record).then(function () {
@@ -1427,6 +1427,15 @@ var BasicModel = AbstractModel.extend({
         }
         list.orderedResIDs = null;
         this._sortList(list);
+    },
+    /**
+     * Overridden to update other records with same res_id, it used in case
+     * when datapoint is grouped by many2many and user update one of the record,
+     * in case of many2many same res_id record can be in multiple group, so to
+     * update record this method will be used.
+     */
+    updateSameResIdRecords(record, changes) {
+
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1183,6 +1183,7 @@ var BasicModel = AbstractModel.extend({
 
                             self.unfreezeOrder(record.id);
 
+                            // TODO: MSH: also reload and update other records with same res_id when editing signle record(not multi edit)
                             // Update the data directly or reload them
                             if (shouldReload) {
                                 self._fetchRecord(record).then(function () {

--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -54,6 +54,7 @@ var KanbanColumn = Widget.extend({
         this.quickCreateView = options.quickCreateView;
         this.groupedBy = options.groupedBy;
         this.grouped_by_m2o = options.grouped_by_m2o;
+        this.grouped_by_m2m = options.grouped_by_m2m;
         this.editable = options.editable;
         this.deletable = options.deletable;
         this.archivable = options.archivable;
@@ -249,6 +250,10 @@ var KanbanColumn = Widget.extend({
      * @return {Promise}
      */
     _addRecord: function (recordState, options) {
+        if (this.grouped_by_m2m) {
+            this.record_options.deletable = false;
+            this.record_options.archivable = false;
+        }
         var record = new this.KanbanRecord(this, recordState, this.record_options);
         this.records.push(record);
         if (options && options.position === 'before') {

--- a/addons/web/static/src/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record.js
@@ -42,6 +42,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
         this.options = options;
         this.editable = options.editable;
         this.deletable = options.deletable;
+        this.archivable = options.archivable;
         this.read_only_mode = options.read_only_mode;
         this.selectionMode = options.selectionMode;
         this.qweb = options.qweb;

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -502,6 +502,7 @@ var KanbanRenderer = BasicRenderer.extend({
         // - is readonly (on the field attrs or in the view)
         var draggable = true;
         let recordDeletable = this.recordOptions.deletable;
+        let recordArchivable = this.recordOptions.archivable;
         var grouped_by_date = false;
         if (groupByFieldAttrs) {
             if (groupByFieldAttrs.type === "date" || groupByFieldAttrs.type === "datetime") {
@@ -511,8 +512,9 @@ var KanbanRenderer = BasicRenderer.extend({
                 // TODO: MSH: should we allow resequencing of record, if yes then this fix is OK else we need to disable recordsDraggable to false
                 // do not allow dragging of record if grouped by many2many
                 draggable = false;
-                // do not allow to delete records if grouped by many2many
+                // do not allow to delete/archive records if grouped by many2many
                 recordDeletable = false;
+                recordArchivable = false;
             } else if (groupByFieldAttrs.readonly !== undefined) {
                 draggable = !(groupByFieldAttrs.readonly);
             }
@@ -537,6 +539,7 @@ var KanbanRenderer = BasicRenderer.extend({
         this.createColumnEnabled = this.groupedByM2O && this.columnOptions.group_creatable;
         this.recordOptions = _.extend(this.recordOptions, {
             deletable: recordDeletable,
+            archivable: recordArchivable,
         });
     },
     /**

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -501,11 +501,18 @@ var KanbanRenderer = BasicRenderer.extend({
         // - is a date or datetime since we group by month or
         // - is readonly (on the field attrs or in the view)
         var draggable = true;
+        let recordDeletable = this.recordOptions.deletable;
         var grouped_by_date = false;
         if (groupByFieldAttrs) {
             if (groupByFieldAttrs.type === "date" || groupByFieldAttrs.type === "datetime") {
                 draggable = false;
                 grouped_by_date = true;
+            } else if (groupByFieldAttrs.type === "many2many") {
+                // TODO: MSH: should we allow resequencing of record, if yes then this fix is OK else we need to disable recordsDraggable to false
+                // do not allow dragging of record if grouped by many2many
+                draggable = false;
+                // do not allow to delete records if grouped by many2many
+                recordDeletable = false;
             } else if (groupByFieldAttrs.readonly !== undefined) {
                 draggable = !(groupByFieldAttrs.readonly);
             }
@@ -528,6 +535,9 @@ var KanbanRenderer = BasicRenderer.extend({
             quick_create: this.quickCreateEnabled && viewUtils.isQuickCreateEnabled(this.state),
         });
         this.createColumnEnabled = this.groupedByM2O && this.columnOptions.group_creatable;
+        this.recordOptions = _.extend(this.recordOptions, {
+            deletable: recordDeletable,
+        });
     },
     /**
      * Remove date/datetime magic grouping info to get proper field attrs/info from state

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -509,7 +509,6 @@ var KanbanRenderer = BasicRenderer.extend({
                 draggable = false;
                 grouped_by_date = true;
             } else if (groupByFieldAttrs.type === "many2many") {
-                // TODO: MSH: should we allow resequencing of record, if yes then this fix is OK else we need to disable recordsDraggable to false
                 // do not allow dragging of record if grouped by many2many
                 draggable = false;
                 // do not allow to delete/archive records if grouped by many2many

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -501,8 +501,6 @@ var KanbanRenderer = BasicRenderer.extend({
         // - is a date or datetime since we group by month or
         // - is readonly (on the field attrs or in the view)
         var draggable = true;
-        let recordDeletable = this.recordOptions.deletable;
-        let recordArchivable = this.recordOptions.archivable;
         var grouped_by_date = false;
         if (groupByFieldAttrs) {
             if (groupByFieldAttrs.type === "date" || groupByFieldAttrs.type === "datetime") {
@@ -511,9 +509,6 @@ var KanbanRenderer = BasicRenderer.extend({
             } else if (groupByFieldAttrs.type === "many2many") {
                 // do not allow dragging of record if grouped by many2many
                 draggable = false;
-                // do not allow to delete/archive records if grouped by many2many
-                recordDeletable = false;
-                recordArchivable = false;
             } else if (groupByFieldAttrs.readonly !== undefined) {
                 draggable = !(groupByFieldAttrs.readonly);
             }
@@ -524,6 +519,7 @@ var KanbanRenderer = BasicRenderer.extend({
             }
         }
         this.groupedByM2O = groupByFieldAttrs && (groupByFieldAttrs.type === 'many2one');
+        this.groupedByM2M = groupByFieldAttrs && (groupByFieldAttrs.type === 'many2many');
         var relation = this.groupedByM2O && groupByFieldAttrs.relation;
         var groupByTooltip = groupByFieldInfo && groupByFieldInfo.options.group_by_tooltip;
         this.columnOptions = _.extend(this.columnOptions, {
@@ -531,15 +527,12 @@ var KanbanRenderer = BasicRenderer.extend({
             group_by_tooltip: groupByTooltip,
             groupedBy: groupByField,
             grouped_by_m2o: this.groupedByM2O,
+            grouped_by_m2m: this.groupedByM2M,
             grouped_by_date: grouped_by_date,
             relation: relation,
             quick_create: this.quickCreateEnabled && viewUtils.isQuickCreateEnabled(this.state),
         });
         this.createColumnEnabled = this.groupedByM2O && this.columnOptions.group_creatable;
-        this.recordOptions = _.extend(this.recordOptions, {
-            deletable: recordDeletable,
-            archivable: recordArchivable,
-        });
     },
     /**
      * Remove date/datetime magic grouping info to get proper field attrs/info from state

--- a/addons/web/static/src/js/views/kanban/kanban_view.js
+++ b/addons/web/static/src/js/views/kanban/kanban_view.js
@@ -68,6 +68,7 @@ var KanbanView = BasicView.extend({
         this.rendererParams.record_options = {
             editable: activeActions.edit,
             deletable: activeActions.delete,
+            archivable: activeActions.edit,
             read_only_mode: params.readOnlyMode,
             selectionMode: params.selectionMode,
         };

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -427,7 +427,8 @@ var ListController = BasicController.extend({
         let isM2MGrouped = false;
         if (state.groupedBy.length) {
             isM2MGrouped = state.groupedBy.some((group) => {
-                return state.fields[group].type === "many2many";
+                const groupByFieldName = group.split(':')[0];
+                return state.fields[groupByFieldName].type === "many2many";
             });
         }
         if (!this.hasActionMenus || !this.selectedRecords.length) {

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -14,6 +14,7 @@ import Dialog from 'web.Dialog';
 import ListConfirmDialog from 'web.ListConfirmDialog';
 import session from 'web.session';
 import viewUtils from 'web.viewUtils';
+import utils from 'web.utils';
 
 var _t = core._t;
 var qweb = core.qweb;
@@ -485,6 +486,37 @@ var ListController = BasicController.extend({
         var fieldName = Object.keys(changes)[0];
         var value = Object.values(changes)[0];
         var recordIds = _.union([recordId], this.selectedRecords);
+
+        // TODO: MSH: even after applying following logic other record in UI will not update
+        // we have update UI for other groups
+        // following is one way to achieve to update other records in other groups, alternative is
+        // to select same record Res ID if other groups has same record and uncheck it if user uncheck
+        // one of the record
+        // OR another alternative is to do changes in list_model.js to avoid confirmation dialog for
+        // "n" records changed while record is same in all groups, apply following logic in list_model.js
+        // const listState = this.model.get(this.handle);
+        // if (listState.groupedBy.length) {
+        //     const isM2MGrouped = listState.groupedBy.some((group) => {
+        //         return listState.fields[group].type === "many2many";
+        //     });
+        //     if (isM2MGrouped) {
+        //         let otherRecords = recordIds.map((nextRecordId) => {
+        //             const record = this.model.get(nextRecordId);
+        //             const resID = record.res_id;
+        //             const records = [];
+        //             utils.traverse_records(listState, function (r) {
+        //                 if (r.res_id === resID) {
+        //                     records.push(r);
+        //                 }
+        //             });
+        //             return records;
+        //         });
+        //         otherRecords = otherRecords.flat();
+        //         const otherRecordIds = otherRecords.map(record => record.id);
+        //         recordIds = [...new Set(recordIds.concat(otherRecordIds))];
+        //     }
+        // }
+
         var validRecordIds = recordIds.reduce((result, nextRecordId) => {
             var record = this.model.get(nextRecordId);
             var modifiers = this.renderer._registerModifiers(node, record);
@@ -495,9 +527,11 @@ var ListController = BasicController.extend({
         }, []);
         return new Promise((resolve, reject) => {
             const saveRecords = () => {
+                debugger;
                 this.model.saveRecords(this.handle, recordId, validRecordIds, fieldName)
                     .then(async () => {
                         this.updateButtons('readonly');
+                        debugger;
                         const state = this.model.get(this.handle);
                         // We need to check the current multi-editable state here
                         // in case the selection is changed. If there are changes

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -423,6 +423,12 @@ var ListController = BasicController.extend({
      * @private
      */
     _getActionMenuItems: function (state) {
+        let isM2MGrouped = false;
+        if (state.groupedBy.length) {
+            isM2MGrouped = state.groupedBy.some((group) => {
+                return state.fields[group].type === "many2many";
+            });
+        }
         if (!this.hasActionMenus || !this.selectedRecords.length) {
             return null;
         }
@@ -434,7 +440,7 @@ var ListController = BasicController.extend({
                 callback: () => this._onExportData()
             });
         }
-        if (this.archiveEnabled) {
+        if (this.archiveEnabled && !isM2MGrouped) {
             otherActionItems.push({
                 description: _t("Archive"),
                 callback: () => {
@@ -450,7 +456,7 @@ var ListController = BasicController.extend({
                 callback: () => this._toggleArchiveState(false)
             });
         }
-        if (this.activeActions.delete) {
+        if (this.activeActions.delete && !isM2MGrouped) {
             otherActionItems.push({
                 description: _t("Delete"),
                 callback: () => this._onDeleteSelectedRecords()

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -487,36 +487,6 @@ var ListController = BasicController.extend({
         var value = Object.values(changes)[0];
         var recordIds = _.union([recordId], this.selectedRecords);
 
-        // TODO: MSH: even after applying following logic other record in UI will not update
-        // we have update UI for other groups
-        // following is one way to achieve to update other records in other groups, alternative is
-        // to select same record Res ID if other groups has same record and uncheck it if user uncheck
-        // one of the record
-        // OR another alternative is to do changes in list_model.js to avoid confirmation dialog for
-        // "n" records changed while record is same in all groups, apply following logic in list_model.js
-        // const listState = this.model.get(this.handle);
-        // if (listState.groupedBy.length) {
-        //     const isM2MGrouped = listState.groupedBy.some((group) => {
-        //         return listState.fields[group].type === "many2many";
-        //     });
-        //     if (isM2MGrouped) {
-        //         let otherRecords = recordIds.map((nextRecordId) => {
-        //             const record = this.model.get(nextRecordId);
-        //             const resID = record.res_id;
-        //             const records = [];
-        //             utils.traverse_records(listState, function (r) {
-        //                 if (r.res_id === resID) {
-        //                     records.push(r);
-        //                 }
-        //             });
-        //             return records;
-        //         });
-        //         otherRecords = otherRecords.flat();
-        //         const otherRecordIds = otherRecords.map(record => record.id);
-        //         recordIds = [...new Set(recordIds.concat(otherRecordIds))];
-        //     }
-        // }
-
         var validRecordIds = recordIds.reduce((result, nextRecordId) => {
             var record = this.model.get(nextRecordId);
             var modifiers = this.renderer._registerModifiers(node, record);
@@ -527,11 +497,9 @@ var ListController = BasicController.extend({
         }, []);
         return new Promise((resolve, reject) => {
             const saveRecords = () => {
-                debugger;
                 this.model.saveRecords(this.handle, recordId, validRecordIds, fieldName)
                     .then(async () => {
                         this.updateButtons('readonly');
-                        debugger;
                         const state = this.model.get(this.handle);
                         // We need to check the current multi-editable state here
                         // in case the selection is changed. If there are changes

--- a/addons/web/static/src/js/views/list/list_model.js
+++ b/addons/web/static/src/js/views/list/list_model.js
@@ -86,7 +86,8 @@
                 let isM2MGrouped = false;
                 if (list.groupedBy.length) {
                     isM2MGrouped = list.groupedBy.some((group) => {
-                        return list.fields[group].type === "many2many";
+                        const groupByFieldName = group.split(':')[0];
+                        return list.fields[groupByFieldName].type === "many2many";
                     });
                 }
 

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1291,7 +1291,7 @@ QUnit.module('Views', {
         list.destroy();
     });
 
-    QUnit.only('basic grouped list rendering with groupby m2m field', async function (assert) {
+    QUnit.test('basic grouped list rendering with groupby m2m field', async function (assert) {
         assert.expect(7);
 
         const list = await createView({
@@ -1305,10 +1305,8 @@ QUnit.module('Views', {
                     <field name="m2m" widget="many2many_tags"/>
                 </tree>`,
             groupBy: ['m2m'],
-            debug: true,
         });
 
-        await testUtils.nextTick();
         assert.strictEqual(list.$('th:contains(1 (3))').length, 1, "should contain 1 in group header");
         assert.strictEqual(list.$('th:contains(2 (2))').length, 1, "should contain 2 in group header");
         assert.strictEqual(list.$('th:contains(3 (1))').length, 1, "should contain 3 in group header");
@@ -1321,7 +1319,32 @@ QUnit.module('Views', {
         await testUtils.dom.click(list.$('th.o_group_name:eq(1)'));
         assert.containsN(list, 'tbody:eq(3) tr', 2, "open group should contain 2 record");
         assert.strictEqual(list.$('tbody:eq(3) tr:first .o_field_many2manytags[name="m2m"]').text().replace(/\s/g, ''),
-            "Value1Value2", "the record 1 should be in first group");
+            "Value1Value2", "the record 1 should be in second group as well");
+
+        list.destroy();
+    });
+
+    QUnit.test('deletion of record is disabled when groupby m2m field', async function (assert) {
+        assert.expect(2);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch:
+                `<tree>
+                    <field name="foo"/>
+                    <field name="m2m" widget="many2many_tags"/>
+                </tree>`,
+            viewOptions: { hasActionMenus: true },
+            groupBy: ['m2m'],
+        });
+
+        await testUtils.dom.click(list.$('.o_group_header:first')); // open first group
+        await testUtils.dom.click(list.$('.o_data_row:eq(0) .o_list_record_selector input'));
+        assert.containsOnce(list.el, 'div.o_control_panel .o_cp_action_menus');
+        assert.containsNone(list.el, 'div.o_control_panel .o_cp_action_menus .o_dropdown_menu',
+            "should not have dropdown as delete item is not there");
 
         list.destroy();
     });
@@ -7966,6 +7989,37 @@ QUnit.module('Views', {
         assert.containsN(document.body, ".modal .o_field_many2manytags .badge", 3);
         assert.strictEqual($(".modal .o_field_many2manytags .badge:last").text().trim(), "Value 3",
             "should have display_name in badge");
+
+        list.destroy();
+    });
+
+    QUnit.test('multi edition: many2many field in grouped list', async function (assert) {
+        assert.expect(2);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch:
+                `<tree multi_edit="1">
+                    <field name="foo"/>
+                    <field name="m2m" widget="many2many_tags"/>
+                </tree>`,
+            groupBy: ['m2m'],
+        });
+
+        await testUtils.dom.click(list.$('.o_group_header:first')); // open first group
+        await testUtils.dom.click(list.$('.o_group_header:eq(1)')); // open second group
+        await testUtils.dom.click(list.$('.o_data_row:eq(0) .o_list_record_selector input'));
+        await testUtils.dom.click(list.$('.o_data_row:eq(0) .o_data_cell:eq(1)'));
+        await testUtils.fields.many2one.clickOpenDropdown('m2m');
+        await testUtils.fields.many2one.clickItem('m2m', 'Value 3');
+        assert.strictEqual(list.$('tbody:eq(1) .o_data_row:first .o_data_cell:eq(1)').text().replace(/\s/g, ''),
+            'Value1Value2Value3',
+            "should have a right value in many2many field");
+        assert.strictEqual(list.$('tbody:eq(3) .o_data_row:first .o_data_cell:eq(1)').text().replace(/\s/g, ''),
+            'Value1Value2Value3',
+            "should have same value in many2many field on all other records with same res_id");
 
         list.destroy();
     });

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1292,14 +1292,14 @@ QUnit.module('Views', {
     });
 
     QUnit.only('basic grouped list rendering with groupby m2m field', async function (assert) {
-        assert.expect(4);
+        assert.expect(7);
 
         const list = await createView({
             View: ListView,
             model: 'foo',
             data: this.data,
             arch:
-                `<tree expand="1">
+                `<tree>
                     <field name="foo"/>
                     <field name="m2o"/>
                     <field name="m2m" widget="many2many_tags"/>
@@ -1309,9 +1309,20 @@ QUnit.module('Views', {
         });
 
         await testUtils.nextTick();
+        assert.strictEqual(list.$('th:contains(1 (3))').length, 1, "should contain 1 in group header");
+        assert.strictEqual(list.$('th:contains(2 (2))').length, 1, "should contain 2 in group header");
+        assert.strictEqual(list.$('th:contains(3 (1))').length, 1, "should contain 3 in group header");
+
         await testUtils.dom.click(list.$('th.o_group_name').first());
-        debugger;
-        // TODO: MSH: Add support of m2m domain in search_read like [('tag_ids', '=', '1')]
+        assert.containsN(list, 'tbody:eq(1) tr', 3, "open group should contain 3 records");
+        assert.strictEqual(list.$('tbody:eq(1) tr:first .o_field_many2manytags[name="m2m"]').text().replace(/\s/g, ''),
+            "Value1Value2", "the record 1 should be in first group");
+
+        await testUtils.dom.click(list.$('th.o_group_name:eq(1)'));
+        assert.containsN(list, 'tbody:eq(3) tr', 2, "open group should contain 2 record");
+        assert.strictEqual(list.$('tbody:eq(3) tr:first .o_field_many2manytags[name="m2m"]').text().replace(/\s/g, ''),
+            "Value1Value2", "the record 1 should be in first group");
+
         list.destroy();
     });
 

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1299,17 +1299,18 @@ QUnit.module('Views', {
             model: 'foo',
             data: this.data,
             arch:
-                `<tree>
+                `<tree expand="1">
                     <field name="foo"/>
-                    <field name="m2m"/>
+                    <field name="m2o"/>
+                    <field name="m2m" widget="many2many_tags"/>
                 </tree>`,
             groupBy: ['m2m'],
             debug: true,
         });
 
         await testUtils.nextTick();
-        debugger;
         await testUtils.dom.click(list.$('th.o_group_name').first());
+        debugger;
         // TODO: MSH: Add support of m2m domain in search_read like [('tag_ids', '=', '1')]
         list.destroy();
     });

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1291,6 +1291,29 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.only('basic grouped list rendering with groupby m2m field', async function (assert) {
+        assert.expect(4);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch:
+                `<tree>
+                    <field name="foo"/>
+                    <field name="m2m"/>
+                </tree>`,
+            groupBy: ['m2m'],
+            debug: true,
+        });
+
+        await testUtils.nextTick();
+        debugger;
+        await testUtils.dom.click(list.$('th.o_group_name').first());
+        // TODO: MSH: Add support of m2m domain in search_read like [('tag_ids', '=', '1')]
+        list.destroy();
+    });
+
     QUnit.test('ordered list, sort attribute in context', async function (assert) {
         assert.expect(1);
         // Equivalent to saving a custom filter

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_serving_base
 from . import test_click_everywhere
 from . import test_base_document_layout
 from . import test_session_info
+from . import test_read_progress_bar

--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -1,0 +1,19 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('read_progress_bar')
+class TestReadProgressBar(TransactionCase):
+
+    def test_read_progress_bar_m2m(self):
+        """ Test that read_progress_bar works with m2m field grouping """
+        progressbar = {
+            'field': 'type',
+            'colors': {
+                'contact': 'success', 'private': 'danger', 'other': 'muted',
+            }
+        }
+        result = self.env['res.partner'].read_progress_bar([], 'category_id', progressbar)
+        # check that it works when grouping by m2m field
+        self.assertTrue(result)
+        # check the null group
+        self.assertIn(False, result)

--- a/odoo/addons/test_read_group/tests/test_m2m_grouping.py
+++ b/odoo/addons/test_read_group/tests/test_m2m_grouping.py
@@ -19,18 +19,22 @@ class TestM2MGrouping(common.TransactionCase):
             {   # both users
                 'name': "Super Mario Bros.",
                 'user_ids': [Command.set(cls.users.ids)],
+                'state': 'done',
             },
             {   # mario only
                 'name': "Paper Mario",
                 'user_ids': [Command.set(cls.users[0].ids)],
+                'state': 'done',
             },
             {   # luigi only
                 'name': "Luigi's Mansion",
                 'user_ids': [Command.set(cls.users[1].ids)],
+                'state': 'in_progress',
             },
             {   # no user
                 'name': 'Donkey Kong',
                 'user_ids': [Command.set([])],
+                'state': 'new',
             },
         ])
 


### PR DESCRIPTION
PURPOSE
Allow to group records by many2many fields.
Use case: turn the user_id m2o field on project.task into a user_ids m2m field in order to assign multiple collaborators on a task

SPEC
Add many2many fields to the 'list of groupable fields'.
When grouping a set of records by a many2many, records linked to multiple records of the comodel will essentially be in multiple 'groups' (even though those are not really 'groups' anymore).
There will also be a "null" group, for records that have an empty value of the many2many, like "unassigned" records.

Example: grouping a project.task linked to 10 res.users by the user_ids many2many field, the project.task will be 'rendered/considered/displayed' 10 times, once per res.users.
Kind of like if we grouped the m2m relation table instead.

When grouping by a m2m field:

    * listview
    -> editing an instance of a record also updates each other instance (if any) the same goes when scheduling an activity, etc.
    -> disable deletion
    the risk here is that the user might expected that this will 'unlike' the record from a specific record of the many2many field
    * kanban
    -> disable drag&drop between groups
    -> disable deletion

TASK 2508608


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
