### PR TITLE
[IMP] base: show running cron

### DIFF
--- a/odoo/addons/base/views/ir_cron_views.xml
+++ b/odoo/addons/base/views/ir_cron_views.xml
@@ -45,6 +45,7 @@
                     <field name="interval_type"/>
                     <field name="numbercall"/>
                     <field name="user_id" invisible="1"/>
+                    <field name="is_running"/>
                     <field name="active"/>
                 </tree>
             </field>


### PR DESCRIPTION
Hi @odony @rco-odoo 

This PR add a little helper when you have a cron use 100% of CPU during a long hours, but you don't know witch cron it is.

This PR add the field `is_running` computed with the method `_try_lock`.

Note : `is_running` stay `False` if cron is launched manually.

cc @Yenthe666 @pedrobaeza 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
