### PR TITLE
[FIX] website: do not allow to create/edit views

### DIFF
--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -321,7 +321,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">website.track</field>
         <field name="view_mode">tree</field>
-        <field name="context">{'search_default_type_url':1}</field>
+        <field name="context">{'search_default_type_url': 1, 'create': False, 'edit': False, 'copy': False}</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'tree', 'view_id': ref('website_visitor_track_view_tree')}),
             (0, 0, {'view_mode': 'graph', 'view_id': ref('website_visitor_track_view_graph')}),


### PR DESCRIPTION
Before this commit, 
User was allowed to create new records from form view through
Graph view' action. Since we do not have a way to prevent opening 
form view from Graph and also we should not Introduce new form view
on stable version.

With this commit,
we are disabling create/edit/copy from action.


PS: I don't think it good idea to add disable_lining on Graph here as we still need to view record from Graph.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
