### PR TITLE
[MERGE][REF] crm: ensure teams and salespersons pipe constant filling

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -492,6 +492,11 @@ msgid "Automated Probability"
 msgstr ""
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_crm_team_member__assignment_max
+msgid "Average Leads Capacity (on 30 days)"
+msgstr ""
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__is_blacklisted
 msgid "Blacklist"
 msgstr ""
@@ -1599,7 +1604,7 @@ msgstr ""
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_team__assignment_max
-msgid "Lead Capacity"
+msgid "Lead Average Capacity"
 msgstr ""
 
 #. module: crm
@@ -1897,11 +1902,6 @@ msgid "Marketing"
 msgstr ""
 
 #. module: crm
-#: model:ir.model.fields,field_description:crm.field_crm_team_member__assignment_max
-msgid "Max Leads (last 30 days)"
-msgstr ""
-
-#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__medium_id
 #: model:ir.model.fields.selection,name:crm.selection__crm_lead__priority__1
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_leads_filter
@@ -2015,7 +2015,7 @@ msgstr ""
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_team__assignment_max
-msgid "Monthly leads for all salesmen belonging to the team"
+msgid "Monthly average leads capacity for all salesmen belonging to the team"
 msgstr ""
 
 #. module: crm

--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -1725,24 +1725,17 @@ msgid "Leads Generation"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_team_member.py:0
-#, python-format
-msgid ""
-"Leads assignment should be done for at least 1 or maximum 30 work days, not "
-"%s."
-msgstr ""
-
-#. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_lead_view_activity
 msgid "Leads or Opportunities"
 msgstr ""
 
 #. module: crm
 #: code:addons/crm/models/crm_team.py:0
+#: code:addons/crm/models/crm_team_member.py:0
 #, python-format
 msgid ""
-"Leads team allocation should be done for at least 1 or maximum 30 work days,"
-" not %s."
+"Leads team allocation should be done for at least 0.2 or maximum 30 work "
+"days, not %.2f."
 msgstr ""
 
 #. module: crm

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1330,7 +1330,7 @@ class Lead(models.Model):
         if include_lost:
             domain += ['|', ('type', '=', 'opportunity'), ('active', '=', True)]
         else:
-            domain += ['&', ('active', '=', True), '|', ('probability', '=', False), ('probability', '<', 100)]
+            domain += ['&', ('active', '=', True), '|', ('stage_id', '=', False), ('stage_id.is_won', '=', False)]
 
         return self.with_context(active_test=False).search(domain)
 

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -497,11 +497,12 @@ class Team(models.Model):
                     leads_assigned += lead
                     leads_done_ids.add(lead.id)
 
-        leads_assigned._handle_salesmen_assignment(user_ids=None, team_id=self.id)
+        duplicates_to_assign = self.env['crm.lead'].union(*leads_dups_dict.keys())
+        (leads_assigned | duplicates_to_assign)._handle_salesmen_assignment(user_ids=None, team_id=self.id)
 
         for lead in leads.filtered(lambda lead: lead in leads_dups_dict):
             lead_duplicates = leads_dups_dict[lead]
-            merged = lead_duplicates._merge_opportunity(user_id=False, team_id=self.id, max_length=0)
+            merged = lead_duplicates._merge_opportunity(user_id=False, team_id=False, max_length=0)
             leads_dup_ids.update((lead_duplicates - merged).ids)
             leads_merged_ids.add(merged.id)
 

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -30,8 +30,8 @@ class Team(models.Model):
     assignment_auto_enabled = fields.Boolean('Auto Assignment', compute='_compute_assignment_enabled')
     assignment_optout = fields.Boolean('Skip auto assignment')
     assignment_max = fields.Integer(
-        'Lead Capacity', compute='_compute_assignment_max',
-        help='Monthly leads for all salesmen belonging to the team')
+        'Lead Average Capacity', compute='_compute_assignment_max',
+        help='Monthly average leads capacity for all salesmen belonging to the team')
     assignment_domain = fields.Char(
         'Assignment Domain', tracking=True,
         help='Additional filter domain when fetching unassigned leads to allocate to the team.')

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -443,7 +443,7 @@ class Team(models.Model):
                     teams_domain[team],
                     [('create_date', '<', max_create_dt)],
                     ['&', ('team_id', '=', False), ('user_id', '=', False)],
-                    ['|', ('stage_id.is_won', '=', False), ('probability', 'not in', [False, 0])]
+                    ['|', ('stage_id', '=', False), ('stage_id.is_won', '=', False)]
                 ])
                 # assign only to reach asked team limit
                 remaining = teams_limit[team] - (len(teams_data[team]['assigned']) + len(teams_data[team]['merged']))

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -342,54 +342,45 @@ class Team(models.Model):
         No salesperson is assigned in this process. Its purpose is simply to
         allocate leads within teams.
 
+        This process allocates all available leads on teams weighted by their
+        maximum assignment by month that indicates their relative workload.
+
         Heuristic of this method is the following:
-
-          * first we randomize all teams;
-          * then for each team
-
-            * find unassigned leads, aka leads being
-
-              * without team, without user -> not assigned;
-              * not in a won stage, and not having False/0 (lost) or 100 (won)
-                probability) -> live leads;
-              * if set, a delay after creation can be applied (see BUNDLE_HOURS_DELAY)
-                parameter explanations here below;
-
-            * keep only leads matching the team's assignment domain (empty means
+          * find unassigned leads for each team, aka leads being
+            * without team, without user -> not assigned;
+            * not in a won stage, and not having False/0 (lost) or 100 (won)
+              probability) -> live leads;
+            * if set, a delay after creation can be applied (see BUNDLE_HOURS_DELAY)
+              parameter explanations here below;
+            * matching the team's assignment domain (empty means
               everything);
-            * assign maximum BUNDLE_SIZE leads to the team, then move to the
-              next team. This is done to ensure every team will have leads
-              enough to fill its capacity based on its domain;
-            * when setting a team on leads, leads belonging to the current batch
-              are also merged. Purpose is to clean database and avoid assigning
+
+          * assign a weight to each team based on their assignment_max that
+            indicates their relative workload;
+
+          * pick a random team using a weighted random choice and find a lead
+            to assign:
+
+            * remove already assigned leads from the available leads. If there
+              is not any lead spare to assign, remove team from active teams;
+            * pick the first lead and set the current team;
+            * when setting a team on leads, leads are also merged with their
+              duplicates. Purpose is to clean database and avoid assigning
               duplicates to same or different teams;
+            * add lead and its duplicates to already assigned leads;
 
-          * evaluate which teams still need to receive leads. This is based on
-            team maximum capacity. We consider a team should receive twice its
-            capacity as leads. That way members will receive leads and can pick
-            some leads in team unassigned pool of leads;
+          * pick another random team until their is no more leads to assign
+            to any team;
 
-        Note that leads are assigned in batch meaning a team could receive
-        leads that could better fit another team. However this heuristics is
-        based on hypothesis that team domains do not overlap. Indeed if a
-        company has several teams they will probably target separate market
-        segments: country-based, customer type or size, ... Having several
-        teams using same assignment domain could lead to less fairness in
-        assignment process but this should not be the target use case of this
-        heuristic.
+        This process ensure that teams having overlapping domains will all
+        receive leads as lead allocation is done one lead at a time. This
+        allocation will be proportional to their size (assignment of their
+        members).
 
-        Leads are allocated by batch. This can be configured using a config
-        parameter (see here below). Batch size depends on cron frequency,
-        lead pipeline size and members assignment maximum. Finding an optimal
-        heuristic for this parameter is not easy as it depends on internal
-        processes and organization. Higher batch size leads to better performances
-        when running automatic assignment. It can also give unfair results
-        if teams domain overlap or if pipeline is not big enough to fill all
-        teams capacity.
-
-        :config int crm.assignment.bundle: optional config parameter allowing
-          to set size of lead batch (BUNDLE_SIZE) allocated to a team at each
-          iteration (50 by default based on experience);
+        :config int crm.assignment.bundle: deprecated
+        :config int crm.assignment.commit.bundle: optional config parameter allowing
+          to set size of lead batch to be committed together. By default 100
+          which is a good trade-off between transaction time and speed
         :config int crm.assignment.delay: optional config parameter giving a
           delay before taking a lead into assignment process (BUNDLE_HOURS_DELAY)
           given in hours. Purpose if to allow other crons or automated actions
