### PR TITLE
[IMP] website: new palette for theme_buzzy

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -1779,6 +1779,19 @@ $o-color-palettes: map-merge($o-color-palettes,
             'footer': 5,
             'copyright': 4,
         ),
+        'buzzy': (
+            'o-color-1': #637bbe,
+            'o-color-2': #8eb9c7,
+            'o-color-3': #f6f0ea,
+            'o-color-4': #FFFFFF,
+            'o-color-5': #343643,
+
+            'o-cc2-headings': 'o-color-5',
+            'o-cc2-h5': 'o-color-1',
+            'menu': 1,
+            'footer': 2,
+            'copyright': 2,
+        ),
     )
 );
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add a new color palette for the new theme : "Buzzy"

Current behavior before PR:
The color palette was in the primary_variables.scss of the theme (theme_buzzy)

Desired behavior after PR is merged:
Move the palette with the others in the primary_variables.scss of website.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
