### PR TITLE
[FIX]website_event:Public User does not book

### DIFF
--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.tools import float_is_zero
 
 
@@ -97,7 +97,7 @@ class EventRegistration(models.Model):
     def _synchronize_so_line_values(self, so_line):
         if so_line:
             return {
-                'partner_id': so_line.order_id.partner_id.id,
+                'partner_id': False if self.env.user._is_public() else so_line.order_id.partner_id.id,
                 'event_id': so_line.event_id.id,
                 'event_ticket_id': so_line.event_ticket_id.id,
                 'sale_order_id': so_line.order_id.id,

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -368,7 +368,7 @@ class WebsiteEventController(http.Controller):
             if not registration_values.get('partner_id') and visitor_sudo.partner_id:
                 registration_values['partner_id'] = visitor_sudo.partner_id.id
             elif not registration_values.get('partner_id'):
-                registration_values['partner_id'] = request.env.user.partner_id.id
+                registration_values['partner_id'] = False if request.env.user._is_public() else request.env.user.partner_id.id
 
             if visitor_sudo:
                 # registration may give a name to the visitor, yay


### PR DESCRIPTION
PURPOSE

Currently, if someone browse the website without
login(as a public user) and register for a free event 
than His attendee is created.

SPECIFICATION

in this PR we are fix the user id, user id is empty if 
user is public.

TaskId: 2508558

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
