### PR TITLE
[13.0][FIX] mail: allow incoming leads with base64 images

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -938,7 +938,7 @@ class MailThread(models.AbstractModel):
 
         # 0. Handle bounce: verify whether this is a bounced email and use it to collect bounce data and update notifications for customers
         #    Bounce regex: typical form of bounce is bounce_alias+128-crm.lead-34@domain
-        #       group(1) = the mail ID; group(2) = the model (if any); group(3) = the record ID 
+        #       group(1) = the mail ID; group(2) = the model (if any); group(3) = the record ID
         #    Bounce message (not alias)
         #       See http://datatracker.ietf.org/doc/rfc3462/?include_text=1
         #        As all MTA does not respect this RFC (googlemail is one of them),
@@ -1065,7 +1065,7 @@ class MailThread(models.AbstractModel):
             else:
                 # if a new thread is created, parent is irrelevant
                 message_dict.pop('parent_id', None)
-                thread = ModelCtx.message_new(message_dict, custom_values)
+                thread = Model.message_new(message_dict, custom_values).with_context(Model._context)
                 thread_id = thread.id
                 subtype_id = thread._creation_subtype().id
 
@@ -1734,7 +1734,7 @@ class MailThread(models.AbstractModel):
             m2m_attachment_ids += [(4, id) for id in attachment_ids]
         # Handle attachments parameter, that is a dictionary of attachments
 
-        if attachments: # generate 
+        if attachments: # generate
             cids_in_body = set()
             names_in_body = set()
             cid_list = []
@@ -1821,7 +1821,7 @@ class MailThread(models.AbstractModel):
             :param str body: body of the message, usually raw HTML that will
                 be sanitized
             :param str subject: subject of the message
-            :param str message_type: see mail_message.message_type field. Can be anything but 
+            :param str message_type: see mail_message.message_type field. Can be anything but
                 user_notification, reserved for message_notify
             :param int parent_id: handle thread formation
             :param int subtype_id: subtype_id of the message, mainly use fore
@@ -2002,7 +2002,7 @@ class MailThread(models.AbstractModel):
     def message_notify(self, *,
                        partner_ids=False, parent_id=False, model=False, res_id=False,
                        author_id=None, email_from=None, body='', subject=False, **kwargs):
