### PR TITLE
Fix webclient boot when user has not apps available

### DIFF
--- a/addons/web/static/src/js/chrome/apps_menu.js
+++ b/addons/web/static/src/js/chrome/apps_menu.js
@@ -38,14 +38,17 @@ var AppsMenu = Widget.extend({
         return this._apps;
     },
     /**
-     * Open the first app in the list of apps
+     * Open the first app in the list of apps. Returns whether one was found.
+     *
+     * @returns {Boolean}
      */
     openFirstApp: function () {
         if (!this._apps.length) {
-            return
+            return false
         }
         var firstApp = this._apps[0];
         this._openApp(firstApp);
+        return true
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/chrome/apps_menu.js
+++ b/addons/web/static/src/js/chrome/apps_menu.js
@@ -44,11 +44,11 @@ var AppsMenu = Widget.extend({
      */
     openFirstApp: function () {
         if (!this._apps.length) {
-            return false
+            return false;
         }
         var firstApp = this._apps[0];
         this._openApp(firstApp);
-        return true
+        return true;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/chrome/menu.js
+++ b/addons/web/static/src/js/chrome/menu.js
@@ -197,10 +197,12 @@ var Menu = Widget.extend({
         return this.current_primary_menu;
     },
     /**
-     * Open the first app
+     * Open the first app, returns whether an application was found.
+     *
+     * @returns {Boolean}
      */
     openFirstApp: function () {
-        this._appsMenu.openFirstApp();
+        return this._appsMenu.openFirstApp();
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/chrome/web_client.js
+++ b/addons/web/static/src/js/chrome/web_client.js
@@ -74,36 +74,31 @@ return AbstractWebClient.extend({
                 return menuData;
             });
     },
-    show_application: function () {
-        var self = this;
+    async show_application() {
         this.set_title();
 
-        return this.menu_dp.add(this.instanciate_menu_widgets()).then(function () {
-            $(window).bind('hashchange', self.on_hashchange);
+        await this.menu_dp.add(this.instanciate_menu_widgets());
+        $(window).bind('hashchange', this.on_hashchange);
 
-            // If the url's state is empty, we execute the user's home action if there is one (we
-            // show the first app if not)
-            var state = $.bbq.getState(true);
-            if (_.keys(state).length === 1 && _.keys(state)[0] === "cids") {
-                return self.menu_dp.add(self._rpc({
-                        model: 'res.users',
-                        method: 'read',
-                        args: [session.uid, ["action_id"]],
-                    }))
-                    .then(function (result) {
-                        var data = result[0];
-                        if (data.action_id) {
-                            return self.do_action(data.action_id[0]).then(function () {
-                                self.menu.change_menu_section(self.menu.action_id_to_primary_menu_id(data.action_id[0]));
-                            });
-                        } else {
-                            self.menu.openFirstApp();
-                        }
-                    });
-            } else {
-                return self.on_hashchange();
-            }
-        });
+        const state = $.bbq.getState(true);
+        if (!_.isEqual(_.keys(state), ["cids"])) {
+            return this.on_hashchange();
+        }
+
+        const [data] = await this.menu_dp.add(this._rpc({
+            model: 'res.users',
+            method: 'read',
+            args: [session.uid, ["action_id"]],
+        }));
+        if (data.action_id) {
+            await this.do_action(data.action_id[0]);
+            this.menu.change_menu_section(this.menu.action_id_to_primary_menu_id(data.action_id[0]));
+            return;
+        }
+
+        if (!this.menu.openFirstApp()) {
+            this.trigger_up('webclient_started');
+        }
     },
 
     instanciate_menu_widgets: function () {


### PR DESCRIPTION
This mostly an issue when trying to run just the tests of `web` (aka `-iweb`) with only community modules available, `TestMenusDemoLight.test_01_click_apps_menus_as_demo`, wait for the ready code times out:

    AssertionError: False is not true : The ready "odoo.isReady === true" code was always falsy

and the test suite fails.

The ready code simply checks that `odoo.isReady` is set. The web client sets `isReady` when `webclient_started` is triggered (specifically in `_onWebClientStarted`, which is the handler for that event).

[The community web client only triggers `webclient_started` at the end of `doAction`][0] meaning the community client is considered ready until after the first action has executed.

[The first action is executed by `show_application`][1] whose process is the following:

1. load and initialize the menus
2. if an action is specified in the URL, run that
3. otherwise if the user has a home action, run that
4. otherwise run the first menu's action

When installing only `web`, the only menus which could be available are Apps and Settings, and the demo user has access to neither. This means the demo user has no applications, and opening the first app is a no-op ([`openFirstApp` has a case just for that situation to ensure it does nothing][2]). As a result, `webclient_started` is never
triggered, `_onWebClientStarted` is never called, `odoo.isReady` is never set, and the tour never runs.

Fix by updating `openFirstApp` to return *whether* it opened an application, and in `show_application` the last fallback if even opening the first application failed is to just declare the web client ready.

While at it, rewrite `show_application` using ES6 facilities and flatten and linearize it using guards. This means the code pretty much tracks the process described above, with one step added:

5. otherwise complete the webclient's startup

[0]: https://github.com/odoo/odoo/blob/1eb474243b55f1b9e10c70d199bbe022e68b51d0/addons/web/static/src/js/chrome/action_manager.js#L174
[1]: https://github.com/odoo/odoo/blob/d1c56ec7c435c5baba8604feccc6116e4c25ca96/addons/web/static/src/js/chrome/web_client.js#L77-L107
[2]: https://github.com/odoo/odoo/blob/e24ab17d38fb049404f04112990e8b2fe1dd7727/addons/web/static/src/js/chrome/apps_menu.js#L44-L46