### PR TITLE
[ADD] project_mail_plugin: add support for project's tasks in mail pl…

### DIFF
--- a/addons/project_mail_plugin/__init__.py
+++ b/addons/project_mail_plugin/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers

--- a/addons/project_mail_plugin/__manifest__.py
+++ b/addons/project_mail_plugin/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Project Mail Plugin',
+    'version': '1.0',
+    'category': 'Services/Project',
+    'sequence': 5,
+    'summary': 'Integrate your inbox with projects',
+    'description': "Turn emails received in your mailbox into tasks and log their content as internal notes.",
+    'data': [
+        'views/project_task_views.xml'
+    ],
+    'website': 'https://www.odoo.com/app/project',
+    'web.assets_backend': [
+        'project_mail_plugin/static/src/to_translate/**/*',
+    ],
+    'depends': [
+        'project',
+        'mail_plugin',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': True
+}

--- a/addons/project_mail_plugin/controllers/__init__.py
+++ b/addons/project_mail_plugin/controllers/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import mail_plugin
+from . import project_client

--- a/addons/project_mail_plugin/controllers/mail_plugin.py
+++ b/addons/project_mail_plugin/controllers/mail_plugin.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo.http import request
+
+from odoo.addons.mail_plugin.controllers import mail_plugin
+
+_logger = logging.getLogger(__name__)
+
+
+class MailPluginController(mail_plugin.MailPluginController):
+
+    def _get_contact_data(self, partner):
+        """
+        Overrides the base module's get_contact_data method by Adding the "tasks" key within the initial contact
+        information dict loaded when opening an email on Outlook.
+        This is structured this way to enable the "project" feature on the Outlook side only if the Odoo version
+        supports it.
+        """
+        contact_values = super(MailPluginController, self)._get_contact_data(partner)
+        if not partner:
+            contact_values['tasks'] = []
+        else:
+            partner_tasks = request.env['project.task'].search(
+                [('partner_id', '=', partner.id)], offset=0, limit=5)
+
+            accessible_projects = partner_tasks.project_id._filter_access_rules('read').mapped("id")
+
+            tasks_values = [
+                {
+                    'task_id': task.id,
+                    'name': task.name,
+                } for task in partner_tasks if task.project_id.id in accessible_projects]
+
+            contact_values['tasks'] = tasks_values
+
+        return contact_values
+
+    def _mail_content_logging_models_whitelist(self):
+        return super(MailPluginController, self)._mail_content_logging_models_whitelist() + ['project.task']
+
+    def _translation_modules_whitelist(self):
+        return super(MailPluginController, self)._translation_modules_whitelist() + ['project_mail_plugin']

--- a/addons/project_mail_plugin/controllers/project_client.py
+++ b/addons/project_mail_plugin/controllers/project_client.py
@@ -1,0 +1,47 @@
+
+from odoo import http
+from odoo.http import request
+
+
+class ProjectClient(http.Controller):
+    @http.route('/mail_plugin/project/search', type='json', auth='outlook', cors="*")
+    def projects_search(self, search_term, limit=5):
+        """
+        Used in the plugin side when searching for projects.
+        Fetches projects that have names containing the search_term.
+        """
+        projects = request.env['project.project'].search([('name', 'ilike', search_term)], limit=limit)
+
+        return [
+            {
+                'project_id': project.id,
+                'name': project.name,
+                'company_id': project.company_id.id
+            }
+            for project in projects
+        ]
+
+    @http.route('/mail_plugin/task/create', type='json', auth='outlook', cors="*")
+    def task_create(self, email_subject, email_body, project_id, partner_id):
+
+        partner = request.env['res.partner'].browse(partner_id).exists()
+        if not partner:
+            return {'error': 'partner_not_found'}
+
+        if not request.env['project.project'].browse(project_id).exists():
+            return {'error': 'project_not_found'}
+
+        record = request.env['project.task'].create({
+            'name': email_subject,
+            'partner_id': partner_id,
+            'description': email_body,
+            'project_id': project_id,
+            'user_id': request.env.uid,
+        })
+
+        return {'task_id': record.id}
+
+    @http.route('/mail_plugin/project/create', type='json', auth='outlook', cors="*")
+    def project_create(self, name):
+        record = request.env['project.project'].create({'name': name})
+        return {"project_id": record.id, "name": record.name}

--- a/addons/project_mail_plugin/static/src/to_translate/translations_outlook.xml
+++ b/addons/project_mail_plugin/static/src/to_translate/translations_outlook.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Terms to translate for the outlook plugin -->
+<ressources>
+    <string>Task</string>
+    <string>Save Contact to create new Tasks.</string>
+    <string>No tasks found for this contact.</string>
+    <string>Tasks (%(count)s)</string>
+    <string>Pick a Project to create a Task</string>
+    <string>Create %(name)s</string>
+    <string>Search Projects...</string>
+    <string>Log Email Into Task</string>
+</ressources>

--- a/addons/project_mail_plugin/views/project_task_views.xml
+++ b/addons/project_mail_plugin/views/project_task_views.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- action used by the mail plugins in order to redirect the user to the newly created task in edit mode-->
+    <record id="project_task_action_form_edit" model="ir.actions.act_window">
+      <field name="name">Task: redirect to form in edit mode</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="res_model">project.task</field>
+      <field name="view_mode">form</field>
+      <field name="view_id" ref="project.view_task_form2"/>
+      <field name="context">{'form_view_initial_mode': 'edit'}</field>
+    </record>
+</odoo>


### PR DESCRIPTION
…ugin

Add support for tasks for the mail plugins via the new project_mail_plugin
module.

The new module provides the following new features:

Enables the user to see tasks related to the selected contact, tasks where the
contact is the customer

Enables the user to log an email directly to a task as this can be useful when
the user finds important information in the email

Enable the user to create a task with the email message being directly set
in the description field, as the user would probable want the email
message to be included in the created task, this is done through the
"create_task" method, which the plugins will use in order to
create the task and send the related information, the plugin would then
directly redirect the user to the task form view realted to the created
record in edit mode.

Purpose is to allow users to connect their tasks to their mailbox.

Which allows for example to create a task from an email received,centralize data
regarding a customer on its task, check ongoing tasks for a customer, ...etc

Task-2518640
UPG-PR: odoo/upgrade#2488

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
