### PR TITLE
[FIX] Control only when move_type is invoice

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -57,7 +57,7 @@ class AccountMove(models.Model):
                 raise ValidationError(_('Tax payer type and vat number are mandatory for this type of '
                                         'document. Please set the current tax payer type of this customer'))
             if rec.journal_id.type == 'sale' and rec.journal_id.l10n_latam_use_documents:
-                if country_id.code != "CL":
+                if country_id.code != "CL" and rec.move_type in rec.get_invoice_types():
                     if not ((tax_payer_type == '4' and latam_document_type_code in ['110', '111', '112']) or (
                             tax_payer_type == '3' and latam_document_type_code in ['39', '41', '61', '56'])):
                         raise ValidationError(_(


### PR DESCRIPTION
This fix consider control only invoice types

**Description of the issue/feature this PR addresses:**
The POS closing event require to post entries and the move_type is 'entry'. 

**Current behavior before PR:**
Bring error when posting entries

**Desired behavior after PR is merged:**
Do not control when mov_type is entry

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
