### PR TITLE
[FIX] website_forum: fix image display in a forum post

### DIFF
--- a/addons/website_forum/static/src/scss/website_forum.scss
+++ b/addons/website_forum/static/src/scss/website_forum.scss
@@ -67,6 +67,10 @@ $bronze: #eea91e;
             margin-bottom: 0.5rem;
         }
 
+        img {
+            max-width: 100%;
+        }
+
         &::after {
             content: "";
             display: table;
@@ -156,10 +160,6 @@ $bronze: #eea91e;
     a.no-decoration {
         cursor: pointer;
         text-decoration: none !important;
-    }
-
-    .forum_answer img, .question-block img {
-        max-width: 100%
     }
 }
 

--- a/addons/website_forum/static/src/scss/website_forum.scss
+++ b/addons/website_forum/static/src/scss/website_forum.scss
@@ -66,6 +66,12 @@ $bronze: #eea91e;
         p {
             margin-bottom: 0.5rem;
         }
+
+        &::after {
+            content: "";
+            display: table;
+            clear: both;
+        }
     }
 
     textarea.o_wysiwyg_loader + .note-editor {


### PR DESCRIPTION
The container size of a forum post was not correct when an image was
displayed with right or left alignment. Also, large images were
overflowing the post.

The css property clear was added at the end of the posts so that
floating elements do not float over the next section.

task-2469516


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
