### PR TITLE
[FIX] attachment_indexation: fix error "cannot contain NUL (0x00)"

### DIFF
--- a/addons/attachment_indexation/models/ir_attachment.py
+++ b/addons/attachment_indexation/models/ir_attachment.py
@@ -125,6 +125,6 @@ class IrAttachment(models.Model):
         for ftype in FTYPES:
             buf = getattr(self, '_index_%s' % ftype)(bin_data)
             if buf:
-                return buf
+                return buf.replace('\x00', '')
 
         return super(IrAttachment, self)._index(bin_data, mimetype)


### PR DESCRIPTION
To reproduce:

* install python package ``pdfminer.six``
* install module attachment_indexation
* upload special attachment

BEFORE:

Error in client:

> TypeError: relatedTemporaryAttachments is not iterable

Error in logs:

> ValueError: A string literal cannot contain NUL (0x00) characters.

AFTER:

No errors

---

opw-2506038

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
