### PR TITLE
[FIX] mrp: fix recursion error when updating quants for kit variant

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -190,4 +190,5 @@ class ProductProduct(models.Model):
         res = super(ProductProduct, components).action_open_quants()
         if bom_kits:
             res['context']['single_product'] = False
+            res['context'].pop('default_product_tmpl_id', None)
         return res


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** Fixes a recursion error and data inconsistency resulting from the update of quantities for the components of a kit product from a kit variant.

**Steps to reproduce the error:**
With stock locations activated:
- Create and configure a storable product with two variants (kit).
- Create a storable product (component).
- Create the BoM for the kit and add the component in the BoM Lines.
- From the kit template, navigate to one of the kit variants and click on Update Quantity.
- Add new quantities for the component.
- Try to go back to the product and you will get the error.


**Current behavior before PR:** 
When updating the quantities available for a product, an inventory move is generated without setting the product_tmpl_id, as this field is related to the product_id of the move. However, when creating the move, Odoo will consider it a default missing value and will try to fill it in the method default_get.

The problem when dealing with kits is that the products available to update their quantities are the components of the kit. When navigating to a variant and updating the quantities of a component of the kit variant, the default product template in the context will be the kit template.

This is causing that, when generating the inventory move, the move is created with product_id of the component, and product_tmpl_id of the kit template. This issue creates a critical data inconsistency as the component's template is set to the kit's template, which apart from making no sense generates a recursion error.

**Desired behavior after PR is merged:** By preventing setting a default product template when the action to create/update quants is triggered for kit products, we prevent writing a wrong template.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
