### PR TITLE
[FIX] point_of_sale: create only one picking when validating order (i…

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -138,8 +138,8 @@ class PosOrder(models.Model):
                 raise
             except Exception as e:
                 _logger.error('Could not fully process the POS Order: %s', tools.ustr(e))
+            pos_order._create_order_picking()
 
-        pos_order._create_order_picking()
         if pos_order.to_invoice and pos_order.state == 'paid':
             pos_order.action_pos_order_invoice()
 


### PR DESCRIPTION
…f the option is activated)

Description of the issue/feature this PR addresses:
With this following configuration: restaurant (with floor management) and the `update quantity in stock` setting set to `real time`, whenever an order is processed (syncing with the database or validating an order), a picking is always created (if there are lines containing storable product).

Current behavior before PR:
Multiple pickings can be created for one order
Desired behavior after PR is merged:
Only one picking is created

