### PR TITLE
[FIX] website_crm: add language to website form

### DIFF
--- a/addons/website_crm/controllers/main.py
+++ b/addons/website_crm/controllers/main.py
@@ -54,8 +54,7 @@ class WebsiteForm(WebsiteForm):
             if 'company_id' not in values:
                 values['company_id'] = request.website.company_id.id
             lang = request.context.get('lang', False)
-            lang_id = request.env["res.lang"].sudo().search([('code', '=', lang)], limit=1).id
-            values['lang_id'] = lang_id
+            values['lang_id'] = values.get('lang_id') or request.env['res.lang']._lang_get_id(lang)
 
         result = super(WebsiteForm, self).insert_record(request, model, values, custom, meta=meta)
 


### PR DESCRIPTION
When the user submits a form, a lead will be created but the language
won't be the one selected by the user.

To reproduce the error:
(Enable debug mode)
1. Settings > Translations > Languages
2. Activate another language L_other
3. On website, add a form:
    - Action: Create an Opportunity
4. Add an existing field: "Language"
5. Submit the form
    - Language must be L_other
6. Consult the new lead

Error: The language is not the selected one.

OPW-2486276