### PR TITLE
[FIX] expression: Better Binaries logs

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -116,6 +116,7 @@ start the server specifying the ``--unaccent`` flag.
 import collections
 
 import logging
+import reprlib
 import traceback
 from functools import partial
 from zlib import crc32
@@ -1087,7 +1088,7 @@ class expression(object):
                     push(create_substitution_leaf(leaf, ('id', inselect_operator, (subselect, params)), model, internal=True))
                 else:
                     _logger.error("Binary field '%s' stored in attachment: ignore %s %s %s",
-                                  field.string, left, operator, right)
+                                  field.string, left, operator, reprlib.repr(right))
                     leaf.leaf = TRUE_LEAF
                     push(leaf)
 


### PR DESCRIPTION
When building a domain `(=|!=)` with
a Binary field stored in attachment and
the right part of the domain is not null,
the full binary content is logged, giving
the logs a huge size.

Now, the use of `reprlib.repr` crop the
variable to a sensible value.

opw-2527629