### PR TITLE
[FIX] portal: fix copyright color on the portal

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -289,7 +289,7 @@ img, .media_iframe_video, .o_image {
 // To be applied to all portal pages if bg-color is white (default).
 @if ($o-portal-use-default-colors) {
     #wrapwrap.o_portal {
-        @include o-bg-color($o-portal-bg-color);
+        @include o-bg-color($o-portal-bg-color, $with-extras: false);
     }
 }
 


### PR DESCRIPTION
Before this commit, the copyright color was set as !important from the
portal and could not be overriden by the website, leading to
inconsistent display between the website and the portal.

Now, we do not change the background color of the header and the footer
of the portal.

task-2468472

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
