### PR TITLE
Master various app menu items sequence dht

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -5,7 +5,7 @@
         id="menu_finance"
         groups="account.group_account_readonly,account.group_account_invoice"
         web_icon="account,static/description/icon.png"
-        sequence="40">
+        sequence="55">
         <menuitem id="menu_board_journal_1" name="Dashboard" action="open_account_journal_dashboard_kanban" groups="account.group_account_readonly" sequence="1"/>
         <menuitem id="menu_finance_receivables" name="Customers" sequence="2">
             <menuitem id="menu_action_move_out_invoice_type" action="action_move_out_invoice_type" sequence="1"/>

--- a/addons/association/views/association_views.xml
+++ b/addons/association/views/association_views.xml
@@ -4,6 +4,6 @@
         <menuitem name="Members"
             id="membership.menu_association"
             groups="account.group_account_user"
-            sequence="15"/>
+            sequence="245"/>
         <menuitem name="Configuration" id="menu_event_config" parent="membership.menu_association" sequence="100"/>
 </odoo>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -382,7 +382,7 @@
     <menuitem
         id="mail_menu_calendar"
         name="Calendar"
-        sequence="2"
+        sequence="10"
         action="action_calendar_event"
         web_icon="calendar,static/description/icon.png"
         groups="base.group_user"/>

--- a/addons/contacts/views/contact_views.xml
+++ b/addons/contacts/views/contact_views.xml
@@ -37,7 +37,7 @@
 
     <menuitem name="Contacts"
         id="menu_contacts"
-        sequence="4"
+        sequence="20"
         web_icon="contacts,static/description/icon.png"
         groups="base.group_user,base.group_partner_manager"/>
 

--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -11,7 +11,7 @@
         name="CRM"
         web_icon="crm,static/description/icon.png"
         groups="sales_team.group_sale_salesman,sales_team.group_sale_manager"
-        sequence="6"/>
+        sequence="25"/>
 
     <!-- SALES (MAIN USER MENU) -->
     <menuitem

--- a/addons/event/views/event_menu_views.xml
+++ b/addons/event/views/event_menu_views.xml
@@ -4,7 +4,7 @@
     <!-- MAIN MENU -->
     <menuitem name="Events"
         id="event_main_menu"
-        sequence="65"
+        sequence="125"
         groups="event.group_event_registration_desk"
         web_icon="event,static/description/icon.png"/>
 

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -105,7 +105,7 @@
         </field>
     </record>
 
-    <menuitem name="Fleet" id="menu_root" sequence="115" groups="fleet_group_user" web_icon="fleet,static/description/icon.png"/>
+    <menuitem name="Fleet" id="menu_root" sequence="220" groups="fleet_group_user" web_icon="fleet,static/description/icon.png"/>
     <menuitem name="Configuration" parent="menu_root" id="fleet_configuration" sequence="100" groups="fleet_group_manager"/>
 
     <record id='fleet_vehicle_model_brand_view_tree' model='ir.ui.view'>

--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -7,7 +7,7 @@
             name="Employees"
             groups="group_hr_manager,group_hr_user,base.group_user"
             web_icon="hr,static/description/icon.png"
-            sequence="75"/>
+            sequence="185"/>
 
         <menuitem
             id="menu_hr_main"

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -223,7 +223,7 @@
 
     <!-- Menus -->
 
-    <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="90" groups="hr_attendance.group_hr_attendance,hr_attendance.group_hr_attendance_kiosk" web_icon="hr_attendance,static/description/icon.png"/>
+    <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="205" groups="hr_attendance.group_hr_attendance,hr_attendance.group_hr_attendance_kiosk" web_icon="hr_attendance,static/description/icon.png"/>
 
     <menuitem id="menu_hr_attendance_my_attendances" name="Check In / Check Out" parent="menu_hr_attendance_root" sequence="1" groups="hr_attendance.group_hr_attendance" action="hr_attendance_action_my_attendances"/>
 

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -1091,7 +1091,7 @@
             </field>
         </record>
 
