### PR TITLE
[FIX] project: display share action on only form view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -774,6 +774,7 @@
             <field name="view_mode">form</field>
             <field name="target">new</field>
             <field name="binding_model_id" ref="model_project_task"/>
+            <field name="binding_view_types">form</field>
         </record>
 
         <record id="unlink_project_action" model="ir.actions.server">


### PR DESCRIPTION
Before this commit,
Share action was displayed on list view as well which
doesn't makes sense as it will always use `active_id` only.

With this commit,
we are displaying `Share` action on form view only.

OPW 2530652

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
