### PR TITLE
[REM] website: remove leftover code of new editor changes

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2791,37 +2791,6 @@ options.registry.ScrollButton = options.Class.extend({
     },
 });
 
-/**
- * Allows for images to be replaced.
- */
-options.registry.ReplaceImage = options.Class.extend({
-    /**
-     * @override
-     */
-    start: function () {
-        const $button = this.$el.find('we-button');
-        const $overlayArea = this.$overlay.find('.oe_snippet_remove');
-        $button.insertBefore($overlayArea);
-
-        return this._super(...arguments);
-    },
-
-    //--------------------------------------------------------------------------
-    // Options
-    //--------------------------------------------------------------------------
-
-    /**
-     * Replaces the image.
-     *
-     * @see this.selectClass for parameters
-     */
-    replaceImage: async function () {
-        // TODO: simulates a double click on an image from summernote,
-        // to be refactored when the new editor is merged
-        this.$target.dblclick();
-    },
-});
-
 return {
     UrlPickerUserValueWidget: UrlPickerUserValueWidget,
     FontFamilyPickerUserValueWidget: FontFamilyPickerUserValueWidget,


### PR DESCRIPTION
XML call to this JS part was removed with https://github.com/odoo/odoo/commit/740168ce8d27da3d6a7156d2d79655a898394923#diff-9f41c68ba854940dda3361dc32795e2d7e9fc5b83ef7f8afd35a455b493e9930L441
But the JS was not removed.

task-2502679
