### PR TITLE
[FW][IMP] l10n_ar: data of perceptions by jurisdiction

### DIFF
--- a/addons/l10n_ar/data/account.account.template.csv
+++ b/addons/l10n_ar/data/account.account.template.csv
@@ -7,19 +7,79 @@ l10n_ar.base_deudores_por_ventas,l10n_ar.l10nar_base_chart_template,1.1.3.01.010
 l10n_ar.base_deudores_por_ventas_pos,l10n_ar.l10nar_base_chart_template,1.1.3.01.020,account.data_account_type_receivable,Deudores por ventas (PoS),True
 l10n_ar.base_ret_percepcion_tasa_municipal,l10n_ar.l10nar_base_chart_template,1.1.4.01.010,account.data_account_type_current_assets,Ret/Percepción Tasa Municipal,False
 l10n_ar.base_saldo_a_favor_tasa_municipal,l10n_ar.l10nar_base_chart_template,1.1.4.01.020,account.data_account_type_current_assets,Saldo a favor Tasa Municipal,False
-l10n_ar.base_saldo_favor_iibb_sf,l10n_ar.l10nar_base_chart_template,1.1.4.02.010,account.data_account_type_current_assets,Saldo a favor IIBB p. Santa Fé,False
-l10n_ar.base_retencion_iibb_sf_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.020,account.data_account_type_current_assets,Retención IIBB p. Santa Fé sufrida,False
-l10n_ar.base_percepcion_iibb_sf_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.030,account.data_account_type_current_assets,Percepción IIBB p. Santa Fé sufrida,False
-l10n_ar.base_saldo_favor_iibb_co,l10n_ar.l10nar_base_chart_template,1.1.4.02.040,account.data_account_type_current_assets,Saldo a favor IIBB p. Córdoba,False
-l10n_ar.base_retencion_iibb_co_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.050,account.data_account_type_current_assets,Retención IIBB p. Córdoba sufrida,False
-l10n_ar.base_percepcion_iibb_co_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.060,account.data_account_type_current_assets,Percepción IIBB p. Córdoba sufrida,False
-l10n_ar.base_saldo_favor_iibb_ba,l10n_ar.l10nar_base_chart_template,1.1.4.02.070,account.data_account_type_current_assets,Saldo a favor IIBB p. Buenos Aires,False
-l10n_ar.base_retencion_iibb_ba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.080,account.data_account_type_current_assets,Retención IIBB p. Buenos Aires sufrida,False
-l10n_ar.base_percepcion_iibb_ba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.090,account.data_account_type_current_assets,Percepción IIBB p. Buenos Aires sufrida,False
-l10n_ar.base_saldo_favor_iibb_caba,l10n_ar.l10nar_base_chart_template,1.1.4.02.100,account.data_account_type_current_assets,Saldo a favor IIBB p. CABA,False
-l10n_ar.base_retencion_iibb_caba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.110,account.data_account_type_current_assets,Retención IIBB CABA sufrida,False
-l10n_ar.base_percepcion_iibb_caba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.120,account.data_account_type_current_assets,Percepción IIBB CABA sufrida,False
-l10n_ar.base_sircreb,l10n_ar.l10nar_base_chart_template,1.1.4.02.130,account.data_account_type_current_assets,SIRCREB,False
+l10n_ar.base_saldo_favor_iibb_caba,l10n_ar.l10nar_base_chart_template,1.1.4.02.010,account.data_account_type_current_assets,Saldo a favor IIBB CABA,False
+l10n_ar.base_retencion_iibb_caba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.020,account.data_account_type_current_assets,Retención IIBB CABA sufrida,False
+l10n_ar.base_percepcion_iibb_caba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.030,account.data_account_type_current_assets,Percepción IIBB CABA sufrida,False
+l10n_ar.base_saldo_favor_iibb_ba,l10n_ar.l10nar_base_chart_template,1.1.4.02.040,account.data_account_type_current_assets,Saldo a favor IIBB Buenos Aires,False
+l10n_ar.base_retencion_iibb_ba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.050,account.data_account_type_current_assets,Retención IIBB Buenos Aires sufrida,False
+l10n_ar.base_percepcion_iibb_ba_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.060,account.data_account_type_current_assets,Percepción IIBB Buenos Aires sufrida,False
+l10n_ar.base_saldo_favor_iibb_ca,l10n_ar.l10nar_base_chart_template,1.1.4.02.070,account.data_account_type_current_assets,Saldo a favor IIBB Catamarca,False
+l10n_ar.base_retencion_iibb_ca_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.080,account.data_account_type_current_assets,Retención IIBB Catamarca sufrida,False
+l10n_ar.base_percepcion_iibb_ca_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.090,account.data_account_type_current_assets,Percepción IIBB Catamarca sufrida,False
+l10n_ar.base_saldo_favor_iibb_co,l10n_ar.l10nar_base_chart_template,1.1.4.02.100,account.data_account_type_current_assets,Saldo a favor IIBB Córdoba,False
+l10n_ar.base_retencion_iibb_co_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.110,account.data_account_type_current_assets,Retención IIBB Córdoba sufrida,False
+l10n_ar.base_percepcion_iibb_co_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.120,account.data_account_type_current_assets,Percepción IIBB Córdoba sufrida,False
+l10n_ar.base_saldo_favor_iibb_rr,l10n_ar.l10nar_base_chart_template,1.1.4.02.130,account.data_account_type_current_assets,Saldo a favor IIBB Corrientes,False
+l10n_ar.base_retencion_iibb_rr_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.140,account.data_account_type_current_assets,Retención IIBB Corrientes sufrida,False
+l10n_ar.base_percepcion_iibb_rr_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.150,account.data_account_type_current_assets,Percepción IIBB Corrientes sufrida,False
+l10n_ar.base_saldo_favor_iibb_er,l10n_ar.l10nar_base_chart_template,1.1.4.02.160,account.data_account_type_current_assets,Saldo a favor IIBB Entre Ríos,False
+l10n_ar.base_retencion_iibb_er_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.170,account.data_account_type_current_assets,Retención IIBB Entre Ríos sufrida,False
+l10n_ar.base_percepcion_iibb_er_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.180,account.data_account_type_current_assets,Percepción IIBB Entre Ríos sufrida,False
+l10n_ar.base_saldo_favor_iibb_ju,l10n_ar.l10nar_base_chart_template,1.1.4.02.190,account.data_account_type_current_assets,Saldo a favor IIBB Jujuy,False
+l10n_ar.base_retencion_iibb_ju_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.200,account.data_account_type_current_assets,Retención IIBB Jujuy sufrida,False
+l10n_ar.base_percepcion_iibb_ju_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.210,account.data_account_type_current_assets,Percepción IIBB Jujuy sufrida,False
+l10n_ar.base_saldo_favor_iibb_za,l10n_ar.l10nar_base_chart_template,1.1.4.02.220,account.data_account_type_current_assets,Saldo a favor IIBB Mendoza,False
+l10n_ar.base_retencion_iibb_za_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.230,account.data_account_type_current_assets,Retención IIBB Mendoza sufrida,False
+l10n_ar.base_percepcion_iibb_za_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.240,account.data_account_type_current_assets,Percepción IIBB Mendoza sufrida,False
+l10n_ar.base_saldo_favor_iibb_lr,l10n_ar.l10nar_base_chart_template,1.1.4.02.250,account.data_account_type_current_assets,Saldo a favor IIBB La Rioja,False
+l10n_ar.base_retencion_iibb_lr_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.260,account.data_account_type_current_assets,Retención IIBB La Rioja sufrida,False
+l10n_ar.base_percepcion_iibb_lr_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.270,account.data_account_type_current_assets,Percepción IIBB La Rioja sufrida,False
+l10n_ar.base_saldo_favor_iibb_sa,l10n_ar.l10nar_base_chart_template,1.1.4.02.280,account.data_account_type_current_assets,Saldo a favor IIBB Salta,False
+l10n_ar.base_retencion_iibb_sa_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.290,account.data_account_type_current_assets,Retención IIBB Salta sufrida,False
+l10n_ar.base_percepcion_iibb_sa_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.300,account.data_account_type_current_assets,Percepción IIBB Salta sufrida,False
+l10n_ar.base_saldo_favor_iibb_nn,l10n_ar.l10nar_base_chart_template,1.1.4.02.310,account.data_account_type_current_assets,Saldo a favor IIBB San Juan,False
+l10n_ar.base_retencion_iibb_nn_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.320,account.data_account_type_current_assets,Retención IIBB San Juan sufrida,False
+l10n_ar.base_percepcion_iibb_nn_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.330,account.data_account_type_current_assets,Percepción IIBB San Juan sufrida,False
+l10n_ar.base_saldo_favor_iibb_sl,l10n_ar.l10nar_base_chart_template,1.1.4.02.340,account.data_account_type_current_assets,Saldo a favor IIBB San Luis,False
+l10n_ar.base_retencion_iibb_sl_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.350,account.data_account_type_current_assets,Retención IIBB San Luis sufrida,False
+l10n_ar.base_percepcion_iibb_sl_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.360,account.data_account_type_current_assets,Percepción IIBB San Luis sufrida,False
+l10n_ar.base_saldo_favor_iibb_sf,l10n_ar.l10nar_base_chart_template,1.1.4.02.370,account.data_account_type_current_assets,Saldo a favor IIBB Santa Fe,False
+l10n_ar.base_retencion_iibb_sf_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.380,account.data_account_type_current_assets,Retención IIBB Santa Fe sufrida,False
+l10n_ar.base_percepcion_iibb_sf_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.390,account.data_account_type_current_assets,Percepción IIBB Santa Fe sufrida,False
+l10n_ar.base_saldo_favor_iibb_se,l10n_ar.l10nar_base_chart_template,1.1.4.02.400,account.data_account_type_current_assets,Saldo a favor IIBB Santiago del Estero,False
+l10n_ar.base_retencion_iibb_se_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.410,account.data_account_type_current_assets,Retención IIBB Santiago del Estero sufrida,False
+l10n_ar.base_percepcion_iibb_se_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.420,account.data_account_type_current_assets,Percepción IIBB Santiago del Estero sufrida,False
+l10n_ar.base_saldo_favor_iibb_tn,l10n_ar.l10nar_base_chart_template,1.1.4.02.430,account.data_account_type_current_assets,Saldo a favor IIBB Tucumán,False
+l10n_ar.base_retencion_iibb_tn_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.440,account.data_account_type_current_assets,Retención IIBB Tucumán sufrida,False
+l10n_ar.base_percepcion_iibb_tn_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.450,account.data_account_type_current_assets,Percepción IIBB Tucumán sufrida,False
+l10n_ar.base_saldo_favor_iibb_ha,l10n_ar.l10nar_base_chart_template,1.1.4.02.460,account.data_account_type_current_assets,Saldo a favor IIBB Chaco,False
+l10n_ar.base_retencion_iibb_ha_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.470,account.data_account_type_current_assets,Retención IIBB Chaco sufrida,False
+l10n_ar.base_percepcion_iibb_ha_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.480,account.data_account_type_current_assets,Percepción IIBB Chaco sufrida,False
+l10n_ar.base_saldo_favor_iibb_ct,l10n_ar.l10nar_base_chart_template,1.1.4.02.490,account.data_account_type_current_assets,Saldo a favor IIBB Chubut,False
+l10n_ar.base_retencion_iibb_ct_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.500,account.data_account_type_current_assets,Retención IIBB Chubut sufrida,False
+l10n_ar.base_percepcion_iibb_ct_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.510,account.data_account_type_current_assets,Percepción IIBB Chubut sufrida,False
+l10n_ar.base_saldo_favor_iibb_fo,l10n_ar.l10nar_base_chart_template,1.1.4.02.520,account.data_account_type_current_assets,Saldo a favor IIBB Formosa,False
+l10n_ar.base_retencion_iibb_fo_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.530,account.data_account_type_current_assets,Retención IIBB Formosa sufrida,False
+l10n_ar.base_percepcion_iibb_fo_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.540,account.data_account_type_current_assets,Percepción IIBB Formosa sufrida,False
+l10n_ar.base_saldo_favor_iibb_mi,l10n_ar.l10nar_base_chart_template,1.1.4.02.550,account.data_account_type_current_assets,Saldo a favor IIBB Misiones,False
+l10n_ar.base_retencion_iibb_mi_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.560,account.data_account_type_current_assets,Retención IIBB Misiones sufrida,False
+l10n_ar.base_percepcion_iibb_mi_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.570,account.data_account_type_current_assets,Percepción IIBB Misiones sufrida,False
+l10n_ar.base_saldo_favor_iibb_ne,l10n_ar.l10nar_base_chart_template,1.1.4.02.580,account.data_account_type_current_assets,Saldo a favor IIBB Neuquén,False
+l10n_ar.base_retencion_iibb_ne_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.590,account.data_account_type_current_assets,Retención IIBB Neuquén sufrida,False
+l10n_ar.base_percepcion_iibb_ne_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.600,account.data_account_type_current_assets,Percepción IIBB Neuquén sufrida,False
+l10n_ar.base_saldo_favor_iibb_lp,l10n_ar.l10nar_base_chart_template,1.1.4.02.610,account.data_account_type_current_assets,Saldo a favor IIBB La Pampa,False
+l10n_ar.base_retencion_iibb_lp_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.620,account.data_account_type_current_assets,Retención IIBB La Pampa sufrida,False
+l10n_ar.base_percepcion_iibb_lp_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.630,account.data_account_type_current_assets,Percepción IIBB La Pampa sufrida,False
+l10n_ar.base_saldo_favor_iibb_rn,l10n_ar.l10nar_base_chart_template,1.1.4.02.640,account.data_account_type_current_assets,Saldo a favor IIBB Río Negro,False
+l10n_ar.base_retencion_iibb_rn_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.650,account.data_account_type_current_assets,Retención IIBB Río Negro sufrida,False
+l10n_ar.base_percepcion_iibb_rn_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.660,account.data_account_type_current_assets,Percepción IIBB Río Negro sufrida,False
+l10n_ar.base_saldo_favor_iibb_az,l10n_ar.l10nar_base_chart_template,1.1.4.02.670,account.data_account_type_current_assets,Saldo a favor IIBB Santa Cruz,False
+l10n_ar.base_retencion_iibb_az_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.680,account.data_account_type_current_assets,Retención IIBB Santa Cruz sufrida,False
+l10n_ar.base_percepcion_iibb_az_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.690,account.data_account_type_current_assets,Percepción IIBB Santa Cruz sufrida,False
+l10n_ar.base_saldo_favor_iibb_tf,l10n_ar.l10nar_base_chart_template,1.1.4.02.700,account.data_account_type_current_assets,Saldo a favor IIBB Tierra del Fuego,False
+l10n_ar.base_retencion_iibb_tf_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.710,account.data_account_type_current_assets,Retención IIBB Tierra del Fuego sufrida,False
+l10n_ar.base_percepcion_iibb_tf_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.02.720,account.data_account_type_current_assets,Percepción IIBB Tierra del Fuego sufrida,False
+l10n_ar.base_sircreb,l10n_ar.l10nar_base_chart_template,1.1.4.02.730,account.data_account_type_current_assets,SIRCREB,False
 l10n_ar.base_saldo_a_favor_suss,l10n_ar.l10nar_base_chart_template,1.1.4.03.010,account.data_account_type_current_assets,Saldo a favor SUSS,False
 l10n_ar.base_retencion_suss_sufrida,l10n_ar.l10nar_base_chart_template,1.1.4.03.020,account.data_account_type_current_assets,Retención SUSS Sufrida,False
 l10n_ar.ri_iva_credito_fiscal,l10n_ar.l10nar_ri_chart_template,1.1.4.04.010,account.data_account_type_current_assets,IVA crédito fiscal,False
