### PR TITLE
[FIX] mrp: use float_time for mrp_time_counter aggregate


### DIFF
--- a/addons/mrp/static/src/js/mrp.js
+++ b/addons/mrp/static/src/js/mrp.js
@@ -262,5 +262,7 @@ field_registry
     .add('mrp_time_counter', TimeCounter)
     .add('embed_viewer', FieldEmbedURLViewer);
 
+fieldUtils.format.mrp_time_counter = fieldUtils.format.float_time;
+
 return FieldEmbedURLViewer;
 });


### PR DESCRIPTION

To display an aggregate in a list view, the field format method is used.

But since mrp_time_counter that extend float_time has no format method,
you would see eg. 2.07 as aggregate and 2:04 on the line which is a
little confusing.

opw-2514634
