### PR TITLE
[IMP] im_livechat: unpin livechat channel after one day

### DIFF
--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -84,6 +84,16 @@ class MailChannel(models.Model):
         values['channel_livechat'] = livechat_channels.channel_info()
         return values
 
+    def channel_seen(self, last_message_id=None):
+        res = super(MailChannel, self).channel_seen(last_message_id)
+        if self.channel_type == 'livechat':
+            pinned_channel_partner = self.channel_last_seen_partner_ids.filtered(
+                lambda cp: cp.is_pinned and cp.partner_id == self.env.user.partner_id
+            )
+            if pinned_channel_partner:
+                pinned_channel_partner.write({'last_seen_date': fields.Datetime.now()})
+        return res
+
     def _channel_get_livechat_visitor_info(self):
         self.ensure_one()
         # remove active test to ensure public partner is taken into account

--- a/addons/im_livechat/models/mail_channel_partner.py
+++ b/addons/im_livechat/models/mail_channel_partner.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ChannelPartner(models.Model):
     _inherit = 'mail.channel.partner'
+
+    last_seen_date = fields.Datetime("Last seen date")
 
     @api.autovacuum
     def _gc_unpin_livechat_sessions(self):
@@ -18,6 +20,6 @@ class ChannelPartner(models.Model):
                 SELECT cp.id FROM mail_channel_partner cp
                 INNER JOIN mail_channel c on c.id = cp.channel_id
                 WHERE c.channel_type = 'livechat' AND cp.is_pinned is true AND
-                    cp.write_date < current_timestamp - interval '1 day'
+                    cp.last_seen_date < current_timestamp - interval '1 day'
             )
         """)


### PR DESCRIPTION
PURPOSE:

livechat channel doesn't unpinned after one day automatically,
even if operator have seen that channel or not. it can be
case where operator is out of office for long and didn't check
the messages

SPECIFICATION:

livechat channel should be unpinned after one day of operator seen
that channel.

task-2446972

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
