### PR TITLE
[IMP] core: speed up loading of registry

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -45,10 +45,7 @@ class SequenceMixin(models.AbstractModel):
                     field=sql.Identifier(self._sequence_field),
                 ))
 
-    def __init__(self, pool, cr):
-        api.constrains(self._sequence_field, self._sequence_date_field)(type(self)._constrains_date_sequence)
-        return super().__init__(pool, cr)
-
+    @api.constrains(lambda self: (self._sequence_field, self._sequence_date_field))
     def _constrains_date_sequence(self):
         # Make it possible to bypass the constraint to allow edition of already messed up documents.
         # /!\ Do not use this to completely disable the constraint as it will make this mixin unreliable.

--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -25,10 +25,9 @@ class Users(models.Model):
     totp_secret = fields.Char(copy=False, groups=fields.NO_ACCESS)
     totp_enabled = fields.Boolean(string="Two-factor authentication", compute='_compute_totp_enabled')
 
-    def __init__(self, pool, cr):
-        init_res = super().__init__(pool, cr)
-        type(self).SELF_READABLE_FIELDS = self.SELF_READABLE_FIELDS + ['totp_enabled']
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['totp_enabled']
 
     def _mfa_url(self):
         r = super()._mfa_url()

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -24,20 +24,14 @@ class User(models.Model):
     google_calendar_sync_token = fields.Char('Next Sync Token', copy=False)
     google_calendar_cal_id = fields.Char('Calendar ID', copy=False, help='Last Calendar ID who has been synchronized. If it is changed, we remove all links between GoogleID and Odoo Google Internal ID')
     google_synchronization_stopped = fields.Boolean('Google Synchronization stopped', copy=False)
