### PR TITLE
[IMP] partner_autocomplete: enrich on demand with vat, name and email

### DIFF
--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -20,6 +20,8 @@
         'views/res_company_views.xml',
         'views/res_config_settings_views.xml',
         'data/cron.xml',
+        'data/ir_action.xml',
+        'data/mail_templates.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/partner_autocomplete/data/ir_action.xml
+++ b/addons/partner_autocomplete/data/ir_action.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="action_enrich_mail" model="ir.actions.server" >
+            <field name="name">Partner Autocomplete</field>
+            <field name="model_id" ref="model_res_partner"/>
+            <field name="binding_model_id" ref="base.model_res_partner"/>
+            <field name="state">code</field>
+            <field name="code">
+    if records:
+        records.autocomplete_on_demand()
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/partner_autocomplete/data/ir_action.xml
+++ b/addons/partner_autocomplete/data/ir_action.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <data>
-        <record id="action_enrich_mail" model="ir.actions.server" >
+        <record id="action_autocomplete_on_demand" model="ir.actions.server">
             <field name="name">Partner Autocomplete</field>
             <field name="model_id" ref="model_res_partner"/>
             <field name="binding_model_id" ref="base.model_res_partner"/>
             <field name="state">code</field>
             <field name="code">
     if records:
-        records.autocomplete_on_demand()
+        records._autocomplete_on_demand()
             </field>
         </record>
 

--- a/addons/partner_autocomplete/data/mail_templates.xml
+++ b/addons/partner_autocomplete/data/mail_templates.xml
@@ -1,30 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
-    <template id="mail_message_partner_vat_notfound">
-        <p>Enrichment (based on VAT number)</p>
+    <template id="mail_message_partner_no_data_found">
+        <p>Enrichment</p>
         <div style="background-color:#ffffff;padding:15px;">
-            <span>No company data found based on the VAT number provided. No credit was consumed.</span>
-        </div>
-    </template>
-
-    <template id="mail_message_partner_name_notfound">
-        <p>Enrichment (based on name)</p>
-        <div style="background-color:#ffffff;padding:15px;">
-            <span>No company data found based on the name provided. No credit was consumed.</span>
-        </div>
-    </template>
-
-    <template id="mail_message_partner_mail_notfound">
-        <p>Enrichment (based on email)</p>
-        <div style="background-color:#ffffff;padding:15px;">
-            <span>Please enter a valid email address.</span>
-        </div>
-    </template>
-
-    <template id="mail_message_partner_mail_data_notfound">
-        <p>Enrichment (based on email)</p>
-        <div style="background-color:#ffffff;padding:15px;">
-            <span>No company data found based on the email provided. No credit was consumed.</span>
+            <span>No company data found based on the data provided. No credit was consumed.</span>
         </div>
     </template>
 </odoo>

--- a/addons/partner_autocomplete/data/mail_templates.xml
+++ b/addons/partner_autocomplete/data/mail_templates.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data noupdate="1">
+    <template id="mail_message_partner_vat_notfound">
+        <p>Enrichment (based on VAT number)</p>
+        <div style="background-color:#ffffff;padding:15px;">
+            <span> No company data found based on the VAT number provided. No credit was consumed. </span>
+        </div>
+    </template>
+
+    <template id="mail_message_partner_name_notfound">
+        <p>Enrichment (based on name)</p>
+        <div style="background-color:#ffffff;padding:15px;">
+            <span>No company data found based on the name provided. No credit was consumed.</span>
+        </div>
+    </template>
+
+    <template id="mail_message_partner_mail_notfound">
+        <p>Enrichment (based on email)</p>
+        <div style="background-color:#ffffff;padding:15px;">
+            <span>Please enter a valid email address.</span>
+        </div>
+    </template>
+
+    <template id="mail_message_partner_mail_data_notfound">
+        <p>Enrichment (based on email)</p>
+        <div style="background-color:#ffffff;padding:15px;">
+            <span>No company data found based on the email provided. No credit was consumed.</span>
+        </div>
+    </template>
+</data></odoo>

--- a/addons/partner_autocomplete/data/mail_templates.xml
+++ b/addons/partner_autocomplete/data/mail_templates.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo><data noupdate="1">
+<odoo noupdate="1">
     <template id="mail_message_partner_vat_notfound">
         <p>Enrichment (based on VAT number)</p>
         <div style="background-color:#ffffff;padding:15px;">
-            <span> No company data found based on the VAT number provided. No credit was consumed. </span>
+            <span>No company data found based on the VAT number provided. No credit was consumed.</span>
         </div>
     </template>
 
@@ -27,4 +27,4 @@
             <span>No company data found based on the email provided. No credit was consumed.</span>
         </div>
     </template>
-</data></odoo>
+</odoo>

--- a/addons/partner_autocomplete/data/mail_templates.xml
+++ b/addons/partner_autocomplete/data/mail_templates.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
-    <template id="mail_message_partner_no_data_found">
-        <p>Enrichment</p>
+    <template id="mail_message_partner_enrich_notfound">
+        <p>Partner Enrichment (based on domain, vat and name)</p>
         <div style="background-color:#ffffff;padding:15px;">
-            <span>No company data found based on the data provided. No credit was consumed.</span>
+            <span>No company data found based on available details. No credit was consumed.</span>
         </div>
     </template>
 </odoo>

--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -5,8 +5,10 @@ import base64
 import json
 import logging
 import requests
