### PR TITLE
[FIX] web_editor: allow svg to be uploaded

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -169,9 +169,10 @@ class Web_Editor(http.Controller):
             format_error_msg = _("Uploaded image's format is not supported. Try with: %s", ', '.join(SUPPORTED_IMAGE_EXTENSIONS))
             try:
                 data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
-                img_extension = tools.base64_to_image(data).format.lower()
-                if img_extension not in [ext.replace('.', '') for ext in SUPPORTED_IMAGE_EXTENSIONS]:
-                    return {'error': format_error_msg}
+                if data[:1] not in ('P', 'P'):  # see ImageProcess.__init__()
+                    img_extension = tools.base64_to_image(data).format.lower()
+                    if img_extension not in [ext.replace('.', '') for ext in SUPPORTED_IMAGE_EXTENSIONS]:
+                        return {'error': format_error_msg}
             except UserError:
                 # considered as an image by the brower file input, but not
                 # recognized as such by PIL, eg .webp


### PR DESCRIPTION
Since 9dab9ffce297 SVG couldn't be uploaded anymore.
Indeed, we get the image format through PIL.Image so we can whitelist only the
formats we want.
But PIL doesn't support SVG, which wasn't expected by the mentioned commit.

task-2523574
