### PR TITLE
[IMP] base, website: add bulk delete action on ir.ui.view

### DIFF
--- a/addons/website/static/src/js/backend/view_hierarchy/view_hierarchy.xml
+++ b/addons/website/static/src/js/backend/view_hierarchy/view_hierarchy.xml
@@ -40,8 +40,11 @@
         <a href="#" t-on-click.stop.prevent="() => this.openFormView(viewTree.id)">
             <i class="fa fa-eye ms-2 text-muted" title="Go to View"/>
         </a>
-        <a class="o_show_diff" href="#" t-on-click.stop.prevent="() => this.onShowDiffClick(viewTree.id)">
+        <a href="#" t-on-click.stop.prevent="() => this.onShowDiffClick(viewTree.id)">
             <i class="fa fa-files-o ms-2 text-muted" title="Show Arch Diff"/>
+        </a>
+        <a href="#" t-on-click.stop.prevent="() => this.bulkDelete(viewTree.id)">
+            <i class="fa fa-trash-o ms-2 text-muted" title="Bulk Delete"/>
         </a>
         <t t-if="state.searchedView.id === viewTree.id">
             <span class="o_tab_hint text-info ms-auto small fst-italic pe-2">Press &lt;Tab&gt; for next [<t t-esc="state.searchedView.index+1"/>/<t t-esc="state.searchedView.total"/>]</span>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -537,6 +537,12 @@ actual arch.
         self.env.registry.clear_cache('templates')
         return super(View, self).unlink()
 
+    def bulk_delete(self):
+        """ Deletes the given views and all their children views, including
+        inactive ones.
+        """
+        return self.with_context(active_test=False, _force_unlink=True).unlink()
+
     def _update_field_translations(self, fname, translations, digest=None):
         return super(View, self.with_context(no_save_prev=True))._update_field_translations(fname, translations, digest)
 

--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -142,6 +142,20 @@
             <field name="binding_view_types">form,list</field>
         </record>
 
+        <!-- Bulk Delete -->
+        <!-- TODO instead of 'main', would need to replace current breadcrumb entry (or just erase previous) -->
+        <record id="bulk_delete_views_action" model="ir.actions.server">
+            <field name="name">Bulk Delete</field>
+            <field name="model_id" ref="model_ir_ui_view"/>
+            <field name="state">code</field>
+            <field name="code">
+records.bulk_delete()
+action_view = env.ref('base.action_ui_view').read()[0]
+action_view['target'] = 'main'
+action = action_view
+            </field>
+        </record>
+
         <!-- View customizations -->
         <record id="view_view_custom_form" model="ir.ui.view">
             <field name="model">ir.ui.view.custom</field>


### PR DESCRIPTION
Before this commit, there was no easy way to delete a whole view tree
hierarchy, you would need to somehow get all the active and inactive views from
that hierarchy in the list view (which is basically impossible), and then
select them all to unlink them.

This commit adds a "Bulk Delete" entry in the control panel action entries in
both the form and list view.
It also adds a "Bulk Delete" button to the QWeb view (hierarchy view).

This is particularly useful in multi-website environment when you need to
delete a whole view hierarchy that had been cow'd.
