### PR TITLE
[FIX] web: fix domain creation in mockserver

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -400,7 +400,7 @@ var MockServer = Class.extend({
             domain = domain.map(function (criterion) {
                 if (criterion[1] === 'child_of') {
                     var oldLength = 0;
-                    var childIDs = [criterion[2]];
+                    var childIDs = criterion[2];
                     while (childIDs.length > oldLength) {
                         oldLength = childIDs.length;
                         _.each(records, function (r) {


### PR DESCRIPTION
before this commit,
it was creating a domain with list of list for ids if
we have used the domain selector as child_of.

after this commit,
it will create a domain with list of ids.

task-2350373

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
