### PR TITLE
[IMP] base: Honduras vat label and currency improvements

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -698,6 +698,7 @@
             <field file="base/static/img/country_flags/hn.png" name="image" type="base64" />
             <field name="currency_id" ref="HNL" />
             <field eval="504" name="phone_code" />
+            <field name="vat_label">RTN</field>
         </record>
         <record id="hr" model="res.country">
             <field name="name">Croatia</field>

--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -405,7 +405,8 @@
             <field name="symbol">L</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Lempira</field>
+            <field name="position">before</field>
+            <field name="currency_unit_label">Lempiras</field>
             <field name="currency_subunit_label">Centavos</field>
         </record>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Adds address format and vat label to Honduras res.country data
- Improve HNL currency setup

**Current behavior before PR:**

- Missing address format and vat label
- Wrong HNL currency position and unit label

**Desired behavior after PR is merged:**

- Honduras address format and vat label comes as part of Honduras country data
- Have a correct HNL currency setup



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
