### PR TITLE
[FIX] stock,mrp: don't unarchive operations from archived warehouses

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -232,10 +232,10 @@ class StockWarehouse(models.Model):
     def _get_picking_type_update_values(self):
         data = super(StockWarehouse, self)._get_picking_type_update_values()
         data.update({
-            'pbm_type_id': {'active': self.manufacture_to_resupply and self.manufacture_steps in ('pbm', 'pbm_sam')},
-            'sam_type_id': {'active': self.manufacture_to_resupply and self.manufacture_steps == 'pbm_sam'},
+            'pbm_type_id': {'active': self.manufacture_to_resupply and self.manufacture_steps in ('pbm', 'pbm_sam') and self.active},
+            'sam_type_id': {'active': self.manufacture_to_resupply and self.manufacture_steps == 'pbm_sam' and self.active},
             'manu_type_id': {
-                'active': self.manufacture_to_resupply,
+                'active': self.manufacture_to_resupply and self.active,
                 'default_location_src_id': self.manufacture_steps in ('pbm', 'pbm_sam') and self.pbm_loc_id.id or self.lot_stock_id.id,
                 'default_location_dest_id': self.manufacture_steps == 'pbm_sam' and self.sam_loc_id.id or self.lot_stock_id.id,
             },

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -747,9 +747,9 @@ class Warehouse(models.Model):
             'in_type_id': {'default_location_dest_id': input_loc.id},
             'out_type_id': {'default_location_src_id': output_loc.id},
             'pick_type_id': {
-                'active': self.delivery_steps != 'ship_only',
+                'active': self.delivery_steps != 'ship_only' and self.active,
                 'default_location_dest_id': output_loc.id if self.delivery_steps == 'pick_ship' else self.wh_pack_stock_loc_id.id},
-            'pack_type_id': {'active': self.delivery_steps == 'pick_pack_ship'},
+            'pack_type_id': {'active': self.delivery_steps == 'pick_pack_ship' and self.active},
             'int_type_id': {},
         }
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

If you modify an archived warehouse, it may happen that the associated operations get unarchived. Operations should be active only if their warehouse is active.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr