### PR TITLE
[FIX] hr_timesheet: Analytic account without company

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -137,7 +137,7 @@ class AccountAnalyticLine(models.Model):
         if vals.get('project_id') and not vals.get('account_id'):
             project = self.env['project.project'].browse(vals.get('project_id'))
             vals['account_id'] = project.analytic_account_id.id
-            vals['company_id'] = project.analytic_account_id.company_id.id
+            vals['company_id'] = project.analytic_account_id.company_id.id or project.company_id.id
             if not project.analytic_account_id.active:
                 raise UserError(_('The project you are timesheeting on is not linked to an active analytic account. Set one on the project configuration.'))
         # employee implies user


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a project P set with analytic account AA and company C
- Allow timesheet on P
- Let's consider a task T belonging to P
- Set AA with comapny = False
- Try to encode a timesheet on T

Bug:

A UserError was raised because the field company_id on account.analytic.line is required

opw:2486034