### PR TITLE
[FIX] resource: allow a working time of 24 hours

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -718,7 +718,7 @@ class ResourceCalendarAttendance(models.Model):
         # avoid negative or after midnight
         self.hour_from = min(self.hour_from, 23.99)
         self.hour_from = max(self.hour_from, 0.0)
-        self.hour_to = min(self.hour_to, 23.99)
+        self.hour_to = min(self.hour_to, 24)
         self.hour_to = max(self.hour_to, 0.0)
 
         # avoid wrong order


### PR DESCRIPTION
It is not possible to define a working time that lasts a whole day. This
can lead to calculation errors.

To reproduce the error:
(Need mrp,hr_payroll)
1. In Settings, enable:
    - Work Orders
2. Create a Work Center WC
    - Working Hours: <Create and Edit>
        - 2 shifts:
            - Monday, From 0 To 24
            - Tuesday, From 0 To 24
3. Create a routing R:
    - Add an operation:
        - Work Center: WC
        - Default Duration: 1440 (i.e., 24h)
4. Create a Bills of Materials BM
    - Routing: R
5. Create a MO:
    - Bill of Material: BM
    - Plan From: Next Monday
6. Save, Mark as ToDo, Plan

Error: Since the operation should last 24 hours, the end time should be
the same. However, the Planned Date field is incorrect: the end time is
one minute too late. This error is even more noticeable when increasing
the quantity to be produced.

On step 2, when setting the 'Work to' field to 24, it automatically
becomes 23:59. The first consequence is directly observable on working
time form: we should have a total of 48 hours/week but the current total
is 47.98 hours/week. Another consequence is the end of the planned date
(as described above).

OPW-2462094