### PR TITLE
[FIX] stock_account: allow to restrict nb of stock moves to fifo vacuum

### DIFF
--- a/addons/stock_account/models/stock.py
+++ b/addons/stock_account/models/stock.py
@@ -419,12 +419,14 @@ class StockMove(models.Model):
         for move in res.filtered(lambda m: m.product_id.valuation == 'real_time' and (m._is_in() or m._is_out() or m._is_dropshipped() or m._is_dropshipped_returned())):
             move._account_entry_move()
 
+        max_moves_to_vacuum = int(self.env['ir.config_parameter'].sudo().get_param('stock_account.max_moves_to_vacuum'))
         products_to_vacuum = defaultdict(lambda: self.env['product.product'])
         for move in res.filtered(lambda m: m.product_id.valuation == 'real_time' and m._is_in() and (m.product_id.property_cost_method == 'fifo' or m.product_id.categ_id.property_cost_method == 'fifo')):
             products_to_vacuum[move.company_id.id] += move.product_id
         for company_id in products_to_vacuum:
             moves_to_vacuum = self.search(
-                [('product_id', 'in', products_to_vacuum[company_id].ids), ('remaining_qty', '<', 0)] + self._get_all_base_domain(company_id=company_id))
+                [('product_id', 'in', products_to_vacuum[company_id].ids), ('remaining_qty', '<', 0)] + self._get_all_base_domain(company_id=company_id),
+                limit=max_moves_to_vacuum)
             moves_to_vacuum._fifo_vacuum()
 
         return res


### PR DESCRIPTION
Linked to commit https://github.com/odoo/odoo/commit/8877e7a3e0e8c823e280cab54f04d65b8de0da00

For existing db with a lot of stock moves with a product (FIFO, Automated) and where
stock valuation has never been executed for this product, _fifo_vacuum method can have
to process thousands of stock moves, which can lead to serious performance issue when
validating a stock move containing this product.

This commit adds a config parameter that allows to only proccess a defined number
of stock moves with _fifo_vacuum when validating a stock move.
This will allows to slowly reduce the stack of stock moves to vacuum at each receipt
without having to experience a timeout.

opw-2523871

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