-        <menuitem id="menu_hr_expense_root" name="Expenses" sequence="100" web_icon="hr_expense,static/description/icon.png"/>
+        <menuitem id="menu_hr_expense_root" name="Expenses" sequence="230" web_icon="hr_expense,static/description/icon.png"/>
 
         <menuitem id="menu_hr_expense_my_expenses" name="My Expenses" sequence="1" parent="menu_hr_expense_root" groups="base.group_user"/>
         <menuitem id="menu_hr_expense_my_expenses_to_submit" sequence="1" parent="menu_hr_expense_my_expenses" action="hr_expense_actions_my_unsubmitted" name="My Expenses to Report"/>

--- a/addons/hr_holidays/views/hr_holidays_views.xml
+++ b/addons/hr_holidays/views/hr_holidays_views.xml
@@ -4,7 +4,7 @@
     <menuitem
         name="Time Off"
         id="menu_hr_holidays_root"
-        sequence="95"
+        sequence="225"
         web_icon="hr_holidays,static/description/icon.png"
         groups="base.group_user"/>
 

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -624,7 +624,7 @@
         id="menu_hr_recruitment_root"
         web_icon="hr_recruitment,static/description/icon.png"
         groups="hr_recruitment.group_hr_recruitment_user"
-        sequence="80"/>
+        sequence="210"/>
 
     <menuitem id="menu_hr_recruitment_configuration" name="Configuration" parent="menu_hr_recruitment_root"
         sequence="100"/>

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -5,7 +5,7 @@
         <!-- Timesheet root menus -->
         <menuitem id="timesheet_menu_root"
             name="Timesheets"
-            sequence="55"
+            sequence="75"
             groups="group_hr_timesheet_user"
             web_icon="hr_timesheet,static/description/icon_timesheet.png"/>
 

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -282,7 +282,7 @@
             name="Live Chat"
             web_icon="im_livechat,static/description/icon.png"
             groups="im_livechat_group_user"
-            sequence="205"/>
+            sequence="240"/>
 
         <menuitem
             id="support_channels"

--- a/addons/lunch/views/lunch_views.xml
+++ b/addons/lunch/views/lunch_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- Top menu item -->
-    <menuitem id='menu_lunch' name='Lunch' sequence="105" groups="group_lunch_user" web_icon="lunch,static/description/icon.png">
+    <menuitem id='menu_lunch' name='Lunch' sequence="235" groups="group_lunch_user" web_icon="lunch,static/description/icon.png">
         <menuitem name="My Lunch" id="menu_lunch_title" sequence="50">
             <menuitem name="New Order" id="lunch_order_menu_form" action="lunch.lunch_product_action_order" sequence="1"/>
             <menuitem name="My Order History" id="lunch_order_menu_tree" action="lunch_order_action" sequence="2"/>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -5,7 +5,7 @@
         action="action_discuss"
         web_icon="mail,static/description/icon.png"
         groups="base.group_user"
-        sequence="1"
+        sequence="5"
     />
 
 	<record id="base.menu_email" model="ir.ui.menu">

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -964,7 +964,7 @@
         id="menu_maintenance_title"
         name="Maintenance"
         web_icon="maintenance,static/description/icon.png"
-        sequence="110"/>
+        sequence="160"/>
 
     <menuitem
         id="menu_m_dashboard"

--- a/addons/mass_mailing/views/mailing_mailing_views_menus.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views_menus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- Marketing / Mailing -->
-    <menuitem name="Email Marketing" id="mass_mailing_menu_root" sequence="60" web_icon="mass_mailing,static/description/icon.png"/>
+    <menuitem name="Email Marketing" id="mass_mailing_menu_root" sequence="115" web_icon="mass_mailing,static/description/icon.png"/>
     <menuitem name="Mailing Lists" id="mass_mailing_mailing_list_menu"
         parent="mass_mailing_menu_root" sequence="2" groups="mass_mailing.group_mass_mailing_user"/>
 

--- a/addons/mass_mailing_sms/views/mailing_sms_menus.xml
+++ b/addons/mass_mailing_sms/views/mailing_sms_menus.xml
@@ -3,7 +3,7 @@
     <!-- SMS Marketing -->
     <menuitem id="mass_mailing_sms_menu_root"
         name="SMS Marketing"
