### PR TITLE
read virtual_available in batch

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -119,16 +119,19 @@ class StockRule(models.Model):
         and cumulative description.
         """
         delay, delay_description = super()._get_lead_days(product)
+        bypass_delay_description = self.env.context.get('bypass_delay_description')
         manufacture_rule = self.filtered(lambda r: r.action == 'manufacture')
         if not manufacture_rule:
             return delay, delay_description
         manufacture_rule.ensure_one()
         manufacture_delay = product.produce_delay
         delay += manufacture_delay
-        delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Manufacturing Lead Time'), manufacture_delay, _('day(s)'))
+        if not bypass_delay_description:
+            delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Manufacturing Lead Time'), manufacture_delay, _('day(s)'))
         security_delay = manufacture_rule.picking_type_id.company_id.manufacturing_lead
         delay += security_delay
-        delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Manufacture Security Lead Time'), security_delay, _('day(s)'))
+        if not bypass_delay_description:
+            delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Manufacture Security Lead Time'), security_delay, _('day(s)'))
         return delay, delay_description
 
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -591,9 +591,7 @@ class ProductProduct(models.Model):
                 'target': 'new'}
 
     def _prepare_sellers(self, params=False):
-        # This search is made to avoid retrieving seller_ids from the cache.
-        return self.env['product.supplierinfo'].search([('product_tmpl_id', '=', self.product_tmpl_id.id),
-                                                        ('name.active', '=', True)]).sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
+        return self.seller_ids.filtered(lambda s: s.name.active).sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
 
     def _select_seller(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):
         self.ensure_one()
@@ -727,7 +725,7 @@ class ProductPackaging(models.Model):
 class SupplierInfo(models.Model):
     _name = "product.supplierinfo"
     _description = "Supplier Pricelist"
-    _order = 'sequence, min_qty desc, price'
+    _order = 'sequence, min_qty DESC, price, id'
 
     name = fields.Many2one(
         'res.partner', 'Vendor',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -110,7 +110,7 @@ class ProductTemplate(models.Model):
     packaging_ids = fields.One2many(
         'product.packaging', string="Product Packages", compute="_compute_packaging_ids", inverse="_set_packaging_ids",
         help="Gives the different ways to package the same product.")
-    seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id', 'Vendors', help="Define vendor pricelists.")
+    seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id', 'Vendors', depends_context=('company',), help="Define vendor pricelists.")
     variant_seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id')
 
     active = fields.Boolean('Active', default=True, help="If unchecked, it will allow you to hide the product without removing it.")

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -148,18 +148,21 @@ class StockRule(models.Model):
         purpose in order to indicate that those options are available.
         """
         delay, delay_description = super()._get_lead_days(product)
+        bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')
         seller = product._prepare_sellers()
         if not buy_rule or not seller:
             return delay, delay_description
         buy_rule.ensure_one()
         supplier_delay = seller[0].delay
-        if supplier_delay:
+        if supplier_delay and not bypass_delay_description:
             delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Vendor Lead Time'), supplier_delay, _('day(s)'))
         security_delay = buy_rule.picking_type_id.company_id.po_lead
-        delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Purchase Security Lead Time'), security_delay, _('day(s)'))
+        if not bypass_delay_description:
+            delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Purchase Security Lead Time'), security_delay, _('day(s)'))
         days_to_purchase = buy_rule.company_id.days_to_purchase
