### PR TITLE
[FIX] crm_livechat: do not set public user partner as lead customer usign /lead command

### DIFF
--- a/addons/crm_livechat/models/mail_channel.py
+++ b/addons/crm_livechat/models/mail_channel.py
@@ -39,7 +39,7 @@ class MailChannel(models.Model):
         # anonymous user whatever the participants. Otherwise keep only share
         # partners (no user or portal user) to link to the lead.
         customers = self.env['res.partner']
-        for customer in channel_partners.partner_id.filtered('partner_share'):
+        for customer in channel_partners.partner_id.filtered('partner_share').with_context(active_test=False):
             if customer.user_ids and all(user._is_public() for user in customer.user_ids):
                 customers = self.env['res.partner']
                 break


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Before this commit, when you create a lead from livechat with the command /lead, the public user is used inside the lead.
Because the public user is archived, and self.env.ref('base.public_partner').user_ids return an empty recordset.

Exemple on runbot : https://7653413-14-0-all.runbot63.odoo.com/web?debug=1#cids=1&id=47&menu_id=400&model=crm.lead&view_type=form


@tde-banana-odoo 

Fine tuning of https://github.com/odoo/odoo/commit/7fbeda3f7d92fa501c2752c873be2255697f5d97

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