-        sequence="60"
+        sequence="120"
         web_icon="mass_mailing_sms,static/description/icon.png"
         groups="mass_mailing.group_mass_mailing_user"/>
 

--- a/addons/mrp/views/mrp_views_menus.xml
+++ b/addons/mrp/views/mrp_views_menus.xml
@@ -4,7 +4,7 @@
         name="Manufacturing"
         groups="group_mrp_user,group_mrp_manager"
         web_icon="mrp,static/description/icon.png"
-        sequence="35">
+        sequence="145">
 
         <menuitem id="menu_mrp_manufacturing"
             name="Operations"

--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -213,7 +213,7 @@
     <menuitem
       id="menu_note_notes"
       name="Notes"
-      sequence="3"
+      sequence="15"
       action="note.action_note_note"
       web_icon="note,static/description/icon.png">
         <menuitem

--- a/addons/point_of_sale/views/point_of_sale_view.xml
+++ b/addons/point_of_sale/views/point_of_sale_view.xml
@@ -6,7 +6,7 @@
         name="Point of Sale"
         groups="group_pos_manager,group_pos_user"
         web_icon="point_of_sale,static/description/icon.png"
-        sequence="20"/>
+        sequence="50"/>
 
     <!-- Orders menu -->
     <menuitem id="menu_point_of_sale"

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -6,7 +6,7 @@
             id="menu_main_pm"
             groups="group_project_manager,group_project_user"
             web_icon="project,static/description/icon.png"
-            sequence="50"/>
+            sequence="70"/>
 
         <menuitem id="menu_project_config" name="Configuration" parent="menu_main_pm"
             sequence="100" groups="project.group_project_manager"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -6,7 +6,7 @@
             id="menu_purchase_root"
             groups="group_purchase_manager,group_purchase_user"
             web_icon="purchase,static/description/icon.png"
-            sequence="25"/>
+            sequence="135"/>
 
         <menuitem id="menu_procurement_management" name="Orders"
             parent="menu_purchase_root" sequence="1" />

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -391,7 +391,7 @@
             </field>
         </record>
 
-        <menuitem action="action_repair_order_tree" id="menu_repair_order" groups="stock.group_stock_user" name="Repairs" sequence="36"
+        <menuitem action="action_repair_order_tree" id="menu_repair_order" groups="stock.group_stock_user" name="Repairs" sequence="165"
             web_icon="repair,static/description/icon.png"/>
 
         <menuitem id="repair_menu_reporting" name="Reporting" parent="menu_repair_order" groups="stock.group_stock_manager"/>

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -6,7 +6,7 @@
             name="Sales"
             web_icon="sale_management,static/description/icon.png"
             active="False"
-            sequence="7"/>
+            sequence="30"/>
 
         <menuitem id="sale_order_menu"
             name="Orders"
@@ -40,7 +40,7 @@
         <menuitem id="menu_sale_config"
             name="Configuration"
             parent="sale_menu_root"
-            sequence="6"
+            sequence="35"
             groups="sales_team.group_sale_manager"/>
 
         <menuitem id="sales_team_config"

--- a/addons/stock/views/stock_menu_views.xml
+++ b/addons/stock/views/stock_menu_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem name="Inventory" id="menu_stock_root" sequence="30"
+    <menuitem name="Inventory" id="menu_stock_root" sequence="140"
         groups="group_stock_manager,group_stock_user"
         web_icon="stock,static/description/icon.png"/>
 

--- a/addons/survey/views/survey_menus.xml
+++ b/addons/survey/views/survey_menus.xml
@@ -4,7 +4,7 @@
     <!-- Main menu -->
     <menuitem name="Surveys"
       id="menu_surveys"
-      sequence="70"
+      sequence="130"
       groups="group_survey_user"
       web_icon="survey,static/description/icon.png"/>
 

--- a/addons/utm/views/utm_views.xml
+++ b/addons/utm/views/utm_views.xml
@@ -2,7 +2,7 @@
 <odoo>
     <menuitem id="menu_link_tracker_root"
         name="Link Tracker"
