### PR TITLE
[FIX] point_of_sale: avoid not-null constraint error

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -595,7 +595,7 @@ class PosConfig(models.Model):
         self = self.sudo()
         if not companies:
             companies = self.env['res.company'].search([])
-        for company in companies:
+        for company in companies.filtered('account_default_pos_receivable_account_id'):
             if company.chart_template_id:
                 cash_journal = self.env['account.journal'].search([('company_id', '=', company.id), ('type', '=', 'cash')], limit=1)
                 pos_receivable_account = company.account_default_pos_receivable_account_id


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

We create payment methods only if the company has default pos receivable account (which only happens if the chart of accounts has the default set). But we may have charts that don't have that default set, so we filter the companies to avoid the not-null constraint.

An example of a chart like this is [l10n_ae.uae_chart_template_standard](https://github.com/odoo/odoo/blob/13.0/addons/l10n_ae/data/l10n_ae_chart_data.xml#L5), which don't have `default_pos_receivable_account_id`.

![Selection_114](https://user-images.githubusercontent.com/25005517/118267650-b183fa80-b4bc-11eb-8154-e1f3550b4d23.png)






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr