### PR TITLE
[13.0][FIX] core: try picking a better env for flushes

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -64,13 +64,18 @@ def flush_env(cr, *, clear=True):
     """ Retrieve and flush an environment corresponding to the given cursor.
         Also clear the environment if ``clear`` is true.
     """
-    env_to_flush = None
+    env_to_flush_candidates = [None, None, None]
     for env in list(Environment.envs):
         # don't flush() on another cursor or with a RequestUID
         if env.cr is cr and (isinstance(env.uid, int) or env.uid is None):
-            env_to_flush = env
+            env_to_flush_candidates[2] = env
             if env.uid is not None:
-                break               # prefer an environment with a real uid
+                env_to_flush_candidates[1] = env               # prefer an environment with a real uid
+                if env.su:
+                    env_to_flush_candidates[0] = env           # prefer an environment with a real uid and sudo
+                    break
+
+    env_to_flush = env_to_flush_candidates[0] or env_to_flush_candidates[1] or env_to_flush_candidates[2] or None
 
     if env_to_flush is not None:
         env_to_flush['base'].flush()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When payment.transactions are created e.g. for paypal payment with a link that contains an access token. The env is owned by public user but a few more envs (some with sudo) are created for the same _cr in the same request. After everything was prepared successfully (e.g. POST /my/orders/.../transaction/?access_token=....) the env is flushed before sending the response to the client. In this env_flush the first env for the same _cr that has a "real" user is picked regardless of its permissions. For our use case we had about a 2/5 chance that an env with su=True was picked and the flush was successful, and a 3/5 chance that an env with su=False was picked and the flush got us a permission error when reading computed fields.

Current behavior before PR:
Flushes prefer any env for the same _cr that has any user set (should be the same user as the _cr)

Desired behavior after PR is merged:
Flushed prefer an env for the same _cr that has a user with su=True set over
an env for the same _cr that has a user over an env for the same _cr

This should fix permission errors that happen because the flush was executed with not enough privileges to flush everything in the _cr.

Info @wt-io-it




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
