### PR TITLE
[FIX] hw_drivers: InterfaceMetaClass violates CPython constraints and breaks imports

### DIFF
--- a/addons/hw_drivers/interface.py
+++ b/addons/hw_drivers/interface.py
@@ -12,8 +12,6 @@ _logger = logging.getLogger(__name__)
 
 class InterfaceMetaClass(type):
     def __new__(cls, clsname, bases, attrs):
-        if clsname in interfaces:
-            return interfaces[clsname]
         new_interface = super(InterfaceMetaClass, cls).__new__(cls, clsname, bases, attrs)
         interfaces[clsname] = new_interface
         return new_interface


### PR DESCRIPTION
Currently, none of the classes derived from `Interface` use `super`. If
it's added, for example by adding this to `SocketInterface`:

```
def __init__(self):
    super().__init__()
```

, a deprecation warning will appear in Python 3.6 and 3.7:

```
2021-04-30 13:14:25,000 24736 WARNING ? py.warnings: /home/pi/odoo/addons/hw_drivers/iot_handlers/interfaces/SocketInterface.py:11: DeprecationWarning: class not set defining 'SocketInterface' as <class 'SocketInterface.py.SocketInterface'>. Was classcell propagated to type.new?
  class SocketInterface(Interface):
```

In Python 3.8 this is no longer a warning and becomes a `RuntimeError`.

The reason this happens is that `InterfaceMetaClass` caches the results
of the `__new__` calls it does in `interfaces`. CPython's data model
specifies that when calling `__new__`, the cell for `__class__` needs to
be passed along to the parent class: https://docs.python.org/3/reference/datamodel.html#creating-the-class-object .

See https://docs.python.org/3/c-api/cell.html for a definition of what
a cell is.

Because of the caching, this doesn't happen when `__new__` is called
multiple times for the same class. In the case of the `SocketInterface`
example, `__new__` is called twice: first when it's imported directly by [`load_iot_handlers`](https://github.com/odoo/odoo/blob/841c016913a87133bf7257c62ae5f6bf7d99e06d/addons/hw_drivers/main.py#L81)
and second when `IngenicoDriver` imports it. The `__class__` cell is
different each time in that case. With the caching present, this means
the second cell isn't propagated correctly, resulting in the warning /
error.

After `load_iot_handlers` has finished, the `Manager`'s `run` method
iterates over `interfaces`, instantiating and starting the loaded
classes. Because of this, simply removing the caching appears to be
sufficient to avoid the issue while keeping the end result the same.