-        sequence="30"
+        sequence="270"
         web_icon="utm,static/description/icon.png"
         groups="base.group_no_one"/>
 

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -523,7 +523,7 @@
         ==================================================================== -->
         <menuitem name="Website"
             id="menu_website_configuration"
-            sequence="9"
+            sequence="95"
             groups="base.group_user"
             web_icon="website,static/description/icon.png"/>
 

--- a/addons/website_slides/views/website_slides_menu_views.xml
+++ b/addons/website_slides/views/website_slides_menu_views.xml
@@ -4,7 +4,8 @@
         id="website_slides_menu_root"
         web_icon="website_slides,static/description/icon.png"
         groups="website_slides.group_website_slides_officer"
-        action="slide_channel_action_overview"/>
+        action="slide_channel_action_overview"
+        sequence="100"/>
 
     <!-- Main top menu elements -->
     <menuitem name="Courses"

--- a/odoo/addons/base/views/base_menus.xml
+++ b/odoo/addons/base/views/base_menus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
       <!-- Top menu item -->
-          <menuitem id="menu_board_root" name="Dashboards" sequence="305" web_icon="base,static/description/board.png" groups="base.group_user"/>
+          <menuitem id="menu_board_root" name="Dashboards" sequence="260" web_icon="base,static/description/board.png" groups="base.group_user"/>
           <menuitem id="menu_reporting_dashboard" name="Dashboards" parent="menu_board_root" sequence="0"/>
           <menuitem id="menu_reporting_config" name="Configuration" parent="menu_board_root" sequence="100" groups="base.group_system"/>
 
@@ -9,9 +9,9 @@
       <menuitem name="Settings"
           id="menu_administration"
           web_icon="base,static/description/settings.png"
-          sequence="500"
+          sequence="550"
           groups="base.group_erp_manager"/>
-          <menuitem id="menu_management" name="Apps" sequence="310" web_icon="base,static/description/modules.png" groups="base.group_system"/>
+          <menuitem id="menu_management" name="Apps" sequence="500" web_icon="base,static/description/modules.png" groups="base.group_system"/>
           <menuitem id="menu_administration_shortcut" parent="menu_administration" name="Custom Shortcuts" sequence="50"/>
           <!-- FYI The group no_one on 'User & Companies' and 'Translations' is a FP/APR request -->
           <menuitem id="menu_users" name="Users &amp; Companies" parent="menu_administration" sequence="1"/>
@@ -28,7 +28,7 @@
               <menuitem id="menu_security" name="Security" parent="menu_custom" sequence="25"/>
               <menuitem id="menu_ir_property" name="Parameters" parent="menu_custom" sequence="24"/>
 
-          <menuitem id="base.menu_tests" name="Tests" sequence="1000000" web_icon="test_exceptions,static/description/icon.png"/>
+          <menuitem id="base.menu_tests" name="Tests" sequence="1000" web_icon="test_exceptions,static/description/icon.png"/>
 
       <record model="ir.ui.menu" id="base.menu_administration">
           <field name="groups_id" eval="[Command.set([ref('group_system'), ref('group_erp_manager')])]"/>

--- a/odoo/addons/test_translation_import/view.xml
+++ b/odoo/addons/test_translation_import/view.xml
@@ -10,7 +10,7 @@
             <field name="target">current</field>
         </record>
 
-        <menuitem id="menu_test_translation" name="Test translation"/>
+        <menuitem id="menu_test_translation" name="Test translation" sequence="650"/>
 
         <menuitem id="menu_test_translation_import"
             name="Test translation import"


### PR DESCRIPTION
PURPOSE

Reorder the menus of the app switcher in order to reduce the distance between correlated applications, and bring the most common apps upward.

SPECIFICATIONS

Current
Currently, in master with all apps installed: https://www.awesomescreenshot.com/image/7489455?key=80bac6cba18b7984fd0b40c11eff6c4e
1) the 'Sales' app is 18 menus away from 'Accounting'
2) 'Social Marketing' is 25 menus away from 'Email Marketing'
3) 'IoT' is on the second line of menus, nowhere close to the inventory apps
4) etc.

To be
Reorder the menus of the app switcher.

PR:  #69984
Task Id: 2513082

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr