### PR TITLE
[FIX] mail : hide public user in activity form

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -135,7 +135,7 @@
                         </group>
                         <group>
                             <field name="date_deadline"/>
-                            <field name="user_id"/>
+                            <field name="user_id" domain="[('share', '=', False)]" options="{'no_create': True, 'no_edit': True}"/>
                         </group>
                     </group>
                     <field name="note" placeholder="Log a note..."/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In database with lot of public user it is not easy to select quickly an internal user when you create an activity.
`mail.activity` is only for internal user, this PR add a domain to select only internal user. Apply the same behaviour of field `default_user_id` in `mail.activity.type`.

@tde-banana-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
