### PR TITLE
clear unmatched string from no_create many2x on blur

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -825,6 +825,8 @@ var FieldMany2One = AbstractField.extend({
             this.reinitialize({ id: firstValue.id, display_name: firstValue.name });
         } else if (this.can_create) {
             new M2ODialog(this, this.string, this.$input.val()).open();
+        } else {
+            this.$input.val("");
         }
     },
     /**
@@ -858,14 +860,6 @@ var FieldMany2One = AbstractField.extend({
             this.floating = true;
             this._updateExternalButton();
         }
-    },
-    /**
-     * @override
-     * @private
-     */
-    _onKeydown: function () {
-        this.floating = false;
-        this._super.apply(this, arguments);
     },
     /**
      * @private

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -2503,7 +2503,7 @@ QUnit.module('fields', {}, function () {
         });
 
         QUnit.test('no_create option on a many2one', async function (assert) {
-            assert.expect(1);
+            assert.expect(2);
 
             var form = await createView({
                 View: FormView,
@@ -2516,10 +2516,11 @@ QUnit.module('fields', {}, function () {
                     '</form>',
             });
 
-            await testUtils.fields.editAndTrigger(form.$('.o_field_many2one input'),
-                'new partner', ['keyup', 'focusout']);
-            await testUtils.nextTick();
+            await testUtils.fields.editInput(form.$('.o_field_many2one input'), 'new partner');
+            form.$('.o_field_many2one input').trigger('keyup').trigger('focusout');
             assert.strictEqual($('.modal').length, 0, "should not display the create modal");
+            assert.strictEqual(form.$('.o_field_many2one input').val(), "",
+                "many2one value should cleared on focusout if many2one is no_create");
             form.destroy();
         });
 


### PR DESCRIPTION
PURPOSE
Currently, many2one and many2many fields on which creation has been disabled only clear the 'unmatched' string when saving the record.
Especially for the many2one, it looks to the user like the new record has been set, even though none has as creation is disabled.
The purpose of this task is to get rid of this awkward behaviour by clearing any 'unmatched string' when leaving the field, not at record save.

SPECIFICATION
When a many2xxx field as no_create=True, clear unmatched string when the focus leaves the field.

TASK 2517593


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
