### PR TITLE
[FIX] web: prevent test_menus loading DiscussWidget if no mail module

### DIFF
--- a/addons/web/static/src/js/tools/test_menus.js
+++ b/addons/web/static/src/js/tools/test_menus.js
@@ -14,7 +14,10 @@
 
     function createWebClientHooks() {
         var AbstractController = odoo.__DEBUG__.services['web.AbstractController'];
-        var DiscussWidget = odoo.__DEBUG__.services['@mail/widgets/discuss/discuss'][Symbol.for("default")];
+        // This test file is not respecting Odoo module dependencies.
+        // The following module might not be loaded (eg. if mail is not installed).
+        const DiscussWidgetModule = odoo.__DEBUG__.services['@mail/widgets/discuss/discuss'];
+        const DiscussWidget = DiscussWidgetModule && DiscussWidgetModule[Symbol.for("default")];
         var WebClient = odoo.__DEBUG__.services["web.WebClient"];
 
         WebClient.include({


### PR DESCRIPTION
Follow up on bd67479316dfb19021de06b7007d2ae3c84284e3

This test file is not respecting Odoo module dependencies.

If the module is not defined, calling `[Symbol.for("default")]` will crash.

Old require system didn't have this syntax, the similar guard was done just
before using the class.
