### PR TITLE
[IMP] mail: add update command and use it on thread viewer

### DIFF
--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -484,6 +484,14 @@ class ModelField {
                             hasChanged = true;
                         }
                         break;
+                    case 'update':
+                        if (!['one2one', 'many2one'].includes(this.relationType)) {
+                            throw new Error(`Field "${record.constructor.modelName}/${this.fieldName}"(${this.fieldType} type) does not support command "update". Only x2one relations are supported.`);
+                        }
+                        if (this._setRelationUpdateX2One(record, newVal, options)) {
+                            hasChanged = true;
+                        }
+                        break;
                     default:
                         throw new Error(`Field "${record.constructor.modelName}/${this.fieldName}"(${this.fieldType} type) does not support command "${commandName}"`);
                 }
@@ -789,6 +797,25 @@ class ModelField {
             case 'one2one':
                 return this._setRelationUnlinkX2One(record, options);
         }
+    }
+
+    /**
+     * Set on this relational field in 'update' mode. Basically data provided
+     * during set on this relational field contain data to update target record.
+     *
+     * @private
+     * @param {mail.model} record
+     * @param {Object} data
+     * @param {Object} [options]
+     * @returns {boolean} whether the value changed for the current field
+     */
+    _setRelationUpdateX2One(record, data, options) {
+        const otherRecord = this.read(record);
+        if (!otherRecord) {
+            throw Error(`Record ${record.localId} cannot update undefined relational field ${this.fieldName}.`);
+        }
+        this.env.modelManager._update(otherRecord, data);
+        return false;
     }
 
     /**

--- a/addons/mail/static/src/model/model_field_command.js
+++ b/addons/mail/static/src/model/model_field_command.js
@@ -174,6 +174,17 @@ function unlinkAll() {
     return new FieldCommand('unlink-all');
 }
 
+/**
+ * Returns an update command to give to the model manager at create/update.
+ * `update` command can be used for x2one relation fields.
+ * - updates the values of the current related record with the given values
+ *
+ * @returns {FieldCommand}
+ */
+function update(newValue) {
+    return new FieldCommand('update', newValue);
+}
+
 export {
     FieldCommand,
     clear,
@@ -187,5 +198,6 @@ export {
     set,
     unlink,
     unlinkAll,
+    update,
 };
 

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -2,7 +2,7 @@
 
 import { registerNewModel } from '@mail/model/model_core';
 import { attr, many2one, one2many, one2one } from '@mail/model/model_field';
-import { clear, create } from '@mail/model/model_field_command';
+import { clear, create, link, unlink, update } from '@mail/model/model_field_command';
 
 function factory(dependencies) {
 
@@ -246,6 +246,21 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {mail.thread_viewer}
+         */
+        _computeThreadViewer() {
+            const threadViewerData = {
+                hasThreadView: this.hasThreadView,
+                thread: this.thread ? link(this.thread) : unlink(),
+            };
+            if (!this.threadViewer) {
+                return create(threadViewerData);
+            }
+            return update(threadViewerData);
+        }
+
+        /**
+         * @private
          * @returns {integer|undefined}
          */
         _computeVisibleIndex() {
@@ -446,10 +461,14 @@ function factory(dependencies) {
          * Determines the `mail.thread_viewer` managing the display of `this.thread`.
          */
         threadViewer: one2one('mail.thread_viewer', {
-            default: create(),
-            inverse: 'chatWindow',
+            compute: '_computeThreadViewer',
+            dependencies: [
+                'hasThreadView',
+                'thread',
+            ],
             isCausal: true,
             readonly: true,
+            required: true,
         }),
         /**
          * This field handle the "order" (index) of the visible chatWindow inside the UI.

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -2,7 +2,7 @@
 
 import { registerNewModel } from '@mail/model/model_core';
 import { attr, many2one, one2one } from '@mail/model/model_field';
-import { create, insert, link } from '@mail/model/model_field_command';
+import { create, insert, link, unlink, update } from '@mail/model/model_field_command';
 
 function factory(dependencies) {
 
@@ -87,6 +87,21 @@ function factory(dependencies) {
          */
         _computeIsDisabled() {
             return !this.thread || this.thread.isTemporary;
+        }
+
+        /**
+         * @private
+         * @returns {mail.thread_viewer}
+         */
+        _computeThreadViewer() {
+            const threadViewerData = {
+                hasThreadView: this.hasThreadView,
+                thread: this.thread ? link(this.thread) : unlink(),
+            };
+            if (!this.threadViewer) {
+                return create(threadViewerData);
+            }
+            return update(threadViewerData);
         }
 
         /**
@@ -320,10 +335,14 @@ function factory(dependencies) {
          * Determines the `mail.thread_viewer` managing the display of `this.thread`.
          */
         threadViewer: one2one('mail.thread_viewer', {
-            default: create(),
-            inverse: 'chatter',
+            compute: '_computeThreadViewer',
+            dependencies: [
+                'hasThreadView',
+                'thread',
+            ],
             isCausal: true,
             readonly: true,
+            required: true,
         }),
     };
 

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -2,7 +2,7 @@
 
 import { registerNewModel } from '@mail/model/model_core';
 import { attr, many2one, one2many, one2one } from '@mail/model/model_field';
-import { clear, create, link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
+import { clear, create, link, replace, unlink, unlinkAll, update } from '@mail/model/model_field_command';
 
 function factory(dependencies) {
 
@@ -353,6 +353,22 @@ function factory(dependencies) {
             return;
         }
 
+        /**
+         * @private
+         * @returns {mail.thread_viewer}
+         */
+        _computeThreadViewer() {
+            const threadViewerData = {
+                hasThreadView: this.hasThreadView,
+                selectedMessage: this.replyingToMessage ? link(this.replyingToMessage) : unlink(),
+                stringifiedDomain: this.stringifiedDomain,
+                thread: this.thread ? link(this.thread) : unlink(),
+            };
+            if (!this.threadViewer) {
+                return create(threadViewerData);
+            }
+            return update(threadViewerData);
+        }
     }
 
     Discuss.fields = {
@@ -552,10 +568,16 @@ function factory(dependencies) {
          * Determines the `mail.thread_viewer` managing the display of `this.thread`.
          */
         threadViewer: one2one('mail.thread_viewer', {
-            default: create(),
-            inverse: 'discuss',
+            compute: '_computeThreadViewer',
+            dependencies: [
+                'hasThreadView',
+                'replyingToMessage',
+                'stringifiedDomain',
+                'thread',
+            ],
             isCausal: true,
             readonly: true,
+            required: true,
         }),
     };
 

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -62,66 +62,6 @@ function factory(dependencies) {
 
         /**
          * @private
-         * @returns {boolean}
-         */
-        _computeHasThreadView() {
-            if (this.chatter) {
-                return this.chatter.hasThreadView;
-            }
-            if (this.chatWindow) {
-                return this.chatWindow.hasThreadView;
-            }
-            if (this.discuss) {
-                return this.discuss.hasThreadView;
-            }
-            return this.hasThreadView;
-        }
-
-        /**
-         * @private
-         * @returns {string}
-         */
-        _computeStringifiedDomain() {
-            if (this.chatter) {
-                return '[]';
-            }
-            if (this.chatWindow) {
-                return '[]';
-            }
-            if (this.discuss) {
-                return this.discuss.stringifiedDomain;
-            }
-            return this.stringifiedDomain;
-        }
-
-        /**
-         * @private
-         * @returns {mail.thread|undefined}
-         */
-         _computeThread() {
-            if (this.chatter) {
-                if (!this.chatter.thread) {
-                    return unlink();
-                }
-                return link(this.chatter.thread);
-            }
-            if (this.chatWindow) {
-                if (!this.chatWindow.thread) {
-                    return unlink();
-                }
-                return link(this.chatWindow.thread);
-            }
-            if (this.discuss) {
-                if (!this.discuss.thread) {
-                    return unlink();
-                }
-                return link(this.discuss.thread);
-            }
-            return;
-        }
-
-        /**
-         * @private
          * @returns {mail.thread_cache|undefined}
          */
         _computeThreadCache() {
@@ -152,107 +92,25 @@ function factory(dependencies) {
 
     ThreadViewer.fields = {
         /**
-         * States the `mail.chatter` managing `this`. This field is computed
-         * through the inverse relation and should be considered read-only.
-         */
-        chatter: one2one('mail.chatter', {
-            inverse: 'threadViewer',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        chatterHasThreadView: attr({
-            related: 'chatter.hasThreadView',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        chatterThread: many2one('mail.thread', {
-            related: 'chatter.thread',
-        }),
-        /**
-         * States the `mail.chat_window` managing `this`. This field is computed
-         * through the inverse relation and should be considered read-only.
-         */
-        chatWindow: one2one('mail.chat_window', {
-            inverse: 'threadViewer',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        chatWindowHasThreadView: attr({
-            related: 'chatWindow.hasThreadView',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        chatWindowThread: many2one('mail.thread', {
-            related: 'chatWindow.thread',
-        }),
-        /**
-         * States the `mail.discuss` managing `this`. This field is computed
-         * through the inverse relation and should be considered read-only.
-         */
-        discuss: one2one('mail.discuss', {
-            inverse: 'threadViewer',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        discussHasThreadView: attr({
-            related: 'discuss.hasThreadView',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        discussStringifiedDomain: attr({
-            related: 'discuss.stringifiedDomain',
-        }),
-        /**
-         * Serves as compute dependency.
-         */
-        discussThread: many2one('mail.thread', {
-            related: 'discuss.thread',
-        }),
-        /**
          * Determines whether `this.thread` should be displayed.
          */
         hasThreadView: attr({
-            compute: '_computeHasThreadView',
             default: false,
-            dependencies: [
-                'chatterHasThreadView',
-                'chatWindowHasThreadView',
-                'discussHasThreadView',
-            ],
         }),
         /**
          * Determines the selected `mail.message`.
          */
-        selectedMessage: many2one('mail.message', {
-            related: 'discuss.replyingToMessage',
-        }),
+        selectedMessage: many2one('mail.message'),
         /**
          * Determines the domain to apply when fetching messages for `this.thread`.
          */
         stringifiedDomain: attr({
-            compute: '_computeStringifiedDomain',
             default: '[]',
-            dependencies: [
-                'discussStringifiedDomain',
-            ],
         }),
         /**
          * Determines the `mail.thread` that should be displayed by `this`.
          */
-        thread: many2one('mail.thread', {
-            compute: '_computeThread',
-            dependencies: [
-                'chatterThread',
-                'chatWindowThread',
-                'discussThread',
-            ],
-        }),
+        thread: many2one('mail.thread'),
         /**
          * States the `mail.thread_cache` that should be displayed by `this`.
          */


### PR DESCRIPTION
Instead of thread viewer having many dependencies, this allows models "having
the thread viewer feature" to keep their own logic for themselves.

The "create or update" part has to be done manually in this case (as opposed to
using "insert") because thread viewer has no clear identifying data, since it
would depend on which model is using it in the first place.