### PR TITLE
[FIX] website: prevent out-of-bounds url autocomplete in linktools

### DIFF
--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -31,7 +31,15 @@ weWidgets.LinkTools.include({
      */
     start: async function () {
         var def = await this._super.apply(this, arguments);
-        wUtils.autocompleteWithPages(this, this.$('input[name="url"]'));
+        const options = {
+            position: {
+                collision: 'flip fit',
+            },
+            classes: {
+                "ui-autocomplete": 'o_website_ui_autocomplete'
+            },
+        }
+        wUtils.autocompleteWithPages(this, this.$('input[name="url"]'), options);
         this._adaptPageAnchor();
         return def;
     },


### PR DESCRIPTION
Since the link tools were moved from the modal to the sidebar, the url autocomplete dropdown stretched out of the bounds of the window.
This fixes that problem while restyling the dropdown to look like the url pickers we already have in the sidebar. In order to achieve that, we apply to it the "o_website_ui_autocomplete", used by UrlPickerUserValueWidget (to which we don't have access in the toolbar).

![image](https://user-images.githubusercontent.com/24205914/117293404-9e947900-ae71-11eb-9b3a-3e4d3f8015cb.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
