### PR TITLE
Master default invoice policy bbh

### DIFF
--- a/addons/sale/data/sale_data.xml
+++ b/addons/sale/data/sale_data.xml
@@ -16,7 +16,5 @@
             <field name="key">sale.default_confirmation_template</field>
             <field name="value" ref="sale.mail_template_sale_confirmation"/>
         </record>
-
-        <function model="ir.default" name="set" eval="('product.template', 'invoice_policy', 'delivery')"/>
     </data>
 </odoo>

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -21,7 +21,7 @@ class ResConfigSettings(models.TransientModel):
         ('order', 'Invoice what is ordered'),
         ('delivery', 'Invoice what is delivered')
         ], 'Invoicing Policy',
-        default='delivery',
+        default='order',
         default_model='product.template')
     deposit_default_product_id = fields.Many2one(
         'product.product',


### PR DESCRIPTION
The purpose of this task is to set the  default invoice policy in the sales module  to ordered quantity and to change the data file according to the new invoice policy. Previously default invoice policy was delivered quantity. 

So In these commits, When the user installs a sales module then default invoice policy will be set to ordered quantity.

Task ID - 2443371



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
