### PR TITLE
[IMP] website_slides : add attendee status, improve invitations to co…

### DIFF
--- a/addons/mass_mailing_slides/views/slide_channel_views.xml
+++ b/addons/mass_mailing_slides/views/slide_channel_views.xml
@@ -5,7 +5,7 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.view_slide_channel_form"/>
         <field name="arch" type="xml">
-            <button name="action_channel_invite" position="after">
+            <button name="action_channel_enroll" position="before">
                 <field name="members_count" invisible="1"/>
                 <button name="action_mass_mailing_attendees" string="Contact Attendees" type="object"
                         class="oe_highlight" attrs="{'invisible': [('members_count', '=', 0)]}"

--- a/addons/website_sale_slides/__manifest__.py
+++ b/addons/website_sale_slides/__manifest__.py
@@ -27,7 +27,10 @@
         'web.assets_frontend': [
             'website_sale_slides/static/src/js/**/*',
             'website_sale_slides/static/src/xml/**/*',
-        ]
+        ],
+        'web.assets_tests': [
+            'website_sale_slides/static/tests/tours/*.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -1,0 +1,30 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+
+registry.category('web_tour.tours').add('invited_on_payment_course_logged', {
+    test: true,
+    steps: [
+{
+    trigger: 'a:contains("Add to Cart")',
+    content: 'Check that the course can be bought but not joined',
+    run: function () {
+        if (document.querySelector('.o_wslides_js_course_join_link')) {
+            throw new Error('The course should not be joinable before buying');
+        }
+    }
+}, {
+    trigger: '.o_wslides_slides_list_slide:contains("Home Gardening")',
+    content: 'Check that non-preview slides are not accessible',
+    run: function () {
+        if (this.$anchor[0].querySelector('.o_wslides_js_slides_list_slide_link')) {
+            throw new Error('Invited attendee should not access non-preview slides');
+        }
+    }
+}, {
+    trigger: 'a:contains("Gardening: The Know-How")',
+    content: 'Check that preview slides are accessible',
+    run: function () {}
+}
+]});

--- a/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_sale_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -1,0 +1,43 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+
+registry.category('web_tour.tours').add('invited_on_payment_course_public', {
+    test: true,
+    steps: [
+{
+    trigger: '.o_wslides_identification_banner a:contains("Log in")',
+    content: 'Check that there is an identification banner',
+    run: function () {}
+}, {
+    trigger: '.o_wslides_js_course_join a:contains("Log in")',
+    run: function () {
+        if (document.querySelector('.o_wslides_js_course_join #add_to_cart')) {
+            throw new Error('The course should not be buyable before logging in');
+        }
+    }
+}, {
+    trigger: '.o_wslides_slides_list_slide:contains("Gardening: The Know-How")',
+    run: function () {
+        if (this.$anchor[0].querySelector('.o_wslides_js_slides_list_slide_link')) {
+            throw new Error('Invited attendee should not access slides, even previews');
+        }
+    }
+}, {
+    trigger: 'a:contains("Log in")',
+}, {
+    trigger: 'input[id="password"]',
+    run: 'text portal',
+}, {
+    trigger: 'button:contains("Log in")',
+}, {
+    trigger: 'a:contains("Gardening: The Know-How")',
+    content: 'Check that preview slides are now accessible',
+    run: function () {}
+}, {
+    trigger: '.o_wslides_js_course_join:contains("Add to Cart")',
+    content: 'Check that the course can now be bought',
+    run: function () {}
+}
+]});

--- a/addons/website_sale_slides/tests/__init__.py
+++ b/addons/website_sale_slides/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_course_purchase_flow
+from . import test_ui_website_sale_slides

--- a/addons/website_sale_slides/tests/test_ui_website_sale_slides.py
+++ b/addons/website_sale_slides/tests/test_ui_website_sale_slides.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, tests
+from odoo.addons.website_slides.tests import test_ui_wslides
+
+
+@tests.common.tagged('post_install', '-at_install')
+class TestUiWebsiteSaleSlides(test_ui_wslides.TestUICommon):
+
+    def setUp(self):
+        super(TestUiWebsiteSaleSlides, self).setUp()
+        self.course_product = self.env['product.product'].create({
+            'name': "Course Product",
+            'standard_price': 100,
+            'list_price': 150,
+            'type': 'service',
+            'invoice_policy': 'order',
+            'is_published': True,
+        })
+
+        self.channel.write({
+            'enroll': 'payment',
+            'product_id': self.course_product.id,
+            'visibility': 'connected',
+        })
+
+        self.channel_partner_portal = self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': self.user_portal.partner_id.id,
+            'member_status': 'invited',
+            'last_invitation_date': fields.Datetime.now(),
+        })
+        self.portal_invite_url = self.channel_partner_portal.invitation_link
+
+    def test_invited_on_payment_course_logged_connected(self):
+        self.start_tour(self.portal_invite_url, 'invited_on_payment_course_logged', login='portal')
+
+    def test_invited_on_payment_course_public_connected(self):
+        self.start_tour(self.portal_invite_url, 'invited_on_payment_course_public', login=None)

--- a/addons/website_sale_slides/views/slide_channel_views.xml
+++ b/addons/website_sale_slides/views/slide_channel_views.xml
@@ -28,7 +28,7 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.slide_channel_view_tree_report"/>
         <field name="arch" type="xml">
-            <field name="members_done_count" position="after">
+            <field name="members_completed_count" position="after">
                 <field name="currency_id" invisible="1"/>
                 <field name="product_sale_revenues" string="Total Revenues" sum="Total Revenues" widget="monetary"/>
             </field>
@@ -40,7 +40,7 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.slide_channel_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='info_total_time']" position="after">
+            <xpath expr="//div[@name='info_avg_rating']" position="after">
                 <div class="d-flex" attrs="{'invisible': [('enroll', '!=', 'payment')]}">
                     <span class="me-auto"><label for="product_sale_revenues" class="mb0">Sales</label></span>
                     <field name="product_sale_revenues" widget="monetary" options="{'currency_field': 'currency_id'}"/>

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -26,7 +26,7 @@
 </template>
 
 <template name="Buy Course To Access Resources or Interact Slide Detail" id="slide_content_detailed_buy_course" inherit_id="website_slides.slide_content_detailed">
-    <xpath expr="//div[hasclass('o_wslides_js_course_join') and hasclass('o_wslides_no_access')]" position="inside">
+    <xpath expr="//div[hasclass('o_wslides_js_course_join') and hasclass('o_wslides_no_access')] //div[@t-else='']" position="before">
         <span t-elif="slide.channel_id.enroll == 'payment'" class="text-muted me-auto border-start ps-3">
             <t t-call="website_sale_slides.course_buy_course_link">
                 <t t-set="for_resources" t-value="1"/>
@@ -125,13 +125,13 @@
                 <span t-field="channel.product_id.list_price" t-options="{'widget': 'monetary', 'display_currency': product_info['currency_id']}"/>
             </div>
         </div>
-        <t t-if="channel.prerequisite_channel_ids and not channel.prerequisite_user_has_completed">
-            <small t-if="len(channel.prerequisite_channel_ids) == 1" class="text-center">
+        <t t-if="not invite_preview and channel.prerequisite_channel_ids and not channel.prerequisite_user_has_completed">
+            <small t-if="len(channel.prerequisite_channel_ids) == 1" class="text-center mb-2">
                 Prerequisite:
-                <a t-attf-href="/slides/{{slug(channel.prerequisite_channel_ids[0])}}"
+                <a t-attf-href="/slides/{{channel.prerequisite_channel_ids[0].id}}"
                    t-out="channel.prerequisite_channel_ids[0].name"/>
             </small>
-            <small t-else="" class="text-center">
+            <small t-else="" class="text-center mb-2">
                 There are some
                 <a href="#" class="o_wslides_js_prerequisite_course"
                    t-att-data-channels="json.dumps([
@@ -142,7 +142,15 @@
                 </a>
             </small>
         </t>
-        <div class="oe_website_sale">
+        <t t-if="invite_preview">
+            <a type="button" class="btn btn-primary text-uppercase ms-2"
+                t-att-aria-label="'Sign up' if is_partner_without_user else 'Log in'"
+                t-attf-href="/slides/#{channel.id}/identify?#{keep_query('invite_partner_id', 'invite_hash')}">
+                <t t-if="is_partner_without_user">Sign up</t>
+                <t t-else="">Log in</t>
+            </a>
+        </t>
+        <div t-else="" class="oe_website_sale">
             <div class="add_to_cart_button">
                 <form action="/shop/cart/update" method="POST">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'eLearning',
-    'version': '2.6',
+    'version': '2.7',
     'sequence': 125,
     'summary': 'Manage and publish an eLearning platform',
     'website': 'https://www.odoo.com/app/elearning',
@@ -77,6 +77,8 @@ Featuring
             'website_slides/static/src/scss/slide_views.scss',
             'website_slides/static/src/js/tours/slides_tour.js',
             'website_slides/static/src/js/components/**/*.js',
+            'website_slides/static/src/views/**/*.js',
+            'website_slides/static/src/views/**/*.xml',
         ],
         'web.assets_frontend': [
             'website_slides/static/src/scss/website_slides.scss',

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -660,14 +660,6 @@ class WebsiteSlides(WebsiteProfile):
 
         return values
 
-    @http.route('/slides/channel/enroll', type='http', auth='public', website=True)
-    def slide_channel_join_http(self, channel_id):
-        # TDE FIXME: why 2 routes ?
-        if not request.website.is_public_user():
-            channel = request.env['slide.channel'].browse(int(channel_id))
-            channel._action_add_member()
-        return request.redirect("/slides/%s" % (slug(channel)))
-
     @http.route(['/slides/channel/join'], type='json', auth='public', website=True)
     def slide_channel_join(self, channel_id):
         if request.website.is_public_user():

--- a/addons/website_slides/data/gamification_data.xml
+++ b/addons/website_slides/data/gamification_data.xml
@@ -101,7 +101,7 @@
         <field name="model_id" ref="website_slides.model_slide_channel_partner"/>
         <field name="condition">higher</field>
         <field name="domain">[
-            ('completed', '=', True)
+            ('member_status', '=', 'completed')
         ]</field>
         <field name="batch_mode">True</field>
         <field name="batch_distinctive_field" ref="website_slides.field_slide_channel_partner__partner_id"/>

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -132,17 +132,38 @@
         </record>
 
         <!-- Slide channel invite feature -->
-        <record id="mail_template_slide_channel_invite" model="mail.template">
-            <field name="name">Elearning: Course Invite</field>
+        <record id="mail_template_slide_channel_enroll" model="mail.template">
+            <field name="name">Elearning: Add Attendees to Course</field>
             <field name="model_id" ref="model_slide_channel_partner" />
             <field name="subject">You have been invited to join {{ object.channel_id.name }}</field>
+            <field name="email_from">{{ user.email_formatted }}</field>
             <field name="use_default_to" eval="True"/>
             <field name="description">Sent to attendees when they are added to a course</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px; font-size: 13px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
         Hello<br/><br/>
-        You have been invited to join a new course: <t t-out="object.channel_id.name or ''">Basics of Gardening</t>.
+        You have been enrolled to a new course: <t t-out="object.channel_id.name or ''">Basics of Gardening</t>.
+    </p>
+</div>
+            </field>
+            <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="auto_delete" eval="True"/>
+        </record>
+
+        <!-- Slide channel sharing feature -->
+        <record id="mail_template_slide_channel_invite" model="mail.template">
+            <field name="name">Elearning: Promotional Course Invitation</field>
+            <field name="model_id" ref="model_slide_channel_partner" />
+            <field name="subject">You have been invited to check out {{ object.channel_id.name }}</field>
+            <field name="email_from">{{ user.email_formatted }}</field>
+            <field name="use_default_to" eval="True"/>
+            <field name="description">Sent to potential attendees to check out the course.</field>
+            <field name="body_html" type="html">
+<div style="margin: 0px; padding: 0px; font-size: 13px;">
+    <p style="margin: 0px; padding: 0px; font-size: 13px;">
+        Hello<br/><br/>
+        You have been invited to check out this course: <t t-out="object.channel_id.name or ''">Basics of Gardening</t>.
     </p>
 </div>
             </field>

--- a/addons/website_slides/data/mail_templates.xml
+++ b/addons/website_slides/data/mail_templates.xml
@@ -29,9 +29,9 @@
         <td style="min-width: 590px;">
             <t t-out="message.body"/>
             <div style="margin: 32px 0px 32px 0px; text-align: center;">
-                <a t-att-href="record.channel_id.website_url"
+                <a t-att-href="record.invitation_link"
                     style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
-                    Click here to start the course
+                    <t t-if="enroll_mode"> Click here to start the course </t> <t t-else=""> Click here to get started </t>
                 </a>
             </div>
             <div style="margin: 0px; padding: 0px; font-size:13px;">

--- a/addons/website_slides/data/slide_channel_demo.xml
+++ b/addons/website_slides/data/slide_channel_demo.xml
@@ -64,7 +64,8 @@
     <record id="slide_channel_demo_3_furn0" model="slide.channel">
         <field name="name">Choose your wood!</field>
         <field name="user_id" ref="base.user_admin"/>
-        <field name="enroll">public</field>
+        <field name="enroll">invite</field>
+        <field name="visibility">members</field>
         <field name="channel_type">training</field>
         <field name="allow_comment" eval="True"/>
         <field name="promote_strategy">latest</field>

--- a/addons/website_slides/models/res_partner.py
+++ b/addons/website_slides/models/res_partner.py
@@ -2,49 +2,62 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.osv import expression
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     slide_channel_ids = fields.Many2many(
+        'slide.channel', string='eLearning Courses',
+        compute='_compute_slide_channel_values',
+        search='_search_slide_channel_ids',
+        groups="website_slides.group_website_slides_officer")
+    slide_channel_all_ids = fields.Many2many(
         'slide.channel', 'slide_channel_partner', 'partner_id', 'channel_id',
-        string='eLearning Courses', groups="website_slides.group_website_slides_officer")
+        string='eLearning Courses and Invitations',
+        groups="website_slides.group_website_slides_officer")
     slide_channel_completed_ids = fields.One2many(
         'slide.channel', string='Completed Courses',
-        compute='_compute_slide_channel_completed_ids',
+        compute='_compute_slide_channel_values',
         search='_search_slide_channel_completed_ids',
         groups="website_slides.group_website_slides_officer")
     slide_channel_count = fields.Integer(
-        'Course Count', compute='_compute_slide_channel_count',
+        'Course Count', compute='_compute_slide_channel_values',
         groups="website_slides.group_website_slides_officer")
     slide_channel_company_count = fields.Integer(
         'Company Course Count', compute='_compute_slide_channel_company_count',
         groups="website_slides.group_website_slides_officer")
 
