### PR TITLE
[FIX] packaging: add num2words debian depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Depends:
  python3-libsass,
  python3-lxml,
  python3-mako,
+ python3-num2words,
  python3-ofxparse,
  python3-passlib,
  python3-polib,


### PR DESCRIPTION
The num2words Debian package exists in Debian Buster [0] and Ubuntu
Focal [1].

[0]: https://packages.debian.org/buster/python3-num2words
[1]: https://packages.ubuntu.com/focal/python3-num2words
