### PR TITLE
[FIX] stock_account: force company when getting computed account for move line

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -225,6 +225,7 @@ class AccountMoveLine(models.Model):
         # OVERRIDE to use the stock input account by default on vendor bills when dealing
         # with anglo-saxon accounting.
         self.ensure_one()
+        self = self.with_context(force_company=self.move_id.journal_id.company_id.id)
         if self.product_id.type == 'product' \
             and self.move_id.company_id.anglo_saxon_accounting \
             and self.move_id.is_purchase_document():


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fixes the method to get the account in account move lines when dealing with anglo-saxon accounting.

Current behavior before PR: The parent method _get_computed_account in the account module it already forces the company to get the correct account, but in the stock_account module the method is overriden when dealing with anglo-saxon accounting.

In the latter, the company is not being forced, so it leads to multi-company errors.

Desired behavior after PR is merged: The account is set considering the company of the journal of the move, as it should be doing to ensure consistency.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
