### PR TITLE
[FIX] website: handle configurator images download timeout

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -335,6 +335,9 @@ class Website(models.Model):
                 try:
                     response = requests.get(image['url'], timeout=3)
                     response.raise_for_status()
+                except Exception as e:
+                    logger.warning("Failed to download image: %s. %s" % (image['url'], e))
+                else:
                     self.env['ir.attachment'].create({
                         'name': image['name'],
                         'website_id': website.id,
@@ -342,8 +345,6 @@ class Website(models.Model):
                         'type': 'binary',
                         'raw': response.content,
                     })
-                except requests.HTTPError:
-                    logger.warning("Failed to download image '%s'", image['url'])
 
         website = self.get_current_website()
 


### PR DESCRIPTION
The timeout for images download from unsplash is set to
3s. The exception raised when this limit is reached was
not correctly handled.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
