### PR TITLE
[FIX] sale: Prevent user to change date order

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1158,7 +1158,7 @@ class SaleOrderLine(models.Model):
 
     def _expected_date(self):
         self.ensure_one()
-        order_date = fields.Datetime.from_string(self.order_id.date_order if self.order_id.state in ['sale', 'done'] else fields.Datetime.now())
+        order_date = fields.Datetime.from_string(self.order_id.date_order if self.order_id.date_order and self.order_id.state in ['sale', 'done'] else fields.Datetime.now())
         return order_date + timedelta(days=self.customer_lead or 0.0)
 
     @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_id')


### PR DESCRIPTION
When the user removes the readonly from the field date order and tries
to modify it it crashes in some cases, this commit adds a constraint
on the server side to prevent customers from bypassing the readonly
on the client side and prevents traceback

opw-2523508