### PR TITLE
[FIX] web_editor: ensure editor in iframe can be scrolled on crop image

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
@@ -17,6 +17,10 @@ body.o_in_iframe {
     background-color: $o-view-background-color;
     display: flex;
 
+    .o_editable {
+        position: relative;
+    }
+
     #oe_snippets {
         top: 0;
     }


### PR DESCRIPTION
The overlay around an image when cropping it is positioned absolutely. If it has no relative ancestor, it will cover the entire body. This is what happend in mass_mailing, making it impossible to scroll the page while cropping. This commit addresses the issue by positioning that editable relatively so that the overlay never goes beyond its bounds.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
