### PR TITLE
[FIX] l10n_fr: assets update on account.account.template.csv

### DIFF
--- a/addons/l10n_fr/data/account.account.template.csv
+++ b/addons/l10n_fr/data/account.account.template.csv
@@ -315,7 +315,7 @@
 "pcg_422","Comités d'entreprise, d'établissement","422000","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"
 "pcg_4246","Participation des salariés aux résultats - Réserve spéciale","424600","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"
 "pcg_4248","Participation des salariés aux résultats - Comptes courants","424800","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"
-"pcg_425","Personnel - Avances et acomptes","425000","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"
+"pcg_425","Personnel - Avances et acomptes","425000","account.data_account_type_current_assets","l10n_fr.l10n_fr_pcg_chart_template","","True"
 "pcg_426","Personnel - Dépôts","426000","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"
 "pcg_427","Personnel - Oppositions","427000","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"
 "pcg_4282","Personnel - Dettes provisionnées pour congés à payer","428200","account.data_account_type_current_liabilities","l10n_fr.l10n_fr_pcg_chart_template","","True"


### PR DESCRIPTION
425000 current assets rather than current liabilities.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
