### PR TITLE
[FIX] microsoft_calendar: permanent event no traceback on open


### DIFF
--- a/addons/microsoft_calendar/utils/microsoft_event.py
+++ b/addons/microsoft_calendar/utils/microsoft_event.py
@@ -178,7 +178,7 @@ class MicrosoftEvent(abc.Set):
             'count': range['numberOfOccurrences'],
             'day': pattern['dayOfMonth'],
             'byday': index_dict.get(pattern['index'], False),
-            'until': range['endDate'],
+            'until': range['type'] == 'endDate' and range['endDate'],
         }
 
         month_by_dict = {


### PR DESCRIPTION
When synchronizing microsoft calendar events, if the event is permanent
Microsoft says the endDate is "0001-01-01": we save that and this causes
an error when it is being parsed in javascript since we require a date
with higher than 1000 years in require('web.field_utils').parseDate
function.

With this changeset, we do not set endDate if the type of the event is not
endDate (as shown[^1] in the documentation endDate only makes sense for
event of type endDate).

[^1]: https://docs.microsoft.com/en-us/graph/outlook-schedule-recurring-events#recurrence-ranges

opw-2479029
