### PR TITLE
[FIX] stock : wrong float_compare

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -413,7 +413,7 @@ class Picking(models.Model):
         pickings.products_availability = _('Available')
         for picking in pickings:
             forecast_date = max(picking.move_lines.filtered('forecast_expected_date').mapped('forecast_expected_date'), default=False)
-            if any(float_compare(move.forecast_availability, move.product_qty, move.product_id.uom_id.rounding) == -1 for move in picking.move_lines):
+            if any(float_compare(move.forecast_availability, move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in picking.move_lines):
                 picking.products_availability = _('Not Available')
                 picking.products_availability_state = 'late'
             elif forecast_date:


### PR DESCRIPTION
Add the name of argument, if not `precision_digits` is used in `float_compare`.

Description of the issue/feature this PR addresses:
The float compare doesn't work properly.

Current behavior before PR:
Wrong products_availability_state

Desired behavior after PR is merged:
Good products_availability_state

@amoyaux 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
