### PR TITLE
[IMP] test_lint: Add eslint to the test suite

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -620,7 +620,7 @@ var DataImport = AbstractAction.extend({
     _cleanFieldComments: function (changedField, fieldRemovedId) {
         // Check that the column was not mapped to same field than another column
         if (fieldRemovedId) {
-            var $sameMappedFields = self.$(`.oe_import_comment_cell[field=\"${fieldRemovedId}\"]`).find('.oe_import_same_mapped_field');
+            var $sameMappedFields = this.$(`.oe_import_comment_cell[field=\"${fieldRemovedId}\"]`).find('.oe_import_same_mapped_field');
             if ($sameMappedFields.length == 2) {
                 // remove all same mapped field comments
                 $sameMappedFields.remove();
@@ -659,7 +659,7 @@ var DataImport = AbstractAction.extend({
     _handleMappingComments: function (changedField, fieldInfo) {
         // check if two columns are mapped on the same fields (for char/text fields)
         var commentsToAdd = [];
-        var $sameMappedFields = self.$('.oe_import_comment_cell[field="' + fieldInfo.id + '"]');
+        var $sameMappedFields = this.$('.oe_import_comment_cell[field="' + fieldInfo.id + '"]');
 
         if (fieldInfo.type == 'many2many') {
             commentsToAdd.push(QWeb.render('ImportView.comment_m2m_field'));

--- a/addons/hw_drivers/static/src/js/worker.js
+++ b/addons/hw_drivers/static/src/js/worker.js
@@ -1,3 +1,4 @@
+/* global display_identifier */
     $(function() {
         "use strict";
         // mergedHead will be turned to true the first time we receive something from a new host
@@ -41,9 +42,11 @@
 
                         // Here we execute the code coming from the pos, apparently $.parseHTML() executes scripts right away,
                         // Since we modify the dom afterwards, the script might not have any effect
+                        /* eslint-disable no-undef */
                         if (typeof foreign_js !== 'undefined' && $.isFunction(foreign_js)) {
                             foreign_js();
                         }
+                        /* eslint-enable no-undef */
                     }
                     longpolling();
                 },

--- a/addons/pad/static/plugin/ep_disable_init_focus/static/js/disable_init_focus.js
+++ b/addons/pad/static/plugin/ep_disable_init_focus/static/js/disable_init_focus.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 exports.aceEditEvent = function(hook, call, editorInfo, rep, documentAttributeManager){
 
     call.editorInfo.ace_focus = focus;

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -1,3 +1,4 @@
+/* global checkVATNumber */
 odoo.define('partner.autocomplete.Mixin', function (require) {
 'use strict';
 

--- a/addons/payment_adyen/static/src/js/payment_form.js
+++ b/addons/payment_adyen/static/src/js/payment_form.js
@@ -1,3 +1,4 @@
+/* global AdyenCheckout */
 odoo.define('payment_adyen.payment_form', require => {
     'use strict';
 

--- a/addons/payment_authorize/static/src/js/payment_form.js
+++ b/addons/payment_authorize/static/src/js/payment_form.js
@@ -1,3 +1,4 @@
+/* global Accept */
 odoo.define('payment_authorize.payment_form', require => {
     'use strict';
 

--- a/addons/payment_stripe/static/src/js/payment_form.js
+++ b/addons/payment_stripe/static/src/js/payment_form.js
@@ -1,3 +1,4 @@
+/* global Stripe */
 odoo.define('payment_stripe.payment_form', require => {
     'use strict';
 

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -195,6 +195,8 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                 if (!result) {
                     await this.showPopup('ErrorPopup', {
                         title: 'Error: no internet connection.',
+                        // FIXME: the variable 'error' is not declared
+                        // eslint-disable-next-line no-undef
                         body: error,
                     });
                 }

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1,3 +1,4 @@
+/* global Backbone, waitForWebfonts */
 odoo.define('point_of_sale.models', function (require) {
 "use strict";
 

--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -1,3 +1,4 @@
+/* global html2canvas */
 odoo.define('point_of_sale.Printer', function (require) {
 "use strict";
 

--- a/addons/point_of_sale/static/tests/tours/point_of_sale.js
+++ b/addons/point_of_sale/static/tests/tours/point_of_sale.js
@@ -1,3 +1,4 @@
+/* global posmodel */
 odoo.define('point_of_sale.tour.pricelist', function (require) {
     "use strict";
 

--- a/addons/point_of_sale/static/tests/unit/test_PaymentScreen.js
+++ b/addons/point_of_sale/static/tests/unit/test_PaymentScreen.js
@@ -1,3 +1,4 @@
+/*global Backbone */
 odoo.define('point_of_sale.tests.PaymentScreen', function (require) {
     'use strict';
 

--- a/addons/point_of_sale/static/tests/unit/test_popups.js
+++ b/addons/point_of_sale/static/tests/unit/test_popups.js
@@ -10,13 +10,12 @@ odoo.define('point_of_sale.test_popups', function(require) {
 
     QUnit.module('unit tests for Popups', {
         before() {
-            class Root extends PopupControllerMixin(PosComponent) {
-                static template = xml`
+            class Root extends PopupControllerMixin(PosComponent) { }
+            Root.template = xml`
                     <div>
                         <t t-if="popup.isShown" t-component="popup.component" t-props="popupProps" t-key="popup.name" />
                     </div>
                 `;
-            }
             Root.env = makePosTestEnv();
             this.Root = Root;
             Registries.Component.freeze();

--- a/addons/pos_hr/static/src/js/CashierName.js
+++ b/addons/pos_hr/static/src/js/CashierName.js
@@ -1,3 +1,4 @@
+/* global Sha1 */
 odoo.define('pos_hr.CashierName', function (require) {
     'use strict';
 

--- a/addons/pos_hr/static/src/js/LoginScreen.js
+++ b/addons/pos_hr/static/src/js/LoginScreen.js
@@ -1,3 +1,4 @@
+/* global Sha1 */
 odoo.define('pos_hr.LoginScreen', function (require) {
     'use strict';
 

--- a/addons/pos_hr/static/src/js/useSelectEmployee.js
+++ b/addons/pos_hr/static/src/js/useSelectEmployee.js
@@ -1,3 +1,4 @@
+/* global Sha1 */
 odoo.define('pos_hr.useSelectEmployee', function (require) {
     'use strict';
 

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -89,7 +89,7 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     }
 
                     if (!amount) {
-                        await this.setNoTip();
+                        await this.setNoTip(serverId);
                     } else {
                         order.finalized = false;
                         order.set_tip(amount);
@@ -111,7 +111,7 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     return confirmed;
                 }
             }
-            async setNoTip() {
+            async setNoTip(serverId) {
                 await this.rpc({
                     method: 'set_no_tip',
                     model: 'pos.order',

--- a/addons/pos_six/static/src/js/payment_six.js
+++ b/addons/pos_six/static/src/js/payment_six.js
@@ -1,3 +1,4 @@
+/* global timapi */
 odoo.define('pos_six.payment', function (require) {
 "use strict";
 

--- a/addons/pos_six/static/src/js/payment_six.js
+++ b/addons/pos_six/static/src/js/payment_six.js
@@ -8,8 +8,8 @@ var PaymentInterface = require('point_of_sale.PaymentInterface');
 
 var _t = core._t;
 
-onTimApiReady = function () {};
-onTimApiPublishLogRecord = function (record) {
+window.onTimApiReady = function () {};
+window.onTimApiPublishLogRecord = function (record) {
     // Log only warning or errors
     if (record.matchesLevel(timapi.LogRecord.LogLevel.warning)) {
         timapi.log(String(record));

--- a/addons/project/static/src/js/burndown_chart/renderer.js
+++ b/addons/project/static/src/js/burndown_chart/renderer.js
@@ -1,9 +1,6 @@
 /** @odoo-module alias=project.BurndownChartRenderer **/
 import * as GraphRenderer from 'web/static/src/js/views/graph/graph_renderer';
-
-const {
-    hexToRGBA,
-} = require("web/static/src/js/views/graph/graph_utils");
+import { hexToRGBA } from "web/static/src/js/views/graph/graph_utils";
 
 export class BurndownChartRenderer extends GraphRenderer {
     /**

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -1,3 +1,4 @@
+/* global ace */
 odoo.define('test_website.reset_views', function (require) {
 'use strict';
 

--- a/addons/web/static/src/js/core/class.js
+++ b/addons/web/static/src/js/core/class.js
@@ -51,6 +51,7 @@ odoo.define('web.Class', function () {
 function OdooClass(){}
 
 var initializing = false;
+// eslint-disable-next-line no-undef
 var fnTest = /xyz/.test(function(){xyz();}) ? /\b_super\b/ : /.*/;
 
 /**

--- a/addons/web/static/src/js/core/error_utils.js
+++ b/addons/web/static/src/js/core/error_utils.js
@@ -46,6 +46,7 @@ export async function annotateTraceback(error) {
     const subst = `:$1`;
     error.stack = error.stack.replace(regex, subst);
   }
+  // eslint-disable-next-line no-undef
   const frames = await StackTrace.fromError(error);
   const lines = traceback.split('\n');
   if (lines[lines.length-1].trim() === "") {

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1,3 +1,4 @@
+/* global ace */
 odoo.define('web.basic_fields', function (require) {
 "use strict";
 

--- a/addons/web/static/src/js/tools/test_menus_loader.js
+++ b/addons/web/static/src/js/tools/test_menus_loader.js
@@ -4,6 +4,7 @@ odoo.define('web.clickEverywhere', function (require) {
     function startClickEverywhere(xmlId, appsMenusOnly) {
         ajax.loadJS('web/static/src/js/tools/test_menus.js').then(
             function() {
+                // eslint-disable-next-line no-undef
                 clickEverywhere(xmlId, appsMenusOnly);
             }
         );

--- a/addons/web/static/src/js/views/abstract_renderer.js
+++ b/addons/web/static/src/js/views/abstract_renderer.js
@@ -6,7 +6,7 @@
  *
  */
 
-var mvc = require('web.mvc');
+import * as mvc from 'web.mvc';
 
 // Renderers may display sample data when there is no real data to display. In
 // this case the data is displayed with opacity and can't be clicked. Moreover,

--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -426,10 +426,10 @@ var CalendarController = AbstractController.extend({
     },
     /**
      * @private
-     * @param {OdooEvent} event
+     * @param {OdooEvent} ev
      */
-    _onPrev: function () {
-        event.stopPropagation();
+    _onPrev: function (ev) {
+        ev.stopPropagation();
         this._move('prev');
     },
 

--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -1,3 +1,4 @@
+/* global FullCalendar */
 odoo.define('web.CalendarRenderer', function (require) {
 "use strict";
 

--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -353,7 +353,7 @@ return AbstractRenderer.extend({
             event: event,
             record: event.extendedProps.record,
             color: this.getColor(event.extendedProps.color_index),
-            showTime: !self.hideTime && event.extendedProps.showTime,
+            showTime: !this.hideTime && event.extendedProps.showTime,
             showLocation: this.state.scale !== 'month'
         };
         this.qweb_context = qweb_context;

--- a/addons/web/static/src/js/views/pivot/pivot_view.js
+++ b/addons/web/static/src/js/views/pivot/pivot_view.js
@@ -18,7 +18,7 @@
     const _t = core._t;
     const _lt = core._lt;
 
-    const searchUtils = require('web.searchUtils');
+    import * as searchUtils from 'web.searchUtils';
     const GROUPABLE_TYPES = searchUtils.GROUPABLE_TYPES;
 
     const PivotView = AbstractView.extend({

--- a/addons/web/static/src/js/views/view_utils.js
+++ b/addons/web/static/src/js/views/view_utils.js
@@ -1,8 +1,8 @@
 /** @odoo-module alias=web.viewUtils **/
 
 
-var dom = require('web.dom');
-var utils = require('web.utils');
+import * as dom from 'web.dom';
+import * as utils from 'web.utils';
 
 var viewUtils = {
     /**

--- a/addons/web/static/tests/views/form_benchmarks.js
+++ b/addons/web/static/tests/views/form_benchmarks.js
@@ -1,3 +1,4 @@
+/* global Benchmark */
 odoo.define('web.form_benchmarks', function (require) {
     "use strict";
 

--- a/addons/web/static/tests/views/kanban_benchmarks.js
+++ b/addons/web/static/tests/views/kanban_benchmarks.js
@@ -1,3 +1,4 @@
+/* global Benchmark */
 odoo.define('web.kanban_benchmarks', function (require) {
     "use strict";
 

--- a/addons/web/static/tests/views/list_benchmarks.js
+++ b/addons/web/static/tests/views/list_benchmarks.js
@@ -1,3 +1,4 @@
+/* global Benchmark */
 odoo.define('web.list_benchmarks', function (require) {
     "use strict";
 

--- a/addons/web_editor/static/shapes/convert.js
+++ b/addons/web_editor/static/shapes/convert.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /*
 The following script can be used to convert SVGs exported from illustrator into
 a format that's compatible with the shape system. It runs with nodejs. Some

--- a/addons/website/static/src/js/backend/dashboard.js
+++ b/addons/website/static/src/js/backend/dashboard.js
@@ -1,3 +1,4 @@
+/* global google, gapi */
 odoo.define('website.backend.dashboard', function (require) {
 'use strict';
 

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1,3 +1,4 @@
+/* globals google*/
 odoo.define('website.editor.snippets.options', function (require) {
 'use strict';
 

--- a/addons/website/static/src/snippets/s_google_map/000.js
+++ b/addons/website/static/src/snippets/s_google_map/000.js
@@ -1,3 +1,4 @@
+/* global google */
 odoo.define('website.s_google_map', function (require) {
 'use strict';
 

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -1,3 +1,4 @@
+/* global ace */
 odoo.define('website.test.html_editor', function (require) {
 'use strict';
 

--- a/addons/website_event_track/static/src/js/service_worker.js
+++ b/addons/website_event_track/static/src/js/service_worker.js
@@ -1,3 +1,6 @@
+/* eslint-env serviceworker */
+/* eslint-disable no-restricted-globals */
+/* global idbKeyval */
 importScripts("/website_event_track/static/lib/idb-keyval/idb-keyval.js");
 
 const PREFIX = "odoo-event";
@@ -5,6 +8,7 @@ const SYNCABLE_ROUTES = ["/event/track/toggle_reminder"];
 const CACHABLE_ROUTES = ["/web/webclient/version_info"];
 const MAX_CACHE_SIZE = 512 * 1024 * 1024; // 500 MB
 const MAX_CACHE_QUOTA = 0.5;
+// eslint-disable-next-line no-undef
 const CDN_URL = __ODOO_CDN_URL__; // {string|undefined} the cdn_url configured for the website if activated
 
 const { Store, set, get, del } = idbKeyval;

--- a/addons/website_event_track_live/static/src/js/website_event_track_live.js
+++ b/addons/website_event_track_live/static/src/js/website_event_track_live.js
@@ -1,3 +1,4 @@
+/* global YT */
 var onYouTubeIframeAPIReady;
 
 odoo.define('website_event_track_live.website_event_youtube_embed', function (require) {

--- a/addons/website_google_map/static/src/js/website_google_map.js
+++ b/addons/website_google_map/static/src/js/website_google_map.js
@@ -1,3 +1,4 @@
+/* global MarkerClusterer, google */
 function initialize_map() {
     'use strict';
 
@@ -73,6 +74,7 @@ function initialize_map() {
         }
     };
 
+    /* eslint-disable no-undef */
     // Create the markers and cluster them on the map
     if (odoo_partner_data){ /* odoo_partner_data special variable should have been defined in google_map.xml */
         for (var i = 0; i < odoo_partner_data.counter; i++) {
@@ -80,6 +82,7 @@ function initialize_map() {
         }
         var markerCluster = new MarkerClusterer(map, markers, options);
     }
+    /* eslint-enable no-undef */
 }
 
 // Initialize map once the DOM has been loaded

--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -1,3 +1,4 @@
+/* global YT */
 var onYouTubeIframeAPIReady = undefined;
 
 odoo.define('website_slides.fullscreen', function (require) {

--- a/addons/website_slides/static/src/js/slides_embed.js
+++ b/addons/website_slides/static/src/js/slides_embed.js
@@ -1,3 +1,4 @@
+/* global PDFSlidesViewer */
 /**
  * This is a minimal version of the PDFViewer widget.
  * It is NOT use in the website_slides module, but it is called when embedding

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -485,7 +485,7 @@ var SlideUploadDialog = Dialog.extend({
                  * In the mean time, this small fix allows not refactoring all of this and can not
                  * cause much harm.
                  */
-                Util = window.pdfjsLib.Util;
+                window.Util = window.pdfjsLib.Util;
                 window.pdfjsLib.getDocument(new Uint8Array(buffer), null, passwordNeeded).then(function getPdf(pdf) {
                     self._formSetFieldValue('duration', (pdf._pdfInfo.numPages || 0) * 5);
                     pdf.getPage(1).then(function getFirstPage(page) {

--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -1,6 +1,7 @@
 from . import test_pylint
 from . import test_pofile
 from . import test_ecmascript
+from . import test_eslint
 from . import test_markers
 from . import test_onchange_domains
 from . import test_dunderinit

--- a/odoo/addons/test_lint/tests/test_eslint.py
+++ b/odoo/addons/test_lint/tests/test_eslint.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import re
+import subprocess
+from unittest import skipIf
+from odoo import tools
+
+from . import lint_case
+
+RULES = ('{'
+        '"no-undef": "error",'
+        '"no-restricted-globals": ["error", "event", "self"]'
+        '}'
+)
+PARSER_OPTIONS = '{ecmaVersion: 2019, sourceType: module}'
+GLOBAL = ','.join([
+        'owl',
+        'odoo',
+        '$',
+        'jQuery',
+        '_',
+        'Chart',
+        'fuzzy',
+        'QWeb2',
+        'Popover',
+        'StackTrace',
+        'QUnit',
+        'moment',
+        'py',
+        'ClipboardJS',
+])
+
+_logger = logging.getLogger(__name__)
+
+try:
+    eslint = tools.misc.find_in_path('eslint')
+except IOError:
+    eslint = None
+
+@skipIf(eslint is None, "eslint tool not found on this system")
+class TestESLint(lint_case.LintCase):
+
+    longMessage = True
+
+    def test_eslint_version(self):
+        """ Test that there are no eslint errors in javascript files """
+
+        files_to_check = [
+            p for p in self.iter_module_files('**/static/**/*.js')
+            if not re.match('.*/libs?/.*', p)  # don't check libraries
+        ]
+
+        _logger.info('Testing %s js files', len(files_to_check))
+        # https://eslint.org/docs/user-guide/command-line-interface
+        cmd = [eslint, '--no-eslintrc', '--env', 'browser', '--env', 'es2017', '--parser-options', PARSER_OPTIONS, '--rule', RULES, '--global', GLOBAL] + files_to_check
+        process = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False)
+        self.assertEqual(process.returncode, 0, msg=process.stdout.decode())


### PR DESCRIPTION
[IMP] test_lint: Add ESLint to the test suite

This commit allows using ESLint on the code JS to disallow undeclared
variables (no-undef) and disallow specific global variables
(no-restricted-globals) (error, event and self).

-----------------
 
[IMP]*: configuration of ESLint for specific files

This commit will add the needed ESLint configurations on the JS files.
These configurations are added if the JS file uses a different
environment (serviceworker, node, etc) or if it uses a specific global
(google, ace, etc).

-----------------
 
[FIX] web, project: use the ES6 import

Remove the CommonJS require from the odoo-modules files and replace it
with the new ES6 imports.

-----------------
 
[FIX] *: undeclared variables and restricted globals