### PR TITLE
[IMP] web: load qweb in parallel with js assets

### DIFF
--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -223,9 +223,13 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
     load_qweb: function (mods) {
         var self = this;
         var lock = this.qweb_mutex.exec(function () {
-            var cacheId = self.cache_hashes && self.cache_hashes.qweb;
-            var route  = '/web/webclient/qweb/' + (cacheId ? cacheId : Date.now());
-            return $.get(route, { bundle: 'web.assets_qweb' }).then(function (doc) {
+            let load = odoo.loadQwebPromise;
+            if (!load){
+                const cacheId = self.cache_hashes && self.cache_hashes.qweb;
+                const route  = '/web/webclient/qweb/' + (cacheId ? cacheId : Date.now());
+                load = $.get(route, { bundle: 'web.assets_qweb' });
+            }
+            return load.then(function (doc) {
                 if (!doc) { return; }
                 const owlTemplates = [];
                 for (let child of doc.querySelectorAll("templates > [owl]")) {

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -289,6 +289,8 @@
                     odoo.session_info = <t t-out="json.dumps(session_info)"/>;
                     odoo.reloadMenus = () => fetch(`/web/webclient/load_menus/${odoo.session_info.cache_hashes.load_menus}`).then(res => res.json());
                     odoo.loadMenusPromise = odoo.reloadMenus();
+                    const loadQweb = () => fetch(`/web/webclient/qweb/${odoo.session_info.cache_hashes.qweb}?bundle=web.assets_qweb`).then(res => res.text()).then(text => (new DOMParser()).parseFromString(text, 'text/xml'));
+                    odoo.loadQwebPromise = loadQweb();
                 </script>
                 <t t-call-assets="web.assets_common" t-js="false"/>
                 <t t-call-assets="web.assets_backend" t-js="false"/>


### PR DESCRIPTION
BEFORE: browser loads js assets first, then qweb, then makes other
initialization.

AFTER: load qweb in parallel with js assets. This saves ~500 ms in runbot

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