@@ -62,10 +122,56 @@ l10n_ar.base_tasa_municipal_a_pagar,l10n_ar.l10nar_base_chart_template,2.1.3.01.
 l10n_ar.base_plan_tasa_municipal_a_pagar,l10n_ar.l10nar_base_chart_template,2.1.3.01.020,account.data_account_type_payable,Plan Tasa Municipal a pagar,True
 l10n_ar.base_iibb_a_pagar,l10n_ar.l10nar_base_chart_template,2.1.3.02.010,account.data_account_type_payable,IIBB a pagar,True
 l10n_ar.ri_retencion_sicore_a_pagar,l10n_ar.l10nar_ex_chart_template,2.1.3.02.020,account.data_account_type_payable,SICORE a pagar,True
-l10n_ar.ri_retencion_iibb_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.030,account.data_account_type_current_liabilities,Retención IIBB aplicada,False
-l10n_ar.ri_percepcion_iibb_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.040,account.data_account_type_current_liabilities,Percepción IIBB aplicada,False
-l10n_ar.ri_retencion_iibb_a_pagar,l10n_ar.l10nar_ex_chart_template,2.1.3.02.050,account.data_account_type_payable,Retención/Percepción IIBB a pagar,True
-l10n_ar.base_plan_de_iibb_a_pagar,l10n_ar.l10nar_base_chart_template,2.1.3.02.060,account.data_account_type_payable,Plan de IIBB a pagar,True
+l10n_ar.ri_retencion_iibb_caba_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.030,account.data_account_type_current_liabilities,Retención IIBB CABA aplicada,False
+l10n_ar.ri_percepcion_iibb_caba_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.040,account.data_account_type_current_liabilities,Percepción IIBB CABA aplicada,False
+l10n_ar.ri_retencion_iibb_ba_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.050,account.data_account_type_current_liabilities,Retención IIBB ARBA aplicada,False
+l10n_ar.ri_percepcion_iibb_ba_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.060,account.data_account_type_current_liabilities,Percepción IIBB ARBA aplicada,False
+l10n_ar.ri_retencion_iibb_ca_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.070,account.data_account_type_current_liabilities,Retención IIBB Catamarca aplicada,False
+l10n_ar.ri_percepcion_iibb_ca_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.080,account.data_account_type_current_liabilities,Percepción IIBB Catamarca aplicada,False
+l10n_ar.ri_retencion_iibb_co_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.090,account.data_account_type_current_liabilities,Retención IIBB Córdoba aplicada,False
+l10n_ar.ri_percepcion_iibb_co_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.100,account.data_account_type_current_liabilities,Percepción IIBB Córdoba aplicada,False
+l10n_ar.ri_retencion_iibb_rr_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.110,account.data_account_type_current_liabilities,Retención IIBB Corrientes aplicada,False
+l10n_ar.ri_percepcion_iibb_rr_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.120,account.data_account_type_current_liabilities,Percepción IIBB Corrientes aplicada,False
+l10n_ar.ri_retencion_iibb_er_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.130,account.data_account_type_current_liabilities,Retención IIBB Entre Río aplicada,False
+l10n_ar.ri_percepcion_iibb_er_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.140,account.data_account_type_current_liabilities,Percepción IIBB Entre Río aplicada,False
+l10n_ar.ri_retencion_iibb_ju_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.150,account.data_account_type_current_liabilities,Retención IIBB Jujuy aplicada,False
+l10n_ar.ri_percepcion_iibb_ju_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.160,account.data_account_type_current_liabilities,Percepción IIBB Jujuy aplicada,False
+l10n_ar.ri_retencion_iibb_za_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.170,account.data_account_type_current_liabilities,Retención IIBB Mendoza aplicada,False
+l10n_ar.ri_percepcion_iibb_za_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.180,account.data_account_type_current_liabilities,Percepción IIBB Mendoza aplicada,False
+l10n_ar.ri_retencion_iibb_lr_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.190,account.data_account_type_current_liabilities,Retención IIBB La Rioja aplicada,False
+l10n_ar.ri_percepcion_iibb_lr_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.200,account.data_account_type_current_liabilities,Percepción IIBB La Rioja aplicada,False
+l10n_ar.ri_retencion_iibb_sa_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.210,account.data_account_type_current_liabilities,Retención IIBB Salta aplicada,False
+l10n_ar.ri_percepcion_iibb_sa_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.220,account.data_account_type_current_liabilities,Percepción IIBB Salta aplicada,False
+l10n_ar.ri_retencion_iibb_nn_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.230,account.data_account_type_current_liabilities,Retención IIBB San Juan aplicada,False
+l10n_ar.ri_percepcion_iibb_nn_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.240,account.data_account_type_current_liabilities,Percepción IIBB San Juan aplicada,False
+l10n_ar.ri_retencion_iibb_sl_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.250,account.data_account_type_current_liabilities,Retención IIBB San Luis aplicada,False
+l10n_ar.ri_percepcion_iibb_sl_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.260,account.data_account_type_current_liabilities,Percepción IIBB San Luis aplicada,False
+l10n_ar.ri_retencion_iibb_sf_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.270,account.data_account_type_current_liabilities,Retención IIBB Santa Fe aplicada,False
+l10n_ar.ri_percepcion_iibb_sf_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.280,account.data_account_type_current_liabilities,Percepción IIBB Santa Fe aplicada,False
+l10n_ar.ri_retencion_iibb_se_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.290,account.data_account_type_current_liabilities,Retención IIBB Santiago del Estero aplicada,False
+l10n_ar.ri_percepcion_iibb_se_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.300,account.data_account_type_current_liabilities,Percepción IIBB Santiago del Estero aplicada,False
+l10n_ar.ri_retencion_iibb_tn_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.310,account.data_account_type_current_liabilities,Retención IIBB Tucumán aplicada,False
+l10n_ar.ri_percepcion_iibb_tn_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.320,account.data_account_type_current_liabilities,Percepción IIBB Tucumán aplicada,False
+l10n_ar.ri_retencion_iibb_ha_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.330,account.data_account_type_current_liabilities,Retención IIBB Chaco aplicada,False
+l10n_ar.ri_percepcion_iibb_ha_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.340,account.data_account_type_current_liabilities,Percepción IIBB Chaco aplicada,False
+l10n_ar.ri_retencion_iibb_ct_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.350,account.data_account_type_current_liabilities,Retención IIBB Chubut aplicada,False
+l10n_ar.ri_percepcion_iibb_ct_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.360,account.data_account_type_current_liabilities,Percepción IIBB Chubut aplicada,False
+l10n_ar.ri_retencion_iibb_fo_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.370,account.data_account_type_current_liabilities,Retención IIBB Formosa aplicada,False
+l10n_ar.ri_percepcion_iibb_fo_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.380,account.data_account_type_current_liabilities,Percepción IIBB Formosa aplicada,False
+l10n_ar.ri_retencion_iibb_mi_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.390,account.data_account_type_current_liabilities,Retención IIBB Misiones aplicada,False
+l10n_ar.ri_percepcion_iibb_mi_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.400,account.data_account_type_current_liabilities,Percepción IIBB Misiones aplicada,False
+l10n_ar.ri_retencion_iibb_ne_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.410,account.data_account_type_current_liabilities,Retención IIBB Neuquén aplicada,False
+l10n_ar.ri_percepcion_iibb_ne_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.420,account.data_account_type_current_liabilities,Percepción IIBB Neuquén aplicada,False
+l10n_ar.ri_retencion_iibb_lp_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.430,account.data_account_type_current_liabilities,Retención IIBB La Pampa aplicada,False
+l10n_ar.ri_percepcion_iibb_lp_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.440,account.data_account_type_current_liabilities,Percepción IIBB La Pampa aplicada,False
+l10n_ar.ri_retencion_iibb_rn_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.450,account.data_account_type_current_liabilities,Retención IIBB Río Negro aplicada,False
+l10n_ar.ri_percepcion_iibb_rn_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.460,account.data_account_type_current_liabilities,Percepción IIBB Río Negro aplicada,False
+l10n_ar.ri_retencion_iibb_az_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.470,account.data_account_type_current_liabilities,Retención IIBB Santa Cruz aplicada,False
+l10n_ar.ri_percepcion_iibb_az_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.480,account.data_account_type_current_liabilities,Percepción IIBB Santa Cruz aplicada,False
+l10n_ar.ri_retencion_iibb_tf_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.490,account.data_account_type_current_liabilities,Retención IIBB Tierra del Fuego aplicada,False
+l10n_ar.ri_percepcion_iibb_tf_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.02.500,account.data_account_type_current_liabilities,Percepción IIBB Tierra del Fuego aplicada,False
+l10n_ar.ri_retencion_iibb_a_pagar,l10n_ar.l10nar_ex_chart_template,2.1.3.02.510,account.data_account_type_payable,Retención/Percepción IIBB a pagar,True
+l10n_ar.base_plan_de_iibb_a_pagar,l10n_ar.l10nar_base_chart_template,2.1.3.02.520,account.data_account_type_payable,Plan de IIBB a pagar,True
 l10n_ar.ri_iva_debito_fiscal,l10n_ar.l10nar_ri_chart_template,2.1.3.03.010,account.data_account_type_current_liabilities,IVA débito fiscal,False
 l10n_ar.ri_iva_saldo_a_pagar,l10n_ar.l10nar_ri_chart_template,2.1.3.03.020,account.data_account_type_payable,IVA saldo a pagar,True
 l10n_ar.ri_retencion_iva_aplicada,l10n_ar.l10nar_ex_chart_template,2.1.3.03.030,account.data_account_type_current_liabilities,Retención IVA aplicada,False
