### PR TITLE
[FIX] web: datepicker week date offset

### DIFF
--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -260,9 +260,11 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
      * @private
      */
     _configureLocale: function () {
+        var dow = (_t.database.parameters.week_start || 0) % 7;
         moment.updateLocale(moment.locale(), {
             week: {
-                dow: (_t.database.parameters.week_start || 0) % 7,
+                dow: dow,
+                doy: 7 + dow - 4 // Note: ISO 8601 week date: https://momentjscom.readthedocs.io/en/latest/moment/07-customization/16-dow-doy/
             },
         });
     },


### PR DESCRIPTION
currently, The week dates computed by our datepicker do not meet the ISO 8601
standard. 1st 2021 falls on a Friday, according to the ISO 8601 standard, the
first week of 2021 should be the one starting on Jan 4th. our datepicker simply
assumes that the first week of the year is simply the one including Jan 1st.

after this commit,datepicker calculate first week of the year according to the
ISO 8601 standard, now the first week of 2021 is the one starting on Jan 4th.

Task - 2458112

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
