### PR TITLE
[FIX] link_tracker: Compute URL with char tracking fields

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -83,8 +83,11 @@ class LinkTracker(models.Model):
         for tracker in self:
             parsed = urls.url_parse(tracker.url)
             utms = {}
-            for key, field, cook in self.env['utm.mixin'].tracking_fields():
-                attr = getattr(tracker, field).name
+            for key, field_name, cook in self.env['utm.mixin'].tracking_fields():
+                field = self._fields[field_name]
+                attr = getattr(tracker, field_name)
+                if field.type == 'many2one':
+                    attr = attr.name
                 if attr:
                     utms[key] = attr
             utms.update(parsed.decode_query())


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When extending utm.mixin with a field which is not relational, the link_tracker fails to generate the URL.

Current behavior before PR:
addons/utm/models/utm_mixin.py doesn't assume the type of tracking fields, but link tracker does. So when a field of type char is added to the list, we have an error only in link_tracker.
Link to related issue: https://www.odoo.com/my/task/2494686

Desired behavior after PR is merged:
Handle fields of type char in utm.mixin model by link_tracker.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
