### PR TITLE
[FIX] product: correctly consider context key for display_name

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -423,6 +423,12 @@ class ProductProduct(models.Model):
             args.append((('categ_id', 'child_of', self._context['search_default_categ_id'])))
         return super(ProductProduct, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
 
+    @api.depends_context('display_default_code')
+    def _compute_display_name(self):
+        # `display_name` is calling `name_get()`` which is overidden on product
+        # to depend on `display_default_code`
+        return super()._compute_display_name()
+
     def name_get(self):
         # TDE: this could be cleaned a bit I think
 

--- a/addons/product/tests/__init__.py
+++ b/addons/product/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_name
 from . import test_variants
 from . import test_pricelist
 from . import test_product_pricelist

--- a/addons/product/tests/test_name.py
+++ b/addons/product/tests/test_name.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestName(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.product_name = 'Product Test Name'
+        self.product_code = 'PTN'
+        self.product = self.env['product.product'].create({
+            'name': self.product_name,
+            'default_code': self.product_code,
+        })
+
+    def test_10_product_name(self):
+        display_name = self.product.display_name
+        self.assertEqual(display_name, "[%s] %s" % (self.product_code, self.product_name),
+                         "Code should be preprended the the name as the context is not preventing it.")
+        display_name = self.product.with_context(display_default_code=False).display_name
+        self.assertEqual(display_name, self.product_name,
+                         "Code should not be preprended to the name as context should prevent it.")


### PR DESCRIPTION
Regarding of the `display_default_code` context value, `display_name` is
supposed to return the product code or not, eg:
```
> product.display_name
> '[FURN_6666] Acoustic Bloc Screens'
> product.with_context(display_default_code=False).display_name
> 'Acoustic Bloc Screens'
```

But since the context was not considered when accessing this field, it would
always return the cached value, which was set from the first time that field
was read, with the `display_default_code` value used at that time.

tl;dr: `display_name` was ignoring the context once cached.

One of the critical issue was that internal code were displayed on the eshop
cart (not the eshop itself), see `name_short`.

task-2517830
