### PR TITLE
[FIX] l10n_in: fix the xpath

### DIFF
--- a/addons/l10n_in/views/uom_uom_views.xml
+++ b/addons/l10n_in/views/uom_uom_views.xml
@@ -16,9 +16,9 @@
         <field name="model">uom.category</field>
         <field name="inherit_id" ref="uom.product_uom_categ_form_view"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <xpath expr="//field[@name='uom_ids']/tree/field[@name='name']" position="after">
                 <field name="l10n_in_code"/>
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Currently, there is traceback while installing the l10n_in module
due to the wrong xpath.

So in this commit, fix the XPath and added the l10n_in_code inside
the uom_ids's tree view instead of uom category.

TaskID: 2515007