-        """ Shortcut allowing to notify partners of messages that shouldn't be 
+        """ Shortcut allowing to notify partners of messages that shouldn't be
         displayed on a document. It pushes notifications on inbox or by email depending
         on the user configuration, like other notifications. """
         if self:
@@ -2601,7 +2601,7 @@ class MailThread(models.AbstractModel):
             'button_access': {'title': 'View Simple Chatter Model',
                             'url': '/mail/view?model=mail.test.simple&res_id=1497'},
             'has_button_access': False,
-            'recipients': [4, 5, 6] 
+            'recipients': [4, 5, 6]
         },
         {
             'actions': [],
@@ -2914,7 +2914,7 @@ class MailThread(models.AbstractModel):
 
         new_partners, new_channels = dict(), dict()
 
-        # return data related to auto subscription based on subtype matching (aka: 
+        # return data related to auto subscription based on subtype matching (aka:
         # default task subtypes or subtypes from project triggering task subtypes)
         updated_relation = dict()
         child_ids, def_ids, all_int_ids, parent, relation = self.env['mail.message.subtype']._get_auto_subscription_subtypes(self._name)
@@ -2972,7 +2972,7 @@ class MailThread(models.AbstractModel):
         in case of a mail redirection to the record. To avoid multi
         company issues when clicking on a link sent by email, this
         could be called to try setting the most suited company on
-        the allowed_company_ids in the context. This method can be 
+        the allowed_company_ids in the context. This method can be
         overridden, for example on the hr.leave model, where the
         most suited company is the company of the leave type, as
         specified by the ir.rule.

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -34,6 +34,7 @@ Content-Transfer-Encoding: quoted-printable
  <body style=3D"margin: 0; padding: 0; background: #ffffff;-webkit-text-size-adjust: 100%;">=20
 
   <p>Please call me as soon as possible this afternoon!</p>
+  {extra_html}
 
   <p>--<br/>
      Sylvie

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -77,8 +77,17 @@ class MailTestFull(models.Model):
     datetime = fields.Datetime(default=fields.Datetime.now)
     mail_template = fields.Many2one('mail.template', 'Template')
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=2)
+    type = fields.Char()
     user_id = fields.Many2one('res.users', 'Responsible', tracking=1)
     umbrella_id = fields.Many2one('mail.test', tracking=True)
+
+    @api.model
+    def create(self, vals):
+        # Emulate an addon that alters the creation context, such as `crm`
+        context = dict(self._context or {})
+        if vals.get('type'):
+            context.setdefault('default_type', vals['type'])
+        return super(MailTestFull, self.with_context(context)).create(vals)
 
     def _track_template(self, changes):
         res = super(MailTestFull, self)._track_template(changes)

--- a/addons/test_mail/tests/common.py
+++ b/addons/test_mail/tests/common.py
@@ -346,16 +346,17 @@ class MockEmails(common.SingleTransactionCase):
 
     def format(self, template, to='groups@example.com, other@gmail.com', subject='Frogs',
                extra='', email_from='"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>',
-               cc='', msg_id='<1198923581.41972151344608186760.JavaMail@agrolait.com>', **kwargs):
-        return template.format(to=to, subject=subject, cc=cc, extra=extra, email_from=email_from, msg_id=msg_id, **kwargs)
+               cc='', msg_id='<1198923581.41972151344608186760.JavaMail@agrolait.com>',
+               extra_html=''):
+        return template.format(to=to, subject=subject, cc=cc, extra=extra, email_from=email_from, msg_id=msg_id, extra_html=extra_html)
 
     def format_and_process(self, template, email_from, to, subject='Frogs', extra='',  cc='', msg_id=False,
-                           model=None, target_model='mail.test.gateway', target_field='name', **kwargs):
+                           model=None, target_model='mail.test.gateway', target_field='name', extra_html='', **kwargs):
         self.assertFalse(self.env[target_model].search([(target_field, '=', subject)]))
         if not msg_id:
             msg_id = "<%.7f-test@iron.sky>" % (time.time())
 
-        mail = self.format(template, to=to, subject=subject, cc=cc, extra=extra, email_from=email_from, msg_id=msg_id, **kwargs)
+        mail = self.format(template, to=to, subject=subject, cc=cc, extra=extra, email_from=email_from, msg_id=msg_id, extra_html=extra_html, **kwargs)
         self.env['mail.thread'].with_context(mail_channel_noautofollow=True).message_process(model, mail)
         return self.env[target_model].search([(target_field, '=', subject)])
 

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -806,6 +806,25 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
         self.assertEqual(self.partner_1.message_bounce, 1)
         self.assertEqual(self.test_record.message_bounce, 0)
 
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_base64_image_to_alias(self):
+        """New record with mail that contains base64 inline image."""
+        target_model = "mail.test.full"
+        alias = self.env["mail.alias"].create({
+            "alias_name": "base64-lover",
+            "alias_model_id": self.env["ir.model"]._get(target_model).id,
+            "alias_defaults": "{'type': 'lead'}",
+            "alias_contact": "everyone",
+        })
+        record = self.format_and_process(
+            MAIL_TEMPLATE,
+            to='%s@%s' % (alias.alias_name, self.catchall_domain),
+            subject='base64 image to alias',
+            target_model=target_model,
+            extra_html='<img src="data:image/png;base64,iV/+OkI=">',
+        )
+        self.assertEqual(len(record.message_ids[0].attachment_ids), 1)
+
     # --------------------------------------------------
     # Thread formation
     # --------------------------------------------------


### PR DESCRIPTION
FWP from 12.0: https://github.com/odoo/odoo/pull/60799

[FIX] mail: allow incoming leads with base64 images

This is a little cumbersome, so read carefully please. The real bug exists in the `crm` module, when creating a new record with a value in the `type` field. However, the fix is in `mail` and the test is in `test_mail` because this problem could potentially affect many other modules.

[`crm` alters the context when creating a new record, adding in this case `default_type` to it][1]. The returned record contains that altered context. This results in other records created from it trying to assign that same default value for `type`. This is a very common name for fields, and happens to exist in `ir.attachment` too.

If you create an alias for incoming leads in your DB with default values `{"type": "lead"}` (something very common), and then an email comes to that alias that contains an inlined base64 image, the attachment creation process would simply fail.

That behavior is imitated and tested in `test_mail`. You can reproduce the bug by undoing the change in `mail_thread.py` and running the new test. It logs this error:

<details>

```
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: ERROR: test_message_process_base64_image_to_alias (odoo.addons.test_mail.tests.test_mail_gateway.TestMailgateway)
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: ` New record with mail that contains base64 inline image.
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: Traceback (most recent call last):
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/test_mail/tests/test_mail_gateway.py", line 472, in test_message_process_base64_image_to_alias
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     extra_html='<img src="data:image/png;base64,iV/+OkI=">',
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/test_mail/tests/common.py", line 264, in format_and_process
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     self.env['mail.thread'].with_context(mail_channel_noautofollow=True).message_process(model, mail)
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 1449, in message_process
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     thread_id = self.message_route_process(msg_txt, msg, routes)
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 1377, in message_route_process
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     new_msg = thread.message_post(**post_params)
2020-10-27 09:41:41,888 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2086, in message_post
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     new_message = MailMessage.create(values)
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "<decorator-gen-103>", line 2, in create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/api.py", line 440, in _model_create_single
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     return create(self, arg)
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/mail/models/mail_message.py", line 986, in create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     values['body'] = _image_dataurl.sub(base64_to_boundary, tools.ustr(values['body']))
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/auto/addons/mail/models/mail_message.py", line 976, in base64_to_boundary
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     'res_id': values.get('res_id'),
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "<decorator-gen-41>", line 2, in create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/api.py", line 461, in _model_create_multi
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     return create(self, [arg])
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_attachment.py", line 517, in create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     return super(IrAttachment, self).create(vals_list)
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "<decorator-gen-3>", line 2, in create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/api.py", line 462, in _model_create_multi
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     return create(self, arg)
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3588, in create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     records = self._create(data_list)
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3674, in _create
2020-10-27 09:41:41,889 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     col_val = field.convert_to_column(val, self, stored)
2020-10-27 09:41:41,890 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2016, in convert_to_column
2020-10-27 09:41:41,890 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     value = self.convert_to_cache(value, record)
2020-10-27 09:41:41,890 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2028, in convert_to_cache
2020-10-27 09:41:41,890 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: `     raise ValueError("Wrong value for %s: %r" % (self, value))
2020-10-27 09:41:41,890 35 ERROR devel odoo.addons.test_mail.tests.test_mail_gateway: ` ValueError: Wrong value for ir.attachment.type: 'lead'
```

</details>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa TT26389