### PR TITLE
[IMP] web: allow lazy-loading asset bundles' templates

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -51,7 +51,7 @@ class Http(models.AbstractModel):
             mods = odoo.conf.server_wide_modules or []
             if request.db:
                 mods = list(request.registry._init_modules) + mods
-            qweb_checksum = HomeStaticTemplateHelpers.get_qweb_templates_checksum(debug=request.session.debug)
+            qweb_checksum = HomeStaticTemplateHelpers.get_qweb_templates_checksum(debug=request.session.debug, bundle="web.assets_qweb")
             lang = user_context.get("lang")
             translation_hash = request.env['ir.translation'].get_web_translations_hash(mods, lang)
             menu_json_utf8 = json.dumps(request.env['ir.ui.menu'].load_menus(request.session.debug), default=ustr, sort_keys=True).encode()

--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -225,7 +225,7 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
         var lock = this.qweb_mutex.exec(function () {
             var cacheId = self.cache_hashes && self.cache_hashes.qweb;
             var route  = '/web/webclient/qweb/' + (cacheId ? cacheId : Date.now());
-            return $.get(route).then(function (doc) {
+            return $.get(route, { bundle: 'web.assets_qweb' }).then(function (doc) {
                 if (!doc) { return; }
                 const owlTemplates = [];
                 for (let child of doc.querySelectorAll("templates > [owl]")) {

--- a/doc/reference/javascript_reference.rst
+++ b/doc/reference/javascript_reference.rst
@@ -1266,7 +1266,9 @@ python implementation.
 Now, let us explain how the templates are loaded.  Whenever the web client
 starts, a rpc is made to the */web/webclient/qweb* route.  The server will then
 return a list of all templates defined in data files for each installed modules.
-The correct files are listed in the *qweb* entry in each module manifest.
+The correct files are listed in the *web.assets_qweb* entry in each module
+manifest. It is also possible to lazy-load another bundle's templates by calling
+this same route and giving it the corresponding "bundle" query parameter.
 
 The web client will wait for that list of template to be loaded, before starting
 its first widget.


### PR DESCRIPTION
Previously, lazy-loading xml templates was only possible by fetching the
xml file directly, this meant that it was impossible to lazy-load an
entire bundle's templates with a single request. Additionally,
requesting the xml files directly meant that no inheritance was applied,
causing the need for a separate inheritance system using t-jquery on the
client-side.

This commit alters the /web/webclient/qweb route so that it now takes an
optional bundle id, meaning that it is now possible to lazy-load the xml
from arbitrary bundles.

task-2497943
