### PR TITLE
[FIX] models: fix group by order (poc)

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2362,7 +2362,10 @@ class BaseModel(metaclass=MetaModel):
         groupby_list = groupby[:1] if lazy else groupby
         annotated_groupbys = [self._read_group_process_groupby(gb, query) for gb in groupby_list]
         groupby_fields = [g['field'] for g in annotated_groupbys]
-        order = orderby or ','.join([g for g in groupby_list])
+        order = orderby or ','.join(
+            [next((o for o in self._order.split(',') if o.split()[0] == g), g)  # find group_field in model._order or use group_field
+            for g in groupby_list]
+        )
         groupby_dict = {gb['groupby']: gb for gb in annotated_groupbys}
 
         self._apply_ir_rules(query, 'read')


### PR DESCRIPTION
Order of read_group is not using the model _order, which can make sence
since the fields used by the default order may not be used in the group by clause.
Anyway, when defining a descending order for a field, we may want to use this
order by default if the read_group is grouping on this field.

This commit proposes to try to get the defined order if there is one for each of
the grouping fields when generating the default order.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
