### PR TITLE
[FIX] website_sale_comparison: not responsible table

### DIFF
--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -101,7 +101,7 @@
                 <div class="container oe_website_sale pt-3">
                     <section class="container">
                         <h3>Compare Products</h3>
-                        <table class="table table-bordered table-hover text-center mt16 table-comparator" id="o_comparelist_table">
+                        <table class="table table-bordered table-hover text-center mt16 table-comparator table-responsive" id="o_comparelist_table">
                             <t t-set="categories" t-value="products._prepare_categories_for_display()"/>
                             <thead>
                                 <tr>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this commit, some data overflow the table.

Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/117715359-6e820880-b1d8-11eb-88b4-188d49c3c5d1.png)

Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/16716992/117715284-56aa8480-b1d8-11eb-92a7-e4176195a712.png)

@JKE-be 
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
