### PR TITLE
[FIX] stock_account: check destination and source locations in forecast

### DIFF
--- a/addons/stock_account/report/report_stock_forecasted.py
+++ b/addons/stock_account/report/report_stock_forecasted.py
@@ -18,7 +18,9 @@ class ReplenishmentReport(models.AbstractModel):
         total_quantity = sum(svl.mapped('quantity'))
         # Because we can have negative quantities, `total_quantity` may be equal to zero even if the warehouse's `quantity` is positive.
         if svl and not float_is_zero(total_quantity, precision_rounding=svl.product_id.uom_id.rounding):
-            quantity = sum(svl.filtered(lambda layer: layer.stock_move_id.location_dest_id.id in wh_location_ids).mapped('quantity'))
+            def filter_on_locations(layer):
+                return layer.stock_move_id.location_dest_id.id in wh_location_ids or layer.stock_move_id.location_id.id in wh_location_ids
+            quantity = sum(svl.filtered(filter_on_locations).mapped('quantity'))
             value = sum(svl.mapped('value')) * (quantity / total_quantity)
         else:
             value = 0


### PR DESCRIPTION
Steps:
- Go to Inventory / Products / Products
- Create a product (2)
  - Storable Product
  - Cost: 10
- Click Update Quantity
- Create a new quantity line with 3 in On Hand Quantity
- Update the line with 1 in On Hand Quantity
- Go back to the product
- Click the "Forecasted" smart button

Bug:
The on hand value is 30 instead of 10.

Explanation:
When `location_dest_id` is the current location, it is used to specify
that a given quantity has been added to this location's stock. However,
when removing a quantity, the move goes from the current location to a
virtual one. The current location is, in this case, stored in
`location_id` and the destination is the virtual location.
This makes stock removals not appear in the on hand value since we only
filter the layers on their move's `location_dest_id`.

This commit assumes that a move always goes from or to a virtual
location and checks if the current location is in `location_dest_id` or
in `location_id`.

opw:2510911