### PR TITLE
[FIX] web_editor: properly remove/update the toolbar on remove image

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -750,8 +750,10 @@ const Wysiwyg = Widget.extend({
             if (!this.lastMediaClicked) {
                 return;
             }
+            const restore = preserveCursor(this.odooEditor.document);
             $(this.lastMediaClicked).remove();
             this.lastMediaClicked = undefined;
+            restore();
         });
         $toolbar.find('#fa-resize div').click(e => {
             if (!this.lastMediaClicked) {


### PR DESCRIPTION
When removing an image, the floating toolbar would stay, which is weird.
This restores the selection where it was before the image was removed, triggering a selectionchange event which updates the state of the toolbar.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
