### PR TITLE
[FIX] stock: do not skip sequence in Orderpoint

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -977,7 +977,7 @@ class Orderpoint(models.Model):
 
     name = fields.Char(
         'Name', copy=False, required=True, readonly=True,
-        default=lambda self: self.env['ir.sequence'].next_by_code('stock.orderpoint'))
+        default=lambda self: _('New'))
     active = fields.Boolean(
         'Active', default=True,
         help="If the active field is set to False, it will allow you to hide the orderpoint without removing it.")
@@ -1024,6 +1024,12 @@ class Orderpoint(models.Model):
     _sql_constraints = [
         ('qty_multiple_check', 'CHECK( qty_multiple >= 0 )', 'Qty Multiple must be greater than or equal to zero.'),
     ]
+
+    @api.model
+    def create(self, vals):
+        if not vals.get('name', False) or vals['name'] == _('New'):
+            vals['name'] = self.env['ir.sequence'].next_by_code('stock.orderpoint')
+        return super(Orderpoint, self).create(vals)
 
     @api.depends('warehouse_id')
     def _compute_allowed_location_ids(self):


### PR DESCRIPTION
- Open a product page, open the reordering rule menu
- Create a new record, a sequence will be preset on the record
- Save the record, it's sequence will change to the next step

opw-2519133

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
