### PR TITLE
[FIX] mass_mailing: keep the cursor in the promo code when emptying it

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -609,7 +609,7 @@
                                 Use This Promo Code BEFORE 1st of August
                             </p>
                             <p class="o_mail_h_padding text-center">
-                                <span style="line-height: 30px;"><small>CODE: </small></span><strong class="o_code h3">45A9E77DGW8455</strong>
+                                <span style="line-height: 30px;"><small>CODE: </small></span><strong class="o_code h3 oe_unremovable">45A9E77DGW8455</strong>
                             </p>
                             <p class="text-center">
                                 and save $20 on your next order!


### PR DESCRIPTION
When selecting the contents of a promo code then typing a letter, that letter was inserted before the promo code instead of in it. It was also impossible to get back inside the promo code after that.

Given the nature of that snippet it seems reasonable to make the promo code itself unremovable. This way we can benefit from the editor's ability to keep the cursor in an empty unremovable inline.

Note: This fix requires a change in the editor: https://github.com/odoo-dev/odoo-editor/commit/1c98f141458de297a4b819f3fb21f532986e9872. Do not merge without it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
