### PR TITLE
[14.0][FIX] Add missing chart_template_id to tax template form

### DIFF
--- a/addons/account/views/account_chart_template_views.xml
+++ b/addons/account/views/account_chart_template_views.xml
@@ -135,6 +135,7 @@
                         <group name="main_group">
                             <group>
                                 <field name="name"/>
+                                <field name="chart_template_id" options="{'no_create': True}"/>
                             </group>
                             <group>
                                 <field name="type_tax_use"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Chart template field is missing from tax template form.

Current behavior before PR:
Cannot set or alter the chart template of a tax template.

Desired behavior after PR is merged:
Can set or alter the chart template of a tax template.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
