### PR TITLE
[FIX] mail: display default name for followers for "other address" pa…

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -119,6 +119,7 @@ class MailController(http.Controller):
             followers.append({
                 'id': follower.id,
                 'name': follower.partner_id.name or follower.channel_id.name,
+                'display_name': follower.partner_id.display_name or follower.channel_id.display_name,
                 'email': follower.partner_id.email if follower.partner_id else None,
                 'res_model': 'res.partner' if follower.partner_id else 'mail.channel',
                 'res_id': follower.partner_id.id or follower.channel_id.id,

--- a/addons/mail/static/src/xml/followers.xml
+++ b/addons/mail/static/src/xml/followers.xml
@@ -38,9 +38,9 @@
         <div role="menuitem" class="o_partner">
             <a class="dropdown-item o_mail_redirect"
                href="#"
-               t-att-title="record.name"
+               t-att-title="record.name or record.display_name"
                t-att-data-oe-model="record.res_model"
-               t-att-data-oe-id="record.res_id"><t t-esc="record.name"/></a>
+               t-att-data-oe-id="record.res_id"><t t-esc="record.name or record.display_name"/></a>
             <img t-att-src="record.avatar_url" alt="Avatar"/>
             <i t-if="record.is_editable" class="fa fa-pencil o_edit_subtype d-none"
                title="Edit subscription"


### PR DESCRIPTION
…rtner

Display the default name (the one displayed in the kanban view) for followers replacing
the False value for "other address" partners, this way the user won't get
confused, furthermore, this fix won't require the name to be mandatory for this
type of contacts.

Task-2514244

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
