### PR TITLE
[IMP] web: manage daterange widget in multi-edit and fix bug in calendar

### DIFF
--- a/addons/web/static/src/js/views/list/list_model.js
+++ b/addons/web/static/src/js/views/list/list_model.js
@@ -40,9 +40,9 @@
          * @param {string} referenceRecordId the record datapoint used to
          *  generate the changes to apply to recordIds
          * @param {string[]} recordIds a list of record datapoint ids
-         * @param {string} fieldName the field to write
+         * @param {string[]} listFieldNames the fields to write
          */
-        saveRecords: function (listDatapointId, referenceRecordId, recordIds, fieldName) {
+        saveRecords: function (listDatapointId, referenceRecordId, recordIds, listFieldNames) {
             var self = this;
             var referenceRecord = this.localData[referenceRecordId];
             var list = this.localData[listDatapointId];
@@ -51,7 +51,11 @@
             // reset same value, we still want to save this value on the other
             // record)
             var allChanges = this._generateChanges(referenceRecord, {changesOnly: false});
-            var changes = _.pick(allChanges, fieldName);
+            const changes = Object.assign({},
+                ...listFieldNames.map(
+                    fieldName => allChanges.hasOwnProperty(fieldName) ? { [fieldName]: allChanges[fieldName] } : {}
+                )
+            );
             var records = recordIds.map(function (recordId) {
                 return self.localData[recordId];
             });

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -872,6 +872,19 @@
     </main>
 </t>
 
+<t t-name="ListView.confirmModal.relatedField">
+    <tr>
+        <td>Field:</td>
+        <td><t t-esc="fieldLabel"/></td>
+    </tr>
+    <tr>
+        <td>Update to:</td>
+        <td>
+            <div class="o_changes_related_widget"/>
+        </td>
+    </tr>
+</t>
+
 <t t-name="FormView.buttons">
     <div class="o_form_buttons_view" role="toolbar" aria-label="Main actions">
         <button t-if="widget.is_action_enabled('edit')" type="button"


### PR DESCRIPTION
## Use daterange widget in multi-edit in list view

Currently, the multi-edit allows the user to change only the
field that he edits. So, when the user uses the daterange widget,
and select the date range, only one of two dates are updated by the
multi-edit.

The manage of daterange widget has been improved in the multi-edit 
mode to allow the user to update the both dates linked in this widget.

task-2463722

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
