### PR TITLE
[FIX] web_editor, website: properly record history on col count change

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1652,7 +1652,7 @@ options.registry.layout_column = options.Class.extend({
             var self = this;
             for (const el of $row.children().slice(count)) {
                 await new Promise(resolve => {
-                    self.trigger_up('remove_snippet', {$snippet: $(el), onSuccess: resolve});
+                    self.trigger_up('remove_snippet', {$snippet: $(el), onSuccess: resolve, shouldRecordUndo: false});
                 });
             }
         }


### PR DESCRIPTION
When changing the number of columns of a snippet, the history was recorded too many times and at wrong moments, resulting in a mess of undos to trigger before restoring the original column state.
The issue was due a combination of dead code and the fact that `_updateColumnCount` triggered `remove_snippet` for each of its columns while `remove_snippet` in turn triggered a history step at every execution.
This fixes it by removing the dead code, replacing it where necessary with a call to the editor's `historyStep` method, and adding an option to `remove_snippet` so its triggering of a history step can be bypassed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
