### PR TITLE
[FIX] account: keep write off sign consistent

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -711,9 +711,9 @@ class AccountPayment(models.Model):
                 writeoff_amount = sum(writeoff_lines.mapped('amount_currency'))
                 counterpart_amount = counterpart_lines['amount_currency']
                 if writeoff_amount > 0.0 and counterpart_amount > 0.0:
-                    sign = 1
-                else:
                     sign = -1
+                else:
+                    sign = 1
 
                 write_off_line_vals = {
                     'name': writeoff_lines[0].name,

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -324,6 +324,96 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             },
         ])
 
+    def test_payment_move_sync_writeoff_sign(self):
+        copy_receivable = self.copy_account(self.company_data['default_account_receivable'])
+
+        pay_form = Form(self.env['account.payment'].with_context(default_journal_id=self.company_data['default_journal_bank'].id))
+        pay_form.amount = 50.0
+        pay_form.payment_type = 'inbound'
+        pay_form.partner_type = 'customer'
+        pay_form.destination_account_id = copy_receivable
+        payment = pay_form.save()
+
+        expected_payment_values = {
+            'amount': 50.0,
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'payment_reference': False,
+            'is_reconciled': False,
+            'currency_id': self.company_data['currency'].id,
+            'partner_id': False,
+            'destination_account_id': copy_receivable.id,
+            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+        }
+        expected_move_values = {
+            'currency_id': self.company_data['currency'].id,
+            'partner_id': False,
+        }
+        expected_liquidity_line = {
+            'debit': 50.0,
+            'credit': 0.0,
+            'amount_currency': 50.0,
+            'currency_id': self.company_data['currency'].id,
+            'account_id': self.payment_debit_account_id.id,
+        }
+        expected_counterpart_line = {
+            'debit': 0.0,
+            'credit': 50.0,
+            'amount_currency': -50.0,
+            'currency_id': self.company_data['currency'].id,
+            'account_id': self.partner_a.property_account_payable_id.id,
+        }
+
+        # ==== Edit the account.move.line ====
+
+        move_form = Form(payment.move_id)
+        with move_form.line_ids.edit(0) as line_form:
+            line_form.currency_id = self.company_data['currency']
+            line_form.amount_currency = 100.0
+        with move_form.line_ids.edit(1) as line_form:
+            line_form.currency_id = self.company_data['currency']
+            line_form.amount_currency = -75.0
+            line_form.account_id = copy_receivable
+        with move_form.line_ids.new() as line_form:
+            line_form.currency_id = self.company_data['currency']
+            line_form.amount_currency = -25.0
+            line_form.account_id = self.company_data['default_account_revenue']
+        move_form.save()
+
+        self.assertRecordValues(payment, [{
+            **expected_payment_values,
+            'amount': 100.0,
+        }])
+
+        # ==== Edit the account.payment amount ====
+
+        pay_form = Form(payment)
+        pay_form.partner_type = 'supplier'
+        pay_form.amount = 100.1
+        pay_form.partner_id = self.partner_a
+        payment = pay_form.save()
+        self.assertRecordValues(payment.line_ids.sorted('balance'), [
+            {
+                **expected_counterpart_line,
+                'debit': 0.0,
+                'credit': 75.1,
+                'amount_currency': -75.1,
+            },
+            {
+                'debit': 0.0,
+                'credit': 25.0,
+                'amount_currency': -25.0,
+                'currency_id': self.company_data['currency'].id,
+                'account_id': self.company_data['default_account_revenue'].id,
+            },
+            {
+                **expected_liquidity_line,
+                'debit': 100.1,
+                'credit': 0.0,
+                'amount_currency': 100.1,
+            },
+        ])
+
     def test_internal_transfer(self):
         copy_receivable = self.copy_account(self.company_data['default_account_receivable'])
 


### PR DESCRIPTION
Create a payment like follow:
- Payment type: receive money
- Partner type: customer
- Destination account: whatever receivable
- Amount: define an amount (i.e. 90.00)
On Save, open the draft jounral entry created.
Lower the liquidity or counterpart amount and add a writeoff
Go back to the payment, change the amount and save.

The journal entry writeoff will swap from debit to credit at every
change made to the amount. This occur also when changing currency on the
payment

opw-2475223

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
