### PR TITLE
[FIX] point_of_sale: post journal entries of cash in/out

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -296,7 +296,7 @@ class PosSession(models.Model):
 
     def _validate_session(self):
         self.ensure_one()
-        if self.order_ids:
+        if self.order_ids or self.statement_ids.line_ids:
             self.cash_real_transaction = self.cash_register_total_entry_encoding
             self.cash_real_expected = self.cash_register_balance_end
             self.cash_real_difference = self.cash_register_difference


### PR DESCRIPTION
When closing a POS session, if there was no sale, the journal entries of
cash in/out will not be posted.

To reproduce the error:
(Need account_accountant)
1. In Point of Sale, open Shop's settings:
    - Enable "Advanced Cash Control"
2. Start a new session:
    - Open POS
    - Close, Confirm
3. Close session
4. Click on "End of Session"
5. Add a "Cash In/out"
    - +$10
6. Set Closing Cash
7. Close Session & Post Entries
8. Accounting > Cash

Error: The $10 line is present but its status is "New". It should be
"Processing".

Since there was no sale during the POS session, the module ignores all
the accounting part. When the session is closed, the accounting part is
ignored because there were no sales. As a result, it does not post the
cash in and out.

OPW-2456395