### PR TITLE
[FIX] event_crm: fix False - False lead creation

### DIFF
--- a/addons/event_crm/models/event_lead_rule.py
+++ b/addons/event_crm/models/event_lead_rule.py
@@ -180,7 +180,7 @@ class EventLeadRule(models.Model):
                                 'description': "%s\n%s" % (lead.description, additionnal_description),
                                 'registration_ids': [(4, reg.id) for reg in group_registrations],
                             })
-                    else:
+                    elif group_registrations:
                         lead_vals_list.append(group_registrations._get_lead_values(rule))
 
         return self.env['crm.lead'].create(lead_vals_list)

--- a/addons/event_crm/tests/test_event_crm_flow.py
+++ b/addons/event_crm/tests/test_event_crm_flow.py
@@ -145,3 +145,23 @@ class TestEventCrmFlow(TestEventCrmCommon):
         })
         self.assertEqual(len(self.event_0.registration_ids), 4)
         self.assertLeadConvertion(self.test_rule_attendee, registration, partner=None)
+
+    @users('user_eventmanager')
+    def test_order_rule_duplicate_lead(self):
+        """ Check when two rules match one event
+            but only one match the registration,
+            only one lead should be created
+        """
+        test_rule_order_2 = self.test_rule_order.copy(default={
+            'event_registration_filter': [['email', 'not ilike', '@test.example.com']]
+        })
+        self.env['event.registration'].create({
+            'name': 'My Registration',
+            'partner_id': False,
+            'email': 'super.email@test.example.com',
+            'phone': False,
+            'mobile': '0456332211',
+            'event_id': self.event_0.id,
+        })
+        self.assertEqual(len(self.test_rule_order.lead_ids), 1)
+        self.assertEqual(len(test_rule_order_2.lead_ids), 0)


### PR DESCRIPTION
Use Case
--------
Have two (or more) rules with mutually exclusive domain for that can be
apply on the same event with lead_creation_basis = order

Create a registration that match one of the rule

Problem
-------
The lead for this rule is created properly but there is also
another lead with the name False - False that is created for the second
rule for which the registration does not match the filter

Solution
--------

Create a lead only when there is a non empty record set in the
registration group



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
