### PR TITLE
[FIX] web, website: display default company name on frontend layout

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -503,7 +503,7 @@
                             <div class="row">
                                 <div class="col-sm text-center text-sm-left text-muted">
                                     <t t-call="web.debug_icon"/>
-                                    <span class="o_footer_copyright_name mr-2">Copyright &amp;copy; Company name</span>
+                                    <span class="o_footer_copyright_name mr-2">Copyright &amp;copy; <span t-field="res_company.name" itemprop="name">Company name</span></span>
                                 </div>
                                 <div class="col-sm text-center text-sm-right">
                                     <t t-call="web.brand_promotion"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -172,6 +172,9 @@
     <xpath expr="//footer[@id='bottom']" position="attributes">
         <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'footer_visible' in main_object and not main_object.footer_visible else ''}" separator=" "/>
     </xpath>
+    <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
+        <span class="o_footer_copyright_name mr-2">Copyright &amp;copy; Company name</span>
+    </xpath>
 </template>
 
 <template id="custom_code_layout" name="Custom Code Layout" inherit_id="website.layout" priority="55">


### PR DESCRIPTION
The "Company name" placeholder was hardcoded in the frontend layout
template, and the user had to change it with his company name from the
website wiew, which was not user-friendly if the website module was not
installed.

By default the frontend layout template displays the user's company
name, and if website module is installed, the frontend layout template
is editable.

task-2468472



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
