### PR TITLE
[FIX] website: ids in xml for accordion rendered by configurator

### DIFF
--- a/addons/website/views/snippets/s_faq_collapse.xml
+++ b/addons/website/views/snippets/s_faq_collapse.xml
@@ -3,19 +3,20 @@
 
 <template id="s_faq_collapse" name="Accordion">
     <section class="s_faq_collapse pt32 pb32">
+        <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
         <div class="container">
             <div id="myCollapse" class="accordion" role="tablist">
                 <div class="card bg-white" data-name="Item">
-                    <a href="#" role="tab" data-toggle="collapse" aria-expanded="true" class="card-header">Terms of service</a>
-                    <div class="collapse show" role="tabpanel">
+                    <a href="#" t-attf-data-target="#myCollapseTab{{uniq}}_1" role="tab" data-toggle="collapse" aria-expanded="true" class="card-header">Terms of service</a>
+                    <div t-attf-id="myCollapseTab{{uniq}}_1" class="collapse show" data-parent="#myCollapse" role="tabpanel">
                         <div class="card-body">
                             <p class="card-text">These terms of service ("Terms", "Agreement") are an agreement between the website ("Website operator", "us", "we" or "our") and you ("User", "you" or "your"). This Agreement sets forth the general terms and conditions of your use of this website and any of its products or services (collectively, "Website" or "Services").</p>
                         </div>
                     </div>
                 </div>
                 <div class="card bg-white" data-name="Item">
-                    <a href="#" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header">Links to other Websites</a>
-                    <div class="collapse" role="tabpanel">
+                    <a href="#" t-attf-data-target="#myCollapseTab{{uniq}}_2" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header">Links to other Websites</a>
+                    <div t-attf-id="myCollapseTab{{uniq}}_2" class="collapse" data-parent="#myCollapse" role="tabpanel">
                         <div class="card-body">
                             <p class="card-text">Although this Website may be linked to other websites, we are not, directly or indirectly, implying any approval, association, sponsorship, endorsement, or affiliation with any linked website, unless specifically stated herein.</p>
                             <p class="card-text">You should carefully review the legal statements and other conditions of use of any website which you access through a link from this Website. Your linking to any other off-site pages or other websites is at your own risk.</p>
@@ -23,8 +24,8 @@
                     </div>
                 </div>
                 <div class="card bg-white" data-name="Item">
-                    <a href="#" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header">Use of Cookies</a>
-                    <div class="collapse" role="tabpanel">
+                    <a href="#" t-attf-data-target="#myCollapseTab{{uniq}}_3" role="tab" data-toggle="collapse" aria-expanded="false" class="collapsed card-header">Use of Cookies</a>
+                    <div t-attf-id="myCollapseTab{{uniq}}_3" class="collapse" data-parent="#myCollapse" role="tabpanel">
                         <div class="card-body">
                             <p class="card-text">Website may use cookies to personalize and facilitate maximum navigation of the User by this site. The User may configure his / her browser to notify and reject the installation of the cookies sent by us.</p>
                         </div>


### PR DESCRIPTION
accordions in pages created by configurator have not been added by a
drag'n'drop. onBuilt is therefore not called and attributes (data-parent
and id for tabpanel and data-target for tab) are not set. We set these
attributes directly in the xml to make accordions work also for configurator.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
