### PR TITLE
[FIX] mrp: display correct uom on by products

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -436,7 +436,9 @@ class MrpByProduct(models.Model):
     product_qty = fields.Float(
         'Quantity',
         default=1.0, digits='Product Unit of Measure', required=True)
-    product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', required=True)
+    product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
+    product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', required=True,
+                                     domain="[('category_id', '=', product_uom_category_id)]")
     bom_id = fields.Many2one('mrp.bom', 'BoM', ondelete='cascade', index=True)
     allowed_operation_ids = fields.One2many('mrp.routing.workcenter', related='bom_id.operation_ids')
     operation_id = fields.Many2one(
@@ -448,14 +450,3 @@ class MrpByProduct(models.Model):
         """ Changes UoM if product_id changes. """
         if self.product_id:
             self.product_uom_id = self.product_id.uom_id.id
-
-    @api.onchange('product_uom_id')
-    def onchange_uom(self):
-        res = {}
-        if self.product_uom_id and self.product_id and self.product_uom_id.category_id != self.product_id.uom_id.category_id:
-            res['warning'] = {
-                'title': _('Warning'),
-                'message': _('The unit of measure you choose is in a different category than the product unit of measure.')
-            }
-            self.product_uom_id = self.product_id.uom_id.id
-        return res

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -17,6 +17,7 @@
                         <field name="allowed_operation_ids" invisible="1"/>
                         <field name="company_id"/>
                         <field name="product_id"/>
+                        <field name="product_uom_category_id" invisible="1"/>
                         <label for="product_qty"/>
                         <div class="o_row">
                             <field name="product_qty"/>
@@ -112,6 +113,7 @@
                             <field name="byproduct_ids"  context="{'form_view_ref' : 'mrp.mrp_bom_byproduct_form_view', 'default_company_id': company_id, 'default_bom_id': id}">
                                 <tree string="By-products"  editable="top">
                                     <field name="company_id" invisible="1"/>
+                                    <field name="product_uom_category_id" invisible="1"/>
                                     <field name="product_id" context="{'default_type': 'product'}"/>
                                     <field name="product_qty"/>
                                     <field name="product_uom_id" groups="uom.group_uom"/>


### PR DESCRIPTION
Before this commit, It was always showing all
Unit of Measures in By Product lines.

With this commit, We are showing UoMs based on Category
of Selected Product's UoM.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
