### PR TITLE
[FIX] mrp: allow to select product w/o bom

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -15,7 +15,7 @@ class MrpUnbuild(models.Model):
     name = fields.Char('Reference', copy=False, readonly=True, default=lambda x: _('New'))
     product_id = fields.Many2one(
         'product.product', 'Product', check_company=True,
-        domain="[('bom_ids', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        domain="[('type', 'in', ['product', 'consu']), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         required=True, states={'done': [('readonly', True)]})
     company_id = fields.Many2one(
         'res.company', 'Company',


### PR DESCRIPTION
Without this commit, User was not allowed to create Unbuild Order
for the product without BoMs from Unbuild Orders menu.
But User was able to create Unbuild Order using 'Unbuild Order' button
on MO.

With this commit, We are allowing user to select Products without BoMs
to make this behavior consistent so user can create Unbuild Order from
Unbuild Orders menu.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
