### PR TITLE
[IMP] sms: Fallback on partner if records don't inherit mail.thread

### DIFF
--- a/addons/calendar_sms/views/calendar_views.xml
+++ b/addons/calendar_sms/views/calendar_views.xml
@@ -34,7 +34,7 @@
                 <button name="action_send_sms" help="Send SMS to attendees" type="object" string="SMS" icon="fa-mobile"/>
             </xpath>
             <xpath expr="//field[@name='phone']" position="replace">
-                <field name="phone" widget="phone" options="{'enable_sms': false}"/>
+                <field name="phone" widget="phone"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before this commit, trying to use the sms composer on a record that is not inheriting
mail.thread and has a  phone field that is related to a partner would be considered invalid
and users would have to retype the number themselves.

After this commit, if the sms composer is used one a phone field from a record that does not
inherit mail.thread but has a partner_id, it  will use the related partner mail.thread abilities
to get the recipients info instead of just considering the number to be invalid.

LINKS:
TaskID: 2514622
PR: #xxxxx




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
