### PR TITLE
[IMP] account_facturx: import by vendor product code

### DIFF
--- a/addons/account_facturx/models/account_invoice.py
+++ b/addons/account_facturx/models/account_invoice.py
@@ -195,7 +195,15 @@ class AccountInvoice(models.Model):
                             invoice_line_form.name = line_elements[0].text
                         line_elements = element.xpath('.//ram:SpecifiedTradeProduct/ram:SellerAssignedID', namespaces=tree.nsmap)
                         if line_elements and line_elements[0].text:
-                            product = self.env['product.product'].search([('default_code', '=', line_elements[0].text)])
+                            code = line_elements[0].text
+                            product = None
+                            if partner:
+                                spinf = self.env['product.supplierinfo'].search([
+                                    ('product_code', '=', code),
+                                    ('name', '=', partner)])
+                                product = spinf and spinf.product_id or None
+                            if not product:
+                                product = self.env['product.product'].search([('default_code', '=', code)])
                             if product:
                                 invoice_line_form.product_id = product
                         if not invoice_line_form.product_id:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

It is unlikely that seller product id is same as internal reference, default_code. However vendor product code is most likely used to insert seller product ids if used.

Current behavior before PR:

Seller product id is searched only in default codes and barcodes.

Desired behavior after PR is merged:

Search seller product id in also supplier info product codes by vendor.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
