### PR TITLE
Master website slides disable set done

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -922,10 +922,23 @@ class WebsiteSlides(WebsiteProfile):
                 'comment': answer['comment']
             }) for answer in answer_ids]
         })
-        return request.env.ref('website_slides.lesson_content_quiz_question')._render({
-            'slide': slide,
-            'question': slide_question,
-        })
+        # along with the rendered question, we provide minimal details needed to immediately display the
+        # validation buttons after question is added
+        channel_slides_ids = slide.channel_id.slide_content_ids.ids
+        slide_index = channel_slides_ids.index(slide.id)
+        next_slide = slide.channel_id.slide_content_ids[slide_index+1] if slide_index < len(channel_slides_ids) - 1 else None
+        return {
+            'quiz_info': self._get_slide_quiz_partner_info(slide),
+            'slide_info': {
+                'channelCanUpload': slide.channel_id.can_upload,
+                'hasNext': 1 if next_slide else 0,
+                'nextSlideUrl': '/slides/slide/%s' % (slug(next_slide)) if next_slide else None,
+            },
+            'renderedQuestion': request.env.ref('website_slides.lesson_content_quiz_question')._render({
+                'slide': slide,
+                'question': slide_question,
+            })
+        }
 
     @http.route('/slides/slide/quiz/get', type="json", auth="public", website=True)
     def slide_quiz_get(self, slide_id):

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -451,7 +451,11 @@ odoo.define('website_slides.quiz', function (require) {
                     slide_id: this.slide.id
                 }
             }).then(function () {
-                window.location.reload();
+                // While resetting the quiz, remove 'quiz_quick_create' query params to
+                // disable adding new question
+                let url = new URL(window.location.href);
+                url.searchParams.delete('quiz_quick_create');
+                window.location.href = url.href;
             });
         },
         /**

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -554,6 +554,7 @@ odoo.define('website_slides.quiz', function (require) {
          * Displays the created Question at the correct place (after the last question or
          * at the first place if there is no questions yet) It also displays the 'Add Question'
          * button or open a new QuestionFormWidget if the user wants to immediately add another one.
+         * If needed, it also disables the 'Set Done' button for the slide.
          *
          * @param event
          * @private
@@ -564,6 +565,7 @@ odoo.define('website_slides.quiz', function (require) {
                 $lastQuestion.after(event.data.newQuestionRenderedTemplate);
             } else {
                 this.$el.prepend(event.data.newQuestionRenderedTemplate);
+                this.trigger_up('slide_disable_setdone');
             }
             this.quiz.questionsCount++;
             event.data.questionFormWidget.destroy();
@@ -679,6 +681,7 @@ odoo.define('website_slides.quiz', function (require) {
         custom_events: {
             slide_go_next: '_onQuizNextSlide',
             slide_completed: '_onQuizCompleted',
+            slide_disable_setdone: '_onDisableSetdone',
         },
 
         //----------------------------------------------------------------------
@@ -712,6 +715,18 @@ odoo.define('website_slides.quiz', function (require) {
         //----------------------------------------------------------------------
         // Handlers
         //---------------------------------------------------------------------
+        /**
+         * When first question for the quiz is added, 'Set Done' button should be disabled
+         *
+         * @private
+         */
+        _onDisableSetdone: function () {
+            let setDoneBtn = this.el.querySelector('a.o_wslides_set_done');
+            if (setDoneBtn && !setDoneBtn.classList.contains('disabled')) {
+                setDoneBtn.classList.add('disabled');
+                setDoneBtn.setAttribute('href', '#');
+            }
+        },
         _onQuizCompleted: function (ev) {
             var slide = ev.data.slide;
             var completion = ev.data.completion;

--- a/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
@@ -157,17 +157,21 @@ var QuestionFormWidget = publicWidget.Widget.extend({
             this._rpc({
                 route: '/slides/slide/quiz/question_add_or_update',
                 params: values
-            }).then(function (renderedQuestion) {
+            }).then(function (result) {
                 if (options.update) {
                     self.trigger_up('display_updated_question', {
-                        newQuestionRenderedTemplate: renderedQuestion,
+                        newQuestionRenderedTemplate: result.renderedQuestion,
                         $editedQuestion: self.$editedQuestion,
+                        quiz_info: result.quiz_info,
+                        slide_info: result.slide_info,
                         questionFormWidget: self,
                     });
                 } else {
                     self.trigger_up('display_created_question', {
-                        newQuestionRenderedTemplate: renderedQuestion,
-                        questionFormWidget: self
+                        newQuestionRenderedTemplate: result.renderedQuestion,
+                        quiz_info: result.quiz_info,
+                        slide_info: result.slide_info,
+                        questionFormWidget: self,
                     });
                 }
             });

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -232,7 +232,7 @@
                     <i class="fa fa-chevron-left mr-2"></i> <span class="d-none d-sm-inline-block">Prev</span>
                 </a>
                 <t t-set="allow_done_btn" t-value="slide.slide_type in ['infographic', 'presentation', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
-                <a t-att-class="'btn btn-primary border text-white %s' % ('disabled' if not allow_done_btn else '')"
+                <a t-att-class="'btn btn-primary border text-white o_wslides_set_done %s' % ('disabled' if not allow_done_btn else '')"
                     role="button" t-att-aria-disabled="'true' if not allow_done_btn else None"
                     t-att-href="'/slides/slide/%s/set_completed?%s' % (slide.id, 'next_slide_id=%s' % (next_slide.id) if next_slide else '') if allow_done_btn else '#'">
                     Set Done


### PR DESCRIPTION
Purpose
when the user clicks on add quiz, the 'Set Done' button should be disabled for fixing the traceback triggered.

Specification
Before adding the first question, the 'set done' button is enabled because we haven't added any questions. after adding the question the 'Set Done' button is disabled from the front-end side. But after we add a question, this button can still be enabled because we do not reload the page during the process. In this case, if the user clicks on the 'Set Done' button, it leads to traceback. then we fix this issue by disabling the 'set done' button

to Be
immediately disable the 'Set Done' button after the first question is added from the front-end.

Task Id - 2380233


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
