### PR TITLE
[IMP] base_address_extended: Try to fall back on the company's format before applying hardcoded default

### DIFF
--- a/addons/base_address_extended/models/res_partner.py
+++ b/addons/base_address_extended/models/res_partner.py
@@ -66,6 +66,7 @@ class Partner(models.Model):
                 continue
 
             street_format = (partner.country_id.street_format or
+                self.env.company.country_id.street_format or
                 '%(street_number)s/%(street_number2)s %(street_name)s')
             street_raw = partner.street
             vals = self._split_street_with_params(street_raw, street_format)

--- a/doc/cla/corporate/hunki-enterprises.md
+++ b/doc/cla/corporate/hunki-enterprises.md
@@ -1,0 +1,15 @@
+The Netherlands, 2021-05-20
+
+Hunki Enterprises agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Holger Brunn mail@hunki-enterprises.com https://github.com/hbrunn
+
+List of contributors:
+
+Holger Brunn mail@hunki-enterprises.com https://github.com/hbrunn


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Use a better default for partners without country

Current behavior before PR: When a partner doesn't have a country set, Odoo falls back to a default format barely any European countries use

Desired behavior after PR is merged: Use the company's country's address format if it exists to parse street names for partners without country

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
