### PR TITLE
[IMP] payment(_adyen): allow to refund confirmed transactions

### DIFF
--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -30,6 +30,7 @@
         'wizards/account_payment_register_views.xml',
         'wizards/payment_acquirer_onboarding_templates.xml',
         'wizards/payment_link_wizard_views.xml',
+        'wizards/payment_refund_wizard_views.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/payment/models/account_payment.py
+++ b/addons/payment/models/account_payment.py
@@ -9,12 +9,17 @@ class AccountPayment(models.Model):
 
     # == Business fields ==
     payment_transaction_id = fields.Many2one(
-        string="Payment Transaction", comodel_name='payment.transaction', readonly=True)
+        string="Payment Transaction",
+        comodel_name='payment.transaction',
+        readonly=True,
+        auto_join=True,  # No access rule bypass since access to payments means access to txs too
+    )
     payment_token_id = fields.Many2one(
         string="Saved Payment Token", comodel_name='payment.token', domain="""[
             ('id', 'in', suitable_payment_token_ids),
         ]""",
         help="Note that only tokens from acquirers allowing to capture the amount are available.")
+    amount_available_for_refund = fields.Monetary(compute='_compute_amount_available_for_refund')
 
     # == Display purpose fields ==
     suitable_payment_token_ids = fields.Many2many(
@@ -25,6 +30,30 @@ class AccountPayment(models.Model):
         compute='_compute_use_electronic_payment_method',
         help='Technical field used to hide or show the payment_token_id if needed.'
     )
+
+    # == Fields used for traceability ==
+    source_payment_id = fields.Many2one(
+        string="Source Payment",
+        comodel_name='account.payment',
+        help="The source payment of related refund payments",
+        related='payment_transaction_id.source_transaction_id.payment_id',
+        readonly=True,
+        store=True,  # Stored for the group by in `_compute_refunds_count`
+    )
+    refunds_count = fields.Integer(string="Refunds Count", compute='_compute_refunds_count')
+
+    def _compute_amount_available_for_refund(self):
+        for payment in self:
+            if payment.payment_transaction_id.sudo().acquirer_id.support_refund:
+                # Only consider refund transactions that are confirmed by summing the amounts of
+                # payments linked to such refund transactions. Indeed, should a refund transaction
+                # be stuck forever in a transient state (due to webhook failure, for example), the
+                # user would never be allowed to refund the source transaction again.
+                refund_payments = self.search([('source_payment_id', '=', self.id)])
+                refunded_amount = abs(sum(refund_payments.mapped('amount')))
+                payment.amount_available_for_refund = payment.amount - refunded_amount
+            else:
+                payment.amount_available_for_refund = 0
 
     @api.depends('payment_method_line_id')
     def _compute_suitable_payment_token_ids(self):
@@ -53,6 +82,19 @@ class AccountPayment(models.Model):
             codes = [key for key in dict(self.env['payment.acquirer']._fields['provider']._description_selection(self.env))]
             payment.use_electronic_payment_method = payment.payment_method_code in codes
 
+    def _compute_refunds_count(self):
+        rg_data = self.env['account.payment'].read_group(
+            domain=[
+                ('source_payment_id', 'in', self.ids),
+                ('payment_transaction_id.operation', '=', 'refund')
+            ],
+            fields=['source_payment_id'],
+            groupby=['source_payment_id']
+        )
+        data = {x['source_payment_id'][0]: x['source_payment_id_count'] for x in rg_data}
+        for payment in self:
+            payment.refunds_count = data.get(payment.id, 0)
+
     @api.onchange('partner_id', 'payment_method_line_id', 'journal_id')
     def _onchange_set_payment_token_id(self):
         codes = [key for key in dict(self.env['payment.acquirer']._fields['provider']._description_selection(self.env))]
@@ -72,6 +114,63 @@ class AccountPayment(models.Model):
             ('acquirer_id.capture_manually', '=', False),
             ('acquirer_id.journal_id', '=', self.journal_id.id),
          ], limit=1)
