### PR TITLE
[FIX] account: speed up reconcilation widget

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -680,7 +680,7 @@ class AccountMoveLine(models.Model):
     amount_residual_currency = fields.Monetary(compute='_amount_residual', string='Residual Amount in Currency', store=True,
         help="The residual amount on a journal item expressed in its currency (possibly not the company currency).")
     tax_base_amount = fields.Monetary(string="Base Amount", compute='_compute_tax_base_amount', currency_field='company_currency_id', store=True)
-    account_id = fields.Many2one('account.account', string='Account', required=True, index=True,
+    account_id = fields.Many2one('account.account', string='Account', required=True, index=True, auto_join=True,
         ondelete='restrict', domain=[('deprecated', '=', False)], default=lambda self: self._context.get('account_id', False))
     move_id = fields.Many2one('account.move', string='Journal Entry', ondelete="cascade",
         help="The move of this entry line.", index=True, required=True, auto_join=True)


### PR DESCRIPTION
BEFORE:

Searching by domain ``('account_id.reconcile', '=', True)``[1] is very slow in
database with many ``account.account`` records, because it's expanded to query condition

``account_id IN (1,2,3, .....)``

That domain is used twice in reconcilation widget in method ``get_move_lines_for_bank_statement_line``. [2]

In a database with 130 K ``account.account``, each query takes more than minute.

[1]
https://github.com/odoo/odoo/blob/74a08e772ce9484be4e0b7d827a3759b9ed08a6f/addons/account/models/reconciliation_widget.py#L498
[2]
https://github.com/odoo/odoo/blob/74a08e772ce9484be4e0b7d827a3759b9ed08a6f/addons/account/models/reconciliation_widget.py#L77-L78

AFTER:

with ``auto_join=True``, time for the whole method is reduced to less than a second

---

opw-2519467

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
