### PR TITLE
format float_time on field blur

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1254,7 +1254,26 @@ var FieldFloatTime = FieldFloat.extend({
     init: function () {
         this._super.apply(this, arguments);
         this.formatType = 'float_time';
-    }
+    },
+    /**
+     * Ensure the widget is re-rendered after being edited s.t. the value is
+     * directly formatted (without waiting for the record to be saved, as we do
+     * by default).
+     *
+     * See InputField@reset: we skip the call to _render if this widget initiated
+     * the change.
+     *
+     * Note: the default behavior could be changed s.t. all fields are formatted
+     * directly on blur.
+     *
+     * @override
+     */
+    async reset() {
+        await this._super(...arguments);
+        if (!this.isDirty) {
+            await this._render();
+        }
+    },
 });
 
 var FieldFloatFactor = FieldFloat.extend({


### PR DESCRIPTION
PURPOSE
Currently, the input set in a 'Time' widget (float_time) is only formatting in to hh:mm when saving the record.
This looks awkward and buggy.
The purpose of this task is to format the content of the float_time widget when it loses focus (i.e. on field blur).

SPECIFICATION
Format the content of the float_time widget on field blur.

TASK 2518730



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
