### PR TITLE
[FIX] account: a percentage can be negative

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -103,7 +103,7 @@ class AccountReconcileModelLine(models.Model):
         for record in self:
             if record.amount_type == 'fixed' and record.amount == 0:
                 raise UserError(_('The amount is not a number'))
-            if record.amount_type == 'percentage' and not 0 < record.amount:
+            if record.amount_type == 'percentage' and record.amount == 0:
                 raise UserError(_('The amount is not a percentage'))
             if record.amount_type == 'regex':
                 try:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
A percentage can only be positive where there is no choice of credit or debit?
Not matching real life, so I hope you agree.

**Current behavior before PR:**
Negative percentage denied by a unreasonable constraint

**Desired behavior after PR is merged:**
Negative percentage is possible for rules to serve credit side too

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
