### PR TITLE
[FIX] sale_stock: compute in batch delivery_count

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -150,8 +150,10 @@ class SaleOrder(models.Model):
 
     @api.depends('picking_ids')
     def _compute_picking_ids(self):
+        data = dict((d['sale_id'][0], d['sale_id_count']) for d in self.env['stock.picking'].read_group(
+            [('sale_id', 'in', self.ids)], ['sale_id'], ['sale_id']))
         for order in self:
-            order.delivery_count = len(order.picking_ids)
+            order.delivery_count = data.get(order.id, 0)
 
     @api.onchange('company_id')
     def _onchange_company_id(self):


### PR DESCRIPTION
Before this commit, when you open a sale order with lot of pickings, it take some time, after this commit it is more faster.
The gain is big when you put `delivery_count in` tree view.

@amoyaux 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
