### PR TITLE
[FIX] web: fix kanban view progressbars related to records in another group (groupby:week)

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import babel.dates
 import pytz
 
-from odoo.tools import pycompat
+from odoo.tools import pycompat, date_utils
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT
 from odoo import _, api, fields, models
 
@@ -50,7 +50,7 @@ class Base(models.AbstractModel):
             # Again, imitating what _read_group_format_result and _read_group_prepare_data do
             if group_by_value and field_type in ['date', 'datetime']:
                 locale = self._context.get('lang') or 'en_US'
-                group_by_value = fields.Datetime.to_datetime(group_by_value)
+                group_by_value = date_utils.start_of(fields.Datetime.to_datetime(group_by_value), group_by_modifier)
                 group_by_value = pytz.timezone('UTC').localize(group_by_value)
                 tz_info = None
                 if field_type == 'datetime' and self._context.get('tz') in pytz.all_timezones:

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_js
 from . import test_menu
 from . import test_serving_base
 from . import test_click_everywhere
+from . import test_read_progress_bar

--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import common
+
+
+class TestReadProgressBar(common.TransactionCase):
+    """Test for read_progress_bar"""
+
+    def setUp(self):
+        super(TestReadProgressBar, self).setUp()
+        self.Model = self.env['res.partner']
+
+    def test_week_grouping(self):
+        """The labels associated to each record in read_progress_bar should match
+        the ones from read_group, even in edge cases like en_US locale on sundays
+        """
+        context = {"lang": "en_US"}
+        groupby = "date:week"
+        self.Model.create({'date': '2021-05-02', 'name': "testWeekGrouping_first"}) # Sunday
+        self.Model.create({'date': '2021-05-09', 'name': "testWeekGrouping_second"}) # Sunday
+        progress_bar = {
+            'field': 'name',
+            'colors': {
+                "testWeekGrouping_first": 'success',
+                "testWeekGrouping_second": 'danger',
+            }
+        }
+        
+        groups = self.Model.with_context(context).read_group(
+            [('name', "like", "testWeekGrouping%")], fields=['date', 'name'], groupby=[groupby])
+        progressbars = self.Model.with_context(context).read_progress_bar(
+            [('name', "like", "testWeekGrouping%")], group_by=groupby, progress_bar=progress_bar)
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(len(progressbars), 2)
+
+        # format the read_progress_bar result to get a dictionary under this format : {record_name: group_name}
+        # original format (after read_progress_bar) is : {group_name: {record_name: count}}
+        pg_groups = {
+            next(record_name for record_name, count in data.items() if count): group_name \
+                for group_name, data in progressbars.items()
+        }
+
+        self.assertEqual(groups[0][groupby], pg_groups["testWeekGrouping_first"])
+        self.assertEqual(groups[1][groupby], pg_groups["testWeekGrouping_second"])


### PR DESCRIPTION
# IMPACTED VERSIONS

12.0+

# HOW TO REPRODUCE

```
locale :  Locale is en_US (or other SUNDAY based)
view:     CRM - My Pipeline - Kanban view
groupBy:  date_deadline:week (Expected closing)
records:  one record with a planned activity, on date_deadline = 2021-05-02 (SUNDAY)
          one record with no planned activity, on date_deadline = 2021-05-09 (SUNDAY)
remark:   don't keep any other record in MAY for better visibility
```

# PROBLEM

The progressbar of the week containing 2021-05-09 displays information about the record
from the week containing 2021-05-02

# CAUSE

1. PostgreSQL `date_trunc` function follows ISO8601 which essentially means that
  the start of a WEEK is always MONDAY. There is no argument to change this.

2. _read_group_format_result
  https://github.com/odoo/odoo/blob/27da86a138089c1838e4b94f8a6976995b9c1fff/odoo/models.py#L2210-L2219

  - Computes a label for a group of records.
  - Follows the locale for the label of the week, based on a date which was
    always a MONDAY because of how `date_trunc` was used previously.

3. read_progress_bar
  https://github.com/odoo/odoo/blob/88957afca09662af7eaa19df1e40b3699e45e79e/addons/web/models/models.py#L167-L175

  - Associates a group label to a record.
  - Follows the locale for the label of the week, based on the date of a record
    which can be any day of the week. If the record is related to a SUNDAY and
    SUNDAY is the first day of the week, it would have been in a group with a
    different label in (2.) than in (3.) prior to this change.

# FIX

In 3., before associating a label to a record, we truncate the date to the
ISO start of the period, so that the label is determined for a record in the
same conditions than in 2. The locale is still used to get language-dependent
outputs with babel, but the grouping will always follows ISO8601 (date_trunc).

# TEST

Added a test for this problem case

TASK-ID : 2517848
