### PR TITLE
[FIX] im_livechat: notify operator on leave channel for sharable support

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat.js
@@ -421,6 +421,7 @@ var LivechatButton = Widget.extend({
         } else {
             this._closeChat();
         }
+        this._visitorLeaveSession();
     },
     /**
      * @private
@@ -469,6 +470,19 @@ var LivechatButton = Widget.extend({
     _onUpdatedUnreadCounter: function (ev) {
         ev.stopPropagation();
         this._chatWindow.renderHeader();
+    },
+    /**
+     * @private
+     * Called when the visitor leaves the livechat chatter the first time (first click on X button)
+     * this will deactivate the mail_channel, notify operator that visitor has left the channel.
+     */
+    _visitorLeaveSession: function () {
+        var cookie = utils.get_cookie('im_livechat_session');
+        if (cookie) {
+            var channel = JSON.parse(cookie);
+            session.rpc('/im_livechat/visitor_leave_session', {uuid: channel.uuid});
+            utils.set_cookie('im_livechat_session', "", -1); // remove cookie
+        }
     },
 });
 

--- a/addons/website_livechat/static/src/legacy/public_livechat.js
+++ b/addons/website_livechat/static/src/legacy/public_livechat.js
@@ -2,7 +2,6 @@ odoo.define('website_livechat.legacy.website_livechat.livechat_request', functio
 "use strict";
 
 var utils = require('web.utils');
-var session = require('web.session');
 var LivechatButton = require('im_livechat.legacy.im_livechat.im_livechat').LivechatButton;
 const config = require('web.config');
 
@@ -40,26 +39,6 @@ LivechatButton.include({
             this.$el.popover({
                 animation: true,
             });
-        }
-    },
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     * Called when the visitor closes the livechat chatter the first time (first click on X button)
-     * this will deactivate the mail_channel, clean the chat request if any
-     * and allow the operators to send the visitor a new chat request
-     */
-    _onCloseChatWindow: function (ev) {
-        this._super(ev);
-        var cookie = utils.get_cookie('im_livechat_session');
-        if (cookie) {
-            var channel = JSON.parse(cookie);
-            session.rpc('/im_livechat/visitor_leave_session', {uuid: channel.uuid});
-            utils.set_cookie('im_livechat_session', "", -1); // remove cookie
         }
     },
 });


### PR DESCRIPTION
**PURPOSE**

when we are using the sharable support page (url : "/im_livechat/support/"),
There is no "visitor left" message sent to the operator when any visitor left
the channel.
Ideally, when any visitor left the channel from the website or the support page
should notify the operator that "Visitor has left the conversation".

**SPECIFICATION**
We are calling the method which sends the operator message on the first click on
the cancel chat button.

Task : 2210040