### PR TITLE
[FIX] pad: copy the pad_content_field content in pad when genrate pad url

### DIFF
--- a/addons/pad/models/pad.py
+++ b/addons/pad/models/pad.py
@@ -62,10 +62,12 @@ class PadCommon(models.AbstractModel):
             field = model._fields[self.env.context['field_name']]
             real_field = field.pad_content_field
 
+            res_id = self.env.context.get("object_id")
+            record = model.browse(res_id)
             # get content of the real field
-            for record in model.browse(self.env.context.get("object_id")):
-                    if record[real_field]:
-                        myPad.setHtmlFallbackText(path, record[real_field])
+            real_field_value = record[real_field] or self.env.context.get('record', {}).get(real_field, '')
+            if real_field_value:
+                myPad.setHtmlFallbackText(path, real_field_value)
 
         return {
             "server": pad["server"],

--- a/addons/pad/static/src/js/pad.js
+++ b/addons/pad/static/src/js/pad.js
@@ -125,7 +125,8 @@ var FieldPad = AbstractField.extend({
                 context: {
                     model: this.model,
                     field_name: this.name,
-                    object_id: this.res_id
+                    object_id: this.res_id,
+                    record: this.recordData,
                 },
             }, {
                 shadow: true

--- a/addons/pad_project/models/project.py
+++ b/addons/pad_project/models/project.py
@@ -12,6 +12,18 @@ class ProjectTask(models.Model):
     description_pad = fields.Char('Pad URL', pad_content_field='description', copy=False)
     use_pad = fields.Boolean(related="project_id.use_pads", string="Use collaborative pad", readonly=True)
 
+    @api.onchange('use_pad')
+    def _onchange_use_pads(self):
+        """ Copy the content in the pad when the user change the project of the task to the one with no pads enabled.
+
+            This case is when the use_pad becomes False and we have already generated the url pad,
+            that is the description_pad field contains the url of the pad.
+        """
+        if not self.use_pad and self.description_pad:
+            vals = {'description_pad': self.description_pad}
+            self._set_pad_to_field(vals)
+            self.description = vals['description']
+
     @api.model
     def create(self, vals):
         # When using quick create, the project_id is in the context, not in the vals


### PR DESCRIPTION
Before this commit, in Project App, when the "Collaborative Pads" is
enabled in the Settings of this app, if the user create a task without
project or in a project that has not the pad enabled and he writes a
description for his new task and select (another) project in which the
pads is enabled then the description field in the form view changed to
have the collaborative pad and the problem is the description is not
copied in the pad and seems erase/delete for the user.

This commit checks if the pad_content_field is not empty after
generating the pad url for the new task/record, if it is the case then
we copy the content in the pad and the user can continue his edition
before saving the task/record.

Step to reproduce:
-----------------

1. Go to Settings of the Project App and enable the Collaborative Pads
2. Go to the Project App, in the Projects dashboard (kanban view of projects)
3. Create two Projects (one called "Project A" and the other called "Project B")
4. Edit the Project B to activate the pad, that is, check the Use
collaborative pads checkbox.
5. Go to the view list of tasks in the "Project A"
6. Click on "Create" button to create a task in the task form view.
7. Write a description for this task.
8. Change the project of this task by the Project B. With this change,
the collaborative pad is actived for this task since the Project B has
the pad, and then the description in the pad is empty rather than have
the content that we have just written.

task-2515150

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
