### PR TITLE
[FIX] rating: Wrong template style

### DIFF
--- a/addons/rating/views/rating_template.xml
+++ b/addons/rating/views/rating_template.xml
@@ -27,7 +27,7 @@
                     <link rel='stylesheet' href='/web/static/lib/bootstrap/css/bootstrap.css'/>
                 </t>
                 <div class="container">
-                    <div class="row">
+                    <div class="row" style="display: inline">
                         <h1 class="text-center">Thanks! We appreciate your feedback.</h1>
                         <h4 class="text-center text-muted" style="margin-bottom: 32px;">Your rating has been submitted.</h4>
                         <div class="float-left">


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Go to helpdesk/configuration/stages
    2. Add rating email template to Solved
    3. Change state of a ticket to Solved
    4. Go to Technical/messages and open the sent message

What is currently happening ?

    The template is not displayed correctly

opw-2476485
