### PR TITLE
[FIX] point_of_sale: fix some issues for POS printing

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1696,6 +1696,9 @@ td {
 }
 
 @media print {
+    body {
+        background: white;
+    }
     body * {
         visibility: hidden;
     }

--- a/addons/point_of_sale/static/src/js/Misc/AbstractReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Misc/AbstractReceiptScreen.js
@@ -39,13 +39,9 @@ odoo.define('point_of_sale.AbstractReceiptScreen', function (require) {
                 return await this._printWeb();
             }
         }
-        /**
-         * https://stackoverflow.com/questions/21285902/printing-a-part-of-webpage-with-javascript
-         */
         async _printWeb() {
             try {
-                const isPrinted = document.execCommand('print', false, null);
-                if (!isPrinted) window.print();
+                window.print();
                 return true;
             } catch (err) {
                 await this.showPopup('ErrorPopup', {

--- a/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
@@ -136,8 +136,7 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
         async _printWeb(receipt) {
             try {
                 $(this.el).find('.pos-receipt-container').html(receipt);
-                const isPrinted = document.execCommand('print', false, null);
-                if (!isPrinted) window.print();
+                window.print();
             } catch (err) {
                 await this.showPopup('ErrorPopup', {
                     title: this.env._t('Printing is not supported on some browsers'),


### PR DESCRIPTION
Like commit odoo/odoo@1c5c762
on some device (like Android Mobile) the black background is printed.
We change the background to white to avoid this.

opw-1940434

----

On mobile, the "document.execCommand('print')" call returns "true"
but do nothing, so it doesn't exec the "window.print()".

As the "print" command is deprecated, "window.print()" can be safely called directly.

opw-2486818
