### PR TITLE
[FIX] point_of_sale: rounding down near 0


### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3327,7 +3327,7 @@ exports.Order = Backbone.Model.extend({
             if (!only_cash || (only_cash && last_line_is_cash)) {
                 var remaining = this.get_total_with_tax() - this.get_total_paid();
                 var total = round_pr(remaining, this.pos.cash_rounding[0].rounding);
-                var sign = total > 0 ? 1.0 : -1.0;
+                var sign = remaining > 0 ? 1.0 : -1.0;
 
                 var rounding_applied = total - remaining;
                 rounding_applied *= sign;


### PR DESCRIPTION
Before 0302552 rounding applied was eg. for these numbers and UP and
DOWN rounding methods to multiple of 10:

```
Numbers | -8 | -2 |  2 |  8 | 12
DOWN    | -2 | -8 | -2 | -8 | -2
UP      |  8 |  2 |  8 |  2 |  8
```

which is correct for positive numbers but UP and DOWN are inversed for
negatives numbers.

After 0302552 this became:

```
Numbers | -8 | -2 |  2 |  8 | 12
DOWN    |  8 |  2 |  8 | -8 | -2
UP      | -2 | -8 | -2 |  2 |  8
```

which is correct for all cases except for positive numbers that are
before HALF of the precision (eg. number 2) for which UP and DOWN are
inversed.

This is happening because 0302552 uses the sign of the rounded value
=> this does not work for 0 so number 2 is broken (and if fixed number
-2 would be broken).

With this commit, the adjustement of sign is done based on original
number, so we get the equivalent of python equivalent methods:

```
Numbers | -8 | -2 |  2 |  8 | 12
DOWN    |  8 |  2 | -2 | -8 | -2
UP      | -2 | -8 |  8 |  2 |  8
```

opw-2451841