### PR TITLE
[FIX] web: remove debug comment on qweb template extension

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -476,7 +476,9 @@ class HomeStaticTemplateHelpers(object):
                 parent_tree = copy.deepcopy(self.template_dict[parent_addon][parent_name])
 
                 xpaths = list(template_tree)
-                if self.debug and inherit_mode == self.EXTENSION_MODE:
+                # owl chokes on comments, disable debug comments for now
+                # pylint: disable=W0125
+                if False: # self.debug and inherit_mode == self.EXTENSION_MODE:
                     for xpath in xpaths:
                         xpath.insert(0, etree.Comment(" Modified by %s from %s " % (template_name, addon)))
                 elif inherit_mode == self.PRIMARY_MODE:

--- a/addons/web/tests/test_serving_base.py
+++ b/addons/web/tests/test_serving_base.py
@@ -145,7 +145,6 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
                 </form>
                 <t t-name="template_1_2">
                     <div>And I grew strong</div>
-                    <!-- Modified by anonymous_template_2 from module_2 -->
                     <div>And I learned how to get along</div>
                 </t>
                 <form t-name="template_2_1" random-attr="gloria">
@@ -351,7 +350,6 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
             <templates>
                 <form t-name="template_1_1">
                     <div>At first I was afraid</div>
-                    <!-- Modified by template_1_2 from module_1 -->
                     <div>I was petrified</div>
                     <div>Kept thinking I could never live without you by my side</div>
                 </form>
@@ -408,9 +406,7 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
             <templates>
                 <form t-name="template_1_1">
                     <div>I am a man of constant sorrow</div>
-                    <!-- Modified by template_2_1 from module_2 -->
                     <div>In constant sorrow all through his days</div>
-                    <!-- Modified by template_3_1 from module_3 -->
                     <div>Oh Brother !</div>
                     <div>I've seen trouble all my days</div>
                 </form>
@@ -476,7 +472,7 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
         expected = b"""
             <templates>
                 <div overriden-attr="overriden" t-name="template_1_1">
-                    <!-- Modified by template_1_2 from module_1 -->And I grew strong
+                    And I grew strong
                 </div>
             </templates>
         """
@@ -510,7 +506,6 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
         expected = b"""
             <templates>
                 <div t-name="template_1_1">
-                    <!-- Modified by template_1_2 from module_1 -->
                     And I grew strong
                     <p>And I learned how to get along</p>
                     And so you're back
@@ -551,7 +546,6 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
         expected = b"""
             <templates>
                 <div t-name="template_1_1">
-                    <!-- Modified by template_1_2 from module_1 -->
                     And I grew strong
                     <p>And I learned how to get along</p>
                 </div>
@@ -590,7 +584,6 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
         expected = b"""
             <templates>
                 <div t-name="template_1_1">
-                    <!-- Modified by template_1_2 from module_1 -->
                     Form replacer
                 </div>
             </templates>


### PR DESCRIPTION
Owl 1 has some issues handling comments. So when people were in odoo
debug mode, inheriting in extension mode a t template, the comment
added from the server would throw a frontend error.
For now, we comment it, waiting for better comment handling in owl.
