### PR TITLE
[IMP] core: reduce registry memory footprint

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -756,7 +756,7 @@ class IrModelFields(models.Model):
                 for dep in model._dependent_fields(field):
                     if dep.manual:
                         failed_dependencies.append((field, dep))
-                for inverse in model._field_inverses.get(field, ()):
+                for inverse in model.pool.field_inverses[field]:
                     if inverse.manual and inverse.type == 'one2many':
                         failed_dependencies.append((field, inverse))
 

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -992,7 +992,7 @@ class IrModelFields(models.Model):
             'store': bool(field.store),
             'copied': bool(field.copy),
             'on_delete': field.ondelete if field.type == 'many2one' else None,
-            'related': ".".join(field.related) if field.related else None,
+            'related': field.related or None,
             'readonly': bool(field.readonly),
             'required': bool(field.required),
             'selectable': bool(field.search or field.store),

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -815,6 +815,7 @@ class IrModelFields(models.Model):
         self._prepare_update()
 
         # determine registry fields corresponding to self
+        triggers = self.pool.field_triggers
         fields = []
         for record in self:
             try:
@@ -838,7 +839,7 @@ class IrModelFields(models.Model):
                 if field is not None:
                     discard_fields(subtree)
 
-        discard_fields(self.pool.field_triggers)
+        discard_fields(triggers)
         self.pool.registry_invalidated = True
 
         # The field we just deleted might be inherited, and the registry is

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2044,18 +2044,18 @@ class TestFields(TransactionCaseWithUserDemo):
         # related fields must use the field 'currency_id' or 'x_currency_id'
         model = self.env['test_new_api.monetary_related']
         field = model._fields['amount']
-        self.assertEqual(field.related, ('monetary_id', 'amount'))
+        self.assertEqual(field.related, 'monetary_id.amount')
         self.assertEqual(field.get_currency_field(model), 'currency_id')
 
         model = self.env['test_new_api.monetary_custom']
         field = model._fields['x_amount']
-        self.assertEqual(field.related, ('monetary_id', 'amount'))
+        self.assertEqual(field.related, 'monetary_id.amount')
         self.assertEqual(field.get_currency_field(model), 'x_currency_id')
 
         # inherited field must use the same field as its parent field
         model = self.env['test_new_api.monetary_inherits']
         field = model._fields['amount']
-        self.assertEqual(field.related, ('monetary_id', 'amount'))
+        self.assertEqual(field.related, 'monetary_id.amount')
         self.assertEqual(field.get_currency_field(model), 'base_currency_id')
 
     def test_94_image(self):

--- a/odoo/addons/test_new_api/tests/test_schema.py
+++ b/odoo/addons/test_new_api/tests/test_schema.py
@@ -59,7 +59,7 @@ class TestReflection(common.TransactionCase):
                         self.assertEqual(ir_field.index, bool(field.index))
                         self.assertEqual(ir_field.store, bool(field.store))
                         self.assertEqual(ir_field.copied, bool(field.copy))
-                        self.assertEqual(ir_field.related, bool(field.related) and ".".join(field.related))
+                        self.assertEqual(ir_field.related, field.related or False)
                         self.assertEqual(ir_field.readonly, bool(field.readonly))
                         self.assertEqual(ir_field.required, bool(field.required))
                         self.assertEqual(ir_field.selectable, bool(field.search or field.store))

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -260,7 +260,7 @@ class Field(MetaField('DummyField', (object,), {})):
 
     def __init__(self, string=Default, **kwargs):
         kwargs['string'] = string
-        self._sequence = kwargs['_sequence'] = next(_global_seq)
+        self._sequence = next(_global_seq)
         self.args = {key: val for key, val in kwargs.items() if val is not Default}
 
     def new(self, **kwargs):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -419,7 +419,9 @@ class Field(MetaField('DummyField', (object,), {})):
         if extra_keys:
             attrs['_extra_keys'] = extra_keys
 
-        self.__dict__.update(attrs)
+        for key, val in attrs.items():
+            if getattr(self, key, Default) != val:
+                setattr(self, key, val)
 
         # prefetch only stored, column, non-manual and non-deprecated fields
         if not (self.store and self.column_type) or self.manual or self.deprecated:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -363,7 +363,7 @@ class Field(MetaField('DummyField', (object,), {})):
         attrs['model_name'] = model_class._name
         attrs['name'] = name
         attrs['_module'] = modules[-1] if modules else None
