### PR TITLE
[FIX] calendar: remove the company name from the email template

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -125,11 +125,18 @@ class Attendee(models.Model):
                                 'mimetype': 'text/calendar',
                                 'datas': base64.b64encode(ics_file)})
                     ]
-                body = invitation_template.with_context(rendering_context)._render_field(
-                    'body_html',
-                    attendee.ids,
-                    compute_lang=True,
-                    post_process=True)[attendee.id]
+                try:
+                    body = invitation_template.with_context(rendering_context)._render_field(
+                        'body_html',
+                        attendee.ids,
+                        compute_lang=True,
+                        post_process=True)[attendee.id]
+                except UserError:   #TO BE REMOVED IN MASTER
+                    body = invitation_template.sudo().with_context(rendering_context)._render_field(
+                        'body_html',
+                        attendee.ids,
+                        compute_lang=True,
+                        post_process=True)[attendee.id]
                 subject = invitation_template._render_field(
                     'subject',
                     attendee.ids,


### PR DESCRIPTION
Steps to follow to reproduce the bug:
- Create a new “Internal User”
- Add him a “default company”
- Add in the “allowed companies” a different company than his default company
- In the “Technical” section, check that the “multi companies” box is checked
- Log in with the new user
- At the top right select a company other than his “default company”
- In the “Calendar” app/ create a new meeting with a future date
- Add another user as a participant
- Confirm the meeting
- Access rights error is triggered

Problem:
When participant are added, an invitation by email must be sent to all participants.
The problem is in the template of the email that is sent, precisely in the "body", we add the name of the user's default company which we do not have access.

Opw-2494399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