-    def _compute_slide_channel_completed_ids(self):
+    def _compute_slide_channel_values(self):
+        data = {
+            (partner.id, member_status): channel_ids
+            for partner, member_status, channel_ids in self.env['slide.channel.partner'].sudo()._read_group(
+                domain=[('partner_id', 'in', self.ids), ('member_status', '!=', 'invited')],
+                groupby=['partner_id', 'member_status'],
+                aggregates=['channel_id:array_agg']
+            )
+        }
+
         for partner in self:
-            partner.slide_channel_completed_ids = self.env['slide.channel.partner'].search([
-                ('partner_id', '=', partner.id),
-                ('completed', '=', True)
-            ]).mapped('channel_id')
+            slide_channel_ids = data.get((partner.id, 'joined'), []) + data.get((partner.id, 'ongoing'), []) + data.get((partner.id, 'completed'), [])
+            partner.slide_channel_ids = slide_channel_ids
+            partner.slide_channel_completed_ids = self.env['slide.channel'].browse(data.get((partner.id, 'completed'), []))
+            partner.slide_channel_count = len(slide_channel_ids)
 
     def _search_slide_channel_completed_ids(self, operator, value):
         cp_done = self.env['slide.channel.partner'].sudo().search([
             ('channel_id', operator, value),
-            ('completed', '=', True)
+            ('member_status', '=', 'completed')
         ])
         return [('id', 'in', cp_done.partner_id.ids)]
 
-    @api.depends('is_company')
-    def _compute_slide_channel_count(self):
-        read_group_res = self.env['slide.channel.partner'].sudo()._read_group(
-            [('partner_id', 'in', self.ids)],
-            ['partner_id'], ['__count']
-        )
-        data = {partner.id: count for partner, count in read_group_res}
-        for partner in self:
-            partner.slide_channel_count = data.get(partner.id, 0)
+    def _search_slide_channel_ids(self, operator, value):
+        cp_enrolled = self.env['slide.channel.partner'].search([
+            ('channel_id', operator, value),
+            ('member_status', '!=', 'invited')
+        ])
+        return [('id', 'in', cp_enrolled.partner_id.ids)]
 
     @api.depends('is_company', 'child_ids.slide_channel_count')
     def _compute_slide_channel_company_count(self):
