### PR TITLE
[FIX] hr_recruitment: allow to restore Application

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -515,7 +515,8 @@ class Applicant(models.Model):
                 ], order='sequence asc', limit=1).id
         for applicant in self:
             applicant.write(
-                {'stage_id': default_stage[applicant.job_id.id], 'refuse_reason_id': False})
+                {'stage_id': applicant.job_id.id and default_stage[applicant.job_id.id],
+                 'refuse_reason_id': False})
 
     def toggle_active(self):
         res = super(Applicant, self).toggle_active()


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a Job Application without Applied Job
- Refuse/Archive it.
- Restore/Unarchive it

Bug:

- KeyError raised due to missing `False` in `default_stage`

Fix:

- Add `stage_id` if Applied Job is selected on the application.

opw:2513147

Co-authored-by: simongoffin <sig@odoo.com>