### PR TITLE
[IMP] payment_adyen : improve the handling of result codes

### DIFF
--- a/addons/payment_adyen/const.py
+++ b/addons/payment_adyen/const.py
@@ -30,4 +30,6 @@ RESULT_CODES_MAPPING = {
     ),
     'done': ('Authorised',),
     'cancel': ('Cancelled',),
+    'error': ('Error',),
+    'refused': ('Refused',),
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Getting an accurate error/refusal message to help developer when resolving problems with Adyen

Current behavior before PR:
We currently support a limited set of result code coming from Adyen's feedback data. Any result code that is not explicitely mapped to a transaction status in Odoo is considered as an error and displayed as such.
For example, if a payment is refused on Adyen side, the message shown to Odoo customers will be: "Adyen: Received data with invalid payment state: Refused".

Desired behavior after PR is merged:
We should at the minimum display a better message since we actually receive the reason why the payment was refused. Note that Adyen discourage disclosing the refusal reason to the customer.
SPECIFICATIONS
For payments whose result code is "Refused", "Error", or "Cancelled", log the refusal reason for easier debugging. It might be the case that cancelled payments don't have a refusal reason; different parts of the doc are contradicting each other.
For payments whose result code is "Refused", adapt the error message to something like "Your payment was refused. Please try again.".
For payments whose result code is "Error", adapt the error message to something like "An error occured during processing of your payment. Please try again.".
Both result codes "Refused" and "Error" should remain mapped to the transaction state "error".


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
