### PR TITLE
[FIX] website: save changes for blog cover options

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2532,7 +2532,7 @@ options.registry.CoverProperties = options.Class.extend({
      */
     start: function () {
         this.$filterValueOpts = this.$el.find('[data-filter-value]');
-
+        this.$target.on('content_changed', this._onCoverUpdate.bind(this));
         return this._super.apply(this, arguments);
     },
 
@@ -2627,6 +2627,19 @@ options.registry.CoverProperties = options.Class.extend({
             return this.$target.data(`use_${params.coverOptName}`) === 'True';
         }
         return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * HACK: add a dirty flag to '[data-oe-field]' elements to allow custom saving.
+     *
+     * @private
+     */
+    _onCoverUpdate() {
+        this.$('[data-oe-field]').addClass('o_dirty');
     },
 });
 


### PR DESCRIPTION
ISSUE :

On blog post page :
    > Edit mode
    > Select a "Size" / "Background Color" option
    > Save > The changes are not applied! (changes are saved
      only when "Filter Intensity" or "BG Image" options are
      changed too).

After checking the code in Editor's '_createWysiwyg()' method,
It seems that only "structure" and "fields" are marked dirty
when updated, and since the "Size" and "Background Color" options
targets the '.o_record_cover_container' element with 'selectClass'
and 'selectStyle' methods, no field will be set as 'dirty' on blog
cover when options changed, as a result, changes won't be saved
[see '_saveViewBlocks()' & '_saveCoverProperties()'].

The goal of this PR is to fix this behaviour by adding a dirty
flag to '[data-oe-field]' elements when blog cover changed in Edit
mode, this way cover properties will be saved for current model.

task-2525059