### PR TITLE
[IMP] {hr_,sale_}timesheet,{sale_}project: improve the tasks portal

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -33,6 +33,11 @@ class TimesheetCustomerPortal(CustomerPortal):
             'task': {'input': 'task', 'label': _('Search in Task')}
         }
 
+    def _task_get_searchbar_sortings(self):
+        values = super()._task_get_searchbar_sortings()
+        values['progress'] = {'label': _('Progress'), 'order': 'progress asc'}
+        return values
+
     def _get_searchbar_groupby(self):
         return {
             'none': {'input': 'none', 'label': _('None')},

--- a/addons/hr_timesheet/views/project_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_portal_templates.xml
@@ -8,10 +8,20 @@
                 <h5 class="mt-2 mb-2">Timesheets</h5>
                 <t t-call="hr_timesheet.portal_timesheet_table"/>
             </div>
-            <t t-if="timesheets_by_subtask">
-                <t t-call="hr_timesheet.portal_subtask_timesheet_tables"/>
-            </t>
         </xpath>
+        <xpath expr="//div[@name='portal_my_task_planned_hours']" position="after">
+            <div t-if="task.planned_hours > 0"><strong>Progress:</strong> <span t-field="task.progress"/>%</div>
+        </xpath>
+        <xpath expr="//div[@name='portal_my_task_planned_hours']/t" position="replace">
+            <t t-call="hr_timesheet.portal_my_task_planned_hours_template"></t>
+        </xpath>
+    </template>
+
+    <template id="portal_my_task_planned_hours_template">
+        <t t-if="is_uom_day and timesheets[0]._convert_hours_to_days(task.planned_hours) > 0">
+            <strong>Planned Days:</strong> <span t-esc="timesheets[0]._convert_hours_to_days(task.planned_hours)" t-options='{"widget": "timesheet_uom"}'/>
+        </t>
+        <t t-if="not is_uom_day and task.planned_hours > 0" t-call="project.portal_my_task_planned_hours_template"></t>
     </template>
 
     <template id="portal_timesheet_table" name="Portal Timesheet Table">
@@ -38,50 +48,23 @@
                 <tr>
                     <th colspan="3"></th>
                     <th class="text-right">
-                        <t t-if="is_uom_day">
-                            Total Days: <span t-esc="timesheets._convert_hours_to_days(round(sum(timesheets.mapped('unit_amount')), 2))" t-options='{"widget": "timesheet_uom"}'/>
-                        </t>
-                        <t t-else="">
-                            Total Hours: <span t-esc="round(sum(timesheets.mapped('unit_amount')), 2)" t-options='{"widget": "float_time"}'/>
-                        </t>
+                        <t t-set="timesheets_amount" t-value="round(sum(timesheets.mapped('unit_amount')), 2) or 0.0"></t>
+                        <div t-if="is_uom_day"><strong>Days recorded:</strong> <span t-esc="timesheets._convert_hours_to_days(timesheets_amount)" t-options='{"widget": "timesheet_uom"}'/></div>
+                        <div t-else=""><strong>Hours recorded:</strong> <span t-esc="timesheets_amount" t-options='{"widget": "float_time"}'/></div>
+                        <t t-set="timesheets_by_subtask_amount" t-value="round(sum(sum(timesheet_by_subtask.mapped('unit_amount') or 0.0) for timesheet_by_subtask in timesheets_by_subtask.values()), 2) or 0.0"></t>
+                        <div t-if="timesheets_by_subtask">
+                            <div t-if="is_uom_day">Days recorded on sub-tasks: <span t-esc="timesheets._convert_hours_to_days(timesheets_by_subtask_amount)" t-options='{"widget": "timesheet_uom"}'/></div>
+                            <div t-else="">Hours recorded on sub-tasks: <span t-esc="timesheets_by_subtask_amount" t-options='{"widget": "float_time"}'/></div>
+                        </div>
+                        <t t-set="planned_time" t-value="task.planned_hours"></t>
+                        <div t-if="planned_time > 0" name="planned_time">
+                            <div t-if="is_uom_day">Remaining Days: <span t-esc="timesheets._convert_hours_to_days(planned_time - timesheets_amount - timesheets_by_subtask_amount)" t-options='{"widget": "timesheet_uom"}'/></div>
+                            <div t-else="">Remaining Hours: <span t-esc="planned_time - timesheets_amount - timesheets_by_subtask_amount" t-options='{"widget": "float_time"}'/></div>
+                        </div>
                     </th>
-                </tr>             
+                </tr>
             </tfoot>
         </table>
-    </template>
-
-    <template id="portal_subtask_timesheet_tables" name="Portal Subtask Timesheet Tables">
-        <t t-foreach="timesheets_by_subtask.values()" t-as="timesheets">
-            <t t-set="total_hours" t-value="round(sum(timesheets.mapped('unit_amount')), 2)"/>
-            <t t-if="total_hours &gt; 0">
-                <div class="container">
-                    <hr class="mt-4 mb-1"/>
-                    <h5 class="mt-2 mb-2">Timesheets for sub-task: <t t-esc="timesheets[0].task_id.name" /></h5>
-                    <table class="table table-sm">
-                        <thead>
-                          <tr>
-                            <th>Date</th>
-                            <th>Employee</th>
-                            <th>Description</th>
-                            <th class="text-right">Duration</th>
-                          </tr>
-                        </thead>
-                        <tr t-foreach="timesheets" t-as="timesheet">
-                            <td><t t-esc="timesheet.date" t-options='{"widget": "date"}'/></td>
-                            <td><t t-esc="timesheet.employee_id.name"/></td>
-                            <td><t t-esc="timesheet.name"/></td>
-                            <td class="text-right"><span t-field="timesheet.unit_amount" t-options='{"widget": "float_time"}'/></td>
-                        </tr>
-                        <tfoot>
-                            <tr>
-                                <th class="text-right" colspan="3"></th>
-                                <th class="text-right">Total Hours: <span t-esc="total_hours" t-options='{"widget": "float_time"}'/></th>
-                            </tr>             
-                        </tfoot>
-                    </table>
-                </div>
-            </t>
-        </t>
     </template>
 
 </odoo>

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -9,14 +9,13 @@ from markupsafe import Markup
 from odoo import http, _
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request
-from odoo.addons.portal.controllers import portal
-from odoo.addons.portal.controllers.portal import pager as portal_pager
+from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 from odoo.tools import groupby as groupbyelem
 
 from odoo.osv.expression import OR
 
 
-class CustomerPortal(portal.CustomerPortal):
+class ProjectCustomerPortal(CustomerPortal):
 
     def _prepare_home_portal_values(self, counters):
         values = super()._prepare_home_portal_values(counters)
@@ -94,39 +93,104 @@ class CustomerPortal(portal.CustomerPortal):
     # My Task
     # ------------------------------------------------------------
     def _task_get_page_view_values(self, task, access_token, **kwargs):
+        try:
+            project_accessible = bool(task.project_id.id and self._document_check_access('project.project', task.project_id.id))
+        except (AccessError, MissingError):
+            project_accessible = False
+
         values = {
             'page_name': 'task',
             'task': task,
-            'user': request.env.user
+            'user': request.env.user,
+            'project_accessible': project_accessible,
         }
         return self._get_page_view_values(task, access_token, values, 'my_tasks_history', False, **kwargs)
 
-    @http.route(['/my/tasks', '/my/tasks/page/<int:page>'], type='http', auth="user", website=True)
-    def portal_my_tasks(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, search=None, search_in='content', groupby=None, **kw):
-        values = self._prepare_portal_layout_values()
-        searchbar_sortings = {
+    def _task_get_searchbar_sortings(self):
+        return {
             'date': {'label': _('Newest'), 'order': 'create_date desc'},
             'name': {'label': _('Title'), 'order': 'name'},
             'stage': {'label': _('Stage'), 'order': 'stage_id, project_id'},
             'project': {'label': _('Project'), 'order': 'project_id, stage_id'},
             'update': {'label': _('Last Stage Update'), 'order': 'date_last_stage_update desc'},
+            'date_deadline': {'label': _('Deadline'), 'order': 'date_deadline asc'},
         }
+
+    def _task_get_searchbar_groupby(self):
+        values = {
+            'none': {'input': 'none', 'label': _('None'), 'order': 1},
+            'project': {'input': 'project', 'label': _('Project'), 'order': 2},
+            'stage': {'input': 'stage', 'label': _('Stage'), 'order': 3},
+            'user': {'input': 'user', 'label': _('Assigned to'), 'order': 6},
+            'customer': {'input': 'customer', 'label': _('Customer'), 'order': 7},
+        }
+        return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
+
+    def _task_get_groupby_mapping(self):
+        return {
+            'project': 'project_id',
+            'stage': 'stage_id',
+            'user': 'user_id',
+            'customer': 'partner_id',
+        }
+
+    def _task_get_order(self, order, groupby):
+        groupby_mapping = self._task_get_groupby_mapping()
+        field_name = groupby_mapping.get(groupby, '')
+        if not field_name:
+            return order
+        return '%s, %s' % (field_name, order)
+
+    def _task_get_grouped_tasks(self, groupby, tasks):
+        if groupby:
+            grouped_tasks = [request.env['project.task'].concat(*g) for k, g in groupbyelem(tasks, itemgetter(groupby))]
+        else:
+            grouped_tasks = [tasks]
+        return grouped_tasks
+
+    def _task_get_searchbar_inputs(self):
+        values = {
+            'all': {'input': 'all', 'label': _('Search in All'), 'order': 1},
+            'content': {'input': 'content', 'label': Markup(_('Search <span class="nolabel"> (in Content)</span>')), 'order': 1},
+            'ref': {'input': 'ref', 'label': _('Search in Ref'), 'order': 1},
+            'project': {'input': 'project', 'label': _('Search in Project'), 'order': 2},
+            'stage': {'input': 'stage', 'label': _('Search in Stages'), 'order': 3},
+            'user': {'input': 'user', 'label': _('Search in Assigned to'), 'order': 7},
+            'message': {'input': 'message', 'label': _('Search in Messages'), 'order': 8},
+        }
+        return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
+
+    def _task_get_search_domain(self, search_in, search):
+        search_domain = []
+        if search_in in ('content', 'all'):
+            search_domain.append([('name', 'ilike', search)])
+            search_domain.append([('description', 'ilike', search)])
+        if search_in in ('customer', 'all'):
+            search_domain.append([('partner_id', 'ilike', search)])
+        if search_in in ('message', 'all'):
+            search_domain.append([('message_ids.body', 'ilike', search)])
+        if search_in in ('stage', 'all'):
+            search_domain.append([('stage_id', 'ilike', search)])
+        if search_in in ('project', 'all'):
+            search_domain.append([('project_id', 'ilike', search)])
+        if search_in in ('ref', 'all'):
+            search_domain.append([('id', 'ilike', search)])
+        if search_in in ('user', 'all'):
+            user_ids = request.env['res.users'].sudo().search([('name', 'ilike', search)])
+            search_domain.append([('user_id', 'in', user_ids.ids)])
+        return OR(search_domain)
+
+    @http.route(['/my/tasks', '/my/tasks/page/<int:page>'], type='http', auth="user", website=True)
+    def portal_my_tasks(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, search=None, search_in='content', groupby=None, **kw):
+        values = self._prepare_portal_layout_values()
+        searchbar_sortings = self._task_get_searchbar_sortings()
+
         searchbar_filters = {
             'all': {'label': _('All'), 'domain': []},
         }
-        searchbar_inputs = {
-            'content': {'input': 'content', 'label': Markup(_('Search <span class="nolabel"> (in Content)</span>'))},
-            'message': {'input': 'message', 'label': _('Search in Messages')},
-            'customer': {'input': 'customer', 'label': _('Search in Customer')},
-            'stage': {'input': 'stage', 'label': _('Search in Stages')},
-            'project': {'input': 'project', 'label': _('Search in Project')},
-            'all': {'input': 'all', 'label': _('Search in All')},
-        }
-        searchbar_groupby = {
-            'none': {'input': 'none', 'label': _('None')},
-            'project': {'input': 'project', 'label': _('Project')},
-            'stage': {'input': 'stage', 'label': _('Stage')},
-        }
+
+        searchbar_inputs = self._task_get_searchbar_inputs()
+        searchbar_groupby = self._task_get_searchbar_groupby()
 
         # extends filterby criteria with project the customer has access to
         projects = request.env['project.project'].search([])
@@ -165,18 +229,7 @@ class CustomerPortal(portal.CustomerPortal):
 
         # search
         if search and search_in:
-            search_domain = []
-            if search_in in ('content', 'all'):
-                search_domain = OR([search_domain, ['|', ('name', 'ilike', search), ('description', 'ilike', search)]])
-            if search_in in ('customer', 'all'):
-                search_domain = OR([search_domain, [('partner_id', 'ilike', search)]])
-            if search_in in ('message', 'all'):
-                search_domain = OR([search_domain, [('message_ids.body', 'ilike', search)]])
-            if search_in in ('stage', 'all'):
-                search_domain = OR([search_domain, [('stage_id', 'ilike', search)]])
-            if search_in in ('project', 'all'):
-                search_domain = OR([search_domain, [('project_id', 'ilike', search)]])
-            domain += search_domain
+            domain += self._task_get_search_domain(search_in, search)
 
         # task count
         task_count = request.env['project.task'].search_count(domain)
@@ -189,20 +242,13 @@ class CustomerPortal(portal.CustomerPortal):
             step=self._items_per_page
         )
         # content according to pager and archive selected
-        if groupby == 'project':
-            order = "project_id, %s" % order  # force sort on project first to group by project in view
-        elif groupby == 'stage':
-            order = "stage_id, %s" % order  # force sort on stage first to group by stage in view
+        order = self._task_get_order(order, groupby)
 
         tasks = request.env['project.task'].search(domain, order=order, limit=self._items_per_page, offset=pager['offset'])
         request.session['my_tasks_history'] = tasks.ids[:100]
 
-        if groupby == 'project':
-            grouped_tasks = [request.env['project.task'].concat(*g) for k, g in groupbyelem(tasks, itemgetter('project_id'))]
-        elif groupby == 'stage':
-            grouped_tasks = [request.env['project.task'].concat(*g) for k, g in groupbyelem(tasks, itemgetter('stage_id'))]
-        else:
-            grouped_tasks = [tasks]
+        groupby_mapping = self._task_get_groupby_mapping()
+        grouped_tasks = self._task_get_grouped_tasks(groupby_mapping.get(groupby), tasks)
 
         values.update({
             'date': date_begin,

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -140,7 +140,13 @@
                                 <th t-if="groupby == 'stage'">
                                     <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in stage:</em>
                                     <span class="text-truncate" t-field="tasks[0].sudo().stage_id.name"/></th>
-                                <th t-if="groupby != 'project'" class="text-center">Project</th>
+                                <th t-if="groupby == 'user'">
+                                    <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().user_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> assigned to:</em>
+                                    <span class="text-truncate" t-field="tasks[0].sudo().user_id.name"/></th>
+                                <th t-if="groupby == 'customer'">
+                                    <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().partner_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for customer:</em>
+                                    <span class="text-truncate" t-field="tasks[0].sudo().partner_id.name"/></th>
+                                <th t-if="groupby != 'project'" class="text-center" name="portal_my_tasks_project_th">Project</th>
                                 <th t-if="groupby != 'stage'" class="text-center">Stage</th>
                             </tr>
                         </thead>
@@ -181,10 +187,12 @@
                     <div class="row no-gutters">
                         <div class="col-12">
                             <h5 class="d-flex mb-1 mb-md-0 row">
-                                <span t-field="task.name" class="col-9 text-truncate"/>
-                                <small class="text-muted d-none d-md-inline"> (#<span t-field="task.id"/>)</small>
-                                <div class="col-3 col-md-2 text-right">
-                                    <small class="text-right">Status:</small>
+                                <div class="col-9">
+                                    <span t-field="task.name" class="text-truncate"/>
+                                    <small class="text-muted d-none d-md-inline"> (#<span t-field="task.id"/>)</small>
+                                </div>
+                                <div class="col-3 text-right">
+                                    <small class="text-right">Stage:</small>
                                     <span t-field="task.stage_id.name" class=" badge badge-pill badge-info" title="Current stage of this task"/>
                                 </div>
                             </h5>
@@ -192,43 +200,47 @@
                     </div>
                 </t>
                 <t t-set="card_body">
-                    <div class="mb-1" t-if="user.partner_id.id in task.sudo().project_id.message_partner_ids.ids">
-                        <strong>Project:</strong> <a t-attf-href="/my/project/#{task.project_id.id}" t-field="task.project_id.name"/>
-                    </div>
-
-                    <div class="row mb-4">
-                        <div class="col-12 col-md-6 mb-1">
-                            <strong>Date:</strong> <span t-field="task.create_date" t-options='{"widget": "date"}'/>
-                        </div>
-                        <div class="col-12 col-md-6" t-if="task.date_deadline">
-                            <strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "date"}'/>
-                        </div>
-                    </div>
-
-                    <div class="row mb-4" t-if="task.user_id or task.partner_id">
+                    <div class="row" t-if="task.user_id or task.partner_id">
                         <div class="col-12 col-md-6 pb-2" t-if="task.user_id">
                             <strong>Assigned to</strong>
                             <div class="row">
-                                <div class="col flex-grow-0 pr-3">
+                                <div class="col d-flex align-items-center flex-grow-0 pr-3">
                                     <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(task.user_id.avatar_1024)" alt="Contact"/>
                                 </div>
                                 <div class="col pl-md-0">
-                                    <div t-field="task.user_id" t-options='{"widget": "contact", "fields": ["name", "email", "phone"]}'/>
+                                    <div t-field="task.user_id" t-options='{"widget": "contact", "fields": ["name"]}'/>
+                                    <a t-attf-href="mailto:{{task.user_id.email}}" t-if="task.user_id.email"><div t-field="task.user_id" t-options='{"widget": "contact", "fields": ["email"]}'/></a>
+                                    <a t-attf-href="tel:{{task.user_id.phone}}" t-if="task.user_id.phone"><div t-field="task.user_id" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
                                 </div>
                             </div>
                         </div>
                         <div class="coll-12 col-md-6 pb-2" t-if="task.partner_id">
-                            <strong>Reported by</strong>
+                            <strong>Customer</strong>
                             <div class="row">
-                                <div class="col flex-grow-0 pr-3">
+                                <div class="col d-flex align-items-center flex-grow-0 pr-3">
                                     <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(task.partner_id.avatar_1024)" alt="Contact"/>
                                 </div>
                                 <div class="col pl-md-0">
-                                    <div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["name", "email", "phone"]}'/>
+                                    <div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["name"]}'/>
+                                    <a t-attf-href="mailto:{{task.partner_id.email}}" t-if="task.partner_id.email"><div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["email"]}'/></a>
+                                    <a t-attf-href="tel:{{task.partner_id.phone}}" t-if="task.partner_id.phone"><div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
                                 </div>
                             </div>
                         </div>
                     </div>
+
+                    <div class="row mb-4">
+                        <div class="col-12 col-md-6">
+                            <div t-if="project_accessible"><strong>Project:</strong> <a t-attf-href="/my/project/#{task.project_id.id}" t-field="task.project_id"/></div>
+                            <div t-else=""><strong>Project:</strong> <a t-field="task.project_id"/></div>
+                            <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "date"}'/></div>
+                            <div name="portal_my_task_planned_hours">
+                                <t t-call="project.portal_my_task_planned_hours_template"/>
+                            </div>
+                        </div>
+                        <div class="col-12 col-md-6" name="portal_my_task_second_column"></div>
+                    </div>
+
                     <div class="row" t-if="task.description or task.attachment_ids">
                         <div t-if="task.description" t-attf-class="col-12 col-lg-7 mb-4 mb-md-0 {{'col-lg-7' if task.attachment_ids else 'col-lg-12'}}">
                             <hr class="mb-1"/>
