### PR TITLE
[FIX] ir.cron: restore INFO logging of job execution

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -323,9 +323,11 @@ class ir_cron(models.Model):
             log_depth = (None if _logger.isEnabledFor(logging.DEBUG) else 1)
             odoo.netsvc.log(_logger, logging.DEBUG, 'cron.object.execute', (self._cr.dbname, self._uid, '*', cron_name, server_action_id), depth=log_depth)
             start_time = False
+            _logger.info('Starting job `%s`.', cron_name)
             if _logger.isEnabledFor(logging.DEBUG):
                 start_time = time.time()
             self.env['ir.actions.server'].browse(server_action_id).run()
+            _logger.info('Job `%s` done.', cron_name)
             if start_time and _logger.isEnabledFor(logging.DEBUG):
                 end_time = time.time()
                 _logger.debug('%.3fs (cron %s, server action %d with uid %d)', end_time - start_time, cron_name, server_action_id, self.env.uid)


### PR DESCRIPTION
The "Starting job X" and "Job X done" logs are very useful to monitor cron executions over time, or to detect a cron job that has been running for a long time.

Those logs were dropped by mistake in #62124 - this patch restores them.