### PR TITLE
[FIX] mail: allow duplicate records with alias for non-admin

### DIFF
--- a/addons/mail/models/mail_alias_mixin.py
+++ b/addons/mail/models/mail_alias_mixin.py
@@ -16,7 +16,7 @@ class AliasMixin(models.AbstractModel):
     _name = 'mail.alias.mixin'
     _inherits = {'mail.alias': 'alias_id'}
     _description = 'Email Aliases Mixin'
-    ALIAS_WRITEABLE_FIELDS = ['alias_name', 'alias_contact', 'alias_defaults']
+    ALIAS_WRITEABLE_FIELDS = ['alias_name', 'alias_contact', 'alias_defaults', 'alias_bounced_content']
 
     alias_id = fields.Many2one('mail.alias', string='Alias', ondelete="restrict", required=True)
 

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -170,6 +170,23 @@ class TestMailAlias(TestMailCommon):
         with self.assertRaises(exceptions.UserError), self.cr.savepoint():
             self.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', new_mail_alias.alias_name)
 
+    def test_alias_mixin_copy(self):
+        user_demo = self.env.ref('base.user_demo')
+        self.assertFalse(user_demo.has_group('base.group_system'), 'Demo user is not supposed to have Administrator access')
+        self._test_alias_mixin_copy(user_demo, 'alias.test1', False)
+        self._test_alias_mixin_copy(user_demo, 'alias.test2', '<p>What Is Dead May Never Die</p>')
+
+    def _test_alias_mixin_copy(self, user, alias_name, alias_bounced_content):
+        record = self.env['mail.test.container'].with_user(user).with_context(lang='en_US').create({
+            'name': 'Test Record',
+            'alias_name': alias_name,
+            'alias_contact': 'followers',
+            'alias_bounced_content': alias_bounced_content,
+        })
+        self.assertEqual(record.alias_bounced_content, alias_bounced_content)
+        record_copy = record.copy()
+        self.assertEqual(record_copy.alias_bounced_content, alias_bounced_content)
+
 
 @tagged('mail_gateway')
 class TestMailgateway(TestMailCommon):


### PR DESCRIPTION
ALIAS_WRITEABLE_FIELDS is used to write alias fields with sudo

Steps to reproduce:

1. Create a user
1.1. Give rights Services -> Project-> Administartor
1.2. Not given rights Administration-> administartor
2. Project app -> open any project -> Action -> duplicate -> it give validation error.

---

opw-2506566

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
