### PR TITLE
[IMP] base: add accounting firm to company data and xml exports

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -93,6 +93,19 @@ class Company(models.Model):
     font = fields.Selection([("Lato", "Lato"), ("Roboto", "Roboto"), ("Open_Sans", "Open Sans"), ("Montserrat", "Montserrat"), ("Oswald", "Oswald"), ("Raleway", "Raleway")], default="Lato")
     primary_color = fields.Char()
     secondary_color = fields.Char()
+
+    agent_name = fields.Char(string="Agent's Name")
+    agent_street = fields.Char()
+    agent_street2 = fields.Char()
+    agent_zip = fields.Char()
+    agent_city = fields.Char()
+    agent_state_id = fields.Many2one('res.country.state', string="Agent's State", domain="[('country_id', '=?', country_id)]")
+    agent_country_id = fields.Many2one('res.country', string="Agent's Country")
+    agent_vat = fields.Char(string="Agent's Tax ID", readonly=False)
+    agent_email = fields.Char(string="Agent's Email", readonly=False)
+    agent_phone = fields.Char(string="Agent's Phone", readonly=False)
+    agent_mobile = fields.Char(string="Agent's Mobile", readonly=False)
+
     _sql_constraints = [
         ('name_uniq', 'unique (name)', 'The company name must be unique !')
     ]

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -44,6 +44,28 @@
                                 <group name="social_media"/>
                             </group>
                         </page>
+                        <page string="Accounting Firm Information" name="agent_info">
+                            <group name="agent_info_group">
+                                <group>
+                                    <field name="agent_name"/>
+                                    <label for="agent_street" string="Agent's Address"/>
+                                    <div class="o_address_format">
+                                        <field name="agent_street" placeholder="Street..." class="o_address_street"/>
+                                        <field name="agent_street2" placeholder="Street 2..." class="o_address_street"/>
+                                        <field name="agent_city" placeholder="City" class="o_address_city"/>
+                                        <field name="agent_state_id" placeholder="State" class="o_address_state" options='{"no_open": True}'/>
+                                        <field name="agent_zip" placeholder="ZIP" class="o_address_zip"/>
+                                        <field name="agent_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
+                                    </div>
+                                    <field name="agent_vat"/>
+                                </group>
+                                <group>
+                                    <field name="agent_phone" class="o_force_ltr"/>
+                                    <field name="agent_mobile" class="o_force_ltr"/>
+                                    <field name="agent_email"/>
+                                </group>
+                            </group>
+                        </page>
                     </notebook>
                     </sheet>
                 </form>


### PR DESCRIPTION
A company may grant a mandate to an accounting firm or an agent
to file its tax return or financial reports.

The goal is to add a tab in the company data
to store the agent's address and VAT number.

While exporting the XML Tax Report, a modal opens up
to ask who is submitting the tax report : the company or its agent.

Task 2526717

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