@@ -151,9 +257,29 @@ l10n_ar.base_seguros_administracion,l10n_ar.l10nar_base_chart_template,5.3.1.01.
 l10n_ar.base_sellados_y_certificaciones,l10n_ar.l10nar_base_chart_template,5.3.1.01.140,account.data_account_type_expenses,Sellados y Certificaciones,False
 l10n_ar.base_tasa_municipal,l10n_ar.l10nar_base_chart_template,5.4.1.01.010,account.data_account_type_expenses,Tasa Municipal,False
 l10n_ar.base_impuestos_iibb_caba,l10n_ar.l10nar_base_chart_template,5.4.2.01.010,account.data_account_type_expenses,IIBB CABA,False
-l10n_ar.base_impuestos_iibb_ba,l10n_ar.l10nar_base_chart_template,5.4.2.01.020,account.data_account_type_expenses,IIBB Prov. Bs. As.,False
-l10n_ar.base_impuestos_iibb_co,l10n_ar.l10nar_base_chart_template,5.4.2.01.030,account.data_account_type_expenses,IIBB Prov. Córdoba,False
-l10n_ar.base_impuestos_iibb_sf,l10n_ar.l10nar_base_chart_template,5.4.2.01.040,account.data_account_type_expenses,IIBB Prov. Santa Fé,False
+l10n_ar.base_impuestos_iibb_ba,l10n_ar.l10nar_base_chart_template,5.4.2.01.020,account.data_account_type_expenses,IIBB ARBA,False
+l10n_ar.base_impuestos_iibb_ca,l10n_ar.l10nar_base_chart_template,5.4.2.01.030,account.data_account_type_expenses,IIBB Catamarca,False
+l10n_ar.base_impuestos_iibb_co,l10n_ar.l10nar_base_chart_template,5.4.2.01.040,account.data_account_type_expenses,IIBB Córdoba,False
+l10n_ar.base_impuestos_iibb_rr,l10n_ar.l10nar_base_chart_template,5.4.2.01.050,account.data_account_type_expenses,IIBB Corrientes,False
+l10n_ar.base_impuestos_iibb_er,l10n_ar.l10nar_base_chart_template,5.4.2.01.060,account.data_account_type_expenses,IIBB Entre Ríos,False
+l10n_ar.base_impuestos_iibb_ju,l10n_ar.l10nar_base_chart_template,5.4.2.01.070,account.data_account_type_expenses,IIBB Jujuy,False
+l10n_ar.base_impuestos_iibb_za,l10n_ar.l10nar_base_chart_template,5.4.2.01.080,account.data_account_type_expenses,IIBB Mendoza,False
+l10n_ar.base_impuestos_iibb_lr,l10n_ar.l10nar_base_chart_template,5.4.2.01.090,account.data_account_type_expenses,IIBB La Rioja,False
+l10n_ar.base_impuestos_iibb_sa,l10n_ar.l10nar_base_chart_template,5.4.2.01.100,account.data_account_type_expenses,IIBB Salta,False
+l10n_ar.base_impuestos_iibb_nn,l10n_ar.l10nar_base_chart_template,5.4.2.01.110,account.data_account_type_expenses,IIBB San Juan,False
+l10n_ar.base_impuestos_iibb_sl,l10n_ar.l10nar_base_chart_template,5.4.2.01.120,account.data_account_type_expenses,IIBB San Luis,False
+l10n_ar.base_impuestos_iibb_sf,l10n_ar.l10nar_base_chart_template,5.4.2.01.130,account.data_account_type_expenses,IIBB Santa Fe,False
+l10n_ar.base_impuestos_iibb_se,l10n_ar.l10nar_base_chart_template,5.4.2.01.140,account.data_account_type_expenses,IIBB Santiago del Estero,False
+l10n_ar.base_impuestos_iibb_tn,l10n_ar.l10nar_base_chart_template,5.4.2.01.150,account.data_account_type_expenses,IIBB Tucumán,False
+l10n_ar.base_impuestos_iibb_ha,l10n_ar.l10nar_base_chart_template,5.4.2.01.160,account.data_account_type_expenses,IIBB Chaco,False
+l10n_ar.base_impuestos_iibb_ct,l10n_ar.l10nar_base_chart_template,5.4.2.01.170,account.data_account_type_expenses,IIBB Chubut,False
+l10n_ar.base_impuestos_iibb_fo,l10n_ar.l10nar_base_chart_template,5.4.2.01.180,account.data_account_type_expenses,IIBB Formosa,False
+l10n_ar.base_impuestos_iibb_mi,l10n_ar.l10nar_base_chart_template,5.4.2.01.190,account.data_account_type_expenses,IIBB Misiones,False
+l10n_ar.base_impuestos_iibb_ne,l10n_ar.l10nar_base_chart_template,5.4.2.01.200,account.data_account_type_expenses,IIBB Neuquén,False
+l10n_ar.base_impuestos_iibb_lp,l10n_ar.l10nar_base_chart_template,5.4.2.01.210,account.data_account_type_expenses,IIBB La Pampa,False
+l10n_ar.base_impuestos_iibb_rn,l10n_ar.l10nar_base_chart_template,5.4.2.01.220,account.data_account_type_expenses,IIBB Río Negro,False
+l10n_ar.base_impuestos_iibb_az,l10n_ar.l10nar_base_chart_template,5.4.2.01.230,account.data_account_type_expenses,IIBB Santa Cruz,False
+l10n_ar.base_impuestos_iibb_tf,l10n_ar.l10nar_base_chart_template,5.4.2.01.240,account.data_account_type_expenses,IIBB Tierra del Fuego,False
 l10n_ar.base_impuestos_debitos_y_creditos,l10n_ar.l10nar_base_chart_template,5.4.3.01.010,account.data_account_type_expenses,Impuestos a los débitos y créditos bancarios,False
 l10n_ar.base_impuestos_a_las_ganancias,l10n_ar.l10nar_ex_chart_template,5.5.1.01.010,account.data_account_type_expenses,Impuestos a las ganancias,False
 l10n_ar.base_resultado_intereses_y_recargos,l10n_ar.l10nar_base_chart_template,5.6.1.01.020,account.data_account_type_expenses,Intereses por préstamos,False