-    
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        google_calendar_fields = [
-            'google_synchronization_stopped',
-        ]
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + google_calendar_fields
-        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + google_calendar_fields
-        return init_res
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['google_synchronization_stopped']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['google_synchronization_stopped']
 
     def _set_auth_tokens(self, access_token, refresh_token, ttl):
         self.write({

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -5,6 +5,70 @@ from odoo import api, models, fields, _, SUPERUSER_ID
 from odoo.exceptions import AccessError
 
 
+HR_READABLE_FIELDS = [
+    'active',
+    'child_ids',
+    'employee_id',
+    'address_home_id',
+    'employee_ids',
+    'employee_parent_id',
+    'hr_presence_state',
+    'last_activity',
+    'last_activity_time',
+    'can_edit',
+]
+
+HR_WRITABLE_FIELDS = [
+    'additional_note',
+    'private_street',
+    'private_street2',
+    'private_city',
+    'private_state_id',
+    'private_zip',
+    'private_country_id',
+    'address_id',
+    'barcode',
+    'birthday',
+    'category_ids',
+    'children',
+    'coach_id',
+    'country_of_birth',
+    'department_id',
+    'display_name',
+    'emergency_contact',
+    'emergency_phone',
+    'employee_bank_account_id',
+    'employee_country_id',
+    'gender',
+    'identification_id',
+    'is_address_home_a_company',
+    'job_title',
+    'private_email',
+    'km_home_work',
+    'marital',
+    'mobile_phone',
+    'notes',
+    'employee_parent_id',
+    'passport_id',
+    'permit_no',
+    'employee_phone',
+    'pin',
+    'place_of_birth',
+    'spouse_birthdate',
+    'spouse_complete_name',
+    'visa_expire',
+    'visa_no',
+    'work_email',
+    'work_location_id',
+    'work_phone',
+    'certificate',
+    'study_field',
+    'study_school',
+    'private_lang',
+    'employee_type',
+]
+
+
 class User(models.Model):
     _inherit = ['res.users']
 
@@ -79,79 +143,13 @@ class User(models.Model):
         for user in self.with_context(active_test=False):
             user.employee_count = len(user.employee_ids)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        hr_readable_fields = [
-            'active',
-            'child_ids',
-            'employee_id',
-            'address_home_id',
-            'employee_ids',
-            'employee_parent_id',
-            'hr_presence_state',
-            'last_activity',
-            'last_activity_time',
-            'can_edit',
-        ]
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + HR_READABLE_FIELDS + HR_WRITABLE_FIELDS
 
-        hr_writable_fields = [
-            'additional_note',
-            'private_street',
-            'private_street2',
-            'private_city',
-            'private_state_id',
-            'private_zip',
-            'private_country_id',
-            'address_id',
-            'barcode',
-            'birthday',
-            'category_ids',
-            'children',
-            'coach_id',
-            'country_of_birth',
-            'department_id',
-            'display_name',
-            'emergency_contact',
-            'emergency_phone',
-            'employee_bank_account_id',
-            'employee_country_id',
-            'gender',
-            'identification_id',
-            'is_address_home_a_company',
-            'job_title',
-            'private_email',
-            'km_home_work',
-            'marital',
-            'mobile_phone',
-            'notes',
-            'employee_parent_id',
-            'passport_id',
-            'permit_no',
-            'employee_phone',
-            'pin',
-            'place_of_birth',
-            'spouse_birthdate',
-            'spouse_complete_name',
-            'visa_expire',
-            'visa_no',
-            'work_email',
-            'work_location_id',
-            'work_phone',
-            'certificate',
-            'study_field',
-            'study_school',
-            'private_lang',
-            'employee_type',
-        ]
-
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + hr_readable_fields + hr_writable_fields
-        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + hr_writable_fields
-        return init_res
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + HR_WRITABLE_FIELDS
 
     @api.model
     def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):

--- a/addons/hr_attendance/models/res_users.py
+++ b/addons/hr_attendance/models/res_users.py
@@ -13,18 +13,12 @@ class User(models.Model):
     last_check_in = fields.Datetime(related='employee_id.last_attendance_id.check_in')
     last_check_out = fields.Datetime(related='employee_id.last_attendance_id.check_out')
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        attendance_readable_fields = [
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + [
             'hours_last_month',
             'hours_last_month_display',
             'attendance_state',
             'last_check_in',
             'last_check_out'
         ]
-        super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + attendance_readable_fields

--- a/addons/hr_contract/models/res_users.py
+++ b/addons/hr_contract/models/res_users.py
@@ -10,16 +10,6 @@ class User(models.Model):
     vehicle = fields.Char(related="employee_id.vehicle")
     bank_account_id = fields.Many2one(related="employee_id.bank_account_id")
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        contract_readable_fields = [
-            'vehicle',
-            'bank_account_id',
-        ]
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + contract_readable_fields
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['vehicle', 'bank_account_id']

--- a/addons/hr_expense/models/hr_employee.py
+++ b/addons/hr_expense/models/hr_employee.py
@@ -46,12 +46,6 @@ class User(models.Model):
 
     expense_manager_id = fields.Many2one(related='employee_id.expense_manager_id', readonly=False)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + ['expense_manager_id']
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['expense_manager_id']

--- a/addons/hr_fleet/models/res_users.py
+++ b/addons/hr_fleet/models/res_users.py
@@ -9,15 +9,9 @@ class User(models.Model):
 
     employee_cars_count = fields.Integer(related='employee_id.employee_cars_count')
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + ['employee_cars_count']
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['employee_cars_count']
 
     def action_get_claim_report(self):
         return self.employee_id.action_get_claim_report()

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -17,13 +17,9 @@ class User(models.Model):
     allocation_display = fields.Char(related='employee_id.allocation_display')
     hr_icon_display = fields.Selection(related='employee_id.hr_icon_display')
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-
-        readable_fields = [
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + [
             'leave_manager_id',
             'show_leaves',
             'allocation_used_count',
@@ -34,10 +30,6 @@ class User(models.Model):
             'allocation_display',
             'hr_icon_display',
         ]
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + readable_fields
-        return init_res
 
     def _compute_im_status(self):
         super(User, self)._compute_im_status()

--- a/addons/hr_maintenance/models/res_users.py
+++ b/addons/hr_maintenance/models/res_users.py
@@ -7,15 +7,9 @@ class Users(models.Model):
     equipment_ids = fields.One2many('maintenance.equipment', 'owner_user_id', string="Managed Equipments")
     equipment_count = fields.Integer(related='employee_id.equipment_count', string="Assigned Equipments")
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        init_res = super(Users, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + ['equipment_count']
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['equipment_count']
 
 
 class Employee(models.Model):

--- a/addons/hr_skills/models/res_users.py
+++ b/addons/hr_skills/models/res_users.py
@@ -9,17 +9,10 @@ class User(models.Model):
     resume_line_ids = fields.One2many(related='employee_id.resume_line_ids', readonly=False)
     employee_skill_ids = fields.One2many(related='employee_id.employee_skill_ids', readonly=False)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        hr_skills_fields = [
-            'resume_line_ids',
-            'employee_skill_ids',
-        ]
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + hr_skills_fields
-        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + hr_skills_fields
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['resume_line_ids', 'employee_skill_ids']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['resume_line_ids', 'employee_skill_ids']

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -12,16 +12,10 @@ class Users(models.Model):
 
     livechat_username = fields.Char("Livechat Username", help="This username will be used as your name in the livechat channels.")
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights on livechat_username
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        init_res = super(Users, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_WRITEABLE_FIELDS = list(self.SELF_WRITEABLE_FIELDS)
-        type(self).SELF_WRITEABLE_FIELDS.extend(['livechat_username'])
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = list(self.SELF_READABLE_FIELDS)
-        type(self).SELF_READABLE_FIELDS.extend(['livechat_username'])
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['livechat_username']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['livechat_username']

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -57,19 +57,13 @@ GROUP BY channel_moderator.res_users_id""", [tuple(self.ids)])
         for user in self:
             user.moderation_counter = result.get(user.id, 0)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights on notification_email_send
-            fields. Access rights are disabled by default, but allowed on some
-            specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        init_res = super(Users, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_WRITEABLE_FIELDS = list(self.SELF_WRITEABLE_FIELDS)
-        type(self).SELF_WRITEABLE_FIELDS.extend(['notification_type'])
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = list(self.SELF_READABLE_FIELDS)
-        type(self).SELF_READABLE_FIELDS.extend(['notification_type'])
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['notification_type']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['notification_type']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -18,12 +18,6 @@ class Users(models.Model):
         ], string="OdooBot Status", readonly=True, required=False)  # keep track of the state: correspond to the code of the last message sent
     odoobot_failed = fields.Boolean(readonly=True)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        init_res = super(Users, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + ['odoobot_state']
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['odoobot_state']

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -20,19 +20,13 @@ class User(models.Model):
     microsoft_calendar_sync_token = fields.Char('Microsoft Next Sync Token', copy=False)
     microsoft_synchronization_stopped = fields.Boolean('Outlook Synchronization stopped', copy=False)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
-        microsoft_calendar_fields = [
-            'microsoft_synchronization_stopped',
-        ]
-        init_res = super(User, self).__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + microsoft_calendar_fields
-        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + microsoft_calendar_fields
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['microsoft_synchronization_stopped']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['microsoft_synchronization_stopped']
 
     def _microsoft_calendar_authenticated(self):
         return bool(self.sudo().microsoft_calendar_rtoken)

--- a/addons/sale_stock/models/res_users.py
+++ b/addons/sale_stock/models/res_users.py
@@ -16,18 +16,10 @@ class Users(models.Model):
         # be also applied in sale_stock/models/sale_order.py/_init_column.
         return self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
 
-    def __init__(self, pool, cr):
-        """ Override of __init__ to add access rights.
-            Access rights are disabled by default, but allowed
-            on some specific fields defined in self.SELF_{READ/WRITE}ABLE_FIELDS.
-        """
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['property_warehouse_id']
 
-        sale_stock_writeable_fields = [
-            'property_warehouse_id',
-        ]
-
-        init_res = super().__init__(pool, cr)
-        # duplicate list to avoid modifying the original reference
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + sale_stock_writeable_fields
-        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + sale_stock_writeable_fields
-        return init_res
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['property_warehouse_id']

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -163,7 +163,7 @@ class WebsiteProfile(http.Controller):
         else:
             user = request.env.user
         values = self._profile_edition_preprocess_values(user, **kwargs)
-        whitelisted_values = {key: values[key] for key in type(user).SELF_WRITEABLE_FIELDS if key in values}
+        whitelisted_values = {key: values[key] for key in user.SELF_WRITEABLE_FIELDS if key in values}
         user.write(whitelisted_values)
         if kwargs.get('url_param'):
             return werkzeug.utils.redirect("/profile/user/%d?%s" % (user.id, kwargs['url_param']))

--- a/addons/website_profile/models/res_users.py
+++ b/addons/website_profile/models/res_users.py
@@ -14,14 +14,15 @@ VALIDATION_KARMA_GAIN = 3
 class Users(models.Model):
     _inherit = 'res.users'
 
-    def __init__(self, pool, cr):
-        init_res = super(Users, self).__init__(pool, cr)
-        type(self).SELF_WRITEABLE_FIELDS = list(
-            set(
-                self.SELF_WRITEABLE_FIELDS +
-                ['country_id', 'city', 'website', 'website_description', 'website_published']))
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + ['karma']
-        return init_res
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ['karma']
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + [
+            'country_id', 'city', 'website', 'website_description', 'website_published',
+        ]
 
     @api.model
     def _generate_profile_token(self, user_id, email):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3086,7 +3086,7 @@ class TestSelectionOndeleteAdvanced(common.TransactionCase):
         # necessary cleanup for resetting changes in the registry
         for model_name in (self.MODEL_BASE, self.MODEL_REQUIRED):
             Model = self.registry[model_name]
-            self.addCleanup(setattr, Model, '__bases__', Model.__bases__)
+            self.addCleanup(setattr, Model, '_BaseModel__base_classes', Model._BaseModel__base_classes)
 
     def test_ondelete_unexisting_policy(self):
         class Foo(models.Model):

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -127,7 +127,12 @@ def constrains(*args):
         sure a constraint will always be triggered (e.g. to test the absence of
         value).
 
+    One may also pass a single function as argument.  In that case, the field
+    names are given by calling the function with a model instance.
+
     """
+    if args and callable(args[0]):
+        args = args[0]
     return attrsetter('_constrains', args)
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -750,9 +750,18 @@ class BaseModel(metaclass=MetaModel):
         def is_constraint(func):
             return callable(func) and hasattr(func, '_constrains')
 
+        def wrap(func, names):
+            # wrap func into a proxy function with explicit '_constrains'
+            @api.constrains(*names)
+            def wrapper(self):
+                return func(self)
+            return wrapper
+
         cls = type(self)
         methods = []
         for attr, func in getmembers(cls, is_constraint):
+            if callable(func._constrains):
+                func = wrap(func, func._constrains(self))
             for name in func._constrains:
                 field = cls._fields.get(name)
                 if not field:


### PR DESCRIPTION
The base classes of models in the registry are modified when models are extended by inheritance.  But modifying cls.__bases__ is a costly operation, so we manage to do it once per model when loading a registry.

Our benchmark consists in loading a registry with 296 modules.  The net time to load the registry is 25% smaller.  In other words, **the registry loads 25% faster**.  Note that the time does not include the time to load modules themselves, which does not change.

The other commits fix tricks with `BaseModel` method `__init__` that no longer work.