### PR TITLE
[FIX] web_editor: show/hide toolbar on click in editor document

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1168,7 +1168,7 @@ var SnippetsMenu = Widget.extend({
         this.customizePanel.classList.add('o_we_customize_panel', 'd-none');
         this._addToolbar();
         this._checkEditorToolbarVisibilityCallback = this._checkEditorToolbarVisibility.bind(this)
-        $(document.body).on('click', this._checkEditorToolbarVisibilityCallback);
+        $(this.options.wysiwyg.odooEditor.document.body).on('click', this._checkEditorToolbarVisibilityCallback);
 
         if (this.options.enableTranslation) {
             // Load the sidebar with the style tab only.


### PR DESCRIPTION
We need to check the selection on click in the editor's document so as to update the visibility of the toolbar (we want to hide it if the selection is in a non-editable area). When the editor was in an iframe however, the wrong document was targeted: we want to check on clicks in the editor's document, not the top document.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
