### PR TITLE
[FIX] website_livechat: error during closing livechat

### DIFF
--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -18,6 +18,6 @@ class ImLivechatChannel(models.Model):
             # TODO DBE : Move this into the proper method (open or init mail channel)
             chat_request_channel = self.env['mail.channel'].sudo().search([('livechat_visitor_id', '=', visitor_sudo.id), ('livechat_active', '=', True)])
             for mail_channel in chat_request_channel:
-                mail_channel._close_livechat_session(cancel=True, speaking_with=operator.name)
+                mail_channel._close_livechat_session(cancel=True, operator=operator.name)
 
         return mail_channel_vals


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
During closing of livechat session an error occur : 
`_get_visitor_leave_message() got an unexpected keyword argument 'speaking_with'
`
Because argument 'speaking_with' is pass in the method https://github.com/odoo/odoo/blob/14.0/addons/im_livechat/models/mail_channel.py#L182, it should be operator.


@tde-banana-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
