### PR TITLE
[FIX] mrp: use MO's UoM on unbuild order creation

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -80,7 +80,7 @@ class MrpUnbuild(models.Model):
     def onchange_product_id(self):
         if self.product_id:
             self.bom_id = self.env['mrp.bom']._bom_find(product=self.product_id)
-            self.product_uom_id = self.product_id.uom_id.id
+            self.product_uom_id = self.mo_id.product_id == self.product_id and self.mo_id.product_uom_id.id or self.product_id.uom_id.id
 
     @api.constrains('product_qty')
     def _check_qty(self):


### PR DESCRIPTION
On unbuild order creation, when the user selects a manufacturing order,
the UoM of the quantity will be defined with the product's UoM instead
of MO's UoM.

To reproduce the error:
(Use demo data)
1. In Settings > General Settings, enable "Units of Measure"
2. Create two products P_finished and P_compo
    - Both are storable
    - Qty on Hand of P_compo = 12
3. Create a Bill of Material
    - Product: P_finished
    - Component: 1 x P_compo
4. Create a Manufacturing Order MO
    - Product: P_finished
    - Quantity To Produce: 1 Dozen(s)
5. Check Availability, Produce, Mark as Done
6. Create an Unbuild Order:
    - Manufacturing Order: MO

Error: The unit of measure of the quantity is incorrect, this is
Unit(s), it should be Dozen(s)

The method `onchange_mo_id` defines the product, therefore the method
`onchange_product_id` is also called and here is the issue:
`onchange_product_id` will override the UoM using the product's UoM.

OPW-2467017