@@ -414,85 +405,92 @@ class Team(models.Model):
             raise ValueError(
                 _('Leads team allocation should be done for at least 0.2 or maximum 30 work days, not %.2f.', work_days)
             )
-        # assignment_max is valid for "30 days" -> divide by requested work_days
-        # to have number of leads to assign
-        assign_ratio = work_days / 30.0
 
         BUNDLE_HOURS_DELAY = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.delay', default=0))
-        BUNDLE_SIZE = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.bundle', default=50))
+        BUNDLE_COMMIT_SIZE = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.commit.bundle', 100))
+        auto_commit = not getattr(threading.currentThread(), 'testing', False)
 
         # leads
         max_create_dt = fields.Datetime.now() - datetime.timedelta(hours=BUNDLE_HOURS_DELAY)
         duplicates_lead_cache = dict()
 
-        # teams
-        team_done = self.env['crm.team']
-        remaining_teams = self.env['crm.team'].browse(random.sample(self.ids, k=len(self.ids)))
-        # compute assign domain for each team before looping on them by bundle size
-        teams_domain = dict(
-            (team, literal_eval(team.assignment_domain or '[]'))
-            for team in remaining_teams
-        )
-        # compute limit of leads to assign to each team: 2 times team capacity, based on given work_days
-        teams_limit = dict(
-            (team, 2 * team.assignment_max * assign_ratio)
-            for team in remaining_teams
-        )
+        # teams data
+        teams_data, population, weights = dict(), list(), list()
+        for team in self:
+            if not team.assignment_max:
+                continue
+
+            lead_domain = expression.AND([
+                literal_eval(team.assignment_domain or '[]'),
+                [('create_date', '<', max_create_dt)],
+                ['&', ('team_id', '=', False), ('user_id', '=', False)],
+                ['|', ('stage_id', '=', False), ('stage_id.is_won', '=', False)]
+            ])
+
+            leads = self.env["crm.lead"].search(lead_domain)
+            # Fill duplicate cache: search for duplicate lead before the assignation
+            # avoid to flush during the search at every assignation
+            for lead in leads:
+                if lead not in duplicates_lead_cache:
+                    duplicates_lead_cache[lead] = lead._get_lead_duplicates(email=lead.email_from)
+
+            teams_data[team] = {
+                "team": team,
+                "leads": leads,
+                "assigned": set(),
+                "merged": set(),
+                "duplicates": set(),
+            }
+            population.append(team)
+            weights.append(team.assignment_max)
+
         # assignment process data
         global_data = dict(assigned=set(), merged=set(), duplicates=set())
-        teams_data = dict.fromkeys(remaining_teams, False)
-        for team in remaining_teams:
-            teams_data[team] = dict(assigned=set(), merged=set(), duplicates=set())
+        leads_done_ids, lead_unlink_ids, counter = set(), set(), 0
+        while population:
+            counter += 1
+            team = random.choices(population, weights=weights, k=1)[0]
 
-        remaining_teams = remaining_teams.filtered('assignment_max')
-        while remaining_teams:
-            for team in remaining_teams:
-                lead_domain = expression.AND([
-                    teams_domain[team],
-                    [('create_date', '<', max_create_dt)],
-                    ['&', ('team_id', '=', False), ('user_id', '=', False)],
-                    ['|', ('stage_id', '=', False), ('stage_id.is_won', '=', False)]
-                ])
-                # assign only to reach asked team limit
-                remaining = teams_limit[team] - (len(teams_data[team]['assigned']) + len(teams_data[team]['merged']))
-                lead_limit = min([BUNDLE_SIZE, remaining if remaining > 0 else 1])
-                leads = self.env["crm.lead"].search(lead_domain, limit=lead_limit)
+            # filter remaining leads, remove team if no more leads for it
+            teams_data[team]["leads"] = teams_data[team]["leads"].filtered(lambda l: l.id not in leads_done_ids)
+            if not teams_data[team]["leads"]:
+                population_index = population.index(team)
+                population.pop(population_index)
+                weights.pop(population_index)
+                continue
 
-                # Fill duplicate cache: search for duplicate lead before the assignation
-                # avoid to flush during the search at every assignation
-                for lead in leads:
-                    if lead not in duplicates_lead_cache:
-                        duplicates_lead_cache[lead] = lead._get_lead_duplicates(email=lead.email_from)
+            # assign + deduplicate and concatenate results in teams_data to keep some history
+            candidate_lead = teams_data[team]["leads"][0]
+            assign_res = team._allocate_leads_deduplicate(candidate_lead, duplicates_cache=duplicates_lead_cache)
+            for key in ('assigned', 'merged', 'duplicates'):
+                teams_data[team][key].update(assign_res[key])
+                leads_done_ids.update(assign_res[key])
+                global_data[key].update(assign_res[key])
+            lead_unlink_ids.update(assign_res['duplicates'])
 
-                # assign + deduplicate and concatenate results in teams_data to keep some history
-                assign_res = team._allocate_leads_deduplicate(leads, duplicates_cache=duplicates_lead_cache)
-                _logger.info('Assigned %d leads among %d candidates to team %s' % (len(assign_res['assigned']) + len(assign_res['merged']), len(leads), team.id))
-                _logger.info('\tLeads: direct assign %s / merge result %s / duplicates merged: %s' % (
-                    assign_res['assigned'], assign_res['merged'], assign_res['duplicates']
-                ))
-                for key in ('assigned', 'merged', 'duplicates'):
-                    global_data[key].update(assign_res[key])
-                    teams_data[team][key].update(assign_res[key])
-
+            # auto-commit except in testing mode. As this process may be time consuming or we
+            # may encounter errors, already commit what is allocated to avoid endless cron loops.
+            if auto_commit and counter % BUNDLE_COMMIT_SIZE == 0:
                 # unlink duplicates once
-                self.env['crm.lead'].browse(assign_res['duplicates']).unlink()
+                self.env['crm.lead'].browse(lead_unlink_ids).unlink()
+                lead_unlink_ids = set()
+                self._cr.commit()
 
-                # either no more lead matching domain, either asked capacity assigned
-                if len(leads) < lead_limit or (len(teams_data[team]['assigned']) + len(teams_data[team]['merged'])) >= teams_limit[team]:
-                    team_done += team
+        # unlink duplicates once
+        self.env['crm.lead'].browse(lead_unlink_ids).unlink()
 
-                # auto-commit except in testing mode. As this process may be time consuming or we
-                # may encounter errors, already commit what is allocated to avoid endless cron loops.
-                auto_commit = not getattr(threading.currentThread(), 'testing', False)
-                if auto_commit:
-                    self._cr.commit()
-
-            remaining_team_ids = (remaining_teams - team_done).ids
-            remaining_teams = self.env['crm.team'].browse(random.sample(remaining_team_ids, k=len(remaining_team_ids)))
+        if auto_commit:
+            self._cr.commit()
 
         # some final log
         _logger.info('## Assigned %s leads' % (len(global_data['assigned']) + len(global_data['merged'])))
-
+        for team, team_data in teams_data.items():
+            _logger.info(
+                '## Assigned %s leads to team %s',
+                len(team_data['assigned']) + len(team_data['merged']), team.id)
+            _logger.info(
+                '\tLeads: direct assign %s / merge result %s / duplicates merged: %s',
+                team_data['assigned'], team_data['merged'], team_data['duplicates'])
         return teams_data
 
     def _allocate_leads_deduplicate(self, leads, duplicates_cache=None):
@@ -537,11 +535,6 @@ class Team(models.Model):
             merged = lead_duplicates._merge_opportunity(user_id=False, team_id=False, auto_unlink=False, max_length=0)
             leads_dup_ids.update((lead_duplicates - merged).ids)
             leads_merged_ids.add(merged.id)
