### PR TITLE
[IMP] hr_expense: make bank journal required for company payment

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -762,7 +762,7 @@
                             <group>
                                 <group>
                                     <field name="journal_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('payment_mode', '!=', 'own_account')]}" context="{'default_company_id': company_id}"/>
-                                    <field name="bank_journal_id" groups="account.group_account_invoice,account.group_account_readonly" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('payment_mode', '!=', 'company_account')]}" context="{'default_company_id': company_id}"/>
+                                    <field name="bank_journal_id" groups="account.group_account_invoice,account.group_account_readonly" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('payment_mode', '!=', 'company_account')], 'required': [('payment_mode', '=', 'company_account')]}" context="{'default_company_id': company_id}"/>
                                     <field name="accounting_date" groups="account.group_account_invoice,account.group_account_readonly" attrs="{'invisible': [('state', 'not in', ['approve', 'post', 'done'])]}"/>
                                 </group>
                                 <group>


### PR DESCRIPTION
Field `bank_journal_id` is required on `account.move`.

Before this commit, Approving expense sheet without `bank_journal_id` 
with `payment_mode` set to `company_account` will give error due to not
setting mandatory field.

With this Commit, Field `bank_journal_id` will be required on view when
`payment_mode` is set to `company_account`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
