### PR TITLE
[IMP] l10n_ar: Update eCommerce module displayed name

### DIFF
--- a/addons/l10n_ar_website_sale/__manifest__.py
+++ b/addons/l10n_ar_website_sale/__manifest__.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
-    'name': 'Argentinean Website',
+    'name': 'Argentinean eCommerce',
     'version': '1.0',
     'category': 'Accounting/Localizations/Website',
     'sequence': 14,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Feedback received: change the name from 'Argentinean Website' to 'Argentinean eCommerce'  in order to stay consistent with the functional name of stadand Apps

Current behavior before PR:
Wrong name
Desired behavior after PR is merged:
Change displayed name of module



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
