### PR TITLE
[FIX] website: remove "add image" button from the normal mode

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1132,7 +1132,7 @@ options.registry.gallery = options.Class.extend({
      */
     removeAllImages: function (previewMode) {
         var $addImg = $('<div>', {
-            class: 'alert alert-info css_editable_mode_display text-center',
+            class: 'alert alert-info css_non_editable_mode_hidden text-center',
         });
         var $text = $('<span>', {
             class: 'o_add_images',


### PR DESCRIPTION
The "Add image" button was shown out of the editor mode when removing
all images from a snippet.

task-2469516


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
