### PR TITLE
[FIX] account: fix fiscal position mapping in pos

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -56,7 +56,7 @@ class AccountFiscalPosition(models.Model):
             return taxes
         result = self.env['account.tax']
         for tax in taxes:
-            taxes_correspondance = self.tax_ids.filtered(lambda t: t.tax_src_id == tax)
+            taxes_correspondance = self.tax_ids.filtered(lambda t: t.tax_src_id == tax._origin)
             result |= taxes_correspondance.tax_dest_id if taxes_correspondance else tax
         return result
 


### PR DESCRIPTION
Have a Fiscal position FPOS which map tax A to tax B
Have products DEMO with tax A and DEMO2
Allow FPOS in POS, Open a session, activate FPOS, sell DEMO and DEMO2
Close POS
Go to Orders, select the last one, hit return, edit, delete DEMO2 line

Tax will be wrong.
This occcur because the fiscal position mapping fail an equivalence
check with a virtual record, so the tax is calculated as A and not B

opw-2485399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
