### PR TITLE
[FIX] project: incorrect creation of recurring tasks

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -208,20 +208,20 @@ class ProjectTaskRecurrence(models.Model):
         create_values = {
             field: value[0] if isinstance(value, tuple) else value for field, value in task_values.items()
         }
-        create_values['stage_id'] = task.project_id.type_ids[0].id if task.project_id.type_ids else task.stage_id
+        create_values['stage_id'] = task.project_id.type_ids[0].id if task.project_id.type_ids else task.stage_id.id
         create_values['user_id'] = False
         return create_values
 
     def _create_next_task(self):
         for recurrence in self:
-            task = self.sudo().task_ids[-1]
+            task = recurrence.sudo().task_ids[-1]
             create_values = recurrence._new_task_values(task)
             new_task = self.env['project.task'].sudo().create(create_values)
             if not new_task.parent_id and task.child_ids:
                 children = []
                 # copy the subtasks of the original task
                 for child in task.child_ids:
-                    child_values = self._new_task_values(child)
+                    child_values = recurrence._new_task_values(child)
                     child_values['parent_id'] = new_task.id
                     children.append(child_values)
                 self.env['project.task'].create(children)


### PR DESCRIPTION
In case X several recurrences are processed in the same cron execution,
only the last recurring task was created X times, while the other tasks
were not created. There is also a missing id preventing a correct use of
the default stage for the new created task.

Description of the issue/feature this PR addresses:

opw-2468881

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
