### PR TITLE
[IMP] account: Usability Improvements for Journal & Duplication traceability

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2,7 +2,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import RedirectWarning, UserError, ValidationError, AccessError
-from odoo.tools import float_compare, date_utils, email_split, email_re
+from odoo.tools import float_compare, date_utils, email_split, email_re, html_escape
 from odoo.tools.misc import formatLang, format_date, get_lang
 
 from datetime import date, timedelta
@@ -1864,7 +1864,12 @@ class AccountMove(models.Model):
             default['date'] = self.company_id._get_user_fiscal_lock_date() + timedelta(days=1)
         if self.move_type == 'entry':
             default['partner_id'] = False
-        return super(AccountMove, self).copy(default)
+        copied_am = super().copy(default)
+        copied_am._message_log(body=_(
+            'This entry has been duplicated from <a href=# data-oe-model=account.move data-oe-id=%(id)d>%(title)s</a>',
+            id=self.id, title=html_escape(self.display_name)
+        ))
+        return copied_am
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2178,9 +2178,9 @@ class AccountMove(models.Model):
         :return:            A string representing the invoice.
         '''
         self.ensure_one()
-        draft_name = ''
+        name = ''
         if self.state == 'draft':
-            draft_name += {
+            name += {
                 'out_invoice': _('Draft Invoice'),
                 'out_refund': _('Draft Credit Note'),
                 'in_invoice': _('Draft Bill'),
@@ -2189,11 +2189,12 @@ class AccountMove(models.Model):
                 'in_receipt': _('Draft Purchase Receipt'),
                 'entry': _('Draft Entry'),
             }[self.move_type]
-            if not self.name or self.name == '/':
-                draft_name += ' (* %s)' % str(self.id)
-            else:
-                draft_name += ' ' + self.name
-        return (draft_name or self.name) + (show_ref and self.ref and ' (%s%s)' % (self.ref[:50], '...' if len(self.ref) > 50 else '') or '')
+            name += ' '
+        if not self.name or self.name == '/':
+            name += '(* %s)' % str(self.id)
+        else:
+            name += self.name
+        return name + (show_ref and self.ref and ' (%s%s)' % (self.ref[:50], '...' if len(self.ref) > 50 else '') or '')
 
     def _get_invoice_delivery_partner_id(self):
         ''' Hook allowing to retrieve the right delivery address depending of installed modules.

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -30,6 +30,11 @@
             <field name="arch" type="xml">
                 <form string="Account Journal">
                     <sheet>
+                        <div name="button_box" class="oe_button_box">
+                            <button class="oe_stat_button" type="action"
+                                    name="%(action_account_moves_all_a)d" icon="fa-book" string="Journal Entries"
+                                    context="{'search_default_journal_id':active_id}"/>
+                        </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <div class="oe_title">
                             <label for="name"/>


### PR DESCRIPTION
- navigation from a journal to its entries improved by adding a smart button on the Journal Form View
- improve traceability of duplicated journal entries by logging a message in the chatter to trace back to its origin entry

was task 2478537

Description of the issue/feature this PR addresses:

Current behavior before PR:

1. There was no link from journals to entries
2. There was no traceability when duplicating a journal entry

Desired behavior after PR is merged:

1. A smart button is available to view entries
2. A message is logged referencing the original entry



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
