### PR TITLE
[FIX] website: launch action todo on website creation

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -249,8 +249,8 @@ class Website(models.Model):
 
     def create_and_redirect_configurator(self):
         self._force()
-        action = self.env['ir.actions.actions']._for_xml_id('website.start_configurator_act_url')
-        return action
+        configurator_action_todo = self.env.ref('website.website_configurator_todo')
+        return configurator_action_todo.action_launch()
 
     # ----------------------------------------------------------
     # Configurator
@@ -288,7 +288,8 @@ class Website(models.Model):
 
     @api.model
     def configurator_skip(self):
-        self.configurator_done = True
+        website = self.get_current_website()
+        website.configurator_done = True
 
     @api.model
     def configurator_apply(self, **kwargs):


### PR DESCRIPTION
When website is installed through CLI, the ir.actions.todo
'website_configurator_todo' is not launched and stays in
'open' state. In this case the FIRST time we create a new
website, this ir.action.todo is launched at the end of the
configurator wheter it fails or not.

- If configurator fails, the ir.actions.todo is returned
  by button_choose_theme when choosing a theme in the
  theme_view_kanban view. /website/configurator is called
  and since configurator_done was not correctly set to true
  on current website, the screen theme_view_kanban was
  rendered a second time.

- If configurator succeeds, the ir.actions.todo is returned
  by button_choose_theme in configurator_apply. The route
  /website/configurator is called a second time and since
  configurator_done is set to true the route redirect to the
  website homepage but not in edit mode.

The fix consists in correctly setting configurator_done in
configurator_skip and in launching the configurator through
the ir.actions.todo in create_and_redirect_configurator.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
