### PR TITLE
[IMP] event, event_sale: improve manual ticket handling in sales orders

### DIFF
--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -554,7 +554,7 @@
                             </group>
                             <group string="Event Information" name="event">
                                 <field class="o_text_overflow" name="event_id" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True}"/>
-                                <field name="event_ticket_id"
+                                <field name="event_ticket_id" string="Ticket Type"
                                     domain="[
                                         ('event_id', '=', event_id),
                                         '|', ('seats_limited', '=', False), ('seats_available', '>', 0)

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -47,6 +47,11 @@ class SaleOrder(models.Model):
         for sale_order in self:
             sale_order.attendee_count = attendee_count_data.get(sale_order.id, 0)
 
+    def action_cancel(self):
+        super(SaleOrder, self).action_cancel()
+        if self.ids:
+            self.env['event.registration'].search([('sale_order_id', 'in', self.ids)]).action_cancel()
+
 
 class SaleOrderLine(models.Model):
 

--- a/addons/event_sale/wizard/event_configurator.py
+++ b/addons/event_sale/wizard/event_configurator.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import date
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class EventConfigurator(models.TransientModel):
@@ -11,3 +12,35 @@ class EventConfigurator(models.TransientModel):
     product_id = fields.Many2one('product.product', string="Product", readonly=True)
     event_id = fields.Many2one('event.event', string="Event")
     event_ticket_id = fields.Many2one('event.event.ticket', string="Event Ticket")
+    has_available_events = fields.Boolean(
+        "Has Available Events",
+        compute="_compute_has_available_events",
+        help="Technical field used to know if the user has at least one event that can be selected and used to configure event tickets on sale order lines")
+
+    @api.model
+    def default_get(self, fields):
+        res = super(EventConfigurator, self).default_get(fields)
+        if 'event_id' in fields and res.get('product_id'):
+            upcoming_events = self.env['event.event'].search(
+                [('event_ticket_ids.product_id', '=', res['product_id']),
+                 ('date_end', '>=',
+                  date.today().strftime('%Y-%m-%d 00:00:00')),
+                 ('stage_id.pipe_end', '=', False), ], limit=2)
+            if len(upcoming_events) == 1:
+                res['event_id'] = upcoming_events
+                if 'event_ticket_id' in fields and len(upcoming_events.event_ticket_ids) == 1:
+                    res['event_ticket_id'] = upcoming_events.event_ticket_ids
+        return res
+
+    @api.depends("product_id")
+    def _compute_has_available_events(self):
+        self.has_available_events = self.env['event.event'].search_count(
+            [('event_ticket_ids.product_id', '=', self.product_id.id),
+             ('date_end', '>=', date.today().strftime('%Y-%m-%d 00:00:00')),
+             ('stage_id.pipe_end', '=', False), ]) > 0
+
+    @api.onchange("event_id")
+    def _onchange_event_id(self):
+        self.ensure_one()
+        if len(self.event_id.event_ticket_ids) == 1:
+            self.event_ticket_id = self.event_id.event_ticket_ids

--- a/addons/event_sale/wizard/event_configurator_views.xml
+++ b/addons/event_sale/wizard/event_configurator_views.xml
@@ -5,18 +5,21 @@
         <field name="model">event.event.configurator</field>
         <field name="arch" type="xml">
             <form js_class="event_configurator_form">
-                <group>
+                <group attrs="{'invisible': [('has_available_events', '=', False)]}">
+                    <field name="has_available_events" invisible="1"/>
                     <field
                         name="event_id"
                         domain="[
                             ('event_ticket_ids.product_id','=', product_id),
-                            ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00'))
+                            ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00')),
+                            ('stage_id.pipe_end', '=', False)
                         ]"
-                        required="1"
+                        attrs="{'required': [('has_available_events', '=', True)]}"
                         options="{'no_open': True, 'no_create': True}"
                     />
                     <field
                         name="event_ticket_id"
