### PR TITLE
[IMP] core: speed up registry setup

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -215,7 +215,7 @@ class AccountBankStatement(models.Model):
     date = fields.Date(required=True, states={'confirm': [('readonly', True)]}, index=True, copy=False, default=fields.Date.context_today)
     date_done = fields.Datetime(string="Closed On")
     balance_start = fields.Monetary(string='Starting Balance', states={'confirm': [('readonly', True)]}, compute='_compute_starting_balance', readonly=False, store=True)
-    balance_end_real = fields.Monetary('Ending Balance', states={'confirm': [('readonly', True)]}, compute='_compute_ending_balance', readonly=False, store=True)
+    balance_end_real = fields.Monetary('Ending Balance', states={'confirm': [('readonly', True)]}, compute='_compute_ending_balance', recursive=True, readonly=False, store=True)
     state = fields.Selection(string='Status', required=True, readonly=True, copy=False, selection=[
             ('open', 'New'),
             ('posted', 'Processing'),

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -355,8 +355,8 @@ class AccountMove(models.Model):
             return current_ids != after_write_ids
         if field.type == 'one2many':
             return True
-        if field.type == 'monetary' and record[field.currency_field]:
-            return not record[field.currency_field].is_zero(record[field_name] - vals[field_name])
+        if field.type == 'monetary' and record[field.get_currency_field(record)]:
+            return not record[field.get_currency_field(record)].is_zero(record[field_name] - vals[field_name])
         if field.type == 'float':
             record_value = field.convert_to_cache(record[field_name], record)
             to_write_value = field.convert_to_cache(vals[field_name], record)

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -43,7 +43,7 @@ class AccountAnalyticGroup(models.Model):
     parent_id = fields.Many2one('account.analytic.group', string="Parent", ondelete='cascade', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     parent_path = fields.Char(index=True)
     children_ids = fields.One2many('account.analytic.group', 'parent_id', string="Childrens")
-    complete_name = fields.Char('Complete Name', compute='_compute_complete_name', store=True)
+    complete_name = fields.Char('Complete Name', compute='_compute_complete_name', recursive=True, store=True)
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
 
     @api.depends('name', 'parent_id.complete_name')

--- a/addons/base_sparse_field/models/fields.py
+++ b/addons/base_sparse_field/models/fields.py
@@ -35,8 +35,8 @@ fields.Field.__doc__ += """
 fields.Field.sparse = None
 
 @monkey_patch(fields.Field)
-def _get_attrs(self, model, name):
-    attrs = _get_attrs.super(self, model, name)
+def _get_attrs(self, model_class, name):
+    attrs = _get_attrs.super(self, model_class, name)
     if attrs.get('sparse'):
         # by default, sparse fields are not stored and not copied
         attrs['store'] = False

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -51,7 +51,7 @@ class Team(models.Model):
         string='Overdue Opportunities Revenues', compute='_compute_opportunities_overdue_data',)
     # alias: improve fields coming from _inherits, use inherited to avoid replacing them
     alias_user_id = fields.Many2one(
-        'res.users', related='alias_id.alias_user_id', inherited=True,
+        'res.users', related='alias_id.alias_user_id', readonly=False, inherited=True,
         domain=lambda self: [('groups_id', 'in', self.env.ref('sales_team.group_sale_salesman_all_leads').id)])
 
     @api.depends('crm_team_member_ids.assignment_max')

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -13,7 +13,7 @@ class Department(models.Model):
     _rec_name = 'complete_name'
 
     name = fields.Char('Department Name', required=True)
-    complete_name = fields.Char('Complete Name', compute='_compute_complete_name', store=True)
+    complete_name = fields.Char('Complete Name', compute='_compute_complete_name', recursive=True, store=True)
     active = fields.Boolean('Active', default=True)
     company_id = fields.Many2one('res.company', string='Company', index=True, default=lambda self: self.env.company)
     parent_id = fields.Many2one('hr.department', string='Parent Department', index=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")

--- a/addons/hr_org_chart/models/hr_org_chart_mixin.py
+++ b/addons/hr_org_chart/models/hr_org_chart_mixin.py
@@ -9,7 +9,7 @@ class HrEmployeeBase(models.AbstractModel):
 
     child_all_count = fields.Integer(
         'Indirect Subordinates Count',
-        compute='_compute_subordinates', store=False,
+        compute='_compute_subordinates', recursive=True, store=False,
         compute_sudo=True)
 
     def _get_subordinates(self, parents=None):

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -110,7 +110,7 @@ class Task(models.Model):
     total_hours_spent = fields.Float("Total Hours", compute='_compute_total_hours_spent', store=True, help="Time spent on this task, including its sub-tasks.")
     progress = fields.Float("Progress", compute='_compute_progress_hours', store=True, group_operator="avg", help="Display progress of current task.")
     overtime = fields.Float(compute='_compute_progress_hours', store=True)
-    subtask_effective_hours = fields.Float("Sub-tasks Hours Spent", compute='_compute_subtask_effective_hours', store=True, help="Time spent on the sub-tasks (and their own sub-tasks) of this task.")
+    subtask_effective_hours = fields.Float("Sub-tasks Hours Spent", compute='_compute_subtask_effective_hours', recursive=True, store=True, help="Time spent on the sub-tasks (and their own sub-tasks) of this task.")
     timesheet_ids = fields.One2many('account.analytic.line', 'task_id', 'Timesheets')
     encode_uom_in_days = fields.Boolean(compute='_compute_encode_uom_in_days', default=lambda self: self._uom_in_days())
 

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -25,7 +25,7 @@ class ProductCategory(models.Model):
 
     name = fields.Char('Name', index=True, required=True)
     complete_name = fields.Char(
-        'Complete Name', compute='_compute_complete_name',
+        'Complete Name', compute='_compute_complete_name', recursive=True,
         store=True)
     parent_id = fields.Many2one('product.category', 'Parent Category', index=True, ondelete='cascade')
     parent_path = fields.Char(index=True)

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -583,7 +583,7 @@ class Task(models.Model):
         copy=False,
         readonly=True)
     project_id = fields.Many2one('project.project', string='Project',
-        compute='_compute_project_id', store=True, readonly=False,
+        compute='_compute_project_id', recursive=True, store=True, readonly=False,
         index=True, tracking=True, check_company=True, change_default=True)
     # Defines in which project the task will be displayed / taken into account in statistics.
     # Example: 1 task A with 1 subtask B in project P
@@ -599,7 +599,7 @@ class Task(models.Model):
         index=True, tracking=True)
     partner_id = fields.Many2one('res.partner',
         string='Customer',
-        compute='_compute_partner_id', store=True, readonly=False,
+        compute='_compute_partner_id', recursive=True, store=True, readonly=False,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     partner_is_company = fields.Boolean(related='partner_id.is_company', readonly=True)
     commercial_partner_id = fields.Many2one(related='partner_id.commercial_partner_id')
@@ -630,7 +630,7 @@ class Task(models.Model):
     allow_subtasks = fields.Boolean(string="Allow Sub-tasks", related="project_id.allow_subtasks", readonly=True)
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count')
     email_from = fields.Char(string='Email From', help="These people will receive email.", index=True,
-        compute='_compute_email_from', store="True", readonly=False)
+        compute='_compute_email_from', recursive=True, store=True, readonly=False)
     project_privacy_visibility = fields.Selection(related='project_id.privacy_visibility', string="Project Visibility")
     # Computed field about working time elapsed between record creation and assignation/closing.
     working_hours_open = fields.Float(compute='_compute_elapsed', string='Working Hours to Assign', store=True, group_operator="avg")

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -48,7 +48,7 @@ class ProjectTask(models.Model):
     sale_order_id = fields.Many2one('sale.order', 'Sales Order', help="Sales order to which the task is linked.")
     sale_line_id = fields.Many2one(
         'sale.order.line', 'Sales Order Item', domain="[('is_service', '=', True), ('order_partner_id', 'child_of', commercial_partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]",
-        compute='_compute_sale_line', store=True, readonly=False, copy=False,
+        compute='_compute_sale_line', recursive=True, store=True, readonly=False, copy=False,
         help="Sales order item to which the project is linked. Link the timesheet entry to the sales order item defined on the project. "
         "Only applies on tasks without sale order item defined, and if the employee is not in the 'Employee/Sales Order Item Mapping' of the project.")
     project_sale_order_id = fields.Many2one('sale.order', string="Project's sale order", related='project_id.sale_order_id')

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -29,7 +29,7 @@ class Location(models.Model):
         return res
 
     name = fields.Char('Location Name', required=True)
-    complete_name = fields.Char("Full Location Name", compute='_compute_complete_name', store=True)
+    complete_name = fields.Char("Full Location Name", compute='_compute_complete_name', recursive=True, store=True)
     active = fields.Boolean('Active', default=True, help="By unchecking the active field, you may hide a location without deleting it.")
     usage = fields.Selection([
         ('supplier', 'Vendor Location'),
@@ -70,7 +70,7 @@ class Location(models.Model):
     last_inventory_date = fields.Date("Last Effective Inventory", readonly=True, help="Date of the last inventory at this location.")
     next_inventory_date = fields.Date("Next Expected Inventory", compute="_compute_next_inventory_date", store=True, help="Date for next planned inventory based on cyclic schedule.")
     warehouse_view_ids = fields.One2many('stock.warehouse', 'view_location_id', readonly=True)
-    warehouse_id = fields.Many2one('stock.warehouse', compute='_compute_warehouse_id')
+    warehouse_id = fields.Many2one('stock.warehouse', compute='_compute_warehouse_id', recursive=True)
     storage_category_id = fields.Many2one('stock.storage.category', string='Storage Category')
     outgoing_move_line_ids = fields.One2many('stock.move.line', 'location_id', help='Technical: used to compute weight.')
     incoming_move_line_ids = fields.One2many('stock.move.line', 'location_dest_id', help='Technical: used to compute weight.')

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -241,7 +241,7 @@ class WebsiteSnippetFilter(models.Model):
                 elif field_widget == 'monetary':
                     model_currency = None
                     if field and field.type == 'monetary':
-                        model_currency = record[record[field_name].currency_field]
+                        model_currency = record[field.get_currency_field(record)]
                     elif 'currency_id' in model._fields:
                         model_currency = record['currency_id']
                     if model_currency:

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -34,7 +34,7 @@ class TestStandardPerformance(UtilPerf):
     def test_10_perf_sql_img_controller(self):
         self.authenticate('demo', 'demo')
         url = '/web/image/res.users/2/image_256'
-        self.assertEqual(self._get_url_hot_query(url), 7)
+        self.assertEqual(self._get_url_hot_query(url), 6)
 
     def test_20_perf_sql_img_controller_bis(self):
         url = '/web/image/website/1/favicon'

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -47,6 +47,12 @@ class TestLivechatBasicFlowHttpCase(tests.HttpCase, TestLivechatCommon):
         # Remove livechat_username
         self.operator.livechat_username = False
 
+        # This fixes an issue in the controller, possibly related to the testing
+        # environment.  The business code unexpectedly uses two cache objects
+        # (env.cache), which triggers cache misses: a field is computed with its
+        # value stored into one cache and retrieved from another cache :-/
+        self.operator.name
+
         # Open a new live chat
         res = self.opener.post(url=self.open_chat_url, json=self.open_chat_params)
         self.assertEqual(res.status_code, 200)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1573,7 +1573,7 @@ class IrModelConstraint(models.Model):
         constraint_module = {
             constraint[0]: cls._module
             for cls in reversed(type(model).mro())
-            if not getattr(cls, 'pool', None)
+            if models.is_definition_class(cls)
             for constraint in getattr(cls, '_local_sql_constraints', ())
         }
 

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -460,8 +460,8 @@ class MonetaryConverter(models.AbstractModel):
         #currency should be specified by monetary field
         field = record._fields[field_name]
 
-        if not options.get('display_currency') and field.type == 'monetary' and field.currency_field:
-            options['display_currency'] = record[field.currency_field]
+        if not options.get('display_currency') and field.type == 'monetary' and field.get_currency_field(record):
+            options['display_currency'] = record[field.get_currency_field(record)]
         if not options.get('display_currency'):
             # search on the model if they are a res.currency field to set as default
             fields = record._fields.items()

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -280,6 +280,7 @@ class IrRule(models.Model):
 # 'global' is a Python keyword. Therefore, we add it to the class by assignment.
 # Note that the attribute '_module' is normally added by the class' metaclass.
 #
-setattr(IrRule, 'global',
-        fields.Boolean(compute='_compute_global', store=True, _module=IrRule._module,
-                       help="If no group is specified the rule is global and applied to everyone"))
+global_ = fields.Boolean(compute='_compute_global', store=True,
+                         help="If no group is specified the rule is global and applied to everyone")
+setattr(IrRule, 'global', global_)
+global_.__set_name__(IrRule, 'global')

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -35,7 +35,7 @@ class IrUiMenu(models.Model):
                                  'menu_id', 'gid', string='Groups',
                                  help="If you have groups, the visibility of this menu will be based on these groups. "\
                                       "If this field is empty, Odoo will compute visibility based on the related object's read access.")
-    complete_name = fields.Char(compute='_compute_complete_name', string='Full Path')
+    complete_name = fields.Char(string='Full Path', compute='_compute_complete_name', recursive=True)
     web_icon = fields.Char(string='Web Icon File')
     action = fields.Reference(selection=[('ir.actions.report', 'ir.actions.report'),
                                          ('ir.actions.act_window', 'ir.actions.act_window'),

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -152,7 +152,7 @@ class Partner(models.Model):
         return values
 
     name = fields.Char(index=True)
-    display_name = fields.Char(compute='_compute_display_name', store=True, index=True)
+    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True, index=True)
     date = fields.Date(index=True)
     title = fields.Many2one('res.partner.title')
     parent_id = fields.Many2one('res.partner', string='Related Company', index=True)
@@ -224,8 +224,9 @@ class Partner(models.Model):
     contact_address = fields.Char(compute='_compute_contact_address', string='Complete Address')
 
     # technical field used for managing commercial fields
-    commercial_partner_id = fields.Many2one('res.partner', compute='_compute_commercial_partner',
-                                             string='Commercial Entity', store=True, index=True)
+    commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity',
+                                            compute='_compute_commercial_partner', recursive=True,
+                                            store=True, index=True)
     commercial_company_name = fields.Char('Company Name Entity', compute='_compute_commercial_company_name',
                                           store=True)
     company_name = fields.Char('Company Name')

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1044,7 +1044,7 @@ class GroupsImplied(models.Model):
     implied_ids = fields.Many2many('res.groups', 'res_groups_implied_rel', 'gid', 'hid',
         string='Inherits', help='Users of this group automatically inherit those groups')
     trans_implied_ids = fields.Many2many('res.groups', string='Transitively inherits',
-        compute='_compute_trans_implied')
+        compute='_compute_trans_implied', recursive=True)
 
     @api.depends('implied_ids.trans_implied_ids')
     def _compute_trans_implied(self):

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -510,8 +510,8 @@ class TestCustomFields(common.TransactionCase):
         })
         query_count = self.cr.sql_log_count - query_count
 
-        # create the related field, and assert it only takes 3 extra queries
-        with self.assertQueryCount(query_count + 3):
+        # create the related field, and assert it only takes 1 extra query
+        with self.assertQueryCount(query_count + 1):
             self.env['ir.model.fields'].create({
                 'model_id': self.env['ir.model']._get_id('res.partner'),
                 'name': 'x_oh_boy',

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -510,8 +510,8 @@ class TestCustomFields(common.TransactionCase):
         })
         query_count = self.cr.sql_log_count - query_count
 
-        # create the related field, and assert it only takes 1 extra query
-        with self.assertQueryCount(query_count + 1):
+        # create the related field, and assert it only takes 3 extra queries
+        with self.assertQueryCount(query_count + 3):
             self.env['ir.model.fields'].create({
                 'model_id': self.env['ir.model']._get_id('res.partner'),
                 'name': 'x_oh_boy',

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -316,14 +316,14 @@ class TestIrModel(TransactionCase):
         """Check that deleting 'x_name' does not crash."""
         record = self.env['x_bananas'].create({'x_name': "Ifan Ben-Mezd"})
         self.assertEqual(record._rec_name, 'x_name')
-        self.assertEqual(record._fields['display_name'].depends, ('x_name',))
+        self.assertEqual(self.registry.field_depends[type(record).display_name], ('x_name',))
         self.assertEqual(record.display_name, "Ifan Ben-Mezd")
 
         # unlinking x_name should fixup _rec_name and display_name
         self.env['ir.model.fields']._get('x_bananas', 'x_name').unlink()
         record = self.env['x_bananas'].browse(record.id)
         self.assertEqual(record._rec_name, None)
-        self.assertEqual(record._fields['display_name'].depends, ())
+        self.assertEqual(self.registry.field_depends[type(record).display_name], ())
         self.assertEqual(record.display_name, f"x_bananas,{record.id}")
 
 

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -64,7 +64,7 @@ class test_inherits(common.TransactionCase):
         field = mother._fields['surname']
 
         # the field dependencies are added
-        self.assertItemsEqual(field.depends, ['name', 'field_in_mother'])
+        self.assertItemsEqual(self.registry.field_depends[field], ['name', 'field_in_mother'])
 
     def test_40_selection_extension(self):
         """ check that attribute selection_add=... extends selection on fields. """

--- a/odoo/addons/test_inherits/tests/test_inherits.py
+++ b/odoo/addons/test_inherits/tests/test_inherits.py
@@ -136,9 +136,9 @@ class test_inherits(common.TransactionCase):
         Box = type(self.env['test.box'])
         Pallet = type(self.env['test.pallet'])
         self.assertTrue(Unit.name.translate)
-        self.assertIn('lang', Unit.display_name.depends_context)
-        self.assertIn('lang', Box.display_name.depends_context)
-        self.assertIn('lang', Pallet.display_name.depends_context)
+        self.assertIn('lang', self.registry.field_depends_context[Unit.display_name])
+        self.assertIn('lang', self.registry.field_depends_context[Box.display_name])
+        self.assertIn('lang', self.registry.field_depends_context[Pallet.display_name])
 
     def test_multi_write_m2o_inherits(self):
         """Verify that an inherits m2o field can be written to in batch"""

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -228,6 +228,7 @@ class Multi(models.Model):
     partner = fields.Many2one('res.partner')
     lines = fields.One2many('test_new_api.multi.line', 'multi')
     partners = fields.One2many(related='partner.child_ids')
+    tags = fields.Many2many('test_new_api.multi.tag', domain=[('name', 'ilike', 'a')])
 
     @api.onchange('name')
     def _onchange_name(self):

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -19,7 +19,8 @@ class Category(models.Model):
     parent = fields.Many2one('test_new_api.category', ondelete='cascade')
     parent_path = fields.Char(index=True)
     root_categ = fields.Many2one(_name, compute='_compute_root_categ')
-    display_name = fields.Char(compute='_compute_display_name', inverse='_inverse_display_name')
+    display_name = fields.Char(compute='_compute_display_name', recursive=True,
+                               inverse='_inverse_display_name')
     dummy = fields.Char(store=False)
     discussions = fields.Many2many('test_new_api.discussion', 'test_new_api_discussion_category',
                                    'category', 'discussion')
@@ -499,8 +500,8 @@ class ComputeRecursive(models.Model):
 
     name = fields.Char(required=True)
     parent = fields.Many2one('test_new_api.recursive', ondelete='cascade')
-    full_name = fields.Char(compute='_compute_full_name')
-    display_name = fields.Char(compute='_compute_display_name', store=True)
+    full_name = fields.Char(compute='_compute_full_name', recursive=True)
+    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True)
 
     @api.depends('name', 'parent.full_name')
     def _compute_full_name(self):
@@ -526,7 +527,7 @@ class ComputeRecursiveTree(models.Model):
     name = fields.Char(required=True)
     parent_id = fields.Many2one('test_new_api.recursive.tree', ondelete='cascade')
     children_ids = fields.One2many('test_new_api.recursive.tree', 'parent_id')
-    display_name = fields.Char(compute='_compute_display_name', store=True)
+    display_name = fields.Char(compute='_compute_display_name', recursive=True, store=True)
 
     @api.depends('name', 'children_ids.display_name')
     def _compute_display_name(self):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2862,12 +2862,12 @@ class TestRequiredMany2one(common.TransactionCase):
         Model = self.env['test_new_api.req_m2o']
         field = Model._fields['foo']
 
-        # invalidate registry to redo the setup afterwards
-        self.registry.registry_invalidated = True
+        # clean up registry after this test
+        self.addCleanup(self.registry.reset_changes)
         self.patch(field, 'ondelete', 'set null')
 
         with self.assertRaises(ValueError):
-            field._setup_regular_base(Model)
+            field.setup_nonrelated(Model)
 
 
 class TestRequiredMany2oneTransient(common.TransactionCase):
@@ -2884,12 +2884,12 @@ class TestRequiredMany2oneTransient(common.TransactionCase):
         Model = self.env['test_new_api.req_m2o_transient']
         field = Model._fields['foo']
 
-        # invalidate registry to redo the setup afterwards
-        self.registry.registry_invalidated = True
+        # clean up registry after this test
+        self.addCleanup(self.registry.reset_changes)
         self.patch(field, 'ondelete', 'set null')
 
         with self.assertRaises(ValueError):
-            field._setup_regular_base(Model)
+            field.setup_nonrelated(Model)
 
 
 @common.tagged('m2oref')

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2042,22 +2042,26 @@ class TestFields(TransactionCaseWithUserDemo):
     def test_93_monetary_related(self):
         """ Check the currency field on related monetary fields. """
         # check base field
-        field = self.env['test_new_api.monetary_base']._fields['amount']
-        self.assertEqual(field.currency_field, 'base_currency_id')
+        model = self.env['test_new_api.monetary_base']
+        field = model._fields['amount']
+        self.assertEqual(field.get_currency_field(model), 'base_currency_id')
 
         # related fields must use the field 'currency_id' or 'x_currency_id'
-        field = self.env['test_new_api.monetary_related']._fields['amount']
+        model = self.env['test_new_api.monetary_related']
+        field = model._fields['amount']
         self.assertEqual(field.related, ('monetary_id', 'amount'))
-        self.assertEqual(field.currency_field, 'currency_id')
+        self.assertEqual(field.get_currency_field(model), 'currency_id')
 
-        field = self.env['test_new_api.monetary_custom']._fields['x_amount']
+        model = self.env['test_new_api.monetary_custom']
+        field = model._fields['x_amount']
         self.assertEqual(field.related, ('monetary_id', 'amount'))
-        self.assertEqual(field.currency_field, 'x_currency_id')
+        self.assertEqual(field.get_currency_field(model), 'x_currency_id')
 
         # inherited field must use the same field as its parent field
-        field = self.env['test_new_api.monetary_inherits']._fields['amount']
+        model = self.env['test_new_api.monetary_inherits']
+        field = model._fields['amount']
         self.assertEqual(field.related, ('monetary_id', 'amount'))
-        self.assertEqual(field.currency_field, 'base_currency_id')
+        self.assertEqual(field.get_currency_field(model), 'base_currency_id')
 
     def test_94_image(self):
         f = io.BytesIO()

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -159,7 +159,7 @@ class TestFields(TransactionCaseWithUserDemo):
             'ttype': 'boolean'
         })
         field = self.env['test_new_api.message']._fields['x_bool_false_computed']
-        self.assertFalse(field.depends)
+        self.assertFalse(self.registry.field_depends[field])
 
     def test_10_computed_custom_invalid_transitive_depends(self):
         self.patch(type(self.env["ir.model.fields"]), "_check_depends", lambda self: True)
@@ -264,7 +264,7 @@ class TestFields(TransactionCaseWithUserDemo):
         field = type(self.env['test_new_api.discussion']).display_name
         self.assertTrue(field.automatic)
         self.assertTrue(field.compute)
-        self.assertEqual(field.depends, ('name',))
+        self.assertEqual(self.registry.field_depends[field], ('name',))
 
     def test_10_non_stored(self):
         """ test non-stored fields """
@@ -517,7 +517,7 @@ class TestFields(TransactionCaseWithUserDemo):
 
     def test_12_dynamic_depends(self):
         Model = self.registry['test_new_api.compute.dynamic.depends']
-        self.assertEqual(Model.full_name.depends, ())
+        self.assertEqual(self.registry.field_depends[Model.full_name], ())
 
         # the dependencies of full_name are stored in a config parameter
         self.env['ir.config_parameter'].set_param('test_new_api.full_name', 'name1,name2')
@@ -525,7 +525,7 @@ class TestFields(TransactionCaseWithUserDemo):
         # this must re-evaluate the field's dependencies
         self.env['base'].flush()
         self.registry.setup_models(self.cr)
-        self.assertEqual(Model.full_name.depends, ('name1', 'name2'))
+        self.assertEqual(self.registry.field_depends[Model.full_name], ('name1', 'name2'))
 
     def test_13_inverse(self):
         """ test inverse computation of fields """

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -54,17 +54,18 @@ def first(records):
 
 def resolve_mro(model, name, predicate):
     """ Return the list of successively overridden values of attribute ``name``
-        in mro order on ``model`` that satisfy ``predicate``.  Model classes
-        (the ones that appear in the registry) are ignored.
+        in mro order on ``model`` that satisfy ``predicate``.  Model registry
+        classes are ignored.
     """
     result = []
-    for cls in model._model_classes:
-        value = cls.__dict__.get(name, Default)
-        if value is Default:
-            continue
-        if not predicate(value):
-            break
-        result.append(value)
+    for cls in type(model).mro():
+        if not is_registry_class(cls):
+            value = cls.__dict__.get(name, Default)
+            if value is Default:
+                continue
+            if not predicate(value):
+                break
+            result.append(value)
     return result
 
 
@@ -4035,5 +4036,6 @@ def apply_required(model, field_name):
 # pylint: disable=wrong-import-position
 from .exceptions import AccessError, MissingError, UserError
 from .models import (
-    check_pg_name, expand_ids, is_definition_class, BaseModel, IdType, NewId, PREFETCH_MAX,
+    check_pg_name, expand_ids, is_definition_class, is_registry_class,
+    BaseModel, IdType, NewId, PREFETCH_MAX,
 )

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -526,7 +526,10 @@ class BaseModel(metaclass=MetaModel):
         if cls._rec_name == name:
             # fixup _rec_name and display_name's dependencies
             cls._rec_name = None
-            cls.display_name.depends = tuple(dep for dep in cls.display_name.depends if dep != name)
+            if cls.display_name in cls.pool.field_depends:
+                cls.pool.field_depends[cls.display_name] = tuple(
+                    dep for dep in cls.pool.field_depends[cls.display_name] if dep != name
+                )
         return field
 
     @api.model
@@ -3132,7 +3135,7 @@ Fields:
                 stored_fields.add(name)
             elif field.compute:
                 # optimization: prefetch direct field dependencies
-                for dotname in field.depends:
+                for dotname in self.pool.field_depends[field]:
                     f = self._fields[dotname.split('.')[0]]
                     if f.prefetch and (not f.groups or self.user_has_groups(f.groups)):
                         stored_fields.add(f.name)

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -9,7 +9,6 @@ from collections.abc import Mapping
 from contextlib import closing, contextmanager
 from functools import partial
 from operator import attrgetter
-from weakref import WeakValueDictionary
 import logging
 import os
 import threading
@@ -37,9 +36,6 @@ class Registry(Mapping):
     """
     _lock = threading.RLock()
     _saved_lock = None
-
-    # a cache for model classes, indexed by their base classes
-    model_cache = WeakValueDictionary()
 
     @lazy_classproperty
     def registries(cls):

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -281,6 +281,15 @@ class Registry(Mapping):
         for model in models:
             model._setup_complete()
 
+        # determine field_depends and field_depends_context
+        self.field_depends = {}
+        self.field_depends_context = {}
+        for model in models:
+            for field in model._fields.values():
+                depends, depends_context = field.get_depends(model)
+                self.field_depends[field] = tuple(depends)
+                self.field_depends_context[field] = tuple(depends_context)
+
         # Reinstall registry hooks. Because of the condition, this only happens
         # on a fully loaded registry, and not on a registry being loaded.
         if self.ready:

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -13,6 +13,7 @@ from weakref import WeakValueDictionary
 import logging
 import os
 import threading
+import time
 
 import psycopg2
 
@@ -71,6 +72,7 @@ class Registry(Mapping):
     @classmethod
     def new(cls, db_name, force_demo=False, status=None, update_module=False):
         """ Create and return a new registry for the given database name. """
+        t0 = time.time()
         with cls._lock:
             with odoo.api.Environment.manage():
                 registry = object.__new__(cls)
@@ -104,6 +106,7 @@ class Registry(Mapping):
             registry.ready = True
             registry.registry_invalidated = bool(update_module)
 
+        _logger.info("Registry loaded in %.3fs", time.time() - t0)
         return registry
 
     def init(self, db_name):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -540,7 +540,7 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
                 field_type = field.type
                 if field_type == 'monetary':
                     # Compare monetary field.
-                    currency_field_name = record._fields[field_name].currency_field
+                    currency_field_name = record._fields[field_name].get_currency_field(record)
                     record_currency = record[currency_field_name]
                     if field_name not in candidate:
                         diff[field_name] = (record_value, None)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -697,6 +697,13 @@ def attrgetter(*items):
             return tuple(resolve_attr(obj, attr) for attr in items)
     return g
 
+def discardattr(obj, key):
+    """ Perform a ``delattr(obj, key)`` but without crashing if ``key`` is not present. """
+    try:
+        delattr(obj, key)
+    except AttributeError:
+        pass
+
 # ---------------------------------------------
 # String management
 # ---------------------------------------------


### PR DESCRIPTION
This proposes a new implementation of
* the "discovery" of fields on a given model;
* the setup of fields;
* the sharing of fields across registries.

This new implementation makes the registry loading faster.  Our benchmark is two registries with 296 modules (all community modules).  Both registries have the same models, so we can see how sharing across registries can save time and/or memory.  Here are time measurements for loading both registries (from scratch):

Time | before | after | difference
---|---|---|---
Loading Odoo modules | 1176ms | 1339ms | +14%
Loading registry 1 | 2042ms | 1067ms | -48%
Loading registry 2 | 990ms | 970ms | -2%

As we can see, there is some extra work done when loading Odoo modules, but this extra work is done once for all registries using those modules.  However, this price is largely compensated by the speedup when loading a registry.  Notice also that the net time to load a registry no longer depends whether other registries are present in the server.

Overall, the loading of the first registry goes from 3218ms to 2406ms, which is 25% faster.  In other words, the bootstrapping time of a server is smaller.