### PR TITLE
[FIX] *: update documentation links

### DIFF
--- a/addons/auth_oauth/views/res_config_settings_views.xml
+++ b/addons/auth_oauth/views/res_config_settings_views.xml
@@ -27,7 +27,7 @@
                                     <label for="auth_oauth_google_client_id" string="Client ID:" class="col-lg-3 o_light_label"/>
                                     <field name="auth_oauth_google_client_id" placeholder="e.g. 1234-xyz.apps.googleusercontent.com"/>
                                 </div>
-                                <a href="https://www.odoo.com/documentation/user/online/general/auth/google.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
+                                <a href="https://www.odoo.com/documentation/13.0/applications/general/auth/google.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
                             </div>
                         </div>
                     </div>

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -99,7 +99,7 @@
                             <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
                         </a>
                     </div>
-                    <a href="https://www.odoo.com/documentation/user/13.0/general/base_import/import_faq.html" target="new">Import FAQ</a>
+                    <a href="https://www.odoo.com/documentation/13.0/applications/general/base_import/import_faq.html" target="new">Import FAQ</a>
                 </div>
             </div>
         </form>

--- a/addons/google_calendar/views/res_config_settings_views.xml
+++ b/addons/google_calendar/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                             <label for="cal_client_secret" string="Client Secret" class="col-3 col-lg-3 o_light_label"/>
                             <field name="cal_client_secret" password="True" nolabel="1"/>
                         </div>
-                        <a href="https://www.odoo.com/documentation/user/13.0/crm/optimize/google_calendar_credentials.html" class="oe-link" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
+                        <a href="https://www.odoo.com/documentation/13.0/applications/sales/crm/optimize/google_calendar_credentials.html" class="oe-link" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
                     </div>
                 </div>
             </field>

--- a/addons/hw_posbox_homepage/views/layout.html
+++ b/addons/hw_posbox_homepage/views/layout.html
@@ -137,7 +137,7 @@
         </div>
         <div class="footer">
             <a href='https://www.odoo.com/help'>Help</a>
-            <a href='https://www.odoo.com/documentation/user/13.0/iot.html'>Documentation</a>
+            <a href='https://www.odoo.com/documentation/13.0/applications/productivity/iot.html'>Documentation</a>
         </div>
     </body>
 </html>

--- a/addons/hw_posbox_homepage/views/upgrade_page.html
+++ b/addons/hw_posbox_homepage/views/upgrade_page.html
@@ -73,7 +73,7 @@
         However the preferred method to upgrade the IoTBox is to flash the sd-card with
         the <a href='http://nightly.odoo.com/master/posbox/iotbox/iotbox-latest.zip'>latest image</a>. The upgrade
         procedure is explained into to the
