### PR TITLE
[IMP] account: use config bar for real config steps

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2645,24 +2645,6 @@ class AccountMove(models.Model):
         partial = self.env['account.partial.reconcile'].browse(partial_id)
         return partial.unlink()
 
-    @api.model
-    def setting_upload_bill_wizard(self):
-        """ Called by the 'First Bill' button of the setup bar."""
-        self.env.company.sudo().set_onboarding_step_done('account_setup_bill_state')
-
-        new_wizard = self.env['account.tour.upload.bill'].create({})
-        view_id = self.env.ref('account.account_tour_upload_bill').id
-
-        return {
-            'type': 'ir.actions.act_window',
-            'name': _('Import your first bill'),
-            'view_mode': 'form',
-            'res_model': 'account.tour.upload.bill',
-            'target': 'new',
-            'res_id': new_wizard.id,
-            'views': [[view_id, 'form']],
-        }
-
     def button_set_checked(self):
         for move in self:
             move.to_check = False

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -95,6 +95,7 @@ class ResCompany(models.Model):
     account_setup_bank_data_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding bank data step", default='not_done')
     account_setup_fy_data_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding fiscal year step", default='not_done')
     account_setup_coa_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding charts of account step", default='not_done')
+    account_setup_taxes_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding Taxes step", default='not_done')
     account_onboarding_invoice_layout_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding invoice layout step", default='not_done')
     account_onboarding_create_invoice_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding create invoice step", default='not_done')
     account_onboarding_sale_tax_state = fields.Selection(ONBOARDING_STEP_STATES, string="State of the onboarding sale tax step", default='not_done')
@@ -210,10 +211,10 @@ class ResCompany(models.Model):
     def get_account_dashboard_onboarding_steps_states_names(self):
         """ Necessary to add/edit steps from other modules (account_winbooks_import in this case). """
         return [
-            'account_setup_bill_state',
             'account_setup_bank_data_state',
             'account_setup_fy_data_state',
             'account_setup_coa_state',
+            'account_setup_taxes_state',
         ]
 
     def get_new_account_code(self, current_code, old_prefix, new_prefix):
@@ -469,6 +470,24 @@ class ResCompany(models.Model):
     def action_open_account_onboarding_create_invoice(self):
         action = self.env["ir.actions.actions"]._for_xml_id("account.action_open_account_onboarding_create_invoice")
         return action
+
+    @api.model
+    def action_open_taxes_onboarding(self):
+        """ Called by the 'Taxes' button of the setup bar."""
+
+        company = self.env.company
+        company.sudo().set_onboarding_step_done('account_setup_taxes_state')
+        view_id_list = self.env.ref('account.view_tax_tree').id
+        view_id_form = self.env.ref('account.view_tax_form').id
+
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Taxes'),
+            'res_model': 'account.tax',
+            'target': 'current',
+            'views': [[view_id_list, 'list'], [view_id_form, 'form']],
+            'context': {'search_default_sale': True, 'search_default_purchase': True, 'active_test': False},
+        }
 
     def action_save_onboarding_invoice_layout(self):
         """ Set the onboarding step as done """

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -298,9 +298,17 @@
                                 </button>
                             </t>
                             <t t-if="journal_type == 'purchase'">
-                                <button class="btn btn-primary o_button_upload_bill oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">
-                                    <span>Upload</span>
-                                </button>
+                                <field name="entries_count" invisible="1"/>
+                                <t t-if="record.entries_count.raw_value > 0">
+                                    <button class="btn btn-primary o_button_upload_bill oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">
+                                        <span>Upload</span>
+                                    </button>
+                                </t>
+                                <t t-else="">
+                                    <button type="object" name="action_create_vendor_bill" class="btn btn-primary oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">
+                                        <span>Upload</span>
+                                    </button>
+                                </t>
                                 <a type="object" name="action_create_new" class="o_invoice_new" groups="account.group_account_invoice">Create Manually</a>
                             </t>
                         </div>

