### PR TITLE
[FIX] hr_attendance: compute worked hours when needed

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -39,7 +39,7 @@ class HrAttendance(models.Model):
     @api.depends('check_in', 'check_out')
     def _compute_worked_hours(self):
         for attendance in self:
-            if attendance.check_out:
+            if attendance.check_out and attendance.check_in:
                 delta = attendance.check_out - attendance.check_in
                 attendance.worked_hours = delta.total_seconds() / 3600.0
             else:


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to Attendances > Manager > Attendances
- Remove Check in value of an hr.attendance record A
- Set Check out to A

Bug:

A traceback was raised

opw:2513143