--- a/addons/l10n_ar/data/account_tax_group.xml
+++ b/addons/l10n_ar/data/account_tax_group.xml
@@ -69,8 +69,129 @@
         <field name="l10n_ar_tribute_afip_code">06</field>
     </record>
 
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_caba">
+        <field name="name">Perc IIBB CABA</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_ba">
+        <field name="name">Perc IIBB ARBA</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_ca">
+        <field name="name">Perc IIBB Catamarca</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_co">
+        <field name="name">Perc IIBB Córdoba</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_rr">
+        <field name="name">Perc IIBB Corrientes</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_er">
+        <field name="name">Perc IIBB Entre Ríos</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_ju">
+        <field name="name">Perc IIBB Jujuy</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_za">
+        <field name="name">Perc IIBB Mendoza</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_lr">
+        <field name="name">Perc IIBB La Rioja</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_sa">
+        <field name="name">Perc IIBB Salta</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_nn">
+        <field name="name">Perc IIBB San Juan</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_sl">
+        <field name="name">Perc IIBB San Luis</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_sf">
+        <field name="name">Perc IIBB Santa Fe</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_se">
+        <field name="name">Perc IIBB Santiago del Estero</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_tn">
+        <field name="name">Perc IIBB Tucumán</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_ha">
+        <field name="name">Perc IIBB Chaco</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_ct">
+        <field name="name">Perc IIBB Chubut</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_fo">
+        <field name="name">Perc IIBB Formosa</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_mi">
+        <field name="name">Perc IIBB Misiones</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_ne">
+        <field name="name">Perc IIBB Neuquén</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_lp">
+        <field name="name">Perc IIBB La Pampa</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_rn">
+        <field name="name">Perc IIBB Río Negro</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_az">
+        <field name="name">Perc IIBB Santa Cruz</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_percepcion_iibb_tf">
+        <field name="name">Perc IIBB Tierra del Fuego</field>
+        <field name="l10n_ar_tribute_afip_code">07</field>
+    </record>
+
     <record model="account.tax.group" id="tax_group_percepcion_iibb">
         <field name="name">IIBB Perceptions</field>
