### PR TITLE
[FIX] web: let companies with long names exist

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -463,7 +463,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-6" name="company_address">
+                <div class="col-12" name="company_address">
                     <div t-field="company.partner_id"
                         t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
                     />


### PR DESCRIPTION
This commits removes the absurdity of only being able to use the left half of the report to display the company name. Avoids breaking layout if the company has a long name.

Prior behavior on such cases:
![imagen](https://user-images.githubusercontent.com/973709/116517016-3f10f900-a8c6-11eb-8fbc-3452d1631044.png)


TT28204
Follow up of https://github.com/odoo/odoo/pull/11031, opened 5 years ago... will my grandchildren be able to have a long-named company? 🤔 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