+
+    def action_post(self):
+        # Post the payments "normally" if no transactions are needed.
+        # If not, let the acquirer update the state.
+
+        payments_need_tx = self.filtered(
+            lambda p: p.payment_token_id and not p.payment_transaction_id
+        )
+        # creating the transaction require to access data on payment acquirers, not always accessible to users
+        # able to create payments
+        transactions = payments_need_tx.sudo()._create_payment_transaction()
+
+        res = super(AccountPayment, self - payments_need_tx).action_post()
+
+        for tx in transactions:  # Process the transactions with a payment by token
+            tx._send_payment_request()
+
+        # Post payments for issued transactions
+        transactions._finalize_post_processing()
+        payments_tx_done = payments_need_tx.filtered(
+            lambda p: p.payment_transaction_id.state == 'done'
+        )
+        super(AccountPayment, payments_tx_done).action_post()
+        payments_tx_not_done = payments_need_tx.filtered(
+            lambda p: p.payment_transaction_id.state != 'done'
+        )
+        payments_tx_not_done.action_cancel()
+
+        return res
+
+    def action_refund_wizard(self):
+        self.ensure_one()
+        return {
+            'name': _("Refund"),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'payment.refund.wizard',
+            'target': 'new',
+        }
+
+    def action_view_refunds(self):
+        self.ensure_one()
+        action = {
+            'name': _("Refund"),
+            'res_model': 'account.payment',
+            'type': 'ir.actions.act_window',
+        }
+        if self.refunds_count == 1:
+            refund_tx = self.env['account.payment'].search([
+                ('source_payment_id', '=', self.id)
+            ], limit=1)
+            action['res_id'] = refund_tx.id
+            action['view_mode'] = 'form'
+        else:
+            action['view_mode'] = 'tree,form'
+            action['domain'] = [('source_payment_id', '=', self.id)]
+        return action
 
     def _get_payment_chatter_link(self):
         self.ensure_one()
@@ -108,32 +207,3 @@ class AccountPayment(models.Model):
             'payment_id': self.id,
             **extra_create_values,
         }
-
-    def action_post(self):
-        # Post the payments "normally" if no transactions are needed.
-        # If not, let the acquirer update the state.
-
-        payments_need_tx = self.filtered(
-            lambda p: p.payment_token_id and not p.payment_transaction_id
-        )
-        # creating the transaction require to access data on payment acquirers, not always accessible to users
-        # able to create payments
-        transactions = payments_need_tx.sudo()._create_payment_transaction()
-
-        res = super(AccountPayment, self - payments_need_tx).action_post()
-
-        for tx in transactions:  # Process the transactions with a payment by token
-            tx._send_payment_request()
-
-        # Post payments for issued transactions
-        transactions._finalize_post_processing()
-        payments_tx_done = payments_need_tx.filtered(
-            lambda p: p.payment_transaction_id.state == 'done'
-        )
-        super(AccountPayment, payments_tx_done).action_post()
-        payments_tx_not_done = payments_need_tx.filtered(
-            lambda p: p.payment_transaction_id.state != 'done'
-        )
-        payments_tx_not_done.action_cancel()
-
-        return res

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -99,7 +99,11 @@ class PaymentAcquirer(models.Model):
     # Feature support fields
     support_authorization = fields.Boolean(string="Authorize Mechanism Supported")
     support_fees_computation = fields.Boolean(string="Fees Computation Supported")
