### PR TITLE
[FIX] web_editor, note: autofocus the editor on load note form view edit

### DIFF
--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -157,7 +157,7 @@
                     <field name="stage_id" domain="[('user_id','=',uid)]" widget="statusbar" options="{'clickable': '1'}"/>
                 </header>
                 <sheet>
-                  <field name="memo" type="html" class="oe_memo" options="{'resizable': false}"/>
+                  <field name="memo" type="html" class="oe_memo" default_focus="1" options="{'resizable': false}"/>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -110,7 +110,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @override
      */
     getFocusableElement: function () {
-        return this.$wysiwygWrapper || $();
+        return this.wysiwyg && this.wysiwyg.$editable || $();
     },
     /**
      * Do not re-render this field if it was the origin of the onchange call.


### PR DESCRIPTION
On creating a new note, the focus was automatically set into the "tags" field. This was inconvenient and was replaced with an autofocus on the note itself so we the user can immediately start typing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
