### PR TITLE
[FIX] website_event: social icons alignment fix

### DIFF
--- a/addons/website_event/static/src/scss/website_event.scss
+++ b/addons/website_event/static/src/scss/website_event.scss
@@ -30,7 +30,9 @@
 
 .o_wevent_social_link {
     $o_link_size: 3em;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     @include size($o_link_size);
     margin: 0 ($spacer * .25) ($spacer * .5) ($spacer * .25);
     line-height: $o_link_size;


### PR DESCRIPTION
A revamp of the scss of 's_share' in '14.0' has caused an issue with the
class '.o_wevent_social_link' of 'website_event', making a wrong
alignment of the social media icons used in this module, especially in
'event_templates_page_registration'.

For this reason, this commit fixes this issue by setting the display of
the '.o_wevent_social_link' class as an 'inline-flex', vertically and
horizontally centered.



--

task-1639805

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
