### PR TITLE
[FIX] mail: prevent useless write

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -775,7 +775,7 @@ class Channel(models.Model):
         """ Hook for website_livechat channel unpin and cleaning """
         self.ensure_one()
         channel_partners = self.env['mail.channel.partner'].search(
-            [('partner_id', '=', self.env.user.partner_id.id), ('channel_id', '=', self.id)])
+            [('partner_id', '=', self.env.user.partner_id.id), ('channel_id', '=', self.id), ('is_pinned', '!=', pinned)])
         self.env['bus.bus'].sendone((self._cr.dbname, 'res.partner', self.env.user.partner_id.id), self.channel_info('unsubscribe' if not pinned else False)[0])
         if channel_partners:
             channel_partners.write({'is_pinned': pinned})


### PR DESCRIPTION
In database with frontend and live chat there are lot bad query error.
From `/web/dataset/call_kw/mail.channel/channel_pin`
```sql
bad query: UPDATE "mail_channel_partner" SET "write_uid"=5,"write_date"=(now() at time zone 'UTC') WHERE id IN (328111)
ERROR: ERREUR:  n'a pas pu sérialiser un accès à cause d'une mise à jour en parallèle
```

for exemple  : 1500 event in 24h.

@rco-odoo @odony 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
