### PR TITLE
[FIX]repair: fix invoice deletion

### DIFF
--- a/addons/repair/models/account_move.py
+++ b/addons/repair/models/account_move.py
@@ -9,7 +9,9 @@ class AccountMove(models.Model):
     repair_ids = fields.One2many('repair.order', 'invoice_id', readonly=True, copy=False)
 
     def unlink(self):
-        self.repair_ids.filtered(lambda repair: repair.state != 'cancel').state = '2binvoiced'
+        repairs = self.sudo().repair_ids.filtered(lambda repair: repair.state != 'cancel')
+        if repairs:
+            repairs.sudo(False).state = '2binvoiced'
         return super().unlink()
 
 


### PR DESCRIPTION
Steps to follow to reproduce the bug :
- Install the Repairs and Accounting application
- Create a new user and give him only access to Accounting
- Connect with this user
- Create a draft invoice
- Try to delete it
- Access rights error is triggered.

Problem:
When we delete an invoice and the Repairs app is installed, we check if it is not an invoice related to a repair.
But the user does not have access to “repair.order”, so we can not check the field "repair_ids".

opw-2507867

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