+        <field name="sequence">25</field>
         <field name="l10n_ar_tribute_afip_code">07</field>
     </record>
 

--- a/addons/l10n_ar/data/account_tax_template_data.xml
+++ b/addons/l10n_ar/data/account_tax_template_data.xml
@@ -140,7 +140,7 @@
             }),
         ]"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb"/>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_caba"/>
     </record>
 
     <record id="ri_tax_percepcion_iibb_ba_sufrida" model="account.tax.template">
@@ -175,7 +175,42 @@
             }),
         ]"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb"/>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ba"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ca_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Catamarca Sufrida</field>
+        <field name="description">Perc IIBB Catamarca S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ca_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ca_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ca"/>
     </record>
 
     <record id="ri_tax_percepcion_iibb_co_sufrida" model="account.tax.template">
@@ -210,13 +245,293 @@
             }),
         ]"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb"/>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_co"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_rr_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Corrientes Sufrida</field>
+        <field name="description">Perc IIBB Corrientes S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_rr_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_rr_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_rr"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_er_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Entre Ríos Sufrida</field>
+        <field name="description">Perc IIBB Entre Ríos S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_er_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_er_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_er"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ju_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Jujuy Sufrida</field>
+        <field name="description">Perc IIBB Jujuy S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ju_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ju_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ju"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_za_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Mendoza Sufrida</field>
+        <field name="description">Perc IIBB Mendoza S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_za_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_za_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_za"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_lr_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB La Rioja Sufrida</field>
+        <field name="description">Perc IIBB La Rioja S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_lr_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_lr_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_lr"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_sa_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Salta Sufrida</field>
+        <field name="description">Perc IIBB Salta S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_sa_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_sa_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_sa"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_nn_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB San Juan Sufrida</field>
+        <field name="description">Perc IIBB San Juan S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_nn_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_nn_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_nn"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_sl_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB San Luis Sufrida</field>
+        <field name="description">Perc IIBB San Luis S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_sl_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_sl_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_sl"/>
     </record>
 
     <record id="ri_tax_percepcion_iibb_sf_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_base_chart_template"/>
