### PR TITLE
[FIX] account_check_printing: Only administrator can print checks

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -84,7 +84,7 @@ class AccountPayment(models.Model):
     def _inverse_check_number(self):
         for payment in self:
             if payment.check_number:
-                sequence = payment.journal_id.check_sequence_id
+                sequence = payment.journal_id.check_sequence_id.sudo()
                 sequence.padding = len(payment.check_number)
 
     @api.depends('payment_type', 'journal_id', 'partner_id')


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a user U not in group group_system
- Log with U
- Create a vendor payment with payment method Checks
- Print it

Bug:

An access error was raised because U didn't have the rights to write on model ir.sequence

opw:2513014