### PR TITLE
[FIX] point_of_sale: fix thai character incorrectly displayed on email

### DIFF
--- a/addons/point_of_sale/static/lib/html2canvas.js
+++ b/addons/point_of_sale/static/lib/html2canvas.js
@@ -1226,7 +1226,26 @@
               }
             });
           }
-    
+
+          // !! ODOO FIX START !!
+          // Based on https://github.com/niklasvh/html2canvas/pull/778
+          // For thai language
+          if (textAlign == 'center') {
+            textList.slice(1).forEach(function(word, index) {
+              if (/[\u0E30-\u0E3A\u0E47-\u0E4E]/.test(word)) {
+                if (textList[index] !== '') {
+                  // for vowel only
+                  textList[index] += word;
+                } else {
+                  // for vowel and tone marks
+                  textList[index-1] += word;
+                }
+                textList[index+1] = '';
+              }
+            });
+          }
+          // !! ODOO FIX END !!
+
           textList.forEach(function(text, index) {
             var bounds = getTextBounds(state, text, textDecoration, (index < textList.length - 1), stack.transform.matrix);
             if (bounds) {


### PR DESCRIPTION
Some thaï character do display incorrectly in the email sent from the PoS.
It can be reproduced by using a name such as: "สมภาร สุมิตร (ร้านภารทองปลื้ม)". Note that the issue only appear in the email being sent to the customer, not the receipt preview shown in Odoo PoS.

This is due to a bug in the html2canvas library, see: `https://github.com/niklasvh/html2canvas/issues/740`
A fix was proposed on the library in 2016 but wasn't merged:
`https://github.com/niklasvh/html2canvas/pull/778`
I did tested it locally and it looks to work like a charm.

![image](https://user-images.githubusercontent.com/60775325/116727536-fd2aa480-a9e4-11eb-84eb-d4394e268846.png)
- On the left: the preview in PoS (the characters are correct)
- On the middle: the receipt picture received by mail prior to the fix -> some characters are wrong (highlighted in yellow)
- On the right: the receipt picture received by mail after the fix => the characters are displayed correctly

OPW-2447562

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
