### PR TITLE
[IMP] account_bank_statement: Display Relevant Fields in Journal Entries

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -462,13 +462,16 @@ class AccountBankStatement(models.Model):
     def button_journal_entries(self):
         return {
             'name': _('Journal Entries'),
-            'view_mode': 'tree,form',
-            'res_model': 'account.move',
-            'view_id': False,
+            'view_mode': 'tree',
+            'res_model': 'account.move.line',
+            'view_id': self.env.ref('account.view_move_line_tree_grouped_bank_cash').id,
             'type': 'ir.actions.act_window',
-            'domain': [('id', 'in', self.line_ids.move_id.ids)],
+            'domain': [('move_id', 'in', self.line_ids.move_id.ids)],
             'context': {
+                'search_default_account_id': self.journal_id.default_account_id.id,
                 'journal_id': self.journal_id.id,
+                'group_by': 'move_id',
+                'expand': True
             }
         }
 


### PR DESCRIPTION
Beforehand, when display the journal entries from a bank statement,
some fields (Due Date, Next Activity, Payment status) that are not very
relevant were displayed.

Now, we use the bank & cash view to display the bank statement in a more relevant manner.

task-2459562
https://www.odoo.com/web#id=2459562&action=333&active_id=967&model=project.task&view_type=form&cids=1&menu_id=4720

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
