### PR TITLE
[FIX] website_forum: add data-parent to fix faq accordion

### DIFF
--- a/addons/website_forum/data/forum_default_faq.xml
+++ b/addons/website_forum/data/forum_default_faq.xml
@@ -12,7 +12,7 @@
                                 <a href="#" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header" data-target="#collapse1">
                                     <b>What kinds of questions can I ask here?</b>
                                 </a>
-                                <div id="collapse1" class="collapse" role="tabpanel">
+                                <div id="collapse1" class="collapse" data-parent="#myCollapse" role="tabpanel">
                                     <div class="card-body">
                                         <p>This community is for professional and enthusiast users, partners and programmers. You can ask questions about:</p>
                                         <ul>
@@ -31,7 +31,7 @@
                                 <a href="#" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header" data-target="#collapse2">
                                     <b>What should I avoid in my questions?</b>
                                 </a>
-                                <div id="collapse2" class="collapse" role="tabpanel">
+                                <div id="collapse2" class="collapse" data-parent="#myCollapse" role="tabpanel">
                                     <div class="card-body">
                                         <p>You should only ask practical, answerable questions based on actual problems that you face. Chatty, open-ended questions diminish the usefulness of this site and push other questions off the front page.</p>
                                         <p>To prevent your question from being flagged and possibly removed, avoid asking subjective questions where …</p>
@@ -58,7 +58,7 @@
                                 <a href="#" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header" data-target="#collapse3">
                                     <b>What should I avoid in my answers?</b>
                                 </a>
-                                <div id="collapse3" class="collapse" role="tabpanel">
+                                <div id="collapse3" class="collapse"  data-parent="#myCollapse" role="tabpanel">
                                     <div class="card-body">
                                         <p><b>Answers should not add or expand questions</b>. Insteadeither edit the question or add a comment.</p>
                                         <p><b>Answers should not comment other answers</b>. Instead add a comment on the other answers.</p>
@@ -74,7 +74,7 @@
                                 <a href="#" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header" data-target="#collapse4">
                                     <b>Why can other people edit my questions/answers?</b>
                                 </a>
-                                <div id="collapse4" class="collapse" role="tabpanel">
+                                <div id="collapse4" class="collapse" data-parent="#myCollapse" role="tabpanel">
                                     <div class="card-body">
                                         <p>The goal of this site is create a relevant knowledge base that would answer questions related to Odoo.</p>
                                         <p>Therefore questions and answers can be edited like wiki pages by experienced users of this site in order to improve the overall quality of the knowledge base content. Such privileges are granted based on user karma level: you will be able to do the same once your karma gets high enough.</p>


### PR DESCRIPTION
website_forum.faq_accordion is not rendered by a drag'n'drop
and data-parent is therefore not set on tabpanels by onBuilt.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
