### PR TITLE
[FIX] account: prevents fields from disappearing from invoices 

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -19,8 +19,12 @@
                         <span t-field="o.number"/>
                     </h2>
 
+                    <div t-if="o.name and len(o.name) &gt;= 50" name="description">
+                        <strong>Description:</strong>
+                        <p class="m-0" t-field="o.name"/>
+                    </div>
                     <div id="informations" class="row mt32 mb32">
-                        <div class="col-auto mw-100 mb-2" t-if="o.name" name="description">
+                        <div class="col-auto mw-100 mb-2" t-if="o.name and len(o.name) &lt; 50" name="description">
                             <strong>Description:</strong>
                             <p class="m-0" t-field="o.name"/>
                         </div>


### PR DESCRIPTION
In 12.0, some fields are not shown on invoices when printing them.

This commit fixes this by displaying long descriptions separately from other information.

Not to be merged!

opw-2451849