### PR TITLE
[FIX] account: display credit notes on portal

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -49,9 +49,9 @@ class PortalAccount(CustomerPortal):
         order = searchbar_sortings[sortby]['order']
 
         searchbar_filters = {
-            'all': {'label': _('All'), 'domain': [('move_type', 'in', ['in_invoice', 'out_invoice'])]},
-            'invoices': {'label': _('Invoices'), 'domain': [('move_type', '=', 'out_invoice')]},
-            'bills': {'label': _('Bills'), 'domain': [('move_type', '=', 'in_invoice')]},
+            'all': {'label': _('All'), 'domain': []},
+            'invoices': {'label': _('Invoices'), 'domain': [('move_type', '=', ('out_invoice', 'out_refund'))]},
+            'bills': {'label': _('Bills'), 'domain': [('move_type', '=', ('in_invoice', 'in_refund'))]},
         }
         # default filter by value
         if not filterby:


### PR DESCRIPTION
- Create an invoice for a portal user
- Add a credit note for that invoice
- Connect with portal user
- On Invoices & Bills menu, the correct count is displayed (i.e. 2)
- Open Invoices & Bills page
The "All" filter only displays out_invoice and in_invoice, making impossible to view
the other types (out_refund, in_refund, out_receipt, in_receipt).

opw-2486471

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
