### PR TITLE
[FIX] web: pdfjs: hide buttons that doesn't work in webviews

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -253,6 +253,25 @@ function getViewerConfiguration() {
 
 function webViewerLoad() {
   var config = getViewerConfiguration();
+  // Start Odoo patch
+  // Source https://github.com/mozilla/pdf.js/pull/11246 (Detect Android and iOS)
+  const userAgent = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+  const platform = (typeof navigator !== 'undefined' && navigator.platform) || '';
+  const maxTouchPoints = (typeof navigator !== 'undefined' && navigator.maxTouchPoints) || 1;
+  const isAndroid = /Android/.test(userAgent);
+  const isIOS = /\b(iPad|iPhone|iPod)(?=;)/.test(userAgent) || (platform === 'MacIntel' && maxTouchPoints > 1);
+  // Hide Open Button
+  config.toolbar.openFile.setAttribute('hidden', 'true');
+  config.secondaryToolbar.openFileButton.setAttribute('hidden', 'true');
+  // Hide Download Button
+  config.toolbar.download.setAttribute('hidden', 'true');
+  config.secondaryToolbar.downloadButton.setAttribute('hidden', 'true');
+  if (isAndroid || isIOS) {
+    // Hide Print Button
+    config.toolbar.print.setAttribute('hidden', 'true');
+    config.secondaryToolbar.printButton.setAttribute('hidden', 'true');
+  }
+  // End Odoo patch
   window.PDFViewerApplication = pdfjsWebApp.PDFViewerApplication;
   window.PDFViewerApplicationOptions = pdfjsWebAppOptions.AppOptions;
   var event = document.createEvent('CustomEvent');


### PR DESCRIPTION
Some features of the PDF.js library doesn't work in the
webview of the mobile apps.

Initially 'window.print' is defined as an empty function in
webviews unlike browsers where it is already ready.
After that, PDF.js needs to monkey patch 'window.print' and
saves a reference to the original definition, which is not
yet fulfilled in by the mobile app (Java part).
So the print of PDF.js doesn't work in webviews and end
users will need to download the file before printing it.

Regarding the Download button, the 'download' attribute is
not supported by the webview as you can see in:
https://bugs.chromium.org/p/chromium/issues/detail?id=432414
As there's many ways to download a file in Odoo it's not
a big deal to simply hide it in PDF.js.

Because it's quite complicated to fix this, we decided
to hide the features that don't work (Download / Print)
or don't make sense (Open file).

Note that a refactoring is already in progress in order to avoid to
patch this library in master.

Task-ID: 2200168

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
