### PR TITLE
[FIX] account: prevent creation of JE on analytic line creation

### DIFF
--- a/addons/account/views/account_analytic_view.xml
+++ b/addons/account/views/account_analytic_view.xml
@@ -18,7 +18,7 @@
                         <group/> <!-- put Accounting group under Amount group -->
                         <group name="accounting" string="Accounting">
                             <field name="general_account_id"/>
-                            <field name="move_id"/>
+                            <field name="move_id" options="{'no_create': True}"/>
                         </group>
                     </group>
                 </data>


### PR DESCRIPTION
When the user creates a new account analytic line, he should not be able
to create a new journal item.

To reproduce the error:
(Use demo data)
1. In Settings, enable "Analytic Accounting"
2. Accounting > Configuration > Analytic Accounts > Administrative >
Cost/Revenue
3. Create a new one
4. Click on "Journal Item" list

Error: the list contains the "Create and Edit..." option. Such an action
should not be possible.

OPW-2481197

closes #69881