### PR TITLE
[FIX] stock: allow to use already defined SN

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -448,17 +448,14 @@ class StockMoveLine(models.Model):
                             # If a picking type is linked, we may have to create a production lot on
                             # the fly before assigning it to the move line if the user checked both
                             # `use_create_lots` and `use_existing_lots`.
-                            if ml.lot_name:
-                                if ml.product_id.tracking == 'lot' and not ml.lot_id:
-                                    lot = self.env['stock.production.lot'].search([
-                                        ('company_id', '=', ml.company_id.id),
-                                        ('product_id', '=', ml.product_id.id),
-                                        ('name', '=', ml.lot_name),
-                                    ], limit=1)
-                                    if lot:
-                                        ml.lot_id = lot.id
-                                    else:
-                                        ml_ids_to_create_lot.add(ml.id)
+                            if ml.lot_name and not ml.lot_id:
+                                lot = self.env['stock.production.lot'].search([
+                                    ('company_id', '=', ml.company_id.id),
+                                    ('product_id', '=', ml.product_id.id),
+                                    ('name', '=', ml.lot_name),
+                                ], limit=1)
+                                if lot:
+                                    ml.lot_id = lot.id
                                 else:
                                     ml_ids_to_create_lot.add(ml.id)
                         elif not picking_type_id.use_create_lots and not picking_type_id.use_existing_lots:


### PR DESCRIPTION
- Define a [DEMO] prod with tracking by SN and add some SNs
- Activate "use existing lot/serial number" on the receipt picking type
- Create a purchase order for [DEMO]
- Process the receipt in the barcode app:
  * Scan the product
  * Scan the SN barcode
  * Validate

User will get an error.
It seems that Odoo is trying to create this SN instead of
matching the existing one

opw-2474347

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
