### PR TITLE
[FIX] sale_timesheet: prevent error when adding timesheets w/o sale rights

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -232,7 +232,7 @@ class ProjectTask(models.Model):
 
     # TODO: [XBO] remove me in master
     non_allow_billable = fields.Boolean("Non-Billable", help="Your timesheets linked to this task will not be billed.")
-    remaining_hours_so = fields.Float('Remaining Hours on SO', compute='_compute_remaining_hours_so')
+    remaining_hours_so = fields.Float('Remaining Hours on SO', compute='_compute_remaining_hours_so', compute_sudo=True)
     remaining_hours_available = fields.Boolean(related="sale_line_id.remaining_hours_available")
 
     @api.depends('sale_line_id', 'timesheet_ids', 'timesheet_ids.unit_amount')


### PR DESCRIPTION
Prior to this commit:

    - If a user without access to sales tries to add timesheets on a task that
      comes from a sale order, the following access error is raised:

        Access Error

        You are not allowed to access 'Sales Order Line' (sale.order.line) records.

After this commit:

    - A user without access to sales will be able to add timesheets to a task that
      comes from a sale order without any error.

task-2566750
opw-2525342


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
