### PR TITLE
[IMP] mail: flag JS "on change" fields as such

### DIFF
--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -24,6 +24,7 @@ class ModelField {
         hashes: extraHashes = [],
         inverse,
         isCausal = false,
+        isOnChange,
         readonly = false,
         related,
         relationType,
@@ -130,6 +131,16 @@ class ModelField {
          * relation is removed, the related record is automatically deleted.
          */
         this.isCausal = isCausal;
+        /**
+         * Determines whether this field is an "on change" field. Only applies
+         * to computed fields. An "on change" is a fake compute designed to be
+         * called when one of its dependencies change. It is called after all
+         * other computes are done, and it does not actually assign any value to
+         * its respective field.
+         * This is deprecated but when it is necessary due to other limitations
+         * in code it is better using "on change" than polluting real computes.
+         */
+        this.isOnChange = isOnChange;
         /**
          * Determines whether the field is read only. Read only field
          * can't be updated once the record is created.
@@ -456,7 +467,7 @@ class ModelField {
                     case 'link':
                         if (this._setRelationLink(record, newVal, options)) {
                             hasChanged = true;
-                        };
+                        }
                         break;
                     case 'replace':
                         if (this._setRelationReplace(record, newVal, options)) {
@@ -464,9 +475,9 @@ class ModelField {
                         }
                         break;
                     case 'unlink':
-                        if (this._setRelationUnlink(record, newVal, options)){
+                        if (this._setRelationUnlink(record, newVal, options)) {
                             hasChanged = true;
-                        };
+                        }
                         break;
                     case 'unlink-all':
                         if (this._setRelationUnlink(record, this.read(record), options)) {

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -54,6 +54,16 @@ class ModelManager {
          */
         this._hasAnyChangeDuringCycle = false;
         /**
+         * States whether an update cycle is currently in progress. The update
+         * cycle is considered in progress while there are computed fields still
+         * to compute or required fields for which to verify the existence.
+         * Life cycle hooks such as `_created()` or "on change" computes are not
+         * considerer part of the update cycle by this variable.
+         * The main goal of this variable is to detect programming errors: to
+         * prevent from calling create/update/delete from inside a compute.
+         */
+        this._isInUpdateCycle = false;
+        /**
          * Set of records that have been updated during the current update
          * cycle. Useful to allow observers (typically components) to detect
          * whether specific records have been changed.
@@ -70,6 +80,14 @@ class ModelManager {
          * O(1) reads/writes.
          */
         this._toComputeFields = new Map();
+        /**
+         * "on change" methods flagged to call during an update cycle. Similar
+         * to computes but called after all other computes are done, and does
+         * not actually assign any value to its respective field.
+         * This is deprecated but when it is necessary due to other limitations
+         * in code it is better using "on change" than polluting real computes.
+         */
+        this._toCallOnChange = new Map();
     }
 
     /**
@@ -300,6 +318,7 @@ class ModelManager {
                             'default',
                             'dependencies',
                             'fieldType',
+                            'isOnChange',
                             'readonly',
                             'related',
                             'required',
@@ -318,6 +337,7 @@ class ModelManager {
                             'fieldType',
                             'inverse',
                             'isCausal',
+                            'isOnChange',
                             'readonly',
                             'related',
                             'relationType',
@@ -362,6 +382,9 @@ class ModelManager {
                     if (unknownDependencies.length > 0) {
                         throw new Error(`Compute field "${Model.modelName}/${fieldName}" contains some unknown dependencies: "${unknownDependencies.join(", ")}".`);
                     }
+                }
+                if (field.isOnChange && !field.compute) {
+                    throw Error(`isOnChange field "${Model.modelName}/${fieldName}" must be a computed field.`);
                 }
                 // 4. Related field.
                 if (field.compute && field.related) {
@@ -642,6 +665,7 @@ class ModelManager {
         // _toComputeFields, but it is not possible until related are also
         // properly unlinked during `set`.
         this._toComputeFields.delete(record);
+        this._toCallOnChange.delete(record);
         delete Model.__records[record.localId];
     }
 
@@ -652,18 +676,23 @@ class ModelManager {
      * @private
      */
     _flushUpdateCycle(func) {
+        if (this._isInUpdateCycle) {
+            throw Error('Already in update cycle. You are probably trying to manually create/update/delete a record from inside a compute method, which is not supported.');
+        }
+        this._isInUpdateCycle = true;
         // Execution of computes
         while (this._toComputeFields.size > 0) {
             for (const [record, fields] of this._toComputeFields) {
-                // delete at every step to avoid recursion, indeed doCompute
-                // might trigger an update cycle itself
+                // Delete at every step to detect if the change due to compute
+                // registered extra fields to compute.
                 this._toComputeFields.delete(record);
                 if (!record.exists()) {
                     throw Error(`Cannot execute computes for already deleted record ${record.localId}.`);
                 }
                 while (fields.size > 0) {
                     for (const field of fields) {
-                        // delete at every step to avoid recursion
+                        // Delete at every step to detect if the change due to
+                        // compute registered extra fields to compute.
                         fields.delete(field);
                         if (field.compute) {
                             this._update(record, { [field.fieldName]: record[field.compute]() }, { allowWriteReadonly: true });
@@ -678,12 +707,28 @@ class ModelManager {
                 }
             }
         }
-
+        // Verify the existence of value for required fields (of non-deleted records).
+        for (const record of this._updatedRecords) {
+            if (!record.exists()) {
+                continue;
+            }
+            for (const required of record.constructor.__requiredFieldsList) {
+                if (record[required.fieldName] === undefined) {
+                    throw Error(`Field ${required.fieldName} of ${record.localId} is required.`);
+                }
+            }
+        }
+        // Increment record rev number (for useStore comparison)
+        for (const record of this._updatedRecords) {
+            record.__state++;
+        }
+        this._updatedRecords.clear();
+        this._isInUpdateCycle = false;
         // Execution of _created
         while (this._createdRecords.size > 0) {
             for (const record of this._createdRecords) {
-                // delete at every step to avoid recursion, indeed _created
-                // might trigger an update cycle itself
+                // Delete at every step to avoid recursion, indeed _created
+                // might trigger an update cycle itself.
                 this._createdRecords.delete(record);
                 if (!record.exists()) {
                     throw Error(`Cannot call _created for already deleted record ${record.localId}.`);
@@ -691,23 +736,32 @@ class ModelManager {
                 record._created();
             }
         }
-
-        // Increment record rev number (for useStore comparison)
-        for (const record of this._updatedRecords) {
-            record.__state++;
-        }
-
-        // handle required field.
-        for (const record of this._updatedRecords) {
-            for (const required of record.constructor.__requiredFieldsList) {
-                if (record[required.fieldName] === undefined) {
-                    throw Error(`Field ${required.fieldName} of ${record.localId} is required.`);
+        // Execution of "on change".
+        while (this._toCallOnChange.size > 0) {
+            for (const [record, fields] of this._toCallOnChange) {
+                // Delete at every step to detect if the change due to "on change"
+                // registered extra fields for which to call "on change".
+                this._toCallOnChange.delete(record);
+                if (!record.exists()) {
+                    throw Error(`Cannot execute 'on change' for already deleted record ${record.localId}.`);
+                }
+                while (fields.size > 0) {
+                    for (const field of fields) {
+                        // Delete at every step to detect if the change due to "on change"
+                        // registered extra fields for which to call "on change".
+                        fields.delete(field);
+                        if (field.compute) {
+                            const res = record[field.compute]();
+                            if (res !== undefined) {
+                                throw new Error("'on change' compute method is not supposed to return any value.");
+                            }
+                            continue;
+                        }
+                        throw new Error("No compute method defined on this field definition");
+                    }
                 }
             }
         }
-
-        this._updatedRecords.clear();
-
         // Trigger at most one useStore call per update cycle
         if (this._hasAnyChangeDuringCycle) {
             this.env.store.state.messagingRevNumber++;
@@ -1035,6 +1089,21 @@ class ModelManager {
     }
 
     /**
+     * Register a pair record/field for the on change step of the update cycle
+     * in progress.
+     *
+     * @private
+     * @param {mail.model} record
+     * @param {ModelField} field
+     */
+    _registerToCallOnChange(record, field) {
+        if (!this._toCallOnChange.has(record)) {
+            this._toCallOnChange.set(record, new Set());
+        }
+        this._toCallOnChange.get(record).add(field);
+    }
+
+    /**
      * Register a pair record/field for the compute step of the update cycle in
      * progress.
      *
@@ -1043,6 +1112,11 @@ class ModelManager {
      * @param {ModelField} field
      */
     _registerToComputeField(record, field) {
+        if (field.isOnChange) {
+            // Separate "on change" computes from real ones.
+            this._registerToCallOnChange(record, field);
+            return;
+        }
         if (!this._toComputeFields.has(record)) {
             this._toComputeFields.set(record, new Set());
         }

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -128,10 +128,11 @@ function factory(dependencies) {
         }
 
         /**
+         * Reconciliation between uploading attachment and real attachment.
+         *
          * @private
-         * @returns {mail.composer[]}
          */
-        _computeComposers() {
+        _created() {
             if (this.isUploading) {
                 return;
             }
@@ -143,9 +144,8 @@ function factory(dependencies) {
             if (relatedUploadingAttachment) {
                 const composers = relatedUploadingAttachment.composers;
                 relatedUploadingAttachment.delete();
-                return replace(composers);
+                this.update({ composers: replace(composers) });
             }
-            return;
         }
 
         /**
@@ -336,7 +336,6 @@ function factory(dependencies) {
         }),
         checkSum: attr(),
         composers: many2many('mail.composer', {
-            compute: '_computeComposers',
             inverse: 'attachments',
         }),
         defaultSource: attr({

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -273,6 +273,7 @@ function factory(dependencies) {
                 'threadId',
                 'threadModel',
             ],
+            isOnChange: true,
         }),
         /**
          * Not a real field, used to trigger its compute method when one of the
@@ -283,6 +284,7 @@ function factory(dependencies) {
             dependencies: [
                 'threadIsLoadingAttachments',
             ],
+            isOnChange: true,
         }),
         /**
          * Determines the `mail.thread` that should be displayed by `this`.

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -960,6 +960,7 @@ function factory(dependencies) {
                 'suggestionSearchTerm',
                 'thread',
             ],
+            isOnChange: true,
         }),
         /**
          * Determines the extra `mail.partner` (on top of existing followers)

--- a/addons/mail/static/src/models/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu/messaging_menu.js
@@ -130,6 +130,7 @@ function factory(dependencies) {
                 'messagingInbox',
                 'messagingInboxMainCache',
             ],
+            isOnChange: true,
         }),
         /**
          * Determine whether the mobile new message input is visible or not.

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1347,7 +1347,10 @@ function factory(dependencies) {
          * @returns {mail.thread_cache}
          */
         _computeMainCache() {
-            return link(this.cache());
+            return insert({
+                stringifiedDomain: '[]',
+                thread: link(this),
+            });
         }
 
         /**
@@ -2059,6 +2062,7 @@ function factory(dependencies) {
             dependencies: [
                 'followersPartner',
             ],
+            isOnChange: true,
         }),
         /**
          * Not a real field, used to trigger `_onChangeLastSeenByCurrentPartnerMessageId` when one of
@@ -2069,6 +2073,7 @@ function factory(dependencies) {
             dependencies: [
                 'lastSeenByCurrentPartnerMessageId',
             ],
+            isOnChange: true,
         }),
         /**
          * Not a real field, used to trigger `_onChangeThreadViews` when one of
@@ -2079,6 +2084,7 @@ function factory(dependencies) {
             dependencies: [
                 'threadViews',
             ],
+            isOnChange: true,
         }),
         /**
          * Not a real field, used to trigger `_onIsServerPinnedChanged` when one of
@@ -2089,6 +2095,7 @@ function factory(dependencies) {
             dependencies: [
                 'isServerPinned',
             ],
+            isOnChange: true,
         }),
         /**
          * Not a real field, used to trigger `_onServerFoldStateChanged` when one of
@@ -2099,6 +2106,7 @@ function factory(dependencies) {
             dependencies: [
                 'serverFoldState',
             ],
+            isOnChange: true,
         }),
         /**
          * All messages ordered like they are displayed.

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -311,6 +311,7 @@ function factory(dependencies) {
             dependencies: [
                 'threadCache'
             ],
+            isOnChange: true,
         }),
         /**
          * Not a real field, used to trigger `_onThreadCacheIsLoadingChanged`
@@ -324,6 +325,7 @@ function factory(dependencies) {
                 'threadCache',
                 'threadCacheIsLoading',
             ],
+            isOnChange: true,
         }),
         /**
          * Determines the domain to apply when fetching messages for `this.thread`.
@@ -420,6 +422,7 @@ function factory(dependencies) {
                 'lastVisibleMessage',
                 'threadCache',
             ],
+            isOnChange: true,
         }),
         /**
          * Determines the `mail.thread_viewer` currently managing `this`.

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -2,7 +2,7 @@
 
 import { registerNewModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
-import { create, link, unlink } from '@mail/model/model_field_command';
+import { create, insert, link, unlink } from '@mail/model/model_field_command';
 
 function factory(dependencies) {
 
@@ -128,7 +128,10 @@ function factory(dependencies) {
             if (!this.thread) {
                 return unlink();
             }
-            return link(this.thread.cache(this.stringifiedDomain));
+            return insert({
+                stringifiedDomain: this.stringifiedDomain,
+                thread: link(this.thread),
+            });
         }
 
         /**


### PR DESCRIPTION
There is currently a limitation with required fields because an "on change"
compute might trigger the check for "required" before all the actual computes
have been done, leading to the required field check incorrectly failing.

The main goal is to ensure the "on change" computes are done after all the other
computes and after the check for required fields.

A check has also been added to ensure no "real" compute can trigger update cycle
side-effects anymore.

Opportunity is also taken to prevent from checking for required fields on a
record that was deleted as part of the same update cycle.

Somewhat part of task-2278551