### PR TITLE
[FIX] event_sale: ticket price with pricelist

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -103,7 +103,7 @@ class SaleOrderLine(models.Model):
             company = self.event_id.company_id or self.env.user.company_id
             currency = company.currency_id or self.env.user.company_id.currency_id
             return currency._convert(
-                self.event_ticket_id.price, self.order_id.currency_id,
+                self.event_ticket_id.price_reduce, self.order_id.currency_id,
                 self.order_id.company_id or self.env.user.company_id,
                 self.order_id.date_order or fields.Date.today())
         else:

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -66,3 +66,59 @@ class EventSaleTest(common.TransactionCase):
         # I check if a registration is created
         registrations = self.EventRegistration.search([('origin', '=', self.sale_order.name)])
         self.assertTrue(registrations, "The registration is not created.")
+
+    def test_01_ticket_price_with_pricelist_and_tax(self):
+        self.env.user.partner_id.country_id = False
+        pricelists = self.env['product.pricelist'].search([])
+        pricelist = pricelists[0]
+        (pricelists - pricelist).write({'active': False})
+
+        tax = self.env['account.tax'].create({
+            'name': "Tax 10",
+            'amount': 10,
+        })
+
+        event_product = self.env['product.template'].create({
+            'name': 'Event Product',
+            'list_price': 10.0,
+        })
+
+        event_product.taxes_id = tax
+
+        event = self.env['event.event'].create({
+            'name': 'New Event',
+            'date_begin': '2020-02-02',
+            'date_end': '2020-04-04',
+        })
+        event_ticket = self.env['event.event.ticket'].create({
+            'name': 'VIP',
+            'price': 1000.0,
+            'event_id': event.id,
+            'product_id': event_product.product_variant_id.id,
+        })
+
+        pricelist.item_ids = self.env['product.pricelist.item'].create({
+            'applied_on': "1_product",
+            'base': "list_price",
+            'compute_price': "fixed",
+            'fixed_price': 6.0,
+            'product_tmpl_id': event_product.id,
+        })
+
+        pricelist.discount_policy = 'without_discount'
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+        })
+        sol = self.env['sale.order.line'].with_context(pricelist=pricelist.id).create({
+            'name': event.name,
+            'product_id': event_product.product_variant_id.id,
+            'product_uom_qty': 1,
+            'product_uom': event_product.uom_id.id,
+            'price_unit': event_product.list_price,
+            'order_id': so.id,
+            'event_id': event.id,
+            'event_ticket_id': event_ticket.id,
+        })
+        sol.product_id_change()
+        self.assertEqual(so.amount_total, 660.0, "Ticket is $1000 but the event product is on a pricelist 10 -> 6. So, $600 + a 10% tax.")

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -12,6 +12,7 @@
                             ('event_ticket_ids.product_id','=', product_id),
                             ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00'))
                         ]"
+                        context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
                         attrs="{'invisible': [('event_ok', '=', False)], 'required': [('event_ok', '!=', False)]}"
                         options="{'no_open': True, 'no_create': True}"
                     />
@@ -22,6 +23,7 @@
                             ('product_id','=',product_id),
                             '|', ('seats_availability', '=', 'unlimited'), ('seats_available', '>', 0)
                         ]"
+                        context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
                         attrs="{
                             'invisible': ['|', ('event_ok', '=', False), ('event_id', '=', False)],
                             'required': [('event_ok', '!=', False), ('event_id', '!=', False)],


### PR DESCRIPTION
Steps:
- Install Events
- Go to Events / Configuration / Settings
- Enable Tickets
- Go to Sales / Configuration / Settings
- Enable Multiple Sales Prices per Product
- Go to Sales / Products
- Edit Event Registration
  - Sales tab
    - Pricing
      - Pricelist: Public Pricelist (USD)
      - Price: $6
- Go to Sales
- Create a new quotation
  - Pricelist: Public Pricelist (USD)
  - Product: Event Registration
  - Event: Design Fair
  - Ticket: VIP

Bug:
The pricelist is not taken into account. Unit price should be $900 but
is $1500.

Explanation:
The original issue comes from this commit: https://github.com/odoo/odoo/commit/379f1490c93dc599a74add2d678c18fbba1efa62
The advertised amount was not the one showing up in the cart. This is
because the pricelist was not taken into account anymore when entering
the payment process.

Using `price_reduce` instead of `price` enables all kinds of discounts
on the final price.
However, `price_reduce` relies on the context to find the current
pricelist.
This commit adds the context needed to compute the price of the tickets
in the event_sale views.
This context is the same as the one in the sales module since pricelists
are working fine there: https://github.com/odoo/odoo/blob/39579d71db7f7c10d6afc57eff95b9bd3f876bd0/addons/sale/views/sale_views.xml#L305

The pricelist context is already given in the website part of this
module. No changes have to be made there.

opw:2519453