### PR TITLE
[FIX] crm: fix query counters: 2 tests sometimes at +3 on runbot

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=251):
+        with self.assertQueryCount(user_sales_manager=254):  # often 251, sometimes +3 on runbot
             test_leads.handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=218):  # still some randomness (217 spotted) - crm only: 215
+        with self.assertQueryCount(user_sales_manager=221):  # crm only: 215 - generally 218, sometimes +2/+3 on runbot
             test_leads.handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)


### PR DESCRIPTION
/shrug
