### PR TITLE
[FIX]point_of_sale : fix the access rights of the user group

### DIFF
--- a/addons/point_of_sale/security/ir.model.access.csv
+++ b/addons/point_of_sale/security/ir.model.access.csv
@@ -32,7 +32,7 @@ access_product_category_manager,product.category manager,product.model_product_c
 access_product_pricelist_manager,product.pricelist manager,product.model_product_pricelist,group_pos_manager,1,1,1,1
 access_product_pricelist_user,product.pricelist user,product.model_product_pricelist,group_pos_user,1,0,0,0
 access_pos_session_user,pos.session user,model_pos_session,group_pos_user,1,1,1,0
-access_pos_config_user,pos.config user,model_pos_config,group_pos_user,1,1,0,0
+access_pos_config_user,pos.config user,model_pos_config,group_pos_user,1,0,0,0
 access_pos_config_manager,pos.config manager,model_pos_config,group_pos_manager,1,1,1,1
 access_product_category_pos_manager,pos.category manager,model_pos_category,group_pos_manager,1,1,1,1
 access_product_category_pos_user,pos.category user,model_pos_category,group_pos_user,1,0,0,0


### PR DESCRIPTION
Steps to reproduce the bug :
- Create a new user and give him “user” access to Point of sale
- Connect with this user
- Go to point of sale > Click on any record in the view list
- The form of the POS appears, and you can edit it

Problem:
User of the "Point of Sale/user" group must have only "read" access right for "pos.config.user".

opw-2462788




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
