### PR TITLE
[FIX] point_of_sale: double dipping in COGS and stock delivered accounts

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -338,7 +338,7 @@ class PosSession(models.Model):
             session_destination_id = picking_type.default_location_dest_id.id
 
         for order in self.order_ids:
-            if order.company_id.anglo_saxon_accounting and order.to_invoice:
+            if order.company_id.anglo_saxon_accounting and order.is_invoiced:
                 continue
             destination_id = order.partner_id.property_stock_customer.id or session_destination_id
             if destination_id in lines_grouped_by_dest_location:


### PR DESCRIPTION
To reproduce:

1. Sell an anglo product (inventory valuation = automated) in the pos app.
2. Go back to the backend, find the pos.order and invoice it.
3. Close the session.
4. Open the journal items related to the session (click the Journal Items
button in the session form).
5. You will see COGS (Expenses) Account and Stock Interim (Delivered) are
debited in two journal entries - one from the invoice and one from the
created picking after the closing of session.

This is because we are not properly skipping the invoiced order when
generating the global picking for the session. This commit fixes the
described issue.

Task-id: 2452252

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
