### PR TITLE
[IMP] base: improve warning on duplicate vat

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -146,13 +146,14 @@
             <field name="arch" type="xml">
                 <form string="Partners">
                 <div class="alert alert-warning oe_edit_only" role="alert" attrs="{'invisible': [('same_vat_partner_id', '=', False)]}">
-                  A partner with the same <span><span class="o_vat_label">Tax ID</span></span> already exists (<field name="same_vat_partner_id"/>), are you sure to create a new one?
+                    A partner with the same <span><span class="o_vat_label">Tax ID</span></span> already exists (<field name="same_vat_partner_id"/>). <span attrs="{'invisible': [('id', '!=', False)]}" >Are you sure to create a new one?</span>
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "image_128"}'/>
                     <div class="oe_title">
+                        <field name="id" invisible="1"/>
                         <field name="is_company" invisible="1"/>
                         <field name="commercial_partner_id" invisible="1"/>
                         <field name="active" invisible="1"/>


### PR DESCRIPTION
Follow up on 0f8be0d75cbcff418fe904c663b3d18262056d91

Before this Fix, Warning of Duplicate VAT was always visible even if the partner is already created which is annoying for users.

Now, we hide  `Are you sure to create a new one?` message from warning if partner is already created.

Closes #50983

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
