### PR TITLE
[FIX] account_edi_facturx: fix filename in pdf embedding

### DIFF
--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -45,6 +45,12 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         return True if self.code == 'facturx_1_0_05' else super()._is_embedding_to_invoice_pdf_needed()
 
+    def _get_embedding_to_invoice_pdf_values(self, invoice):
+        values = super()._get_embedding_to_invoice_pdf_values(invoice)
+        if self.code == 'facturx_1_0_05':
+            values['name'] = 'factur-x.xml'
+        return values
+
     def _export_facturx(self, invoice):
 
         def format_date(dt):

--- a/addons/account_edi_facturx/tests/test_facturx.py
+++ b/addons/account_edi_facturx/tests/test_facturx.py
@@ -210,6 +210,11 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
 
         self.assert_generated_file_equal(self.invoice, self.expected_invoice_facturx_values, applied_xpath)
 
+    def test_export_pdf(self):
+        self.invoice.action_post()
+        pdf_values = self.edi_format._get_embedding_to_invoice_pdf_values(self.invoice)
+        self.assertEqual(pdf_values['name'], 'factur-x.xml')
+
     ####################################################
     # Test import
     ####################################################


### PR DESCRIPTION
When embedding to pdf, the name of the attached file should be 'factur-x.xml' (official specifications, section 6.2)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
