### PR TITLE
[FIX] web: Allow m2m checkboxes widget without values

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2556,7 +2556,7 @@ var FieldMany2ManyCheckBoxes = AbstractField.extend({
     limit: 100000,
     init: function () {
         this._super.apply(this, arguments);
-        this.m2mValues = this.record.specialData[this.name];
+        this.m2mValues = this.record.specialData[this.name] || [];
     },
 
     //--------------------------------------------------------------------------
@@ -2576,7 +2576,7 @@ var FieldMany2ManyCheckBoxes = AbstractField.extend({
      */
     _renderCheckboxes: function () {
         var self = this;
-        this.m2mValues = this.record.specialData[this.name];
+        this.m2mValues = this.record.specialData[this.name] || [];
         this.$el.html(qweb.render(this.template, {widget: this}));
         _.each(this.value.res_ids, function (id) {
             self.$('input[data-record-id="' + id + '"]').prop('checked', true);


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Go to any list view
    2. Add a many2many field (existing or new)
    3. Select the column of this newly added field
    4. Select for Widget = many2many_checkboxes

What is currently happening ?

    Qweb2 error and whole view is not accessible anymore.

Why is this happening ?

    A foreach is done on an array containing all the m2m values, but in the case where there are no values, the array does not exist

How to fix the bug ?

    Add an empty array by default

opw-2497876