### PR TITLE
[FIX] account: fix the order of accounts invoice

### DIFF
--- a/addons/account/wizard/account_invoice_state.py
+++ b/addons/account/wizard/account_invoice_state.py
@@ -16,7 +16,8 @@ class AccountInvoiceConfirm(models.TransientModel):
         context = dict(self._context or {})
         active_ids = context.get('active_ids', []) or []
 
-        for record in self.env['account.invoice'].browse(active_ids):
+        invoice_list = self.env['account.invoice'].browse(active_ids).sorted(lambda i: (i.date_invoice, i.reference or '', i.id))
+        for record in invoice_list:
             if record.state != 'draft':
                 raise UserError(_("Selected invoice(s) cannot be confirmed as they are not in 'Draft' state."))
             record.action_invoice_open()


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Accounting > Create multiple vendor bills with different dates
- In the view list > select the vendor bills created > Action > Post entries

Problem:
The invoice with the most recent date will have the smallest ID in the name (e.g: 2021/05/0001)

opw-2502211





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
