### PR TITLE
[FIX] mrp: do now allow to select cancelled mo

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -4,6 +4,7 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError
 from odoo.tools import float_compare
+from odoo.osv import expression
 
 
 class MrpUnbuild(models.Model):
@@ -76,17 +77,12 @@ class MrpUnbuild(models.Model):
     @api.depends('company_id', 'product_id')
     def _compute_allowed_mo_ids(self):
         for unbuild in self:
-            if unbuild.product_id:
-                domain = [
+            domain = [
                     ('state', '=', 'done'),
-                    ('product_id', '=', unbuild.product_id.id),
                     ('company_id', '=', unbuild.company_id.id)
                 ]
-            else:
-                domain = [
-                    ('state', 'in', ['done', 'cancel']),
-                    ('company_id', '=', unbuild.company_id.id)
-                ]
+            if unbuild.product_id:
+                domain = expression.AND([domain, [('product_id', '=', unbuild.product_id.id)]])
             allowed_mos = self.env['mrp.production'].search_read(domain, ['id'])
             if allowed_mos:
                 unbuild.allowed_mo_ids = [mo['id'] for mo in allowed_mos]


### PR DESCRIPTION
Before this commit, User can select Cancelled MO before selecting Product.
but it is already blocking since we already have constrains to not allow ubnuilding
Cancelled MO.

With this commit, We are always showing Done MO.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
