### PR TITLE
[FIX] crm: fix incorrect prefix removal from phone filter

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -493,7 +493,8 @@ class Lead(models.Model):
         # searching on +32485112233 should also finds 00485112233 (00 / + prefix are both valid)
         # we therefore remove it from input value and search for both of them in db
         if value.startswith('+') or value.startswith('00'):
-            value = value.replace('+', '').replace('00', '', 1)
+            if value.startswith('00'):
+                value = value[2:]
             starts_with = '00|\+'
         else:
             starts_with = '%'

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -386,3 +386,19 @@ class TestCRMLead(TestCrmCommon):
         new_lead.handle_partner_assignment(create_missing=True)
         self.assertEqual(new_lead.partner_id.email, 'unknown.sender@test.example.com')
         self.assertEqual(new_lead.partner_id.team_id, self.sales_team_1)
+
+    @users('user_sales_manager')
+    def test_phone_mobile_search(self):
+        lead_1 = self.env['crm.lead'].create({
+            'name': 'Lead 1',
+            'country_id': self.env.ref('base.be').id,
+            'phone': '+32485001122',
+        })
+        lead_2 = self.env['crm.lead'].create({
+            'name': 'Lead 2',
+            'country_id': self.env.ref('base.be').id,
+            'phone': '+32485112233',
+        })
+        self.assertEqual(lead_1, self.env['crm.lead'].search([
+            ('phone_mobile_search', 'like', '+32485001122')
+        ]))


### PR DESCRIPTION
*Description of the issue/feature this PR addresses:*
The PR addresses a small bug with the phone filter of the CRM kanban view.

*Current behavior before PR:*
The function removes the first occurrence of "00" and "+" from the given phone number if it starts with "+" or "00". As a result, the generated pattern can be wrong and return unintended results if the given phone number starts with "+" and contains two successive "0" (e.g: "+32485001122").

*Desired behavior after PR is merged:*
The function will no longer remove the first occurrence of "00" when the give phone number starts with "+".

Task id: 2479277
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
