### PR TITLE
[FIX] core: avoid deprecation warning in requests_toolbelt

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -137,6 +137,7 @@ def init_logger():
         'reportlab.lib.rl_safe_eval',# reportlab importing ABC from collections
         'ofxparse',# ofxparse importing ABC from collections
         'astroid',  # deprecated imp module (fixed in 2.5.1)
+        'requests_toolbelt', # importing ABC from collections (fixed in 0.9)
     ]:
         warnings.filterwarnings('ignore', category=DeprecationWarning, module=module)
 


### PR DESCRIPTION
The requests_toolbelt package < 0.9 uses `from collections import ...`
which is deprecated in python 3.8 [0].

The request_toolbelt package is not a dependency of Odoo but is needed
by zeep [1]. Unfortunately, the Ubuntu python3-requests-toolbelt package
is still 0.8 [2].

This commit filters out the warning.

[0] https://github.com/requests/toolbelt/commit/979f95266c2044893b05cb2314e94c899915748c
[1] https://packages.ubuntu.com/focal/python3-zeep
[2] https://packages.ubuntu.com/focal/python3-requests-toolbelt

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
