### PR TITLE
[IMP] mail: avoid email loops when Odoo reply automatically

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -20,6 +20,7 @@
         'views/mail_tracking_views.xml',
         'views/mail_notification_views.xml',
         'views/mail_message_views.xml',
+        'views/mail_incoming_message_views.xml',
         'views/mail_mail_views.xml',
         'views/mail_followers_views.xml',
         'views/mail_moderation_views.xml',

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -11,6 +11,7 @@ from . import mail_alias_mixin
 from . import mail_followers
 from . import mail_notification
 from . import mail_message
+from . import mail_incoming_message
 from . import mail_activity
 from . import mail_mail
 from . import mail_thread

--- a/addons/mail/models/mail_incoming_message.py
+++ b/addons/mail/models/mail_incoming_message.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from datetime import datetime, timedelta
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IncomingMessage(models.Model):
+    """Technical model that stores the incoming emails which are not routed or create alias.
+
+    The purpose of this model is to detect loop (e.g.: a auto-replier which send email
+    to Odoo and Odoo might send auto-reply to those emails).
+
+    This table is cleaned automatically to avoid to store a huge amount of records over time.
+    """
+
+    _name = 'mail.incoming.message'
+    _description = 'Incoming Message'
+    _order = 'id desc'
+    _rec_name = 'subject'
+
+    subject = fields.Char('Subject')
+    email_from = fields.Char('From')
+    email_to = fields.Char('To')
+
+    is_routed = fields.Boolean('Is Routed', default=True)
+    alias_model = fields.Char('Created Alias Model', help='Alias model if the message created a record')
+
+    @api.autovacuum
+    def _gc_incoming_message(self):
+        """Remove incoming messages not needed for loop detection."""
+        INCOMING_LIMIT_PERIOD = int(self.env["ir.config_parameter"].sudo().get_param("mail.incoming.limit.period", 60))
+
+        mail_incoming_messages = self.sudo().search([
+            ('create_date', '<', datetime.now() - timedelta(minutes=INCOMING_LIMIT_PERIOD)),
+        ])
+
+        if mail_incoming_messages:
+            _logger.info('Remove %i <mail.incoming.message>', len(mail_incoming_messages))
+            mail_incoming_messages.unlink()

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -2,6 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mail_message_all,mail.message.all,model_mail_message,,1,0,0,0
 access_mail_message_portal,mail.message.portal,model_mail_message,base.group_portal,1,1,1,1
 access_mail_message_user,mail.message.user,model_mail_message,base.group_user,1,1,1,1
+access_mail_incoming_message_user,mail.incoming.message.user,model_mail_incoming_message,base.group_user,1,0,0,0
 access_mail_mail_all,mail.mail.all,model_mail_mail,,0,0,0,0
 access_mail_mail_portal,mail.mail.portal,model_mail_mail,base.group_portal,0,0,0,0
 access_mail_mail_user,mail.mail.user,model_mail_mail,base.group_user,0,0,0,0

--- a/addons/mail/views/mail_incoming_message_views.xml
+++ b/addons/mail/views/mail_incoming_message_views.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="mail_incoming_message_view_tree" model="ir.ui.view">
+            <field name="name">mail.incoming.message.tree</field>
+            <field name="model">mail.incoming.message</field>
+            <field name="priority">20</field>
+            <field name="arch" type="xml">
+                <tree string="Messages">
+                    <field name="subject"/>
+                    <field name="email_from"/>
+                    <field name="email_to"/>
+                    <field name="is_routed"/>
+                    <field name="alias_model"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="mail_incoming_message_view_form" model="ir.ui.view">
+            <field name="name">mail.incoming.message.view.form</field>
+            <field name="model">mail.incoming.message</field>
+            <field name="priority">20</field>
+            <field name="arch" type="xml">
+                <form string="Message">
+                    <sheet>
+                        <group>
+                            <field name="subject"/>
+                            <field name="email_from"/>
+                            <field name="email_to"/>
+                        </group>
+                        <group>
+                            <field name="is_routed"/>
+                            <field name="alias_model"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="mail_incoming_message_view_search" model="ir.ui.view">
+            <field name="name">mail.incoming.message.search</field>
+            <field name="model">mail.incoming.message</field>
+            <field name="priority">25</field>
+            <field name="arch" type="xml">
+                <search string="Messages Search">
+                    <field name="email_from"/>
+                    <field name="email_to"/>
+                    <field name="subject"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="mail_incoming_message_action" model="ir.actions.act_window">
+            <field name="name">Incoming Messages</field>
+            <field name="res_model">mail.incoming.message</field>
+            <field name="view_mode">tree,form</field>
+            <field name="search_view_id" ref="mail_incoming_message_view_search"/>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -97,6 +97,11 @@
         action="mail_blacklist_action"
         parent="mail.mail_menu_technical"
         sequence="22"/>
+    <menuitem id="mail_incoming_message_menu"
+        name="Incoming Messages"
+        action="mail_incoming_message_action"
+        parent="mail.mail_menu_technical"
+        sequence="23"/>
 
     <!--
         This menuitem will be activated by integrations modules (like github, twitter, ...). It


### PR DESCRIPTION
Purpose
=======
Some situations can cause emails loop.

In example, if a auto-replier is set and send email to the catchall
email address, Odoo will respond "You can not contact the catchall
email directly". And the auto-replier will send again an email, etc.

Specifications
==============
To solve this issues, we add 3 system parameters
- <mail.incoming.limit.period>, 60 minutes by default
- <mail.incoming.limit.alias>, 5 by default
- <mail.incoming.limit.replies>, 90 by default

So, when we receive an email, 3 situations can occur.

1. The email is sent to an alias and a record will be created. In that
   case, we look on the last record created <mail.incoming.limit.period>
   minutes ago. If we overcome <mail.incoming.limit.alias> the email
   is ignored.

2. The email is sent to an existing mail thread. In that case, the limit
   is set with the <mail.incoming.limit.replies> parameters (so we can
   have a bigger limit for the replies than for the alias).

3. The email is not routed. In that case we create a unrouted message
   and the alias limit is used.

Task 2294034