-        attrs['_modules'] = set(modules)
+        attrs['_modules'] = tuple(set(modules))
 
         # initialize ``self`` with ``attrs``
         if name == 'state':
@@ -562,8 +562,8 @@ class Field(MetaField('DummyField', (object,), {})):
             # add modules from delegate and target fields; the first one ensures
             # that inherited fields introduced via an abstract model (_inherits
             # being on the abstract model) are assigned an XML id
-            self._modules.update(model._fields[self.related[0]]._modules)
-            self._modules.update(field._modules)
+            delegate_field = model._fields[self.related[0]]
+            self._modules = tuple({*self._modules, *delegate_field._modules, *field._modules})
 
     def traverse_related(self, record):
         """ Traverse the fields of the related field `self` except for the last

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2525,7 +2525,7 @@ class BaseModel(metaclass=MetaModel):
         while field.inherited:
             # retrieve the parent model where field is inherited from
             parent_model = self.env[field.related_field.model_name]
-            parent_fname = field.related[0]
+            parent_fname = field.related.split('.')[0]
             # JOIN parent_model._table AS parent_alias ON alias.parent_fname = parent_alias.id
             parent_alias = query.left_join(
                 alias, parent_fname, parent_model._table, 'id', parent_fname,
@@ -2801,7 +2801,7 @@ class BaseModel(metaclass=MetaModel):
                 self._add_field(name, field.new(
                     inherited=True,
                     inherited_field=field,
-                    related=(parent_fname, name),
+                    related=f"{parent_fname}.{name}",
                     related_sudo=False,
                     copy=field.copy,
                     readonly=field.readonly,
@@ -4488,7 +4488,7 @@ Fields:
                     # `self.env['stock.picking'].search([('product_id', '=', product.id)])`
                     # Should flush `stock.move.picking_ids` as `product_id` on `stock.picking` is defined as:
                     # `product_id = fields.Many2one('product.product', 'Product', related='move_lines.product_id', readonly=False)`
-                    for f in field.related:
+                    for f in field.related.split('.'):
                         rfield = model._fields.get(f)
                         if rfield:
                             to_flush[model._name].add(f)
@@ -4650,7 +4650,7 @@ Fields:
                 with the record ids corresponding to ``old`` and ``new``.
             """
             if field.inherited:
-                pname = field.related[0]
+                pname = field.related.split('.')[0]
                 return get_trans(field.related_field, old[pname], new[pname])
             return "%s,%s" % (field.model_name, field.name), old.id, new.id
 
@@ -4662,7 +4662,7 @@ Fields:
             if not field.copy:
                 continue
 
-            if field.inherited and field.related[0] in excluded:
+            if field.inherited and field.related.split('.')[0] in excluded:
                 # inherited fields that come from a user-provided parent record
                 # must not copy translations, as the parent record is not a copy
                 # of the old parent record

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2883,8 +2883,6 @@ class BaseModel(metaclass=MetaModel):
         self._add_inherited_fields()
 
         # 4. initialize more field metadata
-        cls._field_inverses = Collector()   # inverse fields for related fields
-
         cls._setup_done = True
 
         for field in cls._fields.values():
@@ -3675,7 +3673,7 @@ Fields:
                 # DLE P150: `test_cancel_propagation`, `test_manufacturing_3_steps`, `test_manufacturing_flow`
                 # TODO: check whether still necessary
                 records_to_inverse[field] = self.filtered('id')
-            if field.relational or self._field_inverses[field]:
+            if field.relational or self.pool.field_inverses[field]:
                 relational_names.append(fname)
             if field.inverse or (field.compute and not field.readonly):
                 if field.store or field.type not in ('one2many', 'many2many'):
@@ -4064,7 +4062,7 @@ Fields:
                 else:
                     cache_value = field.convert_to_cache(value, record)
                     self.env.cache.set(record, field, cache_value)
-                    if field.type in ('many2one', 'many2one_reference') and record._field_inverses[field]:
+                    if field.type in ('many2one', 'many2one_reference') and self.pool.field_inverses[field]:
                         inverses_update[(field, cache_value)].append(record.id)
 
         for (field, value), record_ids in inverses_update.items():
