### PR TITLE
[FIX] website: correctly activate tour for each website

### DIFF
--- a/addons/website/data/ir_asset.xml
+++ b/addons/website/data/ir_asset.xml
@@ -25,7 +25,8 @@
         </record>
 
         <record id="website.configurator_tour" model="ir.asset">
-            <field name="name">website.configurator_tour</field>
+            <field name="key">website.configurator_tour</field>
+            <field name="name">Website Configurator Tour</field>
             <field name="bundle">website.assets_editor</field>
             <field name="glob">website/static/src/js/tours/configurator_tour.js</field>
             <field name="active" eval="False"/>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -383,8 +383,8 @@ class Website(models.Model):
         website.configurator_done = True
 
         # Enable tour
-        tour_asset_id = self.env['ir.asset']._get_related_assets([('name', '=', 'website.configurator_tour')])
-        tour_asset_id.sudo().write({'active': True})
+        tour_asset_id = self.env.ref('website.configurator_tour')
+        tour_asset_id.copy({'key': tour_asset_id.key, 'website_id': website.id, 'active': True})
 
         # logo was generated as base64 url
         logo = kwargs.get('logo')

--- a/addons/website/static/src/js/tours/configurator_tour.js
+++ b/addons/website/static/src/js/tours/configurator_tour.js
@@ -1,4 +1,4 @@
-odoo.define("website.configurator.tour", function (require) {
+odoo.define("website.configurator_tour", function (require) {
 "use strict";
 
 const wTourUtils = require("website.tour_utils");

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -55,6 +55,7 @@ function changeColumnSize(position = "right") {
 function changeIcon(snippet, index = 0, position = "bottom") {
     return {
         trigger: `#wrapwrap .${snippet.id} i:eq(${index})`,
+        extra_trigger: "body.editor_enable",
         content: _t("<b>Double click on an icon</b> to change it with one of your choice."),
         position: position,
         run: "dblclick",
@@ -64,6 +65,7 @@ function changeIcon(snippet, index = 0, position = "bottom") {
 function changeImage(snippet, position = "bottom") {
     return {
         trigger: snippet.id ? `#wrapwrap .${snippet.id} img` : snippet,
+        extra_trigger: "body.editor_enable",
         content: _t("<b>Double click on an image</b> to change it with one of your choice."),
         position: position,
         run: "dblclick",
@@ -130,6 +132,7 @@ function clickOnEdit(position = "bottom") {
 function clickOnSnippet(snippet, position = "bottom") {
     return {
         trigger: snippet.id ? `#wrapwrap .${snippet.id}` : snippet,
+        extra_trigger: "body.editor_enable",
         content: _t("<b>Click on a snippet</b> to access its options menu."),
         position: position,
         run: "click",
@@ -158,6 +161,7 @@ function clickOnSave(position = "bottom") {
 function clickOnText(snippet, element, position = "bottom") {
     return {
         trigger: snippet.id ? `#wrapwrap .${snippet.id} ${element}` : snippet,
+        extra_trigger: "body.editor_enable",
         content: _t("<b>Click on a text</b> to start editing it."),
         position: position,
         run: "text",


### PR DESCRIPTION
- Creating a website through the configurator activated the configurator tour.
This tour was active for every websites even the ones not created using the
configurator. Theme tours were overridden by the configurator tour when they
should have been the active tour for website not created using the configurator.

Now the configurator tour is an asset specific to each website. This asset is
deactivated by default and activated for a website only if it is created using
the configurator.

- Some actions of the website tour were also visible when we were not in edit
mode. extra_trigger has been added on these actions to ensure they are visible
only in edit mode.

task-2518565

~Themes PR: odoo/design-themes#1~

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
