### PR TITLE
[FIX] remove undeterministic error in sale_timesheet_tour

### DIFF
--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -18,7 +18,7 @@ tour.register('sale_timesheet_tour', {
         actions.text('Brandon Freeman', this.$anchor.find('input'));
     },
 }, {
-    trigger: 'ul.o_partner_autocomplete_dropdown > li:first-child > a',
+    trigger: 'ul.o_partner_autocomplete_dropdown > li:first-child > a:contains(Freeman)',
     content: 'Select the first item on the autocomplete dropdown',
     run: 'click',
 },
@@ -207,7 +207,7 @@ tour.register('sale_timesheet_tour', {
         actions.text('Azure Interior, Brandon Freeman', this.$anchor.find('input'));
     },
 }, {
-    trigger: 'ul.o_partner_autocomplete_dropdown > li:first-child > a',
+    trigger: 'ul.o_partner_autocomplete_dropdown > li:first-child > a:contains(Freeman)',
     content: 'Select the customer in the autocomplete dropdown',
     run: 'click',
 }, {


### PR DESCRIPTION
Before this commit, the wrong many2one value could have been
selected in the tours, making it fail later on.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
