### PR TITLE
[FIX] web: make '_false' bar clickable after removing filter

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
@@ -42,7 +42,7 @@ var KanbanColumnProgressBar = Widget.extend({
             this.groupCount = state.groupCount;
             this.subgroupCounts = state.subgroupCounts;
             this.totalCounterValue = state.totalCounterValue;
-            this.activeFilter = state.activeFilter;
+            this.activeFilter = columnState.activeFilter || state.activeFilter;
         }
 
         // Prepare currency (TODO this should be automatic... use a field ?)

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -292,6 +292,13 @@ var KanbanModel = BasicModel.extend({
         if (element.parentID) {
             element.limit = this.loadParams.limit;
         }
+        // if list datapoint is reloaded then remove activeFilter from all child datapoint
+        if (element.type === 'list' && !element.parentID && !options || options && !('activeFilter' in options)) {
+            _.each(element.data, (elemId) => {
+                const elem = this.localData[elemId];
+                elem.activeFilter = { domain: [], value: false };
+            });
+        }
         // Register the domain extension in the element.
         if (options && options.activeFilter) {
             element.activeFilter = options.activeFilter || element.activeFilter;

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -193,6 +193,8 @@ var KanbanModel = BasicModel.extend({
                     });
                     loadMoreCount = filteredRecordsTotal - filteredRecords.length;
                     loadMoreOffset = filteredRecords.length;
+                    // Always keep activeFilter
+                    result.activeFilter = dp.activeFilter;
                 }
             }
             result.loadMoreCount = loadMoreCount;
@@ -291,13 +293,6 @@ var KanbanModel = BasicModel.extend({
         // the limit if the current element is a group (and thus, has a parent).
         if (element.parentID) {
             element.limit = this.loadParams.limit;
-        }
-        // if list datapoint is reloaded then remove activeFilter from all child datapoint
-        if (element.type === 'list' && !element.parentID && !options || options && !('activeFilter' in options)) {
-            _.each(element.data, (elemId) => {
-                const elem = this.localData[elemId];
-                elem.activeFilter = { domain: [], value: false };
-            });
         }
         // Register the domain extension in the element.
         if (options && options.activeFilter) {


### PR DESCRIPTION
[FIX] web: make '_false' bar clickable after removing filter

before this commit, the '_false' bar is not clickable after
removing the filter. It happens because '_false' contains
a negative value after removing the filter.

after this commit, the '_false' bar is clickable after removing
the filter.

TaskID-2491196
