### PR TITLE
[FIX] website: fix height and top position of modals

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -187,6 +187,23 @@ $-seen-urls: ();
     }
 }
 
+body:not(.o_fullscreen) {
+    #oe_main_menu_navbar:not(.o_hidden) + #wrapwrap {
+        .o_header_affixed, .modal {
+            // For these elements, in #wrapwrap, position top should be size of
+            // the navbar.
+            top: $o-navbar-height;
+        }
+        .modal {
+            // As the default bootstrap style no longer uses 'bottom: 0' and
+            // added 'height: 100%' since the V4.2 because of a bug on Android.
+            // We have to adapt the height of the modal by removing the height
+            // of the navbar.
+            height: calc(100vh - #{$o-navbar-height});
+        }
+    }
+}
+
 .navbar {
 
     .navbar-collapse {
@@ -772,9 +789,6 @@ $-transition-duration: 200ms;
             }
         }
     }
-}
-#oe_main_menu_navbar + #wrapwrap .o_header_affixed {
-    top: $o-navbar-height;
 }
 
 // Navbar

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -27,6 +27,10 @@ body.o_connected_user {
 
         &.editor_enable.editor_has_snippets {
             padding-right: 0 !important;
+
+            .modal:not(.o_technical_modal) {
+                right: 0;
+            }
         }
         #oe_main_menu_navbar, #web_editor-top-edit {
             transform: translateY(-100%);


### PR DESCRIPTION
Since we added a z-index: 0, on the wrapwrap, the modals are under the
main navbar and therefore partly hidden by the height of this navbar.

After this commit, the top position of a modal is the height of the
main menu navbar but only if that navbar is displayed. The height of
the modals is also reduced with the height of the navigation bar to
avoid overflowing at the bottom.

Some of what this commit did had already been merged in saas-14.2
(in this PR: #69360) but we realized that we also needed this fix in
v14.

task-2501400

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
