### PR TITLE
[FIX] website, web_editor: fix traceback on menu edit

### DIFF
--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -737,7 +737,7 @@ var EditMenuDialog = weWidgets.Dialog.extend({
             }, menu.fields));
             dialog.on('save', this, link => {
                 _.extend(menu.fields, {
-                    'name': link.text,
+                    'name': link.content,
                     'url': link.url,
                     'new_window': link.isNewWindow,
                 });

--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -461,7 +461,7 @@ var MenuEntryDialog = weWidgets.LinkDialog.extend({
             isNewWindow: data.new_window,
         }, data || {}));
 
-        this.linkWidget.xmlDependencies = ['/website/static/src/xml/website.contentMenu.xml'];
+        this.linkWidget.xmlDependencies = this.linkWidget.xmlDependencies.concat(['/website/static/src/xml/website.contentMenu.xml']);
 
         const oldSave = this.linkWidget.save;
         /**

--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -48,7 +48,7 @@ const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
             });
             const data = {
                 id: $menu.data('oe-id'),
-                name: link.text,
+                name: link.content,
                 url: link.url,
             };
             return this._rpc({
@@ -57,7 +57,7 @@ const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
                 args: [websiteId, {'data': [data]}],
             }).then(function () {
                 self.$target.attr('href', link.url);
-                $menu.text(link.text);
+                $menu.text(link.content);
             });
         });
         dialog.open();


### PR DESCRIPTION
Previously:
When trying to add a menu link 2 errors could occur :
a QWeb template error and if the user did not properly fill the
Link Dialog, they would get a Traceback instead of a simple indication
that they did not fill all the fields

Reason:
Because of a refactor done in #69183, linkWidget was missing an XML
dependency. It was also trying to save even if the content was invalid.

Fix:
Combining XML dependencies instead of overwriting them,
checking if the final_data is set before trying to save it.
This commit also adds tests to make sure the edit menu feature works.

task-2513588

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
