### PR TITLE
[FIX] website: fix menu item text edition

### DIFF
--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -48,7 +48,7 @@ const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
             });
             const data = {
                 id: $menu.data('oe-id'),
-                name: link.text,
+                name: link.content,
                 url: link.url,
             };
             return this._rpc({
@@ -57,7 +57,7 @@ const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
                 args: [websiteId, {'data': [data]}],
             }).then(function () {
                 self.$target.attr('href', link.url);
-                $menu.text(link.text);
+                $menu.text(link.content);
             });
         });
         dialog.open();


### PR DESCRIPTION
The text of a menu item was not updated when editing it via the popover
"edit link" button.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
