### PR TITLE
[FIX] payment: enable pay button when clicking back button

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -24,6 +24,11 @@ odoo.define('payment.payment_form', function (require) {
             this._super.apply(this, arguments);
             this.options = _.extend(options || {}, {
             });
+            window.addEventListener('pageshow', function (event) {
+                if (event.persisted) {
+                    window.location.reload();
+                }
+            });
         },
 
         start: function () {


### PR DESCRIPTION
Issue

	Use Safari (or equivalent) browser

	- Install e-commerce
	- Go to Website -> Configuration -> Payment Acquirers
	- Activate Ingenico in test mode
	  (write aaa in required fields)
	- Go to shop, and add product to card
	- Go to checkout
	- Select Ingenico payment mode
	- Click on Pay button
	- When on the ingenico page, press back

	 The page is blocked and the button is disabled.

Cause

	When clicking on Pay button, the page is locked and
	the button is disabled.
	With Chrome, when coming back to previous page,
        this one is regenerated and therefore adapt the button.
	In Safari, it is not the case.

Solution

	On `pageshow` event, if event have `persisted` attribute set to
	to true, meaning using cache, then reload page.

opw-2510281