@@ -265,5 +277,9 @@
                 </t>
             </div>
         </t>
+    </template>
+
+    <template id="portal_my_task_planned_hours_template">
+        <strong>Planned Hours:</strong> <span t-esc="task.planned_hours" t-options='{"widget": "float_time"}'/>
     </template>
 </odoo>

--- a/addons/sale_project/controllers/__init__.py
+++ b/addons/sale_project/controllers/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import controllers
+from . import portal

--- a/addons/sale_project/controllers/portal.py
+++ b/addons/sale_project/controllers/portal.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from operator import itemgetter
+
+from odoo import _
+from odoo.http import request
+from odoo.tools import groupby as groupbyelem
+
+from odoo.osv.expression import OR
+
+from odoo.addons.project.controllers.portal import ProjectCustomerPortal
+
+
+class SaleProjectCustomerPortal(ProjectCustomerPortal):
+
+    def _task_get_searchbar_groupby(self):
+        values = super()._task_get_searchbar_groupby()
+        values['sale_order'] = {'input': 'sale_order', 'label': _('Sales Order'), 'order': 4}
+        values['sale_line'] = {'input': 'sale_line', 'label': _('Sales Order Item'), 'order': 5}
+        return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
+
+    def _task_get_groupby_mapping(self):
+        groupby_mapping = super()._task_get_groupby_mapping()
+        groupby_mapping.update(sale_order='sale_order_id', sale_line='sale_line_id')
+        return groupby_mapping
+
+    def _task_get_grouped_tasks(self, groupby, tasks):
+        if groupby:
+            grouped_tasks = [request.env['project.task'].concat(*g) for k, g in groupbyelem(tasks, itemgetter(groupby))]
+        else:
+            grouped_tasks = super()._task_get_grouped_tasks(groupby, tasks)
+        return grouped_tasks
+
+    def _task_get_searchbar_inputs(self):
+        values = super()._task_get_searchbar_inputs()
+        values['sale_order'] = {'input': 'sale_order', 'label': _('Search in Sales Order'), 'order': 4}
+        values['sale_line'] = {'input': 'sale_line', 'label': _('Search in Sales Order Item'), 'order': 5}
+        values['invoice'] = {'input': 'invoice', 'label': _('Search in Invoice'), 'order': 6}
+        return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
+
+    def _task_get_search_domain(self, search_in, search):
+        search_domain = [super()._task_get_search_domain(search_in, search)]
+        if search_in in ('sale_order', 'all'):
+            search_domain.append([('sale_order_id.name', 'ilike', search)])
+        if search_in in ('sale_line', 'all'):
+            search_domain.append([('sale_line_id.name', 'ilike', search)])
+        if search_in in ('invoice', 'all'):
+            search_domain.append([('sale_order_id.invoice_ids.name', 'ilike', search)])
+        return OR(search_domain)

