### PR TITLE
[IMP] payment_adyen : allow splitting authorization and capture

### DIFF
--- a/addons/payment_adyen/const.py
+++ b/addons/payment_adyen/const.py
@@ -5,10 +5,12 @@
 # See https://docs.adyen.com/api-explorer/#/Recurring/v49/overview for Recurring API
 API_ENDPOINT_VERSIONS = {
     '/disable': 49,                 # Recurring API
+    '/paymentMethods': 67,          # Checkout API
     '/payments': 67,                # Checkout API
     '/payments/details': 67,        # Checkout API
+    '/payments/{}/cancels': 67,     # Checkout API
+    '/payments/{}/captures': 67,    # Checkout API
     '/payments/{}/refunds': 67,     # Checkout API
-    '/paymentMethods': 67,          # Checkout API
 }
 
 # Adyen-specific mapping of currency codes in ISO 4217 format to the number of decimals.

--- a/addons/payment_adyen/data/payment_acquirer_data.xml
+++ b/addons/payment_adyen/data/payment_acquirer_data.xml
@@ -4,7 +4,7 @@
     <record id="payment.payment_acquirer_adyen" model="payment.acquirer">
         <field name="provider">adyen</field>
         <field name="inline_form_view_id" ref="inline_form"/>
-        <field name="support_authorization">False</field>
+        <field name="support_authorization">True</field>
         <field name="support_fees_computation">False</field>
         <field name="support_refund">partial</field>
         <field name="support_tokenization">True</field>

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -21,6 +21,8 @@ class AdyenCommon(PaymentCommon):
         # Override default values
         cls.acquirer = cls.adyen
 
+        cls.psp_reference = '0123456789ABCDEF'
+        cls.original_reference = 'FEDCBA9876543210'
         cls.webhook_notification_payload = {
             'additionalData': {
                 'hmacSignature': 'kK6vSQvfWP3AtT2TTK1ePj9e7XPb7bF5jHC7jDWyU5c='
@@ -32,8 +34,8 @@ class AdyenCommon(PaymentCommon):
             'eventCode': 'AUTHORISATION',
             'merchantAccountCode': 'DuckSACom123',
             'merchantReference': cls.reference,
-            'originalReference': 'FEDCBA9876543210',
-            'pspReference': '0123456789ABCDEF',
+            'originalReference': cls.original_reference,
+            'pspReference': cls.psp_reference,
             'success': 'true',
         }  # Include all keys used in the computation of the signature to the payload
         cls.webhook_notification_batch_data = {
@@ -43,3 +45,8 @@ class AdyenCommon(PaymentCommon):
                 }
             ]
         }
+
+    def create_transaction(self, *args, acquirer_reference=None, **kwargs):
+        if not acquirer_reference:
+            acquirer_reference = self.psp_reference
+        return super().create_transaction(*args, acquirer_reference=acquirer_reference, **kwargs)

--- a/addons/payment_adyen/views/payment_views.xml
+++ b/addons/payment_adyen/views/payment_views.xml
@@ -16,6 +16,17 @@
                     <field name="adyen_recurring_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                 </group>
             </xpath>
+            <xpath expr='//group[@name="acquirer_config"]' position='before'>
+                <div attrs="{'invisible':['|', ('provider', '!=', 'adyen'), ('capture_manually', '=', False)]}"
+                     class="alert alert-warning"
+                     role="alert">
+                    <strong>Warning:</strong> To capture the amount manually, you also need to set
+                    the Capture Delay to manual on your Adyen account settings.
+                    <a href="https://www.odoo.com/documentation/master/applications/finance/payment_acquirers/adyen.html#place-a-hold-on-a-card"
+                       title="Learn More"
+                       target="_blank">Learn More</a>
+                </div>
+            </xpath>
         </field>
     </record>
 

--- a/addons/pos_restaurant_adyen/controllers/main.py
+++ b/addons/pos_restaurant_adyen/controllers/main.py
@@ -13,7 +13,7 @@ _logger = logging.getLogger(__name__)
 class PosRestaurantAdyenController(AdyenController):
 
     @http.route()
-    def adyen_notification(self, **post):
+    def adyen_webhook(self, **post):
         if post.get('eventCode') in ['CAPTURE', 'AUTHORISATION_ADJUSTMENT'] and post.get('success') != 'true':
                 _logger.warning('%s for transaction_id %s failed', post.get('eventCode'), post.get('originalReference'))
-        return super(PosRestaurantAdyenController, self).adyen_notification(**post)
+        return super(PosRestaurantAdyenController, self).adyen_webhook(**post)


### PR DESCRIPTION
Being able to first authorize then capture a payment has several
advantages:
- Confirm a quotation when the payment is authorized and capture it
  when the order is shipped.
- Review orders before capturing the payment.
- Prevent credit card fees in the case of a refund

This commit implements this feature for the payment acquirer Adyen.

task-2507304

See also:
- https://github.com/odoo/upgrade/pull/3088
- https://github.com/odoo/documentation/pull/1153