### PR TITLE
[FIX] web: setting avoid miss visual alignment on mobile

### DIFF
--- a/addons/web/static/src/scss/base_settings.scss
+++ b/addons/web/static/src/scss/base_settings.scss
@@ -57,7 +57,9 @@
             border: 0;
 
             .btn-primary, .btn-link  {
-                padding: $btn-padding-y-sm $btn-padding-x-sm;
+                @include media-breakpoint-up(md) {
+                    padding: $btn-padding-y-sm $btn-padding-x-sm;
+                }
             }
 
             .btn-link {


### PR DESCRIPTION
In the settings view, on mobile the save and the discard button are
wrapped in a dropdown.

As the save button is primary and the discard is secondary when there
are wrapped in the dropdown there are miss aligned as there padding are
not the same.

This commit, avoid to change the padding on mobile of these elements.

Steps to reproduce:
* Open Odoo (on Mobile)
* Go in Settings
* Open the dropdown => BUG

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
