### PR TITLE
[FIX] delivery: Backorder shipping cost with invoice policy in real

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -195,14 +195,13 @@ class StockPicking(models.Model):
             delivery_lines = sale_order.order_line.filtered(lambda l: l.is_delivery and l.currency_id.is_zero(l.price_unit) and l.product_id == self.carrier_id.product_id)
             carrier_price = self.carrier_price * (1.0 + (float(self.carrier_id.margin) / 100.0))
             if not delivery_lines:
-                sale_order._create_delivery_line(self.carrier_id, carrier_price)
-            else:
-                delivery_line = delivery_lines[0]
-                delivery_line[0].write({
-                    'price_unit': carrier_price,
-                    # remove the estimated price from the description
-                    'name': sale_order.carrier_id.with_context(lang=self.partner_id.lang).name,
-                })
+                delivery_lines = [sale_order._create_delivery_line(self.carrier_id, carrier_price)]
+            delivery_line = delivery_lines[0]
+            delivery_line[0].write({
+                'price_unit': carrier_price,
+                # remove the estimated price from the description
+                'name': sale_order.carrier_id.with_context(lang=self.partner_id.lang).name,
+            })
 
     def open_website_url(self):
         self.ensure_one()

--- a/doc/cla/individual/cybernexus.md
+++ b/doc/cla/individual/cybernexus.md
@@ -1,0 +1,11 @@
+United States, 2021-04-08
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pete Snyder cybernexus00@yahoo.com https://github.com/cybernexus


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a delivery carrier DC with invoice policy = 'real'
- Let's consider a consumable product P with a weight = 1kg and sales price = 10€
- Create a sale order SO with 2 P and add DC as shipping cost
- Process the shipment for 1 P and create a backorder
- Process the second shipment with the last P

Bug:

Two lines L1, L2 with DC were created on SO but only L1 as a price unit and a description.
L2 had a price unit = 0€ and no description.

opw:2520135

Co-authored-by: simongoffin <sig@odoo.com>