### PR TITLE
[FIX]  mrp_subcontracting:  Added a missing separator in filter

### DIFF
--- a/addons/mrp_subcontracting/views/res_partner_views.xml
+++ b/addons/mrp_subcontracting/views/res_partner_views.xml
@@ -19,6 +19,7 @@
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='inactive']" position="before">
                 <filter string="Subcontractors" name="type_subcontractors" domain="[('is_subcontractor', '=', True)]" />
+                <separator/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
PURPOSE

There is no separator between "Subcontractors" and "Archived" in the filters of
the 'contacts' module, So on clicking on both filters thus executes an "OR" 
search, which is incorrect. Our purpose is to provide an AND instead of OR 
between them.

SPECIFICATION

 We have added a separator so that the search no longer becomes OR instead 
it becomes "Subcontractors" AND "Archived".
This is the goal of this commit. 


LINKS

PR #70464
Task 2524695