-        <a href='https://www.odoo.com/documentation/user/13.0/iot.html'>IoTBox manual</a>
+        <a href='https://www.odoo.com/documentation/13.0/applications/productivity/iot.html'>IoTBox manual</a>
     </p>
     <p>
         To upgrade the IoTBox, click on the upgrade button. The upgrade will take a few minutes. <b>Do not reboot</b> the IoTBox during the upgrade.

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -9,7 +9,7 @@ Chilean accounting chart and tax localization.
 Plan contable chileno e impuestos de acuerdo a disposiciones vigentes
     """,
     'author': 'Blanco Martín & Asociados',
-    'website': 'https://www.odoo.com/documentation/user/13.0/accounting/fiscal_localizations/localizations/chile.html',
+    'website': 'https://www.odoo.com/documentation/13.0/applications/finance/accounting/fiscal_localizations/localizations/chile.html',
     'category': 'Localization',
     'depends': [
         'contacts',

--- a/addons/payment/views/payment_acquirer_onboarding_templates.xml
+++ b/addons/payment/views/payment_acquirer_onboarding_templates.xml
@@ -45,7 +45,7 @@
                                     <span>Start selling directly without an account; an email will be sent by Paypal to create your new account and collect your payments.</span>
                                 </p>
                                 <p attrs="{'invisible': [('paypal_user_type', '=', 'new_user')]}">
-                                    <a href="https://www.odoo.com/documentation/user/13.0/ecommerce/shopper_experience/paypal.html" target="_blank">
+                                    <a href="https://www.odoo.com/documentation/13.0/applications/general/payment_acquirers/paypal.html" target="_blank">
                                         <span class="fa fa-arrow-right"> How to configure your PayPal account</span>
                                     </a>
                                 </p>

--- a/addons/payment_authorize/views/payment_views.xml
+++ b/addons/payment_authorize/views/payment_views.xml
@@ -15,7 +15,7 @@
                             <field name="authorize_client_key" password="True"/>
                             <button class="oe_link" icon="fa-refresh" type="object" name="action_client_secret" string="Generate Client Key" />
                         </div>
-                        <a colspan="2" href="https://www.odoo.com/documentation/user/online/ecommerce/shopper_experience/authorize.html" target="_blank">How to get paid with Authorize.Net</a>
+                        <a colspan="2" href="https://www.odoo.com/documentation/13.0/applications/general/payment_acquirers/authorize.html" target="_blank">How to get paid with Authorize.Net</a>
                     </group>
                 </xpath>
             </field>

--- a/addons/payment_paypal/views/payment_views.xml
+++ b/addons/payment_paypal/views/payment_views.xml
@@ -13,7 +13,7 @@
                         <field name="paypal_seller_account"/>
                         <field name="paypal_pdt_token"/>
                         <field name="paypal_use_ipn" attrs="{'required':[ ('provider', '=', 'paypal'), ('state', '!=', 'disabled')]}"/>
-                        <a colspan="2" href="https://www.odoo.com/documentation/user/online/ecommerce/shopper_experience/paypal.html" target="_blank">How to configure your paypal account?</a>
+                        <a colspan="2" href="https://www.odoo.com/documentation/13.0/applications/general/payment_acquirers/paypal.html" target="_blank">How to configure your paypal account?</a>
                     </group>
                 </xpath>
             </field>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -289,7 +289,9 @@
                                     <div class="mt16">
                                         <field name="iface_tax_included" class="o_light_label" widget="radio"/>
                                     </div>
-                                    <a attrs="{'invisible': [('iface_tax_included', '!=', 'total')]}" href="https://www.odoo.com/documentation/user/13.0/accounting/others/taxes/tax_included.html"  target="_blank" class="oe-link"><i class="fa fa-fw fa-arrow-right"/>How to manage tax-included prices</a>
+                                    <a attrs="{'invisible': [('iface_tax_included', '!=', 'total')]}"
+                                        href="https://www.odoo.com/documentation/13.0/applications/finance/accounting/taxation/taxes/B2B_B2C.html"
+                                        target="_blank" class="oe-link"><i class="fa fa-fw fa-arrow-right"/>How to manage tax-included prices</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/web/static/src/js/chrome/user_menu.js
+++ b/addons/web/static/src/js/chrome/user_menu.js
@@ -79,7 +79,7 @@ var UserMenu = Widget.extend({
      * @private
      */
     _onMenuDocumentation: function () {
-        window.open('https://www.odoo.com/documentation/user', '_blank');
+        window.open('https://www.odoo.com/documentation/13.0', '_blank');
     },
     /**
      * @private

--- a/addons/web_unsplash/static/src/xml/unsplash_image_widget.xml
+++ b/addons/web_unsplash/static/src/xml/unsplash_image_widget.xml
@@ -49,11 +49,12 @@
         <div class="form-group mt-4 access_key_box">
             <input type="text" class="form-control w-100" id="accessKeyInput" placeholder="Paste your access key here"/>
         </div>
-        <a href="https://www.odoo.com/documentation/user/general/unsplash/unsplash_access_key.html" target="_blank"><i class="fa fa-arrow-right"/> Generate an access key</a>
+        <a href="https://www.odoo.com/documentation/13.0/applications/general/unsplash/unsplash_access_key.html" target="_blank"><i class="fa fa-arrow-right"/> Generate an access key</a>
         <div class="form-group mt-4 access_key_box">
             <input type="text" class="form-control w-100" id="appIdInput" placeholder="Paste your application ID here"/>
         </div>
-        <a href="https://www.odoo.com/documentation/user/general/unsplash/unsplash_application_id.html" target="_blank"><i class="fa fa-arrow-right"/> How to find my Unsplash Application ID?</a>
+        <a href="https://www.odoo.com/documentation/13.0/applications/general/unsplash/unsplash_application_id.html" target="_blank">
+            <i class="fa fa-arrow-right"/> How to find my Unsplash Application ID?</a>
         <button type="button" class="btn btn-primary btn-block mt-4 save_unsplash">Apply</button>
     </div>
 </t>

--- a/addons/web_unsplash/views/res_config_settings_view.xml
+++ b/addons/web_unsplash/views/res_config_settings_view.xml
@@ -12,7 +12,7 @@
                         <field name="unsplash_access_key"/>
                     </div>
                     <div>
-                        <a href="https://www.odoo.com/documentation/user/general/unsplash/unsplash_access_key.html" class="oe_link" target="_blank">
+                        <a href="https://www.odoo.com/documentation/13.0/applications/general/unsplash/unsplash_access_key.html" class="oe_link" target="_blank">
                             <i class="fa fa-arrow-right"/> Generate an Access Key
                         </a>
                     </div>

--- a/addons/website/static/src/xml/website.backend.xml
+++ b/addons/website/static/src/xml/website.backend.xml
@@ -62,13 +62,13 @@
 
     <div t-name="website.ga_dialog_content">
         Your Tracking ID: <input type="text" name="ga_analytics_key" placeholder="UA-XXXXXXXX-Y" t-att-value="ga_analytics_key" style="width: 100%"></input>
-        <a href="https://www.odoo.com/documentation/user/online/website/optimize/google_analytics.html" target="_blank">
+        <a href="https://www.odoo.com/documentation/13.0/applications/websites/website/optimize/google_analytics.html" target="_blank">
             <i class="fa fa-arrow-right"/>
             How to get my Tracking ID
         </a>
         <br/><br/>
         Your Client ID: <input type="text" name="ga_client_id" t-att-value="ga_key" style="width: 100%"></input>
-        <a href="https://www.odoo.com/documentation/user/online/website/optimize/google_analytics_dashboard.html" target="_blank">
+        <a href="https://www.odoo.com/documentation/13.0/applications/websites/website/optimize/google_analytics_dashboard.html" target="_blank">
             <i class="fa fa-arrow-right"/>
             How to get my Client ID
         </a>

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -158,7 +158,7 @@
                                         </div>
                                     </div>
                                     <div attrs="{'invisible': [('has_google_analytics', '=', False)]}">
-                                        <a href="https://www.odoo.com/documentation/user/13.0/website/optimize/google_analytics.html"
+                                        <a href="https://www.odoo.com/documentation/13.0/applications/websites/website/optimize/google_analytics.html"
                                                 class="oe_link" target="_blank">
                                             <i class="fa fa-arrow-right"/>
                                             How to get my Tracking ID
@@ -187,7 +187,7 @@
                                         </div>
                                     </div>
                                     <div attrs="{'invisible': [('has_google_analytics_dashboard', '=', False)]}">
-                                        <a href="https://www.odoo.com/documentation/user/online/website/optimize/google_analytics_dashboard.html"
+                                        <a href="https://www.odoo.com/documentation/13.0/applications/websites/website/optimize/google_analytics_dashboard.html"
                                             class="oe_link" target="_blank">
                                             <i class="fa fa-arrow-right"/>
                                             How to get my Client ID

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -876,7 +876,7 @@ class Users(models.Model):
                     "and *might* be a proxy. If your Odoo is behind a proxy, "
                     "it may be mis-configured. Check that you are running "
                     "Odoo in Proxy Mode and that the proxy is properly configured, see "
-                    "https://www.odoo.com/documentation/13.0/setup/deploy.html#https for details.",
+                    "https://www.odoo.com/documentation/13.0/administration/deployment/deploy.html#https for details.",
                     source
                 )
             raise AccessDenied(_("Too many login failures, please wait a bit before trying again."))

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -784,7 +784,7 @@ class HttpRequest(WebRequest):
 
 Odoo URLs are CSRF-protected by default (when accessed with unsafe
 HTTP methods). See
-https://www.odoo.com/documentation/13.0/reference/http.html#csrf for
+https://www.odoo.com/documentation/13.0/developer/reference/http.html#csrf for
 more details.
 
 * if this endpoint is accessed through Odoo via py-QWeb form, embed a CSRF


### PR DESCRIPTION
Following the recent reorganisation of the documentation in 12.0+, the
majority of the documents have been moved and their old links are no longer
valid.
Some redirection rules will soon be deployed, but those rules might be
dropped in some years and we want the links to still work, 
which is why we still replace the links to the new ones.

FW-Port of odoo/odoo#70675 (13.0)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
