### PR TITLE
[FIX] website_form: make Send button editable

### DIFF
--- a/addons/website_form/static/src/js/website_form_editor.js
+++ b/addons/website_form/static/src/js/website_form_editor.js
@@ -62,6 +62,7 @@ odoo.define('website_form_editor', function (require) {
         start: function () {
             this.$target.addClass('o_fake_not_editable').attr('contentEditable', false);
             this.$target.find('label:not(:has(span)), label span, .o_form_heading').addClass('o_fake_editable').attr('contentEditable', true);
+            this.$target.find('.o_website_form_send').attr('contentEditable', true);
             return this._super.apply(this, arguments);
         },
 


### PR DESCRIPTION
Steps:
- Go to Website
- Click "Go to Website"
- Create a new page
- Add a Form Builder block
- Try to edit the Send button

Bug:
The Send button is not editable

Explanation:
This commit adds the `contenteditable` attribute to the button when in
edit mode.

opw:2481364