### PR TITLE
[FIX] sale: fix search "invoices is not set" for sale.order

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -152,6 +152,8 @@ class SaleOrder(models.Model):
             """, (list(value),))
             so_ids = self.env.cr.fetchone()[0] or []
             return [('id', 'in', so_ids)]
+        if operator == '=' and not value:
+            return [('order_line.invoice_lines', '=', False)]
         return ['&', ('order_line.invoice_lines.invoice_id.type', 'in', ('out_invoice', 'out_refund')), ('order_line.invoice_lines.invoice_id', operator, value)]
 
     name = fields.Char(string='Order Reference', required=True, copy=False, readonly=True, states={'draft': [('readonly', False)]}, index=True, default=lambda self: _('New'))


### PR DESCRIPTION
BEFORE this commit query "invoices is not set" was tranformed to
query "order_line.invoice_lines.invoice_id is False", which doesn't make sense,
because invoice_id is required fields and hence always set. Hence, result of
the query was always empty.

AFTER: just check that there is no invoice_lines. Strictly speacking, is not the
same as checking result of compute method, but because invoice_lines are
supposed to be lines for invoices of out_* type, the result should be the same.

---

opw-2516124

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
