### PR TITLE
[FIX] core: speed up child_of False queries

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -755,6 +755,9 @@ class expression(object):
                 (when available), or as an expanded [(left,in,child_ids)] """
             if not ids:
                 return [FALSE_LEAF]
+            if not all(ids):
+                # [('xxx', 'child_of', [False])] returns all records
+                return [TRUE_LEAF]
             if left_model._parent_store:
                 doms = OR([
                     [('parent_path', '=like', rec.parent_path + '%')]


### PR DESCRIPTION
Domains like ``[('xxx', 'child_of', [False])]`` doesn't filter out any records,
so replace it with ``[(1, '=', 1)]`` to avoid where-clause ``xxx in <all
available ids>``

For example, this domain may be used on searching ``purchase_vendor_bill_id`` in bill form

https://github.com/odoo/odoo/blob/3b8e1e0e30e4d7ec0eb4b1a4b3c4c54132028748/addons/purchase/views/account_move_views.xml#L17

---

opw-2524010

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
