### PR TITLE
[IMP] point_of_sale: Allow another user to resume the session from th…

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -265,8 +265,7 @@ class PosConfig(models.Model):
         """
         for pos_config in self:
             opened_sessions = pos_config.session_ids.filtered(lambda s: not s.state == 'closed')
-            session = pos_config.session_ids.filtered(lambda s: s.user_id.id == self.env.uid and \
-                    not s.state == 'closed' and not s.rescue)
+            session = pos_config.session_ids.filtered(lambda s: not s.state == 'closed' and not s.rescue)
             # sessions ordered by id desc
             pos_config.has_active_session = opened_sessions and True or False
             pos_config.current_session_id = session and session[0].id or False


### PR DESCRIPTION
When a session was opened, another user couldn't see the resume button from the kanban view.
To resume the session, the user had to go threw the pos session view.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
