### PR TITLE
[FIX] sale_timesheet: not use demo data in unit test

### DIFF
--- a/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
@@ -11,10 +11,15 @@ class TestUi(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        service_category_id = cls.env['product.category'].create({
+            'name': 'Services',
+            'parent_id': cls.env.ref('product.product_category_1').id,
+        }).id
+
         uom_hour_id = cls.env.ref('uom.product_uom_hour').id
         cls.prepaid_service_product = cls.env['product.product'].create({
             'name': 'Service Product (Prepaid Hours)',
-            'categ_id': cls.env.ref('product.product_category_3').id,
+            'categ_id': service_category_id,
             'type': 'service',
             'list_price': 250.00,
             'standard_price': 190.00,


### PR DESCRIPTION
Before this commit, we use the 'product.product_category_3'
external_xmlid to find the 'Services' category but this record is in
fact a demo data.

This commit removes this using to create a new category called
'Services' for the product created in this test.

Related PR: #65146

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
