### PR TITLE
[FIX]mail:preview text in chatter

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -231,9 +231,7 @@ class MailRenderMixin(models.AbstractModel):
 
         if preview:
             html_preview = Markup("""
-                <div style="display:none;font-size:1px;height:0px;width:0px;opacity:0;">
                    {}
-                </div>
             """).format(preview)
             return tools.prepend_html_content(html, html_preview)
         return html


### PR DESCRIPTION
Currently, in email marketing -> create email ->
add preview text -> send. If you check the template
in the chatter, the content of the 'text' is
showing with the html tags.

after this commit the content of the 'text' is
properly visible without html tags.

TaskId: 2527288
