### PR TITLE
project show share button edit mode

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -239,7 +239,7 @@
             <field name="arch" type="xml">
                 <form string="Project" delete="0">
                     <header>
-                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only" groups="project.group_project_manager"
+                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight" groups="project.group_project_manager"
                         attrs="{'invisible': [('privacy_visibility', '!=', 'portal')]}"/>
                     </header>
                 <sheet string="Project">


### PR DESCRIPTION
PURPOSE
Share button inside project was displayed only in readonly mode.

SPEC
Remove oe_readonly_mode class from button.

TASK 2513815


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
