### PR TITLE
[FIX] mail: Wrong signature of export_data

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -701,11 +701,11 @@ class Message(models.Model):
             limit=limit, orderby=orderby, lazy=lazy,
         )
 
-    def export_data(self, fields_to_export, raw_data=False):
+    def export_data(self, fields_to_export):
         if not self.env.is_admin():
             raise AccessError(_("Only administrators are allowed to export mail message"))
 
-        return super(Message, self).export_data(fields_to_export, raw_data)
+        return super(Message, self).export_data(fields_to_export)
 
     # ------------------------------------------------------
     # DISCUSS API


### PR DESCRIPTION
Steps to reproduce the bug:

- Try to export mail.message records

Bug:

A traceback was raised

Wrong forward-port of 69b27ac3f778b99a7d583ee6a9e8607a36d0a3b2

opw:2514584