### PR TITLE
[FIX] website_sale_coupon: Change parameters for method "cart"

### DIFF
--- a/addons/website_sale_coupon/controllers/main.py
+++ b/addons/website_sale_coupon/controllers/main.py
@@ -23,10 +23,10 @@ class WebsiteSale(WebsiteSale):
         return super(WebsiteSale, self).payment(**post)
 
     @http.route(['/shop/cart'], type='http', auth="public", website=True)
-    def cart(self, **post):
+    def cart(self, access_token=None, revive='', **post):
         order = request.website.sale_get_order()
         order.recompute_coupon_lines()
-        return super(WebsiteSale, self).cart(**post)
+        return super(WebsiteSale, self).cart(access_token=access_token, revive=revive, **post)
 
     # Override
     # Add in the rendering the free_shipping_line


### PR DESCRIPTION
The original method in website_sale is defined as:
def cart(self, access_token=None, revive='', **post):

So we must include parameters access_token and revive here. Otherwise we might get an error if another module also inherits the same method (with the correct parameters). If the method from website_sale_coupon is processed first, one parameter (post) is expected. So when another module tries to pass three parameters, an error will appear.

Author @axelpriem

@JKE-be 


From https://github.com/odoo/odoo/pull/64486

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
