### PR TITLE
[FIX] account: cash basis taxes: generate correct exchange differencewhen using the same cash basis taxes on multiple lines

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4385,10 +4385,17 @@ class AccountMoveLine(models.Model):
                             continue
 
                         grouping_key = self.env['account.partial.reconcile']._get_cash_basis_base_line_grouping_key_from_record(line, account=account_to_fix)
-                        account_vals_to_fix[grouping_key] = {
-                            **vals,
-                            'account_id': account_to_fix.id,
-                        }
+
+                        if grouping_key not in account_vals_to_fix:
+                            account_vals_to_fix[grouping_key] = {
+                                **vals,
+                                'account_id': account_to_fix.id,
+                            }
+                        else:
+                            # Multiple base lines could share the same key, if the same
+                            # cash basis tax is used alone on several lines of the invoices
+                            account_vals_to_fix[grouping_key]['debit'] += vals['debit']
+                            account_vals_to_fix[grouping_key]['credit'] += vals['credit']
 
                 # ==========================================================================
                 # Subtract the balance of all previously generated cash basis journal entries


### PR DESCRIPTION
To reproduce the bug:
1) Create a cash basis tax for 42%
2) Make an invoice with two lines at 100$, each using this tax
3) Post and register full payment of the invoice

==> An exchange difference has been generated, doing +100 -100. One of its two line has tax_ids set, while the other does not. This makes the base amount shown in the generic tax report wrong: 100 instead of 200.

Actually, this exchange difference entry shouldn't have existed in the first place, as there is no rounding issue to compensate for here. It happens because the grouping keys computed for the two base lines are the same, and the second line overwrites the totals of the first one instead of adding them to its own.

