### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,10 @@ Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
 Pillow==8.1.1 ; python_version > '3.7'
 polib==1.1.0
 psutil==5.6.6
+psutil==5.6.7 ; Windows 10 and python_version >= '3.9'
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
 psycopg2==2.8.5; sys_platform == 'win32' or python_version >= '3.8'
+psycopg2==2.8.6 ; Windows 10 and python_version >= '3.9'
 pydot==1.4.1
 python-ldap==3.1.0; sys_platform != 'win32'
 PyPDF2==1.26.0
@@ -48,6 +50,7 @@ reportlab==3.5.55; python_version >= '3.8'
 requests==2.21.0
 zeep==3.2.0
 python-stdnum==1.8
+python-stdnum==1.8.1 ; Windows 10 and python_version >= '3.9'
 vobject==0.9.6.1
 Werkzeug==0.16.1
 XlsxWriter==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,11 +32,9 @@ Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
 Pillow==8.1.1 ; python_version > '3.7'
 polib==1.1.0
-psutil==5.6.6
-psutil==5.6.7 ; Windows 10 and python_version >= '3.9'
+psutil==5.6.7
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
-psycopg2==2.8.5; sys_platform == 'win32' or python_version >= '3.8'
-psycopg2==2.8.6 ; Windows 10 and python_version >= '3.9'
+psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
 python-ldap==3.1.0; sys_platform != 'win32'
 PyPDF2==1.26.0
@@ -49,8 +47,7 @@ reportlab==3.5.13; python_version < '3.8'
 reportlab==3.5.55; python_version >= '3.8'
 requests==2.21.0
 zeep==3.2.0
-python-stdnum==1.8
-python-stdnum==1.8.1 ; Windows 10 and python_version >= '3.9'
+python-stdnum==1.8.1
 vobject==0.9.6.1
 Werkzeug==0.16.1
 XlsxWriter==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Mako==1.0.7
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
-passlib==1.7.1
+passlib==1.7.2
 Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
 Pillow==8.1.1 ; python_version > '3.7'


### PR DESCRIPTION
Hello,
Impacted Version: Odoo 14 fir Windows 10 and python_version >= '3.9'

I faced many issues during the installation of Odoo with the requirements.txt install.
It's the first time I pull a request, so I put sources of my findings.

I updated the following information:
python-stdnum==1.8 >>>> python-stdnum==1.8.1 (I found this: https://github.com/odoo/odoo/issues/62919)
psutil==5.6.6 >>>> psutil==5.6.7 (I found this: https://github.com/odoo/odoo/issues/62919)
psycopg2==2.8.5 >>>> psycopg2==2.8.6 (I found this: https://pypi.org/project/psycopg2/#files)

Hope it will help!
Best regards,
Adrien


Current behavior before PR:
https://github.com/odoo/odoo/issues/62919

Desired behavior after PR is merged:
Odoo 14 will be installed properly on Window 10 with Python 3.9