-
-            # auto-commit except in testing mode
-            auto_commit = not getattr(threading.currentThread(), 'testing', False)
-            if auto_commit:
-                self._cr.commit()
 
         return {
             'assigned': set(leads_assigned.ids),

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -30,7 +30,9 @@ class Team(models.Model):
     def _compute_lead_month_count(self):
         for member in self:
             if member.user_id.id and member.crm_team_id.id:
-                member.lead_month_count = self.env['crm.lead'].search_count(member._get_lead_month_domain())
+                member.lead_month_count = self.env['crm.lead'].with_context(active_test=False).search_count(
+                    member._get_lead_month_domain()
+                )
             else:
                 member.lead_month_count = 0
 
@@ -53,7 +55,6 @@ class Team(models.Model):
             ('user_id', '=', self.user_id.id),
             ('team_id', '=', self.crm_team_id.id),
             ('date_open', '>=', limit_date),
-            ('probability', '<', 100)
         ]
 
     # ------------------------------------------------------------

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -21,7 +21,7 @@ class Team(models.Model):
     # assignment
     assignment_enabled = fields.Boolean(related="crm_team_id.assignment_enabled")
     assignment_domain = fields.Char('Assignment Domain', tracking=True)
-    assignment_max = fields.Integer('Max Leads (last 30 days)', default=30)
+    assignment_max = fields.Integer('Average Leads Capacity (on 30 days)', default=30)
     lead_month_count = fields.Integer(
         'Leads (30 days)', compute='_compute_lead_month_count',
         help='Lead assigned to this member those last 30 days')
@@ -201,15 +201,11 @@ class Team(models.Model):
         """ Compute assignment quota based on work_days. This quota includes
         a compensation to speedup getting to the lead average (``assignment_max``).
         As this field is a counter for "30 days" -> divide by requested work
-        days in order to have base assign number then add compensation. Limit
-        to max capacity of team member.
+        days in order to have base assign number then add compensation. 
 
         :param float work_days: see ``CrmTeam.action_assign_leads()``;
         """
         assign_ratio = work_days / 30.0
         to_assign = self.assignment_max * assign_ratio
         compensation = max(0, self.assignment_max - (self.lead_month_count + to_assign)) * 0.2
-        return min(
-            self.assignment_max - self.lead_month_count,
-            round(to_assign + compensation)
-        )
+        return round(to_assign + compensation)

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -197,7 +197,7 @@ class Team(models.Model):
             (member_info["team_member"], {"assigned": member_info["assigned"]})
             for member_id, member_info in members_data.items()
         )
-        _logger.info('Assigned %s leads to %s salesmen' % (len(leads_done_ids), len(self)))
+        _logger.info('Assigned %s leads to %s salesmen' % (len(leads_done_ids), len(members)))
         for member, member_info in result_data.items():
             _logger.info('-> member %s: assigned %d leads (%s)' % (member.id, len(member_info["assigned"]), member_info["assigned"]))
         return result_data

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -61,7 +61,7 @@ class Team(models.Model):
     # LEAD ASSIGNMENT
     # ------------------------------------------------------------
 
-    def _assign_and_convert_leads(self, work_days=2):
+    def _assign_and_convert_leads(self, work_days=1):
         """ Main processing method to assign leads to sales team members. It also
         converts them into opportunities. This method should be called after
         ``_allocate_leads`` as this method assigns leads already allocated to
@@ -106,7 +106,7 @@ class Team(models.Model):
         point of view but increases probability leads are correctly distributed
         within the team.
 
-        :param int work_days: see ``CrmTeam.action_assign_leads()``;
+        :param float work_days: see ``CrmTeam.action_assign_leads()``;
 
         :return members_data: dict() with each member assignment result:
           membership: {
@@ -114,9 +114,9 @@ class Team(models.Model):
           }, ...
 
         """
-        if not work_days or work_days > 30:
+        if work_days < 0.2 or work_days > 30:
             raise ValueError(
-                _('Leads assignment should be done for at least 1 or maximum 30 work days, not %s.', work_days)
+                _('Leads team allocation should be done for at least 0.2 or maximum 30 work days, not %.2f.', work_days)
             )
         # assignment_max is valid for "30 days" -> divide by requested work_days
         # to have number of leads to assign

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -118,21 +118,15 @@ class Team(models.Model):
             raise ValueError(
                 _('Leads team allocation should be done for at least 0.2 or maximum 30 work days, not %.2f.', work_days)
             )
-        # assignment_max is valid for "30 days" -> divide by requested work_days
-        # to have number of leads to assign
-        assign_ratio = work_days / 30.0
 
         members_data, population, weights = dict(), list(), list()
-        members = self.filtered(lambda member: member.assignment_max > member.lead_month_count)
+        members = self.filtered(lambda member: member.assignment_max > 0)
         if not members:
             return members_data
 
         # prepare a global lead count based on total leads to assign to salespersons
         lead_limit = sum(
-            min(
-                int(math.ceil(member.assignment_max * assign_ratio)),
-                (member.assignment_max - member.lead_month_count)
-            )
+            member._get_assignment_quota(work_days=work_days)
             for member in members
         )
 
@@ -145,7 +139,7 @@ class Team(models.Model):
 
             leads = self.env["crm.lead"].search(lead_domain, order='probability DESC', limit=lead_limit)
 
-            to_assign = min(member.assignment_max - member.lead_month_count, round(member.assignment_max * assign_ratio))
+            to_assign = member._get_assignment_quota(work_days=work_days)
             members_data[member.id] = {
                 "team_member": member,
                 "max": member.assignment_max,
@@ -202,3 +196,20 @@ class Team(models.Model):
         for member, member_info in result_data.items():
             _logger.info('-> member %s: assigned %d leads (%s)' % (member.id, len(member_info["assigned"]), member_info["assigned"]))
         return result_data
+
+    def _get_assignment_quota(self, work_days=1):
+        """ Compute assignment quota based on work_days. This quota includes
+        a compensation to speedup getting to the lead average (``assignment_max``).
+        As this field is a counter for "30 days" -> divide by requested work
+        days in order to have base assign number then add compensation. Limit
+        to max capacity of team member.
+
+        :param float work_days: see ``CrmTeam.action_assign_leads()``;
+        """
+        assign_ratio = work_days / 30.0
+        to_assign = self.assignment_max * assign_ratio
+        compensation = max(0, self.assignment_max - (self.lead_month_count + to_assign)) * 0.2
+        return min(
+            self.assignment_max - self.lead_month_count,
+            round(to_assign + compensation)
+        )

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -74,7 +74,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'assignment_domain': False,
         })
 
-        (cls.user_sales_manager | cls.user_sales_leads | cls.user_sales_salesman).write({
+        (cls.user_sales_manager + cls.user_sales_leads + cls.user_sales_salesman).write({
             'groups_id': [(4, cls.env.ref('crm.group_use_lead').id)]
         })
 
@@ -137,7 +137,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'team_id': cls.sales_team_1.id,
         })
         cls.lead_team_1_lost.action_set_lost()
-        (cls.lead_team_1_won | cls.lead_team_1_lost).flush()
+        (cls.lead_team_1_won + cls.lead_team_1_lost).flush()
 
         # email / phone data
         cls.test_email_data = [
@@ -200,7 +200,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
 
     def _create_leads_batch(self, lead_type='lead', count=10, email_dup_count=0,
                             partner_count=0, partner_ids=None, user_ids=None,
-                            country_ids=None):
+                            country_ids=None, probabilities=None):
         """ Helper tool method creating a batch of leads, useful when dealing
         with batch processes. Please update me.
 
@@ -268,6 +268,11 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             for idx, lead_data in enumerate(leads_data):
                 lead_data['user_id'] = user_ids[idx % len(user_ids)]
 
+        # probabilities
+        if probabilities:
+            for idx, lead_data in enumerate(leads_data):
+                lead_data['probability'] = probabilities[idx % len(probabilities)]
+
         # duplicates (currently only with email)
         dups_data = []
         if email_dup_count and not partner_ids:
@@ -291,49 +296,44 @@ class TestCrmCommon(TestSalesCommon, MailCase):
           * a lead with customer but another email
           * a lost opportunity with same email_from
         """
