### PR TITLE
[FIX] mrp: fix consumed qty UX

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -71,7 +71,10 @@ class MrpProduction(models.Model):
 
     @api.model
     def _get_default_is_locked(self):
-        return self.user_has_groups('mrp.group_locked_by_default')
+        """ This variable name is reversed due its purpose being changed during a fix (i.e. we can't rename
+        it). We now expect "locked_by_default" to mean we want MOs to be unlocked by default.
+        """
+        return not self.user_has_groups('mrp.group_locked_by_default')
 
     name = fields.Char(
         'Reference', copy=False, readonly=True, default=lambda x: _('New'))
@@ -536,7 +539,11 @@ class MrpProduction(models.Model):
     @api.depends('state')
     def _compute_show_lock(self):
         for order in self:
-            order.show_lock = self.env.user.has_group('mrp.group_locked_by_default') and order.id is not False and order.state not in {'cancel', 'draft'}
+            order.show_lock = order.state == 'done' or (
+                not self.env.user.has_group('mrp.group_locked_by_default')
+                and order.id is not False
+                and order.state not in {'cancel', 'draft'}
+            )
 
     @api.depends('state','move_raw_ids')
     def _compute_show_lot_ids(self):

--- a/addons/mrp/models/res_config_settings.py
+++ b/addons/mrp/models/res_config_settings.py
@@ -18,7 +18,7 @@ class ResConfigSettings(models.TransientModel):
     module_mrp_subcontracting = fields.Boolean("Subcontracting")
     group_mrp_routings = fields.Boolean("MRP Work Orders",
         implied_group='mrp.group_mrp_routings')
-    group_locked_by_default = fields.Boolean("Lock Quantities To Consume", implied_group='mrp.group_locked_by_default')
+    group_locked_by_default = fields.Boolean("Unlock Manufacturing Orders", implied_group='mrp.group_locked_by_default')
 
     @api.onchange('use_manufacturing_lead')
     def _onchange_use_manufacturing_lead(self):
@@ -37,3 +37,14 @@ class ResConfigSettings(models.TransientModel):
             self.module_mrp_workorder = True
         elif not self.env['ir.module.module'].search([('name', '=', 'mrp_workorder'), ('state', '=', 'installed')]):
             self.module_mrp_workorder = False
+
+    @api.onchange('group_locked_by_default')
+    def _onchange_group_locked_by_default(self):
+        """ This variable name is reversed due its purpose being changed during a fix (i.e. we can't rename
+        it). We now expect "locked_by_default" to mean we want MOs to be unlocked by default and existing MOs will
+        automatically be updated to match setting.
+        """
+        if self.group_locked_by_default:
+            self.env['mrp.production'].search([('state', 'not in', ('cancel', 'done')), ('is_locked', '=', True)]).is_locked = False
+        else:
+            self.env['mrp.production'].search([('state', 'not in', ('cancel', 'done')), ('is_locked', '=', False)]).is_locked = True

--- a/addons/mrp/static/src/scss/mrp_fields.scss
+++ b/addons/mrp/static/src/scss/mrp_fields.scss
@@ -9,3 +9,11 @@
 .o_should_consume{
     padding-left: 0.3em;
 }
+
+.btn-link.o_optional_button{
+    color: gray;
+
+    &:hover {
+        filter: brightness(0.9);
+    }
+}

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -364,6 +364,7 @@ class TestMrpOrder(TestMrpCommon):
         production = production_form.save()
         production.action_confirm()
         production.action_assign()
+        production.is_locked = False
         production_form = Form(production)
         # change the quantity producing and the initial demand
         # in the same transaction

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -464,6 +464,7 @@ class TestProcurement(TestMrpCommon):
 
         self.assertEqual(len(mo), 1, "Manufacture order was not automatically created")
         mo.action_assign()
+        mo.is_locked = False
         self.assertEqual(mo.move_raw_ids.reserved_availability, 0, "No components should be reserved yet")
         self.assertEqual(mo.product_qty, 15, "Quantity to produce should be picking demand + reordering rule max qty")
 

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -297,7 +297,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         production = production_form.save()
 
         production.action_confirm()
