### PR TITLE
[FIX] point_of_sale: rounding issue with cash rounding

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3316,8 +3316,10 @@ exports.Order = Backbone.Model.extend({
     get_rounding_applied: function() {
         if(this.pos.config.cash_rounding) {
             const only_cash = this.pos.config.only_round_cash_method;
-            const has_cash = this.selected_paymentline ? this.selected_paymentline.payment_method.is_cash_count == true: false;
-            if (!only_cash || (only_cash && has_cash)) {
+            const paymentlines = this.get_paymentlines();
+            const last_line = paymentlines ? paymentlines[paymentlines.length-1]: false;
+            const last_line_is_cash = last_line ? last_line.payment_method.is_cash_count == true: false;
+            if (!only_cash || (only_cash && last_line_is_cash)) {
                 var remaining = this.get_total_with_tax() - this.get_total_paid();
                 var total = round_pr(remaining, this.pos.cash_rounding[0].rounding);
                 var sign = total > 0 ? 1.0 : -1.0;


### PR DESCRIPTION
The method that computs what is due and the change of an order is based
on the selected payment line which is wrong, because if you add and
remove a payment line, none will be seleced, that lead to issue in this
case because a change is computed, and it won't match the invoices
because an amount_return is sent to server.

To reproduce you can follow this simply procedure:
    - set rounding half-up to 0.05
    - create a product at 0.98
    - open POS and create an order with the product
    - go to payment screen
    - add cash payment (1€ auto filled)
    - add bank payment (It'll autofill -0.02 not really a problem)
    - remove the bank payment => It'll show 0.02 due (it is caused because of no payment method is selected)
    - Set a customer and check the invoice => unbalanced (0.02 probably because it is set in amount_return of the request)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
