### PR TITLE
[IMP] mail: vertical alignment in no activity

### DIFF
--- a/addons/mail/static/src/scss/systray.scss
+++ b/addons/mail/static/src/scss/systray.scss
@@ -94,6 +94,7 @@
             color: grey;
             opacity: 0.5;
             padding: 3px;
+            min-height: inherit;
         }
     }
 }

--- a/addons/mail/static/src/xml/systray.xml
+++ b/addons/mail/static/src/xml/systray.xml
@@ -8,8 +8,8 @@
     <t t-name="mail.systray.ActivityMenu.Previews">
         <t t-set="activities" t-value="widget._activities"/>
         <t t-if="_.isEmpty(activities)">
-            <div class="dropdown-item-text text-center o_no_activity">
-                <span>No activities planned.</span>
+            <div class="dropdown-item-text text-center o_no_activity d-flex justify-content-center">
+                <span>Congratulations, you're done with your activities.</span>
             </div>
         </t>
         <t t-foreach="activities" t-as="activity">


### PR DESCRIPTION
PURPOSE

- A helper should be aligned vertically in the systray menu.
- A sentence should also be changed by
  "Congratulations, you're done with your activities."

SPECIFICATION

- no activity statement should be changed and also it should
  be appear in the middle of the dropdown

task- 2525928

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
