### PR TITLE
[12.0][IMP] Allow to force a colored output even if not in a tty enabled terminal

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -178,7 +178,7 @@ def init_logger():
     def is_a_tty(stream):
         return hasattr(stream, 'fileno') and os.isatty(stream.fileno())
 
-    if os.name == 'posix' and isinstance(handler, logging.StreamHandler) and is_a_tty(handler.stream):
+    if os.name == 'posix' and isinstance(handler, logging.StreamHandler) and (is_a_tty(handler.stream) or os.environ.get("PY_COLORS")):
         formatter = ColoredFormatter(format)
         perf_filter = ColoredPerfFilter()
     else:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**: Check the `PY_COLORS` env variable and force a colored log output even if `is_a_tty` is no true

**Current behavior before PR**: When not in a tty enabled device (e.g. a Python shell that spawns a subprocess), Odoo does not print colored logs

**Desired behavior after PR is merged**: Even if the environment is not detected as tty, it might be able to interpret the colored outputs, so we could be able to force it with a custom option (`PY_COLORS` is used as standard in other Python based tools)

@Tecnativa
TT24972

ping @Yajo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