-    support_tokenization = fields.Boolean(string="Tokenization supported")
+    support_tokenization = fields.Boolean(string="Tokenization Supported")
+    support_refund = fields.Selection(
+        string="Type of Refund Supported",
+        selection=[('full_only', "Full Only"), ('partial', "Partial")],
+    )
 
     # Kanban view fields
     description = fields.Html(

--- a/addons/payment/security/ir.model.access.csv
+++ b/addons/payment/security/ir.model.access.csv
@@ -4,6 +4,7 @@ payment_acquirer_system,payment.acquirer.system,model_payment_acquirer,base.grou
 payment_icon_all,payment.icon.all,model_payment_icon,,1,0,0,0
 payment_icon_system,payment.icon.system,model_payment_icon,base.group_system,1,1,1,1
 payment_link_wizard,payment.link.wizard,model_payment_link_wizard,account.group_account_user,1,1,1,0
+payment_refund_wizard,payment.refund.wizard,model_payment_refund_wizard,account.group_account_invoice,1,1,1,0
 payment_token_all,payment.token.all,model_payment_token,,1,0,0,0
 payment_token_portal,payment.token.portal,model_payment_token,base.group_portal,1,1,1,1
 payment_token_system,payment.token.system,model_payment_token,base.group_system,1,1,1,1

--- a/addons/payment/tests/__init__.py
+++ b/addons/payment/tests/__init__.py
@@ -5,4 +5,5 @@ from . import http_common
 from . import multicompany_common
 from . import test_flows
 from . import test_multicompany_flows
+from . import test_payments
 from . import test_transactions

--- a/addons/payment/tests/test_payments.py
+++ b/addons/payment/tests/test_payments.py
@@ -1,0 +1,117 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.payment.tests.common import PaymentCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestPayments(PaymentCommon):
+
+    def test_no_amount_available_for_refund_when_not_supported(self):
+        self.acquirer.support_refund = False
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        self.assertEqual(
+            tx.payment_id.amount_available_for_refund,
+            0,
+            msg="The value of `amount_available_for_refund` should be 0 when the acquirer doesn't "
+                "support refunds."
+        )
+
+    def test_full_amount_available_for_refund_when_not_yet_refunded(self):
+        self.acquirer.support_refund = 'full_only'  # Should simply not be False
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        self.assertAlmostEqual(
+            tx.payment_id.amount_available_for_refund,
+            tx.amount,
+            places=2,
+            msg="The value of `amount_available_for_refund` should be that of `total` when there "
+                "are no linked refunds."
+        )
+
+    def test_full_amount_available_for_refund_when_refunds_are_pending(self):
+        self.acquirer.write({
+            'support_refund': 'full_only',  # Should simply not be False
+            'support_authorization': True,  # To create transaction in the 'authorized' state
+        })
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        for reference_index, state in enumerate(('draft', 'pending', 'authorized')):
+            self.create_transaction(
+                'dummy',
+                amount=-tx.amount,
+                reference=f'R-{tx.reference}-{reference_index + 1}',
+                state=state,
+                operation='refund',  # Override the computed flow
+                source_transaction_id=tx.id,
+            )
+        self.assertAlmostEqual(
+            tx.payment_id.amount_available_for_refund,
+            tx.payment_id.amount,
+            places=2,
+            msg="The value of `amount_available_for_refund` should be that of `total` when all the "
+                "linked refunds are pending (not in the state 'done')."
+        )
+
+    def test_no_amount_available_for_refund_when_fully_refunded(self):
+        self.acquirer.support_refund = 'full_only'  # Should simply not be False
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        self.create_transaction(
+            'dummy',
+            amount=-tx.amount,
+            reference=f'R-{tx.reference}',
+            state='done',
+            operation='refund',  # Override the computed flow
+            source_transaction_id=tx.id,
+        )._reconcile_after_done()
+        self.assertEqual(
+            tx.payment_id.amount_available_for_refund,
+            0,
+            msg="The value of `amount_available_for_refund` should be 0 when there is a linked "
+                "refund of the full amount that is confirmed (state 'done')."
+        )
+
+    def test_no_full_amount_available_for_refund_when_partially_refunded(self):
+        self.acquirer.support_refund = 'partial'
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        self.create_transaction(
+            'dummy',
+            amount=-(tx.amount / 10),
+            reference=f'R-{tx.reference}',
+            state='done',
+            operation='refund',  # Override the computed flow
+            source_transaction_id=tx.id,
+        )._reconcile_after_done()
+        self.assertAlmostEqual(
+            tx.payment_id.amount_available_for_refund,
+            tx.payment_id.amount - (tx.amount / 10),
+            places=2,
+            msg="The value of `amount_available_for_refund` should be equal to the total amount "
+                "minus the sum of the absolute amount of the refunds that are confirmed (state "
+                "'done')."
+        )
+
+    def test_refunds_count(self):
+        self.acquirer.support_refund = 'full_only'  # Should simply not be False
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        for reference_index, operation in enumerate(
+            ('online_redirect', 'online_direct', 'online_token', 'validation', 'refund')
+        ):
+            self.create_transaction(
+                'dummy',
+                reference=f'R-{tx.reference}-{reference_index + 1}',
+                state='done',
+                operation=operation,  # Override the computed flow
+                source_transaction_id=tx.id,
+            )._reconcile_after_done()
+
+        self.assertEqual(
+            tx.payment_id.refunds_count,
+            1,
+            msg="The refunds count should only consider transactions with operation 'refund'."
+        )

--- a/addons/payment/tests/test_transactions.py
+++ b/addons/payment/tests/test_transactions.py
@@ -8,10 +8,85 @@ from odoo.addons.payment.tests.common import PaymentCommon
 @tagged('-at_install', 'post_install')
 class TestTransactions(PaymentCommon):
 
+    def test_refunds_count(self):
+        self.acquirer.support_refund = 'full_only'  # Should simply not be False
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+        for reference_index, operation in enumerate(
+            ('online_redirect', 'online_direct', 'online_token', 'validation', 'refund')
+        ):
+            self.create_transaction(
+                'dummy',
+                reference=f'R-{tx.reference}-{reference_index + 1}',
+                state='done',
+                operation=operation,  # Override the computed flow
+                source_transaction_id=tx.id,
+            )._reconcile_after_done()
+
+        self.assertEqual(
+            tx.refunds_count,
+            1,
+            msg="The refunds count should only consider transactions with operation 'refund'."
+        )
+
+    def test_refund_transaction_values(self):
+        self.acquirer.support_refund = 'partial'
+        tx = self.create_transaction('redirect', state='done')
+        tx._reconcile_after_done()  # Create the payment
+
+        # Test the default values of a full refund transaction
+        refund_tx = tx._create_refund_transaction()
+        self.assertEqual(
+            refund_tx.reference,
+            f'R-{tx.reference}',
+            msg="The reference of the refund transaction should be the prefixed reference of the "
+                "source transaction."
+        )
+        self.assertLess(
+            refund_tx.amount, 0, msg="The amount of a refund transaction should always be negative."
+        )
+        self.assertAlmostEqual(
+            refund_tx.amount,
+            -tx.amount,
+            places=2,
+            msg="The amount of the refund transaction should be taken from the amount of the "
+                "source transaction."
+        )
+        self.assertEqual(
+            refund_tx.currency_id,
+            tx.currency_id,
+            msg="The currency of the refund transaction should that of the source transaction."
+        )
+        self.assertEqual(
+            refund_tx.operation,
+            'refund',
+            msg="The operation of the refund transaction should be 'refund'."
+        )
+        self.assertEqual(
+            tx,
+            refund_tx.source_transaction_id,
+            msg="The refund transaction should be linked to the source transaction."
+        )
+        self.assertEqual(
+            refund_tx.partner_id,
+            tx.partner_id,
+            msg="The partner of the refund transaction should that of the source transaction."
+        )
+
+        # Test the values of a partial refund transaction with custom refund amount
+        partial_refund_tx = tx._create_refund_transaction(refund_amount=11.11)
+        self.assertAlmostEqual(
+            partial_refund_tx.amount,
+            -11.11,
+            places=2,
+            msg="The amount of the refund transaction should be the negative value of the amount "
+                "to refund."
+        )
+
     def test_no_payment_for_validations(self):
         tx = self.create_transaction(flow='dummy', operation='validation')  # Overwrite the flow
         tx._reconcile_after_done()
         payment_count = self.env['account.payment'].search_count(
             [('payment_transaction_id', '=', tx.id)]
         )
-        self.assertEqual(payment_count, 0, "validation transactions should not create payments")
+        self.assertEqual(payment_count, 0, msg="validation transactions should not create payments")

--- a/addons/payment/views/account_payment_views.xml
+++ b/addons/payment/views/account_payment_views.xml
@@ -6,7 +6,26 @@
         <field name="model">account.payment</field>
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='action_draft']" position="after">
+                <field name="amount_available_for_refund" invisible="1"/>
+                <button type="object"
+                    name="action_refund_wizard"
+                    string="Refund"
+                    groups="account.group_account_invoice"
+                    attrs="{'invisible': [('amount_available_for_refund', '&lt;=', 0)]}"
+                    class="btn-secondary"/>
+            </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_refunds"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-money"
+                    attrs="{'invisible': [('refunds_count', '=', 0)]}">
+                    <field name="refunds_count" widget="statinfo" string="Refunds"/>
+                </button>
+            </xpath>
             <xpath expr='//group[2]' position="inside">
