### PR TITLE
[FIX] account_edi_facturx: avoid crash when no edi attachment

### DIFF
--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -47,7 +47,7 @@ class AccountEdiFormat(models.Model):
 
     def _get_embedding_to_invoice_pdf_values(self, invoice):
         values = super()._get_embedding_to_invoice_pdf_values(invoice)
-        if self.code == 'facturx_1_0_05':
+        if values and self.code == 'facturx_1_0_05':
             values['name'] = 'factur-x.xml'
         return values
 


### PR DESCRIPTION
When we get the values to embed to pdf, these values can be False if
there is no edi attachment on the account_move so try to assign something
to 'values' will fail.

Now there is a check before assignment.

opw-2526280