### PR TITLE
[FIX] account: Wrong amount of tax with different currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -580,7 +580,7 @@ class AccountMove(models.Model):
                 quantity = 1.0
                 tax_type = base_line.tax_ids[0].type_tax_use if base_line.tax_ids else None
                 is_refund = (tax_type == 'sale' and base_line.debit) or (tax_type == 'purchase' and base_line.credit)
-                price_unit_wo_discount = base_line.balance
+                price_unit_wo_discount = base_line.amount_currency
 
             balance_taxes_res = base_line.tax_ids._origin.with_context(force_sign=move._get_tax_force_sign()).compute_all(
                 price_unit_wo_discount,


### PR DESCRIPTION
Steps to reproduce the bug:

- Create an accounting entry AE with $ as default currency
- Add a line L1 with 10 € and a tax of 15%

Bug:

The added tax line was 0.75€ instead of 1.5€

opw:2510338