### PR TITLE
[IMP]partner_autocomplete: company name field length

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -46,7 +46,7 @@ var FieldAutocomplete = FieldChar.extend(AutocompleteMixin, {
 
         if (this.mode === 'edit') {
             this.tagName = 'div';
-            this.className += ' dropdown open';
+            this.className += ' dropdown open w-100';
         }
 
         if (this.debounceSuggestions > 0) {

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -11,7 +11,7 @@
                     <div class="oe_title">
                         <label for="name"/>
                         <h1>
-                            <field name="name" placeholder="e.g. My Awesome Company"/>
+                            <field name="name" placeholder="e.g. My Company"/>
                         </h1>
                     </div>
                     <notebook colspan="4">


### PR DESCRIPTION
PURPOSE

Currently, in the res.company form view
name field is extremely short.

SPECIFICATION

in this we are add the boostrap 
class w-100 in name field div after 
this commit the length of name field 
is should be as long as the res.partner 
one.

Task Id: 2520268

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