-        self.customer = self.env['res.partner'].create({
+        customer = self.env['res.partner'].create({
             'name': 'Lead1 Email Customer',
             'email': lead.email_from,
         })
-        self.lead_email_from = self.env['crm.lead'].create({
+        lead_email_from = self.env['crm.lead'].create({
             'name': 'Duplicate: same email_from',
             'type': 'lead',
             'team_id': lead.team_id.id,
             'email_from': lead.email_from,
         })
-        # self.lead_email_normalized = self.env['crm.lead'].create({
-        #     'name': 'Duplicate: email_normalize comparison',
-        #     'type': 'lead',
-        #     'team_id': lead.team_id.id,
-        #     'stage_id': lead.stage_id.id,
-        #     'email_from': 'CUSTOMER WITH NAME <%s>' % lead.email_normalized.upper(),
-        # })
-        self.lead_partner = self.env['crm.lead'].create({
+        lead_email_normalized = self.env['crm.lead'].create({
+            'name': 'Duplicate: email_normalize comparison',
+            'type': 'lead',
+            'team_id': lead.team_id.id,
+            'stage_id': lead.stage_id.id,
+            'email_from': 'CUSTOMER WITH NAME <%s>' % lead.email_normalized.upper(),
+        })
+        lead_partner = self.env['crm.lead'].create({
             'name': 'Duplicate: customer ID',
             'type': 'lead',
             'team_id': lead.team_id.id,
-            'partner_id': self.customer.id,
+            'partner_id': customer.id,
         })
         if create_opp:
-            self.opp_lost = self.env['crm.lead'].create({
+            opp_lost = self.env['crm.lead'].create({
                 'name': 'Duplicate: lost opportunity',
                 'type': 'opportunity',
                 'team_id': lead.team_id.id,
                 'stage_id': lead.stage_id.id,
                 'email_from': lead.email_from,
             })
-            self.opp_lost.action_set_lost()
+            opp_lost.action_set_lost()
         else:
-            self.opp_lost = self.env['crm.lead']
+            opp_lost = self.env['crm.lead']
 
-        # self.assertEqual(self.lead_email_from.email_normalized, self.lead_email_normalized.email_normalized)
-        # self.assertTrue(lead.email_from != self.lead_email_normalized.email_from)
-        # self.assertFalse(self.opp_lost.active)
-
-        # new_lead = self.lead_email_from | self.lead_email_normalized | self.lead_partner | self.opp_lost
-        new_leads = self.lead_email_from | self.lead_partner | self.opp_lost
+        new_leads = lead_email_from + lead_email_normalized + lead_partner + opp_lost
         new_leads.flush()  # compute notably probability
-        return new_leads
+        return customer, new_leads
 
     @contextmanager
     def assertLeadMerged(self, opportunity, leads, **expected):
@@ -520,12 +520,13 @@ class TestLeadConvertCommon(TestCrmCommon):
                 member_leads.filtered_domain(literal_eval(member.assignment_domain)),
                 member_leads
             )
-        if member.crm_team_id.assignment_domain:
-            self.assertEqual(
-                member_leads.filtered_domain(literal_eval(member.crm_team_id.assignment_domain)),
-                member_leads,
-                'Assign domain not matching: %s' % member.crm_team_id.assignment_domain
-            )
+        # TODO this condition is not fulfilled in case of merge, need to change merge/assignment process
+        # if member.crm_team_id.assignment_domain:
+        #     self.assertEqual(
+        #         member_leads.filtered_domain(literal_eval(member.crm_team_id.assignment_domain)),
+        #         member_leads,
+        #         'Assign domain not matching: %s' % member.crm_team_id.assignment_domain
+        #     )
 
 class TestLeadConvertMassCommon(TestLeadConvertCommon):
 
@@ -599,4 +600,4 @@ class TestLeadConvertMassCommon(TestLeadConvertCommon):
             'stage_id': cls.stage_team1_2.id,
             'active': False,
         })
-        (cls.lead_w_partner | cls.lead_w_partner_company | cls.lead_w_contact | cls.lead_w_email | cls.lead_w_email_lost).flush()
+        (cls.lead_w_partner + cls.lead_w_partner_company + cls.lead_w_contact + cls.lead_w_email + cls.lead_w_email_lost).flush()

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -179,6 +179,32 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.website, lead_data['website'], "Website should keep its initial value")
 
     @users('user_sales_manager')
+    def test_crm_lead_create_pipe_data(self):
+        """ Test creation pipe data: user, team, stage, depending on some default
+        configuration. """
+        # gateway-like creation: no user, no team, generic stage
+        lead = self.env['crm.lead'].with_context(default_user_id=False).create({
+            'name': 'Test',
+            'contact_name': 'Test Contact',
+            'email_from': self.test_email,
+            'phone': self.test_phone,
+        })
+        self.assertEqual(lead.user_id, self.env['res.users'])
+        self.assertEqual(lead.team_id, self.env['crm.team'])
+        self.assertEqual(lead.stage_id, self.stage_gen_1)
+
+        # pipe creation: current user's best team and default stage
+        lead = self.env['crm.lead'].create({
+            'name': 'Test',
+            'contact_name': 'Test Contact',
+            'email_from': self.test_email,
+            'phone': self.test_phone,
+        })
+        self.assertEqual(lead.user_id, self.user_sales_manager)
+        self.assertEqual(lead.team_id, self.sales_team_1)
+        self.assertEqual(lead.stage_id, self.stage_team1_1)
+
+    @users('user_sales_manager')
     def test_crm_lead_partner_sync(self):
         lead, partner = self.lead_1.with_user(self.env.user), self.contact_2
         partner_email, partner_phone = self.contact_2.email, self.contact_2.phone

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -22,11 +22,12 @@ class TestLeadAssignCommon(TestLeadConvertCommon):
 
         # don't mess with existing teams, deactivate them to make tests repeatable
         cls.sales_teams = cls.sales_team_1 + cls.sales_team_convert
-        cls.members = cls.sales_team_1_m1 | cls.sales_team_1_m2 | cls.sales_team_1_m3 | cls.sales_team_convert_m1 | cls.sales_team_convert_m2
+        cls.members = cls.sales_team_1_m1 + cls.sales_team_1_m2 + cls.sales_team_1_m3 + cls.sales_team_convert_m1 + cls.sales_team_convert_m2
         cls.env['crm.team'].search([('id', 'not in', cls.sales_teams.ids)]).write({'active': False})
 
-        # don't mess with existing leads, deactivate those assigned to users used here to make tests repeatable
-        cls.env['crm.lead'].search(['|', ('team_id', '=', False), ('user_id', 'in', cls.sales_teams.member_ids.ids)]).write({'active': False})
+        # don't mess with existing leads, unlink those assigned to users used here to make tests
+        # repeatable (archive is not sufficient because of lost leads)
+        cls.env['crm.lead'].with_context(active_test=False).search(['|', ('team_id', '=', False), ('user_id', 'in', cls.sales_teams.member_ids.ids)]).unlink()
         cls.bundle_size = 5
         cls.env['ir.config_parameter'].set_param('crm.assignment.bundle', '%s' % cls.bundle_size)
         cls.env['ir.config_parameter'].set_param('crm.assignment.delay', '0')
@@ -103,6 +104,66 @@ class TestLeadAssign(TestLeadAssignCommon):
             self.assertFalse(self.assign_cron.active)
             self.assertEqual(self.assign_cron.nextcall, datetime(2020, 11, 1, 10, 0, 0))
 
+    def test_assign_count(self):
+        """ Test number of assigned leads when dealing with some existing data (leads
+        or opportunities) as well as with opt-out management. """
+        leads = self._create_leads_batch(
+            lead_type='lead',
+            user_ids=[False],
+            partner_ids=[False, False, False, self.contact_1.id],
+            probabilities=[30],
+            count=8
+        )
+        # commit probability and related fields
+        leads.flush()
+        self.assertInitialData()
+
+        # archived members should not be taken into account
+        self.sales_team_1_m1.action_archive()
+        # assignment_max = 0 means opt_out
+        self.sales_team_1_m2.assignment_max = 0
+
+        # assign probability to leads (bypass auto probability as purpose is not to test pls)
+        leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
+        for idx, lead in enumerate(leads):
+            lead.probability = idx * 10
+        # commit probability and related fields
+        leads.flush()
+        self.assertEqual(leads[0].probability, 0)
+
+        # create exiting leads for user_sales_salesman (sales_team_1_m3, sales_team_convert_m1)
+        existing_leads = self._create_leads_batch(
+            lead_type='lead', user_ids=[self.user_sales_salesman.id],
+            probabilities=[10],
+            count=14)
+        self.assertEqual(existing_leads.team_id, self.sales_team_1, "Team should have lower sequence")
+        existing_leads[0].active = False  # lost
+        existing_leads[1].probability = 100  # not won
+        existing_leads[2].probability = 0  # not lost
+        existing_leads.flush()
+
+        self.members.invalidate_cache(fnames=['lead_month_count'])
+        self.assertEqual(self.sales_team_1_m3.lead_month_count, 12)
+        self.assertEqual(self.sales_team_convert_m1.lead_month_count, 0)
+
+        with self.with_user('user_sales_manager'):
+            self.env['crm.team'].browse(self.sales_team_1.ids)._action_assign_leads(work_days=4)
+
+        # salespersons assign
+        self.members.invalidate_cache(fnames=['lead_month_count'])
+        self.assertEqual(self.sales_team_1_m1.lead_month_count, 0)  # archived do not get leads
+        self.assertEqual(self.sales_team_1_m2.lead_month_count, 0)  # opt-out through assignment_max = 0
+        self.assertEqual(self.sales_team_1_m3.lead_month_count, 14)  # 15 max on 4 days (2) + existing 12
+
+        with self.with_user('user_sales_manager'):
+            self.env['crm.team'].browse(self.sales_team_1.ids)._action_assign_leads(work_days=4)
+
+        # salespersons assign
+        self.members.invalidate_cache(fnames=['lead_month_count'])
+        self.assertEqual(self.sales_team_1_m1.lead_month_count, 0)  # archived do not get leads
+        self.assertEqual(self.sales_team_1_m2.lead_month_count, 0)  # opt-out through assignment_max = 0
+        self.assertEqual(self.sales_team_1_m3.lead_month_count, 15)  # 15 max on 4 days (2) + existing 14 but capped at 15
+
     @mute_logger('odoo.models.unlink')
     def test_assign_duplicates(self):
         """ Test assign process with duplicates on partner. Allow to ensure notably
@@ -113,6 +174,8 @@ class TestLeadAssign(TestLeadAssignCommon):
             partner_ids=[self.contact_1.id, self.contact_2.id, False, False, False],
             count=50
         )
+        # commit probability and related fields
+        leads.flush()
         self.assertInitialData()
 
         # assign probability to leads (bypass auto probability as purpose is not to test pls)
@@ -121,6 +184,8 @@ class TestLeadAssign(TestLeadAssignCommon):
             sliced_leads = leads[idx:len(leads):5]
             for lead in sliced_leads:
                 lead.probability = (idx + 1) * 10 * ((int(lead.priority) + 1) / 2)
+        # commit probability and related fields
+        leads.flush()
 
         with self.with_user('user_sales_manager'):
             self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
@@ -146,7 +211,7 @@ class TestLeadAssign(TestLeadAssignCommon):
 
         # teams assign: everything should be done due to duplicates
         leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
-        self.assertTrue(len(leads.filtered_domain([('team_id', '=', False)])) == 0)
+        self.assertEqual(len(leads.filtered_domain([('team_id', '=', False)])), 0)
 
         # deduplicate should have removed all duplicated linked to contact_1 and contact_2
         new_assigned_leads_wpartner = self.env['crm.lead'].search([
@@ -163,6 +228,8 @@ class TestLeadAssign(TestLeadAssignCommon):
             partner_ids=[False],
             count=50
         )
+        # commit probability and related fields
+        leads.flush()
         self.assertInitialData()
 
         # assign probability to leads (bypass auto probability as purpose is not to test pls)
@@ -171,6 +238,8 @@ class TestLeadAssign(TestLeadAssignCommon):
             sliced_leads = leads[idx:len(leads):5]
             for lead in sliced_leads:
                 lead.probability = (idx + 1) * 10 * ((int(lead.priority) + 1) / 2)
+        # commit probability and related fields
+        leads.flush()
 
         with self.with_user('user_sales_manager'):
             self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
@@ -203,7 +272,10 @@ class TestLeadAssign(TestLeadAssignCommon):
             country_ids=[self.env.ref('base.be').id, self.env.ref('base.fr').id, False],
             count=_lead_count,
             email_dup_count=_email_dup_count)
+        # commit probability and related fields
+        leads.flush()
         self.assertInitialData()
+
         # assign for one month, aka a lot
         self.env.ref('crm.ir_cron_crm_lead_assign').write({'interval_type': 'days', 'interval_number': 30})
         self.env['ir.config_parameter'].set_param('crm.assignment.bundle', '20')
@@ -246,6 +318,8 @@ class TestLeadAssign(TestLeadAssignCommon):
             sliced_leads = leads[idx:len(leads):5]
             for lead in sliced_leads:
                 lead.probability = (idx + 1) * 10 * ((int(lead.priority) + 1) / 2)
+        # commit probability and related fields
+        leads.flush()
 
         with self.with_user('user_sales_manager'):
             self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
@@ -259,3 +333,78 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertMemberAssign(sales_team_3_m1, 60)  # 60 max on one month
         self.assertMemberAssign(sales_team_3_m2, 60)  # 60 max on one month
         self.assertMemberAssign(sales_team_3_m3, 15)  # 15 max on one month
+
+    def test_assign_specific_won_lost(self):
+        """ Test leads taken into account in assign process: won, lost, stage
+        configuration. """
+        leads = self._create_leads_batch(
+            lead_type='lead',
+            user_ids=[False],
+            partner_ids=[False, False, False, self.contact_1.id],
+            probabilities=[30],
+            count=6
+        )
+        leads[0].stage_id = self.stage_gen_won.id  # is won -> should not be taken into account
+        leads[1].stage_id = False
+        leads[2].update({'stage_id': False, 'probability': 0})
+        leads[3].update({'stage_id': False, 'probability': False})
+        leads[4].active = False  # is lost -> should not be taken into account
+        leads[5].update({'team_id': self.sales_team_convert.id, 'user_id': self.user_sales_manager.id})  # assigned lead should not be re-assigned
+
+        # commit probability and related fields
+        leads.flush()
+
+        with self.with_user('user_sales_manager'):
+            self.env['crm.team'].browse(self.sales_team_1.ids)._action_assign_leads(work_days=4)
+
+        # self.assertEqual(leads[0].team_id, self.env['crm.team'], 'Won lead should not be assigned')
+        # self.assertEqual(leads[0].user_id, self.env['res.users'], 'Won lead should not be assigned')
+        for lead in leads[1:4]:
+            self.assertIn(lead.user_id, self.sales_team_1.member_ids)
+            self.assertEqual(lead.team_id, self.sales_team_1)
+        self.assertEqual(leads[4].team_id, self.env['crm.team'], 'Lost lead should not be assigned')
+        self.assertEqual(leads[4].user_id, self.env['res.users'], 'Lost lead should not be assigned')
+        self.assertEqual(leads[5].team_id, self.sales_team_convert, 'Assigned lead should not be reassigned')
+        self.assertEqual(leads[5].user_id, self.user_sales_manager, 'Assigned lead should not be reassigned')
+
+    @mute_logger('odoo.models.unlink')
+    def test_merge_assign_keep_master_team(self):
+        """ Check existing opportunity keep its team and salesman when merged with a new lead """
+        sales_team_dupe = self.env['crm.team'].create({
+            'name': 'Sales Team Dupe',
+            'sequence': 15,
+            'alias_name': False,
+            'use_leads': True,
+            'use_opportunities': True,
+            'company_id': False,
+            'user_id': False,
+            'assignment_domain': "[]",
+        })
+        self.env['crm.team.member'].create({
+            'user_id': self.user_sales_salesman.id,
+            'crm_team_id': sales_team_dupe.id,
+            'assignment_max': 10,
+            'assignment_domain': "[]",
+        })
+
+        master_opp = self.env['crm.lead'].create({
+            'name': 'Master',
+            'type': 'opportunity',
+            'probability': 50,
+            'partner_id': self.contact_1.id,
+            'team_id': self.sales_team_1.id,
+            'user_id': self.user_sales_manager.id,
+        })
+        dupe_lead = self.env['crm.lead'].create({
+            'name': 'Dupe',
+            'type': 'lead',
+            'email_from': 'Duplicate Email <%s>' % master_opp.email_normalized,
+            'probability': 10,
+            'team_id': False,
+            'user_id': False,
+        })
+
+        sales_team_dupe._action_assign_leads(work_days=2)
+        self.assertFalse(dupe_lead.exists())
+        self.assertEqual(master_opp.team_id, sales_team_dupe, 'Opportunity: current team wins lead even if was on duplicated lead')
+        self.assertEqual(master_opp.user_id, self.user_sales_manager, 'Opportunity: should keep its salesman')

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -167,7 +167,7 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.members.invalidate_cache(fnames=['lead_month_count'])
         self.assertEqual(self.sales_team_1_m1.lead_month_count, 0)  # archived do not get leads
         self.assertEqual(self.sales_team_1_m2.lead_month_count, 0)  # opt-out through assignment_max = 0
-        self.assertEqual(self.sales_team_1_m3.lead_month_count, 15)  # 15 max on 4 days (2) + existing 14 but capped at 15
+        self.assertEqual(self.sales_team_1_m3.lead_month_count, 16)  # 15 max on 4 days (2) + existing 14 and not capped anymore
 
     @mute_logger('odoo.models.unlink')
     def test_assign_duplicates(self):
@@ -363,12 +363,12 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertEqual(
             self.sales_team_1_m1._get_assignment_quota(work_days=30),
             45,
-            "Assignment quota: anyway 45 max available"
+            "Assignment quota: no compensation as exceeding monthly count"
         )
         self.assertEqual(
             self.sales_team_1_m1._get_assignment_quota(work_days=60),
-            45,
-            "Assignment quota: anyway 45 max available"
+            90,
+            "Assignment quota: no compensation and no limit anymore (do as asked)"
         )
 
         # create exiting leads for user_sales_leads (sales_team_1_m1)
@@ -397,13 +397,13 @@ class TestLeadAssign(TestLeadAssignCommon):
         # quota should not exceed maximum
         self.assertEqual(
             self.sales_team_1_m1._get_assignment_quota(work_days=30),
-            15,
-            "Assignment quota: anyway 15 max available (30 already assigned)"
+            45,
+            "Assignment quota: no compensation and no limit anymore (do as asked even with 30 already assigned)"
         )
         self.assertEqual(
             self.sales_team_1_m1._get_assignment_quota(work_days=60),
-            15,
-            "Assignment quota: anyway 15 max available (30 already assigned)"
+            90,
+            "Assignment quota: no compensation and no limit anymore (do as asked even with 30 already assigned)"
         )
 
     def test_assign_specific_won_lost(self):

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -143,8 +143,13 @@ class TestLeadAssign(TestLeadAssignCommon):
         existing_leads.flush()
 
         self.members.invalidate_cache(fnames=['lead_month_count'])
-        self.assertEqual(self.sales_team_1_m3.lead_month_count, 12)
+        self.assertEqual(self.sales_team_1_m3.lead_month_count, 14)
         self.assertEqual(self.sales_team_convert_m1.lead_month_count, 0)
+
+        # re-assign existing leads, check monthly count is updated
+        existing_leads[-2:]._handle_salesmen_assignment(user_ids=self.user_sales_manager.ids)
+        self.members.invalidate_cache(fnames=['lead_month_count'])
+        self.assertEqual(self.sales_team_1_m3.lead_month_count, 12)
 
         with self.with_user('user_sales_manager'):
             self.env['crm.team'].browse(self.sales_team_1.ids)._action_assign_leads(work_days=4)

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -196,6 +196,8 @@ class TestLeadAssign(TestLeadAssignCommon):
             self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
+        # due to duplicate management keeping master team, we may not ensure leads to be
+        # fulfilling their original team volume
         leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
         leads_st1 = leads.filtered_domain([('team_id', '=', self.sales_team_1.id)])
         leads_stc = leads.filtered_domain([('team_id', '=', self.sales_team_convert.id)])
@@ -411,5 +413,5 @@ class TestLeadAssign(TestLeadAssignCommon):
 
         sales_team_dupe._action_assign_leads(work_days=2)
         self.assertFalse(dupe_lead.exists())
-        self.assertEqual(master_opp.team_id, sales_team_dupe, 'Opportunity: current team wins lead even if was on duplicated lead')
+        self.assertEqual(master_opp.team_id, self.sales_team_1, 'Opportunity: should keep its sales team')
         self.assertEqual(master_opp.user_id, self.user_sales_manager, 'Opportunity: should keep its salesman')

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -364,8 +364,8 @@ class TestLeadAssign(TestLeadAssignCommon):
         with self.with_user('user_sales_manager'):
             self.env['crm.team'].browse(self.sales_team_1.ids)._action_assign_leads(work_days=4)
 
-        # self.assertEqual(leads[0].team_id, self.env['crm.team'], 'Won lead should not be assigned')
-        # self.assertEqual(leads[0].user_id, self.env['res.users'], 'Won lead should not be assigned')
+        self.assertEqual(leads[0].team_id, self.env['crm.team'], 'Won lead should not be assigned')
+        self.assertEqual(leads[0].user_id, self.env['res.users'], 'Won lead should not be assigned')
         for lead in leads[1:4]:
             self.assertIn(lead.user_id, self.sales_team_1.member_ids)
             self.assertEqual(lead.team_id, self.sales_team_1)

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -109,7 +109,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
             email=test_lead.email_from,
             include_lost=False
         )
-        self.assertEqual(result, test_lead + dup_leads - (lead_lost + opp_proba100 + opp_won + opp_lost))
+        self.assertEqual(result, test_lead + dup_leads - (lead_lost + opp_won + opp_lost))
 
         # include_lost = remove archived opp only
         result = test_lead._get_lead_duplicates(

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -69,6 +69,56 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         date = Datetime.from_string('2020-01-20 16:00:00')
         cls.crm_lead_dt_mock.now.return_value = date
 
+    @users('user_sales_manager')
+    def test_duplicates_computation(self):
+        """ Test Lead._get_lead_duplicates() and check won / probability usage """
+        test_lead = self.env['crm.lead'].browse(self.lead_1.ids)
+        customer, dup_leads = self._create_duplicates(test_lead)
+        dup_leads += self.env['crm.lead'].create([
+            {'name': 'Duplicate lead: same email_from, lost',
+             'type': 'lead',
+             'email_from': test_lead.email_from,
+             'probability': 0, 'active': False,
+            },
+            {'name': 'Duplicate lead: same email_from, proba 0 but not lost',
+             'type': 'lead',
+             'email_from': test_lead.email_from,
+             'probability': 0, 'active': True,
+            },
+            {'name': 'Duplicate opp: same email_from, won',
+             'type': 'opportunity',
+             'email_from': test_lead.email_from,
+             'probability': 100, 'stage_id': self.stage_team1_won.id,
+            },
+            {'name': 'Duplicate opp: same email_from, proba 100 but not won',
+             'type': 'opportunity',
+             'email_from': test_lead.email_from,
+             'probability': 100, 'stage_id': self.stage_team1_2.id,
+            }
+        ])
+        lead_lost = dup_leads.filtered(lambda lead: lead.name == 'Duplicate lead: same email_from, lost')
+        opp_proba100 = dup_leads.filtered(lambda lead: lead.name == 'Duplicate opp: same email_from, proba 100 but not won')
+        opp_won = dup_leads.filtered(lambda lead: lead.name == 'Duplicate opp: same email_from, won')
+        opp_lost = dup_leads.filtered(lambda lead: lead.name == 'Duplicate: lost opportunity')
+
+        test_lead.write({'partner_id': customer.id})
+
+        # not include_lost = remove archived leads as well as 'won' opportunities
+        result = test_lead._get_lead_duplicates(
+            partner=test_lead.partner_id,
+            email=test_lead.email_from,
+            include_lost=False
+        )
+        self.assertEqual(result, test_lead + dup_leads - (lead_lost + opp_proba100 + opp_won + opp_lost))
+
+        # include_lost = remove archived opp only
+        result = test_lead._get_lead_duplicates(
+            partner=test_lead.partner_id,
+            email=test_lead.email_from,
+            include_lost=True
+        )
+        self.assertEqual(result, test_lead + dup_leads - (lead_lost))
+
     def test_initial_data(self):
         """ Ensure initial data to avoid spaghetti test update afterwards """
         self.assertFalse(self.lead_1.date_conversion)
@@ -341,35 +391,35 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
 
     @users('user_sales_manager')
     def test_lead_merge_duplicates(self):
-        """ Test Lead._get_lead_duplicates() """
+        """ Test Lead._get_lead_duplicates() and check: partner / email fallbacks """
+        customer, dup_leads = self._create_duplicates(self.lead_1)
+        lead_partner = dup_leads.filtered(lambda lead: lead.name == 'Duplicate: customer ID')
+        self.assertTrue(bool(lead_partner))
 
-        # Check: partner / email fallbacks
-        self._create_duplicates(self.lead_1)
         self.lead_1.write({
-            'partner_id': self.customer.id,
+            'partner_id': customer.id,
         })
         convert = self.env['crm.lead2opportunity.partner'].with_context({
             'active_model': 'crm.lead',
             'active_id': self.lead_1.id,
             'active_ids': self.lead_1.ids,
         }).create({})
-        self.assertEqual(convert.partner_id, self.customer)
-        # self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | self.lead_email_from | self.lead_email_normalized | self.lead_partner | self.opp_lost)
-        self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | self.lead_email_from | self.lead_partner | self.opp_lost)
+        self.assertEqual(convert.partner_id, customer)
+        self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | dup_leads)
 
         # Check: partner fallbacks
         self.lead_1.write({
             'email_from': False,
-            'partner_id': self.customer.id,
+            'partner_id': customer.id,
         })
-        self.customer.write({'email': False})
+        customer.write({'email': False})
         convert = self.env['crm.lead2opportunity.partner'].with_context({
             'active_model': 'crm.lead',
             'active_id': self.lead_1.id,
             'active_ids': self.lead_1.ids,
         }).create({})
-        self.assertEqual(convert.partner_id, self.customer)
-        self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | self.lead_partner)
+        self.assertEqual(convert.partner_id, customer)
+        self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | lead_partner)
 
     @users('user_sales_manager')
     def test_lead_merge_duplicates_flow(self):
@@ -379,23 +429,22 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.lead_1.write({
             'email_from': 'Amy Wong <amy.wong@test.example.com>'
         })
-        self._create_duplicates(self.lead_1)
+        customer, dup_leads = self._create_duplicates(self.lead_1)
+        opp_lost = dup_leads.filtered(lambda lead: lead.name == 'Duplicate: lost opportunity')
+        self.assertTrue(bool(opp_lost))
 
         convert = self.env['crm.lead2opportunity.partner'].with_context({
             'active_model': 'crm.lead',
             'active_id': self.lead_1.id,
             'active_ids': self.lead_1.ids,
         }).create({})
-        self.assertEqual(convert.partner_id, self.customer)
-        # TDE FIXME: should check for email_normalized -> lead_email_normalized not correctly found
-        # self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | lead_email_from | lead_email_normalized | lead_partner | opp_lost)
-        self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | self.lead_email_from | self.lead_partner | self.opp_lost)
+        self.assertEqual(convert.partner_id, customer)
+        self.assertEqual(convert.duplicated_lead_ids, self.lead_1 | dup_leads)
 
         convert.action_apply()
         self.assertEqual(
-            # (self.lead_1 | self.lead_email_from | self.lead_email_normalized | self.lead_partner | self.opp_lost).exists(),
-            (self.lead_1 | self.lead_email_from | self.lead_partner | self.opp_lost).exists(),
-            self.opp_lost)
+            (self.lead_1 | dup_leads).exists(),
+            opp_lost)
 
 
 @tagged('lead_manage')

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -109,10 +109,10 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         """ Test duplicated_lead_ids fields having another behavior in mass convert
         because why not. Its use is: among leads under convert, store those with
         duplicates if deduplicate is set to True. """
-        lead_1_dups = self._create_duplicates(self.lead_1, create_opp=False)
+        _customer, lead_1_dups = self._create_duplicates(self.lead_1, create_opp=False)
         lead_1_final = self.lead_1  # after merge: same but with lower ID
 
-        lead_w_partner_dups = self._create_duplicates(self.lead_w_partner, create_opp=False)
+        _customer2, lead_w_partner_dups = self._create_duplicates(self.lead_w_partner, create_opp=False)
         lead_w_partner_final = lead_w_partner_dups[0]  # lead_w_partner has no stage -> lower in sort by confidence
         lead_w_partner_dups_partner = lead_w_partner_dups[1]  # copy with a partner_id (with the same email)
 
@@ -166,7 +166,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         test_leads = self._create_leads_batch(count=50, user_ids=[False])
         user_ids = self.assign_users.ids
 
-        with self.assertQueryCount(user_sales_manager=1367):  # still some randomness (1366 spotted) - crm only: 1357
+        with self.assertQueryCount(user_sales_manager=1368):  # still some randomness (1366 spotted) - crm only: ??
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -34,7 +34,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
             lead_type='lead',
             user_ids=[False],
             partner_ids=[self.contact_1.id, self.contact_2.id, False, False, False],
-            count=50
+            count=200
         )
         # commit probability and related fields
         leads.flush()
@@ -50,34 +50,24 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=483):  # crm only: ??
+            with self.assertQueryCount(user_sales_manager=1333):  # crm only: ??
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
-        # due to duplicate management keeping master team, we may not ensure leads to be
-        # fulfilling their original team volume
         leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
         leads_st1 = leads.filtered_domain([('team_id', '=', self.sales_team_1.id)])
         leads_stc = leads.filtered_domain([('team_id', '=', self.sales_team_convert.id)])
-        self.assertEqual(len(leads_st1), 10)  # 2 * 2 * 75 / 30.0
-        self.assertEqual(len(leads_stc), 12)  # 2 * 2 * 90 / 30.0
+        self.assertLessEqual(len(leads_st1), 128)
+        self.assertLessEqual(len(leads_stc), 96)
+        self.assertEqual(len(leads_st1) + len(leads_stc), len(leads))  # Make sure all lead are assigned
 
         # salespersons assign
         self.members.invalidate_cache(fnames=['lead_month_count'])
-        self.assertMemberAssign(self.sales_team_1_m1, 3)  # 45 max on 2 days
-        self.assertMemberAssign(self.sales_team_1_m2, 1)  # 15 max on 2 days
-        self.assertMemberAssign(self.sales_team_1_m3, 1)  # 15 max on 2 days
-        self.assertMemberAssign(self.sales_team_convert_m1, 2)  # 30 max on 15
-        self.assertMemberAssign(self.sales_team_convert_m2, 4)  # 60 max on 15
-
-        # run a second round to finish leads
-        with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=137):  # crm only: ??
-                self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
-
-        # teams assign: everything should be done due to duplicates
-        leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
-        self.assertEqual(len(leads.filtered_domain([('team_id', '=', False)])), 0)
+        self.assertMemberAssign(self.sales_team_1_m1, 11)  # 45 max on 2 days (3) + compensation (8.4)
+        self.assertMemberAssign(self.sales_team_1_m2, 4)  # 15 max on 2 days (1) + compensation (2.8)
+        self.assertMemberAssign(self.sales_team_1_m3, 4)  # 15 max on 2 days (1) + compensation (2.8)
+        self.assertMemberAssign(self.sales_team_convert_m1, 8)  # 30 max on 15 (2) + compensation (5.6)
+        self.assertMemberAssign(self.sales_team_convert_m2, 15)  # 60 max on 15 (4) + compsantion (11.2)
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.crm.models.crm_team', 'odoo.addons.crm.models.crm_team_member')
     def test_assign_perf_no_duplicates(self):
@@ -85,7 +75,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
             lead_type='lead',
             user_ids=[False],
             partner_ids=[False],
-            count=50
+            count=100
         )
         # commit probability and related fields
         leads.flush()
@@ -99,23 +89,24 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
                 lead.probability = (idx + 1) * 10 * ((int(lead.priority) + 1) / 2)
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=209):  # crm only: 209 (seems reproducible)
+            with self.assertQueryCount(user_sales_manager=580):  # crm only: 580 (seems reproducible)
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
         leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
         leads_st1 = leads.filtered_domain([('team_id', '=', self.sales_team_1.id)])
         leads_stc = leads.filtered_domain([('team_id', '=', self.sales_team_convert.id)])
-        self.assertEqual(len(leads_st1), 10)  # 2 * 2 * 75 / 30.0
-        self.assertEqual(len(leads_stc), 12)  # 2 * 2 * 90 / 30.0
+        self.assertEqual(len(leads_st1) + len(leads_stc), 100)  # 2 * 2 * 75 / 30.0
+        self.assertLessEqual(len(leads_st1), 100)  # 2 * 2 * 75 / 30.0
+        self.assertLessEqual(len(leads_stc), 66)  # 2 * 2 * 90 / 30.0
 
         # salespersons assign
         self.members.invalidate_cache(fnames=['lead_month_count'])
-        self.assertMemberAssign(self.sales_team_1_m1, 3)  # 45 max on 2 days
-        self.assertMemberAssign(self.sales_team_1_m2, 1)  # 15 max on 2 days
-        self.assertMemberAssign(self.sales_team_1_m3, 1)  # 15 max on 2 days
-        self.assertMemberAssign(self.sales_team_convert_m1, 2)  # 30 max on 15
-        self.assertMemberAssign(self.sales_team_convert_m2, 4)  # 60 max on 15
+        self.assertMemberAssign(self.sales_team_1_m1, 11)  # 45 max on 2 days (3) + compensation (8.4)
+        self.assertMemberAssign(self.sales_team_1_m2, 4)  # 15 max on 2 days (1) + compensation (2.8)
+        self.assertMemberAssign(self.sales_team_1_m3, 4)  # 15 max on 2 days (1) + compensation (2.8)
+        self.assertMemberAssign(self.sales_team_convert_m1, 8)  # 30 max on 15 (2) + compensation (5.6)
+        self.assertMemberAssign(self.sales_team_convert_m2, 15)  # 60 max on 15 (4) + compsantion (11.2)
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.crm.models.crm_team', 'odoo.addons.crm.models.crm_team_member')
     def test_assign_perf_populated(self):
@@ -180,9 +171,15 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6293):  # crm only:  ??
+            with self.assertQueryCount(user_sales_manager=5384):  # crm only: ??
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
+        # teams assign
+        leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])
+        self.assertEqual(leads.team_id, sales_teams)
+        self.assertEqual(leads.user_id, sales_teams.member_ids)
+
+        # salespersons assign
         self.members.invalidate_cache(fnames=['lead_month_count'])
         self.assertMemberAssign(self.sales_team_1_m1, 45)  # 45 max on one month
         self.assertMemberAssign(self.sales_team_1_m2, 15)  # 15 max on one month

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -171,7 +171,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=5384):  # crm only: ??
+            with self.assertQueryCount(user_sales_manager=5385):  # crm only: ??
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -54,6 +54,8 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
+        # due to duplicate management keeping master team, we may not ensure leads to be
+        # fulfilling their original team volume
         leads = self.env['crm.lead'].search([('id', 'in', leads.ids)])  # ensure order
         leads_st1 = leads.filtered_domain([('team_id', '=', self.sales_team_1.id)])
         leads_stc = leads.filtered_domain([('team_id', '=', self.sales_team_convert.id)])


### PR DESCRIPTION
RATIONALE

All unassigned leads should be assigned to teams as soon as possible to ease
lead analysis.

Purpose of assign thresholds is to ensure sales people receive at least this
amount of leads within 30 days, counting lost and won leads. Giving them leads
regularly is also one goal of automatic assign.

SPECIFICATIONS: TEAM ALLOCATION

Team assignment has to be updated as we may have team domains that overlap.
We therefore remove maximum number of leads to allocate to teams. Instead all
available unassigned leads are allocated within teams.

  - Solution: assign all available leads and not a count based on team's
    capacity. This notably reverts the main goal of odoo/odoo@6df2f0c
    (see odoo#48422)

This assignment process is done proportionally to the team capacity. It is
computed as the sum of each member's maximum assignment counter. This means
that with a team having twice as much sale capacity than another team sharing
the same domain: first team should receive about 2/3 of leads while the second
one should receive the remaining 1/3.

  - Solution: assign lead one by one. Choose a team randomly using a weighted
    random algorithm, based on team's members capacity.

SPECIFICATIONS: MEMBER ASSIGN

Counting every lead whatever its state may lead to an inconvenient situation.
Moreover salespersons may opt-out from assign by setting their max capacity
to 0, for example when going on holidays.

When doing that lead assignment is not smooth and getting back to a full
pipe may take several days. To solve that issue a compensation is added in
assignment quota done to sales people. Salespersons having few leads will
get a boost in assign as soon as they get back in assign process. When being
near maximum compensation is nearing 0 and daily quota is given.

ENSURE SALES PERSONS PIPE FILLING

Counting every lead whatever its state may lead to an inconvenient situation.
If a salesman always reaches its maximum every days he will always receive the
number of lead he got 30 days ago. For example if the salesman goes in holidays
for few days and set the max to 0 he receives no lead during his vacation.
Then after a few days of assign he reaches its maximum and receive 0 leads
for a few days. This leads to having windows of leads that repeat themselves
every 30 days.

   * Solution: do not limit at maximum capacity anymore. Compensation is voided
     if limit is achieved. However asked assignment is done. Salesman could
     receive more than its max capacity but 30 days window ensure old leads
     are regularly going out of count.

``assignment_max`` is now more a mean target of leads to be assigned during
a 30 days window than a real maximum capacity. Field is renamed accordingly.

WORK DAYS / CRON TIME CONFIGURATION

When running the cron is should assign leads based on its frequency. If cron
runs once every day, work_days given to sub methods should be 1. If it runs
more than once day it should be less than 1. We therefore remove the *2
multiplier and support fraction of days.

As assign process changes in this merge, assigning more strictly compared to
salespersons capacity will not be an issue anymore. Assign process is best
designed to run every few hours (~4 times / day) or each few days. Code and
work_days are updated accordingly.

PERFORMANCE

During team assignment setting team on leads one lead at a time may cause
performance issue. As PLS is computed at each flush we want to flush after
a bunch of lead. For that purpose we need to avoid too much commits and
also avoid to search for duplicate at each assignation.

We therefore perform the search for duplicates before going into allocation
and use a cache through loops to ease using pre-fetched information.

Unlinking duplicates at each iteration is also sub efficient as it causes
recomputation or invalidation. We therefore aggregate all duplicates to
unlink and unlink them in the main team-based loop instead of the sub loop
that is lead-based.

LESS AUTO COMMITS

During team assignation, assigning lead one by one may cause performance issue.
Since PLS is computed at each flush, so we want to flush after a bunch of lead.
To solve that we obviously need to not commit at each assignation but
also avoid to search for duplicate at each assignation, that why the
search for duplicates is done at the beginning of the process and stored
in memory.

ASSIGN WON / LOST LEADS USAGE

In this merge we also

  * use stage instead of probability to exclude won duplicated leads in order
    to include leads with 100% but still not won;
  * count all leads in lead_month_count used in assign to effectively compute
    sales persons workload;
  * keep team when assigning and deduplicating leads instead of erasing
    master opportunity team;
  * crm: correctly filter out won and lost leads for assignment using
    stage;

LINKS

Task ID-2444908 (assign fixes)
Task ID-2489951 (assign process improvements)
COM PR odoo/odoo#70172
