### PR TITLE
[IMP] calendar: use m2o_reference on calendar.event

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -134,8 +134,7 @@ class Meeting(models.Model):
         compute='_compute_dates', inverse='_inverse_dates')
     duration = fields.Float('Duration', compute='_compute_duration', store=True, readonly=False)
     # linked document
-    # LUL TODO use fields.Reference ?
-    res_id = fields.Integer('Document ID')
+    res_id = fields.Many2oneReference('Document ID', model_field='res_model')
     res_model_id = fields.Many2one('ir.model', 'Document Model', ondelete='cascade')
     res_model = fields.Char(
         'Document Model Name', related='res_model_id.model', readonly=True, store=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Let's make use of Many2oneReference as a better tool to link the model and the id.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr