### PR TITLE
[FIX] sale_margin: avoid purchase price reset on order confirm

### DIFF
--- a/addons/sale_margin/models/sale_order.py
+++ b/addons/sale_margin/models/sale_order.py
@@ -29,7 +29,8 @@ class SaleOrderLine(models.Model):
                 # If the standard_price is 0
                 # Avoid unnecessary computations
                 # and currency conversions
-                line.purchase_price = 0.0
+                if not line.purchase_price:
+                    line.purchase_price = 0.0
                 continue
             fro_cur = product.cost_currency_id
             to_cur = line.currency_id or line.order_id.currency_id


### PR DESCRIPTION
- Create a service product with cost 0
- Create a sales quotation
- Add the service product, change the cost to a positive quantity
- Save and Confirm.

Purchase Price (cost) will be reset to 0

opw-2481564

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
