### PR TITLE
[FIX] sale: reposition tooltip to avoid resize flicker


### DIFF
--- a/addons/mrp/static/src/js/mrp.js
+++ b/addons/mrp/static/src/js/mrp.js
@@ -262,5 +262,7 @@ field_registry
     .add('mrp_time_counter', TimeCounter)
     .add('embed_viewer', FieldEmbedURLViewer);
 
+fieldUtils.format.mrp_time_counter = fieldUtils.format.float_time;
+
 return FieldEmbedURLViewer;
 });


### PR DESCRIPTION

Same reason that cdb7a8ad7647649ad8f595454aa9dc0464117568

The tour bubble animation might cause the page to flicker since the
scrollbar might appear disappear depending on size of modal / browser.

opw-2469248
