### PR TITLE
[FIX] crm: Fix issues on lead probability

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -58,8 +58,6 @@ CRM_LEAD_FIELDS_TO_MERGE = [
     'city',
     'state_id',
     'country_id',
-    # probability
-    'probability',
 ]
 
 # Subset of partner fields: sync any of those

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1870,19 +1870,17 @@ class Lead(models.Model):
 
         # get all team_ids from frequencies
         frequency_teams = frequencies.mapped('team_id')
-        frequency_team_ids = [0] + [team.id for team in frequency_teams]
+        frequency_team_ids = [team.id for team in frequency_teams]
 
         # 1. Compute each variable value count individually
         # regroup each variable to be able to compute their own probabilities
         # As all the variable does not enter into account (as we reject unset values in the process)
         # each value probability must be computed only with their own variable related total count
-        # special case: for lead for which team_id is not in frequency table,
+        # special case: for lead for which team_id is not in frequency table or lead with no team_id,
         # we consider all the records, independently from team_id (this is why we add a result[-1])
         result = dict((team_id, dict((field, dict(won_total=0, lost_total=0)) for field in leads_fields)) for team_id in frequency_team_ids)
         result[-1] = dict((field, dict(won_total=0, lost_total=0)) for field in leads_fields)
         for frequency in frequencies:
-            team_result = result[frequency.team_id.id if frequency.team_id else 0]
-
             field = frequency['variable']
             value = frequency['value']
 
@@ -1891,9 +1889,11 @@ class Lead(models.Model):
             if field == 'tag_id' and (frequency['won_count'] + frequency['lost_count']) < 50:
                 continue
 
-            team_result[field][value] = {'won': frequency['won_count'], 'lost': frequency['lost_count']}
-            team_result[field]['won_total'] += frequency['won_count']
-            team_result[field]['lost_total'] += frequency['lost_count']
+            if frequency.team_id:
+                team_result = result[frequency.team_id.id]
+                team_result[field][value] = {'won': frequency['won_count'], 'lost': frequency['lost_count']}
+                team_result[field]['won_total'] += frequency['won_count']
+                team_result[field]['lost_total'] += frequency['lost_count']
 
             if value not in result[-1][field]:
                 result[-1][field][value] = {'won': 0, 'lost': 0}
@@ -1921,8 +1921,8 @@ class Lead(models.Model):
                 lead_probabilities[lead_id] = 100
                 continue
 
-            lead_team_id = lead_values['team_id'] if lead_values['team_id'] else 0  # team_id = None -> Convert to 0
-            lead_team_id = lead_team_id if lead_team_id in result else -1  # team_id not in frequency Table -> convert to -1
+            # team_id not in frequency Table -> convert to -1
+            lead_team_id = lead_values['team_id'] if lead_values['team_id'] in result else -1
             if lead_team_id != save_team_id:
                 save_team_id = lead_team_id
                 team_won = result[save_team_id]['team_won']

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -4,6 +4,7 @@
 from odoo.addons.crm.tests.common import TestLeadConvertMassCommon
 from odoo.fields import Datetime
 from odoo.tests.common import tagged, users
+from odoo.tools import mute_logger
 
 
 @tagged('lead_manage')
@@ -29,8 +30,28 @@ class TestLeadMerge(TestLeadConvertMassCommon):
 
         cls.assign_users = cls.user_sales_manager + cls.user_sales_leads_convert + cls.user_sales_salesman
 
+    def _run_merge_wizard(self, leads):
+        res = self.env['crm.merge.opportunity'].with_context({
+            'active_model': 'crm.lead',
+            'active_ids': leads.ids,
+            'active_id': False,
+        }).create({
+            'team_id': False,
+            'user_id': False,
+        }).action_merge()
+        return self.env['crm.lead'].browse(res['res_id'])
+
     def test_initial_data(self):
