### PR TITLE
[FIX] website_sale: use sudo to search account.fiscal.position to public user

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -291,7 +291,7 @@ class ProductTemplate(models.Model):
             product = self.env['product.product'].browse(combination_info['product_id']) or self
 
             tax_display = self.user_has_groups('account.group_show_line_subtotals_tax_excluded') and 'total_excluded' or 'total_included'
-            fpos = self.env['account.fiscal.position'].get_fiscal_position(partner.id).sudo()
+            fpos = self.env['account.fiscal.position'].sudo().get_fiscal_position(partner.id)
             taxes = fpos.map_tax(product.sudo().taxes_id.filtered(lambda x: x.company_id == company_id), product, partner)
 
             # The list_price is always the price of one.

--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -51,3 +51,4 @@ Yennifer Santiago yennifer@vauxoo.com https://github.com/ysantiago
 Randall Castro randall@vauxoo.com https://github.com/randall-vx
 Alejandro Santillan asantillan@vauxoo.com https://github.com/R4Alex
 Williams Estrada williams@vauxoo.com https://github.com/WR-96
+Fernanda Hernández fernanda@vauxoo.com https://github.com/fernandahf


### PR DESCRIPTION
Currently if public user has a `country_id`, following traceback is throw when URL `/shop` is open:

```
Traceback (most recent call last):
File "/.repo_requirements/odoo/odoo/addons/base/models/qweb.py", line 331, in _compiled_fn
return compiled(self, append, new, options, log)
File "<template>", line 1, in template_website_sale_products_item_306
File "/.repo_requirements/odoo/addons/website_sale/models/product.py", line 294, in _get_combination_info
fpos = self.env['account.fiscal.position'].get_fiscal_position(partner.id).sudo()
File "/.repo_requirements/odoo/addons/account/models/partner.py", line 184, in get_fiscal_position
fp = self._get_fpos_by_region(delivery.country_id.id, delivery.state_id.id, delivery.zip, vat_required)
File "/.repo_requirements/odoo/addons/account/models/partner.py", line 141, in _get_fpos_by_region
fpos = self.search(domain_country + state_domain + zip_domain, limit=1)
File "/.repo_requirements/odoo/odoo/models.py", line 1708, in search
res = self._search(args, offset=offset, limit=limit, order=order, count=count)
File "/.repo_requirements/odoo/odoo/models.py", line 4485, in _search
model.check_access_rights('read')
File "/.repo_requirements/odoo/odoo/models.py", line 3331, in check_access_rights
return self.env['ir.model.access'].check(self._name, operation, raise_exception)
File "<decorator-gen-33>", line 2, in check
File "/.repo_requirements/odoo/odoo/tools/cache.py", line 90, in lookup
value = d[key] = self.method(*args, **kwargs)
File "/.repo_requirements/odoo/odoo/addons/base/models/ir_model.py", line 1792, in check
raise AccessError(msg)
odoo.exceptions.AccessError: You are not allowed to access 'Fiscal Position' (account.fiscal.position) records.

This operation is allowed for the following groups:
- Accounting/Advisor
- User types/Internal User
- User types/Portal

Contact your administrator to request access if necessary.

Error to render compiling AST
AccessError: You are not allowed to access 'Fiscal Position' (account.fiscal.position) records.

This operation is allowed for the following groups:
- Accounting/Advisor
- User types/Internal User
- User types/Portal

Contact your administrator to request access if necessary.
Template: website_sale.products_item
Path: /t/t[2]
Node: <t t-set="combination_info" t-value="product._get_combination_info(only_template=True, add_qty=add_qty or 1, pricelist=pricelist)"/>
```

Above was tested and reproduced in an instance of odoo runbot v14.0:

https://youtu.be/GgUnyna_EX8

That is due to public user has not permission to read model `account.fiscal.position` and in fact in ACL, name permission contains 'public' but is setting `group_portal`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
