### PR TITLE
[FIX] mrp: fix demo data for operation

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -44,6 +44,7 @@
             <field name="name">Manual Assembly</field>
             <field name="time_cycle">60</field>
             <field name="sequence">5</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
         </record>
 
@@ -245,6 +246,7 @@
             <field name="time_cycle">120</field>
             <field name="sequence">10</field>
             <field name="name">Assembly</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
 
@@ -310,6 +312,7 @@
             <field name="name">Manual Assembly</field>
             <field name="time_cycle">60</field>
             <field name="sequence">5</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
         </record>
 
@@ -339,6 +342,7 @@
             <field name="name">Long time assembly</field>
             <field name="time_cycle">180</field>
             <field name="sequence">15</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
 
@@ -348,6 +352,7 @@
             <field name="name">Testing</field>
             <field name="time_cycle">60</field>
             <field name="sequence">10</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
         </record>
 
@@ -357,6 +362,7 @@
             <field name="name">Packing</field>
             <field name="time_cycle">30</field>
             <field name="sequence">5</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
         <record id="mrp_bom_line_plastic_laminate" model="mrp.bom.line">
@@ -607,6 +613,7 @@
             <field name="name">Long time assembly</field>
             <field name="time_cycle">180</field>
             <field name="sequence">15</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
 
@@ -616,6 +623,7 @@
             <field name="name">Testing</field>
             <field name="time_cycle">60</field>
             <field name="sequence">10</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
         </record>
 
@@ -625,6 +633,7 @@
             <field name="name">Packing</field>
             <field name="time_cycle">30</field>
             <field name="sequence">5</field>
+            <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
         <record id="mrp_bom_laptop_cust_rout_line_1" model="mrp.bom.line">


### PR DESCRIPTION
Since df312153d47763e97a50b1d956a5e468db57285c,
the `worksheet_type` default become 'text' instead of PDF. Then,
update the demo operation to show pdf instead of empty text.

task-2523601