### PR TITLE
[FIX] account: fix reconcile rule percentage calculation

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -885,7 +885,7 @@ class AccountReconcileModel(models.Model):
         if line_currency.is_zero(line_residual_after_reconciliation):
             return True
 
-        reconciled_percentage = (abs(line_residual) - abs(line_residual_after_reconciliation)) / abs(line_residual) * 100
+        reconciled_percentage = abs(line_residual) / (abs(line_residual) + abs(line_residual_after_reconciliation)) * 100
         return reconciled_percentage >= self.match_total_amount_param
 
     def _filter_candidates(self, candidates, aml_ids_to_exclude, reconciled_amls_ids):


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/52529/commits/078a3a0f760ff24d02070a343f28d2249a8b5ba7#diff-c217a13a40a3cc27dc516b899793abecfac8cab9a42fed407d4776bcbc9de9a8R812
the way the percentage is calculated is changed.
In the following scenario:
- a reconcile rule allow a reconciliation when 90% of the amount is matched
- an invoice of 200
- a bank statement of 180

Before cited commit : 180 / 200 * 100 = 90% -> reconciled
After cited commit: (180-20) / 180 * 100 = 88.89% -> not reconciled

This will go back to previous calculation.

Task: 2427089