### PR TITLE
Fix product _compute_quantities context dependencies

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -95,7 +95,7 @@ class Product(models.Model):
     @api.depends('stock_move_ids.product_qty', 'stock_move_ids.state')
     @api.depends_context(
         'lot_id', 'owner_id', 'package_id', 'from_date', 'to_date',
-        'company_owned', 'force_company',
+        'company_owned', 'force_company', 'location', 'warehouse'
     )
     def _compute_quantities(self):
         products = self.filtered(lambda p: p.type != 'service')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
_compute_quantities calls _compute_quantities_dict which calls _get_domain_locations, this last function depends also on 'location' and 'warehouse' from context, so also this variables should be put in the depends_context decorator

Current behavior before PR:
product.qty_available and product.with_context(location=x).qty_available return the same value also if the product in stored in more than one location
Desired behavior after PR is merged:
product.with_context(location=x).qty_available should return the quantity available only in location x

This has been already fixed in 14.0.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
