### PR TITLE
[IMP] phone_validation: improve phone/mobile search

### DIFF
--- a/addons/crm_phone_validation/tests/__init__.py
+++ b/addons/crm_phone_validation/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_phone_format

--- a/addons/crm_phone_validation/tests/test_phone_format.py
+++ b/addons/crm_phone_validation/tests/test_phone_format.py
@@ -1,0 +1,102 @@
+from odoo.addons.phone_validation.tools.phone_validation import phone_format
+from odoo.tests.common import Form, SavepointCase
+
+
+class TestPhone(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPhone, cls).setUpClass()
+
+        cls.partner_be = cls.env['res.partner'].create({
+            'name': 'Partner BE',
+            'phone': '+32485001122',
+            'mobile': '0032485001122',
+        })
+        cls.phone_be_formated = '+32 485 00 11 22'
+
+        cls.partner_fr = cls.env['res.partner'].create({
+            'name': 'Partner FR',
+            'phone': '+33123456789',
+            'mobile': '+33 1 23 45 67 89',
+        })
+        cls.phone_fr_formated = '+33 1 23 45 67 89'
+        print(cls.partner_be.fields_get())
+        if 'property_account_receivable_id' in cls.partner_be.fields_get():
+            user_type_payable = cls.env.ref('account.data_account_type_payable')
+            cls.account_payable = cls.env['account.account'].create({
+                'code': 'NC1110',
+                'name': 'Test Payable Account',
+                'user_type_id': user_type_payable.id,
+                'reconcile': True
+            })
+            user_type_receivable = cls.env.ref('account.data_account_type_receivable')
+            cls.account_receivable = cls.env['account.account'].create({
+                'code': 'NC1111',
+                'name': 'Test Receivable Account',
+                'user_type_id': user_type_receivable.id,
+                'reconcile': True
+            })
+            cls.partner_be.write({
+                'property_account_payable_id': cls.account_payable.id,
+                'property_account_receivable_id': cls.account_receivable.id,
+            })
+            cls.partner_fr.write({
+                'property_account_payable_id': cls.account_payable.id,
+                'property_account_receivable_id': cls.account_receivable.id,
+            })
+
+        cls.lead = cls.env['crm.lead'].create({
+            'type': "lead",
+            'name': "Test lead new",
+            'description': "This is the description of the test new lead.",
+        })
+
+    def test_phone_format_partner_lead(self):
+        # BE Partner
+        partner_phone, partner_mobile = '+32485001122', '0032485001122',
+        # check phone_format function result
+        partner_phone_formatted = phone_format(partner_phone, 'BE', '32')
+        partner_mobile_formatted = phone_format(partner_mobile, 'BE', '32')
+        self.assertEqual(partner_phone_formatted, self.phone_be_formated)
+        self.assertEqual(partner_mobile_formatted, self.phone_be_formated)
+        # ensure initial data
+        self.assertEqual(self.partner_be.phone, partner_phone)
+        self.assertEqual(self.partner_be.mobile, partner_mobile)
+        # change country to trigger onchange who formats phone/mobile
+        partner_be_form = Form(self.partner_be)
+        partner_be_form.country_id = self.env.ref('base.be')
+        partner_be_form.save()
+        self.assertEqual(partner_be_form.phone, self.phone_be_formated)
+        self.assertEqual(partner_be_form.mobile, self.phone_be_formated)
+
+        # FR Partner
+        partner_phone, partner_mobile = '+33123456789', '+33 1 23 45 67 89',
+        partner_phone_formatted = phone_format(partner_phone, 'FR', '33')
+        partner_mobile_formatted = phone_format(partner_mobile, 'FR', '33')
+        self.assertEqual(partner_phone_formatted, self.phone_fr_formated)
+        self.assertEqual(partner_mobile_formatted, self.phone_fr_formated)
+        self.assertEqual(self.partner_fr.phone, partner_phone)
+        self.assertEqual(self.partner_fr.mobile, partner_mobile)
+        partner_fr_form = Form(self.partner_fr)
+        partner_fr_form.country_id = self.env.ref('base.be')
+        partner_fr_form.save()
+        self.assertEqual(self.partner_fr.phone, self.phone_fr_formated)
+        self.assertEqual(self.partner_fr.mobile, self.phone_fr_formated)
+
+        # Lead
+        lead_form = Form(self.lead)
+        lead_form.partner_id = self.partner_be # ! updated partner with formated phone
+        self.assertEqual(lead_form.phone, self.phone_be_formated,
+                         'Lead: form automatically formats numbers')
+        self.assertEqual(lead_form.mobile, self.phone_be_formated,
+                         'Lead: form automatically formats numbers')
+
+    def test_phone_mobile_search(self):
+        for term in ['+33', '0033', '+33123', '0033 123', '+33 123456789', '+33 1 23 45 67 89']:
+            self.assertEqual(self.partner_fr, self.env['res.partner'].search([
+                ('phone', 'ilike', term), ('name', '=', 'Partner FR'),
+            ]))
+            self.assertEqual(self.partner_fr, self.env['res.partner'].search([
+                ('mobile', 'ilike', term), ('name', '=', 'Partner FR'),
+            ]))

