### PR TITLE
[FIX] core: initialise registry's field_depends{_context} attributes

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -114,6 +114,8 @@ class Registry(Mapping):
         self._ordinary_tables = None
         self._constraint_queue = deque()
         self.__cache = LRU(8192)
+        self.field_depends = {}
+        self.field_depends_context = {}
 
         # modules fully loaded (maintained during init phase by `loading` module)
         self._init_modules = set()
@@ -277,7 +279,7 @@ class Registry(Mapping):
         for model in models:
             model._setup_complete()
 
-        # determine field_depends and field_depends_context
+        # reset and determine field_depends and field_depends_context
         self.field_depends = {}
         self.field_depends_context = {}
         for model in models:


### PR DESCRIPTION
Prior to this commit, it was possible to do a lookup of the Registry's
field_depends attribute before it was initialised.

This happens because when creating a new Registry, we go through
Registry.setup_models which will in turn call each model's
_setup_fields, this method may perform a lookup in the registry's
field_depends attribute if a field needs to be removed from a model
(_pop_field) which usually happens during uninstall (thus the reason why
this bug was only seen during module uninstall).

Since field_depends was being setup in Registry.setup_models but
**after** the call to BaseModel._setup_fields, this resulted in a
complete crash of the registry.

We can also safely assume that the same applies to the attribute
field_depends_context.