### PR TITLE
[MERGE] mail, various: introduce a composer mixin for invite-based wizards

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -61,7 +61,7 @@
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="subject">${object.company_id.name} Payment Receipt (Ref ${object.name or 'n/a' })</field>
             <field name="partner_to">${object.partner_id.id}</field>
-            <field name="body_html" type="xml">
+            <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
         Dear ${object.partner_id.name}<br/><br/>

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -187,15 +187,14 @@ class ResUsers(models.Model):
             template = self.env.ref('auth_signup.reset_password_email')
         assert template._name == 'mail.template'
 
-        template_values = {
+        email_values = {
             'email_to': '${object.email|safe}',
             'email_cc': False,
             'auto_delete': True,
-            'partner_to': False,
+            'recipient_ids': [],
+            'partner_ids': [],
             'scheduled_date': False,
         }
-        if any(template[field] != value for (field, value) in template_values.items()):
-            template.write(template_values)
 
         for user in self:
             if not user.email:
@@ -203,7 +202,7 @@ class ResUsers(models.Model):
             # TDE FIXME: make this template technical (qweb)
             with self.env.cr.savepoint():
                 force_send = not(self.env.context.get('import_file', False))
-                template.send_mail(user.id, force_send=force_send, raise_exception=True)
+                template.send_mail(user.id, force_send=force_send, raise_exception=True, email_values=email_values)
             _logger.info("Password reset email sent for user <%s> to <%s>", user.login, user.email)
 
     def send_unregistered_user_reminder(self, after_days=5):

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -121,7 +121,7 @@ class Digest(models.Model):
             'digest.digest_mail_main',
             'digest.digest',
             self.ids,
-            engine='qweb',
+            engine='qweb_view',
             add_context={
                 'title': self.name,
                 'top_button_label': _('Connect'),

--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -6,7 +6,7 @@
             <field name="subject">New badge ${object.badge_id.name} granted</field>
             <field name="model_id" ref="gamification.model_gamification_badge_user"/>
             <field name="partner_to">${object.user_id.partner_id.id}</field>
-            <field name="body_html" type="xml">
+            <field name="body_html" type="html">
 <table border="0" cellpadding="0" style="padding-top: 16px; background-color: #F1F1F1; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" width="590" cellpadding="0" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;" summary="o_mail_notification">
 <tbody>

--- a/addons/gift_card/__manifest__.py
+++ b/addons/gift_card/__manifest__.py
@@ -9,7 +9,7 @@
     'version': '1.0',
     'depends': ['sale'],
     'data': [
-        'data/gift_card_template_email.xml',
+        'data/mail_template_data.xml',
         'data/gift_card_data.xml',
         'views/views.xml',
         'views/templates.xml',

--- a/addons/gift_card/data/mail_template_data.xml
+++ b/addons/gift_card/data/mail_template_data.xml
@@ -33,5 +33,6 @@
                 </span>
             </div>
         </field>
+        <field name="auto_delete" eval="True"/>
     </record>
 </odoo>

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import mail_render_mixin
+from . import mail_composer_mixin
+
 from . import mail_message_subtype
 from . import mail_tracking_value
 from . import mail_alias
 from . import mail_alias_mixin
 from . import mail_followers
 from . import mail_notification
-from . import mail_render_mixin
 from . import mail_message
 from . import mail_activity
 from . import mail_mail

--- a/addons/mail/models/mail_composer_mixin.py
+++ b/addons/mail/models/mail_composer_mixin.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class MailComposerMixin(models.AbstractModel):
+    """ Mixin used to edit and render some fields used when sending emails or
+    notifications based on a mail template.
+
+    Main current purpose is to hide details related to subject and body computation
+    and rendering based on a mail.template. It also give the base tools to control
+    who is allowed to edit body, notably when dealing with templating language
+    like jinja or qweb.
+
+    It is meant to evolve in a near future with upcoming support of qweb and fine
+    grain control of rendering access.
+    """
+    _name = 'mail.composer.mixin'
+    _inherit = 'mail.render.mixin'
+    _description = 'Mail Composer Mixin'
+
+    # Content
+    subject = fields.Char('Subject', compute='_compute_subject', readonly=False, store=True)
+    body = fields.Html('Contents', sanitize_style=True, compute='_compute_body', store=True, readonly=False)
+    template_id = fields.Many2one('mail.template', 'Mail Template', domain="[('model', '=', render_model)]")
+    # Access
+    can_edit_body = fields.Boolean('Can Edit Body', compute='_compute_can_edit_body')
+
+    @api.depends('template_id')
+    def _compute_subject(self):
+        for composer_mixin in self:
+            if composer_mixin.template_id:
+                composer_mixin.subject = composer_mixin.template_id.subject
+            elif not composer_mixin.subject:
+                composer_mixin.subject = False
+
+    @api.depends('template_id')
+    def _compute_body(self):
+        for composer_mixin in self:
+            if composer_mixin.template_id:
+                composer_mixin.body = composer_mixin.template_id.body_html
+            elif not composer_mixin.body:
+                composer_mixin.body = False
+
+    @api.depends('template_id')
+    @api.depends_context('uid')
+    def _compute_can_edit_body(self):
+        self.can_edit_body = True

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -67,6 +67,16 @@ class MailTemplate(models.Model):
                                         help="Sidebar action to make this template available on records "
                                              "of the related document model")
 
+    # Overrides of mail.render.mixin
+    @api.depends('model')
+    def _compute_render_model(self):
+        for template in self:
+            template.render_model = template.model
+
+    # ------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------
+
     def unlink(self):
         self.unlink_action()
         return super(MailTemplate, self).unlink()
@@ -163,9 +173,9 @@ class MailTemplate(models.Model):
         results = dict()
         for lang, (template, template_res_ids) in self._classify_per_lang(res_ids).items():
             for field in fields:
-                template = template.with_context(safe=(field == 'subject'))
                 generated_field_values = template._render_field(
                     field, template_res_ids,
+                    options={'render_safe': field == 'subject'},
                     post_process=(field == 'body_html')
                 )
                 for res_id, field_value in generated_field_values.items():

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -52,20 +52,20 @@ class TestMailRender(common.MailCommon):
 </p>"""
         ]
 
-        # some qweb templates and their xml ids
-        cls.base_qweb_templates = cls.env['ir.ui.view'].create([
-            {'name': 'TestRender', 'type': 'qweb',
-             'arch': '<p>Hello</p>',
-            },
-            {'name': 'TestRender2', 'type': 'qweb',
-             'arch': '<p>Hello <t t-esc="object.name"/></p>',
-            },
-            {'name': 'TestRender3', 'type': 'qweb',
-             'arch': """<p>
+        # some qweb templates, their views and their xml ids
+        cls.base_qweb_bits = [
+            '<p>Hello</p>',
+            '<p>Hello <t t-esc="object.name"/></p>',
+            """<p>
     <span t-if="object.lang == 'en_US'">English Speaker</span>
     <span t-else="">Other Speaker</span>
-</p>""",
-            },
+</p>"""
+        ]
+        cls.base_qweb_templates = cls.env['ir.ui.view'].create([
+            {'name': 'TestRender%d' % index,
+             'type': 'qweb',
+             'arch': qweb_content,
+            } for index, qweb_content in enumerate(cls.base_qweb_bits)
         ])
         cls.base_qweb_templates_data = cls.env['ir.model.data'].create([
             {'name': template.name, 'module': 'mail',
@@ -127,23 +127,32 @@ class TestMailRender(common.MailCommon):
         })
 
     @users('employee')
-    def test_render_jinja(self):
-        source = """<p>
-% set line_statement_variable = 3
-<span>We have ${line_statement_variable} cookies in stock</span>
-<span>We have <% set block_variable = 4 %>${block_variable} cookies in stock</span>
-</p>"""
+    def test_evaluation_context(self):
+        """ Test evaluation context and various ways of tweaking it. """
         partner = self.env['res.partner'].browse(self.render_object.ids)
-        result = self.env['mail.render.mixin']._render_template(
-            source,
-            partner._name,
-            partner.ids,
-            engine='jinja',
-        )[partner.id]
-        self.assertEqual(result, """<p>
-<span>We have 3 cookies in stock</span>
-<span>We have 4 cookies in stock</span>
-</p>""")
+        MailRenderMixin = self.env['mail.render.mixin']
+
+        custom_ctx = {'custom_ctx': 'Custom Context Value'}
+        add_context = {
+            'custom_value': 'Custom Render Value'
+        }
+        srces = [
+            '<b>I am ${user.name}</b>',
+            '<span>Datetime is ${format_datetime(datetime.datetime(2021, 6, 1), dt_format="MM - d - YYY")}</span>',
+            '<span>Context ${ctx.get("custom_ctx")}, value ${custom_value}</span>',
+        ]
+        results = [
+            '<b>I am %s</b>' % self.env.user.name,
+            '<span>Datetime is 06 - 1 - 2021</span>',
+            '<span>Context Custom Context Value, value Custom Render Value</span>'
+        ]
+        for src, expected in zip(srces, results):
+            for engine in ['jinja']:
+                result = MailRenderMixin.with_context(**custom_ctx)._render_template(
+                    src, partner._name, partner.ids,
+                    engine=engine, add_context=add_context
+                )[partner.id]
+                self.assertEqual(expected, result)
 
     @users('employee')
     def test_render_mail_template_jinja(self):
@@ -179,13 +188,131 @@ class TestMailRender(common.MailCommon):
             self.assertEqual(rendered, expected)
 
     @users('employee')
-    def test_render_template_qweb(self):
+    def test_render_template_qweb_view(self):
         partner = self.env['res.partner'].browse(self.render_object.ids)
         for source, expected in zip(self.base_qweb_templates_xmlids, self.base_rendered):
             rendered = self.env['mail.render.mixin']._render_template(
                 source,
                 partner._name,
                 partner.ids,
-                engine='qweb',
+                engine='qweb_view',
             )[partner.id].decode()
             self.assertEqual(rendered, expected)
+
+    @users('employee')
+    def test_template_rendering_impersonate(self):
+        """ Test that the use of SUDO do not change the current user. """
+        partner = self.env['res.partner'].browse(self.render_object.ids)
+        src = '${user.name} - ${object.name}'
+        expected = '%s - %s' % (self.env.user.name, partner.name)
+        result = self.env['mail.render.mixin'].sudo()._render_template_jinja(
+            src, partner._name, partner.ids
+        )[partner.id]
+        self.assertIn(expected, result)
+
+    @users('employee')
+    def test_template_rendering_function_call(self):
+        """Test the case when the template call a custom function.
+        This function should not be called when the template is not rendered.
+        """
+        partner = self.env['res.partner'].browse(self.render_object.ids)
+
+        def cust_function():
+            # Can not use "MagicMock" in a Jinja sand-boxed environment
+            # so create our own function
+            cust_function.call = True
+            return 'return value'
+
+        cust_function.call = False
+
+        src = """<h1>This is a test</h1>
+<p>${cust_function()}</p>"""
+        expected = """<h1>This is a test</h1>
+<p>return value</p>"""
+        context = {'cust_function': cust_function}
+
+        result = self.env['mail.render.mixin']._render_template_jinja(
+            src, partner._name, partner.ids,
+            add_context=context
+        )[partner.id]
+        self.assertEqual(expected, result)
+        self.assertTrue(cust_function.call)
+
+    @users('employee')
+    def test_template_rendering_various(self):
+        """ Test static rendering """
+        partner = self.env['res.partner'].browse(self.render_object.ids)
+        MailRenderMixin = self.env['mail.render.mixin']
+
+        # static string
+        src = 'This is a string'
+        expected = 'This is a string'
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(expected, result)
+
+        # code string
+        src = 'This is a string with a number ${13+13}'
+        expected = 'This is a string with a number 26'
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(expected, result)
+
+        # block string
+        src = "This is a string with a block ${'hidden' if False else 'displayed'}"
+        expected = 'This is a string with a block displayed'
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(expected, result)
+
+        # static xml
+        src = '<p class="text-muted"><span>This is a string</span></p>'
+        expected = '<p class="text-muted"><span>This is a string</span></p>'
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(expected, result)
+
+        # code xml
+        src = '<p class="text-muted"><span>This is a string with a number ${13+13}</span></p>'
+        expected = '<p class="text-muted"><span>This is a string with a number 26</span></p>'
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(expected, result)
+
+        # condition block xml
+        src = """<b>Test</b>
+% if False:
+    <b>Code not executed</b>
+% endif"""
+        expected = "<b>Test</b>\n"  # TDE: to check
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(expected, result)
+
+        # complete block xml
+        src = """<p>
+% set line_statement_variable = 3
+<span>We have ${line_statement_variable} cookies in stock</span>
+<span>We have <% set block_variable = 4 %>${block_variable} cookies in stock</span>
+</p>"""
+        expected = """<p>
+<span>We have 3 cookies in stock</span>
+<span>We have 4 cookies in stock</span>
+</p>"""
+        for engine in ['jinja']:
+            result = MailRenderMixin._render_template(
+                src, partner._name, partner.ids, engine=engine,
+            )[partner.id]
+            self.assertEqual(result, expected)

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -274,20 +274,23 @@ class TestMailRender(common.MailCommon):
         # static xml
         src = '<p class="text-muted"><span>This is a string</span></p>'
         expected = '<p class="text-muted"><span>This is a string</span></p>'
-        for engine in ['jinja']:
+        for engine in ['jinja', 'qweb']:
             result = MailRenderMixin._render_template(
                 src, partner._name, partner.ids, engine=engine,
             )[partner.id]
-            self.assertEqual(expected, result)
+            self.assertEqual(expected, result if engine == 'jinja' else result.decode())  # tde: checkme
 
         # code xml
-        src = '<p class="text-muted"><span>This is a string with a number ${13+13}</span></p>'
+        srces = [
+            '<p class="text-muted"><span>This is a string with a number ${13+13}</span></p>',
+            '<p class="text-muted"><span>This is a string with a number <t t-out="13+13"/></span></p>',
+        ]
         expected = '<p class="text-muted"><span>This is a string with a number 26</span></p>'
-        for engine in ['jinja']:
+        for engine, src in zip(['jinja', 'qweb'], srces):
             result = MailRenderMixin._render_template(
                 src, partner._name, partner.ids, engine=engine,
             )[partner.id]
-            self.assertEqual(expected, result)
+            self.assertEqual(expected, result if engine == 'jinja' else result.decode())  # tde: checkme
 
         # condition block xml
         src = """<b>Test</b>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -113,7 +113,7 @@ class MassMailing(models.Model):
         string='Reply To', compute='_compute_reply_to', readonly=False, store=True,
         help='Preferred Reply-To Address')
     # recipients
-    mailing_model_real = fields.Char(string='Recipients Real Model', compute='_compute_model')
+    mailing_model_real = fields.Char(string='Recipients Real Model', compute='_compute_mailing_model_real')
     mailing_model_id = fields.Many2one(
         'ir.model', string='Recipients Model', ondelete='cascade', required=True,
         domain=[('is_mailing_enabled', '=', True)],
@@ -239,9 +239,9 @@ class MassMailing(models.Model):
                 mailing.medium_id = self.env.ref('utm.utm_medium_email').id
 
     @api.depends('mailing_model_id')
-    def _compute_model(self):
-        for record in self:
-            record.mailing_model_real = (record.mailing_model_name != 'mailing.list') and record.mailing_model_name or 'mailing.contact'
+    def _compute_mailing_model_real(self):
+        for mailing in self:
+            mailing.mailing_model_real = (mailing.mailing_model_name != 'mailing.list') and mailing.mailing_model_name or 'mailing.contact'
 
     @api.depends('mailing_model_real')
     def _compute_reply_to_mode(self):
@@ -292,6 +292,12 @@ class MassMailing(models.Model):
 
     def _compute_mail_server_available(self):
         self.mail_server_available = self.env['ir.config_parameter'].sudo().get_param('mass_mailing.outgoing_mail_server')
+
+    # Overrides of mail.render.mixin
+    @api.depends('mailing_model_real')
+    def _compute_render_model(self):
+        for mailing in self:
+            mailing.render_model = mailing.mailing_model_real
 
     # ------------------------------------------------------
     # ORM

--- a/addons/repair/data/mail_template_data.xml
+++ b/addons/repair/data/mail_template_data.xml
@@ -7,7 +7,7 @@
             <field name="subject">${object.partner_id.name} Repair Orders (Ref ${object.name or 'n/a' })</field>
             <field name="email_from">${(object.create_uid.email_formatted or user.email_formatted) | safe}</field>
             <field name="partner_to">${object.partner_id.id}</field>
-            <field name="body_html" type="xml">
+            <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px;font-size: 13px;">
         Hello ${object.partner_id.name},<br/>

--- a/addons/sms/models/sms_template.py
+++ b/addons/sms/models/sms_template.py
@@ -29,6 +29,16 @@ class SMSTemplate(models.Model):
                                         help="Sidebar action to make this template available on records "
                                         "of the related document model")
 
+    # Overrides of mail.render.mixin
+    @api.depends('model')
+    def _compute_render_model(self):
+        for template in self:
+            template.render_model = template.model
+
+    # ------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------
+
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):
         default = dict(default or {},

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Surveys',
-    'version': '3.3',
+    'version': '3.4',
     'category': 'Marketing/Surveys',
     'description': """
 Create beautiful surveys and visualize answers

--- a/addons/survey/data/mail_template_data.xml
+++ b/addons/survey/data/mail_template_data.xml
@@ -4,7 +4,7 @@
         <record id="mail_template_user_input_invite" model="mail.template">
             <field name="name">Survey: Invite</field>
             <field name="model_id" ref="model_survey_user_input" />
-            <field name="subject">Participate to ${object.survey_id.title} survey</field>
+            <field name="subject">Participate to ${object.survey_id.display_name} survey</field>
             <field name="email_to">${(object.partner_id.email_formatted or object.email) |safe}</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px; font-size: 13px;">

--- a/addons/survey/data/mail_template_data.xml
+++ b/addons/survey/data/mail_template_data.xml
@@ -43,31 +43,31 @@
             <field name="subject">Certification: ${object.survey_id.display_name}</field>
             <field name="email_from">${(object.survey_id.create_uid.email_formatted or user.email_formatted or user.company_id.catchall_formatted) |safe}</field>
             <field name="email_to">${(object.partner_id.email_formatted or object.email) |safe}</field>
-            <field name="body_html" type="xml">
-                <div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">
-                    <table style="width:600px;margin:5px auto;">
-                        <tbody>
-                            <tr><td>
-                                <!-- We use the logo of the company that created the survey (to handle multi company cases) -->
-                                <a href="/"><img src="/logo.png?company=${object.survey_id.create_uid.company_id.id}" style="vertical-align:baseline;max-width:100px;" /></a>
-                            </td><td style="text-align:right;vertical-align:middle;">
-                                    Certification: ${object.survey_id.display_name}
-                            </td></tr>
-                        </tbody>
-                    </table>
-                    <table style="width:600px;margin:0px auto;background:white;border:1px solid #e1e1e1;">
-                        <tbody>
-                            <tr><td style="padding:15px 20px 10px 20px;">
-                                <p>Dear <span>${object.partner_id.name or 'participant'}</span></p>
-                                <p>
-                                    Here is, in attachment, your certification document for
-                                        <strong>${object.survey_id.display_name}</strong>
-                                </p>
-                                <p>Congratulations for succeeding the test!</p>
-                            </td></tr>
-                        </tbody>
-                    </table>
-                </div>
+            <field name="body_html" type="html">
+<div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">
+    <table style="width:600px;margin:5px auto;">
+        <tbody>
+            <tr><td>
+                <!-- We use the logo of the company that created the survey (to handle multi company cases) -->
+                <a href="/"><img src="/logo.png?company=${object.survey_id.create_uid.company_id.id}" style="vertical-align:baseline;max-width:100px;" /></a>
+            </td><td style="text-align:right;vertical-align:middle;">
+                    Certification: ${object.survey_id.display_name}
+            </td></tr>
+        </tbody>
+    </table>
+    <table style="width:600px;margin:0px auto;background:white;border:1px solid #e1e1e1;">
+        <tbody>
+            <tr><td style="padding:15px 20px 10px 20px;">
+                <p>Dear <span>${object.partner_id.name or 'participant'}</span></p>
+                <p>
+                    Here is, in attachment, your certification document for
+                        <strong>${object.survey_id.display_name}</strong>
+                </p>
+                <p>Congratulations for succeeding the test!</p>
+            </td></tr>
+        </tbody>
+    </table>
+</div>
             </field>
             <field name="report_template" ref="certification_report"/>
             <field name="report_name">Certification Document</field>

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -15,6 +15,7 @@ emails_split = re.compile(r"[;,\n\r]+")
 
 class SurveyInvite(models.TransientModel):
     _name = 'survey.invite'
+    _inherit = 'mail.composer.mixin'
     _description = 'Survey Invitation Wizard'
 
     @api.model
@@ -28,14 +29,9 @@ class SurveyInvite(models.TransientModel):
         return self.env.user.partner_id
 
     # composer content
-    subject = fields.Char('Subject', compute='_compute_subject', readonly=False, store=True)
-    body = fields.Html('Contents', sanitize_style=True, compute='_compute_body', readonly=False, store=True)
     attachment_ids = fields.Many2many(
         'ir.attachment', 'survey_mail_compose_message_ir_attachments_rel', 'wizard_id', 'attachment_id',
         string='Attachments')
-    template_id = fields.Many2one(
-        'mail.template', 'Use template', index=True,
-        domain="[('model', '=', 'survey.user_input')]")
     # origin
     email_from = fields.Char('From', default=_get_default_from, help="Email address of the sender.")
     author_id = fields.Many2one(
@@ -106,6 +102,11 @@ class SurveyInvite(models.TransientModel):
         for invite in self:
             invite.survey_start_url = werkzeug.urls.url_join(base_url, invite.survey_id.get_start_url()) if invite.survey_id else False
 
+    # Overrides of mail.composer.mixin
+    @api.depends('survey_id')  # fake trigger otherwise not computed in new mode
+    def _compute_render_model(self):
+        self.render_model = 'survey.user_input'
+
     @api.onchange('emails')
     def _onchange_emails(self):
         if self.emails and (self.survey_users_login_required and not self.survey_id.users_can_signup):
@@ -137,22 +138,6 @@ class SurveyInvite(models.TransientModel):
                         'The following recipients have no user account: %s. You should create user accounts for them or allow external signup in configuration.',
                         ', '.join(invalid_partners.mapped('name'))
                     ))
-
-    @api.depends('template_id')
-    def _compute_subject(self):
-        for invite in self:
-            if invite.template_id:
-                invite.subject = invite.template_id.subject
-            elif not invite.subject:
-                invite.subject = False
-
-    @api.depends('template_id')
-    def _compute_body(self):
-        for invite in self:
-            if invite.template_id:
-                invite.body = invite.template_id.body_html
-            elif not invite.body:
-                invite.body = False
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -210,8 +195,8 @@ class SurveyInvite(models.TransientModel):
 
     def _send_mail(self, answer):
         """ Create mail specific for recipient containing notably its access token """
-        subject = self.env['mail.render.mixin'].with_context(safe=True)._render_template(self.subject, 'survey.user_input', answer.ids, post_process=True)[answer.id]
-        body = self.env['mail.render.mixin']._render_template(self.body, 'survey.user_input', answer.ids, post_process=True)[answer.id]
+        subject = self._render_field('subject', answer.ids, post_process=False)[answer.id]
+        body = self._render_field('body', answer.ids, post_process=True)[answer.id]
         # post the message
         mail_values = {
             'email_from': self.email_from,

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -195,7 +195,7 @@ class SurveyInvite(models.TransientModel):
 
     def _send_mail(self, answer):
         """ Create mail specific for recipient containing notably its access token """
-        subject = self._render_field('subject', answer.ids, post_process=False)[answer.id]
+        subject = self._render_field('subject', answer.ids, options={'render_safe': True})[answer.id]
         body = self._render_field('body', answer.ids, post_process=True)[answer.id]
         # post the message
         mail_values = {

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -13,6 +13,7 @@
                             <field name="survey_users_can_signup" invisible="1"/>
                             <field name="survey_id" readonly="context.get('default_survey_id')"/>
                             <field name="existing_mode" widget="radio" invisible="1" />
+                            <field name="render_model" invisible="1"/>
                             <field name="survey_start_url" label="Public share URL" readonly="1" widget="CopyClipboardChar"
                                  attrs="{'invisible':[('survey_access_mode', '!=', 'public')]}"
                                  class="mb16"/>

--- a/addons/test_mail/data/template_data.xml
+++ b/addons/test_mail/data/template_data.xml
@@ -4,7 +4,7 @@
         <field name="name">Mail Test Full: Tracking Template</field>
         <field name="subject">Test Template</field>
         <field name="partner_to">${object.customer_id.id | safe}</field>
-        <field name="body_html" type="xml"><p>Hello ${object.name}</p></field>
+        <field name="body_html" type="html"><p>Hello ${object.name}</p></field>
         <field name="model_id" ref="test_mail.model_mail_test_ticket"/>
         <field name="auto_delete" eval="True"/>
     </record>
@@ -13,7 +13,7 @@
         <field name="name">Mail Test: Template</field>
         <field name="subject">Post on ${object.name}</field>
         <field name="partner_to">${object.customer_id.id}</field>
-        <field name="body_html" type="xml"><p>Adding stuff on ${object.name}</p></field>
+        <field name="body_html" type="html"><p>Adding stuff on ${object.name}</p></field>
         <field name="model_id" ref="test_mail.model_mail_test_container"/>
         <field name="auto_delete" eval="True"/>
     </record>

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -132,6 +132,7 @@ class MailTestComposerMixin(models.Model):
 
     name = fields.Char('Name')
     author_id = fields.Many2one('res.partner')
+    description = fields.Html('Description', render_engine="qweb", render_options={"post_process": True})
 
     def _compute_render_model(self):
         self.render_model = self._name

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -122,3 +122,16 @@ class MailTestContainer(models.Model):
             values['alias_force_thread_id'] = self.id
             values['alias_parent_thread_id'] = self.id
         return values
+
+class MailTestComposerMixin(models.Model):
+    """ A simple invite-like wizard using the composer mixin, rendering on
+    itself. """
+    _description = 'Invite-like Wizard'
+    _name = 'mail.test.composer.mixin'
+    _inherit = ['mail.composer.mixin']
+
+    name = fields.Char('Name')
+    author_id = fields.Many2one('res.partner')
+
+    def _compute_render_model(self):
+        self.render_model = self._name

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -11,6 +11,8 @@ access_mail_test_activity_portal,mail.test.activity.portal,model_mail_test_activ
 access_mail_test_activity_user,mail.test.activity.user,model_mail_test_activity,base.group_user,1,1,1,1
 access_mail_test_ticket_portal,mail.test.ticket.portal,model_mail_test_ticket,base.group_portal,0,0,0,0
 access_mail_test_ticket_user,mail.test.ticket.user,model_mail_test_ticket,base.group_user,1,1,1,1
+access_mail_test_composer_mixin_all,mail.test.composer.mixin.all,model_mail_test_composer_mixin,,0,0,0,0
+access_mail_test_composer_mixin_user,mail.test.composer.mixin.user,model_mail_test_composer_mixin,base.group_user,1,1,1,1
 access_mail_test_container_portal,mail.test.container_portal,model_mail_test_container,base.group_portal,1,1,0,0
 access_mail_test_container_user,mail.test.container.user,model_mail_test_container,base.group_user,1,1,1,1
 access_mail_test_cc_portal,mail.test.cc.portal,model_mail_test_cc,base.group_portal,1,0,0,0

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_invite
 from . import test_ir_actions
 from . import test_mail_activity
 from . import test_mail_composer
+from . import test_mail_composer_mixin
 from . import test_mail_followers
 from . import test_mail_message
 from . import test_mail_mail

--- a/addons/test_mail/tests/test_mail_composer_mixin.py
+++ b/addons/test_mail/tests/test_mail_composer_mixin.py
@@ -39,6 +39,7 @@ class TestMailComposerMixin(TestMailCommon, TestRecipients):
             'name': 'Invite',
             'subject': 'Subject for ${object.name}',
             'body': '<p>Content from ${user.name}</p>',
+            'description': '<p>Description for <t t-esc="object.name"/></p>',
         })
         self.assertEqual(record.subject, 'Subject for ${object.name}')
         self.assertEqual(record.body, '<p>Content from ${user.name}</p>')
@@ -47,3 +48,5 @@ class TestMailComposerMixin(TestMailCommon, TestRecipients):
         self.assertEqual(subject, 'Subject for %s' % record.name)
         body = record._render_field('body', record.ids)[record.id]
         self.assertEqual(body, '<p>Content from %s</p>' % self.env.user.name)
+        description = record._render_field('description', record.ids)[record.id]
+        self.assertEqual(description, '<p>Description for </p>')

--- a/addons/test_mail/tests/test_mail_composer_mixin.py
+++ b/addons/test_mail/tests/test_mail_composer_mixin.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.test_mail.tests.common import TestMailCommon, TestRecipients
+from odoo.tests import tagged
+from odoo.tests.common import users
+
+
+@tagged('mail_composer_mixin')
+class TestMailComposerMixin(TestMailCommon, TestRecipients):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMailComposerMixin, cls).setUpClass()
+        cls._init_mail_gateway()
+
+        cls.mail_template = cls.env['mail.template'].create({
+            'subject': 'Subject for ${object.name}',
+            'body_html': '<p>Body for ${object.name}</p>',
+        })
+
+    @users("employee")
+    def test_content_sync(self):
+        record = self.env['mail.test.composer.mixin'].create({
+            'name': 'Invite',
+            'template_id': self.mail_template.id,
+        })
+        self.assertEqual(record.subject, self.mail_template.subject)
+        self.assertEqual(record.body, self.mail_template.body_html)
+
+        subject = record._render_field('subject', record.ids)[record.id]
+        self.assertEqual(subject, 'Subject for %s' % record.name)
+        body = record._render_field('body', record.ids)[record.id]
+        self.assertEqual(body, '<p>Body for %s</p>' % record.name)
+
+    @users("employee")
+    def test_rendering(self):
+        record = self.env['mail.test.composer.mixin'].create({
+            'name': 'Invite',
+            'subject': 'Subject for ${object.name}',
+            'body': '<p>Content from ${user.name}</p>',
+        })
+        self.assertEqual(record.subject, 'Subject for ${object.name}')
+        self.assertEqual(record.body, '<p>Content from ${user.name}</p>')
+
+        subject = record._render_field('subject', record.ids)[record.id]
+        self.assertEqual(subject, 'Subject for %s' % record.name)
+        body = record._render_field('body', record.ids)[record.id]
+        self.assertEqual(body, '<p>Content from %s</p>' % self.env.user.name)

--- a/addons/test_mail_full/tests/test_sms_template.py
+++ b/addons/test_mail_full/tests/test_sms_template.py
@@ -23,6 +23,9 @@ class TestSmsTemplate(TestMailFullCommon, TestMailFullRecipients):
         rendered_body = self.sms_template._render_template(self.sms_template.body, self.sms_template.model, self.test_record.ids)
         self.assertEqual(rendered_body[self.test_record.id], 'Dear %s this is an SMS.' % self.test_record.display_name)
 
+        rendered_body = self.sms_template._render_field('body', self.test_record.ids)
+        self.assertEqual(rendered_body[self.test_record.id], 'Dear %s this is an SMS.' % self.test_record.display_name)
+
     def test_sms_template_lang(self):
         self.env['res.lang']._activate_lang('fr_FR')
         self.user_admin.write({'lang': 'en_US'})

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -5,7 +5,7 @@
         <field name="model_id" ref="website_event_track.model_event_track"/>
         <field name="subject">Confirmation of ${object.name}</field>
         <field name="use_default_to" eval="True"/>
-        <field name="body_html" type="xml">
+        <field name="body_html" type="html">
 <div>
     Dear ${object.partner_id.name or object.partner_name or ''}<br/>
     We are pleased to inform you that your proposal ${object.name} has been accepted and confirmed for the event ${object.event_id.name}.

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -7,7 +7,7 @@
             <field name="subject">You left items in your cart!</field>
             <field name="email_from">${(object.user_id.email_formatted or user.email_formatted or '') | safe}</field>
             <field name="partner_to">${object.partner_id.id}</field>
-            <field name="body_html" type="xml">
+            <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
 <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>

--- a/addons/website_sale_slides/views/slide_channel_views.xml
+++ b/addons/website_sale_slides/views/slide_channel_views.xml
@@ -28,18 +28,12 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.slide_channel_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='website_published']" position="before">
-                <field name="enroll"/>
-            </xpath>
             <xpath expr="//div[@name='info_total_time']" position="after">
                 <div class="d-flex" attrs="{'invisible': [('enroll', '!=', 'payment')]}">
                     <span class="mr-auto"><label for="product_sale_revenues" class="mb0">Sales</label></span>
                     <field name="product_sale_revenues" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                     <field name="currency_id" attrs="{'invisible': True}"/>
                 </div>
-            </xpath>
-            <xpath expr="//a[@name='action_channel_invite']" position="attributes">
-                <attribute name="attrs">{'invisible': [('enroll', '=', 'payment')]}</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'eLearning',
-    'version': '2.3',
+    'version': '2.4',
     'sequence': 125,
     'summary': 'Manage and publish an eLearning platform',
     'website': 'https://www.odoo.com/page/slides',

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Channels">
                     <header>
-                        <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight"  attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
+                        <button name="action_channel_invite" string="Invite" type="object" class="oe_highlight" attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
@@ -207,6 +207,7 @@
             <field name="arch" type="xml">
                 <kanban string="eLearning Overview" class="o_emphasize_colors o_kanban_dashboard o_slide_kanban breadcrumb_item active" edit="false" sample="1">
                     <field name="color"/>
+                    <field name="enroll"/>
                     <field name="website_published"/>
                     <templates>
                         <t t-name="kanban-box">
@@ -231,7 +232,8 @@
                                             <div role="menuitem">
                                                 <a name="action_view_slides" type="object">Lessons</a>
                                             </div>
-                                            <div role="menuitem" name="action_channel_invite">
+                                            <div role="menuitem" name="action_channel_invite"
+                                                attrs="{'invisible': [('enroll', '!=', 'invite')]}">
                                                 <a name="action_channel_invite" type="object">Invite</a>
                                             </div>
                                         </div>

--- a/addons/website_slides/wizard/slide_channel_invite.py
+++ b/addons/website_slides/wizard/slide_channel_invite.py
@@ -61,6 +61,8 @@ class SlideChannelInvite(models.TransientModel):
 
         if not self.env.user.email:
             raise UserError(_("Unable to post message, please configure the sender's email address."))
+        if not self.partner_ids:
+            raise UserError(_("Please select at least one recipient."))
 
         mail_values = []
         for partner_id in self.partner_ids:
@@ -68,15 +70,13 @@ class SlideChannelInvite(models.TransientModel):
             if slide_channel_partner:
                 mail_values.append(self._prepare_mail_values(slide_channel_partner))
 
-        # TODO awa: change me to create multi when mail.mail supports it
-        for mail_value in mail_values:
-            self.env['mail.mail'].sudo().create(mail_value)
+        self.env['mail.mail'].sudo().create(mail_values)
 
         return {'type': 'ir.actions.act_window_close'}
 
     def _prepare_mail_values(self, slide_channel_partner):
         """ Create mail specific for recipient """
-        subject = self._render_field('subject', slide_channel_partner.ids, post_process=True)[slide_channel_partner.id]
+        subject = self._render_field('subject', slide_channel_partner.ids, options={'render_safe': True})[slide_channel_partner.id]
         body = self._render_field('body', slide_channel_partner.ids, post_process=True)[slide_channel_partner.id]
         # post the message
         mail_values = {

--- a/addons/website_slides/wizard/slide_channel_invite.py
+++ b/addons/website_slides/wizard/slide_channel_invite.py
@@ -6,7 +6,6 @@ import re
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import formataddr
 
 _logger = logging.getLogger(__name__)
 
@@ -15,35 +14,20 @@ emails_split = re.compile(r"[;,\n\r]+")
 
 class SlideChannelInvite(models.TransientModel):
     _name = 'slide.channel.invite'
+    _inherit = 'mail.composer.mixin'
     _description = 'Channel Invitation Wizard'
 
     # composer content
-    subject = fields.Char('Subject', compute='_compute_subject', readonly=False, store=True)
-    body = fields.Html('Contents', sanitize_style=True, compute='_compute_body', readonly=False, store=True)
     attachment_ids = fields.Many2many('ir.attachment', string='Attachments')
-    template_id = fields.Many2one(
-        'mail.template', 'Use template',
-        domain="[('model', '=', 'slide.channel.partner')]")
     # recipients
     partner_ids = fields.Many2many('res.partner', string='Recipients')
     # slide channel
     channel_id = fields.Many2one('slide.channel', string='Slide channel', required=True)
 
-    @api.depends('template_id')
-    def _compute_subject(self):
-        for invite in self:
-            if invite.template_id:
-                invite.subject = invite.template_id.subject
-            elif not invite.subject:
-                invite.subject = False
-
-    @api.depends('template_id')
-    def _compute_body(self):
-        for invite in self:
-            if invite.template_id:
-                invite.body = invite.template_id.body_html
-            elif not invite.body:
-                invite.body = False
+    # Overrides of mail.composer.mixin
+    @api.depends('channel_id')  # fake trigger otherwise not computed in new mode
+    def _compute_render_model(self):
+        self.render_model = 'slide.channel.partner'
 
     @api.onchange('partner_ids')
     def _onchange_partner_ids(self):
@@ -92,8 +76,8 @@ class SlideChannelInvite(models.TransientModel):
 
     def _prepare_mail_values(self, slide_channel_partner):
         """ Create mail specific for recipient """
-        subject = self.env['mail.render.mixin']._render_template(self.subject, 'slide.channel.partner', slide_channel_partner.ids, post_process=True)[slide_channel_partner.id]
-        body = self.env['mail.render.mixin']._render_template(self.body, 'slide.channel.partner', slide_channel_partner.ids, post_process=True)[slide_channel_partner.id]
+        subject = self._render_field('subject', slide_channel_partner.ids, post_process=True)[slide_channel_partner.id]
+        body = self._render_field('body', slide_channel_partner.ids, post_process=True)[slide_channel_partner.id]
         # post the message
         mail_values = {
             'email_from': self.env.user.email_formatted,

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -11,7 +11,8 @@
                             <field name="partner_ids"
                                 widget="many2many_tags_email"
                                 placeholder="Add existing contacts..."
-                                context="{'force_email':True, 'show_email':True, 'no_create_edit': True}"/>
+                                required="1"
+                                context="{'force_email':True, 'show_email':True, 'no_create_edit': True, 'no_quick_create': True}"/>
                         </group>
                         <group col="2">
                             <field name="render_model" invisible="1"/>

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -14,6 +14,7 @@
                                 context="{'force_email':True, 'show_email':True, 'no_create_edit': True}"/>
                         </group>
                         <group col="2">
+                            <field name="render_model" invisible="1"/>
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="body" options="{'style-inline': true}"/>


### PR DESCRIPTION
PURPOSE

Improve mail rendering tools and prepare ground for QWeb rendering.

SPECIFICATIONS: MODEL FOR RENDERING

Currently ``mail.render.mixin`` offers rendering tools, some of them being
based on a ``model`` field. It allows to know which model to use to fetch
records on which we perform rendering. However this field is not defined at
mixin level but in inheriting models without being clearly implemented that
way (see ``mail.template`` or ``sms.template`` models).

In order to clean this mixin it is now defined at mixin level, using a
not stored computed field allowing to define how to find this model. Sub
models are updated accordingly.

SPECIFICATIONS: COMPOSER MIXIN

This merge introduces a new mixin ``mail.composer.mixin`` used when sending
emails or notifications based on a mail template.

Main current purpose is to hide details related to subject and body computation
and rendering based on a mail.template. It also give the base tools to control
who is allowed to edit body, notably when dealing with templating language
like jinja or qweb.

It is meant to evolve in a near future with upcoming support of qweb and fine
grain control of rendering access.

Use it in survey and slides invite wizards, as well as appraisal and appraisal
survey (in enterprise). Use it in mail composer in a minimal way.

SPECIFICATIONS: QWeb

Temporarily and experimentally support Qweb rendering even if not used
functionally, to prepare QWeb templates.

LINKS

COM PR odoo/odoo#70889
ENT PR odoo/enterprise#18352
UPG PR odoo/upgrade#2490