### PR TITLE
[FIX] mrp: correct report name

### DIFF
--- a/addons/mrp/report/mrp_report_views_main.xml
+++ b/addons/mrp/report/mrp_report_views_main.xml
@@ -12,12 +12,12 @@
             <field name="binding_type">report</field>
         </record>
         <record id="action_report_bom_structure" model="ir.actions.report">
-            <field name="name">BoM Structure</field>
+            <field name="name">BoM Structure &amp; Cost</field>
             <field name="model">mrp.bom</field>
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">mrp.report_bom_structure</field>
             <field name="report_file">mrp.report_bom_structure</field>
-            <field name="print_report_name">'Bom Structure - %s' % object.display_name</field>
+            <field name="print_report_name">'Bom Structure &amp; Cost - %s' % object.display_name</field>
             <field name="binding_model_id" ref="model_mrp_bom"/>
             <field name="binding_type">report</field>
         </record>


### PR DESCRIPTION
Steps:
 - BoM --> Print --> BoM Structure

Issue:
- It is actually Printing BoM Structure and Cost Report

Fix:
- Now we are using correct Report/File name

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
