### PR TITLE
[IMP] l10n_ar: electronic invoicing of docs 60 and 61

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -81,6 +81,7 @@ class AccountJournal(models.Model):
         receipt_m_code = ['54']
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
+        liq_product_codes = ['60', '61']
         if self.type != 'sale':
             return []
         elif self.l10n_ar_afip_pos_system == 'II_IM':
@@ -88,7 +89,7 @@ class AccountJournal(models.Model):
             return usual_codes + receipt_codes + expo_codes + invoice_m_code + receipt_m_code
         elif self.l10n_ar_afip_pos_system in ['RAW_MAW', 'RLI_RLM']:
             # electronic/online invoice
-            return usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes
+            return usual_codes + receipt_codes + invoice_m_code + receipt_m_code + mipyme_codes + liq_product_codes
         elif self.l10n_ar_afip_pos_system in ['CPERCEL', 'CPEWS']:
             # invoice with detail
             return usual_codes + invoice_m_code


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Add mapping rules to enable the electronic invoicing of document types:
 * CUENTAS DE VENTA Y LIQUIDO PRODUCTO A (60)
 * CUENTAS DE VENTA Y LIQUIDO PRODUCTO B (61)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
