### PR TITLE
[IMP] l10n_latam_base: performance improvement default `l10n_latam_identification_type_id`

### DIFF
--- a/addons/l10n_latam_base/__init__.py
+++ b/addons/l10n_latam_base/__init__.py
@@ -5,4 +5,10 @@ from odoo import api, SUPERUSER_ID
 
 def _set_default_identification_type(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    env['res.partner'].search([]).write({'l10n_latam_identification_type_id': env.ref('l10n_latam_base.it_vat').id})
+    env.cr.execute(
+        """
+            UPDATE res_partner
+               SET l10n_latam_identification_type_id = %s
+        """,
+        [env.ref('l10n_latam_base.it_vat').id]
+    )


### PR DESCRIPTION
This revision solves two things:
 - On installation of `l10n_latam_base`,
   `l10n_latam_base` is set as default as `l10n_latam_identification_type_id`
   for all partners in the database.
   The ORM method `write` was used to do so.
   With a database having a large number of partners,
   such as multiple hundred of thousands,
   this leaded to performance issues when `l10n_latam_base`
   got installed.
   I checked compute methods that could depends on this field,
   and the only one I found is `_compute_l10n_ar_vat`,
   which is not yet `installed/loaded` when this posthook takes place,
   as it's in the module `l10n_ar` which depends on `l10n_latam_base`
   and therefore is loaded after. So, it was already not executed/computed
   when using the ORM `write` method before this revision.
   Therefore, the use of plain SQL can be used to speed up the performance.
 - Also, the ORM `write` triggered unexpected compute fields
   which could raise exceptions, because of the `commercial_partner_id`
   synchronization.
   For instance:
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/14.0/odoo/service/server.py", line 1198, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 455, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 348, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 239, in load_module_graph
    getattr(py_module, post_init)(cr, registry)
  File "/home/odoo/src/odoo/14.0/addons/l10n_latam_base/__init__.py", line 8, in _set_default_identification_type
    env['res.partner'].search([]).write({'l10n_latam_identification_type_id': env.ref('l10n_latam_base.it_vat').id})
  File "/home/odoo/src/odoo/14.0/addons/base_vat/models/res_partner.py", line 538, in write
    return super(ResPartner, self).write(values)
  File "/home/odoo/src/odoo/14.0/addons/snailmail/models/res_partner.py", line 26, in write
    return super(ResPartner, self).write(vals)
  File "/home/odoo/src/odoo/14.0/addons/partner_autocomplete/models/res_partner.py", line 199, in write
    res = super(ResPartner, self).write(values)
  File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/res_partner.py", line 550, in write
    partner._fields_sync(vals)
  File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/res_partner.py", line 469, in _fields_sync
    self._children_sync(values)
  File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/res_partner.py", line 478, in _children_sync
    self._commercial_sync_to_children()
  File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/res_partner.py", line 452, in _commercial_sync_to_children
    sync_children._compute_commercial_partner()
  File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/res_partner.py", line 297, in _compute_commercial_partner
    partner.commercial_partner_id = partner.parent_id.commercial_partner_id
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1127, in __set__
    records.write({self.name: write_value})
  File "/home/odoo/src/odoo/14.0/addons/base_vat/models/res_partner.py", line 538, in write
    return super(ResPartner, self).write(values)
  File "/home/odoo/src/odoo/14.0/addons/snailmail/models/res_partner.py", line 26, in write
    return super(ResPartner, self).write(vals)
  File "/home/odoo/src/odoo/14.0/addons/partner_autocomplete/models/res_partner.py", line 199, in write
    res = super(ResPartner, self).write(values)
  File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/res_partner.py", line 546, in write
    result = result and super(Partner, self).write(vals)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_activity.py", line 766, in write
    return super(MailActivityMixin, self).write(vals)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_thread.py", line 322, in write
    result = super(MailThread, self).write(values)
  File "/home/odoo/src/odoo/14.0/addons/website/models/mixins.py", line 182, in write
    return super(WebsitePublishedMixin, self).write(values)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3640, in write
    self.modified(relational_names, before=True)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5786, in modified
    tocompute = list(tocompute)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5862, in _modified_triggers
    yield from records._modified_triggers(val)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5858, in _modified_triggers
    records |= model.search([(key.name, 'in', real_records.ids)], order='id')
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 1708, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4492, in _search
    self._flush_search(args, order=order)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4470, in _flush_search
    self.env[model_name].flush(field_names)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5442, in flush
    self.recompute(fnames, records=records)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5908, in recompute
    process(field)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5879, in process
    field.recompute(recs)
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1145, in recompute
    self.compute_value(record)
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1175, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4068, in _compute_field_value
    self.filtered('id')._validate_fields(fnames)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 1260, in _validate_fields
    check(self)
  File "/home/odoo/src/odoo/14.0/addons/sale_project/models/project.py", line 70, in _check_sale_line_type
    product_id=task.sale_line_id.product_id.display_name,
odoo.exceptions.ValidationError: You cannot link the order item SO/2019/11374 - [COMOD2H] Servicio de Correctivo dos Horas to this task because it is a re-invoiced expense.
```
upg-11324
