### PR TITLE
[FIX] mail: & &amp; not transformed in & &


### DIFF
--- a/addons/mail/static/src/js/models/threads/thread.js
+++ b/addons/mail/static/src/js/models/threads/thread.js
@@ -295,7 +295,7 @@ var Thread = AbstractThread.extend(ServicesMixin, {
     _generateEmojis: function (htmlString) {
         _.each(emojis, function (emoji) {
             _.each(emoji.sources, function (source) {
-                var escapedSource = String(source).replace(/([.*+?=^!:${}()|[\]/\\])/g, '\\$1');
+                var escapedSource = _.escape(String(source)).replace(/([.*+?=^!:${}()|[\]/\\])/g, '\\$1');
                 var regexp = new RegExp("(\\s|^)(" + escapedSource + ")(?=\\s|$)", 'g');
                 htmlString = htmlString.replace(regexp, '$1' + emoji.unicode);
             });

--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -37,10 +37,17 @@ function linkify(text, attrs) {
     attrs = _.map(attrs, function (value, key) {
         return key + '="' + _.escape(value) + '"';
     }).join(' ');
-    return text.replace(urlRegexp, function (url) {
+    var curIndex = 0;
+    var result = "";
+    var match;
+    while ((match = urlRegexp.exec(text)) !== null) {
+        result += _.escape(text.slice(curIndex, match.index));
+        var url = _.escape(match[0]);
         var href = (!/^https?:\/\//i.test(url)) ? "http://" + url : url;
-        return '<a ' + attrs + ' href="' + href + '">' + url + '</a>';
-    });
+        result += '<a ' + attrs + ' href="' + href + '">' + url + '</a>';
+        curIndex = match.index + match[0].length;
+    }
+    return result + _.escape(text.slice(curIndex));
 }
 
 function addLink(node, transformChildren) {
@@ -59,7 +66,7 @@ function stripHTML(node, transformChildren) {
 }
 
 function inline(node, transform_children) {
-    if (node.nodeType === 3) return node.data;
+    if (node.nodeType === 3) return _.escape(node.data);
     if (node.nodeType === 8) return "";
     if (node.tagName === "BR") return " ";
     if (node.tagName.match(/^(A|P|DIV|PRE|BLOCKQUOTE)$/)) return transform_children();

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -35,5 +35,110 @@ QUnit.test('add_link utility function', function (assert) {
     });
 });
 
+QUnit.test('addLink: linkify inside text node (0 occurrence)', function (assert) {
+    assert.expect(1);
+
+    var content = '&amp; &amp;amp; &gt; &lt;';
+    var linkified = utils.parseAndTransform(content, utils.addLink);
+    assert.strictEqual(
+        linkified,
+        content,
+        "linkifying text should not break html entities"
+    );
+});
+
+QUnit.test('addLink: linkify inside text node (1 occurrence)', function (assert) {
+    assert.expect(6);
+
+    var content = '<p>some text https://somelink.com</p>';
+    var linkified = utils.parseAndTransform(content, utils.addLink);
+    assert.ok(
+        linkified.startsWith('<p>some text <a'),
+        "linkified text should start with non-linkified start part, followed by an '<a>' tag"
+    );
+    assert.ok(
+        linkified.endsWith('</a></p>'),
+        "linkified text should end with closing '<a>' tag"
+    );
+
+    // linkify may add some attributes. Since we do not care of their exact
+    // stringified representation, we continue deeper assertion with query
+    // selectors.
+    var fragment = document.createDocumentFragment();
+    var div = document.createElement('div');
+    fragment.appendChild(div);
+    div.innerHTML = linkified;
+    assert.strictEqual(
+        div.textContent,
+        'some text https://somelink.com',
+        "linkified text should have same text content as non-linkified version"
+    );
+    assert.strictEqual(
+        div.querySelectorAll(':scope a').length,
+        1,
+        "linkified text should have an <a> tag"
+    );
+    assert.strictEqual(
+        div.querySelector(':scope a').textContent,
+        'https://somelink.com',
+        "text content of link should be equivalent of its non-linkified version"
+    );
+
+    content = '&quot;www.example.com/?q=a&amp;lang=b&quot;';
+    linkified = utils.parseAndTransform(content, utils.addLink);
+    assert.strictEqual(
+        linkified,
+        "&quot;<a target=\"_blank\" href=\"http://www.example.com/?q=a&amp;lang=b\">" +
+        "www.example.com/?q=a&amp;lang=b</a>&quot;",
+        "linkifying text should not break html entities"
+    );
+});
+
+QUnit.test('addLink: linkify inside text node (2 occurrences)', function (assert) {
+    assert.expect(4);
+
+    // linkify may add some attributes. Since we do not care of their exact
+    // stringified representation, we continue deeper assertion with query
+    // selectors.
+    var content = '<p>some text https://somelink.com and again https://somelink2.com ...</p>';
+    var linkified = utils.parseAndTransform(content, utils.addLink);
+    var fragment = document.createDocumentFragment();
+    var div = document.createElement('div');
+    fragment.appendChild(div);
+    div.innerHTML = linkified;
+    assert.strictEqual(
+        div.textContent,
+        'some text https://somelink.com and again https://somelink2.com ...',
+        "linkified text should have same text content as non-linkified version"
+    );
+    assert.strictEqual(
+        div.querySelectorAll(':scope a').length,
+        2,
+        "linkified text should have 2 <a> tags"
+    );
+    assert.strictEqual(
+        div.querySelectorAll(':scope a')[0].textContent,
+        'https://somelink.com',
+        "text content of 1st link should be equivalent to its non-linkified version"
+    );
+    assert.strictEqual(
+        div.querySelectorAll(':scope a')[1].textContent,
+        'https://somelink2.com',
+        "text content of 2nd link should be equivalent to its non-linkified version"
+    );
+});
+
+QUnit.test('inline: inline utility function', function (assert) {
+    assert.expect(1);
+
+    var content = '&amp; &amp;amp; &gt; &lt;';
+    var linkified = utils.parseAndTransform(content, utils.inline);
+    assert.strictEqual(
+        linkified,
+        content,
+        "inlining text should not break html entities"
+    );
+});
+
 });
 });


### PR DESCRIPTION
The current linkifying (and inline as well) function transforms HTML
entities (added when the text was escaped) to their original form.

For `&lt;` this is prevented by replacing it with `"OPEN" + Date.now()`
before linkficiation and then replacing `"OPEN" + Date.now()` by `&lt;`
after.

But if you had as source `& &amp;` (escaped to `&amp; &amp;amp;`) this
would become `& &` (escaped to `& &amp;`) when the message is posted.

With the fix, the two added test fails with error:

    [method] should not break html entities
    Expected: `"&amp; &amp;amp; &gt; &lt;"`
    Result: `"& &amp; > &lt;"`

issue found when working on unrelated opw-2528583