### PR TITLE
[FIX] hr_holidays: Email template error fix

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -676,7 +676,7 @@ class HolidaysRequest(models.Model):
                 else:
                     display_date = fields.Date.to_string(leave.date_from)
                     if leave.number_of_days > 1:
-                        display_date += ' ⇨ %s' % fields.Date.to_string(leave.date_to)
+                        display_date += ' / %s' % fields.Date.to_string(leave.date_to)
                     if self.env.context.get('hide_employee_name') and 'employee_id' in self.env.context.get('group_by', []):
                         res.append((
                             leave.id,


### PR DESCRIPTION
Currently, In TimeOff module If we schedule activity for Leave to Defer In
the subject of email we see some extra string before arrow  that is because
of whitespace before the arrow.

In these commit we remove the extra string by removing the leading whitespace.

**Task Id: 2501374**

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
