### PR TITLE
[IMP] mail: compute messaging menu counter with dependencies

### DIFF
--- a/addons/mail/static/src/components/notification_alert/notification_alert.js
+++ b/addons/mail/static/src/components/notification_alert/notification_alert.js
@@ -37,7 +37,7 @@ class NotificationAlert extends Component {
         return (
             windowNotification &&
             windowNotification.permission !== "granted" &&
-            !this.env.messaging.isNotificationPermissionDefault()
+            !this.env.messaging.isNotificationPermissionDefault
         );
     }
 

--- a/addons/mail/static/src/components/notification_list/notification_list.js
+++ b/addons/mail/static/src/components/notification_list/notification_list.js
@@ -143,7 +143,7 @@ class NotificationList extends Component {
                 }).concat(notifications);
         }
         // native notification request
-        if (props.filter === 'all' && this.env.messaging.isNotificationPermissionDefault()) {
+        if (props.filter === 'all' && this.env.messaging.isNotificationPermissionDefault) {
             notifications.unshift({
                 type: 'odoobotRequest',
                 uniqueId: 'odoobotRequest',

--- a/addons/mail/static/src/components/notification_request/notification_request.js
+++ b/addons/mail/static/src/components/notification_request/notification_request.js
@@ -52,8 +52,7 @@ class NotificationRequest extends Component {
      * @param {string} value
      */
     _handleResponseNotificationPermission(value) {
-        // manually force recompute because the permission is not in the store
-        this.env.messaging.messagingMenu.update();
+        this.env.messaging.refreshIsNotificationPermissionDefault();
         if (value !== 'granted') {
             this.env.services['bus_service'].sendNotification({
                 message: this.env._t("Odoo will not have the permission to send native notifications on this device."),

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -223,8 +223,6 @@ function factory(dependencies) {
                 }
             }));
             this.messaging.notificationGroupManager.computeGroups();
-            // manually force recompute of counter (after computing the groups)
-            this.messaging.messagingMenu.update();
         }
 
         /**

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -271,8 +271,6 @@ function factory(dependencies) {
             if (!wasChannelExisting) {
                 return;
             }
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -325,8 +323,6 @@ function factory(dependencies) {
                 // FIXME force the computing of message values (cf task-2261221)
                 this.env.models['mail.message_seen_indicator'].recomputeSeenValues(channel);
             }
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -382,8 +378,6 @@ function factory(dependencies) {
             if (originThread && message.isNeedaction) {
                 originThread.update({ message_needaction_counter: increment() });
             }
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -487,8 +481,6 @@ function factory(dependencies) {
                 });
             }
             // a new thread with unread messages could have been added
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -512,8 +504,6 @@ function factory(dependencies) {
             }
             // deleting message might have deleted notifications, force recompute
             this.messaging.notificationGroupManager.computeGroups();
-            // manually force recompute of counter (after computing the groups)
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -532,8 +522,6 @@ function factory(dependencies) {
                 }
             }
             this.messaging.notificationGroupManager.computeGroups();
-            // manually force recompute of counter (after computing the groups)
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -577,8 +565,6 @@ function factory(dependencies) {
                 // messages on the server.
                 inbox.mainCache.update({ hasToLoadMessages: true });
             }
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -594,8 +580,6 @@ function factory(dependencies) {
             if (moderationMailbox) {
                 moderationMailbox.update({ counter: increment() });
             }
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**
@@ -641,8 +625,6 @@ function factory(dependencies) {
                 isTransient: true,
             }));
             this._notifyThreadViewsMessageReceived(message);
-            // manually force recompute of counter
-            this.messaging.messagingMenu.update();
         }
 
         /**

--- a/addons/mail/static/src/models/model/model.js
+++ b/addons/mail/static/src/models/model/model.js
@@ -231,38 +231,6 @@ function factory() {
             return _.uniqueId(`${this.modelName}_`);
         }
 
-        /**
-         * This function is called when this record has been explicitly updated
-         * with `.update()` or static method `.create()`, at the end of an
-         * record update cycle. This is a backward-compatible behaviour that
-         * is deprecated: you should use computed fields instead.
-         *
-         * @deprecated
-         * @abstract
-         * @private
-         * @param {Object} previous contains data that have been stored by
-         *   `_updateBefore()`. Useful to make extra update decisions based on
-         *   previous data.
-         */
-        _updateAfter(previous) {}
-
-        /**
-         * This function is called just at the beginning of an explicit update
-         * on this function, with `.update()` or static method `.create()`. This
-         * is useful to remember previous values of fields in `_updateAfter`.
-         * This is a backward-compatible behaviour that is deprecated: you
-         * should use computed fields instead.
-         *
-         * @deprecated
-         * @abstract
-         * @private
-         * @param {Object} data
-         * @returns {Object}
-         */
-        _updateBefore() {
-            return {};
-        }
-
     }
 
     /**

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -411,8 +411,6 @@ function factory(dependencies) {
             const channels = this.env.models['mail.thread'].insert(
                 channelInfos.map(channelInfo => this.env.models['mail.thread'].convertData(channelInfo))
             );
-            // manually force recompute of counter
-            this.env.messaging.messagingMenu.update();
             return channels;
         }
 
@@ -2015,8 +2013,14 @@ function factory(dependencies) {
             inverse: 'thread',
             isCausal: true,
         }),
+        /**
+         * States the current messaging instance. Not useful by itself because
+         * messaging is already in the env. But this allows the inverse relation
+         * to contain all known threads. It also serves as compute dependency.
+         */
         messaging: many2one('mail.messaging', {
             compute: '_computeMessaging',
+            inverse: 'allThreads',
         }),
         messagingCurrentPartner: many2one('mail.partner', {
             related: 'messaging.currentPartner',


### PR DESCRIPTION
It was the last remaining usage of the deprecated `_updateAfter` which is
therefore removed too.

Part of task-2258617