### PR TITLE
[FIX] mail: & &amp; not transformed in & &


### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -15,16 +15,13 @@ var _t = core._t;
  * @returns {string}
  */
 function parseAndTransform(htmlString, transformFunction) {
-    var openToken = "OPEN" + Date.now();
-    var string = htmlString.replace(/&lt;/g, openToken);
     var children;
     try {
-        children = $('<div>').html(string).contents();
+        children = $('<div>').html(htmlString).contents();
     } catch (e) {
-        children = $('<div>').html('<pre>' + string + '</pre>').contents();
+        children = $('<div>').html('<pre>' + htmlString + '</pre>').contents();
     }
-    return _parseAndTransform(children, transformFunction)
-                .replace(new RegExp(openToken, "g"), "&lt;");
+    return _parseAndTransform(children, transformFunction);
 }
 
 /**
@@ -71,8 +68,9 @@ function linkify(text, attrs) {
 
 function addLink(node, transformChildren) {
     if (node.nodeType === 3) {  // text node
-        const linkified = linkify(node.data);
-        if (linkified !== node.data) {
+        const data = owl.utils.escape(node.data);
+        const linkified = linkify(data);
+        if (linkified !== data) {
             const div = document.createElement('div');
             div.innerHTML = linkified;
             for (const childNode of [...div.childNodes]) {
@@ -81,7 +79,7 @@ function addLink(node, transformChildren) {
             node.parentNode.removeChild(node);
             return linkified;
         }
-        return node.textContent;
+        return data;
     }
     if (node.tagName === "A") return node.outerHTML;
     transformChildren();
@@ -110,13 +108,13 @@ function htmlToTextContentInline(htmlString) {
 }
 
 function stripHTML(node, transformChildren) {
-    if (node.nodeType === 3) return node.data;  // text node
+    if (node.nodeType === 3) return owl.utils.escape(node.data);  // text node
     if (node.tagName === "BR") return "\n";
     return transformChildren();
 }
 
 function inline(node, transform_children) {
-    if (node.nodeType === 3) return node.data;
+    if (node.nodeType === 3) return owl.utils.escape(node.data);
     if (node.nodeType === 8) return "";
     if (node.tagName === "BR") return " ";
     if (node.tagName.match(/^(A|P|DIV|PRE|BLOCKQUOTE)$/)) return transform_children();

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -35,6 +35,18 @@ QUnit.test('add_link utility function', function (assert) {
     });
 });
 
+QUnit.test('addLink: linkify inside text node (0 occurrence)', function (assert) {
+    assert.expect(1);
+
+    const content = '&amp; &amp;amp; &gt; &lt;';
+    const linkified = utils.parseAndTransform(content, utils.addLink);
+    assert.strictEqual(
+        linkified,
+        content,
+        "linkifying text should not break html entities"
+    );
+});
+
 QUnit.test('addLink: linkify inside text node (1 occurrence)', function (assert) {
     assert.expect(5);
 
@@ -104,6 +116,30 @@ QUnit.test('addLink: linkify inside text node (2 occurrences)', function (assert
         div.querySelectorAll(':scope a')[1].textContent,
         'https://somelink2.com',
         "text content of 2nd link should be equivalent to its non-linkified version"
+    );
+});
+
+QUnit.test('inline: inline utility function', function (assert) {
+    assert.expect(1);
+
+    const content = '&amp; &amp;amp; &gt; &lt;';
+    const linkified = utils.parseAndTransform(content, utils.inline);
+    assert.strictEqual(
+        linkified,
+        content,
+        "inlining text should not break html entities"
+    );
+});
+
+QUnit.test('stripHTML: stripHTML utility function', function (assert) {
+    assert.expect(1);
+
+    const content = '&amp; &amp;amp; &gt; &lt;';
+    const linkified = utils.parseAndTransform(content, utils.stripHTML);
+    assert.strictEqual(
+        linkified,
+        content,
+        "stripHTML should not break html entities"
     );
 });
 


### PR DESCRIPTION

The current linkifying (and inline/stripHTML as well) function
transforms HTML entities (added when the text was escaped) to their
original form.

For `&lt;` this is prevented by replacing it with `"OPEN" + Date.now()`
before linkification and then replacing `"OPEN" + Date.now()` by `&lt;`
after.

But if you had as source `& &amp;` (escaped to `&amp; &amp;amp;`) this
would become `& &` (escaped to `& &amp;`) when the message is posted.

With the fix, all added test fails with error:

    [method] should not break html entities
    Expected: `"&amp; &amp;amp; &gt; &lt;"`
    Result: `"& &amp; > &lt;"`

issue found when working on unrelated opw-2528583
