### PR TITLE
[FIX] web_editor: properly display list buttons as a dropdown in toolbar

### DIFF
--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -114,10 +114,19 @@
                 </div>
             </div>
 
-            <div id="list" class="button-group">
-                <div id="unordered" data-call="toggleList" data-arg1="UL" title="Toggle unordered list" class="fa fa-list-ul fa-fw btn"></div>
-                <div id="ordered" data-call="toggleList" data-arg1="OL" title="Toggle ordered list" class="fa fa-list-ol fa-fw btn"></div>
-                <div id="checklist" data-call="toggleList" data-arg1="CL" title="Toggle checklist" class="fa fa-tasks fa-fw btn"></div>
+            <div id="list" class="btn-group dropdown">
+                <button type="button" class="btn dropdown-toggle"
+                    data-toggle="dropdown" title="Toggle List" tabindex="-1"
+                    data-original-title="List" aria-expanded="false">
+                    <i id="justifyDropdownButton" class="fa fa-list-ul fa-fw"></i>
+                </button>
+                <div class="dropdown-menu">
+                    <div class="btn-group">
+                        <div id="unordered" data-call="toggleList" data-arg1="UL" title="Toggle unordered list" class="fa fa-list-ul fa-fw btn"></div>
+                        <div id="ordered" data-call="toggleList" data-arg1="OL" title="Toggle ordered list" class="fa fa-list-ol fa-fw btn"></div>
+                        <div id="checklist" data-call="toggleList" data-arg1="CL" title="Toggle checklist" class="fa fa-tasks fa-fw btn"></div>
+                    </div>
+                </div>
             </div>
 
             <div id="table" class="btn-group">


### PR DESCRIPTION
The list buttons in the toolbar were stacked, messing up the layout of the toolbar. This restores them as they were before
https://github.com/odoo/odoo/commit/b2dd95937346561495ab86b90715210ffd9a474a somehow messed it up.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