@@ -5215,7 +5213,7 @@ Fields:
                 inv_recs = self[field.name].filtered(lambda r: not r.id)
                 if not inv_recs:
                     continue
-                for invf in self._field_inverses[field]:
+                for invf in self.pool.field_inverses[field]:
                     # DLE P98: `test_40_new_fields`
                     # /home/dle/src/odoo/master-nochange-fp/odoo/addons/test_new_api/tests/test_new_fields.py
                     # Be careful to not break `test_onchange_taxes_1`, `test_onchange_taxes_2`, `test_onchange_taxes_3`
@@ -5798,7 +5796,7 @@ Fields:
 
         # invalidate fields and inverse fields, too
         spec = [(f, ids) for f in fields] + \
-               [(invf, None) for f in fields for invf in self._field_inverses[f]]
+               [(invf, None) for f in fields for invf in self.pool.field_inverses[f]]
         self.env.cache.invalidate(spec)
 
     def modified(self, fnames, create=False, before=False):
@@ -5899,7 +5897,7 @@ Fields:
             else:
                 # val is another tree of dependencies
                 model = self.env[key.model_name]
-                for invf in model._field_inverses[key]:
+                for invf in model.pool.field_inverses[key]:
                     # use an inverse of field without domain
                     if not (invf.type in ('one2many', 'many2many') and invf.domain):
                         if invf.type == 'many2one_reference':

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -472,7 +472,7 @@ class BaseModel(metaclass=MetaModel):
         * If :attr:`._name` is set, name(s) of parent models to inherit from
         * If :attr:`._name` is unset, name of a single model to extend in-place
     """
-    _inherits = {}
+    _inherits = frozendict()
     """dictionary {'parent_model': 'm2o_field'} mapping the _name of the parent business
     objects to the names of the corresponding foreign key fields to use::
 
@@ -519,7 +519,7 @@ class BaseModel(metaclass=MetaModel):
     as attribute.
     """
 
-    _depends = {}
+    _depends = frozendict()
     """dependencies of models backed up by SQL views
     ``{model_name: field_names}``, where ``field_names`` is an iterable.
     This is only used to determine the changes to flush to database before
@@ -697,8 +697,8 @@ class BaseModel(metaclass=MetaModel):
         cls._table = cls._name.replace('.', '_')
         cls._sequence = None
         cls._log_access = cls._auto
-        cls._inherits = {}
-        cls._depends = {}
+        inherits = {}
+        depends = {}
         cls._sql_constraints = {}
 
         for base in reversed(cls.__bases__):
@@ -711,16 +711,22 @@ class BaseModel(metaclass=MetaModel):
                 cls._sequence = base._sequence or cls._sequence
                 cls._log_access = getattr(base, '_log_access', cls._log_access)
 
-            cls._inherits.update(base._inherits)
+            inherits.update(base._inherits)
 
             for mname, fnames in base._depends.items():
-                cls._depends.setdefault(mname, []).extend(fnames)
+                depends.setdefault(mname, []).extend(fnames)
 
             for cons in base._sql_constraints:
                 cls._sql_constraints[cons[0]] = cons
 
         cls._sequence = cls._sequence or (cls._table + '_id_seq')
         cls._sql_constraints = list(cls._sql_constraints.values())
+
+        # avoid assigning an empty dict to save memory
+        if inherits:
+            cls._inherits = inherits
+        if depends:
+            cls._depends = depends
 
         # update _inherits_children of parent models
         for parent_name in cls._inherits:
@@ -2830,7 +2836,7 @@ class BaseModel(metaclass=MetaModel):
                     field.required = True
                 if field.ondelete.lower() not in ('cascade', 'restrict'):
                     field.ondelete = 'cascade'
-                self._inherits[field.comodel_name] = field.name
+                type(self)._inherits = {**self._inherits, field.comodel_name: field.name}
                 self.pool[field.comodel_name]._inherits_children.add(self._name)
 
     @api.model

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -20,7 +20,8 @@ import odoo
 from .. import SUPERUSER_ID
 from odoo.sql_db import TestCursor
 from odoo.tools import (config, existing_tables, ignore,
-                        lazy_classproperty, lazy_property, sql, OrderedSet)
+                        lazy_classproperty, lazy_property, sql,
+                        Collector, OrderedSet)
 from odoo.tools.lru import LRU
 
 _logger = logging.getLogger(__name__)
