### PR TITLE
[FIX] hr_holidays: Leaves for partial time are wrongly counted

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -481,6 +481,8 @@ class HolidaysRequest(models.Model):
         """ Returns a float equals to the timedelta between two dates given as string."""
         if employee_id:
             employee = self.env['hr.employee'].browse(employee_id)
+            if self.request_unit_half:
+                return 0.5
             return employee.get_work_days_data(date_from, date_to)['days']
 
         today_hours = self.env.user.company_id.resource_calendar_id.get_work_hours_count(
@@ -488,7 +490,9 @@ class HolidaysRequest(models.Model):
             datetime.combine(date_from.date(), time.max),
             False)
 
-        return self.env.user.company_id.resource_calendar_id.get_work_hours_count(date_from, date_to) / (today_hours or HOURS_PER_DAY)
+        hours = self.env.user.company_id.resource_calendar_id.get_work_hours_count(date_from, date_to) / (today_hours or HOURS_PER_DAY)
+        days = hours / (today_hours or HOURS_PER_DAY) if not self.request_unit_half else 0.5
+        return days
 
     ####################################################
     # ORM Overrides methods

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -34,8 +34,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysBase):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_display, 0)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_display, 4.0)
 
     def test_single_attendance_on_morning_and_afternoon(self):
         calendar = self.env['resource.calendar'].create({
@@ -144,13 +144,13 @@ class TestAutomaticLeaveDates(TestHrHolidaysBase):
             # Ask for morning
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
             self.assertEqual(leave_form.number_of_hours_display, 8)
 
             # Ask for afternoon
             leave_form.request_date_from_period = 'pm'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
             self.assertEqual(leave_form.number_of_hours_display, 8)
 
     def test_attendance_next_day(self):
@@ -177,8 +177,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysBase):
             leave_form.request_date_from_period = 'am'
 
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_display, 0)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_display, 4.0)
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
@@ -206,7 +206,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysBase):
             leave_form.request_date_from_period = 'am'
 
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_display, 0)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_display, 4.0)
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 3, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 3, 10, 0, 0))


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an employee E that doesn't work on Monday morning
- Create a half day leave request LR for E on a Monday afternoon
- Save

Bug:

The duration of LR was counted as one day instead of 0.5

Backport of f66e083880a3e6155bd30003b247a161b24b7de9

opw:2491784