### PR TITLE
partner name displayed with unnecessary comma

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -663,7 +663,8 @@ class Partner(models.Model):
         name = name.replace('\n\n', '\n')
         name = name.replace('\n\n', '\n')
         if self._context.get('address_inline'):
-            name = name.replace('\n', ', ')
+            splitted_names = name.split("\n")
+            name = ", ".join([n for n in splitted_names if n.strip()])
         if self._context.get('show_email') and partner.email:
             name = "%s <%s>" % (name, partner.email)
         if self._context.get('html_format'):

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -19,6 +19,22 @@ class TestPartner(TransactionCase):
         ns_res = self.env['res.partner'].name_search('Vlad', args=[('user_ids.email', 'ilike', 'vlad')])
         self.assertEqual(set(i[0] for i in ns_res), set(test_user.partner_id.ids))
 
+    def test_name_get(self):
+        """ Check name_get on partner, especially with different context
+        Check name_get correctly return name with context. """
+        test_partner_jetha = self.env['res.partner'].create({'name': 'Jethala', 'street': 'Powder gali', 'street2': 'Gokuldham Society'})
+        test_partner_bhide = self.env['res.partner'].create({'name': 'Atmaram Bhide'})
+
+        res_jetha = test_partner_jetha.with_context(show_address=1).name_get()
+        self.assertEqual(res_jetha[0][1], "Jethala\nPowder gali\nGokuldham Society\n  \n", "name should contain comma separated name and address")
+        res_bhide = test_partner_bhide.with_context(show_address=1).name_get()
+        self.assertEqual(res_bhide[0][1], "Atmaram Bhide\n  \n", "name should contain only name if address is not available, without extra commas")
+
+        res_jetha = test_partner_jetha.with_context(show_address=1, address_inline=1).name_get()
+        self.assertEqual(res_jetha[0][1], "Jethala, Powder gali, Gokuldham Society", "name should contain comma separated name and address")
+        res_bhide = test_partner_bhide.with_context(show_address=1, address_inline=1).name_get()
+        self.assertEqual(res_bhide[0][1], "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
+
     def test_company_change_propagation(self):
         """ Check propagation of company_id across children """
         User = self.env['res.users']


### PR DESCRIPTION
PURPOSE
when partner is only created with name(i.e. without address) and when 'address_inline' is passed in context then partner name shows with unnecessary commas.

SPEC
partner name should not have unncessary commas in case of 'address_inline' passed in context.

TASK 2502597


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
