### PR TITLE
[FIX] sale_stock: fix Lots/SN access for stock user with sales user r…

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -123,7 +123,10 @@ class ProductionLot(models.Model):
             ]).mapped('move_id')
             stock_moves = stock_moves.search([('id', 'in', stock_moves.ids)]).filtered(
                 lambda move: move.picking_id.location_dest_id.usage == 'customer' and move.state == 'done')
-            lot.sale_order_ids = stock_moves.mapped('sale_line_id.order_id')
+            if self.env.user.has_group('stock.group_stock_user'):
+                lot.sale_order_ids = stock_moves.sudo().mapped('sale_line_id.order_id')
+            else:
+                lot.sale_order_ids = stock_moves.mapped('sale_line_id.order_id')
             lot.sale_order_count = len(lot.sale_order_ids)
 
     def action_view_so(self):


### PR DESCRIPTION
…ights

- Create a Storable Product tracked by Lot (i.e. Product X)
- Update its quantity and set a lot (i.e. Lot001)
- Create SO with Product X and deliver it
- Create an Internal User with the following rights:
  * Inventory: User
  * Sales: User: Own Documents Only
- Connect with created user
- Go to Inventory > Master Data > Lot/Serial Numbers
- Open Lot001 of Product X
An Access Error is triggered because SO cannot be computed on the lot.
There is no issue if no right is given for Sales.

opw-2486758

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
