### PR TITLE
[FIX] website_sale_stock : show correct price

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -175,6 +175,7 @@ class ProductTemplate(models.Model):
     def _compute_cost_currency_id(self):
         self.cost_currency_id = self.env.company.currency_id.id
 
+    @api.depends_context('pricelist', 'partner', 'quantity', 'uom', 'date', 'no_variant_attributes_price_extra')
     def _compute_template_price(self):
         prices = self._compute_template_price_no_inverse()
         for template in self:

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -23,7 +23,7 @@ class ProductTemplate(models.Model):
         virtual_available = 0
         if product:
             website = self.env['website'].get_current_website()
-            product = product.sudo().with_context(warehouse=website.warehouse_id.id)
+            product = product.sudo().with_context(warehouse=website._get_warehouse_available())
             virtual_available = product.virtual_available
             add_qty = min(add_qty, virtual_available)
 

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -17,6 +17,16 @@ class ProductTemplate(models.Model):
     custom_message = fields.Text(string='Custom Message', default='', translate=True)
 
     def _get_combination_info(self, combination=False, product_id=False, add_qty=1, pricelist=False, parent_combination=False, only_template=False):
+        product, __ = self._get_product_combination_info(
+            combination, product_id, parent_combination, only_template)
+
+        virtual_available = 0
+        if product:
+            website = self.env['website'].get_current_website()
+            product = product.sudo().with_context(warehouse=website.warehouse_id.id)
+            virtual_available = product.virtual_available
+            add_qty = min(add_qty, virtual_available)
+
         combination_info = super(ProductTemplate, self)._get_combination_info(
             combination=combination, product_id=product_id, add_qty=add_qty, pricelist=pricelist,
             parent_combination=parent_combination, only_template=only_template)


### PR DESCRIPTION
Impacted versions: 14.0 (and maybe other)

Steps to reproduce:
- create a product, set 2 unit in stock, choose Availability : Show inventory on website and prevent sales if not enough stock
- add pricelist : 1 unit = 100€, 2 unit = 80 €, 3 unit = 60€, 4 unit = 50€
- go to web shop, 
- buy product, click on the plus button, to go 3, quantity is set 2 by Odoo (qty in stock) but the price is 60 €.

Note : if you add in the cart then go in the cart the price is 80 €.

Current behavior:
Price is 60 €

Expected behavior:
Price should be 80 €

Video/Screenshot link (optional):

https://user-images.githubusercontent.com/16716992/116474537-eb2bf300-a878-11eb-99c9-a4e0d634fd69.mov

Support ticket number submitted via odoo.com/help (optional):
OPW #2519174
