### PR TITLE
[FIX] mail: Fix MemoryError if there are too many messages to fetch

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1029,7 +1029,7 @@ class Message(models.Model):
 
         return vals_list
 
-    def message_fetch_failed(self):
+    def message_fetch_failed(self, limit=80):
         """Returns all messages, sent by the current user, that have errors, in
         the format expected by the web client."""
         messages = self.search([
@@ -1038,7 +1038,7 @@ class Message(models.Model):
             ('res_id', '!=', 0),
             ('model', '!=', False),
             ('message_type', '!=', 'user_notification')
-        ])
+        ], limit=limit)
         return messages._message_notification_format()
 
     @api.model


### PR DESCRIPTION
# Description of the issue/feature this PR addresses

Opening a sale.order or account.invoice or any model that trigger the failed message a MemoryError is raised using the "admin" user (id 3)

# Current behavior before PR
```
File "mail/controllers/main.py", line 263, in mail_init_messaging
    'mail_failures': request.env['mail.message'].message_fetch_failed(),
File "mail/models/mail_message.py", line 1042, in message_fetch_failed
    return messages._message_notification_format()
File "mail/models/mail_message.py", line 1151, in _message_notification_format
    return [{
File "mail/models/mail_message.py", line 1153, in <listcomp>
    'res_id': message.res_id,
File "odoo/fields.py", line 996, in __get__
    recs._fetch_field(self)
File "odoo/models.py", line 3069, in _fetch_field
    self._read(fnames)
File "odoo/models.py", line 3137, in _read
    result += cr.fetchall()
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
File "odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
File "odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
MemoryError
```

It is a database migrated from 11.0 to 14.0 and currently the following domain:
```python
messages = env['mail.message'].search([
             ('has_error', '=', True),
             ('author_id', '=', 3),
             ('res_id', '!=', 0),
             ('model', '!=', False),
             ('message_type', '!=', 'user_notification')
         ])
```
is returning 300k records

# Desired behavior after PR is merged:
Limit the messages to 80 instead of MemoryError:
 - ![image](https://user-images.githubusercontent.com/6644187/117706796-5a67e800-b193-11eb-9828-27783547b6f9.png)
