### PR TITLE
[13.0][FIX] website_sale_stock: global stock

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -25,8 +25,8 @@ class ProductTemplate(models.Model):
             return combination_info
 
         if combination_info['product_id']:
-            product = self.env['product.product'].sudo().browse(combination_info['product_id'])
             website = self.env['website'].get_current_website()
+            product = self.env['product.product'].with_context(force_company=website.company_id.id).sudo().browse(combination_info['product_id'])
             virtual_available = product.with_context(warehouse=website.warehouse_id.id).virtual_available
             combination_info.update({
                 'virtual_available': virtual_available,


### PR DESCRIPTION
FWP from 12.0: https://github.com/odoo/odoo/pull/60190
Description of the issue/feature this PR addresses:

- Create two unrelated companies.

- In a website published product put some stock in the Company 1 WH, and some more in the Company 2 WH. For example:

C1 WHC1 Product1 --> 20 u.

C2 WHC2 Product1 --> 30 u.

- Configure the website preferences of the product to allways display the availability

Current behavior before PR::

- In the backend, the users will see the stock from the locations belonging to their company. Following with the example, 20u. or 30u.

- But in the e-commerce they'll see the stock for every company: so 50u. are available for sale.

Desired behavior after PR is merged::

- Only the stock belonging to the website's company is shown

opw-2363507

cc @Tecnativa Tecnativa-Task #26275

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
