### PR TITLE
[FIX] point_of_sale: restore feature that closes open pos from other tabs

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -130,6 +130,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
                 this.env.pos = new models.PosModel(posModelDefaultAttributes);
                 await this.env.pos.ready;
                 this._buildChrome();
+                this._closeOtherTabs();
                 this.env.pos.set(
                     'selectedCategoryId',
                     this.env.pos.config.iface_start_categ_id
@@ -405,6 +406,32 @@ odoo.define('point_of_sale.Chrome', function(require) {
                     e.preventDefault();
                 }
             });
+        }
+        _closeOtherTabs() {
+            localStorage['message'] = '';
+            localStorage['message'] = JSON.stringify({
+                message: 'close_tabs',
+                session: this.env.pos.pos_session.id,
+            });
+
+            window.addEventListener(
+                'storage',
+                (event) => {
+                    if (event.key === 'message' && event.newValue) {
+                        const msg = JSON.parse(event.newValue);
+                        if (
+                            msg.message === 'close_tabs' &&
+                            msg.session == this.env.pos.pos_session.id
+                        ) {
+                            console.info(
+                                'POS / Session opened in another window. EXITING POS'
+                            );
+                            this._closePos();
+                        }
+                    }
+                },
+                false
+            );
         }
     }
     Chrome.template = 'Chrome';


### PR DESCRIPTION
After the pos owl refactoring, the feature that closes pos from other
browser tabs was removed. Having multiple open pos for the same session
in the same browser session may cause issues when syncing orders because
the tabs share the same localStorage, and the localStorage is the source
of data when syncing orders to the backend.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
