### PR TITLE
[FIX] stock, mrp: Fix precision overflow in forecasted report

### DIFF
--- a/addons/stock/report/report_stock_forecasted.py
+++ b/addons/stock/report/report_stock_forecasted.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 
 from odoo import api, models
-from odoo.tools import float_is_zero, format_datetime, format_date
+from odoo.tools import float_is_zero, format_datetime, format_date, float_round
 
 
 class ReplenishmentReport(models.AbstractModel):
@@ -125,7 +125,7 @@ class ReplenishmentReport(models.AbstractModel):
             'receipt_date': format_datetime(self.env, move_in.date, timezone, dt_format=False) if move_in else False,
             'delivery_date': format_datetime(self.env, move_out.date, timezone, dt_format=False) if move_out else False,
             'is_late': is_late,
-            'quantity': quantity,
+            'quantity': float_round(quantity, precision_rounding=product.uom_id.rounding),
             'move_out': move_out,
             'move_in': move_in,
             'reservation': reservation,


### PR DESCRIPTION
- Fix tends to prevent precision overflow in forecasted report

Current behavior before PR:
- If there are 2 units in stock and product_uom_qty is set to 0.66 the free_stock will be equal to 1.3399999999999999

Desired behavior after PR is merged:
- If there are 2 units in stock and product_uom_qty is set to 0.66 the free_stock should be equal to 1.34

opw-2425473
opw-2459650
opw-2448443
opw-2446985
opw-2440853
opw-2464507