### PR TITLE
[FIX] web_editor: apply "editor_enable" class to iframe body

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -132,7 +132,7 @@ const Wysiwyg = Widget.extend({
         }
 
         if (options.snippets) {
-            $('body').addClass('editor_enable');
+            $(this.odooEditor.document.body).addClass('editor_enable');
             this.snippetsMenu = new snippetsEditor.SnippetsMenu(this, Object.assign({
                 wysiwyg: this,
                 selectorEditableArea: '.o_editable',

--- a/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
@@ -18,7 +18,6 @@ body.o_in_iframe {
     display: flex;
 
     #oe_snippets {
-        position: relative;
         top: 0;
     }
 
@@ -29,10 +28,6 @@ body.o_in_iframe {
 
     .iframe-utils-zone {
         display: flex;
-    }
-
-    &.editor_enable {
-        padding-top: var(--o-we-toolbar-height) !important;
     }
 
     .note-statusbar {


### PR DESCRIPTION
Before introducing the new Odoo Editor, the body of an iframe containing the editor has the class "editor_enable". Now it's applied to the main document's body. This ensure the class is applied on the iframe's body like before.
As a consequence, some CSS had to be adapted:
- The position property of the snippets menu which had been overridden, probably as an ad-hoc fix for the fact that this class was missing.
- The top padding which is applied to accomodate a top toolbar which was removed with the new editor and can now be removed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
