### PR TITLE
[IMP] website_slides: remove the automatic creation of link trackers

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -385,20 +385,11 @@ class Slide(models.Model):
 
     @api.depends('name', 'channel_id.website_id.domain')
     def _compute_website_url(self):
-        # TDE FIXME: clena this link.tracker strange stuff
         super(Slide, self)._compute_website_url()
         for slide in self:
             if slide.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
                 base_url = slide.channel_id.get_base_url()
-                # link_tracker is not in dependencies, so use it to shorten url only if installed.
-                if self.env.registry.get('link.tracker'):
-                    url = self.env['link.tracker'].sudo().create({
-                        'url': '%s/slides/slide/%s' % (base_url, slug(slide)),
-                        'title': slide.name,
-                    }).short_url
-                else:
-                    url = '%s/slides/slide/%s' % (base_url, slug(slide))
-                slide.website_url = url
+                slide.website_url = '%s/slides/slide/%s' % (base_url, slug(slide))
 
     @api.depends('channel_id.can_publish')
     def _compute_can_publish(self):


### PR DESCRIPTION
# Purpose
Before, each time the name of a slide was modified then a new link
tracker was created.

# Specifications
After discussion, we agreed to remove the automatic creation of link
tracker and let the user creates it manually if he really wants one.

The slides already have a lot of statistics that can be used without
the need of a link tracker.

# Links
task-2511961