@@ -59,13 +72,15 @@ class ResPartner(models.Model):
     def action_view_courses(self):
         """ View partners courses. In singleton mode, return courses followed
         by all its contacts (if company) or by themselves (if not a company).
-        Otherwise simply set a domain on required partners. """
+        Otherwise simply set a domain on required partners. The courses to which
+        the partner(s) is not enrolled (e.g. invited) are not shown. """
         action = self.env["ir.actions.actions"]._for_xml_id("website_slides.slide_channel_partner_action")
-        action['name'] = _('Followed Courses')
+        action['display_name'] = _('Courses')
+        action['domain'] = [('member_status', '!=', 'invited')]
         if len(self) == 1 and self.is_company:
-            action['domain'] = [('partner_id', 'in', self.child_ids.ids)]
+            action['domain'] = expression.AND([action['domain'], [('partner_id', 'in', self.child_ids.ids)]])
         elif len(self) == 1:
             action['context'] = {'search_default_partner_id': self.id}
         else:
-            action['domain'] = [('partner_id', 'in', self.ids)]
+            action['domain'] = expression.AND([action['domain'], [('partner_id', 'in', self.ids)]])
         return action

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -74,6 +74,7 @@ class SlidePartnerRelation(models.Model):
         self.env['slide.channel.partner'].search([
             ('channel_id', 'in', self.channel_id.ids),
             ('partner_id', 'in', self.partner_id.ids),
+            ('member_status', 'not in', ('completed', 'invited'))
         ])._recompute_completion()
 
 

--- a/addons/website_slides/security/website_slides_security.xml
+++ b/addons/website_slides/security/website_slides_security.xml
@@ -41,7 +41,7 @@
         </record>
 
         <record id="rule_slide_channel_visibility_signed_in_user" model="ir.rule">
-            <field name="name">Channel: portal/user: restricted to published, public or connected User</field>
+            <field name="name">Channel: portal/user: restricted to published, public or (invited) attendee, connected user</field>
             <field name="model_id" ref="model_slide_channel"/>
             <field name="groups" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
             <field name="domain_force">[
@@ -49,7 +49,7 @@
                     ('website_published', '=', True),
                     '|',
                         ('visibility', 'in', ('public', 'connected')),
-                        ('partner_ids', '=', user.partner_id.id),
+                        ('partner_all_ids', '=', user.partner_id.id),
                 ]
             </field>
             <field name="perm_unlink" eval="0"/>
@@ -128,7 +128,7 @@
         </record>
 
         <record id="rule_slide_slide_signed_in_user" model="ir.rule">
-            <field name="name">Slide: portal/user: restricted to published and connected user</field>
+            <field name="name">Slide: portal/user: restricted to published and connected user, (invited) attendee if course visible to attendees only</field>
             <field name="model_id" ref="model_slide_slide"/>
             <field name="groups" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
             <field name="domain_force">[
@@ -140,7 +140,9 @@
                             ('channel_id.website_published', '=', True),
                     '|',
                         '&amp;',
+                            '|',
                                 ('channel_id.visibility', 'in', ('public','connected')),
+                                ('channel_id.partner_all_ids', 'in', user.partner_id.ids),
                             '|',
                                 ('is_category', '=', True),
                                 ('is_preview', '=', True),

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -61,12 +61,14 @@
                 hasNext: false,
                 completed: false,
                 isMember: false,
+                isMemberOrInvited: false,
             });
             this.quiz = quiz_data || false;
             if (this.quiz) {
                 this.quiz.questionsCount = quiz_data.questions.length;
             }
             this.isMember = slide_data.isMember || false;
+            this.isMemberOrInvited = slide_data.isMemberOrInvited || false;
             this.publicUser = session.is_website_user;
             this.userId = session.user_id;
             this.redirectURL = encodeURIComponent(document.URL);
@@ -324,6 +326,7 @@
                     isQuiz: true,
                     channel: this.channel,
                     isMember: this.isMember,
+                    isMemberOrInvited: this.isMemberOrInvited,
                     publicUser: this.publicUser,
                     beforeJoin: this._saveQuizAnswersToSession.bind(this),
                     afterJoin: this._afterJoin.bind(this),

--- a/addons/website_slides/static/src/js/slides_course_unsubscribe.js
+++ b/addons/website_slides/static/src/js/slides_course_unsubscribe.js
@@ -33,6 +33,7 @@ var SlideUnsubscribeDialog = Dialog.extend({
         this.channelID = parseInt(options.channelId, 10);
         this.isFollower = options.isFollower === 'True';
         this.enroll = options.enroll;
+        this.visibility = options.visibility;
     },
     /**
      * @override
@@ -92,13 +93,16 @@ var SlideUnsubscribeDialog = Dialog.extend({
         this.set('state', '_subscription');
     },
 
-    _onClickLeaveCourseSubmit: function () {
-        this._rpc({
+    _onClickLeaveCourseSubmit: async function () {
+        await this._rpc({
             route: '/slides/channel/leave',
             params: {channel_id: this.channelID},
-        }).then(function () {
-            window.location.reload();
         });
+        if (this.visibility === 'public' || this.visibility === 'connected') {
+            window.location.reload();
+        } else {
+            window.location.href = '/slides';
+        }
     },
 
     _onClickSubscriptionSubmit: function () {

--- a/addons/website_slides/static/src/views/slide_channel_partner_list/slide_channel_partner_list_controller.js
+++ b/addons/website_slides/static/src/views/slide_channel_partner_list/slide_channel_partner_list_controller.js
@@ -1,0 +1,35 @@
+/** @odoo-module **/
+
+import { ListController } from '@web/views/list/list_controller';
+import { useService } from '@web/core/utils/hooks';
+
+
+export default class SlideChannelPartnerListController extends ListController {
+    setup() {
+        super.setup();
+        this.action = useService('action');
+        this.orm = useService('orm');
+        this.channelId = this.props.context.default_channel_id || false;
+    }
+
+    /**
+     * Method opening the wizard to enroll new slide channel partners.
+     * Reloads the model afterwards to see new attendees.
+     * 
+     * @private
+     */
+    async _openEnrollWizard() {
+        const action = await this.orm.call(
+            'slide.channel',
+            'action_channel_enroll',
+            [this.channelId]
+        );
+        this.action.doAction(action, {
+            onClose: async () => {
+                await this.model.load();
+                this.model.useSampleModel = false;
+                this.render(true);
+            }
+        });
+    }
+}

--- a/addons/website_slides/static/src/views/slide_channel_partner_list/slide_channel_partner_list_view.js
+++ b/addons/website_slides/static/src/views/slide_channel_partner_list/slide_channel_partner_list_view.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { listView } from '@web/views/list/list_view';
+import { registry } from '@web/core/registry';
+
+import SlideChannelPartnerListController from './slide_channel_partner_list_controller.js';
+
+export const SlideChannelPartnerListView = {
+    ...listView,
+    Controller: SlideChannelPartnerListController,
+    buttonTemplate: 'website_slides.SlideChannelPartnerListView.buttons',
+};
+
+registry.category('views').add('slide_channel_partner_enroll_tree', SlideChannelPartnerListView);

--- a/addons/website_slides/static/src/views/slide_channel_partner_list/slide_channel_partner_list_view.xml
+++ b/addons/website_slides/static/src/views/slide_channel_partner_list/slide_channel_partner_list_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+
+    <t t-inherit="web.ListView.Buttons" t-inherit-mode="primary" owl="1" t-name="website_slides.SlideChannelPartnerListView.buttons">
+        <xpath expr="//t[@t-foreach='archInfo.headerButtons']" position="after">
+            <button t-if="channelId" type="button" class="btn btn-primary" t-on-click="_openEnrollWizard">
+                New
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/website_slides/static/src/xml/slide_course_join.xml
+++ b/addons/website_slides/static/src/xml/slide_course_join.xml
@@ -7,8 +7,25 @@
                 title="Join the Course" aria-label="Join the Course"
                 href="#">
                 <t t-if="widget.channel.channelEnroll == 'public'" t-esc="widget.joinMessage"/>
+                <t t-if="widget.channel.channelEnroll == 'invite' and widget.isMemberOrInvited" t-esc="widget.joinMessage"/>
             </a>
         </div>
+    </t>
+
+    <t t-name="slide.course.join.popupContent">
+        <t t-if="widget.invitePreview">
+            Please <a t-attf-href="/slides/#{channelId}/identify?invite_partner_id=#{widget.invitePartnerId}&amp;invite_hash=#{widget.inviteHash}">
+            <t t-if="widget.isPartnerWithoutUser">create an account</t><t t-else="">login</t>
+            </a> to join this course
+        </t>
+        <t t-else="">
+            <t t-if="errorSignupAllowed">
+                Please <a t-attf-href="/web/login?redirect=#{courseUrl}">login</a> or <a t-attf-href="/web/signup?redirect=#{courseUrl}">create an account</a> to join this course
+            </t>
+            <t t-else="">
+                Please <a t-attf-href="/web/login?redirect=#{courseUrl}">login</a> to join this course
+            </t>
+        </t>
     </t>
 
     <t t-name="slide.course.join.request">

--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -46,7 +46,7 @@
         <div id="validation">
             <div t-if="!widget.isMember">
                 <div class="o_wslides_join_course alert alert-info d-flex align-items-center justify-content-between">
-                    <div t-if="widget.channel.channelEnroll == 'invite'">
+                    <div t-if="widget.channel.channelEnroll == 'invite' and !widget.isMemberOrInvited">
                         <b>This course is private.
                             <span t-if="widget.publicUser">
                                 Please
@@ -73,7 +73,7 @@
                     </div>
                     <div t-else="" class="w-100">
                         <b class="h5 mb-0 o_wslides_quiz_join_course_message">
-                            <span t-if="widget.channel.channelEnroll == 'public'">
+                            <span t-if="widget.channel.channelEnroll == 'public' or (widget.isMemberOrInvited and widget.channel.channelEnroll == 'invite')">
                                 <t t-if="widget.publicUser">
                                     Sign in and join the course to verify your answers!
                                 </t>

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+
+registry.category('web_tour.tours').add('invite_check_channel_preview_as_logged', {
+    test: true,
+    steps: [
+{
+    trigger: 'a:contains("Gardening: The Know-How")',
+    content: 'Check that the previews are accessible',
+    run: function () {}
+}, {
+    trigger: '.o_wslides_slides_list_slide:contains("Home Gardening")',
+    content: 'Check that other slides are not accessible',
+    run: function () {
+        if (this.$anchor[0].querySelector('.o_wslides_js_slides_list_slide_link')) {
+            throw new Error('Invited attendee should not see non-preview slides');
+        }
+    }
+}, {
+    trigger: 'a:contains("Join this Course")',
+}, {
+    trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
+    content: 'Check that user is enrolled',
+    run: function () {}
+}, {
+    trigger: '.o_wslides_js_slides_list_slide_link:contains("Home Gardening")',
+    content: 'Check that slides are now accessible',
+    run: function () {}
+},
+]});

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -1,0 +1,40 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+
+registry.category('web_tour.tours').add('invite_check_channel_preview_as_public', {
+    test: true,
+    steps: [
+{
+    trigger: '.o_wslides_identification_banner',
+    content: 'Check that there is an identification banner',
+    run: function () {}
+}, {
+    trigger: '.o_wslides_slides_list_slide:contains("Gardening: The Know-How")',
+    run: function () {
+        if (this.$anchor[0].querySelector('.o_wslides_js_slides_list_slide_link')) {
+            throw new Error('The preview should not allow the public user to browse slides');
+        }
+    }
+}, {
+    trigger: 'a:contains("Join this Course")',
+}, {
+    trigger: 'a:contains("login")',
+}, {
+    trigger: 'input[id="password"]',
+    run: 'text portal',
+}, {
+    trigger: 'button:contains("Log in")',
+}, {
+    trigger: 'a:contains("Join this Course")',
+}, {
+    trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
+    content: 'Check that user is enrolled',
+    run: function () {}
+}, {
+    trigger: '.o_wslides_js_slides_list_slide_link:contains("Gardening: The Know-How")',
+    content: 'Check that slides are now accessible',
+    run: function () {}
+}
+]});

--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_attendee
 from . import test_embed_detection
 from . import test_gamification_karma
 from . import test_security

--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -1,0 +1,493 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
+from odoo.addons.http_routing.models.ir_http import slug
+from odoo.addons.website_slides.tests import common
+from odoo.tests import tagged, users
+
+from werkzeug.urls import url_decode
+
+@tagged('post_install', '-at_install')
+class TestAttendee(common.SlidesCase):
+
+    @users('user_officer')
+    def test_attendee_course_completion_values(self):
+        """ Check that once completed, the member_status remains 'completed', except if
+            attendee leaves course and is reinvited / rejoins the course, it is then recomputed."""
+
+        def check_course_completion_values(member_status='completed'):
+            """ Check that the course completion is still accounted for, with given member_status """
+            self.assertEqual(user_portal_channel_partner.member_status, member_status)
+            self.assertEqual(user_portal_channel_partner.completion, 100)
+            self.assertTrue(self.channel.with_user(self.user_portal).completed)
+
+        user_portal_partner = self.user_portal.partner_id
+        user_portal_channel_partner = self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': user_portal_partner.id,
+        })
+        (self.slide | self.slide_2 | self.slide_3).with_user(self.user_portal)._action_mark_completed()
+        check_course_completion_values()
+
+        # A new slide should not update status / completion
+        self.env['slide.slide'].create({
+            'name': 'About completion',
+            'channel_id': self.channel.id,
+            'slide_category': 'document',
+            'is_published': True,
+            'completion_time': 2.0,
+            'sequence': 10,
+        })
+        check_course_completion_values()
+
+        # Unpublish a slide user has completed
+        self.slide.is_published = False
+        check_course_completion_values()
+
+        # Archive attendee
+        user_portal_channel_partner.action_archive()
+        check_course_completion_values()
+
+        # Invited attendee only gets status update
+        self.channel._action_add_members(self.user_portal.partner_id, member_status='invited')
+        check_course_completion_values(member_status='invited')
+
+        # Pulbishing a slide user has completed. This will update user values,
+        # but only on channel (those are used for diplay and not before joining)
+        self.slide.is_published = True
+        self.assertEqual(user_portal_channel_partner.member_status, 'invited')
+        self.assertEqual(user_portal_channel_partner.completion, 100)
+        self.assertEqual(self.channel.with_user(self.user_portal).completion, 75)
+        self.assertFalse(self.channel.with_user(self.user_portal).completed)
+
+        # Once they are enrolled (or join), values are now updated and completion is lost.
+        self.channel._action_add_members(self.user_portal.partner_id)
+        self.assertEqual(user_portal_channel_partner.member_status, 'ongoing')
+        self.assertEqual(user_portal_channel_partner.completion, 75)
+        self.assertEqual(self.channel.with_user(self.user_portal).completion, 75)
+        self.assertFalse(self.channel.with_user(self.user_portal).completed)
+
+    @users('user_officer')
+    def test_enroll_to_course(self):
+        user_portal_partner = self.user_portal.partner_id
+        self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
+
+        # Enroll partner to course
+        self.slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
+            'channel_id': self.channel.id,
+            'partner_ids': [(6, 0, [self.user_portal.partner_id.id])],
+            'enroll_mode': True,
+        })
+        self.slide_channel_invite_wizard.action_invite()
+
+        # The partner should be in the attendees as 'joined'
+        user_portal_channel_partner = self.channel.channel_partner_all_ids.filtered(lambda p: p.partner_id.id == user_portal_partner.id)
+        self.assertTrue(user_portal_channel_partner)
+        self.assertFalse(self.channel.with_user(self.user_portal).is_member_invited)
+        self.assertTrue(user_portal_channel_partner.id in self.channel.channel_partner_ids.ids)
+        self.assertTrue(self.channel.with_user(self.user_portal).is_member)
+        self.assertEqual(user_portal_channel_partner.member_status, 'joined')
+
+        # Subscribe enrolled attendees to the chatter
+        self.assertTrue(user_portal_partner.id in self.channel.message_partner_ids.ids)
+
+    @users('user_officer')
+    def test_invite_to_course(self):
+        user_portal_partner = self.user_portal.partner_id
+        self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
+
+        # Invite partner to course
+        self.slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
+            'channel_id': self.channel.id,
+            'partner_ids': [(6, 0, [self.user_portal.partner_id.id])],
+            'send_email': True,
+        })
+        self.slide_channel_invite_wizard.action_invite()
+
+        # The partner should be in the attendees as 'invited'
+        user_portal_channel_partner = self.channel.channel_partner_all_ids.filtered(lambda p: p.partner_id.id == user_portal_partner.id)
+        self.assertTrue(user_portal_channel_partner)
+        self.assertTrue(self.channel.with_user(self.user_portal).is_member_invited)
+        self.assertFalse(user_portal_channel_partner.id in self.channel.channel_partner_ids.ids)
+        self.assertFalse(self.channel.with_user(self.user_portal).is_member)
+        self.assertEqual(user_portal_channel_partner.member_status, 'invited')
+
+        # Do not subscribe invited members to the chatter
+        self.assertFalse(user_portal_partner.id in self.channel.message_partner_ids.ids)
+
+    @users('user_officer')
+    def test_invite_archived_attendees_to_course(self):
+        # Make user_portal have ongoing progress in the course
+        user_portal_partner = self.user_portal.partner_id
+        user_portal_channel_partner = self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': user_portal_partner.id,
+        })
+        self.slide.with_user(self.user_portal).sudo().action_mark_completed()
+        user_portal_channel_partner.action_archive()
+        self.assertEqual(user_portal_channel_partner.member_status, 'ongoing')
+
+        # Invite archived ongoing partner to course
+        self.slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
+            'channel_id': self.channel.id,
+            'partner_ids': [(6, 0, [self.user_portal.partner_id.id])],
+            'send_email': True,
+        })
+        self.slide_channel_invite_wizard.action_invite()
+
+        # The partner should be reactivated in the attendees as 'invited'
+        self.assertTrue(user_portal_channel_partner.active)
+        self.assertTrue(user_portal_channel_partner.completion > 0)
+        self.assertEqual(user_portal_channel_partner.member_status, 'invited')
+
+        # Archive then enroll the attendee
+        user_portal_channel_partner.action_archive()
+        self.slide_channel_invite_wizard.enroll_mode = True
+        self.slide_channel_invite_wizard.flush_recordset()
+        self.slide_channel_invite_wizard.action_invite()
+
+        # The partner should be reactivated in the attendees as 'ongoing'
+        self.assertTrue(user_portal_channel_partner.active)
+        self.assertTrue(user_portal_channel_partner.completion > 0)
+        self.assertEqual(user_portal_channel_partner.member_status, 'ongoing')
+
+    @users('user_officer')
+    def test_join_invite_enroll_channel(self):
+        self.channel.enroll = 'invite'
+        user_portal_partner = self.user_portal.partner_id
+
+        # Uninvited partner cannot join the course
+        self.channel.with_user(self.user_portal)._action_add_members(user_portal_partner)
+        self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
+
+        user_portal_channel_partner = self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': user_portal_partner.id,
+            'member_status': 'invited'
+        })
+
+        self.assertTrue(user_portal_partner.id in self.channel.partner_all_ids.ids)
+        self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
+        # Invited partner can join the course and enroll itself. Sudo is used in controller if invited.
+        self.assertTrue(self.channel.with_user(self.user_portal).is_member_invited)
+        self.channel.with_user(self.user_portal).sudo()._action_add_members(user_portal_partner)
+        self.assertEqual(user_portal_channel_partner.member_status, 'joined')
+        self.assertTrue(user_portal_partner.id in self.channel.partner_ids.ids)
+        self.assertTrue(self.user_portal.partner_id.id in self.channel.message_partner_ids.ids)
+
+    @users('user_officer')
+    def test_member_default_create(self):
+        slide_channel_partner = self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': self.user_portal.partner_id.id
+        })
+
+        # By default, partner is enrolled
+        self.assertFalse(self.channel.with_user(self.user_portal).is_member_invited)
+        self.assertTrue(self.channel.with_user(self.user_portal).is_member)
+        self.assertEqual(slide_channel_partner.member_status, 'joined')
+
+    @users('user_officer')
+    def test_partners_and_search_on_slide_channel(self):
+        ''' Check that partner_ids contains enrolled partners and partner_all_ids contains both invited and enrolled partners'''
+        invited_cp, joined_cp = self.env['slide.channel.partner'].create([{
+            'channel_id': self.channel.id,
+            'partner_id': self.user_portal.partner_id.id,
+            'member_status': 'invited'
+        }, {
+            'channel_id': self.channel.id,
+            'partner_id': self.user_emp.partner_id.id,
+            'member_status': 'joined'
+        }])
+
+        # Search partner_ids on model
+        invited_cp_channel_ids = self.env['slide.channel'].search([('partner_ids', '=', invited_cp.partner_id.id)])
+        self.assertFalse(self.channel in invited_cp_channel_ids)
+        joined_cp_channel_ids = self.env['slide.channel'].search([('partner_ids', '=', joined_cp.partner_id.id)])
+        self.assertTrue(self.channel in joined_cp_channel_ids)
+
+        # Search partner_all_ids on model
+        invited_cp_channel_ids = self.env['slide.channel'].search([('partner_all_ids', '=', invited_cp.partner_id.id)])
+        self.assertTrue(self.channel in invited_cp_channel_ids)
+        joined_cp_channel_ids = self.env['slide.channel'].search([('partner_all_ids', '=', joined_cp.partner_id.id)])
+        self.assertTrue(self.channel in joined_cp_channel_ids)
+
+        # partner_ids should only contain enrolled channel partners
+        partner_ids = self.channel.partner_ids
+        self.assertFalse(invited_cp.partner_id in partner_ids)
+        self.assertTrue(joined_cp.partner_id in partner_ids)
+
+        # partner_all_ids also contains invited channel partners.
+        partner_all_ids = self.channel.partner_all_ids
+        self.assertTrue(joined_cp.partner_id in partner_all_ids)
+        self.assertTrue(invited_cp.partner_id in partner_all_ids)
+
+
+@tagged('-at_install', 'post_install')
+class TestAttendeeCase(HttpCaseWithUserPortal):
+
+    def setUp(self):
+        super(TestAttendeeCase, self).setUp()
+        self.user_admin = self.env.ref('base.user_admin')
+        self.user_emp = mail_new_test_user(
+            self.env,
+            email='employee@example.com',
+            groups='base.group_user',
+            login='user_emp',
+            name='Eglantine Employee',
+            notification_type='email',
+        )
+        self.channel = self.env['slide.channel'].with_user(self.user_admin).create({
+            'name': 'All about attendee status - Attendees only',
+            'channel_type': 'training',
+            'enroll': 'public',
+            'visibility': 'public',
+            'is_published': True,
+        })
+        self.slide = self.env['slide.slide'].with_user(self.user_admin).create({
+            'name': 'How to understand membership',
+            'channel_id': self.channel.id,
+            'slide_type': 'article',
+            'is_published': True,
+            'completion_time': 2.0,
+            'sequence': 1,
+        })
+        self.partner_no_user = self.env['res.partner'].create({
+            'country_id': self.env.ref('base.be').id,
+            'email': 'partner_no_user@example.com',
+            'name': 'Partner Without User',
+        })
+        # Enrolled by default
+        self.channel_partner_emp, self.channel_partner_no_user = self.env['slide.channel.partner'].create([{
+            'channel_id': self.channel.id,
+            'partner_id': self.user_emp.partner_id.id
+        }, {
+            'channel_id': self.channel.id,
+            'partner_id': self.partner_no_user.id
+        }])
+
+    def test_direct_enroll_link_redirection(self):
+        ''' Check that the /invite route redirects properly when enrolled user clicks their invitation link.'''
+        invite_url_emp = self.channel_partner_emp.invitation_link
+        invite_url_no_user = self.channel_partner_no_user.invitation_link
+
+        # No user logged. Partner has a user. Redirects to login.
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/login' in res.url, "Should redirect to login page if not logged in.")
+        self.assertTrue('auth_login=user_emp' in res.url, "The login should correspond to the invited partner.")
+        self.assertTrue(f'redirect=/slides/{self.channel.id}' in res.url, "Login should redirect to the course.")
+
+        # No user logged. Partner has no user. Redirects to a prepared signup. Decode is used because of signup prepare.
+        res = self.url_open(invite_url_no_user)
+        decoded_url = url_decode(res.url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/signup' in res.url, "Should redirect to signup page if not logged in and without user.")
+        self.assertEqual(self.partner_no_user.signup_token, decoded_url['token'], "Signup should correspond to the invited partner.")
+        self.assertEqual(f'/slides/{self.channel.id}', decoded_url['redirect'], "Signup should redirect to the course.")
+
+        # Logged user is an attendee of the course
+        self.authenticate("user_emp", "user_emp")
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(f'slides/{slug(self.channel)}' in res.url, "Should redirect the logged attendee to the course page")
+
+        # Logged user is not an attendee of the course, and has no rights to see it.
+        self.channel_partner_emp.sudo().unlink()
+        self.channel.visibility = 'members'
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(f'slides/{slug(self.channel)}' in res.url, "Should not redirect the logged attendee to the course page")
+
+    def test_direct_invite_link_members_visibility_as_archived(self):
+        ''' Check that archived attendees are not given access to the course with the link, whatever their status.'''
+        self.channel.visibility = 'members'
+        self.channel_partner_emp.action_archive()
+        invite_url_emp = self.channel_partner_emp.invitation_link
+
+        # No user logged, 'joined' and archived
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=expired' in res.url, "Archived 'joined' attendees cannot access 'members only' courses")
+
+        # No user logged, 'invited' and archived
+        self.channel_partner_emp.member_status = 'invited'
+        self.channel_partner_emp.last_invitation_date = fields.Datetime.now()
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=expired' in res.url, "Archived 'invited' attendees cannot access 'members only' courses")
+
+    def test_direct_invite_link_public_visibility(self):
+        ''' Check that 'invited' attendees will be redirected to the course with public visibility'''
+        self.channel_partner_emp.member_status = 'invited'
+        self.channel_partner_emp.last_invitation_date = fields.Datetime.now()
+        invite_url_emp = self.channel_partner_emp.invitation_link
+
+        # No user logged.
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(f'/slides/{self.channel.id}' in res.url, "Invited partners should always see the public course page")
+
+    def test_direct_invite_link_not_public_visibility(self):
+        ''' Check that 'invited' attendees are redirected to courses with 'members' and 'connected' visibilities.'''
+        self.channel_partner_emp.member_status = 'invited'
+        self.channel_partner_emp.last_invitation_date = fields.Datetime.now()
+        invite_url_emp = self.channel_partner_emp.invitation_link
+
+        # No user logged, but access granted via parameters in url.
+        self.channel.visibility = 'connected'
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(f'/slides/{self.channel.id}' in res.url, "Partners being invited to the course can access the course page")
+
+        self.channel.visibility = 'members'
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(f'/slides/{self.channel.id}' in res.url, "Partners being invited to the course can access the course page")
+
+        # Courses must still be published to access.
+        self.channel.sudo().is_published = False
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_rights' in res.url, "Invited partners cannot access non published courses")
+
+        # If removed from invited attendees, the link is not valid anymore.
+        self.channel.sudo().is_published = True
+        self.channel_partner_emp.sudo().unlink()
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=expired' in res.url, "Using an expired link should redirect to the main /slides page")
+
+    def test_generic_invite_link_members_visiblity_as_archived_connected(self):
+        ''' Check that connected archived attendees are not given access to 'members' courses, whatever their status.'''
+        self.channel_partner_emp.action_archive()
+        self.channel.visibility = 'members'
+
+        # Connected, 'invited' and archived
+        self.authenticate("user_emp", "user_emp")
+        res = self.url_open(f'/slides/{self.channel.id}')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_rights' in res.url, "Archived 'invited' attendees cannot access 'members only' courses")
+
+        # Connected, 'joined' and archived
+        self.channel_partner_emp.member_status = 'joined'
+        res = self.url_open(f'/slides/{self.channel.id}')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_rights' in res.url, "Archived 'joined' attendees cannot access 'members only' courses")
+
+    def test_generic_invite_link_public_visibility(self):
+        ''' Check that generic invite link for public course is accessible, even if not logged.'''
+        invite_url = f"/slides/{self.channel.id}"
+        res = self.url_open(invite_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(invite_url in res.url, "Public course should be accessible from its invitation link.")
+
+    def test_generic_invite_link_not_public_visibility(self):
+        ''' Check that generic route properly the (not) logged user for courses with 'members' and 'connected' visibilities.'''
+        invite_url = f"/slides/{self.channel.id}"
+
+        # No user logged
+        self.channel.visibility = 'connected'
+        res = self.url_open(invite_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_rights' in res.url, "The public user has no access to connected-only courses.")
+
+        # No user logged
+        self.channel.visibility = 'members'
+        res = self.url_open(invite_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_rights' in res.url, "The public user has no access to members-only courses.")
+
+        # User logged but not invited nor enrolled
+        self.authenticate("portal", "portal")
+        res = self.url_open(invite_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_rights' in res.url, "An external user has no access to members-only courses.")
+
+        # Logged user now has a pending invitation to the course
+        self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': self.user_portal.partner_id.id,
+            'member_status': 'invited'
+        })
+
+        # User logged and invited
+        res = self.url_open(invite_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(invite_url in res.url, "Invited partner should be allowed the access to the course page")
+
+    def test_invite_route_errors_handling(self):
+        ''' Check that the /invite route redirects properly when an error is encountered, and current user has no rights to the course.'''
+        invite_url_emp = self.channel_partner_emp.invitation_link
+        invite_url_no_user = self.channel_partner_no_user.invitation_link
+        self.channel.visibility = 'members'
+
+        # No such channel
+        invite_url = "/slides/-1"
+        res = self.url_open(invite_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=no_channel' in res.url, "This channel does not exist. Redirect to the main /slides page.")
+
+        # Hash is wrong
+        invite_url_false_hash = invite_url_emp + 'abc'
+        res = self.url_open(invite_url_false_hash)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=hash_fail' in res.url, "A wrong hash should redirect to the main /slides page")
+
+        # Link is for another user
+        self.authenticate("user_emp", "user_emp")
+        res = self.url_open(invite_url_no_user)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=partner_fail' in res.url, "Using an other user's invitation link should redirect to the course page")
+
+        # Expired Link. Redirects to the main slides page.
+        self.channel_partner_emp.sudo().unlink()
+        res = self.url_open(invite_url_emp)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=expired' in res.url, "Using an expired link should redirect to the main /slides page for non public courses")
+
+    def test_members_invitation_expiration(self):
+        ''' Check invitations are expired after 3 months, and that garbage collector remove appropriate records.'''
+        # Let user_emp be completed
+        self.slide.with_user(self.user_emp).action_mark_completed()
+        self.assertEqual(self.channel_partner_emp.member_status, 'completed')
+        self.assertTrue(self.channel_partner_emp.completion > 0)
+
+        # Logged user_emp has been reinvited more than three months ago and link should be expired
+        self.channel_partner_emp.write({
+            'member_status': 'invited',
+            'last_invitation_date': fields.Datetime.subtract(fields.Datetime.now(), months=3, days=5)
+        })
+        self.channel.visibility = 'members'
+        res = self.url_open(self.channel_partner_emp.invitation_link)
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue('/slides?invite_error=expired' in res.url, "Using an expired link should redirect to the main /slides page")
+
+        # Let user_portal be invited, with completion = 0, outdated
+        outdated_portal_membership_values = {
+            'channel_id': self.channel.id,
+            'partner_id': self.user_portal.partner_id.id,
+            'member_status': 'invited',
+            'last_invitation_date': fields.Datetime.subtract(fields.Datetime.now(), months=3, days=5)
+        }
+        channel_partner_portal = self.env['slide.channel.partner'].create(outdated_portal_membership_values)
+
+        # Clean expired records with no progress and 'invited'
+        self.env['slide.channel.partner']._gc_slide_channel_partner()
+        self.assertTrue(self.channel_partner_emp.exists(), 'Memberships with progress should never be removed.')
+        self.assertFalse(channel_partner_portal.exists(), 'Expired invitations with no progress should be removed by the GC.')
+        self.assertTrue(self.channel_partner_no_user.exists(), 'Joined members should never be removed.')
+
+        channel_partner_portal = self.env['slide.channel.partner'].create(outdated_portal_membership_values)
+        channel_partner_portal.action_archive()
+        self.channel_partner_emp.action_archive()
+        self.channel_partner_no_user.member_status = 'invited'
+
+        # Clean outdated archived records as well, and ones 'invited' with no last_invitation_date
+        self.env['slide.channel.partner']._gc_slide_channel_partner()
+        self.assertFalse(channel_partner_portal.exists(), 'Expired invitations should be removed, even if archived')
+        self.assertTrue(self.channel_partner_emp.exists(), 'Memberships with progress should never be removed, even archived.')
+        self.assertFalse(self.channel_partner_no_user.exists(), 'No Last Invitation Date is considered as expired for invited members')

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -35,7 +35,7 @@ class TestSlidesManagement(slides_common.SlidesCase):
 
         self.assertTrue(self.channel.active)
         self.assertTrue(self.channel.is_published)
-        self.assertFalse(channel_partner.completed)
+        self.assertFalse(channel_partner.member_status == 'completed')
         for slide in self.channel.slide_ids:
             self.assertTrue(slide.active, "All slide should be archived when a channel is archived")
             self.assertTrue(slide.is_published, "All slide should be unpublished when a channel is archived")
@@ -44,7 +44,7 @@ class TestSlidesManagement(slides_common.SlidesCase):
         self.assertFalse(self.channel.active)
         self.assertFalse(self.channel.is_published)
         # channel_partner should still NOT be marked as completed
-        self.assertFalse(channel_partner.completed)
+        self.assertFalse(channel_partner.member_status == 'completed')
 
         for slide in self.channel.slide_ids:
             self.assertFalse(slide.active, "All slides should be archived when a channel is archived")
@@ -149,7 +149,7 @@ class TestSlidesManagement(slides_common.SlidesCase):
                 any(mail.model == 'slide.channel.partner' and user.partner_id in mail.recipient_ids
                     for mail in created_mails)
             )
-        # user_portal has not finished the course, it should not receive anything
+        # user_portal has not completed the course, they should not receive anything
         self.assertFalse(
             any(mail.model == 'slide.channel.partner' and self.user_portal.partner_id in mail.recipient_ids
                 for mail in created_mails)

--- a/addons/website_slides/tests/test_statistics.py
+++ b/addons/website_slides/tests/test_statistics.py
@@ -47,12 +47,12 @@ class TestChannelStatistics(common.SlidesCase):
         # slide statistics computation
         self.assertEqual(float_compare(channel_publisher.total_time, sum(s.completion_time for s in channel_publisher.slide_content_ids), 3), 0)
         # members computation
-        self.assertEqual(channel_publisher.members_count, 1)
-        channel_publisher._action_add_member()
-        self.assertEqual(channel_publisher.members_count, 1)
+        self.assertEqual(channel_publisher.members_all_count, 1)
+        channel_publisher._action_add_members(self.user_officer.partner_id)
+        self.assertEqual(channel_publisher.members_all_count, 1)
         channel_publisher._action_add_members(self.user_emp.partner_id)
         channel_publisher.invalidate_recordset(['partner_ids'])
-        self.assertEqual(channel_publisher.members_count, 2)
+        self.assertEqual(channel_publisher.members_all_count, 2)
         self.assertEqual(channel_publisher.partner_ids, self.user_officer.partner_id | self.user_emp.partner_id)
 
     @mute_logger('odoo.models')

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -19,7 +19,7 @@ class TestUICommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         img_path = get_module_resource('website_slides', 'static', 'src', 'img', 'slide_demo_gardening_1.jpg')
         img_content = base64.b64encode(open(img_path, "rb").read())
 
-        self.env['slide.channel'].create({
+        self.channel = self.env['slide.channel'].create({
             'name': 'Basics of Gardening - Test',
             'user_id': self.env.ref('base.user_admin').id,
             'enroll': 'public',
@@ -146,6 +146,44 @@ class TestUiPublisher(HttpCaseWithUserDemo):
         })
 
         self.start_tour(self.env['website'].get_client_action_url('/slides'), 'course_publisher_standard', login=user_demo.login)
+
+
+@tests.common.tagged('post_install', '-at_install')
+class TestUiMemberInvited(TestUICommon):
+
+    def setUp(self):
+        super(TestUiMemberInvited, self).setUp()
+        self.channel_partner_portal = self.env['slide.channel.partner'].create({
+            'channel_id': self.channel.id,
+            'partner_id': self.user_portal.partner_id.id,
+            'member_status': 'invited',
+            'last_invitation_date': Datetime.now(),
+        })
+        self.portal_invite_url = self.channel_partner_portal.invitation_link
+
+    def test_invite_check_channel_preview_as_logged_connected_on_invite(self):
+        self.channel.enroll = 'invite'
+        self.channel.visibility = 'connected'
+        self.start_tour(self.portal_invite_url, 'invite_check_channel_preview_as_logged', login='portal')
+
+    def test_invite_check_channel_preview_as_public_connected_on_invite(self):
+        self.channel.enroll = 'invite'
+        self.channel.visibility = 'connected'
+        self.start_tour(self.portal_invite_url, 'invite_check_channel_preview_as_public', login=None)
+
+    def test_invite_check_channel_preview_as_logged_members(self):
+        self.channel.visibility = 'members'
+        self.start_tour(self.portal_invite_url, 'invite_check_channel_preview_as_logged', login='portal')
+
+    def test_invite_check_channel_preview_as_public_members(self):
+        self.channel.visibility = 'members'
+        self.start_tour(self.portal_invite_url, 'invite_check_channel_preview_as_public', login=None)
+
+    def test_invite_check_channel_preview_as_logged_public(self):
+        self.start_tour(self.portal_invite_url, 'invite_check_channel_preview_as_logged', login='portal')
+
+    def test_invite_check_channel_preview_as_public_public(self):
+        self.start_tour(self.portal_invite_url, 'invite_check_channel_preview_as_public', login=None)
 
 
 @tests.common.tagged('external', 'post_install', '-standard', '-at_install')

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -5,16 +5,20 @@
             <field name="name">slide.channel.partner.search</field>
             <field name="model">slide.channel.partner</field>
             <field name="arch" type="xml">
-                <search string="Channel Member">
+                <search string="Course Member">
                     <field name="partner_id"/>
                     <field name="partner_email"/>
                     <field name="channel_id" string="Course"/>
                      <separator/>
-                    <filter string="Completed" name="filter_completed" domain="[('completed', '=', True)]"/>
-                    <separator/>
                     <filter string="Archived" name="filter_archived" domain="[('active', '=', False)]"/>
+                    <separator/>
+                    <filter string="Invite Sent" name="filter_invited" domain="[('member_status', '=', 'invited')]"/>
+                    <filter string="Joined" name="filter_joined" domain="[('member_status', '=', 'joined')]"/>
+                    <filter string="Ongoing" name="filter_ongoing" domain="[('member_status', '=', 'ongoing')]"/>
+                    <filter string="Completed" name="filter_completed" domain="[('member_status', '=', 'completed')]"/>
                     <group expand="0" string="Group By">
-                        <filter string="Channel" name="groupby_channel_id" context="{'group_by': 'channel_id'}"/>
+                        <filter string="Course" name="groupby_channel_id" context="{'group_by': 'channel_id'}"/>
+                        <filter string="Status" name="groupby_member_status" context="{'group_by': 'member_status'}"/>
                     </group>
                 </search>
             </field>
@@ -24,14 +28,21 @@
             <field name="name">slide.channel.partner.tree</field>
             <field name="model">slide.channel.partner</field>
             <field name="arch" type="xml">
-                <tree string="Attendees" editable="top" sample="1">
+                <tree string="Attendees" js_class="slide_channel_partner_enroll_tree" create="0" sample="1">
                     <field name="channel_id" string="Course Name"/>
-                    <field name="channel_user_id"/>
+                    <field name="partner_id"/>
                     <field name="partner_email" string="Email"/>
-                    <field name="create_date" string="Enrolled On"/>
+                    <field name="create_date" string="Added On"/>
                     <field name="write_date" string="Last Action On"/>
+                    <field name="last_invitation_date" string="Last Invitation" optional="hide"/>
+                    <field name="member_status" string="Status" widget="badge"
+                        decoration-success="member_status == 'completed'"
+                        decoration-info="member_status == 'ongoing'"
+                        decoration-warning="member_status == 'joined'"
+                        decoration-muted="member_status == 'invited'"/>
                     <field name="completion" string="Progress" widget="progressbar"/>
                     <field name="next_slide_id"/>
+                    <field name="channel_user_id" widget="many2one_avatar_user" optional="hide"/>
                     <field name="channel_type" optional="hide"/>
                     <field name="channel_visibility" optional="hide"/>
                     <field name="channel_enroll" widget="badge"
@@ -41,8 +52,10 @@
                         optional="hide"/>
                     <field name="channel_website_id" groups="website.group_multi_website" optional="hide"/>
                     <field name="active" invisible="1"/>
-                    <button name="action_archive" title="Archive" icon="fa-times" type="object" attrs="{'invisible': [('active', '=', False)]}"/>
-                    <button name="action_unarchive" title="Unarchive" icon="fa-undo" type="object" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <button name="action_archive" title="Archive" icon="fa-times" type="object"
+                        attrs="{'invisible': [('active', '=', False)]}"/>
+                    <button name="action_unarchive" title="Unarchive" icon="fa-undo" type="object"
+                        attrs="{'invisible': [('active', '=', True)]}"/>
                 </tree>
             </field>
         </record>
@@ -51,7 +64,7 @@
             <field name="name">slide.channel.partner.view.kanban</field>
             <field name="model">slide.channel.partner</field>
             <field name="arch" type="xml">
-                <kanban string="Followed Courses" class="o_slide_attendee_kanban">
+                <kanban string="Attendees" class="o_slide_attendee_kanban">
                     <field name="active"/>
                     <templates>
                         <t t-name="kanban-box">
@@ -80,10 +93,28 @@
             </field>
         </record>
 
+        <record id="slide_channel_partner_view_graph" model="ir.ui.view">
+            <field name="name">slide.channel.partner.view.graph</field>
+            <field name="model">slide.channel.partner</field>
+            <field name="arch" type="xml">
+                <graph string="Attendees" stacked="0" sample="1"/>
+            </field>
+        </record>
+
+        <record id="slide_channel_partner_view_pivot" model="ir.ui.view">
+            <field name="name">slide.channel.partner.view.pivot</field>
+            <field name="model">slide.channel.partner</field>
+            <field name="arch" type="xml">
+                <pivot string="Attendees" sample="1">
+                    <field name="completion" invisible="1"/>
+                </pivot>
+            </field>
+        </record>
+
         <record id="slide_channel_partner_action" model="ir.actions.act_window">
             <field name="name">Attendees</field>
             <field name="res_model">slide.channel.partner</field>
-            <field name="view_mode">tree,form,kanban</field>
+            <field name="view_mode">tree,kanban</field>
             <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -98,9 +129,9 @@
         <record id="slide_channel_partner_action_report" model="ir.actions.act_window">
             <field name="name">Attendees</field>
             <field name="res_model">slide.channel.partner</field>
-            <field name="view_mode">tree,form,kanban</field>
+            <field name="view_mode">graph,pivot,tree,kanban</field>
             <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
-            <field name="context">{'search_default_groupby_channel': 1}</field>
+            <field name="context">{'search_default_groupby_member_status': 1}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     <strong>No Attendees Yet!</strong>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -8,7 +8,8 @@
             <field name="arch" type="xml">
                 <form string="Channels">
                     <header>
-                        <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight" attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
+                        <button name="action_channel_enroll" string="Add Attendees" type="object" class="oe_highlight"/>
+                        <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight btn btn-secondary"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
@@ -29,14 +30,14 @@
                                     Published Contents
                                 </span>
                             </button>
-                            <button name="action_redirect_to_done_members"
+                            <button name="action_redirect_to_completed_members"
                                 type="object"
                                 icon="fa-trophy"
                                 class="oe_stat_button"
                                 groups="website_slides.group_website_slides_officer">
                                 <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="members_done_count" nolabel="1"/></span>
-                                    <span name="members_done_count_label" class="o_stat_text">Finished</span>
+                                    <span class="o_stat_value"><field name="members_completed_count" nolabel="1"/></span>
+                                    <span name="members_completed_count_label" class="o_stat_text">Finished</span>
                                 </div>
                             </button>
                             <button name="action_redirect_to_members"
@@ -44,7 +45,7 @@
                                 icon="fa-graduation-cap"
                                 class="oe_stat_button"
                                 groups="website_slides.group_website_slides_officer">
-                                <field name="members_count" string="Attendees" widget="statinfo"/>
+                                <field name="members_all_count" string="Attendees" widget="statinfo"/>
                             </button>
                              <button name="action_view_ratings"
                                 type="object"
@@ -103,10 +104,10 @@
                                         <field name="prerequisite_of_channel_ids" widget="many2many_tags" readonly="1"
                                                attrs="{'invisible': [('prerequisite_of_channel_ids', '=', [])]}"/>
                                         <field name="visibility" widget="radio" options="{'horizontal': true}"/>
-                                        <field name="enroll" widget="radio" options="{'horizontal': true}" attrs="{'invisible': [('visibility', '=', 'course_attendees')]}"/>
+                                        <field name="enroll" widget="radio" options="{'horizontal': true}" attrs="{'invisible': [('visibility', '=', 'members')]}"/>
                                         <field name="upload_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
                                         <field name="enroll_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
-                                        <field name="enroll_msg" attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
+                                        <field name="enroll_msg" attrs="{'invisible': ['|', ('enroll', '!=', 'invite'), ('visibility', '=', 'members')]}"/>
                                     </group>
                                 </group>
                                 <group>
@@ -184,7 +185,7 @@
                     <field name="rating_avg_stars" string="Average Review"/>
                     <field name="total_time" string="Total Duration" widget="float_time" sum="Total Duration"/>
                     <field name="members_count" string="# Attendees" sum="Total Attendees"/>
-                    <field name="members_done_count" string="# Completed" sum="Total Completed"/>
+                    <field name="members_completed_count" string="# Completed" sum="Total Completed"/>
                 </tree>
             </field>
         </record>
@@ -257,10 +258,8 @@
                                     <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                                 </t>
                                 <a role="menuitem" type="edit" class="dropdown-item">Edit</a>
-                                <a role="menuitem" name="action_channel_invite" class="dropdown-item"
-                                    type="object" attrs="{'invisible': [('enroll', '!=', 'invite')]}">
-                                    Invite
-                                </a>
+                                <a role="menuitem" name="action_channel_enroll" class="dropdown-item" type="object">Add Attendees</a>
+                                <a role="menuitem" name="action_channel_invite" class="dropdown-item" type="object">Invite</a>
                             </div>
                         </t>
                         <t t-name="kanban-box">
@@ -293,37 +292,47 @@
                                             <button class="btn btn-primary" name="open_website_url" type="object">View course</button>
                                         </div>
                                         <div class="col-6 o_kanban_primary_right">
-                                            <div class="d-flex" t-if="record.rating_count.raw_value">
-                                                <a name="action_view_ratings" type="object" class="me-auto"><field name="rating_count"/> Reviews</a>
-                                                <span><field name="rating_avg_stars"/> / 5</span>
-                                            </div>
                                             <div class="d-flex">
                                                 <span class="me-auto"><label for="total_views" class="mb0">Views</label></span>
                                                 <field name="total_views"/>
+                                            </div>
+                                            <div class="d-flex" name="info_total_slides">
+                                                <span class="me-auto"><label for="total_slides" class="mb0">Contents</label></span>
+                                                <field name="total_slides"/>
                                             </div>
                                             <div class="d-flex" name="info_total_time">
                                                 <span class="me-auto"><label for="total_time" class="mb0">Duration</label></span>
                                                 <field name="total_time" widget="float_time"/>
                                             </div>
+                                            <div class="d-flex" name="info_avg_rating" t-if="record.rating_count.raw_value">
+                                                <a name="action_view_ratings" type="object" class="me-auto"><field name="rating_count"/> Reviews</a>
+                                                <span><field name="rating_avg_stars"/> / 5</span>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="row mt3">
-                                        <div class="col-5 border-end">
-                                            <a name="action_view_slides" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="fw-bold"><field name="total_slides"/></span>
-                                                <span class="text-muted">Published Contents</span>
+                                    <div class="row mt3 o_kanban_card_attendees_buttons">
+                                        <div class="col-3 border-end">
+                                            <a name="action_redirect_to_invited_members" type="object" class="d-flex flex-column align-items-center">
+                                                <field name="members_invited_count" class="fw-bold"/>
+                                                <span class="text-muted">Invited</span>
                                             </a>
                                         </div>
                                         <div class="col-3 border-end">
-                                            <a name="action_redirect_to_members" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="fw-bold"><field name="members_count"/></span>
-                                                <span class="text-muted">Attendees</span>
+                                            <a name="action_redirect_to_engaged_members" type="object" class="d-flex flex-column align-items-center">
+                                                <field name="members_engaged_count" class="fw-bold"/>
+                                                <span class="text-muted">Ongoing</span>
+                                            </a>
+                                        </div>
+                                        <div class="col-3 border-end">
+                                            <a name="action_redirect_to_completed_members" type="object" class="d-flex flex-column align-items-center">
+                                                <field name="members_completed_count" class="fw-bold"/>
+                                                <span name="done_members_count_label" class="text-muted">Finished</span>
                                             </a>
                                         </div>
                                         <div class="col-3">
-                                            <a name="action_redirect_to_done_members" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="fw-bold"><field name="members_done_count"/></span>
-                                                <span name="done_members_count_label" class="text-muted">Finished</span>
+                                            <a name="action_redirect_to_members" type="object" class="d-flex flex-column align-items-center">
+                                                <field name="members_all_count" class="fw-bold"/>
+                                                <span class="text-muted">Total</span>
                                             </a>
                                         </div>
                                     </div>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -14,16 +14,19 @@
                         </li>
                         <t t-set="breadcrumb_class" t-value="'breadcrumb-item %s' % ('fw-bold' if not slide else '')" />
                         <li t-att-class="'breadcrumb-item %s' % ('fw-bold' if not search_category and not search_tag and not search_slide_category and not slide else '')">
-                            <a t-att-href="'/slides/%s' % slug(channel)"><span t-esc="channel.name"/></a>
+                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}?#{keep_query('invite_hash', 'invite_partner_id')}"><span t-esc="channel.name"/></a>
+                            <a t-else="" t-attf-href="/slides/#{slug(channel)}"><span t-esc="channel.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_category" t-if="search_category">
-                            <a t-att-href="'/slides/%s/category/%s' % (slug(channel), slug(search_category))"><span t-esc="search_category.name"/></a>
+                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}/category/#{search_category.id}?#{keep_query('invite_hash', 'invite_partner_id')}"><span t-esc="search_category.name"/></a>
+                            <a t-else="" t-attf-href="/slides/#{slug(channel)}/category/#{slug(search_category)}"><span t-esc="search_category.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_tag" t-if="search_tag">
                             <a t-att-href="'/slides/%s/tag/%s' % (slug(channel), slug(search_tag))"><span t-esc="search_tag.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_uncategorized" t-if="search_uncategorized">
-                            <a t-att-href="'/slides/%s?search_uncategorized=1' % (slug(channel))">Uncategorized</a>
+                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}?uncategorized=1&amp;#{keep_query('invite_hash', 'invite_partner_id')}">Uncategorized</a>
+                            <a t-else="" t-attf-href="/slides/#{slug(channel)}?uncategorized=1">Uncategorized</a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_slide_category" t-if="search_slide_category">
                             <a t-att-href="'/slides/%s?slide_category=%s' % (slug(channel), search_slide_category)"><span t-esc="slide_categories[search_slide_category]"/></a>
@@ -58,16 +61,19 @@
                             <div class="dropdown-menu">
                                 <a class="dropdown-item" href="/slides">Home</a>
                                 <t t-set="dropdown_class" t-value="'dropdown-item %s' % ('active' if not slide else '')"/>
-                                <a t-att-class="'dropdown-item %s' % ('active' if not search_category and not search_tag and not search_slide_category else '')" t-att-href="'/slides/%s' % slug(channel)">
+                                <a t-attf-class="dropdown-item #{'active' if not search_category and not search_tag and not search_slide_category else ''}"
+                                    t-attf-href="/slides/#{channel.id if invite_preview else slug(channel)}?#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">
                                     &#9492;<span class="ms-1" t-esc="channel.name"/>
                                 </a>
-                                <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_category" t-if="search_category" t-att-href="'/slides/%s/category/%s' % (slug(channel), slug(search_category))">
+                                <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_category" t-if="search_category"
+                                    t-attf-href="/slides/#{channel.id if invite_preview else slug(channel)}/category/#{search_category.id if invite_preview else slug(search_category)}?#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">
                                     &#9492;<span class="ms-1" t-esc="search_category.name"/>
                                 </a>
                                 <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_tag" t-if="search_tag" t-att-href="'/slides/%s/tag/%s' % (slug(channel), slug(search_tag))">
                                     &#9492;<span class="ms-1" t-esc="search_tag.name"/>
                                 </a>
-                                <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_uncategorized" t-if="search_uncategorized" t-att-href="'/slides/%s?search_uncategorized=1' % (slug(channel))">
+                                <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_uncategorized" t-if="search_uncategorized"
+                                    t-attf-href="/slides/#{channel.id if invite_preview else slug(channel)}?uncategorized=1&amp;#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">
                                     &#9492;<span class="ms-1">Uncategorized</span>
                                 </a>
                                 <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_slide_category" t-if="search_slide_category" t-att-href="'/slides/%s?slide_category=%s' % (slug(channel), search_slide_category)">
@@ -190,6 +196,14 @@
                                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                                         You need to join this course to access &quot;<t t-out="access_error_content_name"/>&quot;.
                                     </div>
+                                    <!-- ==== Invitation Banner ==== -->
+                                    <div t-if="invite_preview" class="o_wslides_identification_banner alert alert-success mb-4 p-2 px-3" role="alert">
+                                        You have been invited to this course.
+                                        <a class="o_underline" t-attf-href="/slides/#{channel.id}/identify?#{keep_query('invite_partner_id', 'invite_hash')}">
+                                            <t t-if="is_partner_without_user">Sign up</t>
+                                            <t t-else="">Log in</t>
+                                        </a> to browse preview content and enroll.
+                                    </div>
                                     <div t-if="channel.channel_type == 'training' and (channel_frontend_tags or channel.can_upload)"
                                          class="mb-1 pt-1">
                                         <t t-if="channel_frontend_tags">
@@ -275,11 +289,118 @@
 
 <template id="course_join">
     <div class="o_wslides_js_course_join flex-grow-1 d-grid">
-        <t t-if="channel.is_member">
+        <t t-if="(invite_preview and channel.enroll in ['public', 'invite']) or (not channel.is_member and (channel.enroll == 'public' or (channel.is_member_invited and channel.enroll == 'invite')))">
+           <div t-if="not invite_preview and channel.prerequisite_channel_ids and not channel.prerequisite_user_has_completed" class="text-center">
+                <div class="alert my-0 bg-100">
+                    <h6>
+                        <i class="fa fa-lock"/>
+                        <span>Course Locked</span>
+                    </h6>
+                    <div>
+                        <small>
+                            Finish
+                            <a t-if="len(channel.prerequisite_channel_ids) == 1"
+                                t-attf-href="/slides/{{channel.prerequisite_channel_ids[0].id}}"
+                                t-out="channel.prerequisite_channel_ids[0].name"/>
+                            <a t-else="" href="#" class="o_wslides_js_prerequisite_course"
+                                t-att-data-channels="json.dumps(
+                                    [{'course_id': course.id, 'course_name': course.name}
+                                    for course in channel.prerequisite_channel_ids]
+                                )">
+                                courses
+                            </a>
+                            to unlock
+                        </small>
+                        <small>
+                            or 
+                            <a role="button" class="o_wslides_js_course_join_link"
+                                title="Start Course" aria-label="Start Course" href="#"
+                                t-att-data-channel-id="channel.id"
+                                t-att-data-channel-enroll="channel.enroll"
+                                t-att-data-invite-hash="invite_hash"
+                                t-att-data-invite-partner-id="invite_partner_id"
+                                t-att-data-invite-preview="invite_preview"
+                                t-att-data-is-member-or-invited="channel.is_member or channel.is_member_invited"
+                                t-att-data-is-partner-without-user="is_partner_without_user">
+                                <t t-if="channel.channel_type == 'documentation'">start</t>
+                                <t t-else="">join</t>
+                            </a> anyway
+                        </small>
+                    </div>
+                </div>
+            </div>
+            <a t-else="" role="button" class="btn btn-primary btn-block o_wslides_js_course_join_link"
+               title="Start Course" aria-label="Start Course" href="#"
+               t-att-data-channel-id="channel.id"
+               t-att-data-channel-enroll="channel.enroll"
+               t-att-data-invite-hash="invite_hash"
+               t-att-data-invite-partner-id="invite_partner_id"
+               t-att-data-invite-preview="invite_preview"
+               t-att-data-is-member-or-invited="channel.is_member or channel.is_member_invited"
+               t-att-data-is-partner-without-user="is_partner_without_user">
+                <span class="cta-title text_small_caps">
+                    <t t-if="channel.channel_type == 'documentation'">Start this Course</t>
+                    <t t-else="">Join this Course</t>
+                </span>
+            </a>
+        </t>
+        <div t-elif="not invite_preview and channel.enroll == 'invite' and not channel.is_member and not channel.is_member_invited" class="text-center">
+            <div t-if="channel.prerequisite_channel_ids and not channel.prerequisite_user_has_completed" class="text-center">
+                <div class="alert my-0 bg-100">
+                    <h6>
+                        <i class="fa fa-lock"/>
+                        <span>Course Locked</span>
+                    </h6>
+                    <div>
+                        <small>
+                            Finish
+                            <a t-if="len(channel.prerequisite_channel_ids) == 1"
+                                t-attf-href="/slides/{{channel.prerequisite_channel_ids[0].id}}"
+                                t-out="channel.prerequisite_channel_ids[0].name"/>
+                            <a t-else="" href="#" class="o_wslides_js_prerequisite_course"
+                                t-att-data-channels="json.dumps(
+                                    [{'course_id': course.id, 'course_name': course.name}
+                                    for course in channel.prerequisite_channel_ids]
+                                )">
+                                courses
+                            </a>
+                            to unlock
+                        </small>
+                        <small t-if="is_public_user">
+                            or <a t-att-href="'/web/login?redirect=/slides/%s' % (slug(channel))">sign in</a> to request access
+                        </small>
+                        <small t-else="">
+                            or <a href="#" class="o_wslides_js_channel_enroll" t-att-data-channel-id="channel.id">request</a> direct access
+                        </small>
+                    </div>
+                </div>
+            </div>
+            <div t-else="" t-attf-class="alert my-0 bg-100 p-2 #{'o_wslides_js_channel_enroll' if not is_public_user else ''}"
+                t-att-data-channel-id="channel.id">
+                Private Course
+                <div t-if="is_public_user">
+                    <small>
+                        Please <a t-att-href="'/web/login?redirect=/slides/%s' % (slug(channel))">sign in</a> to contact responsible
+                    </small>
+                </div>
+                <div t-elif="channel.has_requested_access">
+                    <small class="text-success">
+                        Request already sent
+                    </small>
+                </div>
+                <div t-else="" class="o_wslides_enroll_msg">
+                    <small>
+                        <div t-field="channel.enroll_msg"/>
+                    </small>
+                </div>
+            </div>
+        </div>
+        <t t-elif="channel.is_member">
             <button class="d-flex align-items-center alert my-0 px-2 px-xl-3 bg-100 w-100 o_wslides_js_channel_unsubscribe"
                     t-att-data-channel-id="channel.id"
                     t-att-data-is-follower="channel.message_is_follower"
-                    t-att-data-enroll="channel.enroll">
+                    t-att-data-enroll="channel.enroll"
+                    t-att-data-visibility="channel.visibility">
                 <t t-call="website_slides.slides_misc_user_image">
                     <t t-set="img_class" t-value="'rounded-circle me-1'"/>
                     <t t-set="img_style" t-value="'width: 1.4em; height: 1.4em; object-fit: cover;'"/>
@@ -301,76 +422,6 @@
                     </div>
                 </div>
             </div>
-        </t>
-        <t t-elif="channel.enroll in ['public', 'invite']">
-            <div t-if="channel.prerequisite_channel_ids and not channel.prerequisite_user_has_completed"
-                 class="text-center">
-                <div class="alert my-0 bg-100">
-                    <h6>
-                        <i class="fa fa-lock"/>
-                        <span>Course Locked</span>
-                    </h6>
-                    <div>
-                        <small>
-                            Finish
-                            <a t-if="len(channel.prerequisite_channel_ids) == 1"
-                               t-attf-href="/slides/{{slug(channel.prerequisite_channel_ids[0])}}"
-                               t-out="channel.prerequisite_channel_ids[0].name"/>
-                            <a t-else="" href="#" class="o_wslides_js_prerequisite_course"
-                               t-att-data-channels="json.dumps(
-                                  [{'course_id': course.id, 'course_name': course.name}
-                                  for course in channel.prerequisite_channel_ids]
-                               )">
-                                courses
-                            </a>
-                            to unlock
-                        </small>
-                    </div>
-                    <div>
-                        <small t-if="channel.enroll == 'public'">
-                            or
-                            <a href="#" class="o_wslides_js_course_join_link"
-                               t-att-data-channel-id="channel.id"
-                               t-att-data-channel-enroll="channel.enroll">
-                                join
-                            </a> anyway.
-                        </small>
-                        <small t-else="">
-                            or <a href="#" class="o_wslides_js_channel_enroll" t-att-data-channel-id="channel.id">request</a> direct access.
-                        </small>
-                    </div>
-                </div>
-            </div>
-            <t t-else="">
-                <a t-if="channel.enroll == 'public'" role="button"
-                    class="btn btn-primary o_wslides_js_course_join_link"
-                    title="Start Course" aria-label="Start Course Channel" href="#"
-                    t-att-data-channel-id="channel.id"
-                    t-att-data-channel-enroll="channel.enroll">
-                    <span class="cta-title text_small_caps">
-                        Join this Course
-                    </span>
-                </a>
-                <div t-if="channel.enroll == 'invite'" class="text-center">
-                    <div t-attf-class="alert my-0 bg-100 p-2 #{'o_wslides_js_channel_enroll' if not is_public_user else ''}"
-                         t-att-data-channel-id="channel.id">
-                        Private Course
-                        <div t-if="is_public_user">
-                            <small>
-                                Please <a t-attf-href="/web/login?redirect=/slides/{{slug(channel)}}">sign in</a> to contact responsible.
-                            </small>
-                        </div>
-                        <div t-elif="channel.has_requested_access">
-                            <small class="text-success">
-                                Request already sent
-                            </small>
-                        </div>
-                        <div t-else="" class="o_wslides_enroll_msg">
-                            <small t-field="channel.enroll_msg"/>
-                        </div>
-                    </div>
-                </div>
-            </t>
         </t>
     </div>
 </template>
@@ -451,11 +502,19 @@
                 href="#" role="button"
                 groups="website_slides.group_website_slides_officer"><i class="fa fa-folder-o me-1"/><span>Add Section</span></a>
         </div>
-        <t t-if="not channel.slide_ids and channel.can_publish">
-            <t t-call="website_slides.course_slides_list_sample"/>
-        </t>
+        <t t-if="not channel.slide_ids and channel.can_publish" t-call="website_slides.course_slides_list_sample"/>
+        <t t-elif="slide_count == 0 and not channel.can_publish" t-call="website_slides.course_slides_list_placeholder"/>
     </div>
     <div t-field="channel.description_html"/>
+</template>
+
+<template id="course_slides_list_placeholder" name="Course Placeholder Content">
+    <div class="my-5 d-flex">
+        <div class="mx-auto">
+            <img class="mx-auto mb-3" src="/web/static/img/smiling_face.svg"/>
+            <div class="text-muted fw-bold">No lessons are available yet.</div>
+        </div>
+    </div>
 </template>
 
 <template id="course_slides_list_sample" name="Course Sample Content">
@@ -539,7 +598,7 @@
             <t t-set="icon_class" t-value="'py-2 mx-2'"/>
         </t>
         <div class="text-truncate me-auto">
-            <a t-if="slide.is_preview or channel.is_member or channel.can_publish" class="o_wslides_js_slides_list_slide_link" t-attf-href="/slides/slide/#{slug(slide)}">
+            <a t-if="not invite_preview and (slide.is_preview or channel.is_member or channel.can_publish)" class="o_wslides_js_slides_list_slide_link" t-attf-href="/slides/slide/#{slug(slide)}">
                 <span t-field="slide.name"/>
             </a>
             <span t-else="">
@@ -586,7 +645,7 @@
     <div class="o_wslides_promoted_slide">
         <div t-if="not search and not search_slide_category and slide_promoted" class="container py-1 mb-2">
             <div class="card flex-column flex-lg-row">
-                <a t-if="slide_promoted.is_preview or channel.is_member or is_slides_publisher" t-attf-href="/slides/slide/#{slug(slide_promoted)}#{query_string}" class="w-100 w-lg-50 flex-shrink-0 rounded">
+                <a t-if="not invite_preview and (slide_promoted.is_preview or channel.is_member or is_slides_publisher)" t-attf-href="/slides/slide/#{slug(slide_promoted)}#{query_string}" class="w-100 w-lg-50 flex-shrink-0 rounded">
                     <div t-field="slide_promoted.image_1920" t-options="{'widget': 'image', 'style': 'height:100%', 'preview_image': 'image_512'}" class="h-100"/>
                 </a>
                 <div t-else="" class="w-100 w-lg-50 flex-shrink-0 rounded">
@@ -594,14 +653,15 @@
                 </div>
 
                 <div class="card-body">
-                    <a t-if="slide_promoted.is_preview or channel.is_member or is_slides_publisher"
+                    <a t-if="not invite_preview and (slide_promoted.is_preview or channel.is_member or is_slides_publisher)"
                     t-attf-href="/slides/slide/#{slug(slide_promoted)}#{query_string}"
                     class="h4 d-block pb-2 border-bottom" t-att-title="slide_promoted.name" t-field="slide_promoted.name"/>
                     <h4 t-else="" class="text-muted pb-2 border-bottom" t-field="slide_promoted.name"/>
                     <div class="o_wslides_desc_truncate_10 mt-3" t-field="slide_promoted.description"/>
                     <div t-if="slide_promoted.tag_ids" class="mt-2 pt-1">
                         <t t-foreach="slide_promoted.tag_ids" t-as="tag">
-                            <a t-att-href="'/slides/%s/tag/%s' % (slug(slide_promoted.channel_id), slug(tag))" class="badge text-bg-light" t-esc="tag.name"/>
+                            <h4 t-if="invite_preview" class="badge text-bg-light" t-esc="tag.name"/>
+                            <a t-else="" t-attf-href="/slides/#{slug(slide_promoted.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-light" t-esc="tag.name"/>
                         </t>
                     </div>
                 </div>
@@ -611,7 +671,7 @@
 </template>
 
 <template id="course_slides_cards" name="Documentation Course content: cards / categories">
-    <div class="o_wslides_lesson_nav mb-4">
+    <div t-if="not invite_preview" class="o_wslides_lesson_nav mb-4">
         <div class="container">
             <div class="row">
                 <nav class="navbar navbar-expand-lg navbar-light bg-transparent col">
@@ -758,11 +818,11 @@
                 <t t-set="is_empty_editable" t-value="not category['slides'] and channel.can_publish"/>
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3" t-if="category['id'] and query_string != '?search_uncategorized=1'">
                     <h5 t-attf-class="m-0 #{'text-muted' if is_empty_editable else ''}"><t t-esc="category['name']"/></h5>
-                    <a t-if="category['id'] and not is_empty_editable" t-att-href="'/slides/%s/category/%s' % (slug(channel), category['slug_name'])">View all</a>
+                    <a t-if="category['id'] and not is_empty_editable" t-attf-href="/slides/#{channel.id}/category/#{category['id']}?#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">View all</a>
                 </div>
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3" t-if="not category['id'] and len(category['slides']) > 0">
                     <h5 t-if="len(category_data) > 1" t-attf-class="m-0 #{'text-muted' if is_empty_editable else ''}"><t t-esc="category['name']"/></h5>
-                    <a t-att-href="'/slides/%s?uncategorized=1' % (slug(channel))">View all</a>
+                    <a t-attf-href="/slides/#{channel.id}?uncategorized=1&amp;#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">View all</a>
                 </div>
                 <div class="row mx-n2">
                     <t t-foreach="category['slides']" t-as="slide">
@@ -786,7 +846,7 @@
 <template id='lesson_card' name="Lesson Card">
     <div class="card w-100 o_wslides_lesson_card mb-4">
         <t t-if="slide.is_new_slide and not channel_progress[slide.id].get('completed')" t-call="website_slides.course_card_information"/>
-        <t t-set="can_access" t-value="slide.is_preview or channel.is_member or channel.can_publish"/>
+        <t t-set="can_access" t-value="not invite_preview and (slide.is_preview or channel.is_member or channel.can_publish)"/>
         <a t-if="can_access" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-title="slide.name" style="height:150px">
             <div t-field="slide.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image h-100"/>
         </a>
@@ -807,7 +867,8 @@
             </div>
             <div class="text-muted o_wslides_desc_truncate_2 my-2">
                 <t t-foreach="slide.tag_ids" t-as="tag">
-                    <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-light" t-esc="tag.name"/>
+                    <h4 t-if="invite_preview" class="badge text-bg-light" t-esc="tag.name"/>
+                    <a t-else="" t-attf-href="/slides/#{slug(slide.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-light" t-esc="tag.name"/>
                 </t>
             </div>
             <span t-if="channel.is_member and channel_progress[slide.id].get('completed')" class="badge rounded-pill text-bg-success align-self-start"><i class="fa fa-check me-1"/>Completed</span>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -101,6 +101,7 @@
                         </div>
                     </div>
                     <div t-att-class="'col-lg-9 pe-lg-5 order-lg-1' if has_side_column else 'col-lg pr-lg'">
+                        <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-esc="invite_error_msg"/>
                         <div class="o_wslides_home_content_section mb-3"
                             t-if="not channels_popular">
                             <p class="h2">No Course created yet.</p>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -189,7 +189,8 @@
                             </div>
                         </t>
                         <div t-else="" class="o_wslides_js_course_join o_wslides_no_access">
-                            <li t-if="aside_slide.channel_id.enroll == 'public'" class="text-decoration-none small">
+                            <li t-if="aside_slide.channel_id.enroll == 'public' or (aside_slide.channel_id.enroll == 'invite' and aside_slide.channel_id.is_member_invited)"
+                                class="text-decoration-none small">
                                 <i class="fa fa-download me-1"/>
                                 <t t-call="website_slides.join_course_link">
                                     <t t-set="for_resources" t-value="1"/>
@@ -448,10 +449,10 @@
                     Additional Resources
                 </span>
                 <div class="o_wslides_js_course_join o_wslides_no_access">
-                    <div t-if="slide.channel_id.enroll == 'invite'">
-                        <span>Content only accessible to course members.</span>
+                    <div t-if="slide.channel_id.enroll == 'invite' and not slide.channel_id.is_member_invited">
+                        <span>Content only accessible to course attendees.</span>
                     </div>
-                    <div t-if="slide.channel_id.enroll == 'public'" class="text-muted me-auto border-start ps-3">
+                    <div t-else="" class="text-muted me-auto border-start ps-3">
                         <t t-call="website_slides.join_course_link">
                             <t t-set="for_resources" t-value="1"/>
                         </t>
@@ -475,6 +476,7 @@
         t-att-data-name="slide.name"
         t-att-data-slide-category="slide.slide_category"
         t-att-data-is-member="slide.channel_id.is_member"
+        t-att-data-is-member-or-invited="slide.channel_id.is_member or slide.channel_id.is_member_invited"
         t-att-data-can-self-mark-completed="slide.can_self_mark_completed"
         t-att-data-can-self-mark-uncompleted="slide.can_self_mark_uncompleted"
         t-att-data-completed="slide_completed"

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -108,6 +108,8 @@
             <t t-foreach="slides" t-as="slide">
                 <t t-set="slide_completed" t-value="channel_progress[slide.id].get('completed')"/>
                 <t t-set="can_access" t-value="can_access_channel or slide.is_preview"/>
+                <t t-set="is_member" t-value="current_slide.channel_id.is_member"/>
+                <t t-set="is_member_or_invited" t-value="is_member or current_slide.channel_id.is_member_invited"/>
                 <li t-attf-class="o_wslides_fs_sidebar_list_item d-flex py-1 #{'active' if slide.id == current_slide.id else ''}"
                     t-att-data-id="slide.id"
                     t-att-data-can-access="can_access"
@@ -122,6 +124,7 @@
                     t-att-data-can-self-mark-completed="slide.can_self_mark_completed"
                     t-att-data-can-self-mark-uncompleted="slide.can_self_mark_uncompleted"
                     t-att-data-is-member="is_member"
+                    t-att-data-is-member-or-invited="is_member_or_invited"
                     t-att-data-session-answers="session_answers"
                     t-att-data-website-share-url="slide.website_share_url">
                     <t t-call="website_slides.slide_sidebar_done_button"/>
@@ -158,7 +161,8 @@
                                 </div>
                             </t>
                             <div t-else="" class="o_wslides_js_course_join o_wslides_no_access ps-0">
-                                <li t-if="slide.channel_id.enroll == 'public'" class="o_wslides_fs_slide_link mb-1">
+                                <li t-if="slide.channel_id.enroll == 'public' or (slide.channel_id.enroll == 'invite' and slide.channel_id.is_member_invited)"
+                                    class="o_wslides_fs_slide_link mb-1">
                                     <i class="fa fa-download me-1"/>
                                     <t t-call="website_slides.join_course_link">
                                         <t t-set="for_resources" t-value="1"/>
@@ -178,6 +182,7 @@
                                 t-att-data-can-self-mark-completed="slide.can_self_mark_completed"
                                 t-att-data-can-self-mark-uncompleted="slide.can_self_mark_uncompleted"
                                 t-att-data-is-member="is_member"
+                                t-att-data-is-member-or-invited="is_member_or_invited"
                                 t-att-data-session-answers="session_answers"
                                 t-att-data-website-share-url="slide.website_share_url">
                                 <a t-if="can_access" class="o_wslides_fs_slide_quiz o_wslides_fs_slide_name" href="#" t-att-index="i">

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -23,11 +23,11 @@
                     </div>
                 </div>
                 <div class="mb32">
-                    <h5 class="border-bottom pb-1">Followed Courses</h5>
+                    <h5 class="border-bottom pb-1">Ongoing Courses</h5>
                     <t t-if="courses_ongoing" t-call="website_slides.display_course">
                         <t t-set="courses" t-value="courses_ongoing"></t>
                     </t>
-                    <p t-else="" class="text-muted">No followed courses yet!</p>
+                    <p t-else="" class="text-muted">No ongoing courses yet!</p>
                 </div>
             </t>
         </xpath>

--- a/addons/website_slides/wizard/slide_channel_invite.py
+++ b/addons/website_slides/wizard/slide_channel_invite.py
@@ -19,47 +19,67 @@ class SlideChannelInvite(models.TransientModel):
 
     # composer content
     attachment_ids = fields.Many2many('ir.attachment', string='Attachments')
+    send_email = fields.Boolean('Send Email', compute="_compute_send_email", readonly=False, store=True)
     # recipients
     partner_ids = fields.Many2many('res.partner', string='Recipients')
     # slide channel
-    channel_id = fields.Many2one('slide.channel', string='Slide channel', required=True)
+    channel_id = fields.Many2one('slide.channel', string='Course', required=True)
+    channel_invite_url = fields.Char('Course Link', compute='_compute_channel_invite_url')
+    channel_visibility = fields.Selection(related='channel_id.visibility')
+    channel_published = fields.Boolean(related='channel_id.is_published')
+    # membership
+    enroll_mode = fields.Boolean(
+        'Enroll partners', readonly=True,
+        help='Whether invited partners will be added as enrolled. Otherwise, they will be added as invited.')
+
+    @api.depends('channel_id')
+    def _compute_channel_invite_url(self):
+        for invite in self:
+            channel = invite.channel_id
+            invite.channel_invite_url = f'{channel.get_base_url()}/slides/{channel.id}'
 
     # Overrides of mail.composer.mixin
     @api.depends('channel_id')  # fake trigger otherwise not computed in new mode
     def _compute_render_model(self):
         self.render_model = 'slide.channel.partner'
 
-    @api.onchange('partner_ids')
-    def _onchange_partner_ids(self):
-        if self.partner_ids:
-            signup_allowed = self.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'
-            if not signup_allowed:
-                invalid_partners = self.env['res.partner'].search([
-                    ('user_ids', '=', False),
-                    ('id', 'in', self.partner_ids.ids)
-                ])
-                if invalid_partners:
-                    raise UserError(_(
-                        'The following recipients have no user account: %s. You should create user accounts for them or allow external sign up in configuration.',
-                        ', '.join(invalid_partners.mapped('name'))
-                    ))
+    @api.depends('channel_id', 'enroll_mode')
+    def _compute_send_email(self):
+        self.send_email = self.channel_visibility != 'public' or self.enroll_mode
 
     def action_invite(self):
-        """ Process the wizard content and proceed with sending the related
-            email(s), rendering any template patterns on the fly if needed """
+        """ Process the wizard content and proceed with sending the related email(s),
+            rendering any template patterns on the fly if needed. This method is used both
+            to add members as 'joined' (when adding attendees) and as 'invited' (on invitation),
+            depending on the value of enroll_mode. Archived members can be invited or enrolled.
+            They will become 'invited', or another status if enrolled depending on their progress.
+            Invited members can be reinvited, or enrolled depending on enroll_mode. """
         self.ensure_one()
 
+        if not self.send_email:
+            return
         if not self.env.user.email:
             raise UserError(_("Unable to post message, please configure the sender's email address."))
         if not self.partner_ids:
             raise UserError(_("Please select at least one recipient."))
 
         mail_values = []
-        for partner_id in self.partner_ids:
-            slide_channel_partner = self.channel_id._action_add_members(partner_id, raise_on_access=True)
-            if slide_channel_partner:
-                mail_values.append(self._prepare_mail_values(slide_channel_partner))
+        attendees_to_reinvite = self.env['slide.channel.partner'].search([
+            ('member_status', '=', 'invited'),
+            ('channel_id', '=', self.channel_id.id),
+            ('partner_id', 'in', self.partner_ids.ids)
+        ]) if not self.enroll_mode else self.env['slide.channel.partner']
 
+        channel_partners = self.channel_id._action_add_members(
+            self.partner_ids - attendees_to_reinvite.partner_id,
+            member_status='joined' if self.enroll_mode else 'invited',
+            raise_on_access=True
+        )
+        if not self.enroll_mode:
+            (attendees_to_reinvite | channel_partners).last_invitation_date = fields.Datetime.now()
+
+        for channel_partner in (attendees_to_reinvite | channel_partners):
+            mail_values.append(self._prepare_mail_values(channel_partner))
         self.env['mail.mail'].sudo().create(mail_values)
 
         return {'type': 'ir.actions.act_window_close'}

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -6,34 +6,47 @@
             <field name="model">slide.channel.invite</field>
             <field name="arch" type="xml">
                 <form string="Compose Email" class="o_mail_composer_form">
-                    <group col="1">
-                        <group col="2">
-                            <field name="channel_id" invisible="1"/>
-                            <field name="partner_ids"
-                                widget="many2many_tags_email"
-                                placeholder="Add existing contacts..."
-                                required="1"
-                                context="{'force_email':True, 'show_email':True, 'no_create_edit': True, 'no_quick_create': True}"/>
-                        </group>
-                        <group col="2">
-                            <field name="lang" invisible="1"/>
-                            <field name="render_model" invisible="1"/>
-                            <field name="subject" placeholder="Subject..."/>
-                        </group>
-                        <field name="can_edit_body" invisible="1"/>
-                        <field name="body" class="oe-bordered-editor" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
-                        <group>
-                            <group>
-                                <field name="attachment_ids" widget="many2many_binary"/>
+                    <div class="alert alert-warning text-center mb-0" role="alert" attrs="{'invisible': ['|', ('channel_published', '=', True), ('channel_id', '=', False)]}">
+                        This course is not published. Attendees may not be able to access its contents.
+                    </div>
+                    <sheet>
+                        <field name="channel_id" invisible="1"/>
+                        <field name="channel_published" invisible="1"/>
+                        <field name="channel_visibility" invisible="1"/>
+                        <field name="enroll_mode" invisible="1"/>
+                        <group col="1">
+                            <group col="2" attrs="{'invisible':['|', ('enroll_mode', '=', True), ('channel_visibility', '!=', 'public')]}">
+                                <field name="channel_invite_url" readonly="1" widget="CopyClipboardChar"/>
+                                <field name="send_email" widget="boolean_toggle" options="{'autosave': False}"/>
                             </group>
-                            <group>
-                                <field name="template_id" label="Use template" context="{'default_model': 'slide.channel.partner'}"/>
+                            <group col="2" attrs="{'invisible':[('send_email', '=', False)]}">
+                                <field name="partner_ids"
+                                    widget="many2many_tags_email"
+                                    placeholder="Add contacts..."
+                                    attrs="{'required':[('send_email', '=', True)]}"
+                                    context="{'force_email':True, 'show_email':True, 'no_create_edit': True, 'no_quick_create': True}"/>
+                            </group>
+                            <group col="2" attrs="{'invisible':[('send_email', '=', False)]}">
+                                <field name="lang" invisible="1"/>
+                                <field name="render_model" invisible="1"/>
+                                <field name="subject" placeholder="Subject..."/>
+                            </group>
+                            <field name="can_edit_body" invisible="1"/>
+                            <field name="body" class="oe-bordered-editor" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)], 'invisible':[('send_email', '=', False)]}" force_save="1"/>
+                            <group attrs="{'invisible':[('send_email', '=', False)]}">
+                                <group>
+                                    <field name="attachment_ids" widget="many2many_binary"/>
+                                </group>
+                                <group>
+                                    <field name="template_id" label="Use template" context="{'default_model': 'slide.channel.partner'}"/>
+                                </group>
                             </group>
                         </group>
-                    </group>
+                    </sheet>
                     <footer>
-                        <button string="Send" name="action_invite" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                        <button string="Send" attrs="{'invisible':[('send_email', '=', False)]}" name="action_invite" type="object" class="btn-primary" data-hotkey="q"/>
+                        <button string="Close" attrs="{'invisible':[('send_email', '=', True)]}" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                        <button string="Cancel" attrs="{'invisible':[('send_email', '=', False)]}" class="btn-secondary" special="cancel" data-hotkey="z"/>
                     </footer>
                 </form>
             </field>

--- a/addons/website_slides_forum/views/website_slides_templates.xml
+++ b/addons/website_slides_forum/views/website_slides_templates.xml
@@ -3,7 +3,7 @@
     <template id='course_main' inherit_id="website_slides.course_main">
         <!-- Channel main template: add link to forum -->
         <xpath expr="//li[hasclass('o_wslides_course_header_nav_review')]" position="after">
-            <li class="nav-item" t-if="channel.forum_id">
+            <li class="nav-item" t-if="not invite_preview and (channel.is_member or channel.visibility == 'public') and channel.forum_id">
                 <a t-att-href="'/forum/%s' % (slug(channel.forum_id))"
                     t-att-class="'nav-link'" target="new">Forum</a>
             </li>
@@ -12,7 +12,7 @@
 
     <template id="slide_fullscreen" inherit_id="website_slides.slide_fullscreen">
         <xpath expr="//a[hasclass('o_wslides_fs_review')]" position="after">
-            <a t-if="slide.channel_id.forum_id" id="fullscreen_forum_button"
+            <a t-if="(channel.is_member or channel.visibility == 'public') and slide.channel_id.forum_id" id="fullscreen_forum_button"
                 class="d-flex align-items-center px-3" t-attf-href="/forum/#{slug(slide.channel_id.forum_id)}"
                 target="new" title="Forum">
                 <i class="fa fa-comments"/><span class="ms-1 d-none d-md-inline-block">Forum</span>

--- a/addons/website_slides_survey/views/slide_channel_views.xml
+++ b/addons/website_slides_survey/views/slide_channel_views.xml
@@ -5,7 +5,7 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.view_slide_channel_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//span[@name='members_done_count_label']" position="replace">
+            <xpath expr="//span[@name='members_completed_count_label']" position="replace">
                 <field  name="nbr_certification" invisible="1"/>
                 <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '>', 0)]}">Finished</span>
                 <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '=', 0)]}">Certified</span>


### PR DESCRIPTION
…urse.

RATIONALE

Improve and make easier the invitations on courses, whatever the enroll policy.
The goal is to increase the number of attendees easily

PREVIOUS BEHAVIOUR

Before this commit, the attendees of a course were always enrolled.
No distinction existed. Inviting partners meant enrolling them at once, even if
they did not want to join. Also, invitations to a 'members only'-visibility
course were a problem since the invited member could not reach the course page
if not logged in. Therefore the invitation link in invitation mail was often
not usable (403 error). The invitation link did not act as a user creation link
if the partner was not linked to any user

PURPOSE OF THIS COMMIT

After this commit, attendees to a course can either be enrolled (default behavior)
or have pending invitation, allowing to preview the course before joining it.
Also, the invitation links redirect the partner according to their (potential)
linked user, their log in status and the ACL's. All course completion and
invitation status are covered by the new member_status selection field for attendees:
- 'invited' : member with pending invitation
- 'joined' : enrolled member, not started
- 'ongoing' : enrolled member, started but never finished
- 'completed' : enrolled member who completed the course

A) INVITATIONS: ADD ATTENDEES and INVITE

The way to add and invite attendees to a course attendees in now centralized in
two options, the buttons for which being added on the course forms / kanban cards
dot menu. On the attendee list view coming from a course, only the [NEW] button
is shown (= ADD ATTENDEES). Using the buttons will open the invite wizard. (the
same one, the difference being the value of the new boolean enroll_mode)

In both cases, when sending a link to a given partner, it will contain both a hash
based on the couple (partner_id, channel_id) and the value of partner_id. This will
allow giving access to the invited partner even if not logged in and for all visibilities

    1) INVITE: copy the course link OR add partners as 'invited' + send them an email

    This new option is meant for promotional purposes. It will give a preview access
    to potential new members, but will not add them as enrolled. It will send an
    email to partners not already in the active attendees, to invite them to check
    the course

    Clicking the invitation link will lead them on the course page, where a [BANNER]
    will explicitely ask the invited partner to LOG IN or to SIGN UP depending on
    them having a user or not, and explain them that they must first be logged to
    access previews and join / buy the course. Before that, they can only see a
    [PREVIEW] of the course: browse the list of contents (i.e. categories are available),
    to allow them to see whether the course is of interest (forum / reviews are hidden
    too). If they are logged, or once they are logged, they will see the course as if
    it were public, no matter its visibility. (they can join - buy - browse previews)

        [LOG IN / SIGN UP] links (see /identify route): they will bypass the value of
        the 'Free Sign Up' setting and route will 1) check the invitation values
        (hash, partner_id), and that there exists a matching attendee for the current
        course. 2) prepare the signup / login. This prevents the invited partner from
        being locked outside of the course, not being able to join it (as not able to
        create user)

        ENROLL policies:
        -> 'on invite': inviting is considered as granting access. The partner will
            not have to ask for access again, but will be able to join in directly.
        -> 'on payment': users will NOT be able to join the course without buying it.
            The buy button on the course page will be replace by [LOG IN / SIGN UP].
            We do not want them to buy a course and potentially be locked out.
            (further work should deal with the generic case of this issue.)

    2) ADD ATTENDEES: add partners as 'joined' and send them an email

    This option is the same as what existed before: partners are added as enrolled
    attendees and invited by email. When they click on the link, they will be able
    to create an account if they do not have a user, or to log in if they have one,
    whatever the visibility, BEFORE being redirected to the course. They are enrolled,
    so they need to log in in order to use the course. 'invited' members will also be
    enrolled and upgraded to 'joined' and sent a joining email.

    3) About (archived) ATTENDEES and COMPLETION:

    (From task 2199207 on, attendees are now archived instead of deleted, in order to
    keep track of progression. Status and completion updates must be dealt with when
    using invitation / adding attendees)

    Now, [ONCE 'COMPLETED', ATTENDEES REMAIN SO], whatever slides they mark as
    uncompleted / completed or is created / archived on the course. Karma for
    finishing the course is won only once. test_attendee_course_completion_values
    is added. Even archived, we never recompute completion (remains 100) and status
    of 'completed' members. The same is true for 'invited' members, we do not make
    any update. This means that archived 'invited' members can have positive completion.

    In addition to the obvious (recompute status and completion when completing a slide
    as 'joined' or 'ongoing'), we only recompute member_status and completion when
    enrolling an attendee as 'joined', in the method _action_add_members with
    member_status = 'joined'. We explicitely recompute the values then. This happens
    on joining (possibly from an 'invited' state), on adding members as 'joined', or
    when unarchiving a record at least 'joined'.

        3.1) Archived with progress:

        When inviting an archived member with progress, we set their member_status
        to 'invited', and unarchive them. It means that completion could be > 0 for
        active (or inactive) 'invited' members. When enrolling them, we set them to
        'joined' but we need to recompute their completion to update the completion
        value (there may have been changes in the contents) and their member_status
        accordingly.

        3.2) Archived as 'invited' (no progress):

        When inviting them, we simply unarchive them. When enrolling them, they are
        unarchived and set to 'joined', status and completion being then recomputed.

        3.3) A complex and full example.

        Attendee A completed the course C, having 4 contents. member_status is
        'completed' and completion = 100. Then A leaves the course and is archived.
        Later, C gets 1 more content. The member_status and completion do not change.
        A is invited. Its member_status is now 'invited', and completion 100. 3 contents
        are archived. Again, values do not change. A clicks the link and enrolls. It
        is added as 'joined' and _recompute_completion is called. completion is set
        to 50% and status to 'ongoing'. As the completion was 100 but is not anymore,
        the karma for completing the course is lost. They see the new slide and are
        set to completion = 100 and 'completed', winning the course karma back.

B) ACCESS RIGHTS UPDATES

    1) PREVIEW:
    In order to give access to 'members only' courses even without logging in, we
    use the url parameters invite_hash and partner_id. They can access as sudo the
    course but _can_publish and _can_upload stay False. Categories can also be clicked.
    No slides are accessible, only the course page, checking the access values each time
    the channel route changes. See _get_channel_values_from_invite for all the checks on
    the direct invitation parameters invite_partner_id and invite_hash)

    The breadcrumbs and routes are updated to use channel_id instead of slug (since it
    would lead to a 403 error) The course_id routes should only be used in the context of
    an invitation. (generic or direct). Also, the main channel route now checks the access
    rights to the course and redirect to /slides if the access is not granted, useful for
    the generic invitation.

    2) ACLS
    - Slides: invited members to 'members only' courses now have the same access as
    anyone for public courses: previews and categories, once logged in.
    - Course: invited members have access to the course
    - Self-enroll: 'invited' member can self-enroll to 'on invite' courses, this is done
    with a sudo on the /join route.

    3) About ARCHIVED ATTENDEES. [FIX] (tests included)

    (*) In task 2199207, the ACL's were not updated to prevent archived members to have the
    same rights as if they were active. This is because the active value is not tested by
    default in rules. It is done by changing partner_ids into a computed field search method.

C) MODELS

    1) SLIDE.CHANNEL.PARTNER
    - new: invitation_link computed field. It generates invite_hash with course and
    partner_id and contains invite_partner_id as well, used for verifications.
    - recompute_completion will always recompute the completion %. However, member_status
    will only be updated if not currently 'invited' and currently active. One should write
    'joined' on attendees before in order to see the status of an 'invited' member updated.

    2) SLIDE.CHANNEL
    - channel_partner_ids / partner_ids keep the meaning of enrolled attendees/partners.
    partner_ids is now replaced with a compute field, and channel_partner_ids has a
    domain on member_status. search method is implemented (*)
    - new: channel_partner_all_ids / partner_all_ids also includes invited attendees /
    partners. partner_all_ids is also a computed field. search is implemented (*)
    - new: is_member / is_member_invited are computed fields to indicate the current
    user's membership status to the course

    - _action_add_member is removed and _action_add_members now centralizes the logic of
    adding an attendee. It will now return all NEW ACTIVE MEMBERS for the given status.
    The ones unarchived, the ones created, and the ones enrolling from 'invited' state
    for parameter = 'joined'. Therefore, reinvitation of 'invited' members in dealt with
    in action_invite in slide.channel.invite model as they will not be returned.

    3) RES.PARTNER
    As a rule of thumb, the fields and display are the same as before. They cover the
    courses partner is enrolled to. Changes are done to ease the search on partners:
    - slide_channel_ids keeps the same meaning: the courses the partner is enrolled to.
    It is changed to a compute field since we do not want to consider 'invited'
    members. search method is implemented
    - new slide_channel_all_ids contains all the courses: the ones the partner is
    invited to or enrolled in
    - Most compute methods are centralized in a single method and read_group is used.

D) VIEWS AND OTHER MAIN CHANGES

INVITE WIZARD
    - As a course can be only shared via its generic link, the invite wizard now has
    a [TOGGLE] 'send_email' that is visible for public courses and allow to either
    copy and share the generic link, or, if toggled, show and use the email composer.
    - if course is not published, a warning alert message is shown at the top. In
    order to have a clean UI, the form is restructured using a sheet
    - The course field is now hidden and is directly shown in the title of the wizard

ATTENDEE LIST VIEW
    - [NEW] button when coming from a course (i.e. not for reporting), acting as the
      [ADD ATTENDEES] button
    - new columns

OTHER VIEWS
    - Pivot and graph reporting views are added. A default member_status groupby too,
    on all reporting views. The % of completed slides is not used as measure on pivot
    view. However, it is on the graph view to compare completion of different members
    easily. Avg is used as an operator, as sum of percentages does not mean much here
    - Attendees kanban view update and new filters / group by's
    - Quicksearch 'Tags' and 'Responsible' on slide.channel model

MISC
    - Use 'course' instead of 'channel' in readable labels
    - Use 'attendee' instead of 'member' in readable labels

MISC
    - Use 'course' instead of 'channel' in readable labels
    - Use 'attendee' instead of 'member' in readable labels
    - Error mgmt: clicking the invitation link may lead to an error, as well as
    accessing a course without the rights. The user will be redirected to the main
    /slides page with the appropriate error message
    - Add a new template similar to the one used to join a course, but for the
    invitation action
    - New template for the popup appearing when joining a course. (Login or Signup)
    - Use fstrings and t-attf when possible
    - Use native js instead of jquery
    - New placeholder if no contents on course page in the front-end
    - Markup is used when possible

E) Invitation Expiration

As the invitation could be used as a promotion tool, there may be a lot of records
created as 'invited'. In order to monitor that number, we use a garbage collector.
It will remove attendees as 'invited', active or not, with completion = 0 and invited
for the last time at least THREE MONTHS before (at least invited once). Also, an
invitation older than 3 months will become expired and will not grant access.

In order to track the invitation dates, a new field last_invitation_date is added to
the slide.channel.partner model. Every time one invites an attendee, it is set to the
current date. One can reinvite attendees and send them an email more than once. This
may prevent the invitation to be collected by the GC.

F) TESTS and TOURS

Extensive tests and tours are added for the different new flows coming from
this new distinction between joined and invited members, and invitation flows.
They test functionality, UI, security (access rights) and model correctness.

--- Links ---
Task-2508019
COM PR - odoo/odoo#70291
UPG PR - odoo/upgrade#2572