### PR TITLE
[FIX] website_forum: fix aligned images display in posts

### DIFF
--- a/addons/website_forum/static/src/scss/website_forum.scss
+++ b/addons/website_forum/static/src/scss/website_forum.scss
@@ -63,6 +63,14 @@
     }
 }
 
+.question, .forum_answer {
+    .oe_no_empty::after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+}
+
 img.o_forum_avatar {
     max-height: 40px;
     margin-right: 10px;


### PR DESCRIPTION
The container size of a forum post was not correct when an image was
displayed with right or left alignment. Also, large images were
overflowing the post.

The css property clear was added at the end of the posts so that
floating elements do not float over the next section.

task-2469516

This PR should not be forwarded. A fix for 13.0 can be found here https://github.com/odoo/odoo/pull/70235

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
