### PR TITLE
[FIX] delivery: do not overlap smart button

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -157,6 +157,7 @@ msgid ""
 msgstr ""
 
 #. module: delivery
+#: model_terms:ir.ui.view,arch_db:delivery.view_delivery_carrier_form
 #: model_terms:ir.ui.view,arch_db:delivery.view_delivery_carrier_search
 msgid "Archived"
 msgstr ""

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -49,7 +49,6 @@
             <field name="arch" type="xml">
                 <form string="Carrier">
                     <sheet>
-                      <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_button_box" name="button_box">
                             <button name="toggle_prod_environment"
                                     attrs="{'invisible': ['|', '|', ('prod_environment', '=', False), ('delivery_type', '=', 'fixed'), ('delivery_type', '=', 'base_on_rule')]}"
@@ -87,6 +86,7 @@
                                 </div>
                             </button>
                         </div>
+                        <widget name="web_ribbon" text="Archived" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title" name="title">
                             <label for="name" string="Name" class="oe_edit_only"/>
                             <h1>


### PR DESCRIPTION
This commit is fixing two issues:
1: make ribbon translatable
2: display ribbon below smart button

closes #68438