### PR TITLE
[FIX] calendar: performance bottleneck with recurrent events

### DIFF
--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -316,7 +316,7 @@ class TestCalendar(TransactionCase):
         })
 
         start_recurring_dates = m.with_context({'tz': 'Europe/Brussels'})._get_recurrent_date_by_event()
-        self.assertEqual(len(start_recurring_dates), 4)
+        self.assertEqual(len(list(start_recurring_dates)), 4)
 
         for d in start_recurring_dates:
             self.assertEqual(d.tzinfo, pytz.UTC)


### PR DESCRIPTION
When some calendar event(s) with big recursion configuration exists and you want to see some week or month view, odoo freezes.


https://user-images.githubusercontent.com/973709/116058365-ac7b1a80-a677-11eb-8e8f-9603b57aff49.mp4



This fixes that use case, although the same bottleneck still exists when searching for meetings in list view. At least, this is still better.

The strategies followed are:

1. Do not use lists everywhere, but generators instead. This saves some unneeded computations.
2. Filter the recurring ruleset by start and stop dates, if those are provided while searching. This is the case for calendar views. This forces the loop to consider only recurrent events that would land in the wanted search window. If the event has 1 million repetitions and you're searching just one week, you can save 9.999.993 loops.

To achieve this, some signatures are changed. Default values are provided. Since these are private low-level methods, this doesn't seem like a big problem for a stable version.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

OPW-2516423

@Tecnativa TT29361