### PR TITLE
[FIX] im_livechat: add missed assets for chat widget

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -187,6 +187,8 @@
             <link rel="stylesheet" type="text/scss" href="/mail/static/src/scss/abstract_thread_window.scss"></link>
             <link rel="stylesheet" type="text/scss" href="/mail/static/src/scss/thread.scss"></link>
             <link rel="stylesheet" type="text/scss" href="/im_livechat/static/src/scss/im_livechat.scss"/>
+            <link rel="stylesheet" type="text/css" href="/web/static/lib/fontawesome/css/font-awesome.css"/>
+            <link rel="stylesheet" type="text/less" href="/web/static/src/scss/fontawesome_overridden.scss"/>
         </template>
 
         <!-- the js code to initialize the LiveSupport object -->


### PR DESCRIPTION
On using livechat widget on a page without font-awesome css, close button (arrow
icon) is not visible if screen is small enough. This confuse user who cannot
quit the chat.

To reproduce:
* create new page
* click ``Customize >> HTML CSS/JS Editor``
* replace content with a <div> with widget code inside
* save
* shrink browser window
* open widget chat

---

opw-2501026

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
