### PR TITLE
[FIX] im_livechat: Add missing file in external_lib bundle

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -97,6 +97,7 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/src/js/boot.js',
             'web/static/src/js/libs/download.js',
             'web/static/src/js/libs/content-disposition.js',
+            'web/static/src/js/libs/pdfjs.js',
             'web/static/src/js/services/config.js',
             'web/static/src/js/core/abstract_service.js',
             'web/static/src/js/core/class.js',


### PR DESCRIPTION
The module `@web/js/libs/pdfjs` was imported in the legacy file by PR #70375.
So the file has to be added in external_lib bundle.