### PR TITLE
[FIX] web_editor: ensure proper jquery reference on snippets editor $el

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1158,11 +1158,14 @@ var SnippetsMenu = Widget.extend({
      */
     async start() {
         var defs = [this._super.apply(this, arguments)];
-        this.$el.data('snippetMenu', this);
         this.ownerDocument = this.$el[0].ownerDocument;
         this.$document = $(this.ownerDocument);
         this.window = this.ownerDocument.defaultView;
         this.$window = $(this.window);
+        // In an iframe, we need to make sure the element is using jquery on its
+        // own window and not on the top window lest jquery behave unexpectedly.
+        this.$el = this.window.$(this.$el);
+        this.$el.data('snippetMenu', this);
 
         this.customizePanel = document.createElement('div');
         this.customizePanel.classList.add('o_we_customize_panel', 'd-none');

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -901,7 +901,10 @@ const Wysiwyg = Widget.extend({
      */
     _updateEditorUI: function (e) {
         this.odooEditor.automaticStepSkipStack();
-        const $target = e ? $(e.target) : $();
+        // We need to use the editor's window so the tooltip displays in its
+        // document even if it's in an iframe.
+        const editorWindow = this.odooEditor.document.defaultView;
+        const $target = e ? editorWindow.$(e.target) : editorWindow.$();
         // Restore paragraph dropdown button's default ID.
         this.toolbar.$el.find('#mediaParagraphDropdownButton').attr('id', 'paragraphDropdownButton');
         // Remove the alt tools.


### PR DESCRIPTION
In an iframe, we need to make sure the element is using jquery on its own window and not on the top window lest jquery behave unexpectedly. This was apparent with tooltip which was called in snippets.editor with the "wrong jquery", with the result that tooltip.js had a reference to the top window/document instead of that of the iframe. Because of that, it appended its tooltips to the top window instead of the iframe, and as a result, said tooltips were wrongly positioned.

Co-authored-by: Antoine Guenet <age@odoo.com>
Co-authored-by: Nicolas Bayet <nby@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
