### PR TITLE
[FIX] account: create account move line from its form

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3538,7 +3538,7 @@ class AccountMoveLine(models.Model):
     def _onchange_amount_currency(self):
         for line in self:
             company = line.move_id.company_id
-            balance = line.currency_id._convert(line.amount_currency, company.currency_id, company, line.move_id.date)
+            balance = line.currency_id._convert(line.amount_currency, company.currency_id, company, line.move_id.date) if line.currency_id else line.amount_currency
             line.debit = balance if balance > 0.0 else 0.0
             line.credit = -balance if balance < 0.0 else 0.0
 
@@ -3559,7 +3559,7 @@ class AccountMoveLine(models.Model):
 
     @api.onchange('currency_id')
     def _onchange_currency(self):
-        for line in self:
+        for line in self.filtered(lambda l: l.currency_id):
             company = line.move_id.company_id
 
             if line.move_id.is_invoice(include_receipts=True):


### PR DESCRIPTION
Requesting the form for a new account move line may lead to an error
with a traceback.

To reproduce the error:
(Use demo data)
1. In Settings, enable "Analytic Accounting"
2. Accounting > Configuration > Analytic Accounts > Administrative >
Cost/Revenue
3. Create a new one
4. In "Journal Item" field, enter a new journal item name and, in the
suggestions list, click on "Create"

Error: an Odoo Error with a traceback is displayed ("[...]
AssertionError: convert amount from unknown currency")

When clicking on 'Create', this leads to the creation form opening.
Therefore, the `onchange` methods are triggered. Because of
https://github.com/odoo/odoo/blob/4b0f86107e9ecaf734ebc95ccc0013cc25c65e64/addons/account/views/account_move_views.xml#L61-L64
`_onchange_amount_currency` and `_onchange_currency` are called. Both of
these methods execute such a line:
```python
balance = line.currency_id._convert(line.amount_currency, ...
```
However, `line.currency_id` is not yet defined. Therefore, in `_convert`
method, an error will be raised because of:
https://github.com/odoo/odoo/blob/24ab21811ef71f75a24fdeb441c299435789e8fb/odoo/addons/base/models/res_currency.py#L190

OPW-2481197