### PR TITLE
[FIX] account: fix a domain in the carryover lines model

### DIFF
--- a/addons/account/models/account_tax_carryover_line.py
+++ b/addons/account/models/account_tax_carryover_line.py
@@ -17,9 +17,9 @@ class AccountTaxCarryoverLine(models.Model):
     foreign_vat_fiscal_position_id = fields.Many2one(comodel_name='account.fiscal.position',
                                                      string='Fiscal position',
                                                      help="The foreign fiscal position for which this carryover is made.",
-                                                     domain=[('company_id', '=', company_id),
-                                                             ('country_id', '=', tax_report_country_id),
-                                                             ('foreign_vat', '!=', False)])
+                                                     domain="[('company_id', '=', company_id), "
+                                                            "('country_id', '=', tax_report_country_id), "
+                                                            "('foreign_vat', '!=', False)]")
 
     @api.constrains('foreign_vat_fiscal_position_id')
     def _check_fiscal_position(self):


### PR DESCRIPTION
The domain for the fiscal position in the carryover lines was incorrect,
missing the required quotes.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
