### PR TITLE
[FIX] mail: Allow to navigate quickly among the different attachments

### DIFF
--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -160,7 +160,7 @@ class AttachmentViewer extends Component {
         const image = refs[`image_${this.attachmentViewer.attachment.id}`];
         if (
             this.attachmentViewer.attachment.fileType === 'image' &&
-            !image.complete
+            (!image || !image.complete)
         ) {
             this.attachmentViewer.update({ isImageLoading: true });
         }


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Create a record and add two attachments
    2. Navigate quickly between these attachments
   
You can use the original ticket to try, I added two images in the chatter
https://www.odoo.com/web#id=2521901&action=3531&model=project.task&view_type=form&cids=1&menu_id=4720

What is currently happening ?

    Traceback
    TypeError: Cannot read property 'complete' of undefined
        at AttachmentViewer._handleImageLoad (https://www.odoo.com/mail/static/src/components/attachment_viewer/attachment_viewer.js:163:20)

opw-2521901
