### PR TITLE
[FIX] account,mail: link attachment to invoice

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -22,3 +22,4 @@ from . import account_incoterms
 from . import digest
 from . import res_users
 from . import ir_actions_report
+from . import mail_thread

--- a/addons/account/models/mail_thread.py
+++ b/addons/account/models/mail_thread.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    def _message_post_process_attachments(self, attachments, attachment_ids, message_values):
+        """ This method extension ensures that, when using the "Send & Print" feature, if the user
+        adds an attachment, the latter will be linked to the record. """
+        record = self.env.context.get('attached_to')
+        # link mail.compose.message attachments to attached_to
+        if record and record._name == 'account.move':
+            message_values['model'] = record._name
+            message_values['res_id'] = record.id
+        res = super()._message_post_process_attachments(attachments, attachment_ids, message_values)
+        # link account.invoice.send attachments to attached_to
+        model = message_values['model']
+        res_id = message_values['res_id']
+        att_ids = [att[1] for att in res.get('attachment_ids') or []]
+        if att_ids and model == 'account.move':
+            filtered_attachment_ids = self.env['ir.attachment'].sudo().browse(att_ids).filtered(
+                lambda a: a.res_model in ('account.invoice.send',) and a.create_uid.id == self._uid)
+            if filtered_attachment_ids:
+                filtered_attachment_ids.write({'res_model': model, 'res_id': res_id})
+        return res

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -360,7 +360,7 @@ class MailComposer(models.TransientModel):
                     new_attach_id = self.env['ir.attachment'].browse(attach_id).copy({'res_model': self._name, 'res_id': self.id})
                     attachment_ids.append(new_attach_id.id)
                 attachment_ids.reverse()
-                mail_values['attachment_ids'] = self.env['mail.thread']._message_post_process_attachments(
+                mail_values['attachment_ids'] = self.env['mail.thread'].with_context(attached_to=record)._message_post_process_attachments(
                     mail_values.pop('attachments', []),
                     attachment_ids,
                     {'model': 'mail.message', 'res_id': 0}


### PR DESCRIPTION
When using the "Send & Print" functionality, if the user adds an
attachment, the latter won't be linked to the record.

To reproduce the error:
1. Open a posted invoice
2. Send & Print
3. Attach a file > Select a file on your device
4. Send the email

Error: The invoice's PDF is added to record's attachments, but not the
other file (from step 3).

When the module selects the attachments that need to be linked to the
invoice, it only keeps the ones currently linked to `mail.compose.message`. 
This is correct when the user creates a message directly in the chatter. 
However, when the mail is created thanks to `Send & Print` functionality, 
the attachment is linked to `account.invoice.send`.

OPW-2438457