+import re
 
 from odoo import api, fields, models, tools, _
+
 
 _logger = logging.getLogger(__name__)
 
@@ -181,3 +183,97 @@ class ResPartner(models.Model):
             self._update_autocomplete_data(values.get('vat', False))
 
         return res
+
+    @api.model
+    def autocomplete_on_demand(self):
+        if self.vat:
+            vat = self.vat
+            logo = {}
+            vat_data = self.read_by_vat(vat)
+            if vat_data:
+                for rec in vat_data:
+                    logo.update({'logo': rec['logo']})
+                    img = self._iap_replace_logo(logo)
+                    self.write({'name': self.name,
+                                'website': self.website if self.website else rec['website'],
+                                'vat': self.vat,
+                                'image_1920': self.image_1920 if self.image_1920 else img.get('image_1920')})
+            else:
+                self.message_post_with_view(
+                    'partner_autocomplete.mail_message_partner_vat_notfound',
+                    subtype_id=self.env.ref('mail.mt_note').id)
+
+        elif not self.vat and not self.email:
+            query = self.name
+            logo = {}
+            name_data = (self.autocomplete(query))
+            if name_data:
+                for rec in name_data:
+                    if rec['name'] == self.name:
+                        logo.update({'logo': rec['logo']})
+                        img = self._iap_replace_logo(logo)
+                        self.write({'name': self.name,
+                                    'website': self.website if self.website else rec['website'],
+                                    'vat': rec['vat'],
+                                    'image_1920': self.image_1920 if self.image_1920 else img.get('image_1920'),
+                                  })
+                    else:
+                        self.message_post_with_view(
+                            'partner_autocomplete.mail_message_partner_name_notfound',
+                            subtype_id=self.env.ref('mail.mt_note').id)
+
+            else:
+                self.message_post_with_view(
+                    'partner_autocomplete.mail_message_partner_name_notfound',
+                    subtype_id=self.env.ref('mail.mt_note').id)
+
+        elif self.email and not self.vat:
+            match = re.match(r'^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', self.email)
+            if match:
+                company_domain = self.email.split('@')[1]
+                vat = self.vat
+                partner_gid = self.partner_gid
+                logo = {}
+                result = {}
+                if company_domain:
+                    mail_data = self.enrich_company(company_domain, partner_gid, vat)
+                    if mail_data.get('error'):
+                        self.env['bus.bus'].sendone(
+                            (self._cr.dbname, 'res.partner', self.env.user.partner_id.id),
+                            {'type': 'simple_notification', 'title': _("Warning"),
+                             'message': _("%s", mail_data.get('error_message'))}
+                        )
+                    elif mail_data:
+                        logo.update({'logo': mail_data.get('logo')})
+                        img = self._iap_replace_logo(logo)
+                        for rec in mail_data.get('child_ids'):
+                            country = self._iap_replace_location_codes(rec.get('country_id'))
+                            result.update({'name': self.name,
+                                           'phone': self.phone if self.phone else rec.get('phone'),
+                                           'vat': self.vat if self.vat else rec.get('vat'),
+                                           'street': self.street if self.street else rec.get('street'),
+                                           'city': self.city if self.city else rec.get('city'),
+                                           'zip': self.zip if self.zip else rec.get('zip'),
+                                           'country_id': self.country_id if self.country_id else country.get('id'),
+                                           'image_1920': self.image_1920 if self.image_1920 else img.get('image_1920'),
+                                           'additional_info': mail_data.get('additional_info')
+                                           })
+                        if result:
+                            template_values = json.loads(result.get('additional_info'))
+                            template_values['flavor_text'] = _("Partner created by Odoo Partner Autocomplete Service")
+                            self.message_post_with_view(
+                                'iap_mail.enrich_company',
+                                values=template_values,
+                                subtype_id=self.env.ref('mail.mt_note').id,
+                            )
+                            self.write(result)
+                        else:
+                            self.message_post_with_view(
+                                'partner_autocomplete.mail_message_partner_mail_data_notfound',
+                                subtype_id=self.env.ref('mail.mt_note').id)
+
+            else:
+                self.message_post_with_view(
+                    'partner_autocomplete.mail_message_partner_mail_notfound',
+                    subtype_id=self.env.ref('mail.mt_note').id
+                )


### PR DESCRIPTION
PURPOSE

allow users to get extra info from IAP even though they missed
the opportunity to call it from the "inline" autocomplete.

SPECIFICATIONS

allow users to get extra info from IAP even though they missed
the opportunity to call it from the "inline" autocomplete. for
that a new button "Partner Autocomplete" is added in the action.

mainly there is three criterions based on which the autocomplete
works, they are name, VAT number and email domain of the partner.
in this method we are giving the most priority to VAT number
as its a unique number which differ from partner to partner,
so we will have always a name of partner with us because it is
a required field, here we are executing this auto complete
with three conditions.

- if there is VAT number and name field we will first search in
  IAP database for data matching exactly to the similar VAT.
- if we did not get any matching data we will search in IAP database
  for data matching exactly to the similar name.
- from here also if we did not get any matching data we will
  check if there is any valid email provided, if yes
  we will search with the email domain of partner, in this
  case if any data is found we will display Html log note.
  or else if we did not get any matching data after searching
  by all three criterion we will log a note saying data not found.

LINKS
PR #69747
Task 2360079
