### PR TITLE
[FIX] mail.py: sanitize do not remove file icon


### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -50,7 +50,7 @@ safe_attrs = clean.defs.safe_attrs | frozenset(
      'data-o-mail-quote',  # quote detection
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-id', 'data-oe-nodeid',
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
-     'data-class',
+     'data-class', 'data-mimetype',
      ])
 
 


### PR DESCRIPTION

Scenario:

- add a file in mass mailing editor => an icon is added linking the file
- save
- edit => the icon is replaced by a generic icon
- save
- send mail => no icon is shown in email received

The system is using eg. `data-mimetype="pdf"` to show the icon, before
12.0 this worked but in saas-12.3 the system uses mailing.mailing
body_arch's field that is sanitizing attributes and remove it on save,
so the icon is only working in received email if you save one and only
one time after adding file inside the mass mailing.

opw-2474053 (ticket for similar issue in 14.0)
