### PR TITLE
[FIX] base: avoid recursive loading of the registry

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -546,6 +546,12 @@ class Module(models.Model):
 
     @api.multi
     def _button_immediate_function(self, function):
+        if not self.env.registry.loaded:
+            # We are currently loading the registry. Avoid recursive loading. Change the modules
+            # states (call the `function`) and let the loop loading (STEP 3) handle the changes.
+            function(self)
+            return True
+
         try:
             # This is done because the installation/uninstallation/upgrade can modify a currently
             # running cron job and prevent it from finishing, and since the ir_cron table is locked


### PR DESCRIPTION
During an upgrade, it may happen that the `ir.module.module` functions
`button_immediate_{action}` are called. Normally, these functions will
reload the registry to act the {action} on modules. During an upgrade,
this is, firstly, not needed, and secondly interferes with the upgrade
engine, skipping scripts.

--
While this has only be observed during a 13.0 upgrade, this patch should be backported to previous versions.