### PR TITLE
[IMP] misc: add feature to parse a date

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1208,6 +1208,25 @@ def format_date(env, value, lang_code=False, date_format=False):
 
     return babel.dates.format_date(value, format=date_format, locale=locale)
 
+def parse_date(env, value, lang_code=False):
+    '''
+        Parse the date from a given format. If it is not a valid format for the
+        localization, return the original string.
+
+        :param env: an environment.
+        :param string value: the date to parse.
+        :param string lang_code: the lang code, if not specified it is extracted from the
+            environment context.
+        :return: date object from the localized string
+        :rtype: datetime.date
+    '''
+    lang = env['res.lang']._lang_get(lang_code or env.context.get('lang') or 'en_US')
+    locale = babel_locale_parse(lang.code)
+    try:
+        return babel.dates.parse_date(value, locale=locale)
+    except:
+        return value
+
 def _consteq(str1, str2):
     """ Constant-time string comparison. Suitable to compare bytestrings of fixed,
         known length only, because length difference is optimized. """


### PR DESCRIPTION
This commit will allow to parse a date.
If it's valid date, it will return a localized date object.
If it is not a valid format for the localization, return the original string.

part cherry-pick : https://github.com/odoo/odoo/pull/32631/commits/09e17e92757e02cd5ccce1b4ac365644dbad1549

opw-2517923