-        <field name="name">Percepción IIBB Santa Fé Sufrida</field>
-        <field name="description">Perc IIBB Santa Fé S</field>
+        <field name="name">Percepción IIBB Santa Fe Sufrida</field>
+        <field name="description">Perc IIBB Santa Fe S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -245,13 +560,398 @@
             }),
         ]"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb"/>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_sf"/>
     </record>
 
-    <record id="ri_tax_percepcion_iibb_aplicada" model="account.tax.template">
+    <record id="ri_tax_percepcion_iibb_se_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Santiago del Estero Sufrida</field>
+        <field name="description">Perc IIBB Santiago del Estero S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_se_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_se_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_se"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_tn_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Tucumán Sufrida</field>
+        <field name="description">Perc IIBB Tucumán S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_tn_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_tn_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_tn"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ha_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Chaco Sufrida</field>
+        <field name="description">Perc IIBB Chaco S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ha_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ha_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ha"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ct_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Chubut Sufrida</field>
+        <field name="description">Perc IIBB Chubut S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ct_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ct_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ct"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_fo_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Formosa Sufrida</field>
+        <field name="description">Perc IIBB Formosa S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_fo_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_fo_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_fo"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_mi_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Misiones Sufrida</field>
+        <field name="description">Perc IIBB Misiones S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_mi_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_mi_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_mi"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ne_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Neuquén Sufrida</field>
+        <field name="description">Perc IIBB Neuquén S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ne_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_ne_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ne"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_lp_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB La Pampa Sufrida</field>
+        <field name="description">Perc IIBB La Pampa S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_lp_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_lp_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_lp"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_rn_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Río Negro Sufrida</field>
+        <field name="description">Perc IIBB Río Negro S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_rn_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_rn_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_rn"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_az_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Santa Cruz Sufrida</field>
+        <field name="description">Perc IIBB Santa Cruz S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_az_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_az_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_az"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_tf_sufrida" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_base_chart_template"/>
+        <field name="name">Percepción IIBB Tierra del Fuego Sufrida</field>
+        <field name="description">Perc IIBB Tierra del Fuego S</field>
+        <field name="sequence">4</field>
+        <field name="amount_type">fixed</field>
+        <field eval="1.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_tf_sufrida'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('base_percepcion_iibb_tf_sufrida'),
+            }),
+        ]"/>
+        <field name="type_tax_use">purchase</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_tf"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_caba_aplicada" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
-        <field name="name">Percepción IIBB Aplicada</field>
-        <field name="description">Perc IIBB A</field>
+        <field name="name">Percepción IIBB CABA Aplicada</field>
+        <field name="description">Perc IIBB CABA A</field>
         <field name="sequence">4</field>
         <field name="active" eval="False"/>
         <field name="amount_type">fixed</field>
