### PR TITLE
calendar sidebar name cropped

### DIFF
--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -509,7 +509,7 @@ $o-cw-filter-avatar-size: 20px;
             }
 
             .o_cw_filter_title {
-                line-height: 1;
+                line-height: $o-line-height-base;
                 flex-grow: 1;
             }
 


### PR DESCRIPTION
PURPOSE
Calendar view sidebar filter names were getting cropped at bottom

SPEC
Calendar view sidebar filter names should not be cropped, increase line-height property.

TASK 2519813




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
