### PR TITLE
[FIX] purchase_product_matrix: avoid crash on product reorder

### DIFF
--- a/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
+++ b/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
@@ -99,7 +99,7 @@ var MatrixConfiguratorWidget = relationalFields.FieldMany2One.extend({
      */
     reset: async function (record, ev) {
         await this._super(...arguments);
-        if (ev.data.changes && ev.data.changes.product_template_id && record.data.product_template_id.data.id) {
+        if (ev && ev.data.changes && ev.data.changes.product_template_id && record.data.product_template_id.data.id) {
             this._onTemplateChange(record.data.product_template_id.data.id, ev.data.dataPointID);
         }
     },


### PR DESCRIPTION
Open a purchase order with several lines
Switch to Edit mode
Use the movement arrow on the left of a line to move it upward/downward
At the end of the operation a traceback will popup

opw-2508480

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
