### PR TITLE
[FIX] web: limit mouse events on colorpicker to its own document context

### DIFF
--- a/addons/web/static/src/js/widgets/colorpicker.js
+++ b/addons/web/static/src/js/widgets/colorpicker.js
@@ -39,7 +39,7 @@ var ColorpickerWidget = Widget.extend({
         this.selectedHexValue = '';
 
         // Needs to be bound on document to work in all possible cases.
-        const $document = $(document);
+        const $document = $(parent.el && parent.el.ownerDocument || document);
         $document.on(`mousemove.${this.uniqueId}`, _.throttle((ev) => {
             this._onMouseMovePicker(ev);
             this._onMouseMoveSlider(ev);


### PR DESCRIPTION
When the colorpicker is in an iframe, listening to mouse events on the global document can have unexpected effects. Namely clicking in the colorpicker, then moving the mouse outside the iframe made it move the color cursor.
This fixes that by binding it to the parent widget's document, with a fallback on the global document in case it's missing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
