### PR TITLE
[FIX] hr_expense: Wrong journal entries

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -401,16 +401,10 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
 
     def _get_expense_account_destination(self):
         self.ensure_one()
-        account_dest = self.env['account.account']
-        if self.payment_mode == 'company_account':
-            if not self.sheet_id.bank_journal_id.payment_credit_account_id:
-                raise UserError(_("No Outstanding Payments Account found for the %s journal, please configure one.") % (self.sheet_id.bank_journal_id.name))
-            account_dest = self.sheet_id.bank_journal_id.payment_credit_account_id.id
-        else:
-            if not self.employee_id.sudo().address_home_id:
-                raise UserError(_("No Home Address found for the employee %s, please configure one.") % (self.employee_id.name))
-            partner = self.employee_id.sudo().address_home_id.with_company(self.company_id)
-            account_dest = partner.property_account_payable_id.id or partner.parent_id.property_account_payable_id.id
+        if not self.employee_id.sudo().address_home_id:
+            raise UserError(_("No Home Address found for the employee %s, please configure one.") % (self.employee_id.name))
+        partner = self.employee_id.sudo().address_home_id.with_company(self.company_id)
+        account_dest = partner.property_account_payable_id.id or partner.parent_id.property_account_payable_id.id
         return account_dest
 
     def _get_account_move_line_values(self):
@@ -550,8 +544,11 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
                 expense.sheet_id.paid_expense_sheets()
 
         # post the moves
-        for move in move_group_by_sheet.values():
-            move._post()
+        for expense in self:
+            if not expense.payment_mode == 'company_account':
+                for move in move_group_by_sheet[expense.sheet_id.id]:
+                    if move.state != 'posted':
+                        move._post()
 
         return move_group_by_sheet
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an expense E paid by the company
- Validate E and post journal entries

Bug:

Two journal entries were created:

1. Outstanding payments (debit) / Account Payable (credit) as draft instead of posted
2. Expense (debit) / Outstanding payments (credit) as posted instead of draft

opw:2510663