### PR TITLE
[FIX] repair: filter taxes with current company

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -672,7 +672,8 @@ class RepairLine(models.Model):
                     # Check automatic detection
                     fp_id = self.env['account.fiscal.position'].get_fiscal_position(partner.id, delivery_id=self.repair_id.address_id.id)
                     fp = self.env['account.fiscal.position'].browse(fp_id)
-                self.tax_id = fp.map_tax(self.product_id.taxes_id, self.product_id, partner).ids
+                taxes = self.product_id.taxes_id.filtered(lambda x: x.company_id == self.repair_id.company_id)
+                self.tax_id = fp.map_tax(taxes, self.product_id, partner).ids
             warning = False
             if not pricelist:
                 warning = {
@@ -739,7 +740,8 @@ class RepairFee(models.Model):
                 # Check automatic detection
                 fp_id = self.env['account.fiscal.position'].get_fiscal_position(partner.id, delivery_id=self.repair_id.address_id.id)
                 fp = self.env['account.fiscal.position'].browse(fp_id)
-            self.tax_id = fp.map_tax(self.product_id.taxes_id, self.product_id, partner).ids
+            taxes = self.product_id.taxes_id.filtered(lambda x: x.company_id == self.repair_id.company_id)
+            self.tax_id = fp.map_tax(taxes, self.product_id, partner).ids
         if self.product_id:
             if partner:
                 self.name = self.product_id.with_context(lang=partner.lang).display_name


### PR DESCRIPTION
When adding a product to a repair order, the module automatically adds
all product's taxes, even if some taxes belong to other companies.

To reproduce the error
(Need 2 companies C01 and C02. Let C01 be the current company)
1. Create a product P
    - Must have a tax T_C01
2. Switch to C02
3. Edit P
    - Add a tax T_C02
4. Activate C01
5. Create a Repair Order
    - Add a customer
    - Add a line with product P

Error: Both T_C01 and T_C02 are added. However, since C02 is the current
company, T_C01 should not be added.

(Similar issue possible with `repair.fee`)

OPW-2486791
closes #68079