### PR TITLE
[FIX] survey: allow to modify a completed survey

### DIFF
--- a/addons/survey/models/survey_user.py
+++ b/addons/survey/models/survey_user.py
@@ -535,10 +535,20 @@ class SurveyUserInputLine(models.Model):
         return super(SurveyUserInputLine, self).create(vals_list)
 
     def write(self, vals):
-        score_vals = self._get_answer_score_values(vals, compute_speed_score=False)
-        if not vals.get('answer_score'):
-            vals.update(score_vals)
-        return super(SurveyUserInputLine, self).write(vals)
+        res = True
+        for line in self:
+            vals_copy = {**vals}
+            getter_params = {
+                'user_input_id': line.user_input_id.id,
+                'answer_type': line.answer_type,
+                'question_id': line.question_id.id,
+                **vals_copy
+            }
+            score_vals = self._get_answer_score_values(getter_params, compute_speed_score=False)
+            if not vals_copy.get('answer_score'):
+                vals_copy.update(score_vals)
+            res = super(SurveyUserInputLine, line).write(vals_copy) and res
+        return res
 
     @api.model
     def _get_answer_score_values(self, vals, compute_speed_score=True):


### PR DESCRIPTION
Updating a completed survey will raise an error with a traceback.

To reproduce the error:
(Use demo data)
1. Survey > Participations
2. Select a completed form
3. Change one answer, Save

Error: A traceback appears "[...] ValueError: Computing score requires a
question in arguments."

Here is an extract from the method concerned:
```python
@api.model
def _get_answer_score_values(self, vals, compute_speed_score=True):
    """
        [...]
    """
    user_input_id = vals.get('user_input_id')
    answer_type = vals.get('answer_type')
    question_id = vals.get('question_id')
    if not question_id:
        raise ValueError(_('Computing score requires a question in
arguments.'))
```
This method needs some information to work properly.

OPW-2488974