### PR TITLE
[IMP] Introduce tax units (community part)

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -27,12 +27,30 @@ class AccountTaxGroup(models.Model):
     property_advance_tax_payment_account_id = fields.Many2one('account.account', company_dependent=True, string='Advance Tax payment account')
     country_id = fields.Many2one(string="Country", comodel_name='res.country', help="The country for which this tax group is applicable.")
 
-    def _any_is_configured(self, company_id):
-        domain = expression.OR([[('property_tax_payable_account_id', '!=', False)],
-                                [('property_tax_receivable_account_id', '!=', False)],
-                                [('property_advance_tax_payment_account_id', '!=', False)]])
-        group_with_config = self.with_company(company_id).search_count(domain)
-        return group_with_config > 0
+    @api.model
+    def _check_misconfigured_tax_groups(self, company, countries):
+        """ Searches the tax groups used on the taxes from company in countries that don't have
+        at least a tax payable account, a tax receivable account or an advance tax payment account.
+
+        :return: A boolean telling whether or not there are misconfigured groups for any
+                 of these countries, in this company
+        """
+
+        # This cannot be refactored to check for misconfigured groups instead
+        # because of an ORM limitation with search on property fields:
+        # searching on property = False also returns the properties using the default value,
+        # even if it's non-empty.
+        # (introduced here https://github.com/odoo/odoo/pull/6044)
+        all_configured_groups_ids = self.with_company(company)._search([
+            ('property_tax_payable_account_id', '!=', False),
+            ('property_tax_receivable_account_id', '!=', False),
+        ])
+
+        return bool(self.env['account.tax'].search([
+            ('company_id', '=', company.id),
+            ('tax_group_id', 'not in', all_configured_groups_ids),
+            ('country_id', 'in', countries.ids),
+        ], limit=1))
 
 
 class AccountTax(models.Model):

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -362,19 +362,21 @@ class AccountTestInvoicingCommon(TransactionCase):
         })
 
     @classmethod
-    def init_invoice(cls, move_type, partner=None, invoice_date=None, post=False, products=[], amounts=[], taxes=None):
-        move_form = Form(cls.env['account.move'].with_context(default_move_type=move_type, account_predictive_bills_disable_prediction=True))
+    def init_invoice(cls, move_type, partner=None, invoice_date=None, post=False, products=None, amounts=None, taxes=None, company=False):
+        move_form = Form(cls.env['account.move'] \
+                    .with_company(company or cls.env.company) \
+                    .with_context(default_move_type=move_type, account_predictive_bills_disable_prediction=True))
         move_form.invoice_date = invoice_date or fields.Date.from_string('2019-01-01')
         move_form.partner_id = partner or cls.partner_a
 
-        for product in products:
+        for product in (products or []):
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.product_id = product
                 if taxes:
                     line_form.tax_ids.clear()
                     line_form.tax_ids.add(taxes)
 
-        for amount in amounts:
+        for amount in (amounts or []):
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.name = "test line"
                 # We use account_predictive_bills_disable_prediction context key so that

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -213,9 +213,22 @@
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="country_id"/>
-                    <field name="property_tax_payable_account_id"/>
-                    <field name="property_tax_receivable_account_id"/>
-                    <field name="property_advance_tax_payment_account_id"/>
+
+                    <!--
+                        'force_account_company' context key is used so that the RedirectWarning
+                        potentially raised during tax closing doesn't allow the user choosing
+                        accounts from another company in case the multicompany selector
+                        currently grants access to multiple companies.
+                    -->
+                    <field name="property_tax_payable_account_id"
+                        domain="[('company_id', '=', context['force_account_company'])] if context.get('force_account_company') else []"
+                    />
+                    <field name="property_tax_receivable_account_id"
+                        domain="[('company_id', '=', context['force_account_company'])] if context.get('force_account_company') else []"
+                    />
+                    <field name="property_advance_tax_payment_account_id"
+                        domain="[('company_id', '=', context['force_account_company'])] if context.get('force_account_company') else []"
+                    />
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Enterprise part: https://github.com/odoo/enterprise/pull/18234


[IMP] account: better tax groups configuration check for tax closing 

Tax groups configuration is now checked differently, and by country. Tax groups are considered properly configured if all the groups used by active taxes from that country have a tax receivable and tax payable accuont defined (by default or not) for the company.


[IMP] account: tax groups tree view: allow forcing the company of the accounts in domain

This was required by the introduction of tax units on enterprise. When making the closing for a tax unit, it is possible one (or more) of its companies don't have proper receivable/payable accounts configured on their tax groups. If so, a RedirectWarnings is raised pointing to this view in order to configure the groups from the company. All the companies of the unit are then active in the company selector, meaning that the record rules allow choosing accounts from any company, which is confusing and very error-prone.

To solve that, we introduce a context key, used to reduce to 1 the number of companie whose accounts are considered in the domains when configuring the tax groups.