### PR TITLE
[FIX] im_livechat: reading message_ids to check if there's one is inefficient

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -76,7 +76,7 @@ class ImLivechatChannel(models.Model):
     def _compute_nbr_channel(self):
         data = self.env['mail.channel'].read_group([
             ('livechat_channel_id', 'in', self._ids),
-            ('message_ids', '!=', False)], ['__count'], ['livechat_channel_id'], lazy=False)
+            ('has_message', '=', True)], ['__count'], ['livechat_channel_id'], lazy=False)
         channel_count = {x['livechat_channel_id'][0]: x['__count'] for x in data}
         for record in self:
             record.nbr_channel = channel_count.get(record.id, 0)

--- a/addons/im_livechat/views/mail_channel_views.xml
+++ b/addons/im_livechat/views/mail_channel_views.xml
@@ -129,7 +129,7 @@
             <field name="name">Sessions</field>
             <field name="res_model">mail.channel</field>
             <field name="view_mode">tree,form</field>
-            <field name="domain">[('livechat_channel_id', 'in', [active_id]), ('message_ids', '!=', False)]</field>
+            <field name="domain">[('livechat_channel_id', 'in', [active_id]), ('has_message', '=', True)]</field>
             <field name="context">{
                 'search_default_livechat_channel_id': [active_id],
                 'default_livechat_channel_id': active_id,

--- a/addons/website_crm_livechat/models/crm_lead.py
+++ b/addons/website_crm_livechat/models/crm_lead.py
@@ -17,5 +17,5 @@ class Lead(models.Model):
     def action_redirect_to_livechat_sessions(self):
         visitors = self.visitor_ids
         action = self.env["ir.actions.actions"]._for_xml_id("website_livechat.website_visitor_livechat_session_action")
-        action['domain'] = [('livechat_visitor_id', 'in', visitors.ids), ('message_ids', '!=', False)]
+        action['domain'] = [('livechat_visitor_id', 'in', visitors.ids), ('has_message', '=', True)]
         return action

--- a/addons/website_livechat/models/website.py
+++ b/addons/website_livechat/models/website.py
@@ -41,7 +41,7 @@ class Website(models.Model):
                 ('livechat_visitor_id', '=', visitor.id),
                 ('livechat_channel_id', '=', self.channel_id.id),
                 ('livechat_active', '=', True),
-                ('message_ids', '!=', False)
+                ('has_message', '=', True)
             ], order='create_date desc', limit=1)
             if chat_request_channel:
                 return {

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -5,7 +5,7 @@
         <field name="res_model">mail.channel</field>
         <field name="view_mode">tree,form</field>
         <field name="view_id" ref="im_livechat.mail_channel_view_tree"/>
-        <field name="domain">[('livechat_visitor_id', '=', active_id), ('message_ids', '!=', False)]</field>
+        <field name="domain">[('livechat_visitor_id', '=', active_id), ('has_message', '=', True)]</field>
         <field name="context">{
                 'search_default_livechat_visitor_id': [active_id],
                 'default_livechat_visitor_id': active_id,


### PR DESCRIPTION
For channels with huge number of message_ids for a single 
livechat_channel_id takes ages with ORM, while SQL can be more efficient 
in this specific use case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