+                <field name="source_payment_id" attrs="{'invisible': [('source_payment_id', '=', False)]}"/>
                 <field name="payment_transaction_id" groups="base.group_no_one" attrs="{'invisible': [('use_electronic_payment_method', '!=', True)]}"/>
             </xpath>
             <field name="payment_method_line_id" position="after">

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -19,11 +19,20 @@
                                 attrs="{'invisible': [('invoices_count', '=', 0)]}">
                             <field name="invoices_count" widget="statinfo" string="Invoice(s)"/>
                         </button>
+                        <button name="action_view_refunds"
+                                type="object"
+                                class="oe_stat_button"
+                                icon="fa-money"
+                                attrs="{'invisible': [('refunds_count', '=', 0)]}">
+                            <field name="refunds_count" widget="statinfo" string="Refunds"/>
+                        </button>
                     </div>
                     <group>
                         <group name="transaction_details">
                             <field name="reference"/>
                             <field name="payment_id"/>
+                            <field name="source_transaction_id"
+                                   attrs="{'invisible': [('source_transaction_id', '=', False)]}"/>
                             <field name="amount"/>
                             <field name="fees" attrs="{'invisible': [('fees', '=', 0.0)]}"/>
                             <field name="currency_id" invisible="1"/>

--- a/addons/payment/wizards/__init__.py
+++ b/addons/payment/wizards/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_payment_register
 from . import payment_acquirer_onboarding_wizard
 from . import payment_link_wizard
