### PR TITLE
[IMP] AWS load balancers do not provide X-Forwarded-Host.

### DIFF
--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -42,8 +42,15 @@ class TestHttpMisc(TestHttpBase):
             self.assertEqual(res.json()['REMOTE_ADDR'], reverseproxy_ip)
             self.assertEqual(res.json()['HTTP_HOST'], '')
 
-        # Trust proxy-sent forwarded headers
+        # Don't trust proxy-sent forwarded host by default
         with patch.object(config, 'options', {**config.options, 'proxy_mode': True}):
+            res = self.nodb_url_open('/test_http/wsgi_environ', headers=headers)
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.json()['REMOTE_ADDR'], client_ip)
+            self.assertEqual(res.json()['HTTP_HOST'], '')
+
+        # Trust proxy-sent forwarded host
+        with patch.object(config, 'options', {**config.options, 'proxy_mode': True, 'proxy_x_host': 1}):
             res = self.nodb_url_open('/test_http/wsgi_environ', headers=headers)
             self.assertEqual(res.status_code, 200)
             self.assertEqual(res.json()['REMOTE_ADDR'], client_ip)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -148,11 +148,7 @@ import werkzeug.wsgi
 from werkzeug.urls import URL, url_parse, url_encode, url_quote
 from werkzeug.exceptions import (HTTPException, BadRequest, Forbidden,
                                  NotFound, InternalServerError)
-try:
-    from werkzeug.middleware.proxy_fix import ProxyFix as ProxyFix_
-    ProxyFix = functools.partial(ProxyFix_, x_for=1, x_proto=1, x_host=1)
-except ImportError:
-    from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 try:
     from werkzeug.utils import send_file as _send_file
@@ -1918,14 +1914,14 @@ class Application:
         current_thread.query_time = 0
         current_thread.perf_t0 = time.time()
 
-        if odoo.tools.config['proxy_mode'] and environ.get("HTTP_X_FORWARDED_HOST"):
+        if odoo.tools.config['proxy_mode']:
             # The ProxyFix middleware has a side effect of updating the
             # environ, see https://github.com/pallets/werkzeug/pull/2184
             def fake_app(environ, start_response):
                 return []
             def fake_start_response(status, headers):
                 return
-            ProxyFix(fake_app)(environ, fake_start_response)
+            ProxyFix(fake_app, x_for=config['proxy_x_for'], x_proto=config['proxy_x_proto'], x_host=config['proxy_x_host'], x_port=config['proxy_x_port'], x_prefix=config['proxy_x_prefix'])(environ, fake_start_response)
 
         # Some URLs in website are concatenated, first url ends with /,
         # second url starts with /, resulting url contains two following

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -142,13 +142,28 @@ class configmanager(object):
                          help="Listen port for the gevent worker", type="int", metavar="PORT")
         group.add_option("--no-http", dest="http_enable", action="store_false", my_default=True,
                          help="Disable the HTTP and Longpolling services entirely")
+
+        # HTTP: configure werkzeug proxy mode
+        # https://werkzeug.palletsprojects.com/en/0.16.x/middleware/proxy_fix/
         group.add_option("--proxy-mode", dest="proxy_mode", action="store_true", my_default=False,
                          help="Activate reverse proxy WSGI wrappers (headers rewriting) "
                               "Only enable this when running behind a trusted web proxy!")
+        group.add_option("--proxy-x-for", dest="proxy_x_for", type="int", my_default=1,
+                         help="Number of values to trust for X-Forwarded-For.")
+        group.add_option("--proxy-x-proto", dest="proxy_x_proto", type="int", my_default=1,
+                         help="Number of values to trust for X-Forwarded-Proto.")
+        group.add_option("--proxy-x-host", dest="proxy_x_host", type="int", my_default=0,
+                         help="Number of values to trust for X-Forwarded-Host.")
+        group.add_option("--proxy-x-port", dest="proxy_x_port", type="int", my_default=0,
+                         help="Number of values to trust for X-Forwarded-Port.")
+        group.add_option("--proxy-x-prefix", dest="proxy_x_prefix", type="int", my_default=0,
+                         help="Number of values to trust for X-Forwarded-Prefix.")
+
         group.add_option("--x-sendfile", dest="x_sendfile", action="store_true", my_default=False,
                          help="Activate X-Sendfile (apache) and X-Accel-Redirect (nginx) "
                               "HTTP response header to delegate the delivery of large "
                               "files (assets/attachments) to the web server.")
+
         # HTTP: hidden backwards-compatibility for "*xmlrpc*" options
         hidden = optparse.SUPPRESS_HELP
         group.add_option("--xmlrpc-interface", dest="http_interface", help=hidden)


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Amazon does not set the X-Forwarded-Host header for Classic and Application load balancers.

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html

I have independently confirmed this with tcpdump and Wireshark.

### Current behavior before PR:

Even with --proxy-mode set, the request must also have the X-Forwarded-Host header set or the ProxyFix middleware is not activated.

### Desired behavior after PR is merged:

Odoo --proxy-mode works correctly for Amazon load balancers and any other reverse proxy that does not set X-Forwarded-Host.

I agree with the sentiment of the FIXME comment by @xmo-odoo. Checking for the presence of HTTP_X_FORWARDED_HOST is worse than not useful; it breaks intended functionality. We should rely upon Werkzeug to inspect the headers and adjust the environ appropriately.

https://werkzeug.palletsprojects.com/en/0.16.x/middleware/proxy_fix/

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
