### PR TITLE
add basic search for binary field

### DIFF
--- a/addons/web/static/src/js/control_panel/search_utils.js
+++ b/addons/web/static/src/js/control_panel/search_utils.js
@@ -11,6 +11,10 @@ odoo.define('web.searchUtils', function (require) {
 
     // Filter menu parameters
     const FIELD_OPERATORS = {
+        binary: [
+            { symbol: "!=", description: _lt("is set"), value: false },
+            { symbol: "=", description: _lt("is not set"), value: false },
+        ],
         boolean: [
             { symbol: "=", description: _lt("is true"), value: true },
             { symbol: "!=", description: _lt("is false"), value: true },
@@ -66,6 +70,7 @@ odoo.define('web.searchUtils', function (require) {
         ],
     };
     const FIELD_TYPES = {
+        binary: 'binary',
         boolean: 'boolean',
         char: 'char',
         date: 'date',

--- a/addons/web/static/tests/control_panel/custom_filter_item_tests.js
+++ b/addons/web/static/tests/control_panel/custom_filter_item_tests.js
@@ -16,6 +16,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
                 date_field: { name: 'date_field', string: "A date", type: 'date', searchable: true },
                 date_time_field: { name: 'date_time_field', string: "DateTime", type: 'datetime', searchable: true },
                 boolean_field: { name: 'boolean_field', string: "Boolean Field", type: 'boolean', default: true, searchable: true },
+                binary_field: { name: 'binary_field', string: "Binary Field", type: 'binary', searchable: true },
                 char_field: { name: 'char_field', string: "Char Field", type: 'char', default: "foo", trim: true, searchable: true },
                 float_field: { name: 'float_field', string: "Floaty McFloatface", type: 'float', searchable: true },
                 color: { name: 'color', string: "Color", type: 'selection', selection: [['black', "Black"], ['white', "White"]], searchable: true },
@@ -112,6 +113,49 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
             cfi.destroy();
         });
 
+        QUnit.test('binary field: basic search', async function (assert) {
+            assert.expect(4);
+
+            let expectedFilters;
+            class MockedSearchModel extends ActionModel {
+                dispatch(method, ...args) {
+                    assert.strictEqual(method, 'createNewFilters');
+                    const preFilters = args[0];
+                    assert.deepEqual(preFilters, expectedFilters);
+                }
+            }
+            const searchModel = new MockedSearchModel();
+            const cfi = await createComponent(CustomFilterItem, {
+                props: {
+                    fields: this.fields,
+                },
+                env: { searchModel },
+            });
+
+            // Default value
+            expectedFilters = [{
+                description: 'Binary Field is set',
+                domain: '[["binary_field","!=",False]]',
+                type: 'filter',
+            }];
+            await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'binary_field');
+            await cpHelpers.applyFilter(cfi);
+
+            // Updated value
+            expectedFilters = [{
+                description: 'Binary Field is not set',
+                domain: '[["binary_field","=",False]]',
+                type: 'filter',
+            }];
+            await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'binary_field');
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_operator'), '=');
+            await cpHelpers.applyFilter(cfi);
+
+            cfi.destroy();
+        });
+
         QUnit.test('selection field: default and updated value', async function (assert) {
             assert.expect(4);
 
@@ -179,6 +223,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
             });
 
             await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'boolean_field');
             await cpHelpers.applyFilter(cfi);
 
             // The only thing visible should be the button 'Add Custome Filter';


### PR DESCRIPTION
PURPOSE

Allow to check whether a binary field is set or not by adding a basic filtering on binary fields.
The main use case is to give users a way to filter records (e.g. products, contacts) that (do not) have a image set.

SPECIFICATION

Add binary fields to the list of field types usable in custom filters.
The only supported operators are 'set' and 'not set' (just like when filtering based on a boolean field).

TASK 2512226

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
