### PR TITLE
[13.0] [IMP] sale_coupon: improve performance

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -281,15 +281,17 @@ class SaleCouponProgram(models.Model):
         Returns the programs when the reward is actually in the order lines
         """
         programs = self.env['sale.coupon.program']
+        program_ids = set()
+        order_lines_product_ids = set(order.mapped('order_line.product_id').ids)
         for program in self:
             if program.reward_type == 'product' and \
-               not order.order_line.filtered(lambda line: line.product_id == program.reward_product_id):
+               not program.reward_product_id.id in order_lines_product_ids:
                 continue
             elif program.reward_type == 'discount' and program.discount_apply_on == 'specific_products' and \
-               not order.order_line.filtered(lambda line: line.product_id in program.discount_specific_product_ids):
+               not set(program.discount_specific_product_ids.ids) & order_lines_product_ids:
                 continue
-            programs |= program
-        return programs
+            program_ids |= set(program.ids)
+        return programs.browse(list(program_ids))
 
     @api.model
     def _filter_programs_from_common_rules(self, order, next_order=False):


### PR DESCRIPTION
This patch improve the performance of sale_coupon, especially when there
are a lot of programs and sale lines. The use of filtered() in this
context induces a high runtime penalty, and replacing it with set
operations improves the performance greatly.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
