### PR TITLE
[IMP] mail: add retry button for multiple records

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -100,6 +100,9 @@ class MailMail(models.Model):
             self = self.with_context(dict(self._context, default_type=None))
         return super(MailMail, self).default_get(fields)
 
+    def action_retry(self):
+        self.filtered(lambda mail: mail.state == 'exception').mark_outgoing()
+
     def mark_outgoing(self):
         return self.write({'state': 'outgoing'})
 

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -67,6 +67,9 @@
             <field name="model">mail.mail</field>
             <field name="arch" type="xml">
                 <tree string="Emails" decoration-muted="state in ('sent', 'cancel')" decoration-info="state=='outgoing'" decoration-danger="state=='exception'">
+                    <header>
+                        <button name="action_retry" string="Retry" type="object"/>
+                    </header>
                     <field name="date"/>
                     <field name="subject"/>
                     <field name="author_id" string="User"/>


### PR DESCRIPTION
Add a retry button to enable the user to try and resend multiple emails at once,
purpose is to allow users to easily send back multiple emails which crashed for
a "one-shot" reason instead of asking them to resubmit them one by one.

Task-2492990

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
