### PR TITLE
[FIX] web: avoid traceback on pivot view

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_model.js
+++ b/addons/web/static/src/js/views/pivot/pivot_model.js
@@ -593,7 +593,8 @@ var PivotModel = AbstractModel.extend({
         };
         this._computeDerivedParams();
 
-        this.data.rowGroupBys = !_.isEmpty(this.data.groupedBy) ? this.data.groupedBy : this.initialRowGroupBys;
+        this.data.groupedBy = this.data.groupedBy.slice();
+        this.data.rowGroupBys = !_.isEmpty(this.data.groupedBy) ? this.data.groupedBy : this.initialRowGroupBys.slice();
 
         var defaultOrder = params.default_order && params.default_order.split(' ');
         if (defaultOrder) {
@@ -644,7 +645,8 @@ var PivotModel = AbstractModel.extend({
         }
         this._computeDerivedParams();
 
-        this.data.rowGroupBys = !_.isEmpty(this.data.groupedBy) ? this.data.groupedBy : this.initialRowGroupBys;
+        this.data.groupedBy = this.data.groupedBy.slice();
+        this.data.rowGroupBys = !_.isEmpty(this.data.groupedBy) ? this.data.groupedBy : this.initialRowGroupBys.slice();
 
         if (!_.isEqual(oldRowGroupBys, self.data.rowGroupBys)) {
             this.data.expandedRowGroupBys = [];

--- a/addons/web/static/tests/views/pivot_tests.js
+++ b/addons/web/static/tests/views/pivot_tests.js
@@ -1545,6 +1545,271 @@ QUnit.module('Views', {
         pivot.destroy();
     });
 
+    QUnit.test('correctly group data after flip (1)', async function (assert) {
+        assert.expect(4);
+        const actionManager = await createActionManager({
+            data: this.data,
+            archs: {
+                'partner,false,pivot': "<pivot/>",
+                'partner,false,search': `<search><filter name="bayou" string="Bayou" domain="[(1,'=',1)]"/></search>`,
+                'partner,false,list': '<tree><field name="foo"/></tree>',
+                'partner,false,form': '<form><field name="foo"/></form>',
+            },
+        });
+
+        await actionManager.doAction({
+            res_model: 'partner',
+            type: 'ir.actions.act_window',
+            views: [[false, 'pivot']],
+            context: { group_by: ["product_id"] },
+        });
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // flip axis
+        await testUtils.dom.click(actionManager.el.querySelector('.o_cp_buttons .o_pivot_flip_button'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+            ]
+        );
+
+        // select filter "Bayou" in control panel
+        await cpHelpers.toggleFilterMenu(actionManager);
+        await cpHelpers.toggleMenuItem(actionManager, "Bayou");
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // close row header "Total"
+        await testUtils.dom.click(actionManager.el.querySelector('tbody .o_pivot_header_cell_opened'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total"
+            ]
+        );
+
+        actionManager.destroy();
+    });
+
+    QUnit.test('correctly group data after flip (2)', async function (assert) {
+        assert.expect(5);
+        const actionManager = await createActionManager({
+            data: this.data,
+            archs: {
+                'partner,false,pivot': "<pivot/>",
+                'partner,false,search': `<search><filter name="bayou" string="Bayou" domain="[(1,'=',1)]"/></search>`,
+                'partner,false,list': '<tree><field name="foo"/></tree>',
+                'partner,false,form': '<form><field name="foo"/></form>',
+            },
+        });
+
+        await actionManager.doAction({
+            res_model: 'partner',
+            type: 'ir.actions.act_window',
+            views: [[false, 'pivot']],
+            context: { group_by: ["product_id"] },
+        });
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // select filter "Bayou" in control panel
+        await cpHelpers.toggleFilterMenu(actionManager);
+        await cpHelpers.toggleMenuItem(actionManager, "Bayou");
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // flip axis
+        await testUtils.dom.click(actionManager.el.querySelector('.o_cp_buttons .o_pivot_flip_button'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total"
+            ]
+        );
+
+        // unselect filter "Bayou" in control panel
+        await cpHelpers.toggleFilterMenu(actionManager);
+        await cpHelpers.toggleMenuItem(actionManager, "Bayou");
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad" 
+            ]
+        );
+
+        // close row header "Total"
+        await testUtils.dom.click(actionManager.el.querySelector('tbody .o_pivot_header_cell_opened'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...actionManager.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total"
+            ]
+        );
+
+        actionManager.destroy();
+    });
+
+    QUnit.test('correctly group data after flip (3))', async function (assert) {
+        assert.expect(10);
+        var pivot = await createView({
+            View: PivotView,
+            model: "partner",
+            data: this.data,
+            arch: `
+                <pivot>
+                    <field name="product_id" type="row"/>
+                    <field name="company_type" type="col"/>
+                </pivot>
+            `,
+            archs: {
+                'partner,false,search': `<search><filter name="bayou" string="Bayou" domain="[(1,'=',1)]"/></search>`,
+            }
+        });
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("thead th")].map(e => e.innerText),
+            [
+                "", "Total",                 "",
+                    "Company", "individual",
+                    "Count",   "Count",      "Count"
+            ]
+        );
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // close col header "Total"
+        await testUtils.dom.click(pivot.el.querySelector('thead .o_pivot_header_cell_opened'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("thead th")].map(e => e.innerText),
+            [
+                "", "Total",
+                    "Count"
+              ]
+        );
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // flip axis
+        await testUtils.dom.click(pivot.el.querySelector('.o_cp_buttons .o_pivot_flip_button'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("thead th")].map(e => e.innerText),
+            [
+                "", "Total",           "",
+                    "xphone", "xpad",
+                    "Count",  "Count", "Count"
+            ]
+        );
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total"
+            ]
+        );
+
+        // select filter "Bayou" in control panel
+        await cpHelpers.toggleFilterMenu(pivot);
+        await cpHelpers.toggleMenuItem(pivot, "Bayou");
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("thead th")].map(e => e.innerText),
+            [
+                "", "Total",           "",
+                    "xphone", "xpad",
+                    "Count",  "Count", "Count"
+            ]
+        );
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total",
+                    "xphone",
+                    "xpad"
+            ]
+        );
+
+        // close row header "Total"
+        await testUtils.dom.click(pivot.el.querySelector('tbody .o_pivot_header_cell_opened'));
+        await testUtils.nextTick();
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("thead th")].map(e => e.innerText),
+            [
+                "", "Total",           "",
+                    "xphone", "xpad",
+                    "Count",  "Count", "Count"
+            ]
+        );
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll("tbody th")].map(e => e.innerText),
+            [
+                "Total"
+            ]
+        );
+
+        pivot.destroy();
+    });
+
     QUnit.test('correctly uses pivot_ keys from the context (at reload)', async function (assert) {
         assert.expect(8);
 


### PR DESCRIPTION
Accounting->Reporting->Invoice Analysis
Open Pivot view
Click on 'Flip Axis'
Remove field from rows. Add field 'Sales Team'
Add filter Invoice Date>Q2
Remove field from rows.

Traceback will occur

opw-2511057

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
