### PR TITLE
[FIX] slides: Verifying the returned value of re.search before accessing the capture groups.

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -739,9 +739,10 @@ class Slide(models.Model):
         youtube_duration = youtube_values.get('contentDetails', {}).get('duration')
         if youtube_duration:
             parsed_duration = re.search(r'^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$', youtube_duration)
-            values['completion_time'] = (int(parsed_duration.group(1) or 0)) + \
-                                        (int(parsed_duration.group(2) or 0) / 60) + \
-                                        (int(parsed_duration.group(3) or 0) / 3600)
+            if parsed_duration:
+                values['completion_time'] = (int(parsed_duration.group(1) or 0)) + \
+                                            (int(parsed_duration.group(2) or 0) / 60) + \
+                                            (int(parsed_duration.group(3) or 0) / 3600)
 
         if youtube_values.get('snippet'):
             snippet = youtube_values['snippet']


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the user adds a Youtube video on a course, the system can sometimes throw an exception.

Current behavior before PR:
The system throws an exception when the duration string provided by Youtube does not match with the pattern we defined in the 'slide.slide' model. This can happen when `contentDetails` is not provided by Youtube.

Desired behavior after PR is merged:
The system should no longer throw an exception when the duration string provided by Youtube does not match with the pattern we defined in the 'slide.slide' model. (see the commit message for more details).

Task id: 2525007

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
