### PR TITLE
[FIX] project: portal access error

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -17,8 +17,13 @@ class CustomerPortal(CustomerPortal):
 
     def _prepare_home_portal_values(self):
         values = super(CustomerPortal, self)._prepare_home_portal_values()
-        values['project_count'] = request.env['project.project'].search_count([])
-        values['task_count'] = request.env['project.task'].search_count([])
+        values['project_count'] = request.env[
+            'project.project'].search_count([]) \
+            if request.env['project.project'].check_access_rights(
+            'read', raise_exception=False) else 0
+        values['task_count'] = request.env['project.task'].search_count([]) \
+            if request.env['project.task'].check_access_rights(
+            'read', raise_exception=False) else 0
         return values
 
     # ------------------------------------------------------------


### PR DESCRIPTION
- Install project
- Ceate an internal user without any access rights
- Go to `/my`

A 500 error is raised because of an AccessError.

When the user has no access rights to any of the mentioned applications,
the `search` call returns an AccessError.

We prevent the access error and return 0 as a fallback.

Same as https://github.com/odoo/odoo/commit/54ef98c613219aba3bda41817f7767261b8092d2


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
