### PR TITLE
[FIX] website: fix blog cover text color

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2365,6 +2365,17 @@ options.registry.CoverProperties = options.Class.extend({
         this.$filter.css('opacity', widgetValue || 0);
         this.$filter.toggleClass('oe_black', parseFloat(widgetValue) !== 0);
     },
+    /**
+     * @override
+     */
+    selectStyle(previewMode, widgetValue, params) {
+        this._super(...arguments);
+        if (!previewMode && params.name === 'bg_color_opt') {
+            const isCSSColor = ColorpickerWidget.isCSSColor(widgetValue);
+            this.$target[0].dataset.bgColorClass = isCSSColor ? '' : weUtils.computeColorClasses([widgetValue])[0];
+            this.$target[0].dataset.bgColorStyle = isCSSColor ? `background-color: ${widgetValue};` : '';
+        }
+    },
 
     //--------------------------------------------------------------------------
     // Public
@@ -2387,15 +2398,6 @@ options.registry.CoverProperties = options.Class.extend({
         this.$target[0].dataset.coverClass = coverClass;
         this.$target[0].dataset.textAlignClass = this.$el.find('[data-cover-opt-name="text_align"] we-button.active').data('selectClass') || '';
         this.$target[0].dataset.filterValue = this.$filterValueOpts.filter('.active').data('filterValue') || 0.0;
-        let colorPickerWidget = null;
-        this.trigger_up('user_value_widget_request', {
-            name: 'bg_color_opt',
-            onSuccess: _widget => colorPickerWidget = _widget,
-        });
-        const color = colorPickerWidget._value;
-        const isCSSColor = ColorpickerWidget.isCSSColor(color);
-        this.$target[0].dataset.bgColorClass = isCSSColor ? '' : weUtils.computeColorClasses([color])[0];
-        this.$target[0].dataset.bgColorStyle = isCSSColor ? `background-color: ${color};` : '';
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1925,6 +1925,8 @@
          t-att-data-use_text_align="use_text_align"
          t-att-data-res-model="request.env.user.has_group('website.group_website_publisher') and _record._name"
          t-att-data-res-id="request.env.user.has_group('website.group_website_publisher') and _record.id"
+         t-att-data-bg-color-style="_cp.get('background_color_style')"
+         t-att-data-bg-color-class="_cp.get('background_color_class')"
          t-attf-class="o_record_cover_container d-flex flex-column h-100 o_colored_level o_cc #{_cp.get('background_color_class')} #{use_size and _cp.get('resize_class')} #{use_text_align and _cp.get('text_align_class')} #{additionnal_classes}">
         <div t-attf-class="o_record_cover_component o_record_cover_image #{snippet_autofocus and 'o_we_snippet_autofocus'}" t-attf-style="background-image: #{_cp.get('background-image')};"/>
         <div t-if="use_filters" t-attf-class="o_record_cover_component o_record_cover_filter oe_black" t-attf-style="opacity: #{_cp.get('opacity', 0.0)};"/>


### PR DESCRIPTION
ISSUE:

On blog post page:
    > Edit mode > Disable background image for cover & set color
      combination from colorPicker > Save.
    > Edit mode
    > Change any other option for the cover.
    > Save > The color combination class won't be applied.

When options updated, The code in 'updateUI' will set an empty
string in 'this.$target[0].dataset.bgColorClass' if the value
in 'colorPickerWidget' isCSSColor. (even if the background option
is not updated).

A possible solution is to move this code in 'selectStyle', this way
data attributes will be changed only after background changes.

task-2525059