-from . import account_payment_register
+from . import payment_refund_wizard

--- a/addons/payment/wizards/payment_refund_wizard.py
+++ b/addons/payment/wizards/payment_refund_wizard.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class PaymentRefundWizard(models.TransientModel):
+    _name = 'payment.refund.wizard'
+    _description = "Payment Refund Wizard"
+
+    payment_id = fields.Many2one(
+        string="Payment",
+        comodel_name='account.payment',
+        readonly=True,
+        default=lambda self: self.env.context.get('active_id'),
+    )
+    transaction_id = fields.Many2one(
+        string="Payment Transaction", related='payment_id.payment_transaction_id'
+    )
+    payment_amount = fields.Monetary(string="Payment Amount", related='payment_id.amount')
+    refunded_amount = fields.Monetary(string="Refunded Amount", compute='_compute_refunded_amount')
+    amount_available_for_refund = fields.Monetary(
+        string="Maximum Refund Allowed", related='payment_id.amount_available_for_refund'
+    )
+    amount_to_refund = fields.Monetary(
+        string="Refund Amount", compute='_compute_amount_to_refund', store=True, readonly=False
+    )
+    currency_id = fields.Many2one(string="Currency", related='transaction_id.currency_id')
+    support_refund = fields.Selection(related='transaction_id.acquirer_id.support_refund')
+    has_pending_refund = fields.Boolean(
+        string="Has a pending refund", compute='_compute_has_pending_refund'
+    )
+
+    @api.constrains('amount_to_refund')
+    def _check_amount_to_refund_within_boundaries(self):
+        for wizard in self:
+            if not 0 < wizard.amount_to_refund <= wizard.amount_available_for_refund:
+                raise ValidationError(_(
+                    "The amount to be refunded must be positive and cannot be superior to %s.",
+                    wizard.amount_available_for_refund
+                ))
+
+    @api.depends('amount_available_for_refund')
+    def _compute_refunded_amount(self):
+        for wizard in self:
+            wizard.refunded_amount = wizard.payment_amount - wizard.amount_available_for_refund
+
+    @api.depends('amount_available_for_refund')
+    def _compute_amount_to_refund(self):
+        """ Set the default amount to refund to the amount available for refund. """
+        for wizard in self:
+            wizard.amount_to_refund = wizard.amount_available_for_refund
+
+    @api.depends('payment_id')  # To always trigger the compute
+    def _compute_has_pending_refund(self):
+        for wizard in self:
+            pending_refunds_count = self.env['payment.transaction'].search_count([
+                ('source_transaction_id', '=', wizard.payment_id.payment_transaction_id.id),
+                ('operation', '=', 'refund'),
+                ('state', 'in', ['draft', 'pending', 'authorized']),
+            ])
+            wizard.has_pending_refund = pending_refunds_count > 0
+
+    def action_refund(self):
+        for wizard in self:
+            wizard.transaction_id.action_refund(amount_to_refund=wizard.amount_to_refund)

