### PR TITLE
[FIX] im_livechat: 'Visitor' translated in livechat


### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -5,7 +5,7 @@ import random
 import re
 from datetime import datetime, timedelta
 
-from odoo import api, fields, models, modules, tools
+from odoo import api, fields, models, modules, tools, _
 
 class ImLivechatChannel(models.Model):
     """ Livechat Channel
@@ -193,6 +193,8 @@ class ImLivechatChannel(models.Model):
 
     @api.model
     def get_livechat_info(self, channel_id, username='Visitor'):
+        if username == 'Visitor':
+            username = _('Visitor')
         info = {}
         info['available'] = len(self.browse(channel_id).get_available_users()) > 0
         info['server_url'] = self.env['ir.config_parameter'].sudo().get_param('web.base.url')


### PR DESCRIPTION

Make translation work for "Visitor" that was appearing in livechat
session to the visitor.

opw-2504461