@@ -265,7 +965,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('ri_percepcion_iibb_aplicada'),
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_caba_aplicada'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -277,11 +977,839 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('ri_percepcion_iibb_aplicada'),
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_caba_aplicada'),
             }),
         ]"/>
         <field name="type_tax_use">sale</field>
-        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb"/>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_caba"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ba_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB ARBA Aplicada</field>
+        <field name="description">Perc IIBB ARBA A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ba_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ba_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ba"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ca_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Catamarca Aplicada</field>
+        <field name="description">Perc IIBB Catamarca A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ca_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ca_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ca"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_co_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Córdoba Aplicada</field>
+        <field name="description">Perc IIBB Córdoba A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_co_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_co_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_co"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_rr_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Corrientes Aplicada</field>
+        <field name="description">Perc IIBB Corrientes A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_rr_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_rr_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_rr"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_er_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Entre Ríos Aplicada</field>
+        <field name="description">Perc IIBB Entre Ríos A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_er_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_er_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_er"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ju_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Jujuy Aplicada</field>
+        <field name="description">Perc IIBB Jujuy A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ju_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ju_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ju"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_za_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Mendoza Aplicada</field>
+        <field name="description">Perc IIBB Mendoza A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_za_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_za_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_za"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_lr_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB La Rioja Aplicada</field>
+        <field name="description">Perc IIBB La Rioja A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_lr_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_lr_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_lr"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_sa_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Salta Aplicada</field>
+        <field name="description">Perc IIBB Salta A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_sa_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_sa_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_sa"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_nn_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB San Juan Aplicada</field>
+        <field name="description">Perc IIBB San Juan A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_nn_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_nn_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_nn"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_sl_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB San Luis Aplicada</field>
+        <field name="description">Perc IIBB San Luis A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_sl_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_sl_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_sl"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_sf_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Santa Fe Aplicada</field>
+        <field name="description">Perc IIBB Santa Fe A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_sf_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_sf_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_sf"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_se_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Santiago del Estero Aplicada</field>
+        <field name="description">Perc IIBB Santiago del Estero A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_se_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_se_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_se"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_tn_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Tucumán Aplicada</field>
+        <field name="description">Perc IIBB Tucumán A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_tn_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_tn_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_tn"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ha_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Chaco Aplicada</field>
+        <field name="description">Perc IIBB Chaco A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ha_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ha_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ha"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ct_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Chubut Aplicada</field>
+        <field name="description">Perc IIBB Chubut A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ct_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ct_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ct"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_fo_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Formosa Aplicada</field>
+        <field name="description">Perc IIBB Formosa A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_fo_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_fo_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_fo"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_mi_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Misiones Aplicada</field>
+        <field name="description">Perc IIBB Misiones A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_mi_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_mi_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_mi"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_ne_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Neuquén Aplicada</field>
+        <field name="description">Perc IIBB Neuquén A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ne_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_ne_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_ne"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_lp_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB La Pampa Aplicada</field>
+        <field name="description">Perc IIBB La Pampa A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_lp_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_lp_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_lp"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_rn_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Río Negro Aplicada</field>
+        <field name="description">Perc IIBB Río Negro A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_rn_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_rn_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_rn"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_az_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Santa Cruz Aplicada</field>
+        <field name="description">Perc IIBB Santa Cruz A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_az_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_az_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_az"/>
+    </record>
+
+    <record id="ri_tax_percepcion_iibb_tf_aplicada" model="account.tax.template">
+        <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
+        <field name="name">Percepción IIBB Tierra del Fuego Aplicada</field>
+        <field name="description">Perc IIBB Tierra del Fuego A</field>
+        <field name="sequence">4</field>
+        <field name="active" eval="False"/>
+        <field name="amount_type">fixed</field>
+        <field eval="0.0" name="amount"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_tf_aplicada'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ar.ri_percepcion_iibb_tf_aplicada'),
+            }),
+        ]"/>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="l10n_ar.tax_group_percepcion_iibb_tf"/>
     </record>
 
     <!-- Only for Responsable Inscription account.chart.template -->

