### PR TITLE
[FIX] web_editor: prevent linktool destroy on autocomplete click

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -546,7 +546,7 @@ const Wysiwyg = Widget.extend({
                 const $btn = this.toolbar.$el.find('#create-link');
                 this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this}, this.odooEditor.editable, {}, $btn, link);
                 const _onMousedown = ev => {
-                    if (!ev.target.closest('.oe-toolbar')) {
+                    if (!ev.target.closest('.oe-toolbar') && !ev.target.closest('.ui-autocomplete')) {
                         // Destroy the link tools on click anywhere outside the
                         // toolbar.
                         this.linkTools && this.linkTools.destroy();


### PR DESCRIPTION
Odoo task : https://www.odoo.com/web#id=2516361&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
