### PR TITLE
[FIX] mrp: use cache in method explode

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -114,8 +114,9 @@ class ProductProduct(models.Model):
         res = super(ProductProduct, self - kits)._compute_quantities_dict(lot_id, owner_id, package_id, from_date=from_date, to_date=to_date)
         qties = self.env.context.get("mrp_compute_quantities", {})
         qties.update(res)
+        cache = {}
         for product in bom_kits:
-            boms, bom_sub_lines = bom_kits[product].explode(product, 1)
+            boms, bom_sub_lines = bom_kits[product].with_context(mrp_explode_cache=cache).explode(product, 1)
             ratios_virtual_available = []
             ratios_qty_available = []
             ratios_incoming_qty = []


### PR DESCRIPTION
this speeds up reading qty_available field in product templates with hundreds
variants.

Test for a product with 712 variants:

BEFORE: 1563 3.700 2.184
AFTER: 523 1.153 1.582

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