-        """ Ensure initial data to avoid spaghetti test update afterwards """
+        """ Ensure initial data to avoid spaghetti test update afterwards
+
+        Original order:
+
+        lead_w_contact ----------lead---seq=30---proba=15
+        lead_w_email ------------lead---seq=3----proba=15
+        lead_1 ------------------lead---seq=1----proba=?
+        lead_w_partner ----------lead---seq=False---proba=10
+        lead_w_partner_company --lead---seq=False---proba=15
+        """
         self.assertFalse(self.lead_1.date_conversion)
         self.assertEqual(self.lead_1.date_open, Datetime.from_string('2020-01-15 11:30:00'))
         self.assertEqual(self.lead_1.user_id, self.user_sales_leads)
@@ -58,6 +79,7 @@ class TestLeadMerge(TestLeadConvertMassCommon):
         self.assertEqual(self.lead_w_email_lost.team_id, self.sales_team_1)
 
     @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
     def test_lead_merge_internals(self):
         """ Test internals of merge wizard. In this test leads are ordered as
 
@@ -98,6 +120,7 @@ class TestLeadMerge(TestLeadConvertMassCommon):
         self.assertEqual(merge_opportunity.stage_id, self.stage_gen_1)
 
     @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
     def test_lead_merge_mixed(self):
         """ In case of mix, opportunities are on top, and result is an opportunity
 
@@ -143,6 +166,50 @@ class TestLeadMerge(TestLeadConvertMassCommon):
         self.assertEqual(merge_opportunity.stage_id, self.stage_team_convert_1)
 
     @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
+    def test_lead_merge_probability_auto(self):
+        """ Check master lead keeps its automated probability when merged. """
+        leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
+        merged_lead = self._run_merge_wizard(leads)
+        self.assertEqual(merged_lead, self.lead_1)
+        self.assertTrue(merged_lead.is_automated_probability, "lead with Auto proba should remain with auto probability")
+
+    @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
+    def test_lead_merge_probability_auto_empty(self):
+        """ Check master lead keeps its automated probability when merged
+        even if its probability is 0. """
+        self.lead_1.write({'probability': 0, 'automated_probability': 0})
+        leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
+        merged_lead = self._run_merge_wizard(leads)
+        self.assertEqual(merged_lead, self.lead_1)
+        self.assertTrue(merged_lead.is_automated_probability, "lead with Auto proba should remain with auto probability")
+
+    @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
+    def test_lead_merge_probability_manual(self):
+        """ Check master lead keeps its manual probability when merged. """
+        self.lead_1.write({'probability': 40})
+        leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
+        merged_lead = self._run_merge_wizard(leads)
+        self.assertEqual(merged_lead, self.lead_1)
+        self.assertEqual(merged_lead.probability, 40, "Manual Probability should remain the same after the merge")
+        self.assertFalse(merged_lead.is_automated_probability)
+
+    @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
+    def test_lead_merge_probability_manual_empty(self):
+        """ Check master lead keeps its manual probability when merged even if
+        its probability is 0. """
+        self.lead_1.write({'probability': 0})
+        leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
+        merged_lead = self._run_merge_wizard(leads)
+        self.assertEqual(merged_lead, self.lead_1)
+        self.assertEqual(merged_lead.probability, 0, "Manual Probability should remain the same after the merge")
+        self.assertFalse(merged_lead.is_automated_probability)
+
+    @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
     def test_merge_method(self):
         """ In case of mix, opportunities are on top, and result is an opportunity
 


### PR DESCRIPTION
compute no team lead probability based on all lead
=================================================

Before this commit, lead with no team_id set had their automated
probability computed based on the subset of lead with no team_id.

Since all lead should end up we a team_id unless they do not match
any team criteria. the subset of lead without team is not a good
subset to estimate the probability of a new lead.

After this commit, a lead with no team_id set yet will have its
automated probability computed based on the entire lead set


do not erase 0% auto proba during merge
====================================

Issue
-----

When a lead with an automated probability is merged with other lead,
and this probability is 0, it will be considered as null value
and will be erased by the value of the next lead with a probability > 0

The final lead gets a probability != automated_probability and is
considered is_automated_probability = False and thus the automated
proability will be never set on the probability anymore

Expected behavior:
-----------------
If the probability is auto on the master keep the auto probability
If the probability is manual on the master keep that manual value
even if it's 0
in other words never take the probability from the merged records
and always keep the master one



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