+                        string="Ticket Type"
                         domain="[
                             ('event_id', '=', event_id),
                             ('product_id','=',product_id),
@@ -24,14 +27,17 @@
                         ]"
                         attrs="{
                             'invisible': [('event_id', '=', False)],
-                            'required': [('event_id', '!=', False)],
+                            'required': [('event_id', '!=', False), ('has_available_events', '=', True)],
                         }"
                         options="{'no_open': True, 'no_create': True}"
                     />
                     <field name="product_id" invisible="1"/>
                 </group>
+                <div attrs="{'invisible': [('has_available_events', '=', True)]}">
+                    No upcoming events with tickets, please go to Events to create or edit some.
+                </div>
                 <footer>
-                    <button string="Ok" class="btn-primary o_event_sale_js_event_configurator_ok" special="save"/>
+                    <button string="Confirm" class="btn-primary o_event_sale_js_event_configurator_ok" special="save" attrs="{'invisible': [('has_available_events', '=', False)]}"/>
                     <button string="Cancel" class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
@@ -39,7 +45,7 @@
     </record>
 
     <record id="event_configurator_action" model="ir.actions.act_window">
-        <field name="name">Configure an event</field>
+        <field name="name">Select an event</field>
         <field name="res_model">event.event.configurator</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>

--- a/addons/event_sale/wizard/event_edit_registration.xml
+++ b/addons/event_sale/wizard/event_edit_registration.xml
@@ -6,17 +6,19 @@
             <field name="model">registration.editor</field>
             <field name="arch" type="xml">
                 <form string="Registration">
-                    <p>Before confirming <field name="sale_order_id" readonly="1" class="oe_inline"/>
-                    please give details about the registrations</p>
+                    <p >Before confirming this order, please enter the attendees' contact details, this will be displayed on their tickets</p>
+                    <field name="sale_order_id" readonly="1" class="oe_inline" invisible="1"/>
+                    <field name="show_event_column" invisible="1"/>
                     <field name="event_registration_ids">
-                        <tree string="Registration" editable="top" create="false" delete="false">
-                            <field name="event_id" readonly='1' force_save="1"/>
-                            <field name="registration_id" readonly='1' force_save="1"/>
+                        <tree string="Registration" create="false" delete="false" editable="bottom">
+                            <field name="event_id" readonly="1" attrs="{'column_invisible': [('parent.show_event_column', '=', False)]}"/>
+                            <field name="registration_id" readonly='1' force_save="1" invisible="1"/>
                             <field name="event_ticket_id" domain="[('event_id', '=', event_id)]" readonly='1' force_save="1"/>
-                            <field name="name"/>
+                            <field name="name" string="Attendee Name"/>
                             <field name="email"/>
-                            <field name="mobile" class="o_force_ltr"/>
+                            <field name="mobile" class="o_force_ltr" optional="hide"/>
                             <field name="phone" class="o_force_ltr"/>
+                            <field name="state" />
                             <field name="sale_order_line_id" invisible="1"/>
                         </tree>
                     </field>


### PR DESCRIPTION
Improve event sale order configurator wording, to make it easier for the user to
understand what that wizzard does, wording in the event registration form has
also been changed for consistency with the wizzard

In the event selector wizzard, when no events are available, add a configure
events button which saves the record and redirects the user to the events kanban
view, purpose is to allow the user to easily create events without having to
close the sales order and to go manually to the events kanban view.

In the sales order confirmation modal:

- Change the fields of event registrations by eliminating non useful and
  confusing fields to improve the user experience

- Show the different registrations inside sections (using fake lines), each
  section corresponds to an event related sales order line, for each section
  show relevant information (event and ticket name, added and removed
  quantities), purpose is to allow the user to easily cancel attendees when
  removing quantities and to also easily provide information about new attendees
  when the quantity increases.

When canceling a sales order containing event registrations, also cancel the
event registrations to ensure that everything is consistant.

Task-2485710

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
