### PR TITLE
[FIX] web: route /web/session/modules returns a list

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1223,7 +1223,7 @@ class Session(http.Controller):
     @http.route('/web/session/modules', type='json', auth="user")
     def modules(self):
         # return all installed modules. Web client is smart enough to not load a module twice
-        return request.env.registry._init_modules | set([module.current_test] if module.current_test else [])
+        return list(request.env.registry._init_modules | set([module.current_test] if module.current_test else []))
 
     @http.route('/web/session/save_session_action', type='json', auth="user")
     def save_session_action(self, the_action):

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -56,3 +56,9 @@ class TestSessionInfo(common.HttpCase):
             result['user_companies'],
             expected_user_companies,
             "The session_info['user_companies'] does not have the expected structure")
+
+    def test_session_modules(self):
+        self.authenticate(self.user.login, self.user_password)
+        response = self.url_open("/web/session/modules", data=self.payload, headers=self.headers)
+        data = response.json()
+        self.assertTrue(isinstance(data['result'], list))


### PR DESCRIPTION
Since the changing of assets (8cc066173dfb61bd95b8e1f0716f71f4e251810a)
the /web/session/modules route returned a stringified set instead of a list

After this commit, the route returns a list

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
