### PR TITLE
[FIX] product: use decimal accuracy of product price for pricelist

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -464,10 +464,11 @@ class PricelistItem(models.Model):
             self.name = _("All Products")
 
         if self.compute_price == 'fixed':
+            decimal_places = self.env['decimal.precision'].precision_get('Product Price')
             self.price = ("%s %s") % (
                 float_repr(
                     self.fixed_price,
-                    self.pricelist_id.currency_id.decimal_places,
+                    decimal_places,
                 ),
                 self.pricelist_id.currency_id.name
             )


### PR DESCRIPTION
To reproduce the error:
(Enable debug mode)
1. In Settings, enable "Multiple Sales Prices per Product - Prices
computed from formulas"
2. In Decimal Accuracy, edit Product Price:
    - Digits: 3
3. Open a pricelist, add a line:
    - Compute Price: Fix Price
    - Value: 0.889

Error: On pricelist form, the value is rounded (0.89)

Partial backport of #40777

OPW-2483262