### PR TITLE
[IMP] website_event_track_quiz: improved ux for quizzes on tracks

### DIFF
--- a/addons/website_event_track_quiz/data/quiz_demo.xml
+++ b/addons/website_event_track_quiz/data/quiz_demo.xml
@@ -3,6 +3,7 @@
 
     <record id="event_7_track_1_quiz" model="event.quiz">
         <field name="name">What This Event Is All About</field>
+        <field name="event_track_id" ref="website_event_track.event_7_track_1"/>
     </record>
 
     <record id="event_7_track_1_question_0" model="event.quiz.question">
@@ -48,12 +49,9 @@
         <field name="question_id" ref="event_7_track_1_question_1"/>
     </record>
 
-    <record id="website_event_track.event_7_track_1" model="event.track">
-        <field name="quiz_id" ref="website_event_track_quiz.event_7_track_1_quiz"/>
-    </record>
-
     <record id="event_7_track_5_quiz" model="event.quiz">
         <field name="name">Securing your Lumber during transport</field>
+        <field name="event_track_id" ref="website_event_track.event_7_track_5"/>
     </record>
 
     <record id="event_7_track_5_question_0" model="event.quiz.question">
@@ -99,12 +97,9 @@
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
 
-    <record id="website_event_track.event_7_track_5" model="event.track">
-        <field name="quiz_id" ref="website_event_track_quiz.event_7_track_5_quiz"/>
-    </record>
-
     <record id="event_7_track_13_quiz" model="event.quiz">
         <field name="name">Pretty. Ugly. Lovely.</field>
+        <field name="event_track_id" ref="website_event_track.event_7_track_13"/>
     </record>
 
     <record id="event_7_track_13_question_0" model="event.quiz.question">
@@ -132,9 +127,6 @@
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
 
-    <record id="website_event_track.event_7_track_13" model="event.track">
-        <field name="quiz_id" ref="website_event_track_quiz.event_7_track_13_quiz"/>
-    </record>
     <record id="event.event_7" model="event.event">
         <field name="community_menu" eval="True"/>
     </record>

--- a/addons/website_event_track_quiz/models/event_quiz.py
+++ b/addons/website_event_track_quiz/models/event_quiz.py
@@ -11,18 +11,10 @@ class Quiz(models.Model):
 
     name = fields.Char('Name', required=True, translate=True)
     question_ids = fields.One2many('event.quiz.question', 'quiz_id', string="Questions")
-    event_track_ids = fields.One2many('event.track', 'quiz_id', string="Tracks")
-    event_track_id = fields.Many2one(
-        'event.track', compute='_compute_event_track_id',
-        readonly=True, store=True)
+    event_track_id = fields.Many2one('event.track', readonly=True)
     event_id = fields.Many2one(
         'event.event', related='event_track_id.event_id',
         readonly=True, store=True)
-
-    @api.depends('event_track_ids.quiz_id')
-    def _compute_event_track_id(self):
-        for quiz in self:
-            quiz.event_track_id = quiz.event_track_ids[0] if quiz.event_track_ids else False
 
 
 class QuizQuestion(models.Model):

--- a/addons/website_event_track_quiz/views/event_quiz_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_views.xml
@@ -39,10 +39,14 @@
                             placeholder="e.g. Test your Knowledge"/>
                     </h1>
                     <group>
-                        <field name="event_track_id"/>
-                        <field name="event_id"/>
+                        <group>
+                            <field name="event_id"/>
+                        </group>
+                        <group>
+                            <field name="event_track_id"/>
+                        </group>
                     </group>
-                    <group name="questions" string="Questions">
+                    <group name="questions">
                         <field name="question_ids" nolabel="1"
                             context="{
                                 'tree_view_ref': 'website_event_track_quiz.event_quiz_question_view_tree_from_quiz',
@@ -51,17 +55,6 @@
                     </group>
                 </sheet>
             </form>
-        </field>
-    </record>
-
-    <record id="event_quiz_view_form_from_track" model="ir.ui.view">
-        <field name="name">event.quiz.view.form</field>
-        <field name="model">event.quiz</field>
-        <field name="inherit_id" ref="website_event_track_quiz.event_quiz_view_form"/>
-        <field name="mode">primary</field>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='event_track_id']" position="replace"></xpath>
-            <xpath expr="//field[@name='event_id']" position="replace"></xpath>
         </field>
     </record>
 

--- a/addons/website_event_track_quiz/views/event_track_views.xml
+++ b/addons/website_event_track_quiz/views/event_track_views.xml
@@ -5,12 +5,19 @@
         <field name="model">event.track</field>
         <field name="inherit_id" ref="website_event_track.view_event_track_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='event_track_cta_group']" position="after">
-                <group name="event_track_quiz_group">
-                    <field name="quiz_id"
-                        context="{'form_view_ref': 'website_event_track_quiz.event_quiz_view_form_from_track'}"/>
-                </group>
-            </xpath>
+            <field name='stage_id' position="before">
+                <field name="quiz_id" invisible="1"/>
+                <button name="action_add_quiz"
+                    type="object" class="btn btn-primary" string="Add Quiz"
+                    attrs="{'invisible': [('quiz_id', '!=', False)]}" >
+                </button>
+            </field>
+            <field name='is_published' position="before">
+                <button name="action_view_quiz" type="object" class="oe_stat_button"
+                    string="Go to Quiz" icon="fa-question-circle" widget="stat_info"
+                    attrs="{'invisible': [('quiz_id', '=', False)]}">
+                </button>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
PURPOSE
Currently, if we go to tracks in corresponding events, we have a many2one field 
of the 'quiz_id' for selecting or quickly creating a quiz. But this does not 
contribute to an easy workflow. 
The purpose of this commit is to create a flow for creating quiz in form view 
thus improving its ux.

SPECIFICATIONS
-  We removed the many2one field for the quiz from track and created a separate
  action for the quiz in a form so that one user can directly create and add further info.
- Added a primary button 'Add Quiz' if currently there is no quiz associated
  with track.
- Once a track has a quiz, the 'Add Quiz' button will disappear and the
 'Go to Quiz'  stat button will appear, which takes the user to the corresponding
  quiz of the track.
-One can get rid of a quiz either by assigning it to another track or by deleting it.

This is the goal of this commit.

LINKS

PR #70067
Task 2486552
 
