### PR TITLE
[FIX] hw_drivers: socket needs to listen before calling accept

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -574,6 +574,7 @@ class SocketManager(Thread):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind(('', port))
+        self.sock.listen()
 
     @staticmethod
     def create_socket_device(dev, addr):


### PR DESCRIPTION
While a listen backlog of 1 isn't needed, removing the entire listen
call was too much, because accept needs it to be there.
