### PR TITLE
[FIX] base_address_extended: split 'correctly' street name

### DIFF
--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -98,10 +98,18 @@ class Partner(models.Model):
             if separator and field_name:
                 #maxsplit set to 1 to unpack only the first element and let the rest untouched
                 tmp = street_raw.split(separator, 1)
+                if previous_greedy in vals:
+                    # attach part before space to preceding greedy field
+                    append_previous, sep, tmp[0] = tmp[0].rpartition(' ')
+                    street_raw = separator.join(tmp)
+                    vals[previous_greedy] += sep + append_previous
                 if len(tmp) == 2:
                     field_value, street_raw = tmp
                     vals[field_name] = field_value
             if field_value or not field_name:
+                previous_greedy = None
+                if field_name == 'street_name' and separator == ' ':
+                    previous_greedy = field_name
                 # select next field to find (first pass OR field found)
                 # [2:-2] is used to remove the extra chars '%(' and ')s'
                 field_name = re_match.group()[2:-2]

--- a/addons/base_address_extended/tests/test_street_fields.py
+++ b/addons/base_address_extended/tests/test_street_fields.py
@@ -40,7 +40,8 @@ class TestStreetFields(TransactionCase):
         self.create_and_assert('Test00', self.env.ref('base.us').id, '40/2b Chaussee de Namur', 'Chaussee de Namur', '40', '2b')
         self.create_and_assert('Test01', self.env.ref('base.us').id, '40 Chaussee de Namur', 'Chaussee de Namur', '40', '')
         self.create_and_assert('Test02', self.env.ref('base.us').id, 'Chaussee de Namur', 'de Namur', 'Chaussee', '')
-        self.create_and_assert('Test03', self.env.ref('base.mx').id, 'Av. Miguel Hidalgo y Costilla 601', 'Av.', 'Miguel Hidalgo y Costilla 601', '')
+        self.create_and_assert('Test03', self.env.ref('base.mx').id, 'Av. Miguel Hidalgo y Costilla 601', 'Av. Miguel Hidalgo y Costilla', '601', '')
+        self.create_and_assert('Test04', self.env.ref('base.mx').id, 'Av. Miguel Hidalgo y Costilla 601/40', 'Av. Miguel Hidalgo y Costilla', '601', '40')
 
     def test_01_header_trailer(self):
         self.create_and_assert('Test10', self.env.ref('base.ch').id, 'header Chaussee de Namur, 40 - 2b trailer', 'Chaussee de Namur', '40', '2b')


### PR DESCRIPTION
Issue

	- Install "Contacts" & 'base_address_extended' modules
	- Go to contacts and create a contact with value:
	  - street name : Chaussee de Namur
	  - House : 40
	- Save and edit again
	- Set country to 'Netherlands' then save.

	Address not splited well (wrong values for street name and house).
	The issue is not present in UI but is in tests.
	(Issue in UI from odoo 14.0+)

Cause

	There is 2 '_split_street_with_params'
	(inverse function that set street fields):
	- partner_autocomplete_address_extended (removed in 14.0)
	- base_address_extended

	The 'spliting' logic is not the same in both function.

	In UI, looks like it does not call '_split_street_with_params'
	from 'base_address_extended' since no super(Partner, self)...

	However in testing, it does call it from module
	'base_address_extended' and therefore trigger the issue.

Solution

	Adapt _split_street_with_params function
	(in 'base_address_extended' module):
	If previous field (from 'street_format') to parse
	in 'street_raw' is 'street_name', then:
	- set `tmp` to: splitted (max 1 split) street_raw
	  with current field seperator
	- set `append_previous, sep, tmp[0]` to:
	  splitted tmp[0] (first part of splited street_raw) with `rpartition(' ')`
	- add 'append_previous' to 'street_name' value
	- join 'tmp' values and set it to street
	  (should equal to what left from `rpartition(' ')` split
	  + second part of first normal split)
	- continue normal parsing flow

opw-2476096