### PR TITLE
[FIX] requirements: with Python >= 3.8 passlib >= 1.7.2 is required on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ MarkupSafe==1.1.0
 mock==2.0.0
 num2words==0.5.6
 ofxparse==0.19
-passlib==1.7.1
+passlib==1.7.1 ; sys_platform != 'win32' or python_version < '3.8'
+passlib==1.7.2 ; sys_platform == 'win32' and python_version >= '3.8'
 Pillow==5.4.1 ; python_version < '3.7' or sys_platform != 'win32'
 Pillow==6.1.0 ; sys_platform == 'win32' and python_version >= '3.7'
 polib==1.1.0


### PR DESCRIPTION
From Python 3.8, the `time.clock()` function has been definitively removed, leading to the following `passlib` issue on Windows:
`ImportError: cannot import name 'clock' from 'time' (unknown location)`.

This point has been fixed in `passlib` `1.7.2`.

Due to #51784, this passlib version update, is only done from Odoo 13.0.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
