### PR TITLE
[FIX] coupon: restrict delete field discount_line_product_id on coupon.reward

### DIFF
--- a/addons/coupon/models/coupon_reward.py
+++ b/addons/coupon/models/coupon_reward.py
@@ -48,7 +48,7 @@ class CouponReward(models.Model):
         help="Maximum amount of discount that can be provided")
     discount_fixed_amount = fields.Float(string="Fixed Amount", help='The discount in fixed amount')
     reward_product_uom_id = fields.Many2one(related='reward_product_id.product_tmpl_id.uom_id', string='Unit of Measure', readonly=True)
-    discount_line_product_id = fields.Many2one('product.product', string='Reward Line Product', copy=False,
+    discount_line_product_id = fields.Many2one('product.product', string='Reward Line Product', copy=False, ondelete="restrict",
         help="Product used in the sales order to apply the discount. Each coupon program has its own reward product for reporting purpose")
 
     @api.constrains('discount_percentage')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
restrict delete field discount_line_product_id on coupon.reward

**Current behavior before PR:**
If the product on coupon program(discount_line_product_id) is deleted in odoo, when customer  add a product to cart, error raise:

> ERROR: new row for relation "sale_order_line" violates check constraint "sale_order_line_accountable_required_fields"
> DETAIL:  Failing row contains (7750, 4300, Discount: 经销商折扣价 - On product with following tax..., 10, no, -279.5000, null, null, null, null, null, null, 0.00, null, 1, null, null, 0, 0, null, null, null, null, null, null, null, null, null, null, draft, 0, null, 1, 2021-05-10 08:46:10.771395, 1, 2021-05-10 08:46:10.771395, null, null, null, null, f, t, null, null, null, null, null, null).

**Desired behavior after PR is merged:**
Do not allow to delete coupon reward product, to avoid this error.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
