### PR TITLE
do not close column quick create on first column

### DIFF
--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column_quick_create.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column_quick_create.js
@@ -36,6 +36,7 @@ var ColumnQuickCreate = Widget.extend({
         this.examples = options.examples;
         this.folded = true;
         this.isMobile = false;
+        this.isFirstColumn = options.isFirstColumn;
     },
     /**
      * @override
@@ -45,8 +46,10 @@ var ColumnQuickCreate = Widget.extend({
         this.$quickCreateUnfolded = this.$('.o_quick_create_unfolded');
         this.$input = this.$('input');
 
-        // destroy the quick create when the user clicks outside
-        core.bus.on('click', this, this._onWindowClicked);
+        if (!this.isFirstColumn) {
+            // destroy the quick create when the user clicks outside
+            core.bus.on('click', this, this._onWindowClicked);
+        }
 
         this._update();
 

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
@@ -376,6 +376,7 @@ var KanbanRenderer = BasicRenderer.extend({
                 this.quickCreate = new ColumnQuickCreate(this, {
                     applyExamplesText: this.examples && this.examples.applyExamplesText,
                     examples: this.examples && this.examples.examples,
+                    isFirstColumn: !self.state.data.length,
                 });
                 this.defs.push(this.quickCreate.appendTo(fragment).then(function () {
                     // Open it directly if there is no column yet

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -3853,6 +3853,38 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test('quick create column should not be closed on widnow click if there is no column', async function (assert) {
+        assert.expect(4);
+
+        const kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <kanban class="o_kanban_test">
+                    <field name="product_id"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="foo"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ['product_id'],
+            domain: [['foo', '=', 'norecord']],
+        });
+
+        assert.containsNone(kanban, '.o_kanban_group');
+        assert.containsOnce(kanban, '.o_column_quick_create');
+        assert.ok(kanban.$('.o_column_quick_create input').is(':visible'),
+            "the quick create should be opened");
+        // click outside should not discard quick create column
+        await testUtils.dom.click(kanban.$('.o_kanban_example_background_container'));
+        assert.ok(kanban.$('.o_column_quick_create input').is(':visible'),
+            "the quick create should still be opened");
+
+        kanban.destroy();
+    });
+
     QUnit.test('quick create several columns in a row', async function (assert) {
         assert.expect(10);
 


### PR DESCRIPTION
PURPOSE
At the creation of a new project, the kanban view is empty.
The next step for the user is to start adding the stages (i.e. columns) of the project pipeline.

Problem is, if the user happen to click outside of the draft column before adding any, the draft column is disarded and the 'mockup' columns disappear.

Since there are no advantage of discarding the draft column, and users might be confused and not think about clicking back on 'Add a column', we'd rather keep the draft column displayed until the column is actually created.

SPECIFICATION
If there are no columns displayed in the pipeline kanban, do not discard the draft columns and columns placeholders when the user clicks out of the draft column.

TASK 2517684