### PR TITLE
[IMP] l10_fr_reports: carry over tax grid 27 to tax grid 22

### DIFF
--- a/addons/account/models/account_tax_carryover_line.py
+++ b/addons/account/models/account_tax_carryover_line.py
@@ -2,6 +2,7 @@ from odoo import api, fields, models, _
 
 from odoo.exceptions import ValidationError
 
+
 class AccountTaxCarryoverLine(models.Model):
     _name = 'account.tax.carryover.line'
     _description = 'Tax carryover line'
@@ -9,17 +10,26 @@ class AccountTaxCarryoverLine(models.Model):
     name = fields.Char(required=True)
     amount = fields.Float(required=True, default=0.0)
     date = fields.Date(required=True, default=fields.Date.context_today, readonly=True)
-    tax_report_line_id = fields.Many2one(comodel_name='account.tax.report.line', string="Tax report line")
-    tax_report_country_id = fields.Many2one(related='tax_report_line_id.report_id.country_id')
-    company_id = fields.Many2one(comodel_name='res.company', string='Company',
-                                 required=True,
-                                 default=lambda self: self.env.company)
-    foreign_vat_fiscal_position_id = fields.Many2one(comodel_name='account.fiscal.position',
-                                                     string='Fiscal position',
-                                                     help="The foreign fiscal position for which this carryover is made.",
-                                                     domain="[('company_id', '=', company_id), "
-                                                            "('country_id', '=', tax_report_country_id), "
-                                                            "('foreign_vat', '!=', False)]")
+    tax_report_line_id = fields.Many2one(
+        comodel_name='account.tax.report.line',
+        string="Tax report line",
+        domain="[('report_id', '=', tax_report_id)]",
+    )
+    tax_report_id = fields.Many2one(related='tax_report_line_id.report_id')
+    tax_report_country_id = fields.Many2one(related='tax_report_id.country_id')
+    company_id = fields.Many2one(
+        comodel_name='res.company', string='Company',
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    foreign_vat_fiscal_position_id = fields.Many2one(
+        comodel_name='account.fiscal.position',
+        string="Fiscal position",
+        help="The foreign fiscal position for which this carryover is made.",
+        domain="[('company_id', '=', company_id), "
+               "('country_id', '=', tax_report_country_id), "
+               "('foreign_vat', '!=', False)]",
+    )
 
     @api.constrains('foreign_vat_fiscal_position_id')
     def _check_fiscal_position(self):

--- a/addons/account/views/account_tax_report_views.xml
+++ b/addons/account/views/account_tax_report_views.xml
@@ -56,10 +56,11 @@
                 <tree>
                     <field name="company_id" invisible="1"/>
                     <field name="tax_report_country_id" invisible="1"/>
+                    <field name="tax_report_id" invisible="1"/>
                     <field name="name"/>
                     <field name="date"/>
                     <field name="amount"/>
-                    <field name="foreign_vat_fiscal_position_id"/>
+                    <field name="foreign_vat_fiscal_position_id"  optional="hide"/>
                 </tree>
             </field>
         </record>
@@ -72,6 +73,7 @@
                     <sheet>
                         <group>
                             <group>
+                                <field name="tax_report_id" invisible="1"/>
                                 <field name="name"/>
                                 <field name="tax_report_line_id"/>
                                 <field name="tax_report_country_id"/>
@@ -109,12 +111,14 @@
                             <field name="formula"/>
                         </group>
                     </group>
-                    <group>
+                    <group string="Carryover">
                         <group>
                             <field name="carry_over_condition_method" placeholder="No carryover"/>
+                            <field name="is_carryover_persistent"/>
                         </group>
                         <group>
                             <field name="carry_over_destination_line_id" placeholder="Same report line"/>
+                            <field name="is_carryover_used_in_balance"/>
                         </group>
                     </group>
                     <notebook>

--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -403,6 +403,7 @@
         <field name="parent_id" ref="tax_report_tva_deductible"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">4</field>
+        <field name="is_carryover_used_in_balance">True</field>
     </record>
 
     <record id="tax_report_2C" model="account.tax.report.line">
@@ -486,6 +487,9 @@
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">4</field>
         <field name="formula">box_25 - box_26 - box_AA if box_25 - box_26 - box_AA > 0 else 0</field>
+        <field name="carry_over_condition_method">always_carry_over_and_set_to_0</field>
+        <field name="carry_over_destination_line_id" ref="tax_report_22"/>
+        <field name="is_carryover_persistent">False</field>
     </record>
 
     <record id="tax_report_taxes_a_payer" model="account.tax.report.line">


### PR DESCRIPTION
Using the new carryover feature, improve the french tax report to
properly carryover the values from the tax grid 27 to the tax grid 22
of the next period.

Task id #2452451

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
