### PR TITLE
[FIX] web_editor: ensure document filename doesn't overflow its cell

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -274,6 +274,10 @@ body .modal {
                     }
                 }
 
+                .o_file_name {
+                    @include o-text-overflow;
+                }
+
                 &:hover {
                     .o_existing_attachment_optimize, .o_existing_attachment_remove {
                         opacity: 1;


### PR DESCRIPTION
The media modal's document tab has cells with icons and filenames. If the filename was too long, it would overflow its cell, which caused an ugly design glitch. This ensures an ellipsis on the filename when it is too long.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
