### PR TITLE
[FIX] fleet: new contract no vehicle no error


### DIFF
--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -59,7 +59,7 @@ class FleetVehicleLogContract(models.Model):
     def _compute_contract_name(self):
         for record in self:
             name = record.vehicle_id.name
-            if record.cost_subtype_id.name:
+            if name and record.cost_subtype_id.name:
                 name = record.cost_subtype_id.name + ' ' + name
             record.name = name
 


### PR DESCRIPTION

If you set the type (cost_subtype_id) of a new contract
(fleet.vehicle.log.contract) before setting vehicle_id you got an error:

 name = record.cost_subtype_id.name + ' ' + name

 TypeError: can only concatenate str (not "bool") to str

 because vehicle name was False.

 opw-2527268
