### PR TITLE
[FIX] purchase: speed up search for purchase_vendor_bill_id

### DIFF
--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -12,7 +12,7 @@
                 <field name="purchase_vendor_bill_id"
                        attrs="{'invisible': ['|', '|', ('state','not in',['draft']), ('state', '=', 'purchase'), ('type', '!=', 'in_invoice')]}"
                        class="oe_edit_only"
-                       domain="[('company_id', '=', company_id), ('partner_id','child_of', [partner_id])]"
+                       domain="partner_id and [('company_id', '=', company_id), ('partner_id','child_of', [partner_id])] or [('company_id', '=', company_id)]"
                        placeholder="Select a purchase order or an old bill"
                        context="{'show_total_amount': True}"
                        options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
When partner is not selected, Odoo sends name_search request
`[..., ('partner_id', 'child_of', [False])]`. It's not obvious what does such
domain mean ( see #70584 ). This commit clarifies what do we expect to get:
we want all records without restrictions on `partner_id` value.

This also fixes performance issue because domain leaf `('partner_id',
'child_of', [False])` is converted to where-clause `<table>.partner_id in <all
or almost all ids>`

---

opw-2524010

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
