### PR TITLE
[FIX] crm: make help note translatable

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -106,6 +106,12 @@ msgid "<p><b>Send messages</b> to your prospect and get replies automatically at
 msgstr ""
 
 #. module: crm
+#: code:addons/crm/models/crm_team.py:152
+#, python-format
+msgid "<p>As you don't belong to any Sales Team, Odoo opens the first one by default.</p>"
+msgstr ""
+
+#. module: crm
 #. openerp-web
 #: code:addons/crm/static/src/js/tour.js:52
 #, python-format

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -149,7 +149,7 @@ class Team(models.Model):
     as a member of one of the Sales Team.
 </p>""")
             if user_team_id:
-                action['help'] += "<p>As you don't belong to any Sales Team, Odoo opens the first one by default.</p>"
+                action['help'] += _("<p>As you don't belong to any Sales Team, Odoo opens the first one by default.</p>")
 
         action_context = safe_eval(action['context'], {'uid': self.env.uid})
         if user_team_id:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:


Current behavior before PR:
Now there is no possibility to translate part of the helping note in the CRM module

Desired behavior after PR is merged:
Helping note is fully translatable



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