--- a/addons/account/views/account_onboarding_templates.xml
+++ b/addons/account/views/account_onboarding_templates.xml
@@ -30,13 +30,9 @@
         <t t-call="base.onboarding_step">
             <t t-set="title">Bank Account</t>
             <t t-set="description">
-                <t t-if="env.user.has_group('account.group_account_user')">
-                    Setup your bank account to sync bank feeds.
-                </t>
-                <t t-else="">
-                    Setup your bank account to receive payments.
-                </t>
+                Connect your financial accounts in seconds.
             </t>
+            <t t-set="btn_text">Add a bank account</t>
             <t t-set="done_text">Step Completed!</t>
             <t t-set="method" t-value="'setting_init_bank_account_action'" />
             <t t-set="model" t-value="'res.company'" />
@@ -59,21 +55,21 @@
             <t t-set="title">Chart of Accounts</t>
             <t t-set="description">Setup your chart of accounts and record initial balances.</t>
             <t t-set="btn_text">Review</t>
-            <t t-set="done_text">Chart of account set.</t>
+            <t t-set="done_text">Chart of accounts set.</t>
             <t t-set="method" t-value="'setting_chart_of_accounts_action'" />
             <t t-set="model" t-value="'res.company'" />
             <t t-set="state" t-value="state.get('account_setup_coa_state')" />
         </t>
     </template>
-    <template id="dashboard_onboarding_bill_step">
+    <template id="onboarding_taxes_step">
         <t t-call="base.onboarding_step">
-            <t t-set="title">First Bill</t>
-            <t t-set="description">Digitalize your vendor bills with OCR and Artificial Intelligence.</t>
-            <t t-set="btn_text">Let's start!</t>
-            <t t-set="done_text">All done!</t>
-            <t t-set="method" t-value="'setting_upload_bill_wizard'"/>
-            <t t-set="model" t-value="'account.move'"/>
-            <t t-set="state" t-value="state.get('account_setup_bill_state')"/>
+            <t t-set="title">Taxes</t>
+            <t t-set="description">Set default Taxes for sales and purchase transactions.</t>
+            <t t-set="btn_text">Review</t>
+            <t t-set="done_text">Taxes set.</t>
+            <t t-set="method" t-value="'action_open_taxes_onboarding'" />
+            <t t-set="model" t-value="'res.company'" />
+            <t t-set="state" t-value="state.get('account_setup_taxes_state')" />
         </t>
     </template>
     <!-- ONBOARDING PANELS -->
@@ -98,10 +94,10 @@
             <t t-set="close_method" t-value="'action_close_account_dashboard_onboarding'"/>
             <t t-set="close_model" t-value="'res.company'"/>
 
-            <t t-call="account.dashboard_onboarding_bill_step" name="company_step" />
-            <t t-call="account.onboarding_bank_account_step" name="bank_account_step" />
             <t t-call="account.onboarding_fiscal_year_step" name="fiscal_year_step" />
             <t t-call="account.onboarding_chart_of_account_step" name="chart_of_account_step" />
+            <t t-call="account.onboarding_taxes_step" name="taxes_step" />
+            <t t-call="account.onboarding_bank_account_step" name="bank_account_step" />
         </t>
     </template>
     <!-- SAMPLE INVOICE EMAIL -->

--- a/addons/account/wizard/account_tour_upload_bill.xml
+++ b/addons/account/wizard/account_tour_upload_bill.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <form>
                     <sheet>
-                        <h2>With Odoo, you won't have to records bills manually</h2>
+                        <h2>With Odoo, you won't have to record bills manually</h2>
                         <p>We process bills automatically so that you only have to validate them. Choose how you want to test our artificial intelligence engine:</p>
                         <group>
                             <group>


### PR DESCRIPTION
The purpose is to use config bar for real config steps rather than highlighting tour steps.

Mainly by:
- Removing "First Bill" step from the configuration bar and replacing it by "Company Data".
- Adding "Taxes Review" step in the configuration bar as the last step (after CoA). This step opens the Taxes list view.
- Adapting the Tour according to these changes.

Task: 2475085

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
