### PR TITLE
Master mass mailing segmentation mub

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -32,6 +32,7 @@
         'wizard/mailing_list_merge_views.xml',
         'wizard/mailing_mailing_test_views.xml',
         'wizard/mailing_mailing_schedule_date_views.xml',
+        'views/mailing_filter_views.xml',
         'views/mailing_mailing_views_menus.xml',
         'views/mailing_trace_views.xml',
         'views/link_tracker_views.xml',
@@ -77,9 +78,11 @@
     'application': True,
     'assets': {
         'web.assets_backend': [
+            'mass_mailing/static/src/scss/mailing_filter_widget.scss',
             'mass_mailing/static/src/scss/mass_mailing.scss',
             'mass_mailing/static/src/scss/mass_mailing_mobile.scss',
             'mass_mailing/static/src/css/email_template.css',
+            'mass_mailing/static/src/js/mailing_filter_widget.js',
             'mass_mailing/static/src/js/mass_mailing.js',
             'mass_mailing/static/src/js/mass_mailing_widget.js',
             'mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js',
@@ -98,6 +101,7 @@
         ],
         'web.qunit_suite_tests': [
             'mass_mailing/static/tests/field_html_test.js',
+            'mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js',
             'mass_mailing/static/src/js/mass_mailing_snippets.js',
             'mass_mailing/static/src/snippets/s_blockquote/options.js',
             'mass_mailing/static/src/snippets/s_media_list/options.js',

--- a/addons/mass_mailing/models/__init__.py
+++ b/addons/mass_mailing/models/__init__.py
@@ -7,6 +7,7 @@ from . import mailing_contact
 from . import mailing_list
 from . import mailing_trace
 from . import mailing
+from . import mailing_filter
 from . import mail_mail
 from . import mail_render_mixin
 from . import mail_thread

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -291,12 +291,17 @@ class MassMailing(models.Model):
     @api.depends('mailing_model_id')
     def _compute_mailing_model_real(self):
         for mailing in self:
-            mailing.mailing_model_real = (mailing.mailing_model_name != 'mailing.list') and mailing.mailing_model_name or 'mailing.contact'
+            mailing.mailing_model_real = (mailing.mailing_model_id.model != 'mailing.list') and mailing.mailing_model_id.model or 'mailing.contact'
 
-    @api.depends('mailing_model_real')
+    @api.depends('mailing_model_id')
     def _compute_reply_to_mode(self):
+        """ For main models not really using chatter to gather answers (contacts
+        and mailing contacts), set reply-to as email-based. Otherwise answers
+        by default go on the original discussion thread (business document). Note
+        that mailing_model being mailing.list means contacting mailing.contact
+        (see mailing_model_name versus mailing_model_real). """
         for mailing in self:
-            if mailing.mailing_model_real in ['res.partner', 'mailing.contact']:
+            if mailing.mailing_model_id.model in ['res.partner', 'mailing.list']:
                 mailing.reply_to_mode = 'new'
             else:
                 mailing.reply_to_mode = 'update'
@@ -309,10 +314,10 @@ class MassMailing(models.Model):
             elif mailing.reply_to_mode == 'update':
                 mailing.reply_to = False
 
-    @api.depends('mailing_model_name', 'contact_list_ids')
+    @api.depends('mailing_model_id', 'contact_list_ids', 'mailing_type')
     def _compute_mailing_domain(self):
         for mailing in self:
-            if not mailing.mailing_model_name:
+            if not mailing.mailing_model_id:
                 mailing.mailing_domain = ''
             else:
                 mailing.mailing_domain = repr(mailing._get_default_mailing_domain())

--- a/addons/mass_mailing/models/mailing_filter.py
+++ b/addons/mass_mailing/models/mailing_filter.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from ast import literal_eval
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class MailingFilter(models.Model):
+    """ This model stores mass mailing or marketing campaign domain as filters
+    (quite similar to 'ir.filters' but dedicated to mailing apps). Frequently
+    used domains can be reused easily. """
+    _name = 'mailing.filter'
+    _description = 'Mailing Favorite Filters'
+    _order = 'create_date DESC'
+
+    # override create_uid field to display default value while creating filter from 'Configuration' menus
+    create_uid = fields.Many2one('res.users', 'Saved by', index=True, readonly=True, default=lambda self: self.env.user)
+    name = fields.Char(string='Filter Name', required=True)
+    mailing_domain = fields.Char(string='Filter Domain', required=True)
+    mailing_model_id = fields.Many2one('ir.model', string='Recipients Model', required=True, ondelete='cascade')
+    mailing_model_name = fields.Char(string='Recipients Model Name', related='mailing_model_id.model')
+
+    @api.constrains('mailing_domain', 'mailing_model_id')
+    def _check_mailing_domain(self):
+        """ Check that if the mailing domain is set, it is a valid one """
+        for mailing_filter in self:
+            if mailing_filter.mailing_domain != "[]":
+                try:
+                    self.env[mailing_filter.mailing_model_id.model].search_count(literal_eval(mailing_filter.mailing_domain))
+                except:
+                    raise ValidationError(
+                        _("The filter domain is not valid for this recipients.")
+                    )

--- a/addons/mass_mailing/security/ir.model.access.csv
+++ b/addons/mass_mailing/security/ir.model.access.csv
@@ -21,3 +21,4 @@ access_mailing_list_merge,access.mailing.list.merge,model_mailing_list_merge,mas
 access_mailing_mailing_test,access.mailing.mailing.test,model_mailing_mailing_test,mass_mailing.group_mass_mailing_user,1,1,1,0
 access_mailing_contact_to_list,access.mailing.contact.to.list,model_mailing_contact_to_list,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_schedule_date,access.mailing.schedule.date,model_mailing_mailing_schedule_date,mass_mailing.group_mass_mailing_user,1,1,1,1
+access_mailing_filter_mailing_user,access.mailing.filter.mailing.user,model_mailing_filter,mass_mailing.group_mass_mailing_user,1,1,1,1

--- a/addons/mass_mailing/static/src/js/mailing_filter_widget.js
+++ b/addons/mass_mailing/static/src/js/mailing_filter_widget.js
@@ -1,0 +1,215 @@
+/** @odoo-module alias=mass_mailing.MailingFilterWidget **/
+
+import { FieldMany2One } from 'web.relational_fields';
+import core from 'web.core';
+import fieldRegistry from 'web.field_registry';
+
+const _t = core._t;
+
+/**
+ * Widget to create / remove favorite filters on mass mailing and/or marketing automation, extended
+ * from FieldMany2One. This widget is designed specifically for 'mailing_filter_id'
+ * field on 'mailing.mailing' and 'marketing.campaign' form view.
+ *
+ * In edit mode, it will allow to save the latest configured domain
+ * in form of the favorite filter, or to remove the store filters.
+ *
+ * @class
+ */
+const FieldMailingFilter = FieldMany2One.extend({
+    template: 'mass_mailing.FieldMailingFilter',
+    events: Object.assign({}, FieldMany2One.prototype.events, {
+        'click .o_mass_mailing_btn_save_filter': '_onFavoriteFilterSaveClick',
+        'click .o_mass_mailing_remove_filter': '_onFavoriteFilterRemoveClick',
+        'keydown .o_mass_mailing_filter_name': '_onFavoriteFilterNameInputKeydown',
+        'shown.bs.dropdown': '_onFavoriteFilterDropdownShown',
+    }),
+    resetOnAnyFieldChange: true,
+
+    /**
+     * This widget is used for 'mass.mailing' and 'marketing.campaign', but
+     * the field names that stores domain and recipient models are different
+     * for both. So, it is strongly recommended to pass them explicitly with
+     * `nodeOptions`.
+     *
+     * @override
+     */
+    init() {
+        this._super(...arguments);
+        this.domainFieldName = this.nodeOptions.domain_field || 'mailing_domain';
+        this.modelFieldName = this.nodeOptions.model_field || 'mailing_model_id';
+    },
+
+    /**
+     * This widget now has two inputs, one for m2o and another for filter
+     * name. So this override makes sure that 'this.$input' now refers to
+     * only main input instead of both.
+     * see FieldMany2One#start for more details.
+     *
+     * @override
+     */
+    start() {
+        const def = this._super(...arguments);
+        this.$input = this.$('input.o_input');
+        return def;
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+    /**
+     * @override
+     * @private
+     */
+    _renderEdit() {
+        this._super(...arguments);
+        this._updateFilterIcons();
+    },
+
+    /**
+     * Updates the 'Add to favorite' / 'Remove' star icons' visibility based on
+     * the current state.
+     *
+     * The filter can be saved if one of those conditions is matched:
+     * - No favorite filter is currently set
+     * - User emptied the input
+     * - User changed the domain when favorite filter is set
+     * - The input is currently being edited, known by the "this.floating" variable
+     *   (see FieldMany2One#start for more information about the floating variable).
+     *
+     * @private
+     */
+    _updateFilterIcons: function () {
+        const hasDomain = this.recordData[this.domainFieldName] && this.recordData[this.domainFieldName] !== '[]';
+        this.el.querySelector('.o_mass_mailing_filter_container').classList.toggle('invisible', !hasDomain);
+        const canSaveFilter = !this.recordData.mailing_filter_id
+            || !this.$input.val().length
+            || this.floating
+            || this.recordData.mailing_filter_domain !== this.recordData[this.domainFieldName];
+        this.el.querySelector('.o_mass_mailing_save_filter_container').classList.toggle('d-none', !canSaveFilter);
+        this.el.querySelector('.o_mass_mailing_remove_filter').classList.toggle('d-none', canSaveFilter);
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+    /**
+     * On opening the drop-down, remove existing input value (if any) and set
+     * focus on input
+     *
+     * @private
+     * @param {event} ev
+     */
+    _onFavoriteFilterDropdownShown(ev) {
+        const filterInput = ev.target.querySelector('input.o_mass_mailing_filter_name');
+        filterInput.value = '';
+        filterInput.focus();
+    },
+
+    /**
+     * Focus the 'Save' button on 'Tab' key, or directly save the filter on 'Enter'
+     *
+     * @private
+     * @param {event} ev
+     */
+    _onFavoriteFilterNameInputKeydown(ev) {
+        const btnSave = this.el.querySelector('.o_mass_mailing_btn_save_filter');
+        if (ev.key === 'Tab') {
+            btnSave.focus();
+        } else if (ev.key === 'Enter') {
+            btnSave.click();
+        }
+    },
+
+    /**
+     * Prevent opening m2o drop-down on click of filter's input (if drop-down is open)
+     *
+     * @override
+     * @private
+     */
+    _onInputClick: function () {
+        if (!this.el.querySelector('.o_mass_mailing_save_filter_container .dropdown-menu').classList.contains('show')) {
+            this._super(...arguments);
+        }
+    },
+
+    /**
+     * Update the filter / filter icons visibility with respect to current state
+     *
+     * @override
+     * @private
+     * @param {event} ev
+     */
+    _onInputKeyup(ev) {
+        this._super(...arguments);
+        this._updateFilterIcons();
+    },
+
+    /**
+     * Deletes the saved filter, but we do not reset the applied domain
+     * in this case.
+     *
+     * @private
+     * @param {event} ev
+     */
+    async _onFavoriteFilterRemoveClick(ev) {
+        const filterId = this.recordData.mailing_filter_id.res_id;
+        const mailingDomain = this.recordData[this.domainFieldName];
+        // Prevent multiple clicks to avoid trying to deleting same record multiple times.
+        ev.target.disabled = true;
+        // Avoid calling any 'onchange' (that depends on filter and might reset the domain) immediately
+        // after filter is removed. It should have any side effects because we don't want to change
+        // anything in any case when filter is unliked with with this widget.
+        this._setValue(false, {notifyChange: false});
+        await this._rpc({
+            model: 'mailing.filter',
+            method: 'unlink',
+            args: [filterId],
+        });
+        // When a filter is removed, compute method on mass mailing resets the domain while saving the
+        // record. This hack re-applies the domain and thus we don't loose it when record is saved.
+        this.trigger_up('field_changed', {
+            dataPointID: this.record.id,
+            changes: {
+                [this.domainFieldName]: mailingDomain,
+            },
+        });
+    },
+
+    /**
+     * Creates a new favorite filter, with the name provided from drop-down and
+     * with the 'up to date' domain. If the input is blank, displays the warning
+     * and keeps the popup open by preventing event propagation.
+     *
+     * Note: We do not disable the save button here to avoid multiple clicks as for the delete,
+     * because as soon as the 'Save' button is clicked, the popup will be closed immediately.
+     *
+     * @private
+     * @param {event} ev
+     */
+    async _onFavoriteFilterSaveClick(ev) {
+        const filterInput = this.el.querySelector('input.o_mass_mailing_filter_name');
+        const filterName = filterInput.value.trim();
+        if (filterName.length === 0) {
+            this.displayNotification({ message: _t("Please provide a name for the filter"), type: 'danger' });
+            // Keep the drop-down open, and re-focus the input
+            ev.stopPropagation();
+            filterInput.focus();
+        } else {
+            const newFilterId = await this._rpc({
+                model: 'mailing.filter',
+                method: 'create',
+                args: [{
+                    name: filterName,
+                    mailing_domain: this.recordData[this.domainFieldName],
+                    mailing_model_id: this.recordData[this.modelFieldName].data.id,
+                }]
+            });
+            this._setValue(newFilterId);
+        }
+    },
+});
+
+fieldRegistry.add('mailing_filter', FieldMailingFilter);
+
+export default FieldMailingFilter;

--- a/addons/mass_mailing/static/src/scss/mailing_filter_widget.scss
+++ b/addons/mass_mailing/static/src/scss/mailing_filter_widget.scss
@@ -1,0 +1,6 @@
+.o_form_view .o_mass_mailing_filter_container {
+    .o_mass_mailing_add_filter, .o_mass_mailing_remove_filter {
+        color: gold;
+        cursor: pointer;
+    }
+}

--- a/addons/mass_mailing/static/src/scss/mass_mailing_mobile.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing_mobile.scss
@@ -4,4 +4,9 @@
         margin: 0 auto;
         justify-content: space-between !important;
     }
+    // For field to occupy full width in small devices. We need '!important'
+    // here because of the 'w-auto' class used in the view.
+    .o_form_editable div[name="mailing_filter_id"] {
+        width: 100% !important;
+    }
 }

--- a/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <!-- Template for 'mailing_filter' widget, specific for mailing form view -->
+    <t t-name="mass_mailing.FieldMailingFilter" t-extend="FieldMany2One" primary="True">
+        <t t-jquery="div.o_field_many2one_selection" t-operation="append">
+            <div class="o_mass_mailing_filter_container">
+                <div class="o_mass_mailing_save_filter_container pt-1">
+                    <i class="o_mass_mailing_add_filter fa fa-star-o px-3 py-1" data-toggle="dropdown" title="Add to Favorites"/>
+                    <div class="dropdown-menu dropdown-menu-right">
+                        <span class="ml-2 text-muted">Create Favorite Filter</span><br/>
+                        <div class="d-inline-flex">
+                            <input type="text" class="o_mass_mailing_filter_name w-auto ml-2" placeholder='e.g. "VIP Customers"'/>
+                            <button class="btn btn-sm btn-primary o_mass_mailing_btn_save_filter mx-2">
+                                Add
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <div class="o_mass_mailing_remove_filter pt-1">
+                    <i class="fa fa-star px-3 py-1" title="Remove from Favorites"/>
+                </div>
+            </div>
+        </t>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
@@ -1,0 +1,289 @@
+/** @odoo-module alias=mass_mailing.FieldMassMailingFavoriteFilter.test */
+
+import FormView from 'web.FormView';
+import testUtils from 'web.test_utils';
+
+QUnit.module('mass_mailing_favourite_filter', {}, function () {
+QUnit.module('favorite filter widget', {
+    beforeEach: function () {
+        this.data = {
+            'mailing.mailing': {
+                fields: {
+                    display_name: {
+                        string: 'Display name',
+                        type: 'char',
+                    },
+                    subject: {
+                        string: 'subject',
+                        type: 'char',
+                    },
+                    mailing_model_id: {
+                        string: 'Recipients',
+                        type: 'many2one',
+                        relation: 'ir.model',
+                    },
+                    mailing_model_name: {
+                        string: 'Recipients Model Name',
+                        type: 'char',
+                    },
+                    mailing_filter_id: {
+                        string: 'Filters',
+                        type: 'many2one',
+                        relation: 'mailing.filter',
+                    },
+                    mailing_domain: {
+                        string: 'Domain',
+                        type: 'char',
+                    },
+                    mailing_filter_domain: {
+                        string: 'Domain',
+                        type: 'char',
+                        related: 'mailing_filter_id.mailing_domain',
+                    },
+                },
+                records: [{
+                    id: 1,
+                    display_name: 'Belgian Event promotion',
+                    subject: 'Early bird discount for Belgian Events! Register Now!',
+                    mailing_model_id: 1,
+                    mailing_model_name: 'event',
+                    mailing_domain: '[["country","=","be"]]',
+                    mailing_filter_id: 1,
+                    mailing_filter_domain: '[["country","=","be"]]',
+                }, {
+                    id: 2,
+                    display_name: 'New Users Promotion',
+                    subject: 'Early bird discount for new users! Register Now!',
+                    mailing_model_id: 1,
+                    mailing_model_name: 'event',
+                    mailing_domain: '[["new_user","=",True]]',
+                    mailing_filter_domain: '[["new_user","=",True]]',
+                }],
+            },
+            'ir.model': {
+                fields: {
+                    model: {string: 'Model', type: 'char'},
+                },
+                records: [{
+                    id: 1, name: 'Event', model: 'event',
+                }, {
+                    id: 2, name: 'Partner', model: 'partner',
+                }],
+            },
+            'mailing.filter': {
+                fields: {
+                    name: {
+                        string: 'Name',
+                        type: 'char',
+                    },
+                    mailing_domain: {
+                        string: 'Mailing Domain',
+                        type: 'char',
+                    },
+                    mailing_model_id: {
+                        string: 'Recipients Model',
+                        type: 'many2one',
+                        relation: 'ir.model'
+                    },
+                },
+                records: [{
+                    id: 1,
+                    name: 'Belgian Events',
+                    mailing_domain: '[["country","=","be"]]',
+                    mailing_model_id: 1,
+                }],
+            },
+        };
+    },
+
+}, function () {
+
+    QUnit.test('create favorite filter', async function (assert) {
+        assert.expect(8);
+
+        const form = await testUtils.createView({
+            View: FormView,
+            model: 'mailing.mailing',
+            data: this.data,
+            arch: `<form>
+                    <field name="display_name"/>
+                    <field name="subject"/>
+                    <field name="mailing_domain"/>
+                    <field name="mailing_model_name" invisible="1"/>
+                    <field name="mailing_model_id"/>
+                    <field name="mailing_filter_domain" invisible="1"/>
+                    <field name="mailing_filter_id"
+                        widget="mailing_filter"
+                        options="{'no_create': '1', 'no_open': '1', 'domain_field': 'mailing_domain', 'model': 'mailing_model_id'}"/>
+                </form>`,
+            res_id: 2,
+            mockRPC: function (route, args) {
+                if (args.method === 'create' && args.model === 'mailing.filter') {
+                    assert.deepEqual(args.args,
+                        [{mailing_domain: '[["new_user","=",True]]', mailing_model_id: 1, name: 'event promo - new users'}],
+                        "should pass correct data in create");
+                }
+                return this._super.apply(this, arguments);
+            },
+        });
+
+        await testUtils.form.clickEdit(form);
+        const $dropdown = form.$('.o_field_many2one[name="mailing_filter_id"] input').autocomplete('widget');
+        assert.isNotVisible(form.$('.o_mass_mailing_remove_filter'),
+            "should hide the option to remove filter if no filter is set");
+        assert.isVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should have option to save filter if no filter is set");
+        await testUtils.dom.click('.o_field_many2one[name="mailing_filter_id"] input');
+        assert.containsOnce($dropdown, 'li.ui-menu-item',
+            "there should be only one existing filter");
+        // create a new filter
+        await testUtils.dom.click(form.$('.o_mass_mailing_add_filter'));
+        form.el.querySelector('.o_mass_mailing_filter_name').value = 'event promo - new users';
+        // Simulate 'Enter' key, which actually 'clicks' the 'o_mass_mailing_btn_save_filter' btn
+        await testUtils.fields.triggerKeydown(form.el.querySelector('.o_mass_mailing_filter_name'), 'enter');
+
+        // check if filter is set correctly
+        assert.strictEqual(
+            form.el.querySelector('.o_field_many2one[name="mailing_filter_id"] input').value,
+            'event promo - new users', "saved filter should be set automatically");
+
+        assert.isVisible(form.$('.o_mass_mailing_remove_filter'),
+            "should have option to remove filter if filter is already set");
+        assert.isNotVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should not have option to save filter if filter is already set");
+        await testUtils.dom.click('.o_field_many2one[name="mailing_filter_id"] input');
+        assert.containsN($dropdown, 'li.ui-menu-item', 2,
+            "there should be two existing filters");
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+
+    QUnit.test('unlink favorite filter', async function (assert) {
+        assert.expect(10);
+
+        const form = await testUtils.createView({
+            View: FormView,
+            model: 'mailing.mailing',
+            data: this.data,
+            arch: `<form>
+                    <field name="display_name"/>
+                    <field name="subject"/>
+                    <field name="mailing_domain"/>
+                    <field name="mailing_model_id"/>
+                    <field name="mailing_filter_domain" invisible="1"/>
+                    <field name="mailing_filter_id"
+                        widget="mailing_filter"
+                        options="{'no_create': '1', 'no_open': '1', 'domain_field': 'mailing_domain', 'model': 'mailing_model_id'}"/>
+                </form>`,
+            res_id: 1,
+            mockRPC: function (route, args) {
+                if (args.method === 'unlink' && args.model === 'mailing.filter') {
+                    assert.strictEqual(args.args[0], 1, "should pass correct filter ID for deletion");
+                } else if (args.method === 'write' && args.model === 'mailing.mailing') {
+                    assert.strictEqual(args.args[1].mailing_filter_id,
+                        false, "filter id should be");
+                    assert.strictEqual(args.args[1].mailing_domain,
+                        '[["country","=","be"]]', "mailing domain should be retained while unlinking filter");
+                }
+                return this._super.apply(this, arguments);
+            },
+        });
+
+        await testUtils.form.clickEdit(form);
+        assert.strictEqual(
+            form.el.querySelector('.o_field_many2one[name="mailing_filter_id"] input').value,
+            'Belgian Events', "there should be filter set");
+        assert.isVisible(form.$('.o_mass_mailing_remove_filter'),
+            "should have option to remove filter if filter is already set");
+        assert.isNotVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should hide the option to save filter if filter is already set");
+        // unlink filter
+        await testUtils.dom.click(form.$('.o_mass_mailing_remove_filter'));
+        assert.strictEqual(
+            form.el.querySelector('.o_field_many2one[name="mailing_filter_id"] input').value,
+            '', "filter should be empty");
+        assert.isNotVisible(form.$('.o_mass_mailing_remove_filter'),
+            "should hide the option to remove filter if no filter is set");
+        assert.isVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should not hide the option to save filter if no filter is set");
+        // check drop-down after filter deletion
+        const $dropdown = form.$('.o_field_many2one[name="mailing_filter_id"] input').autocomplete('widget');
+        await testUtils.dom.click('.o_field_many2one[name="mailing_filter_id"] input');
+        assert.containsNone($dropdown, 'li.ui-menu-item',
+            "there should be no available filters");
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+
+    QUnit.test('changing filter correctly applies the domain', async function (assert) {
+        assert.expect(2);
+
+        this.data.partner = {
+            fields: {
+                name: {string: 'Name', type: 'char', searchable: true},
+            },
+            records: [
+                {id: 1, name: 'Azure Interior'},
+                {id: 2, name: 'Deco Addict'},
+                {id: 3, name: 'Marc Demo'},
+            ]
+        };
+
+        this.data['mailing.filter'].records = [{
+            id: 1,
+            name: 'Azure Partner Only',
+            mailing_domain: "[['name','=', 'Azure Interior']]",
+            mailing_model_id: 2,
+        }];
+
+        this.data['mailing.mailing'].records.push({
+            id: 3,
+            display_name: 'Partner Event promotion',
+            subject: 'Early bird discount for Partners!',
+            mailing_model_id: 2,
+            mailing_model_name: 'partner',
+            mailing_domain: "[['name','!=', 'Azure Interior']]",
+        });
+
+        this.data['mailing.mailing'].onchanges = {
+            mailing_filter_id: obj => {
+                obj.mailing_domain = this.data['mailing.filter'].records.filter(r => r.id === obj.mailing_filter_id)[0].mailing_domain;
+            },
+        };
+
+        const form = await testUtils.createView({
+            View: FormView,
+            model: 'mailing.mailing',
+            data: this.data,
+            arch: `<form>
+                    <field name="display_name"/>
+                    <field name="subject"/>
+                    <field name="mailing_model_name" invisible="1"/>
+                    <field name="mailing_model_id"/>
+                    <field name="mailing_filter_id" widget="mailing_filter" options="{'no_create': '1', 'no_open': '1', 'domain_field': 'mailing_domain', 'model': 'mailing_model_id'}"/>
+                    <group>
+                        <field name="mailing_domain"
+                            widget="domain"
+                            options="{'model': 'mailing_model_name'}"/>
+                    </group>
+                </form>`,
+            res_id: 3,
+        });
+
+        await testUtils.form.clickEdit(form);
+        assert.equal(form.$('.o_domain_show_selection_button').text().trim(), '2 record(s)',
+            "default domain should filter 2 records (all but Azure)");
+
+        await testUtils.dom.click('.o_field_many2one[name="mailing_filter_id"] input');
+        const $dropdown = form.$('.o_field_many2one[name="mailing_filter_id"] input').autocomplete('widget');
+        await testUtils.dom.click($dropdown[0].lastElementChild);
+        assert.equal(form.$('.o_domain_show_selection_button').text().trim(), '1 record(s)',
+            "applied filter should only display single record (only Azure)");
+        await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+});
+});

--- a/addons/mass_mailing/views/mailing_filter_views.xml
+++ b/addons/mass_mailing/views/mailing_filter_views.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mailing_filter_view_search" model="ir.ui.view">
+        <field name="name">mailing.filter.view.search</field>
+        <field name="model">mailing.filter</field>
+        <field name="arch" type="xml">
+           <search string="Mailing Filters">
+                <field name="name"/>
+                <field name="mailing_model_id"/>
+                <filter string="My Filters"
+                        name="filter_saved_by_me"
+                        domain="[('create_uid', '=', uid)]"
+                        help="Filters saved by me"/>
+                <group string="Group By">
+                    <filter name="groupby_recepient_model"
+                            context="{'group_by' : 'mailing_model_id'}"
+                            string="Recipients"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="mailing_filter_view_tree" model="ir.ui.view">
+        <field name="name">mailing.filter.view.tree</field>
+        <field name="model">mailing.filter</field>
+        <field name="arch" type="xml">
+            <tree string="Mailing filters" sample="1">
+                <field name="name"/>
+                <field name="create_uid" string="Saved by" widget="many2one_avatar_user"/>
+                <field name="mailing_model_id" string="Recipients"/>
+                <field name="mailing_domain" string="Domain" optional="hide"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="mailing_filter_view_form" model="ir.ui.view">
+        <field name="name">mailing.filter.view.form</field>
+        <field name="model">mailing.filter</field>
+        <field name="arch" type="xml">
+            <form string="Mailing filters">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="mailing_model_id" options="{'no_create': True, 'no_open': True}"/>
+                        </group>
+                        <group>
+                            <field name="create_uid" widget="many2one_avatar_user"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="mailing_model_name" invisible="1"/>
+                        <field name="mailing_domain" string="Domain" widget="domain"
+                               options="{'model': 'mailing_model_name'}"
+                               attrs="{'invisible': [('mailing_model_id', '=', False)]}"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="mailing_filter_action" model="ir.actions.act_window">
+        <field name="name">Favorite Filters</field>
+        <field name="res_model">mailing.filter</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_filter_saved_by_me': 1}
+        </field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No saved filter yet!
+            </p><p>
+                While designing the mailing, you can define the rules to filter recipients.
+                To save the same criteria for future use, you can add it to the favorite list
+                by clicking on <i class="fa fa-star-o text-warning"></i> icon next to "Recipients".
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -185,6 +185,18 @@
                                                 'readonly': [('state', 'in', ('sending', 'done'))]
                                         }"/>
                                     </div>
+                                    <div attrs="{'invisible': [('mailing_model_name', '=', 'mailing.list')]}" class="col-xs-12 col-md-9 o_td_label">
+                                        <!-- We don't want to display label in edit mode, unless mailing is in sending or done state (where filter will be readonly) -->
+                                        <label for="mailing_filter_id" string="Filter" class="oe_read_only mr-4"
+                                               attrs="{'invisible': ['|', ('state', 'in', ('sending', 'done')), ('mailing_filter_id', '=', False)]}"/>
+                                        <label for="mailing_filter_id" string="Filter" class="mr-4"
+                                               attrs="{'invisible': ['|', ('state', 'not in', ('sending', 'done')), ('mailing_filter_id', '=', False)]}"/>
+                                        <field name="mailing_filter_id" placeholder="Reload a favorite filter"
+                                               class="w-auto" widget="mailing_filter"
+                                               options="{'no_create': 1, 'no_open': 1, 'domain_field': 'mailing_domain', 'model_field': 'mailing_model_id'}"
+                                               attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                    </div>
+                                    <field name="mailing_filter_domain" invisible="1"/>
                                 </div>
 
                                 <field name="mailing_model_name" invisible="1"/>

--- a/addons/mass_mailing/views/mailing_mailing_views_menus.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views_menus.xml
@@ -15,6 +15,11 @@
         action="mail.mail_blacklist_action"
         parent="mass_mailing_configuration"/>
 
+    <!-- Configuration / Favorite Filters -->
+    <menuitem id="mailing_filter_menu_action"
+        action="mailing_filter_action"
+        parent="mass_mailing_configuration"/>
+
     <!-- Technical / Mass Mailing -->
     <menuitem id="mailing_mailing_menu_technical"
         name="Mass Mailing"


### PR DESCRIPTION
Whether targeting business objects or using mailing lists and contacts, marketing users usually refine the audience they're going to reach with a specific mailing thanks to filters.
This commit allow users to save filters in mass_mailing to be able to reuse mailing lists and not be forced to recreate the audience they want to target.

taskid:2092853




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