-        delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Days to Purchase'), days_to_purchase, _('day(s)'))
+        if not bypass_delay_description:
+            delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Days to Purchase'), days_to_purchase, _('day(s)'))
         return delay + supplier_delay + security_delay + days_to_purchase, delay_description
 
     @api.model

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -149,10 +149,11 @@ class StockRule(models.Model):
         """
         delay, delay_description = super()._get_lead_days(product)
         buy_rule = self.filtered(lambda r: r.action == 'buy')
-        if not buy_rule or not product._prepare_sellers():
+        seller = product._prepare_sellers()
+        if not buy_rule or not seller:
             return delay, delay_description
         buy_rule.ensure_one()
-        supplier_delay = product._prepare_sellers()[0].delay
+        supplier_delay = seller[0].delay
         if supplier_delay:
             delay_description += '<tr><td>%s</td><td class="text-right">+ %d %s</td></tr>' % (_('Vendor Lead Time'), supplier_delay, _('day(s)'))
         security_delay = buy_rule.picking_type_id.company_id.po_lead

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -331,7 +331,7 @@ class StockWarehouseOrderpoint(models.Model):
             product = self.env['product.product'].browse(product).with_prefetch(all_product_ids)
             warehouse = self.env['stock.warehouse'].browse(warehouse).with_prefetch(all_warehouse_ids)
             rules = product._get_rules_from_location(warehouse.lot_stock_id)
-            lead_days = rules._get_lead_days(product)[0]
+            lead_days = rules.with_context(bypass_delay_description=True)._get_lead_days(product)[0]
             pwh_per_day[(lead_days, warehouse)].append(product.id)
         for (days, warehouse), p_ids in pwh_per_day.items():
             products = self.env['product.product'].browse(p_ids)

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -319,19 +319,28 @@ class StockWarehouseOrderpoint(models.Model):
         # Recompute the forecasted quantity for missing product today but at this time
         # with their real lead days.
         key_to_remove = []
+
+        # group product by lead_days and warehouse in order to read virtual_available
+        # in batch
+        pwh_per_day = defaultdict(list)
         for (product, warehouse), quantity in to_refill.items():
             product = self.env['product.product'].browse(product)
             warehouse = self.env['stock.warehouse'].browse(warehouse)
             rules = product._get_rules_from_location(warehouse.lot_stock_id)
             lead_days = rules._get_lead_days(product)[0]
-            virtual_available = product.with_context(
+            pwh_per_day[(lead_days, warehouse)].append(product.id)
+        for (days, warehouse), p_ids in pwh_per_day.items():
+            products = self.env['product.product'].browse(p_ids)
+            qties = products.with_context(
                 warehouse=warehouse.id,
-                to_date=fields.datetime.now() + relativedelta.relativedelta(days=lead_days)
-            ).virtual_available
-            if float_compare(virtual_available, 0, precision_rounding=product.uom_id.rounding) >= 0:
-                key_to_remove.append((product.id, warehouse.id))
-            else:
-                to_refill[(product.id, warehouse.id)] = virtual_available
+                to_date=fields.datetime.now() + relativedelta.relativedelta(days=days)
+            ).read(['virtual_available'])
+            for qty in qties:
+                if float_compare(qty['virtual_available'], 0, precision_rounding=product.uom_id.rounding) >= 0:
+                    key_to_remove.append((qty['id'], warehouse.id))
+                else:
+                    to_refill[(qty['id'], warehouse.id)] = qty['virtual_available']
+
         for key in key_to_remove:
             del to_refill[key]
         if not to_refill:

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -325,7 +325,10 @@ class StockRule(models.Model):
         :rtype: tuple
         """
         delay = sum(self.filtered(lambda r: r.action in ['pull', 'pull_push']).mapped('delay'))
-        delay_description = ''.join(['<tr><td>%s %s</td><td class="text-right">+ %d %s</td></tr>' % (_('Delay on'), html_escape(rule.name), rule.delay, _('day(s)')) for rule in self if rule.action in ['pull', 'pull_push'] and rule.delay])
+        if self.env.context.get('bypass_delay_description'):
+            delay_description = ""
+        else:
+            delay_description = ''.join(['<tr><td>%s %s</td><td class="text-right">+ %d %s</td></tr>' % (_('Delay on'), html_escape(rule.name), rule.delay, _('day(s)')) for rule in self if rule.action in ['pull', 'pull_push'] and rule.delay])
         return delay, delay_description
 
 


### PR DESCRIPTION
Performance patch on replenishement menu.
Tested on a database with 50k products, the routes and locations are the default ones on a standard Stock installation.

Scenario : opening the replenishement menu

Before the patch : around 2m30sec
After the patch : 7sec

Before : 
![image](https://user-images.githubusercontent.com/12071695/117451149-6dd04480-af42-11eb-9ff0-4450196ede6f.png)

After : 
![image](https://user-images.githubusercontent.com/12071695/117451277-98ba9880-af42-11eb-81c9-96d43771cbb0.png)

Some work needs to be done on `_get_rules()` to decrease more the processing time but require a change in the method signature. This improvement will be done in the next version. 

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
