### PR TITLE
[REM] delete UFO comment

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -1,4 +1,3 @@
-#odoo.loggers.handlers. -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import configparser as ConfigParser


### PR DESCRIPTION
Apparently, it was added by mistake 7 years ago in https://github.com/odoo/odoo/commit/e9d047e6119d8065a8d31a7d3b374630ab90c40d

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
