### PR TITLE
[FIX] crm: correctly compute phone_sanitized without having crm_sms i…

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1516,6 +1516,10 @@ class Lead(models.Model):
                     break
         return result
 
+    def _phone_get_number_fields(self):
+        """ Use mobile or phone fields to compute sanitized phone number """
+        return ['mobile', 'phone']
+
     @api.model
     def get_import_templates(self):
         return [{

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -129,12 +129,12 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'philip.j.fry@test.example.com',
             'turanga.leela@test.example.com',
         ]
-        cls.test_pĥone_data = [
+        cls.test_phone_data = [
             '+1 202 555 0122',  # formatted US number
             '202 555 0999',  # local US number
             '202 555 0888',  # local US number
         ]
-        cls.test_pĥone_data_sanitized = [
+        cls.test_phone_data_sanitized = [
             '+12025550122',
             '+12025550999',
             '+12025550888',
@@ -153,7 +153,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.contact_1 = cls.env['res.partner'].create({
             'name': 'Philip J Fry',
             'email': cls.test_email_data[1],
-            'mobile': cls.test_pĥone_data[0],
+            'mobile': cls.test_phone_data[0],
             'title': cls.env.ref('base.res_partner_title_mister').id,
             'function': 'Delivery Boy',
             'phone': False,
@@ -167,8 +167,8 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.contact_2 = cls.env['res.partner'].create({
             'name': 'Turanga Leela',
             'email': cls.test_email_data[2],
-            'mobile': cls.test_pĥone_data[1],
-            'phone': cls.test_pĥone_data[2],
+            'mobile': cls.test_phone_data[1],
+            'phone': cls.test_phone_data[2],
             'parent_id': False,
             'is_company': False,
             'street': 'Cookieville Minimum-Security Orphanarium',

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -408,6 +408,12 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.mobile, self.test_phone_data[2])
         self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[2])
 
+        # updating country should trigger sanitize computation
+        lead.write({'country_id': self.env.ref('base.be').id})
+        self.assertEqual(lead.phone, self.test_phone_data[1])
+        self.assertEqual(lead.mobile, self.test_phone_data[2])
+        self.assertFalse(lead.phone_sanitized)
+
     @users('user_sales_manager')
     def test_phone_mobile_search(self):
         lead_1 = self.env['crm.lead'].create({

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -217,16 +217,16 @@ class TestCRMLead(TestCrmCommon):
         lead_form = Form(lead)
 
         # reset partner phone to a local number and prepare formatted / sanitized values
-        partner_phone, partner_mobile = self.test_pĥone_data[2], self.test_pĥone_data[1]
+        partner_phone, partner_mobile = self.test_phone_data[2], self.test_phone_data[1]
         partner_phone_formatted = phone_format(partner_phone, 'US', '1')
         partner_phone_sanitized = phone_format(partner_phone, 'US', '1', force_format='E164')
         partner_mobile_formatted = phone_format(partner_mobile, 'US', '1')
         partner_mobile_sanitized = phone_format(partner_mobile, 'US', '1', force_format='E164')
         partner_email, partner_email_normalized = self.test_email_data[2], self.test_email_data_normalized[2]
         self.assertEqual(partner_phone_formatted, '+1 202-555-0888')
-        self.assertEqual(partner_phone_sanitized, self.test_pĥone_data_sanitized[2])
+        self.assertEqual(partner_phone_sanitized, self.test_phone_data_sanitized[2])
         self.assertEqual(partner_mobile_formatted, '+1 202-555-0999')
-        self.assertEqual(partner_mobile_sanitized, self.test_pĥone_data_sanitized[1])
+        self.assertEqual(partner_mobile_sanitized, self.test_phone_data_sanitized[1])
         # ensure initial data
         self.assertEqual(partner.phone, partner_phone)
         self.assertEqual(partner.mobile, partner_mobile)
@@ -388,13 +388,34 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(new_lead.partner_id.team_id, self.sales_team_1)
 
     @users('user_sales_manager')
+    def test_phone_mobile_update(self):
+        lead = self.env['crm.lead'].create({
+            'name': 'Lead 1',
+            'country_id': self.env.ref('base.us').id,
+            'phone': self.test_phone_data[0],
+        })
+        self.assertEqual(lead.phone, self.test_phone_data[0])
+        self.assertFalse(lead.mobile)
+        self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[0])
+
+        lead.write({'phone': False, 'mobile': self.test_phone_data[1]})
+        self.assertFalse(lead.phone)
+        self.assertEqual(lead.mobile, self.test_phone_data[1])
+        self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[1])
+
+        lead.write({'phone': self.test_phone_data[1], 'mobile': self.test_phone_data[2]})
+        self.assertEqual(lead.phone, self.test_phone_data[1])
+        self.assertEqual(lead.mobile, self.test_phone_data[2])
+        self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[2])
+
+    @users('user_sales_manager')
     def test_phone_mobile_search(self):
         lead_1 = self.env['crm.lead'].create({
             'name': 'Lead 1',
             'country_id': self.env.ref('base.be').id,
             'phone': '+32485001122',
         })
-        lead_2 = self.env['crm.lead'].create({
+        _lead_2 = self.env['crm.lead'].create({
             'name': 'Lead 2',
             'country_id': self.env.ref('base.be').id,
             'phone': '+32485112233',

--- a/addons/crm_sms/models/crm_lead.py
+++ b/addons/crm_sms/models/crm_lead.py
@@ -10,4 +10,5 @@ class CrmLead(models.Model):
     def _sms_get_number_fields(self):
         """ This method returns the fields to use to find the number to use to
         send an SMS on a record. """
+        # TDE FIXME: to be cleaned in 14.4+ as it conflicts with _phone_get_number_fields
         return ['mobile', 'phone']

--- a/addons/crm_sms/tests/__init__.py
+++ b/addons/crm_sms/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_crm_lead

--- a/addons/crm_sms/tests/test_crm_lead.py
+++ b/addons/crm_sms/tests/test_crm_lead.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.tests.common import Form, users
+
+
+class TestCRMLead(TestCrmCommon):
+
+    @users('user_sales_manager')
+    def test_phone_mobile_update(self):
+        lead = self.env['crm.lead'].create({
+            'name': 'Lead 1',
+            'country_id': self.env.ref('base.us').id,
+            'phone': self.test_phone_data[0],
+        })
+        self.assertEqual(lead.phone, self.test_phone_data[0])
+        self.assertFalse(lead.mobile)
+        self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[0])
+
+        lead.write({'phone': False, 'mobile': self.test_phone_data[1]})
+        self.assertFalse(lead.phone)
+        self.assertEqual(lead.mobile, self.test_phone_data[1])
+        self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[1])
+
+        lead.write({'phone': self.test_phone_data[1], 'mobile': self.test_phone_data[2]})
+        self.assertEqual(lead.phone, self.test_phone_data[1])
+        self.assertEqual(lead.mobile, self.test_phone_data[2])
+        self.assertEqual(lead.phone_sanitized, self.test_phone_data_sanitized[2])

--- a/addons/mass_mailing_sms/models/mailing_contact.py
+++ b/addons/mass_mailing_sms/models/mailing_contact.py
@@ -11,4 +11,5 @@ class MailingContact(models.Model):
     mobile = fields.Char(string='Mobile')
 
     def _sms_get_number_fields(self):
+        # TDE note: should override _phone_get_number_fields but ok as sms is in dependencies
         return ['mobile']

--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -43,7 +43,7 @@ class PhoneMixin(models.AbstractModel):
         help="Indicates if a blacklisted sanitized phone number is a mobile number. Helps distinguish which number is blacklisted \
             when there is both a mobile and phone field in a model.")
 
-    @api.depends(lambda self: self._phone_get_number_fields())
+    @api.depends(lambda self: self._phone_get_sanitize_triggers())
     def _compute_phone_sanitized(self):
         self._assert_phone_field()
         number_fields = self._phone_get_number_fields()
@@ -112,6 +112,11 @@ class PhoneMixin(models.AbstractModel):
             raise UserError(_('Invalid primary phone field on model %s', self._name))
         if not any(fname in self and self._fields[fname].type == 'char' for fname in self._phone_get_number_fields()):
             raise UserError(_('Invalid primary phone field on model %s', self._name))
+
+    def _phone_get_sanitize_triggers(self):
+        """ Tool method to get all triggers for sanitize """
+        res = [self._phone_get_country_field()] if self._phone_get_country_field() else []
+        return res + self._phone_get_number_fields()
 
     def _phone_get_number_fields(self):
         """ This method returns the fields to use to find the number to use to

--- a/addons/sms/models/res_partner.py
+++ b/addons/sms/models/res_partner.py
@@ -17,4 +17,5 @@ class ResPartner(models.Model):
     def _sms_get_number_fields(self):
         """ This method returns the fields to use to find the number to use to
         send an SMS on a record. """
+        # TDE note: should override _phone_get_number_fields but ok as sms override it
         return ['mobile', 'phone']

--- a/addons/test_mail_full/models/test_mail_models.py
+++ b/addons/test_mail_full/models/test_mail_models.py
@@ -45,6 +45,7 @@ class MailTestSMSBL(models.Model):
         return ['customer_id']
 
     def _sms_get_number_fields(self):
+        # TDE note: should override _phone_get_number_fields but ok as sms in dependencies
         return ['phone_nbr', 'mobile_nbr']
 
 


### PR DESCRIPTION
…nstalled

Currently phone_sanitized computation on lead model works only if crm_sms
is installed. Indeed an override of ``_phone_get_number_fields`` is missing.
However ``_sms_get_number_fields`` coming with ``crm_sms`` and its ``sms``
dependency hides the issue as those modules are auto-install. However if
``crm_sms`` is uninstalled phone_sanitized is not correctly computed anymore.
