### PR TITLE
[IMP] payment_buckaroo : better handle status code response

### DIFF
--- a/addons/payment_buckaroo/const.py
+++ b/addons/payment_buckaroo/const.py
@@ -7,4 +7,6 @@ STATUS_CODES_MAPPING = {
     'pending': (790, 791, 792, 793),
     'done': (190,),
     'cancel': (890, 891),
+    'refused': (690,),
+    'error': (490, 491, 492,),
 }

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -135,6 +135,10 @@ class PaymentTransaction(models.Model):
             self._set_done()
         elif status_code in STATUS_CODES_MAPPING['cancel']:
             self._set_canceled()
+        elif status_code in STATUS_CODES_MAPPING['refused']:
+            self._set_error(_("Your payment was refused (code %s). Please try again.", status_code))
+        elif status_code in STATUS_CODES_MAPPING['error']:
+            self._set_error(_("An error occured during processing of your payment (code %s). Please try again.", status_code))
         else:
             _logger.warning("Buckaroo: received unknown status code: %s", status_code)
             self._set_error("Buckaroo: " + _("Unknown status code: %s", status_code))


### PR DESCRIPTION
Before this commit, status codes were partially handled and users may not had a proper feedback on the status of their payment.

Task #2517498

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
