### PR TITLE
[FIX] sale_product_matrix: avoid traceback when using Order Grid Entry

### DIFF
--- a/addons/sale_product_matrix/models/product_template.py
+++ b/addons/sale_product_matrix/models/product_template.py
@@ -14,5 +14,8 @@ class ProductTemplate(models.Model):
 
     def get_single_product_variant(self):
         res = super(ProductTemplate, self).get_single_product_variant()
-        res['mode'] = self.product_add_mode
+        if self.has_configurable_attributes:
+            res['mode'] = self.product_add_mode
+        else:
+            res['mode'] = 'configurator'
         return res


### PR DESCRIPTION
- Enable 'product configurator' and 'variant grid entry'
- Go to product [DEMO]:
  - Add an optional product.
  - Go to the variants tab and add some variants
- Select 'order grid entry'
- Remove all the variants
- Create a SO adding [DEMO]

Traceback will occur

opw-2439764

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
