### PR TITLE
[IMP] payment : add a sequence to the payment icons

### DIFF
--- a/addons/payment/models/payment_icon.py
+++ b/addons/payment/models/payment_icon.py
@@ -6,6 +6,7 @@ from odoo import fields, models
 class PaymentIcon(models.Model):
     _name = 'payment.icon'
     _description = 'Payment Icon'
+    _order = 'sequence, name'
 
     name = fields.Char(string="Name")
     acquirer_ids = fields.Many2many(
@@ -17,3 +18,4 @@ class PaymentIcon(models.Model):
     image_payment_form = fields.Image(
         string="Image displayed on the payment form", related='image', store=True, max_width=45,
         max_height=30)
+    sequence = fields.Integer('Sequence', default=1)

--- a/addons/payment/views/payment_icon_views.xml
+++ b/addons/payment/views/payment_icon_views.xml
@@ -21,6 +21,17 @@
         </field>
     </record>
 
+    <record id="payment_icon_tree" model="ir.ui.view">
+        <field name="name">payment.icon.tree</field>
+        <field name="model">payment.icon</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
     <record id="action_payment_icon" model="ir.actions.act_window">
         <field name="name">Payment Icons</field>
         <field name="res_model">payment.icon</field>


### PR DESCRIPTION
The user can reorder the payment method to put his favorite forth on their /payment page..

Description of the issue/feature this PR addresses:
There is currently no forced ordering of payment icon records, meaning that they are ordered by DB ID.

Current behavior before PR:
Inside each acquirer's card on the payment form you can find a list of supported payment icons. It's initially collapsed so that it only shows the *first* three icon assigned to an acquirer.

Desired behavior after PR is merged:
Allow users to decide in which order payment method should appear on their /payment page.
He can reorder them in the payment icon list, in debug mode.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
