### PR TITLE
[FIX] web_editor: preserve note-editable class on editable in iframe

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -121,7 +121,7 @@ Wysiwyg.include({
 
                 const $iframeWrapper = $('<div class="iframe-editor-wrapper">');
                 const $codeview = $('<textarea class="o_codeview d-none"/>');
-                self.$editable.attr('class', 'o_editable oe_structure');
+                self.$editable.addClass('o_editable oe_structure');
 
                 $iframeTarget.append($iframeWrapper);
                 $iframeTarget.append($utilsZone);


### PR DESCRIPTION
The "note-editable" class was lost on the editable element when loading it into an iframe. As a result, some selectors failed, making 
it so that some options wouldn't activate when they should.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
