### PR TITLE
[FIX] payment_ogone: accept tokenizing cards with missing number

### DIFF
--- a/addons/payment_ogone/models/payment_transaction.py
+++ b/addons/payment_ogone/models/payment_transaction.py
@@ -202,9 +202,11 @@ class PaymentTransaction(models.Model):
         :param dict data: The feedback data from Flexcheckout
         :return: None
         """
+        token_name = data.get('CARDNUMBER') \
+                     or payment_utils.build_token_name()  # CARD.CARNUMBER not requested in backend
         token = self.env['payment.token'].create({
             'acquirer_id': self.acquirer_id.id,
-            'name': data.get('CARDNUMBER'),  # Already padded with 'X's
+            'name': token_name,  # Already padded with 'X's
             'partner_id': self.partner_id.id,
             'acquirer_ref': data['ALIASID'],
             'verified': False,  # No payment has been processed through this token yet


### PR DESCRIPTION
In Ogone's backend, it is possible to remove `CARD.CARDNUMBER` from
Flexcheckout's feedback data (Configuration -> Technical information ->
Transaction feedback -> Alias gateway and Tokenization -> Dynamic
parameters). Since this is the configuration that was suggested to Odoo
customers migrating from a previous version, we must be able to process
feedback data when the card number is missing.

This commit creates an anonymous card number ('XXXX...') if one is not
provided by Ogone.

task-2494916