### PR TITLE
[FIX] website_sale: make "Terms & Conditions" checkbox optional again

### DIFF
--- a/addons/test_website_slides_full/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/tests/tours/slides_certification_member.js
@@ -54,9 +54,6 @@ var buyCertificationSteps = [{
     trigger: 'input[name="customer_input"]',
     run: 'text 4242424242424242'
 }, {
-    content: "Accept the Terms & conditions",
-    trigger: '#checkbox_tc',
-}, {
     content: 'eCommerce: pay',
     trigger: 'button[name="o_payment_submit_button"]'
 }, {

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -82,10 +82,6 @@ tour.register('event_buy_tickets', {
             trigger: '#payment_method label:contains("Wire Transfer")',
         },
         {
-            content: "Accept the Terms & conditions",
-            trigger: '#checkbox_tc',
-        },
-        {
             content: "Pay",
             //Either there are multiple payment methods, and one is checked, either there is only one, and therefore there are no radio inputs
             // extra_trigger: '#payment_method input:checked,#payment_method:not(:has("input:radio:visible"))',

--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -70,10 +70,6 @@ tour.register('shop_buy_product', {
             trigger: '#payment_method label:contains("Wire Transfer")',
         },
         {
-            content: "Accept the Terms & conditions",
-            trigger: '#checkbox_tc',
-        },
-        {
             content: "Pay Now",
             //Either there are multiple payment methods, and one is checked, either there is only one, and therefore there are no radio inputs
             extra_trigger: '#payment_method label:contains("Wire Transfer") input:checked,#payment_method:not(:has("input:radio:visible"))',

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -133,10 +133,6 @@ odoo.define('website_sale_tour.tour', function (require) {
         trigger: '#payment_method label:contains("Wire Transfer")',
     },
     {
-        content: "Accept the Terms & conditions",
-        trigger: '#checkbox_tc',
-    },
-    {
         content: "Pay Now",
         // extra_trigger: '#payment_method label:contains("Wire Transfer") input:checked,#payment_method:not(:has("input:radio:visible"))',
         trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)',
@@ -285,10 +281,6 @@ odoo.define('website_sale_tour.tour', function (require) {
         trigger: '#payment_method label:contains("Wire Transfer")',
     },
     {
-        content: "Accept the Terms & conditions",
-        trigger: '#checkbox_tc',
-    },
-    {
         content: "Pay Now",
         extra_trigger: '#payment_method label:contains("Wire Transfer") input:checked,#payment_method:not(:has("input:radio:visible"))',
         trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)',
@@ -392,10 +384,6 @@ odoo.define('website_sale_tour.tour', function (require) {
     {
         content: "Select `Wire Transfer` payment method",
         trigger: '#payment_method label:contains("Wire Transfer")',
-    },
-    {
-        content: "Accept the Terms & conditions",
-        trigger: '#checkbox_tc',
     },
     {
         content: "Pay Now",

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1549,13 +1549,9 @@
         </t>
     </template>
 
-    <template id="payment_footer" name="Payment Footer">
-        <div class="custom-control custom-checkbox mt-2 o_accept_tc_button">
-            <input type="checkbox" id="checkbox_tc" class="custom-control-input"/>
-            <label for="checkbox_tc" class="custom-control-label">
-                I agree to the <a target="_BLANK" href="/terms">terms &amp; conditions</a>
-            </label>
-        </div>
+    <template id="payment_footer" name="Payment">
+        <div name="o_checkbox_container"
+             class="custom-control custom-checkbox mt-2 o_accept_tc_button"/>
         <div class="float-left mt-2">
             <a role="button" href="/shop/cart" class="btn btn-secondary">
                 <i class="fa fa-chevron-left"/> Return to Cart
@@ -1570,6 +1566,15 @@
                 <t t-esc="submit_button_label"/> <i class="fa fa-chevron-right"/>
             </button>
         </div>
+    </template>
+
+    <template id="payment_sale_note" inherit_id="payment_footer" name="Accept Terms &amp; Conditions" customize_show="True" active="False">
+        <xpath expr="//div[@name='o_checkbox_container']" position="inside">
+            <input type="checkbox" id="checkbox_tc" class="custom-control-input"/>
+            <label for="checkbox_tc" class="custom-control-label">
+                I agree to the <a target="_BLANK" href="/terms">terms &amp; conditions</a>
+            </label>
+        </xpath>
     </template>
 
     <template id="short_cart_summary" name="Short Cart right column">

--- a/addons/website_sale_delivery/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale_delivery/static/tests/tours/website_free_delivery.js
@@ -41,10 +41,6 @@ tour.register('check_free_delivery', {
             trigger: '#payment_method label:contains("Wire Transfer")',
         },
         {
-            content: "Accept the Terms & conditions",
-            trigger: '#checkbox_tc',
-        },
-        {
             content: "Click on Pay Now",
             trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)',
         },


### PR DESCRIPTION
The "Accept Terms & Conditions" toggle had been mistakenly removed from
the "Customize" tab by commit 573ed74.

task-2494916
