### PR TITLE
[FIX] web: remove bottom border of first table raw

### DIFF
--- a/addons/web/static/src/scss/layout_boxed.scss
+++ b/addons/web/static/src/scss/layout_boxed.scss
@@ -65,18 +65,18 @@
         background-color: gray('200');
     }
     /* compat 12.0 */
-    .row:not(#total) > div > table tr:not(:first-child):not(:last-child) td:last-child {
+    .row:not(#total) > div > table tbody tr:not(:last-child) td:last-child {
         background-color: gray('200');
     }
     /*Total table*/
     /* row div rule compat 12.0 */
     .row > div > table,
     div#total table {
+        thead tr:first-child,
+        tr.o_subtotal {
+            border-bottom: 1px solid gray('700');
+        }
         tr {
-            &:first-child,
-            &.o_subtotal {
-                border-bottom: 1px solid gray('700');
-            }
             &.o_subtotal{
                 td:first-child {
                     border-right: none;


### PR DESCRIPTION
When using the boxed layout, if the business document has a table, its
first row (after the table head) will have a bottom border and the last
cell in the row has a white background.

To reproduce the error:
(Need timesheet_grid. Use demo data)
1. In Settings > General Settings, Change Document Template:
    - Select the second template
2. In Timesheets, select list view
3. Select several lines
4. Print > Timesheet Entries

Error: In PDF, the first timesheet row has a bottom line and its last
cell has a white background (instead of grey).

The bottom line should only be applied on row in table header. The
background color should also be applied on first row in table body.

OPW-2478311