### PR TITLE
[FIX] account_facturx: gross price must be subtotal not unit price

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -29,7 +29,7 @@
                         <ram:GrossPriceProductTradePrice>
                             <ram:ChargeAmount
                                 t-att-currencyID="currency.name"
-                                t-esc="format_monetary(line.price_unit, currency)"/>
+                                t-esc="format_monetary(line.price_subtotal, currency)"/>
 
                             <!-- Discount. -->
                             <ram:AppliedTradeAllowanceCharge t-if="line.discount">


### PR DESCRIPTION
Facturx expects line price to be subtotal, not unit price. Odoo parser is also dividing the gross price by quantity. So before this commit, importing PDF invoice rendered by Odoo, results in: unit price / quantity.

The bug was introduced in odoo/odoo#53894

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
