### PR TITLE
[FIX] im_livechat: noupdate around default livechat channel

### DIFF
--- a/addons/im_livechat/data/im_livechat_channel_data.xml
+++ b/addons/im_livechat/data/im_livechat_channel_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <odoo>
-    <data>
+    <data noupdate="1">
         <record id="im_livechat_channel_data" model="im_livechat.channel">
             <field name="name">YourWebsite.com</field>
             <field name="default_message">Hello, how may I help you?</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: data is updated that shouldn't.

Current behavior before PR: if you would update the module the default livechat details would be reset.

Desired behavior after PR is merged: 
By wrapping it in a no-update they're not updated with a module update.


Fixes https://github.com/odoo/odoo/issues/69960
Closes https://github.com/odoo/odoo/issues/69960

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
