### PR TITLE
[FIX] bad states in decoration-info of purchase.order tree view

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -515,11 +515,11 @@
             <field name="priority" eval="1"/>
             <field name="arch" type="xml">
                 <tree string="Purchase Order" decoration-bf="message_unread==True"
-                      decoration-muted="state=='cancel'" decoration-info="state in ('wait','confirmed')" sample="1">
+                      decoration-muted="state=='cancel'" sample="1">
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="message_unread" invisible="1"/>
                     <field name="partner_ref" optional="hide"/>
-                    <field name="name" string="Reference" readonly="1"/>
+                    <field name="name" string="Reference" readonly="1" decoration-info="state in ('draft','sent')"/>
                     <field name="date_order" invisible="not context.get('quotation_only', False)" optional="show"/>
                     <field name="date_approve" invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="partner_id" readonly="1"/>
@@ -580,7 +580,6 @@
             <field name="arch" type="xml">
                 <tree decoration-bf="message_unread==True"
                     decoration-muted="state=='cancel'"
-                    decoration-info="state in ('wait','confirmed')"
                     string="Purchase Order"
                     class="o_purchase_order"
                     sample="1">
@@ -590,7 +589,7 @@
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="message_unread" invisible="1"/>
                     <field name="partner_ref" optional="hide"/>
-                    <field name="name" string="Reference" readonly="1" decoration-bf="1"/>
+                    <field name="name" string="Reference" readonly="1" decoration-bf="1" decoration-info="state in ('draft','sent')"/>
                     <field name="date_approve" widget="date" invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="partner_id"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>


### PR DESCRIPTION
Trivial patch.

Set correct ``decoration-info`` attribute on ``purchase.order`` tree view, replacing unexisting states ``('wait','confirmed')`` by existing ones ``('draft','sent')``

See list of valid states : https://github.com/odoo/odoo/blob/master/addons/purchase/models/purchase.py#L97

Note : this bug is present since at least V12.0

CC : @Yenthe666, @quentindupont


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
