### PR TITLE
[FIX] web: fix crash on editable list view when moving over a RO field

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -266,7 +266,7 @@ ListRenderer.include({
                     currentWidget = self.allFieldWidgets[currentRowID][self.currentFieldIndex];
                     if (currentWidget) {
                         focusedElement = currentWidget.getFocusableElement().get(0);
-                        if (currentWidget.formatType !== 'boolean') {
+                        if (currentWidget.formatType !== 'boolean' && focusedElement) {
                             selectionRange = dom.getSelectionRange(focusedElement);
                         }
                     }


### PR DESCRIPTION
This is a forward-port of commit https://github.com/odoo/odoo/commit/970387f91fea0cb47404612f7d519ffba2c9ad3b

In editable list view, moving to next cell using TAB key crash when the
following field is read-only (i.e non-focusable) and an onchange() event
is triggered.

Consider an editable tree view like this:

<form>
   <field name="o2m" onchange="1">
       <tree>
          <field name="description"/>
          <field name="date" readonly="1"/>
          <field name="type"/>
       </tree>
   </field>
</form>

1. Adding a new line will give focus to `description` field widget
   (currentFieldIndex is 0)

2. issuing a TAB keypress, will call _onNavigationMove which calls
   _selectCell() with fieldIndex of 1

3. The _selectCell() method set widget currentFieldIndex to the new value
   (currentFieldIndex is 1) add call _activateFieldWidget() to activate
   on the corresponding widget.

4. _activateFieldWidget() will fail to activate the `date` field as it's
   readonly, then try for next ones and succeed to activate the `type` field
   cell

5. When focus is given a `type`, the `description` field is blurred which
   trigger an onchange() and the controller apply those changes to the
   editable list rendererd using the confirmUpdate() method.

   The confirmUpdate() will try to get the current selection, but that
   field is actually set to the `date` field (currentFieldIndex = 1),
   which is readonly and so has no focusedElement - triggering the crash.

This commit ensure we don't try to call getSelectionRange() it current widget
has no focusable element.

opw-2523630

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
