### PR TITLE
[FIX] mass_mailing: total field make lot of time to compute

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -313,7 +313,6 @@
                     <field name='user_id'/>
                     <field name='expected'/>
                     <field name='failed'/>
-                    <field name='total'/>
                     <field name='mailing_model_id'/>
                     <field name='mailing_model_name'/>
                     <field name='sent_date'/>
@@ -367,7 +366,6 @@
                                     <div class="o_kanban_record_body" t-if="!selection_mode" attrs="{'invisible': [('sent_date', '=', False), ('schedule_date', '=', False), ('state', '!=', 'in_queue')]}">
                                         <div>
                                             <span attrs="{'invisible': [('sent_date', '=', False)]}"><b><field name="delivered"/> / <field name="expected"/></b> Delivered to</span>
-                                            <span attrs="{'invisible': [('sent_date', '!=', False)]}"><b><field name='total'/></b></span>
                                             <field name='mailing_model_id' attrs="{'invisible': [('mailing_model_name','=','mailing.list')]}"/>
                                             <span attrs="{'invisible': [('mailing_model_name','!=','mailing.list')]}">Mailing Contact</span>
                                         </div>
@@ -395,12 +393,6 @@
                                             t-attf-title="Scheduled on #{record.schedule_date.value}" class="d-inline-flex">
                                             <span class="fa fa-hourglass-half mr-2 small my-auto" aria-label="Scheduled date"/>
                                             <span class="align-self-baseline"><field name="schedule_date" widget="date"/></span>
-                                        </span>
-                                        <span attrs="{'invisible': ['|', '|', ('sent_date', '!=', False), ('schedule_date', '!=', False), ('state', '=', 'in_queue')]}"
-                                            class="oe_clear">
-                                            <b><field name='total'/></b>
-                                            <field name='mailing_model_id' attrs="{'invisible': [('mailing_model_name','=','mailing.list')]}"/>
-                                            <span attrs="{'invisible': [('mailing_model_name','!=','mailing.list')]}">Mailing Contact</span>
                                         </span>
                                         <span attrs="{'invisible': ['|', '|', ('schedule_date', '!=', False), ('state', '!=', 'in_queue'), ('next_departure', '=', False)]}"
                                             t-attf-title="Scheduled on #{record.next_departure.value}" class="d-inline-flex">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On large database with lot of mailing.mailing with complexe domain, the kanban view take lot of time to load (10 seconds with 56 mailings).

Because the field total is a computed field with domain made by user (not the most optimized domain :-) ).

Note 1 : I don't know if it is the best solution
Note 2 : This issue exist in V14 (but I make the PR in master).

@tde-banana-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
