### PR TITLE
[FIX] web: Allow accented uppercase characters in sign

### DIFF
--- a/addons/web/static/src/js/widgets/name_and_signature.js
+++ b/addons/web/static/src/js/widgets/name_and_signature.js
@@ -346,8 +346,7 @@ var NameAndSignature = Widget.extend({
      * @returns {string} cleaned name
      */
     _getCleanedName: function () {
-        var regexRemoveSpecialCharacters = /[^\w\u00E0-\u00FC-'" ]/g;
-        var text = this.getName().replace(regexRemoveSpecialCharacters, '');
+        var text = this.getName();
         if (this.signatureType === 'initial') {
             return (text.split(' ').map(function (w) {
                 return w[0];


### PR DESCRIPTION
When signing a document, characters with accents are not rendered if
they are uppercase.

To reproduce the error:
(Need sale_management)
1. Create a SO
2. Customer Preview
3. Sign & Pay
4. Select "Auto" with this Full Name: ÜÄÏÖ

Error: None of the letters are rendered

Backport of 0684219d59b0653ed3380fef73b4bd75f3bae84f

OPW-2475740