### PR TITLE
[FIX] product: barcode should not disappear on archiving product

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -264,16 +264,19 @@ class ProductTemplate(models.Model):
     def _compute_barcode(self):
         self.barcode = False
         for template in self:
-            if len(template.product_variant_ids) == 1:
-                template.barcode = template.product_variant_ids.barcode
+            product_variant_ids = template.with_context(active_test=False).product_variant_ids
+            if len(product_variant_ids) == 1:
+                template.barcode = product_variant_ids.barcode
 
     def _search_barcode(self, operator, value):
         templates = self.with_context(active_test=False).search([('product_variant_ids.barcode', operator, value)])
         return [('id', 'in', templates.ids)]
 
     def _set_barcode(self):
-        if len(self.product_variant_ids) == 1:
-            self.product_variant_ids.barcode = self.barcode
+        for template in self:
+            product_variant_ids = template.with_context(active_test=False).product_variant_ids
+            if len(product_variant_ids) == 1:
+                product_variant_ids.barcode = template.barcode
 
     @api.model
     def _get_weight_uom_id_from_ir_config_parameter(self):


### PR DESCRIPTION
Fixing 42e6396d4a62340540a14f6252032f64d315be86

Before this commit when a user archives the product, the barcode
field in its template used to get disappeared as on archiving template
its variants are also archived, so product_variant_ids will be empty record set.

With this commit, we pass `active_test=False` so it also consider archived 
product_variant_ids.

OPW 2530648


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
