### PR TITLE
[FIX] stock_account: return correct empty value for consumable

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -451,12 +451,13 @@ class StockMove(models.Model):
     def _account_entry_move(self, qty, description, svl_id, cost):
         """ Accounting Valuation Entries """
         self.ensure_one()
+        am_vals = []
         if self.product_id.type != 'product':
             # no stock valuation for consumable products
-            return False
+            return am_vals
         if self.restrict_partner_id:
             # if the move isn't owned by the company, we don't make any valuation
-            return False
+            return am_vals
 
         company_from = self._is_out() and self.mapped('move_line_ids.location_id.company_id') or False
         company_to = self._is_in() and self.mapped('move_line_ids.location_dest_id.company_id') or False
@@ -464,7 +465,6 @@ class StockMove(models.Model):
         journal_id, acc_src, acc_dest, acc_valuation = self._get_accounting_data_for_valuation()
         # Create Journal Entry for products arriving in the company; in case of routes making the link between several
         # warehouse of the same company, the transit location belongs to this company, so we don't need to create accounting entries
-        am_vals = []
         if self._is_in():
             if self._is_returned(valued_type='in'):
                 am_vals.append(self.with_company(company_to)._prepare_account_move_vals(acc_dest, acc_valuation, journal_id, qty, description, svl_id, cost))

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -171,6 +171,26 @@ class TestStockValuation(TransactionCase):
         self.assertEqual(price_change_aml.ref, 'prda')
         self.assertEqual(price_change_aml.product_id, self.product1)
 
+    def test_realtime_consumable(self):
+        """ An automatic consumable product should not create any account move entries"""
+        # Enter 10 products while price is 5.0
+        self.product1.standard_price = 5.0
+        self.product1.type = 'consu'
+        move1 = self.env['stock.move'].create({
+            'name': 'IN 10 units @ 10.00 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 10.0,
+        })
+        move1._action_confirm()
+        move1._action_assign()
+        move1.move_line_ids.qty_done = 10.0
+        move1._action_done()
+        self.assertTrue(move1.stock_valuation_layer_ids)
+        self.assertFalse(move1.stock_valuation_layer_ids.account_move_id)
+
     def test_fifo_perpetual_1(self):
         self.product1.categ_id.property_cost_method = 'fifo'
 


### PR DESCRIPTION
Creating an account move from a valuation layer is bypassed in
case the product is consumable. Since 7fa9ec263876, the signature
of _account_entry_move() changed. It no longer return an account move
but a list of values to create everything in batch.
Testing the product type should now return `[]` instead of `False` in
order to be added to the existing list.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