--- a/addons/l10n_ar/demo/account_tax_demo.xml
+++ b/addons/l10n_ar/demo/account_tax_demo.xml
@@ -88,7 +88,13 @@
 
     <function model="account.tax" name="write" context="{'active_test': False}">
         <value model="account.tax" eval="obj().search([('company_id', '=', ref('company_ri')), ('tax_group_id', 'in',
-            [ref('tax_group_percepcion_iva'), ref('tax_group_percepcion_ganancias'), ref('tax_group_percepcion_iibb'), ref('account.tax_group_taxes')]
+            [ref('tax_group_percepcion_iva'),
+             ref('tax_group_percepcion_ganancias'),
+             ref('tax_group_percepcion_iibb_caba'),
+             ref('tax_group_percepcion_iibb_ba'),
+             ref('tax_group_percepcion_iibb_co'),
+             ref('tax_group_percepcion_iibb_sf'),
+             ref('account.tax_group_taxes')]
         )]).ids"/>
         <value eval="{'amount': 0.1, 'active': True}"/>
     </function>

--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -759,11 +759,6 @@ msgid "IIBB - Sales by jurisdiction"
 msgstr "IIBB - Ventas por Jurisdicción"
 
 #. module: l10n_ar
-#: model:account.tax.group,name:l10n_ar.tax_group_percepcion_iibb
-msgid "IIBB Perceptions"
-msgstr "Percepción de IIBB"
-
-#. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.custom_header
 msgid "IIBB:"
 msgstr ""

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -736,11 +736,6 @@ msgid "IIBB - Sales by jurisdiction"
 msgstr ""
 
 #. module: l10n_ar
-#: model:account.tax.group,name:l10n_ar.tax_group_percepcion_iibb
-msgid "IIBB Perceptions"
-msgstr ""
-
-#. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.custom_header
 msgid "IIBB:"
 msgstr ""


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
We add all the data related to the Argentinean
perceptions for each jurisdiction.

For each jurisdiction (xx) we have a new:
 * Tax: Percepción IIBB xx Sufrida
 * Tax: Percepción IIBB Catamarca Aplicada
 * Tax group: Perc IIBB xx
 * Account: Saldo a favor IIBB xx
 * Account: Retención IIBB xx sufrida
 * Account: Percepción IIBB xx sufrida
 * Account: Retención IIBB xx aplicada
 * Account: Percepción IIBB xx aplicada
 * Account: IIBB xx

Also, we activate some perceptions to work with demo data

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Forward-Port-Of: #67149