### PR TITLE
[FIX] web: cursor:default on many2many tags

### DIFF
--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -103,7 +103,6 @@
             flex: 0 0 auto;
             border: 0;
             font-size: 12px;
-            cursor: pointer;
             user-select: none;
 
             a {


### PR DESCRIPTION
currently, when we hovering badge of many2many field, the cursor is pointer
(i.e. a hand)

after this commit, when we hovering badge of many2many field, the cursor is not
pointer(i.e. a hand) now it shows default cursor(i.e. arrow).

Task: 2515190

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
