### PR TITLE
[13.0] Remove UserError on update of tasks

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -71,8 +71,6 @@ class AccountAnalyticLine(models.Model):
         values = super(AccountAnalyticLine, self)._timesheet_preprocess(values)
         # task implies so line (at create)
         if 'task_id' in values and not values.get('so_line') and (values.get('employee_id') or self.mapped('employee_id')):
-            if not values.get('employee_id') and len(self.mapped('employee_id')) > 1:
-                raise UserError(_('You can not modify timesheets from different employees'))
             task = self.env['project.task'].sudo().browse(values['task_id'])
             employee = self.env['hr.employee'].sudo().browse(values['employee_id']) if values.get('employee_id') else self.mapped('employee_id')
             values['so_line'] = self._timesheet_determine_sale_line(task, employee).id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Impossible to edit task_id on multiple TSLines
It was introduced by 419112ec634a11bcc7c2c28b81fd27128b6d5d1e .

Current behavior before PR:

Impossible to perform a `write()` on TSLines to update the task_id.
I tested the case that should be covered by the PR listed above and it worked well without this.
Sidenote, it would be cleaner to backport the actual fix that landed on V14.0. I can open an OPW to give you the time to check this.

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr