### PR TITLE
Replace session_gc by @autovacuum on ir_http

### DIFF
--- a/doc/cla/corporate/archeti.md
+++ b/doc/cla/corporate/archeti.md
@@ -1,0 +1,15 @@
+Canada, 2021-04-28
+
+ArcheTI agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Loïc Faure-Lacroix llacroix@archeti.com https://github.com/llacroix
+
+List of contributors:
+
+Loïc Faure-Lacroix llacroix@archeti.com https://github.com/llacroix


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Move the session_gc behaviour into a cron job instead of having it forced every 1000 http requests on average.

Current behavior before PR:

session_gc is called 1 time every 1000 http requests

Desired behavior after PR is merged:

session_gc is never called but session_gc becomes called by the autovacuum cron job. It can be inherited in modules
to handle session gc differently based on the session store being used.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