@@ -132,8 +133,8 @@ class Registry(Mapping):
         self.ready = False              # whether everything is set up
 
         # field dependencies
-        self.field_depends = {}
-        self.field_depends_context = {}
+        self.field_depends = Collector()
+        self.field_depends_context = Collector()
 
         # Inter-process signaling:
         # The `base_registry_signaling` sequence indicates the whole registry

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -135,6 +135,7 @@ class Registry(Mapping):
         # field dependencies
         self.field_depends = Collector()
         self.field_depends_context = Collector()
+        self.field_inverses = Collector()
 
         # Inter-process signaling:
         # The `base_registry_signaling` sequence indicates the whole registry
@@ -271,20 +272,23 @@ class Registry(Mapping):
         for model in models:
             model._prepare_setup()
 
-        # do the actual setup from a clean state
-        self._m2m = defaultdict(list)
+        self.field_depends.clear()
+        self.field_depends_context.clear()
+        self.field_inverses.clear()
+
+        # do the actual setup
         for model in models:
             model._setup_base()
 
+        self._m2m = defaultdict(list)
         for model in models:
             model._setup_fields()
+        del self._m2m
 
         for model in models:
             model._setup_complete()
 
         # determine field_depends and field_depends_context
-        self.field_depends.clear()
-        self.field_depends_context.clear()
         for model in models:
             for field in model._fields.values():
                 depends, depends_context = field.get_depends(model)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -959,23 +959,27 @@ class frozendict(dict):
     def __hash__(self):
         return hash(frozenset((key, freehash(val)) for key, val in self.items()))
 
-class Collector(Mapping):
-    """ A mapping from keys to lists. This is essentially a space optimization
-        for ``defaultdict(list)``.
+
+class Collector(dict):
+    """ A mapping from keys to tuples.  This implements a relation, and can be
+        seen as a space optimization for ``defaultdict(tuple)``.
     """
-    __slots__ = ['_map']
-    def __init__(self):
-        self._map = {}
-    def add(self, key, val):
-        vals = self._map.setdefault(key, [])
-        if val not in vals:
-            vals.append(val)
+    __slots__ = ()
+
     def __getitem__(self, key):
-        return self._map.get(key, ())
-    def __iter__(self):
-        return iter(self._map)
-    def __len__(self):
-        return len(self._map)
+        return self.get(key, ())
+
+    def __setitem__(self, key, val):
+        val = tuple(val)
+        if val:
+            super().__setitem__(key, val)
+        else:
+            super().pop(key, None)
+
+    def add(self, key, val):
+        vals = self[key]
+        if val not in vals:
+            self[key] = vals + (val,)
 
 
 class StackMap(MutableMapping):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -940,22 +940,32 @@ def clean_context(context):
     """ This function take a dictionary and remove each entry with its key starting with 'default_' """
     return {k: v for k, v in context.items() if not k.startswith('default_')}
 
+
 class frozendict(dict):
     """ An implementation of an immutable dictionary. """
+    __slots__ = ()
+
     def __delitem__(self, key):
         raise NotImplementedError("'__delitem__' not supported on frozendict")
+
     def __setitem__(self, key, val):
         raise NotImplementedError("'__setitem__' not supported on frozendict")
+
     def clear(self):
         raise NotImplementedError("'clear' not supported on frozendict")
+
     def pop(self, key, default=None):
         raise NotImplementedError("'pop' not supported on frozendict")
+
     def popitem(self):
         raise NotImplementedError("'popitem' not supported on frozendict")
+
     def setdefault(self, key, default=None):
         raise NotImplementedError("'setdefault' not supported on frozendict")
+
     def update(self, *args, **kwargs):
         raise NotImplementedError("'update' not supported on frozendict")
+
     def __hash__(self):
         return hash(frozenset((key, freehash(val)) for key, val in self.items()))
 


### PR DESCRIPTION
This is a bunch of commits that reduce the memory taken by a registry.

On a registry with 296 modules, this saves 3 megabytes (out of 13.5) of memory, which is about 22% of the registry's memory footprint.