### PR TITLE
[FIX] point_of_sale: compute_all moved without retrocompatibility

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2006,6 +2006,23 @@ exports.Orderline = Backbone.Model.extend({
 
         return taxes;
     },
+    /**
+     * Mirror JS method of:
+     * _compute_amount in addons/account/models/account.py
+     */
+    _compute_all: function(tax, base_amount, quantity, price_exclude) {
+        return this.pos._compute_all(tax, base_amount, quantity, price_exclude)
+    },
+    /**
+     * Mirror JS method of:
+     * compute_all in addons/account/models/account.py
+     *
+     * Read comments in the python side method for more details about each sub-methods.
+     */
+    compute_all: function(taxes, price_unit, quantity, currency_rounding, handle_price_include=true) {
+        return this.pos.compute_all(taxes, price_unit, quantity, currency_rounding, handle_price_include)
+
+    },
     get_all_prices: function(){
         var self = this;
 
@@ -2064,11 +2081,11 @@ exports.Orderline = Backbone.Model.extend({
 
             if (mapped_included_taxes.length > 0) {
                 if (new_included_taxes.length > 0) {
-                    var price_without_taxes = this.compute_all(mapped_included_taxes, price, 1, order.pos.currency.rounding, true).total_excluded
-                    return this.compute_all(new_included_taxes, price_without_taxes, 1, order.pos.currency.rounding, false).total_included
+                    var price_without_taxes = this.pos.compute_all(mapped_included_taxes, price, 1, order.pos.currency.rounding, true).total_excluded
+                    return this.pos.compute_all(new_included_taxes, price_without_taxes, 1, order.pos.currency.rounding, false).total_included
                 }
                 else{
-                    return this.compute_all(mapped_included_taxes, price, 1, order.pos.currency.rounding, true).total_excluded;
+                    return this.pos.compute_all(mapped_included_taxes, price, 1, order.pos.currency.rounding, true).total_excluded;
                 }
             }
         }


### PR DESCRIPTION
We moved the function compute_all in 13.0, but didn't let it
retrocompatbile for external modules.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
