### PR TITLE
[FIX] core: integrate locale dependency in SQL groupby queries

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2048,7 +2048,12 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             }
             if tz_convert:
                 qualified_field = "timezone('%s', timezone('UTC',%s))" % (self._context.get('tz', 'UTC'), qualified_field)
-            qualified_field = "date_trunc('%s', %s::timestamp)" % (gb_function or 'month', qualified_field)
+            delta_start_week = 0
+            if gb_function == 'week':
+                iso_week_start = babel.Locale.parse(get_lang(self.env).code).first_week_day
+                delta_start_week = (7 - iso_week_start) % 7
+            qualified_field = "date_trunc('{0}', {1}::timestamp + interval '{delta} days') - interval '{delta} days'".format(
+                gb_function or 'month', qualified_field, delta=delta_start_week)
         if field_type == 'boolean':
             qualified_field = "coalesce(%s,false)" % qualified_field
         return {


### PR DESCRIPTION
# IMPACTED VERSIONS

12.0 : PR : https://github.com/odoo/odoo/pull/69946
13.0+ (this commit)

# HOW TO REPRODUCE

```
locale :  Locale is en_US (or other SUNDAY based)
view:     CRM - My Pipeline - Kanban view
groupBy:  date_deadline:week (Expected closing)
records:  one record with a planned activity on date_deadline = 2021-05-02 (SUNDAY)
          one record with no planned activity on date_deadline = 2021-05-09 (SUNDAY)
remark:   don't keep any other record in MAY for better visibility
```

# PROBLEM

The progressbar of the week containing 2021-05-09 makes reference to the record
from the week containing 2021-05-02

# CAUSE

1. PostgreSQL `date_trunc` function follows ISO8601 which essentially means that
  the start of a WEEK is always MONDAY. There is no argument to change this.

2. _read_group_format_result
  https://github.com/odoo/odoo/blob/27da86a138089c1838e4b94f8a6976995b9c1fff/odoo/models.py#L2210-L2219

  - Computes a label for a group of records.
  - Follows the locale for the label of the week, based on a date which was
    always a MONDAY because of how `date_trunc` was used previously.

3. read_progress_bar
  https://github.com/odoo/odoo/blob/88957afca09662af7eaa19df1e40b3699e45e79e/addons/web/models/models.py#L167-L175

  - Associates a group label to a record.
  - Follows the locale for the label of the week, based on the date of a record
    which can be any day of the week. If the record is related to a SUNDAY and
    SUNDAY is the first day of the week, it would have been in a group with a
    different label in (2.) than in (3.) prior to this change.

# FIX

To get the correct WEEK grouping according to the desired locale, we can add
the amount of DAYS between the desired start of the past week (START_DAY) and
MONDAY to the records in the function call, so that START_DAY will be virtually
considered as MONDAY for the grouping. Then, we remove this amount of DAYS to
recover the real start of the week according to the locale.

TASK-ID : 2517848