### PR TITLE
[FIX] web: make test pass on chrome 90

### DIFF
--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -4670,7 +4670,7 @@ QUnit.module('relational_fields', {
         var positions = [
             [6, 0, 'top', [3, 6, 1, 2, 5, 7, 4]], // move the last to the first line
             [5, 1, 'top', [7, 6, 1, 2, 5]], // move the penultimate to the second line
-            [2, 5, 'center', [1, 2, 5, 6]], // move the third to the penultimate line
+            [2, 5, 'bottom', [1, 2, 5, 6]], // move the third to the penultimate line
         ];
         function dragAndDrop() {
             var pos = positions.shift();


### PR DESCRIPTION
The changed test uses the drag&drop helper, and an operation does
not work as expected with the given params on chrome 90. The runbot
currently uses chrome 80, so it is not an issue, but if your chrome
is up-to-date, and you try to run the test suite, this test would
fail.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
