### PR TITLE
[FIX] mail: impossible to update image of user on large database

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -25,7 +25,7 @@ class ChannelPartner(models.Model):
 
     custom_channel_name = fields.Char('Custom channel name')
     partner_id = fields.Many2one('res.partner', string='Recipient', ondelete='cascade')
-    partner_email = fields.Char('Email', related='partner_id.email', readonly=False)
+    partner_email = fields.Char('Email', related='partner_id.email', depends=['partner_id'], readonly=False)
     channel_id = fields.Many2one('mail.channel', string='Channel', ondelete='cascade')
     fetched_message_id = fields.Many2one('mail.message', string='Last Fetched')
     seen_message_id = fields.Many2one('mail.message', string='Last Seen')

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -80,7 +80,7 @@ class Message(models.Model):
     author_id = fields.Many2one(
         'res.partner', 'Author', index=True, ondelete='set null',
         help="Author of the message. If not set, email_from may hold an email address that did not match any partner.")
-    author_avatar = fields.Binary("Author's avatar", related='author_id.image_128', readonly=False)
+    author_avatar = fields.Binary("Author's avatar", related='author_id.image_128', depends=['author_id'], readonly=False)
     # recipients: include inactive partners (they may have been archived after
     # the message was sent, but they should remain visible in the relation)
     partner_ids = fields.Many2many('res.partner', string='Recipients', context={'active_test': False})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On large database with million of messages made by one user.
When you try to update the image of user, it take lot of time (CPU time limit)

I don't know if it is an issue of ORM, but ORM try to read mail_ids of messages (3 million in my case) here : https://github.com/odoo/odoo/blob/14.0/odoo/models.py#L5843

@rco-odoo @xmo-odoo @tde-banana-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
