### PR TITLE
[FIX] mrp: add domain in workorder action

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -374,6 +374,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">mrp.workorder</field>
         <field name="view_type">form</field>
+        <field name="domain">[('production_state','not in',('done','cancel'))]</field>
         <field name="view_mode">gantt,tree,form,calendar,pivot,graph</field>
         <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
         <field name="view_id" ref="mrp_workorder_view_gantt"/>


### PR DESCRIPTION
The action is for planning "active" workorders, no need to fetch
already done or canceled ones. The same domain is applied on the
action_mrp_workorder_production, so this will make it consistent.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
