### PR TITLE
[FIX] purchase_stock: Use the correct name of method.

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -312,7 +312,7 @@ class PurchaseOrderLine(models.Model):
 
         not_ppg_cancel_lines = self.filtered(lambda line: not line.propagate_cancel)
         not_ppg_cancel_lines.move_dest_ids.write({'procure_method': 'make_to_stock'})
-        not_ppg_cancel_lines.move_dest_ids.recompute_state()
+        not_ppg_cancel_lines.move_dest_ids._recompute_state()
 
         return super().unlink()
 


### PR DESCRIPTION
This bug is cause in this PR https://github.com/odoo/odoo/pull/70312

Description of the issue/feature this PR addresses:

Current behavior before PR:
When remove an item for a Purchase order, an error with the name of method is called

Desired behavior after PR is merged:
Remove items without errors.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
