### PR TITLE
[13.0] HR: hr_employee remove domain on coach_id

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -29,7 +29,7 @@ class HrEmployeeBase(models.AbstractModel):
     resource_id = fields.Many2one('resource.resource')
     resource_calendar_id = fields.Many2one('resource.calendar', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     parent_id = fields.Many2one('hr.employee', 'Manager', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    coach_id = fields.Many2one('hr.employee', 'Coach', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    coach_id = fields.Many2one('hr.employee', 'Coach')
     tz = fields.Selection(
         string='Timezone', related='resource_id.tz', readonly=False,
         help="This field is used in order to define in which timezone the resources will work.")

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -28,7 +28,7 @@ class HrEmployeeBase(models.AbstractModel):
     user_id = fields.Many2one('res.users')
     resource_id = fields.Many2one('resource.resource')
     resource_calendar_id = fields.Many2one('resource.calendar', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    parent_id = fields.Many2one('hr.employee', 'Manager', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    parent_id = fields.Many2one('hr.employee', 'Manager')
     coach_id = fields.Many2one('hr.employee', 'Coach')
     tz = fields.Selection(
         string='Timezone', related='resource_id.tz', readonly=False,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In a multicompany context an employee from another company can be the coach of someone from another company.
The need is the same for parent_id "manager"

Current behavior before PR:

You cannot set as a coach someone that is from another company.

Desired behavior after PR is merged:
Onto the employee A I should be able to assign employee B:
- regardless companies (what is done into this PR)
- or employeeA company is in employeeB.allowed_companies

OPW #2528652


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
