### PR TITLE
[FIX] l10n_latam_invoice_document: header/footer in mutli-print


### DIFF
--- a/addons/l10n_latam_invoice_document/views/report_templates.xml
+++ b/addons/l10n_latam_invoice_document/views/report_templates.xml
@@ -7,7 +7,7 @@
             <attribute name="t-if">not custom_header</attribute>
         </div>
         <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout">
+            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
                 <t t-if="custom_header" t-call="#{custom_header}"/>
             </div>
         </div>
@@ -18,7 +18,7 @@
         </div>
 
         <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout">
+            <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout" t-if="custom_footer">
                 <t t-if="custom_footer" t-raw="custom_footer"/>
             </div>
         </div>
@@ -30,7 +30,7 @@
             <attribute name="t-if">not custom_header</attribute>
         </div>
         <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout">
+            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
                 <div class="o_clean_header">
                     <t t-if="custom_header" t-call="#{custom_header}"/>
                 </div>
@@ -42,7 +42,7 @@
             <attribute name="t-if">not custom_footer</attribute>
         </div>
         <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout">
+            <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout" t-if="custom_footer">
                 <t t-if="custom_footer" t-raw="custom_footer"/>
             </div>
         </div>
@@ -54,7 +54,7 @@
             <attribute name="t-if">not custom_header</attribute>
         </div>
         <div t-attf-class="header o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="header o_company_#{company.id}_layout" >
+            <div t-attf-class="header o_company_#{company.id}_layout" t-if="custom_header">
                 <div class="o_boxed_header">
                     <t t-if="custom_header" t-call="#{custom_header}"/>
                 </div>
@@ -66,7 +66,7 @@
             <attribute name="t-if">not custom_footer</attribute>
         </div>
         <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout" position="after">
-            <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout">
+            <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout" t-if="custom_footer">
                 <t t-if="custom_footer" t-raw="custom_footer"/>
             </div>
         </div>
@@ -78,7 +78,7 @@
             <attribute name="t-if">not custom_header</attribute>
         </div>
         <div t-attf-class="o_company_#{company.id}_layout header" position="after">
-            <div t-attf-class="o_company_#{company.id}_layout header">
+            <div t-attf-class="o_company_#{company.id}_layout header" t-if="custom_header">
                 <div class="o_background_header">
                     <t t-if="custom_header" t-call="#{custom_header}"/>
                 </div>
@@ -90,7 +90,7 @@
             <attribute name="t-if">not custom_footer</attribute>
         </div>
         <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer" position="after">
-            <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer">
+            <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer" t-if="custom_footer">
                 <t t-if="custom_footer" t-raw="custom_footer"/>
             </div>
         </div>


### PR DESCRIPTION
When l10n_latam_invoice_document is installed and the current company
does not have a custom header (in stable, only Chile and Argentina with
their localization installed use custom header), printing multiple
invoice at once, one out of two had no header or footer.

This is because `<div class="header"/>` and `<div class="footer"/>`
should be unique per record being printed, and when a custom header was
not used they were duplicated with the duplicate empty.

As an example, if we had 3 documents:

- record 1 : good header
- record 1 : empty header
- record 1 : body
- record 1 : good footer
- record 1 : empty footer

- record 2 : good header
- record 2 : empty header
- record 2 : body
- record 2 : good footer
- record 2 : empty footer

- record 3 : good header
- record 3 : empty header
- record 3 : body
- record 3 : good footer
- record 3 : empty footer

When we give them to wkhtmltopdf, it would be mismatched:

- headers:
  - record 1 : good header
  - record 1 : empty header
  - record 2 : good header

- bodies:
  - record 1 : body
  - record 2 : body
  - record 3 : body

- footers:
  - record 1 : good footer
  - record 1 : empty footer
  - record 2 : good footer

so record 2 will have empty header/footer, and record 3 will get those
of record 2.

opw-2507137