--- a/addons/sale_project/views/sale_project_portal_templates.xml
+++ b/addons/sale_project/views/sale_project_portal_templates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="portal_my_tasks_inherit" inherit_id="project.portal_my_tasks">
+        <xpath expr="//t[@t-call='portal.portal_table']//thead/tr/th[@name='portal_my_tasks_project_th']" position="before">
+            <th t-if="groupby == 'sale_order'">
+                <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().sale_order_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order:</em>
+                <span class="text-truncate" t-field="tasks[0].sudo().sale_order_id"/></th>
+            <th t-if="groupby == 'sale_line'">
+                <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().sale_line_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order item:</em>
+                <span class="text-truncate" t-field="tasks[0].sudo().sale_line_id"/></th>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -98,4 +98,38 @@
         </xpath>
     </template>
 
+    <template id="portal_my_task_inherit" inherit_id="project.portal_my_task">
+        <xpath expr="//div[@name='portal_my_task_second_column']" position="inside">
+            <t t-if="task.project_id.allow_billable">
+                <div t-if="task.sale_order_id"><strong>Sales Order:</strong>
+                    <span t-if="so_accessible"><a t-attf-href="/my/orders/{{ task.sale_order_id.id }}" t-field="task.sale_order_id"></a></span>
+                    <span t-else="" t-field="task.sale_order_id"></span>
+                </div>
+                <div t-if="task.sale_order_id.invoice_ids"><strong>Invoices:</strong>
+                    <span t-foreach="task.sale_order_id.invoice_ids" t-as="invoice_line">
+                        <t t-if="invoice_line.id in invoices_accessible">
+                            <a t-attf-href="/my/invoices/{{ invoice_line.id }}" t-esc="invoice_line.name"></a><span t-if="not invoice_line_last">,</span>
+                        </t>
+                        <t t-else=""><span t-esc="invoice_line.name"></span><span t-if="not invoice_line_last">,</span></t>
+                    </span>
+                </div>
+                <div t-if="task.sale_line_id.untaxed_amount_invoiced > 0"><strong>Invoiced:</strong>
+                    <span t-field="task.sale_line_id.untaxed_amount_invoiced"/>
+                </div>
+                <div t-if="task.sale_line_id.untaxed_amount_to_invoice > 0"><strong>To invoice:</strong>
+                    <span t-field="task.sale_line_id.untaxed_amount_to_invoice"/>
+                </div>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="portal_timesheet_table_inherit" inherit_id="hr_timesheet.portal_timesheet_table">
+        <xpath expr="//div[@name='planned_time']" position="after">
+            <span t-if="task.allow_billable and task.sale_line_id">
+                <div t-if="is_uom_day">Remaining Days on SO: <span t-esc="timesheets._convert_hours_to_days(task.remaining_hours_so)" t-options='{"widget": "timesheet_uom"}'/></div>
+                <div t-else="">Remaining Hours on SO: <span t-esc="task.remaining_hours_so" t-options='{"widget": "float_time"}'/></div>
+            </span>
+        </xpath>
+    </template>
+
 </odoo>


### PR DESCRIPTION
Generic UX improvements for the task portal.
Added new sort by, group by and searches options in the tasks portal. Some options have been renamed, the style has been slightly revised.
The timesheet details of each sub-task from the parent form view has also been removed.

task-2508883
See upgrade https://github.com/odoo/upgrade/pull/2580
Related PR: https://github.com/odoo/odoo/pull/71753

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
