### PR TITLE
[FIX] repair: correctly group invoices

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -334,7 +334,7 @@ class Repair(models.Model):
             if not journal:
                 raise UserError(_('Please define an accounting sales journal for the company %s (%s).') % (company.name, company.id))
 
-            if (partner_invoice.id, currency.id) not in grouped_invoices_vals:
+            if (partner_invoice.id, currency.id, company.id) not in grouped_invoices_vals:
                 grouped_invoices_vals[(partner_invoice.id, currency.id, company.id)] = []
             current_invoices_list = grouped_invoices_vals[(partner_invoice.id, currency.id, company.id)]
 


### PR DESCRIPTION
Have 2 repair records with the same partner_id, ready to be invoiced
In list view select both records and click Action>Create invoices
In the wizard check 'Group by partner invoice address', create invoices.

Separate invoices will be created, but while grouping 1 invoice should
be created joining the 2 repairs

opw-2476539

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
