### PR TITLE
[FIX] point_of_sale: number popup test timeout error

### DIFF
--- a/addons/point_of_sale/static/tests/unit/test_popups.js
+++ b/addons/point_of_sale/static/tests/unit/test_popups.js
@@ -76,13 +76,13 @@ odoo.define('point_of_sale.test_popups', function(require) {
         let promResponse, userResponse;
 
         // Step: show NumberPopup and confirm with empty buffer
-        promResponse = root.showPopup('NumberPopup', {});
+        promResponse = root.showPopup('NumberPopup', { startingValue: 1 });
         await testUtils.nextTick();
         testUtils.dom.triggerEvent(root.el.querySelector('.confirm'), 'mousedown');
         await testUtils.nextTick();
         userResponse = await promResponse;
         assert.strictEqual(userResponse.confirmed, true);
-        assert.strictEqual(userResponse.payload, "");
+        assert.strictEqual(userResponse.payload, "1");
 
         // Step: show NumberPopup and cancel
         promResponse = root.showPopup('NumberPopup', {});


### PR DESCRIPTION
A fix was made in https://github.com/odoo/odoo/pull/66466 to consider
the situation where pin of employee is scanned using barcode. This
results to a change in behaviour in the NumberPopup where it no longer
accepts empty string as payload when it is confirmed. There are multiple
ways to solve this issue, and the simplest is just to adapt the test
following the behavior change. In this fix, we modify the starting
value of the popup so that when confirmed, the popup successfully
resolves.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
