### PR TITLE
[IMP] base: use contextvars instead of werkzeug Locals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Babel==2.6.0
 chardet==3.0.4
+contextvars==2.4; python_version < '3.7'
 decorator==4.3.0
 docutils==0.14
 ebaysdk==2.1.5


### PR DESCRIPTION
Since version 3.7 python has a [contextvars](https://docs.python.org/3.7/library/contextvars.html) module which provides similar functionality to thread local variables.

By using it we
- use a stdlib feature and remove a dependency on werkzeug in a place where it is not necessary
- allow using the Odoo api where Odoo Environments span several threads launched from an async context (such as an ASGI server)

If this patch is accepted, I can look at doing something similar for the dbname thread local that is used in a few places.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
