### PR TITLE
[FIX] hr_expense: Wrong tax in multi companies

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -486,10 +486,10 @@ class HrExpense(models.Model):
             'employee_id': employee.id,
             'product_id': product.id,
             'product_uom_id': product.uom_id.id,
-            'tax_ids': [(4, tax.id, False) for tax in product.supplier_taxes_id],
+            'tax_ids': [(4, tax.id, False) for tax in product.supplier_taxes_id.filtered(lambda r: r.company_id == company)],
             'quantity': 1,
             'unit_amount': price,
-            'company_id': employee.company_id.id,
+            'company_id': company.id,
             'currency_id': employee.company_id.currency_id.id,
         })
         if account:


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two companies C1 and C2 where C1 is the parent of C2
- Let's consider an expense product P with T1 as tax in C1 and T2 as tax in C2
- Let's consider an expense alias A defned for C1 and C2
- Let's consider an employee E in C2 with work email address W
- Send from W to A an email with subject [internal reference of P] Test Expense 1000€

Bug:

An expense is created in C2 with T1 and T2 as supplier taxes instead of only T2

Inspired from function _compute_tax_id defined in model sale.order and purchase.order

opw:2507162