### PR TITLE
[FIX] stock: don't auto remove 0 quant with user

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -626,7 +626,8 @@ class StockQuant(models.Model):
         # Use a select instead of ORM search for UoM robustness.
         query = """SELECT id FROM stock_quant WHERE (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
                                                      AND round(reserved_quantity::numeric, %s) = 0
-                                                     AND (round(inventory_quantity::numeric, %s) = 0 OR inventory_quantity IS NULL);"""
+                                                     AND (round(inventory_quantity::numeric, %s) = 0 OR inventory_quantity IS NULL)
+                                                     AND user_id IS NULL;"""
         params = (precision_digits, precision_digits, precision_digits)
         self.env.cr.execute(query, params)
         quant_ids = self.env['stock.quant'].browse([quant['id'] for quant in self.env.cr.dictfetchall()])


### PR DESCRIPTION
Before this commit, when quants where automatically unlinked, all empty quants were took.
Now, quants with a defined `user_id` will not be unlinked because they can legitimately be to 0 and we should wait inventory was processed before empty quants were unlinked (as once the inventory is processed, the `user_id` on quant is removed).