### PR TITLE
[FIX] payment_stripe_sca, *: use setup_future_usage when saving card

### DIFF
--- a/addons/account_payment/models/payment.py
+++ b/addons/account_payment/models/payment.py
@@ -15,6 +15,7 @@ class PaymentTransaction(models.Model):
     def render_invoice_button(self, invoice, submit_txt=None, render_values=None):
         values = {
             'partner_id': invoice.partner_id.id,
+            'type': self.type,
         }
         if render_values:
             values.update(render_values)

--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -226,6 +226,7 @@ class WebsitePayment(http.Controller):
 
         render_values = {
             'partner_id': partner_id,
+            'type': tx.type,
         }
 
         return acquirer.sudo().render(tx.reference, float(amount), int(currency_id), values=render_values)

--- a/addons/payment_stripe_sca/models/payment.py
+++ b/addons/payment_stripe_sca/models/payment.py
@@ -40,6 +40,8 @@ class PaymentAcquirerStripeSCA(models.Model):
             "payment_intent_data[description]": tx_values["reference"],
             "customer_email": tx_values.get("partner_email") or tx_values.get("billing_partner_email"),
         }
+        if tx_values['type'] == 'form_save':
+            stripe_session_data["payment_intent_data[setup_future_usage]"] = "off_session"
         tx_values["session_id"] = self._create_stripe_session(stripe_session_data)
 
         return tx_values

--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -170,6 +170,7 @@ class PaymentTransaction(models.Model):
     def render_sale_button(self, order, submit_txt=None, render_values=None):
         values = {
             'partner_id': order.partner_id.id,
+            'type': self.type,
         }
         if render_values:
             values.update(render_values)


### PR DESCRIPTION
*: account_payment, payment, sale

Steps:
- Install eCommerce
- Go to Website / Configuration / eCommerce / Payment Acquirers
- Configure Stripe:
  - Save Cards: Always
  - Payment Flow: Redirection to the acquirer website
- Go to /shop
- Add a product to the cart
- Process Checkout
- Select Stripe
- Pay Now
- Enter test data in Stripe Checkout form (https://stripe.com/docs/testing#cards)
- Pay
- Go to /shop
- Add a product to the cart
- Process Checkout
- Select your saved card
- Pay Now

Bug:
Stripe Error:
The provided PaymentMethod was previously used with a PaymentIntent
without Customer attachment, shared with a connected account without
Customer attachment, or was detached from a Customer. It may not be used
again. To use a PaymentMethod multiple times, you must attach it to a
Customer first.

Explanation:
https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_intent_data-setup_future_usage
> Indicates that you intend to make future payments with the payment
> method collected by this Checkout Session.

According to this doc, `setup_future_usage` must be set in order to use
the saved card afterwards.

opw:2452452
opw:2498571
opw:2509897