### PR TITLE
14.0 gantt perf boi

### DIFF
--- a/addons/web/static/src/js/core/time.js
+++ b/addons/web/static/src/js/core/time.js
@@ -300,7 +300,34 @@ function getLangDatetimeFormat() {
     return strftime_to_moment_format(_t.database.parameters.date_format + " " + _t.database.parameters.time_format);
 }
 
+const dateFormatWoZeroCache = {};
+/**
+ * Get date format of the user's language - allows non padded
+ */
+function getLangDateFormatWoZero() {
+    const dateFormat = getLangDateFormat();
+    if (!dateFormat in dateFormatWoZeroCache) {
+        dateFormatWoZeroCache[dateFormat] = dateFormat
+            .replace('MM', 'M')
+            .replace('DD', 'D');
+    }
+    return dateFormatWoZeroCache[dateFormat];
+}
 
+const timeFormatWoZeroCache = {};
+/**
+ * Get time format of the user's language - allows non padded
+ */
+function getLangTimeFormatWoZero() {
+    const timeFormat = getLangTimeFormat();
+    if (!timeFormat in timeFormatWoZeroCache) {
+        timeFormatWoZeroCache[timeFormat] = timeFormat
+            .replace('HH', 'H')
+            .replace('mm', 'm')
+            .replace('ss', 's');
+    }
+    return timeFormatWoZeroCache[timeFormat];
+}
 
 return {
     date_to_utc: date_to_utc,
@@ -316,6 +343,8 @@ return {
     moment_to_strftime_format: moment_to_strftime_format,
     getLangDateFormat: getLangDateFormat,
     getLangTimeFormat: getLangTimeFormat,
+    getLangDateFormatWoZero: getLangDateFormatWoZero,
+    getLangTimeFormatWoZero: getLangTimeFormatWoZero,
     getLangDatetimeFormat: getLangDatetimeFormat,
 };
 

--- a/addons/web/static/src/js/core/utils.js
+++ b/addons/web/static/src/js/core/utils.js
@@ -268,6 +268,25 @@ var utils = {
         return Math.max(min, Math.min(max, val));
     },
     /**
+     * Looks through the list and returns the first value that matches all
+     * of the key-value pairs listed in properties.
+     * If no match is found, or if list is empty, undefined will be returned.
+     *
+     * @param {Array} list
+     * @param {Object} props
+     * @returns {any|undefined} first element in list that matches all props
+     */
+    findWhere: function (list, props) {
+        if (!Array.isArray(list) || !props) {
+            return;
+        }
+        return list.filter((item) => item !== undefined).find((item) => {
+            return Object.keys(props).every((key) => {
+                return item[key] === props[key];
+            })
+        });
+    },
+    /**
      * @param {number} value
      * @param {integer} decimals
      * @returns {boolean}

--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -511,10 +511,10 @@ function parseDateTime(value, field, options) {
     if (!value) {
         return false;
     }
-    var datePattern = time.getLangDateFormat(),
-        timePattern = time.getLangTimeFormat();
-    var datePatternWoZero = datePattern.replace('MM','M').replace('DD','D'),
-        timePatternWoZero = timePattern.replace('HH','H').replace('mm','m').replace('ss','s');
+    const datePattern = time.getLangDateFormat();
+    const timePattern = time.getLangTimeFormat();
+    const datePatternWoZero = time.getLangDateFormatWoZero();
+    const timePatternWoZero = time.getLangTimeFormatWoZero();
     var pattern1 = datePattern + ' ' + timePattern;
     var pattern2 = datePatternWoZero + ' ' + timePatternWoZero;
     var datetime;

--- a/addons/web/static/tests/core/util_tests.js
+++ b/addons/web/static/tests/core/util_tests.js
@@ -7,6 +7,29 @@ QUnit.module('core', {}, function () {
 
     QUnit.module('utils');
 
+    QUnit.test('findWhere', function (assert) {
+        assert.expect(7);
+
+        const { findWhere } = utils;
+
+        const list = [
+            undefined,
+            { a: 1, b: 2 },
+            { a: 2, b: 2 },
+            { a: 1, b: 3 },
+            { a: 1, b: 4 },
+            { a: 2, b: 4 },
+        ];
+
+        assert.deepEqual(findWhere(list, { a: 1 }), { a: 1, b: 2 });
+        assert.deepEqual(findWhere(list, { a: 2 }), { a: 2, b: 2 });
+        assert.deepEqual(findWhere(list, { b: 4 }), { a: 1, b: 4 });
+        assert.deepEqual(findWhere(list, { b: 4, a: 2 }), { a: 2, b: 4 });
+        assert.ok(findWhere([], { a: 1 }) === undefined);
+        assert.ok(findWhere(list, { a: 1, b: 5 }) === undefined);
+        assert.ok(findWhere(list, { c: 1 }) === undefined);
+    });
+
     QUnit.test('groupBy', function (assert) {
         assert.expect(7);
 


### PR DESCRIPTION
https://github.com/odoo/enterprise/pull/18366
https://github.com/odoo/documentation/pull/978
Taskid: 2412172

**Description of the issue/feature this PR addresses:**
With 500 employees, the gantt view tries to load more than 20.000 work entries. 

The browser painfully dies while loading the DOM. (1-2 seconds to load the records, 1 minute to load the DOM)

We already did some optimisations with VSC, but this is cleary not enough, and as the amount of employees is increasing, it will become more and more difficult to display the work entries.

I see 2 more ways to optimise the loading of the view:
    1/ Add the possibility to disable the drag and drop (that add a lot of useless stuff on each box), which is not useful for the work entries.
   2/ Add the possibility to display a pager (opt-in too) ==> _not retained as this feature is not a simple task, it should have its own task_

**Current behavior before PR:**

Tested on my local machine with 2000 employees - 60000 work entries.
The browser loads the DOM within 125 seconds (in debug=assets mode).

**Desired behavior after PR is merged:**
Tested on my local machine with 2000 employees - 60000 work entries.
The browser loads the DOM within 40 seconds (in debug=assets mode). Still slow, but 3x better.
An option has also been added to disable the drag&drop feature on a gantt view, which cut off by 5 sec when activated: 35sec in total.
Improvements could also be made on the python model side. `search_read` takes 15 to 20 seconds with this work entries count.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