-
+        production.is_locked = False
         production_form = Form(production)
         with production_form.move_raw_ids.new() as move:
             move.product_id = new_product

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -80,7 +80,7 @@
                     <button name="button_scrap" type="object" string="Scrap" attrs="{'invisible': [('state', 'in', ('cancel', 'draft'))]}"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,progress,done"/>
                     <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', False)]}" string="Unlock" groups="mrp.group_mrp_manager" type="object" help="Unlock the manufacturing order to adjust what has been consumed or produced."/>
-                    <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', True)]}" string="Lock" groups="mrp.group_mrp_manager" type="object" help="Lock the manufacturing order to prevent changes to what has been consumed or produced."/>/>
+                    <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', True)]}" string="Lock" groups="mrp.group_mrp_manager" type="object" help="Lock the manufacturing order to prevent changes to what has been consumed or produced."/>
                     <button name="action_cancel" type="object" string="Cancel"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('state', 'in', ('done', 'cancel')), ('confirm_cancel', '=', True)]}"/>
                     <button name="action_cancel" type="object" string="Cancel"
@@ -216,7 +216,7 @@
                                 attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" editable="bottom">
                                     <field name="product_id" force_save="1" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '|', ('has_move_lines', '=', True), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
-
+                                    <field name="location_id" string="From" readonly="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="move_line_ids" invisible="1">
                                         <tree>
                                             <field name="lot_id" invisible="1"/>
@@ -266,7 +266,7 @@
                                     <field name="quantity_done" string="Consumed"
                                         decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"
                                         decoration-warning="not is_done and (quantity_done - should_consume_qty &gt; 0.0001)"
-                                        attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('show_details_visible', '=', True)]}"/>
+                                        attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('has_tracking', '!=','none'), ('show_details_visible', '=', True)]}"/>
                                     <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
@@ -277,7 +277,8 @@
                                         domain="[('product_id','=',product_id)]"
                                     />
                                     <field name="group_id" invisible="1"/>
-                                    <button name="action_show_details" type="object" icon="fa-list" context="{'default_product_uom_qty': 0}" attrs="{'invisible': [('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button name="action_show_details" type="object" icon="fa-list" context="{'default_product_uom_qty': 0}" attrs="{'invisible': ['|', ('has_tracking', '=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button class="o_optional_button" name="action_show_details" type="object" icon="fa-list" context="{'default_product_uom_qty': 0}" attrs="{'invisible': ['|', ('has_tracking', '!=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
                                 </tree>
                             </field>
                         </page>
@@ -289,6 +290,7 @@
                                 <tree default_order="is_done,sequence" decoration-muted="is_done" editable="bottom">
                                     <field name="byproduct_id" invisible="1"/>
                                     <field name="product_id" context="{'default_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
+                                    <field name="location_dest_id" string="To" readonly="1" groups="stock.group_stock_multi_locations"/>
 
                                     <field name="move_line_ids" invisible="1">
                                         <tree>
@@ -339,7 +341,8 @@
                                         context="{'default_company_id': company_id, 'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"
                                     />
-                                    <button name="action_show_details" type="object" icon="fa-list" attrs="{'invisible': [('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button name="action_show_details" type="object" icon="fa-list" attrs="{'invisible': ['|', ('has_tracking', '=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button class="o_optional_button" name="action_show_details" type="object" icon="fa-list" attrs="{'invisible': ['|', ('has_tracking', '!=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
                                 </tree>
                             </field>
                         </page>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -61,7 +61,7 @@
                                 <div class="o_setting_right_pane">
                                     <label for="group_locked_by_default"/>
                                     <div class="text-muted">
-                                        Prevent manufacturing users from modifying quantities to consume, unless a manager has unlocked the document
+                                        Allow manufacturing users to modify quantities to consume, without the need for prior approval
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Handles 2 UX problems:
1 - Having manufacturing orders (MOs) unlocked by default. This means users are more likely to accidentally edit the "To Consumed" rather than the "Consumed" amount. Therefore we lock them by default and re-purpose the `group_locked_by_default` setting to allow users to manually unlock MOs rather than manually lock them.
2 - When multi-location setting is active, users are required to use a widget button to input a component's consumed quantity. This is annoying and cumbersome when users want to input consumed amounts using the default (MO's) component location. Therefore we loosen the restriction so users can still edit the consumed directly when dealing with a non-tracked component, but can also still use the widget when they want or when they do want to choose specific child locations. Additionally we change the color of the widget in this case to indicate that it is optional.

Task: 2518523
ENT PR (fix test only): odoo/enterprise#18317

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
