### PR TITLE
[IMP] stock: allow to use return picking model

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -24,10 +24,10 @@ class ReturnPicking(models.TransientModel):
 
     @api.model
     def default_get(self, fields):
-        if len(self.env.context.get('active_ids', list())) > 1:
-            raise UserError(_("You may only return one picking at a time."))
         res = super(ReturnPicking, self).default_get(fields)
         if self.env.context.get('active_id') and self.env.context.get('active_model') == 'stock.picking':
+            if len(self.env.context.get('active_ids', list())) > 1:
+                raise UserError(_("You may only return one picking at a time."))
             picking = self.env['stock.picking'].browse(self.env.context.get('active_id'))
             if picking.exists():
                 res.update({'picking_id': picking.id})


### PR DESCRIPTION
Before this commit, 
We were checking for multiple `active_ids` before checking for `active_model` in context,
which was blocking point if user want to use this model with `active_ids` with 
different `active_model`.

With this commit,
we are checking condition of multiple `active_ids` if `active_model` is `stock.picking`.
so other users can use this model with `active_ids` without changing any flow.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
