### PR TITLE
[13.0][FIX] sale: error when a employee timesheet a task which is linked to a SO

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -475,7 +475,10 @@ class SaleOrder(models.Model):
 
         if 'invoice_status' in values:
             if values['invoice_status'] == 'upselling':
-                filtered_self = self.search([('id', 'in', self.ids),
+                # When a employee timesheet a task which is linked to a SO, 
+                # he might not have the rights to read on SO. 
+                # But we need the system to seach SO (so 'read' access), hence the `sudo`.
+                filtered_self = self.sudo().search([('id', 'in', self.ids),
                                              ('user_id', '!=', False),
                                              ('invoice_status', '!=', 'upselling')])
                 filtered_self.activity_unlink(['sale.mail_act_sale_upsell'])


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When a employee timesheet a task which is linked to a SO,  he might not have the rights to read on SO. But we need the system to seach SO to create a new activity to upsell the SO

**Current behavior before PR:**

An error occurred, employee cannot timesheet a task which is linked to a SO

**Desired behavior after PR is merged:**

Employee can timesheet a task which is linked to a SO



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
