### PR TITLE
[FIX] pos_cache: Products not loading

### DIFF
--- a/addons/pos_cache/static/src/js/pos_cache.js
+++ b/addons/pos_cache/static/src/js/pos_cache.js
@@ -39,6 +39,7 @@ models.PosModel = models.PosModel.extend({
             return records.then(function (products) {
                 self.db.add_products(_.map(products, function (product) {
                     product.categ = _.findWhere(self.product_categories, {'id': product.categ_id[0]});
+                    product.pos = self;
                     return new models.Product({}, product);
                 }));
             });


### PR DESCRIPTION
Steps:
- Have a local V13 with pos_cache
- Just open a session and click anywhere

Analysis:
When trying to get the display price of the products,
it fails because the `pos` is undefined on the product.

OPW-2522293 and few others




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
