### PR TITLE
[FIX] mrp: Use the float_round method to make quantity with the same …

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -132,12 +132,13 @@ class ProductProduct(models.Model):
                 qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, raise_if_failure=False)
                 if not qty_per_kit:
                     continue
-                component_res = qties.get(component.id, {
-                    "virtual_available": component.virtual_available,
-                    "qty_available": component.qty_available,
-                    "incoming_qty": component.incoming_qty,
-                    "outgoing_qty": component.outgoing_qty,
-                    "free_qty": component.free_qty,
+                rounding = component.uom_id.rounding
+                component_res = res.get(component.id, {
+                    "virtual_available": float_round(component.virtual_available, precision_rounding=rounding),
+                    "qty_available": float_round(component.qty_available, precision_rounding=rounding),
+                    "incoming_qty": float_round(component.incoming_qty, precision_rounding=rounding),
+                    "outgoing_qty": float_round(component.outgoing_qty, precision_rounding=rounding),
+                    "free_qty": float_round(component.free_qty, precision_rounding=rounding),
                 })
                 ratios_virtual_available.append(component_res["virtual_available"] / qty_per_kit)
                 ratios_qty_available.append(component_res["qty_available"] / qty_per_kit)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -4,7 +4,7 @@
 from odoo import exceptions
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo.tools import float_compare, float_round
+from odoo.tools import float_compare, float_round, float_repr
 
 
 class TestBoM(TestMrpCommon):
@@ -277,6 +277,41 @@ class TestBoM(TestMrpCommon):
         # for the components available qty.
         kit_product_qty, _, _ = (self.product_7_3 + self.product_2 + self.product_3).mapped("qty_available")
         self.assertEqual(kit_product_qty, 2)
+
+    def test_13_negative_on_hand_qty(self):
+        # We set the Product Unit of Measure digits to 5.
+        # Because float_round(-384.0, 5) = -384.00000000000006
+        # And float_round(-384.0, 2) = -384.0
+        precision = self.env.ref('product.decimal_product_uom')
+        precision.digits = 5
+
+        # We set the Unit(s) rounding to 0.0001 (digit = 4)
+        uom_unit = self.env.ref('uom.product_uom_unit')
+        uom_unit.rounding = 0.0001
+
+        _ = self.env['mrp.bom'].create({
+            'product_id': self.product_2.id,
+            'product_tmpl_id': self.product_2.product_tmpl_id.id,
+            'product_uom_id': uom_unit.id,
+            'product_qty': 1.00,
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {
+                    'product_id': self.product_3.id,
+                    'product_qty': 1.000,
+                }),
+            ]
+        })
+
+        self.env['stock.quant']._update_available_quantity(self.product_3, self.env.ref('stock.stock_location_stock'), -384.0)
+
+        kit_product_qty = self.product_2.qty_available  # Without product_3 in the prefetch
+        # Use the float_repr to remove extra small decimal (and represent the front-end behavior)
+        self.assertEqual(float_repr(float_round(kit_product_qty, precision_digits=precision.digits), precision_digits=precision.digits), '-384.00000')
+
+        self.product_2.invalidate_cache(fnames=['qty_available'], ids=self.product_2.ids)
+        kit_product_qty, _ = (self.product_2 + self.product_3).mapped("qty_available")  # With product_3 in the prefetch
+        self.assertEqual(float_repr(float_round(kit_product_qty, precision_digits=precision.digits), precision_digits=precision.digits), '-384.00000')
 
     def test_20_bom_report(self):
         """ Simulate a crumble receipt with mrp and open the bom structure


### PR DESCRIPTION
…decimal places while we compute stock_quants.

upg:- 6588

Description of the issue/feature this PR addresses:

To avoid On hand negative quantity, since there was no proper methodology used to handle the case, it was rounding it up to the very next highest number.

Hence, that was creating the discrepancy for the data of the database in order to bypass that I have used the proper function to resolve it.

If there is no raw material set in MRP, then we can assign it to the kit.

This results in negative quantity and if quantity comes in negative, then this issue can occur in standard script.

So here we are using the float_round method to make quantity with the same decimal places while we compute stock_quants.

Current behavior before PR:

When we have related inventory_quantity of stock_quants quantity like -384.00000000000006 then it will set its rounding in qty_available of product in floats like  -385.00000000000006. This is causing the problem. 

For example:-
Here for this product
min(-384.00000000000006, 5311) // 1
min(-384.00000000000006, 5311)  = -384.00000000000006
but when we do "// 1"
then
min(-384.00000000000006, 5311) // 1 =  -385.00000000000006

The same issue gets generated on runbot also:- https://drive.google.com/file/d/1-MOGHwWE-NuFVgOVK9BrANoT2Nh-sT_Z/view

When the decimal accuracy for the product UOM is set at 5, then only this issue gets generated.

Desired behavior after PR is merged:

The value of related inventory_quantity of stock_quants quantity and qty_available of the product will be equal.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
