### PR TITLE
[FIX] web: Allow user to add product Description with studio

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -238,7 +238,7 @@ var FormRenderer = BasicRenderer.extend({
             const name = notebook.dataset.name;
             if (name in state) {
                 const navs = notebook.querySelectorAll(':scope .o_notebook_headers .nav-item');
-                const pages = notebook.querySelectorAll(':scope .tab-content > .tab-pane');
+                const pages = notebook.querySelectorAll(':scope > .tab-content > .tab-pane');
                 // We can't base the amount on the 'navs' length since some overrides
                 // are adding pageless nav items.
                 const validTabsAmount = pages.length;


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. From the product form, go to the website version, edit it to add tabs
    2. Using studio, add the field "Description for website" to a tab of the notebook
    3. Save, click Edit, go to the tab that has the field

What is currently happening ?

    Traceback:
    form_renderer.js:258 Uncaught (in promise) TypeError: Cannot read property 'querySelector' of undefined
        at Class.setLocalState (form_renderer.js:258)
        at Class.setLocalState (form_editor.js:131)
        at Class.prototype.<computed> [as setLocalState] (class.js:90)
        at view_editor_manager.js:184

What are you expecting to happen ?

    Correctly add product description without tracebacks

Why is this happening ?

    Because the number of tab is not equal to the number of pages

How to fix the bug ?

    Before accessing the element, check if it exists

opw-2378743