### PR TITLE
[FIX] mail: Wrong signature of export_data

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1130,11 +1130,11 @@ class Message(models.Model):
             limit=limit, orderby=orderby, lazy=lazy,
         )
 
-    def export_data(self, fields_to_export, raw_data=False):
+    def export_data(self, fields_to_export):
         if not self.env.is_admin():
             raise AccessError(_("Only administrators are allowed to export mail message"))
 
-        return super(Message, self).export_data(fields_to_export, raw_data)
+        return super(Message, self).export_data(fields_to_export)
 
     # --------------------------------------------------
     # Moderation


### PR DESCRIPTION
Steps to reproduce the bug:

- Try to export mail.message records

Bug:

A traceback was raised

Wrong forward-port of 69b27ac

opw:2514584