### PR TITLE
[FIX] stock: fix the manual reservation option

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -59,6 +59,10 @@ class ResConfigSettings(models.TransientModel):
             self.group_stock_multi_locations = True
 
     def set_values(self):
+        if self.module_procurement_jit == '0':
+            self.env['ir.config_parameter'].sudo().set_param('stock.picking_no_auto_reserve', True)
+        else:
+            self.env['ir.config_parameter'].sudo().set_param('stock.picking_no_auto_reserve', False)
         warehouse_grp = self.env.ref('stock.group_stock_multi_warehouses')
         location_grp = self.env.ref('stock.group_stock_multi_locations')
         base_user = self.env.ref('base.group_user')


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to inventory settings > select "Reservation: Manually or based on Automatic scheduler" option
- Create a storable product
- Create a planned delivery order for a created product
- Click on “Mark as to do” > the order status becomes "waiting"
- Process a receipt for the same product.

Problem:
The status of the delivery order is changed from "waiting” to "ready" and the product is automatically reserved

solution:
In this commit, we fix this by adding a parameter "stock.picking_no_auto_reserve" to ir.config_parameter when the manual reservation option is enabled

opw-2520742



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