--- a/addons/payment/wizards/payment_refund_wizard_views.xml
+++ b/addons/payment/wizards/payment_refund_wizard_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="payment_refund_wizard_view_form" model="ir.ui.view">
+        <field name="name">payment.refund.wizard.form</field>
+        <field name="model">payment.refund.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Refund">
+                <field name="has_pending_refund" invisible="1"/>
+                <div class="alert alert-warning"
+                     id="alert_draft_refund_tx"
+                     role="alert"
+                     attrs="{'invisible': [('has_pending_refund', '=', False)]}">
+                    <p>
+                        <strong>Warning!</strong> There is a refund pending for this payment.
+                        Wait a moment for it to be processed. If the refund is still pending in a
+                        few minutes, please check your payment acquirer configuration.
+                    </p>
+                </div>
+                <group>
+                    <group>
+                        <field name="payment_id" invisible="1"/>
+                        <field name="transaction_id" invisible="1"/>
+                        <field name="currency_id" invisible="1"/>
+                        <field name="support_refund" invisible="1"/>
+                        <field name="payment_amount"/>
+                        <field name="refunded_amount"
+                               attrs="{'invisible': [('refunded_amount', '&lt;=', 0)]}"/>
+                        <field name="amount_available_for_refund"/>
+                        <field name="amount_to_refund"
+                               attrs="{'readonly': [('support_refund', '=', 'full_only')]}"/>
+                    </group>
+                </group>
+                <footer>
+                    <button string="Refund" type="object" name="action_refund" class="btn-primary"/>
+                    <button string="Close" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/payment_adyen/const.py
+++ b/addons/payment_adyen/const.py
@@ -4,11 +4,12 @@
 # See https://docs.adyen.com/api-explorer/#/CheckoutService/v53/overview for Checkout API
 # See https://docs.adyen.com/api-explorer/#/Recurring/v49/overview for Recurring API
 API_ENDPOINT_VERSIONS = {
-    '/disable': 49,           # Recurring API
-    '/originKeys': 53,        # Checkout API
-    '/payments': 53,          # Checkout API
-    '/payments/details': 53,  # Checkout API
-    '/paymentMethods': 53,    # Checkout API
+    '/disable': 49,                 # Recurring API
+    '/originKeys': 53,              # Checkout API
+    '/payments': 53,                # Checkout API
+    '/payments/details': 53,        # Checkout API
+    '/payments/{}/refunds': 67,     # Checkout API
+    '/paymentMethods': 53,          # Checkout API
 }
 
 # Adyen-specific mapping of currency codes in ISO 4217 format to the number of decimals.

--- a/addons/payment_adyen/data/payment_acquirer_data.xml
+++ b/addons/payment_adyen/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">partial</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_alipay/data/payment_acquirer_data.xml
+++ b/addons/payment_alipay/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">True</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_authorize/data/payment_acquirer_data.xml
+++ b/addons/payment_authorize/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">True</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_buckaroo/data/payment_acquirer_data.xml
+++ b/addons/payment_buckaroo/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_odoo/data/payment_acquirer_data.xml
+++ b/addons/payment_odoo/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_ogone/data/payment_acquirer_data.xml
+++ b/addons/payment_ogone/data/payment_acquirer_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
-    
+
     <record id="payment.payment_acquirer_ogone" model="payment.acquirer">
         <field name="provider">ogone</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
@@ -8,6 +8,7 @@
         <field name="support_fees_computation">False</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
+        <field name="support_refund"></field>
     </record>
 
     <record id="payment_method_ogone" model="account.payment.method">
@@ -15,5 +16,5 @@
         <field name="code">ogone</field>
         <field name="payment_type">inbound</field>
     </record>
-    
+
 </odoo>

--- a/addons/payment_paypal/data/payment_acquirer_data.xml
+++ b/addons/payment_paypal/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">True</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_payulatam/data/payment_acquirer_data.xml
+++ b/addons/payment_payulatam/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_payumoney/data/payment_acquirer_data.xml
+++ b/addons/payment_payumoney/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_sips/data/payment_acquirer_data.xml
+++ b/addons/payment_sips/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_stripe/data/payment_acquirer_data.xml
+++ b/addons/payment_stripe/data/payment_acquirer_data.xml
@@ -5,6 +5,7 @@
         <field name="provider">stripe</field>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_test/data/payment_acquirer_data.xml
+++ b/addons/payment_test/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_transfer/data/payment_acquirer_data.xml
+++ b/addons/payment_transfer/data/payment_acquirer_data.xml
@@ -7,6 +7,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund"></field>
         <field name="support_tokenization">False</field>
         <!-- Clear the default value to trigger the computation of the message -->
         <field name="pending_msg" eval="False"/>


### PR DESCRIPTION
[IMP] payment(_adyen): allow to refund confirmed transactions 

Before this commit, it was not possible to refund a payment from Odoo.
Users had to go through the payment acquirer's backend and update the
payment accordingly in Odoo.

With this commit, refunds are made available in Odoo directly from the
payment form, for acquirers that support them. Acquirer can either only
support full refunds or also support partial refunds.

As of now, the only acquirer allowing refunds is Adyen, with partial
refund support.

ENT: https://github.com/odoo/enterprise/pull/19829
UPGRADE: https://github.com/odoo/upgrade/pull/2689

task-2527891
