### PR TITLE
[FIX] point_of_sale: use lot's location for SML's location source

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -960,7 +960,8 @@ class PosOrder(models.Model):
                             if stock_production_lot.product_id.tracking == 'lot':
                                 qty = abs(pos_pack_lot.pos_order_line_id.qty)
                             qty_done += qty
-                            pack_lots.append({'lot_id': stock_production_lot.id, 'qty': qty})
+                            quant = stock_production_lot.quant_ids.filtered(lambda q: q.quantity > 0.0 or q.location_id.parent_path.startswith(move.location_id.parent_path))[-1:]
+                            pack_lots.append({'lot_id': stock_production_lot.id, 'quant_location_id': quant.location_id.id, 'qty': qty})
                         else:
                             has_wrong_lots = True
                 elif move.product_id.tracking == 'none' or not lots_necessary:
@@ -968,14 +969,14 @@ class PosOrder(models.Model):
                 else:
                     has_wrong_lots = True
                 for pack_lot in pack_lots:
-                    lot_id, qty = pack_lot['lot_id'], pack_lot['qty']
+                    lot_id, quant_location_id, qty = pack_lot['lot_id'], pack_lot['quant_location_id'], pack_lot['qty']
                     self.env['stock.move.line'].create({
                         'picking_id': move.picking_id.id,
                         'move_id': move.id,
                         'product_id': move.product_id.id,
                         'product_uom_id': move.product_uom.id,
                         'qty_done': qty,
-                        'location_id': move.location_id.id,
+                        'location_id': quant_location_id or move.location_id.id,
                         'location_dest_id': move.location_dest_id.id,
                         'lot_id': lot_id,
                     })


### PR DESCRIPTION
When selling a tracked product that comes from a specific place in the
warehouse, the module will ignore this information and set the parent
warehouse as source location.

To reproduce the error:
(Use demo data)
1. In Settings, enable "Multi-Warehouses"
2. Create a product P:
    - Product Type: Storable Product
    - Available in Pos: True
    - Tracking: By Unique Serial Number
3. Update its quantity:
    - Location: WH/Stock/Shelf 1
    - Serial Number: USN01
    - Qty: 1
4. Start a POS session
5. Sell P
    - Enter the same serial number
6. Go back to quantity update page for product P

Error: The quantity for "WH/Stock/Shelf 1, USN01" is still 1, it should
be 0. Moreover, a new line appeared: "WH/Stock, USN01, -1" which is
incorrect. The POS module considered that the product sold came from
WH/Stock instead of WH/Stock/Shelf 1.

OPW-2473002