### PR TITLE
[IMP] mass_mailing: use m2o_reference on mailing.trace

### DIFF
--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -67,7 +67,7 @@ class MailingTrace(models.Model):
     source_id = fields.Many2one(related='mass_mailing_id.source_id')
     # document
     model = fields.Char(string='Document model')
-    res_id = fields.Integer(string='Document ID')
+    res_id = fields.Many2oneReference(string='Document ID', model_field='model')
     # campaign / wave data
     mass_mailing_id = fields.Many2one('mailing.mailing', string='Mailing', index=True, ondelete='cascade')
     campaign_id = fields.Many2one(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Let's make use of Many2oneReference as a better tool to link the model and the id.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr