### PR TITLE
[FIX] website: fix race condition on link popover tour

### DIFF
--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -4,6 +4,13 @@ odoo.define("website.tour.edit_link_popover", function (require) {
 const tour = require('web_tour.tour');
 const wTourUtils = require('website.tour_utils');
 
+const FIRST_PARAGRAPH = '#wrap .s_text_image p:nth-child(2)';
+
+const clickFooter = {
+    content: "Save the link by clicking outside the URL input (not on a link element)",
+    trigger: 'footer h5',
+};
+
 tour.register('edit_link_popover', {
     test: true,
     url: '/?enable_editor=1',
@@ -15,11 +22,10 @@ tour.register('edit_link_popover', {
     }),
     {
         content: "Click on a paragraph",
-        trigger: '#wrap .s_text_image p:nth-child(2)',
+        trigger: FIRST_PARAGRAPH,
     },
     {
         content: "Click on 'Link' to open Link Dialog",
-        extra_trigger: '#wrap .s_text_image p:nth-child(2)',
         trigger: "#toolbar #create-link",
     },
     {
@@ -27,17 +33,14 @@ tour.register('edit_link_popover', {
         trigger: '#o_link_dialog_url_input',
         run: 'text /contactus'
     },
-    {
-        content: "Save the link by clickng on itself",
-        trigger: '#wrap .s_text_image p:nth-child(2)',
-    },
+    clickFooter,
     {
         content: "Click on newly created link",
-        trigger: '#wrap .s_text_image p:nth-child(2) a',
+        trigger: `${FIRST_PARAGRAPH} a`,
     },
     {
         content: "Popover should be shown",
-        trigger: '.o_edit_menu_popover .o_we_url_link:contains("Contact Us")',
+        trigger: '.o_edit_menu_popover .o_we_url_link:contains("Contact Us")', // At this point preview is loaded
         run: function () {}, // it's a check
     },
     {
@@ -49,13 +52,10 @@ tour.register('edit_link_popover', {
         trigger: '#o_link_dialog_url_input',
         run: "text /"
     },
-    {
-        content: "Save the link by clickng on itself",
-        trigger: '#wrap .s_text_image p:nth-child(2)',
-    },
+    clickFooter,
     {
         content: "Click on link",
-        trigger: '#wrap .s_text_image p:nth-child(2) a',
+        trigger: `${FIRST_PARAGRAPH} a`,
     },
     {
         content: "Popover should be shown with updated preview data",
@@ -68,7 +68,7 @@ tour.register('edit_link_popover', {
     },
     {
         content: "Link should be removed",
-        trigger: '#wrap .s_text_image p:nth-child(2):not(:has(a))',
+        trigger: `${FIRST_PARAGRAPH}:not(:has(a))`,
         run: function () {}, // it's a check
     },
     // 2. Test links in navbar (website)


### PR DESCRIPTION
Attempt to fix race condition:
> Tour edit_link_popover failed at step Change the URL
  (trigger: #o_link_dialog_url_input)

According to the runbot build screenshot from the error [1], when clicking on
the navbar `Home` menu, the previously deleted link on the `<p/>` is not really
deleted.

According to the runbot logs, some extra calls are done to `/`, probably coming
from extra preview calls.
It might be coming from the fact we click on the link itself to exit the right
panel URL edition.

This commit click on a non-link element to exit the right panel URL edition,
avoiding to show a popover for nothing.

[1] See the image on pull request
