### PR TITLE
[FIX] stock_landed_costs: use the correct split method landed cost

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
                 'name': l.product_id.name,
                 'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id,
                 'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, l.move_id.date),
-                'split_method': 'equal',
+                'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
         })
         action = self.env["ir.actions.actions"]._for_xml_id("stock_landed_costs.action_stock_landed_cost")


### PR DESCRIPTION
Steps to follow to reproduce the bug:
- Install Inventory and Purchase
- In the inventory settings, Enable the "Landed Costs" option
- Go to Purchase > create a Service type product
- In the Purchase tab > Enable "is landed cost" option and choose "by quantity" in the default split method
- Go to Orders > Requests for quotation > Create a new RFQ > add Any product and confirm the order
- Validate receipt of the product
- Create a bill > add the Service you created at the beginning
- Create Landed Costs

Problem:
we do not use the split method landed cost of the product, we automatically set it to "equal"

opw-2465753

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