--- a/addons/phone_validation/models/phone_validation_mixin.py
+++ b/addons/phone_validation/models/phone_validation_mixin.py
@@ -1,13 +1,48 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import models, api, _
+from odoo.exceptions import UserError
 from odoo.addons.phone_validation.tools import phone_validation
 
 
 class PhoneValidationMixin(models.AbstractModel):
     _name = 'phone.validation.mixin'
     _description = 'Phone Validation Mixin'
+
+    def _search_phone_mobile_search(self, value, field_name):
+        if len(value) <= 2:
+            raise UserError(_('Please enter at least 3 digits when searching on phone / mobile.'))
+
+        # searching on +32485112233 shouldonvert the search on real ids in the case it was asked on virtual ids, then call superalso finds 00485112233 (00 / + prefix are both valid)
+        # we therefore remove it from input value and search for both of them in db
+        if value.startswith('+') or value.startswith('00'):
+            value = value.replace('+', '').replace('00', '', 1)
+            starts_with = '(00|\+)'
+        else:
+            starts_with = '%'
+
+        query = f"""
+                SELECT model.id
+                FROM {self._table} model
+                WHERE REGEXP_REPLACE(model.{field_name}, '[^\d+]+', '', 'g') SIMILAR TO CONCAT(%s, REGEXP_REPLACE(%s, '\D+', '', 'g'), '%%')
+            """
+
+        self._cr.execute(query, (starts_with, value))
+        res = self._cr.fetchall()
+        if not res:
+            return (0, '=', 1)
+        return ('id', 'in', [r[0] for r in res])
+
+    @api.model
+    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
+        """ Overide search to use improved search for ilike phone/mobile"""
+        args = list(args)
+        if any([leaf for leaf in args if leaf[0] in ["phone", 'mobile'] and leaf[1] == "ilike"]):
+            for index in range(len(args)):
+                if args[index][0] in ["phone", 'mobile'] and args[index][1] == "ilike":
+                    args[index] = self._search_phone_mobile_search(args[index][2], args[index][0])
+        return super(PhoneValidationMixin, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
 
     def _phone_get_country(self):
         if 'country_id' in self and self.country_id:


### PR DESCRIPTION
Issue

	- Install "Contact" module
	- Create a contact A with phone "0033123456789"
	- Create a contact B with phone "+33123456789"
	- Install "CRM Phone Validation" module
	- Go to Contact module

	- In search bar, type `+33` and select `phone` field:
	Contact A is not displayed.

        - Reset search bar, type `0033` and select `phone` field:
        Contact B is not displayed.

Cause

	When `phone_validation` module is installed,
	the phone for partners and lead will be saved in DB
	as formatted (ex:003312... -> +33 1 2...) if match
	record country phone format, lefting no possible way to
	save the phone in old format (old records in DB are
	still with old format).
	Therefore, when doing a search, the search value must
	be exactly inside the record phone.

Solution

	This commit will improve the phone/mobile search;
	when a domain leaf contain 'phone' or 'mobile'
	as field and 'ilike' as operator, it will replace
	the domain by a domain with the ids of records
	where the phone does match with the optimized phone
	search.

opw-2517540
