### PR TITLE
[FIX] project : open the task when clicking on the title of the task …

### DIFF
--- a/addons/project/static/src/js/project_name_with_subtask_count_widget.js
+++ b/addons/project/static/src/js/project_name_with_subtask_count_widget.js
@@ -5,7 +5,22 @@ odoo.define('project.name_with_subtask_count', function (require) {
     const FieldChar = require('web.basic_fields').FieldChar;
 
     const FieldNameWithSubTaskCount = FieldChar.extend({
-        _render: function () {
+        /**
+         * @override
+         */
+        init() {
+            this._super(...arguments);
+            if (this.viewType === 'kanban') {
+                // remove click event handler
+                const {click, ...events} = this.events;
+                this.events = events;
+            }
+        },
+
+        /**
+         * @override
+         */
+        _render() {
             let result = this._super.apply(this, arguments);
             if (this.recordData.child_text) {
                 this.$el.append($('<span>')


### PR DESCRIPTION
…in kanban

Currently, in the kanban view of the tasks when you click on title of the task,
It will not open the task in the form view.

By this commit, you can open the task when clicking on its title.

TaskID: 2510169

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
