### PR TITLE
[FIX] *: avoid cutting 0.0 value in first row

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -784,7 +784,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                         if lines2:
                             # merge first line with record's main line
                             for j, val in enumerate(lines2[0]):
-                                if val or isinstance(val, bool):
+                                if val or isinstance(val, (int, float)):
                                     current[j] = val
                             # append the other lines at the end
                             lines += lines2[1:]


### PR DESCRIPTION
Have in a purchase order a first row with unit price 0
Export the PO adding unit price in the list of fields to export
The unit price is not reported

This occur because the first line of the order lines is meld with the
purchase order line but in the process the 0.0 values is discarded

opw-2510917

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
