### PR TITLE
[FIX] mass_mailing, web_tour: skip a unsuitable parent for the tour tip

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -454,6 +454,12 @@ var MassMailingFieldHtml = FieldHtml.extend({
 
         $selectTemplateBtn.on('click', () => {
             $snippetsSideBar.data('snippetMenu').activateCustomTab($themeSelector);
+            /**
+             * Ensure the parent of the theme selector is not used as parent for a
+             * tooltip as it is overflow auto and would result in the tooltip being
+             * hidden by the body of the mail.
+             */
+            $themeSelector.parent().addClass('o_forbidden_tooltip_parent');
             $selectTemplateBtn.addClass('active');
         });
 

--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -281,6 +281,7 @@ var Tip = Widget.extend({
         } while (
             $location.hasClass('dropdown-menu') ||
             $location.hasClass('o_notebook_headers') ||
+            $location.hasClass('o_forbidden_tooltip_parent') ||
             (
                 (o === "visible" || o.includes("hidden")) && // Possible case where the overflow = "hidden auto"
                 p !== "fixed" &&


### PR DESCRIPTION
This makes it possible to declare an element unsuitable as parent of the tour tip via the "o_forbidden_tooltip_parent" class.
We then apply this class to the "o_we_customize_panel" of mass_mailing's snippets menu so the tip is applied to its parent like in saas-14.2.
Without that, the tip is hidden by the body of the mail. The reason it was positioned in the parent in saas-14.2 is that the theme selector wasn't in the customize panel but positioned absolutely above it.
This is an ad-hoc fix to something of an ad-hoc situation, given the relative weirdness of the html environment (the snippets menu is in the padding of the body of an iframe).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
