### PR TITLE
[IMP] stock: show inventory date on form

### DIFF
--- a/addons/stock/views/stock_inventory_views.xml
+++ b/addons/stock/views/stock_inventory_views.xml
@@ -199,6 +199,7 @@
                         <field name="exhausted"/>
                     </group>
                     <group>
+                        <field name="date"/>
                         <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                         <field name="prefill_counted_quantity" widget="radio"
                                attrs="{'invisible': [('state', '!=', 'draft')]}"/>


### PR DESCRIPTION
Before this commit, Field `date` is only displayed on list view.

With this commit, we are displaying `date` on form view as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
