### PR TITLE
[IMP] web: grey out avatar of archived users/employees

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -156,10 +156,10 @@ QUnit.module('hr', {}, function () {
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), '/web/image/hr.employee.public/11/avatar_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1) > img').data('src'), '/web/image/hr.employee.public/7/avatar_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2) > img').data('src'), '/web/image/hr.employee.public/11/avatar_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3) > img').data('src'), '/web/image/hr.employee.public/23/avatar_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), '/web/image/hr.employee.public/11/avatar_128?grayscale=1');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1) > img').data('src'), '/web/image/hr.employee.public/7/avatar_128?grayscale=1');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2) > img').data('src'), '/web/image/hr.employee.public/11/avatar_128?grayscale=1');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3) > img').data('src'), '/web/image/hr.employee.public/23/avatar_128?grayscale=1');
 
         kanban.destroy();
     });

--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
@@ -46,6 +46,7 @@ QUnit.test('on leave & online', async function (assert) {
         id: 7,
         name: "Demo User",
         im_status: 'leave_online',
+        active: true,
     });
     await this.createPartnerImStatusIcon(partner);
     assert.hasClass(
@@ -68,6 +69,7 @@ QUnit.test('on leave & away', async function (assert) {
         id: 7,
         name: "Demo User",
         im_status: 'leave_away',
+        active: true,
     });
     await this.createPartnerImStatusIcon(partner);
     assert.hasClass(
@@ -90,6 +92,7 @@ QUnit.test('on leave & offline', async function (assert) {
         id: 7,
         name: "Demo User",
         im_status: 'leave_offline',
+        active: true,
     });
     await this.createPartnerImStatusIcon(partner);
     assert.hasClass(

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -7,7 +7,7 @@
                 <div class="o_Activity_sidebar">
                     <div class="o_Activity_user">
                         <t t-if="activity.assignee">
-                            <img class="o_Activity_userAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/avatar_128" t-att-alt="activity.assignee.nameOrDisplayName"/>
+                            <img class="o_Activity_userAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/avatar_128?grayscale=1" t-att-alt="activity.assignee.nameOrDisplayName"/>
                         </t>
                         <div class="o_Activity_iconContainer"
                             t-att-class="{
@@ -65,7 +65,7 @@
                                     <dt>Created</dt>
                                     <dd class="o_Activity_detailsCreation">
                                         <t t-esc="formattedCreateDatetime"/>
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar" t-attf-src="/web/image/res.users/{{ activity.creator.id }}/avatar_128" t-att-title="activity.creator.nameOrDisplayName" t-att-alt="activity.creator.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar" t-attf-src="/web/image/res.users/{{ activity.creator.id }}/avatar_128?grayscale=1" t-att-title="activity.creator.nameOrDisplayName" t-att-alt="activity.creator.nameOrDisplayName"/>
                                         <span class="o_Activity_detailsCreator">
                                             <t t-esc="activity.creator.nameOrDisplayName"/>
                                         </span>
@@ -74,7 +74,7 @@
                                 <t t-if="activity.assignee">
                                     <dt>Assigned to</dt>
                                     <dd class="o_Activity_detailsAssignation">
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/avatar_128" t-att-title="activity.assignee.nameOrDisplayName" t-att-alt="activity.assignee.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/avatar_128?grayscale=1" t-att-title="activity.assignee.nameOrDisplayName" t-att-alt="activity.assignee.nameOrDisplayName"/>
                                         <t t-esc="activity.assignee.nameOrDisplayName"/>
                                     </dd>
                                 </t>

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -1324,7 +1324,7 @@ QUnit.test('basic rendering of message', async function (assert) {
     );
     assert.strictEqual(
         message.querySelector(`:scope .o_Message_authorAvatar`).dataset.src,
-        "/web/image/res.partner/11/avatar_128",
+        "/web/image/res.partner/11/avatar_128?grayscale=1",
         "should have url of message in author avatar sidebar"
     );
     assert.strictEqual(

--- a/addons/mail/static/src/components/message/message_tests.js
+++ b/addons/mail/static/src/components/message/message_tests.js
@@ -88,7 +88,7 @@ QUnit.test('basic rendering', async function (assert) {
     );
     assert.strictEqual(
         messageEl.querySelector(`:scope .o_Message_authorAvatar`).dataset.src,
-        '/web/image/res.partner/7/avatar_128',
+        '/web/image/res.partner/7/avatar_128?grayscale=1',
         "message author avatar should GET image of the related partner"
     );
     assert.strictEqual(

--- a/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.xml
+++ b/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.xml
@@ -14,7 +14,7 @@
             t-on-click="_onClick"
             t-att-data-partner-local-id="partner ? partner.localId : undefined"
         >
-            <t t-if="partner" name="rootCondition">
+            <t t-if="partner and partner.active" name="rootCondition">
                 <t t-if="props.hasBackground">
                     <i class="o_PartnerImStatusIcon_outerBackground fa fa-circle fa-stack-1x"/>
                     <i class="o_PartnerImStatusIcon_innerBackground fa fa-circle fa-stack-1x"/>

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -373,7 +373,7 @@ function factory(dependencies) {
             if (this === this.env.messaging.partnerRoot) {
                 return '/mail/static/src/img/odoobot.png';
             }
-            return `/web/image/res.partner/${this.id}/avatar_128`;
+            return `/web/image/res.partner/${this.id}/avatar_128?grayscale=1`;
         }
 
         /**
@@ -444,9 +444,7 @@ function factory(dependencies) {
     }
 
     Partner.fields = {
-        active: attr({
-            default: true,
-        }),
+        active: attr(),
         avatarUrl: attr({
             compute: '_computeAvatarUrl',
             dependencies: [

--- a/addons/mail/static/tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/m2x_avatar_user_tests.js
@@ -113,10 +113,10 @@ QUnit.module('mail', {}, function () {
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), '/web/image/res.users/11/avatar_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1) > img').data('src'), '/web/image/res.users/7/avatar_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2) > img').data('src'), '/web/image/res.users/11/avatar_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3) > img').data('src'), '/web/image/res.users/23/avatar_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), '/web/image/res.users/11/avatar_128?grayscale=1');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1) > img').data('src'), '/web/image/res.users/7/avatar_128?grayscale=1');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2) > img').data('src'), '/web/image/res.users/11/avatar_128?grayscale=1');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3) > img').data('src'), '/web/image/res.users/23/avatar_128?grayscale=1');
 
         kanban.destroy();
     });

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -1049,7 +1049,7 @@ const Many2OneAvatar = FieldMany2One.extend({
      */
     _render() {
         const m2oAvatar = qweb.render(this._template, {
-            url: `/web/image/${this.field.relation}/${this.value.res_id}/avatar_128`,
+            url: `/web/image/${this.field.relation}/${this.value.res_id}/avatar_128?grayscale=1`,
             value: this.m2o_value,
             widget: this,
         });

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
@@ -3637,7 +3637,7 @@ QUnit.module('fields', {}, function () {
 
             assert.hasClass(form.$('.o_form_view'), 'o_form_readonly');
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Aline');
-            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128"]');
+            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
 
             await testUtils.form.clickEdit(form);
 
@@ -3645,16 +3645,16 @@ QUnit.module('fields', {}, function () {
             assert.containsOnce(form, '.o_input_dropdown');
             assert.strictEqual(form.$('.o_input_dropdown input').val(), 'Aline');
             assert.containsOnce(form, '.o_external_button');
-            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128"]');
+            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
 
             await testUtils.fields.many2one.clickOpenDropdown("user_id");
             await testUtils.fields.many2one.clickItem("user_id", "Christine");
-            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128"]');
+            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128?grayscale=1"]');
             await testUtils.form.clickSave(form);
 
             assert.hasClass(form.$('.o_form_view'), 'o_form_readonly');
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Christine');
-            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128"]');
+            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128?grayscale=1"]');
 
             await testUtils.form.clickEdit(form);
             await testUtils.fields.editAndTrigger(form.$('.o_field_many2one[name="user_id"] input'),
@@ -3697,12 +3697,12 @@ QUnit.module('fields', {}, function () {
 
             assert.hasClass(form.$('.o_form_view'), 'o_form_editable');
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Aline');
-            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128"]');
+            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
 
             await testUtils.fields.editInput(form.$('.o_field_widget[name=int_field]'), 1);
 
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Christine');
-            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128"]');
+            assert.containsOnce(form, '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128?grayscale=1"]');
 
             await testUtils.fields.editInput(form.$('.o_field_widget[name=int_field]'), 2);
 
@@ -3729,9 +3729,9 @@ QUnit.module('fields', {}, function () {
             });
 
             assert.strictEqual(list.$('.o_data_cell span').text(), 'AlineChristineAline');
-            assert.containsOnce(list.$('.o_data_cell:nth(0)'), '.o_m2o_avatar >img[data-src="/web/image/user/17/avatar_128"]');
-            assert.containsOnce(list.$('.o_data_cell:nth(1)'), '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128"]');
-            assert.containsOnce(list.$('.o_data_cell:nth(2)'), '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(0)'), '.o_m2o_avatar >img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(1)'), '.o_m2o_avatar > img[data-src="/web/image/user/19/avatar_128?grayscale=1"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(2)'), '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
             assert.containsNone(list.$('.o_data_cell:nth(3)'), '.o_m2o_avatar > img');
 
             list.destroy();
@@ -3754,10 +3754,10 @@ QUnit.module('fields', {}, function () {
             });
 
             assert.strictEqual(list.$('.o_data_cell span').text(), 'AlineChristineAline');
-            assert.containsOnce(list.$('.o_data_cell:nth(0)'), '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(0)'), '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
 
             await testUtils.dom.click(list.$('.o_data_row:first() .o_data_cell:first()'));
-            assert.containsOnce(list.$('.o_data_cell:nth(0)'), '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(0)'), '.o_m2o_avatar > img[data-src="/web/image/user/17/avatar_128?grayscale=1"]');
 
             list.destroy();
         });

--- a/odoo/addons/base/tests/test_image.py
+++ b/odoo/addons/base/tests/test_image.py
@@ -132,6 +132,12 @@ class TestImage(TransactionCase):
         image = tools.base64_to_image(tools.image_process(self.base64_1920x1080_jpeg, quality=95))
         self.assertEqual(image.size, (1920, 1080), "OK return the image")
 
+        image = tools.base64_to_image(tools.image_process(self.base64_1920x1080_jpeg, grayscale=True))
+        self.assertEqual(image.mode, 'L', "archived user avatar contains gray color")
+
+        image = tools.base64_to_image(tools.image_process(self.base64_1920x1080_jpeg, grayscale=False))
+        self.assertEqual(image.mode, 'RGB', "unarchived user avatar contains RGB color")
+
         # test that nothing happens if no operation has been requested
         # (otherwise those would raise because of wrong base64)
         self.assertEqual(tools.image_process(wrong_base64), wrong_base64)

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -4,7 +4,7 @@ import base64
 import binascii
 import io
 
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, ImageChops, ImageEnhance
 # We can preload Ico too because it is considered safe
 from PIL import IcoImagePlugin
 
@@ -261,17 +261,28 @@ class ImageProcess():
             self.operationsCount += 1
         return self
 
+    def grayscale(self):
+        if self.image:
+            self.image = ImageOps.grayscale(self.image)
+            image = ImageChops.constant(self.image, 150)
+            self.image.paste(image, mask=image)
+            self.image = ImageEnhance.Brightness(self.image).enhance(1.30)
+            self.operationsCount += 1
+        return self
 
-def image_process(base64_source, size=(0, 0), verify_resolution=False, quality=0, crop=None, colorize=False, output_format=''):
+
+def image_process(base64_source, size=(0, 0), verify_resolution=False, quality=0, crop=None, colorize=False, output_format='', grayscale=False):
     """Process the `base64_source` image by executing the given operations and
     return the result as a base64 encoded image.
     """
-    if not base64_source or ((not size or (not size[0] and not size[1])) and not verify_resolution and not quality and not crop and not colorize and not output_format):
+    if not base64_source or ((not size or (not size[0] and not size[1])) and not verify_resolution and not quality and not crop and not colorize and not output_format and not grayscale):
         # for performance: don't do anything if the image is falsy or if
         # no operations have been requested
         return base64_source
 
     image = ImageProcess(base64_source, verify_resolution)
+    if grayscale:
+        image.grayscale()
     if size:
         if crop:
             center_x = 0.5


### PR DESCRIPTION
The purpose of this commit is to let users know when
another user or employee has been archived.
This is done by differentiates the archived user or employee
by greying out the avatar of it.

TaskID-2514400