### PR TITLE
[FIX] product: quick create a partner in product supplier info, the partner should be a vendor. 

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -657,7 +657,7 @@
             <field name="arch" type="xml">
                 <tree string="Vendor Information" multi_edit="1">
                     <field name="sequence" widget="handle"/>
-                    <field name="name" readonly="1"/>
+                    <field name="name" readonly="1" context="{'res_partner_search_mode': 'supplier'}"/>
                     <field name="product_id" readonly="1" optional="hide"
                         invisible="context.get('product_template_invisible_variant', False)"
                         groups="product.group_product_variant"/>


### PR DESCRIPTION
Current behavior before PR:
<img width="1453" alt="image" src="https://user-images.githubusercontent.com/5561864/117760344-0f63d880-b258-11eb-9e7a-c3f69b2101bb.png">

Quick create a partner here , the partner will not be shown in Vendors.
This pr fix this.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
