### PR TITLE
[IMP] account: allow filter and group by partners country on moves and lines

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -188,6 +188,7 @@ class AccountMove(models.Model):
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity', store=True, readonly=True,
         compute='_compute_commercial_partner_id')
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    partner_country_id = fields.Many2one(string="Partner's Country", related='partner_id.country_id', store=True)
     user_id = fields.Many2one(string='User', related='invoice_user_id',
         help='Technical field used to fit the generic behavior in mail templates.')
     is_move_sent = fields.Boolean(
@@ -3090,6 +3091,7 @@ class AccountMoveLine(models.Model):
         help="This field is used for payable and receivable journal entries. You can put the limit date for the payment of this line.")
     currency_id = fields.Many2one('res.currency', string='Currency', required=True)
     partner_id = fields.Many2one('res.partner', string='Partner', ondelete='restrict')
+    partner_country_id = fields.Many2one(string="Partner's Country", related='partner_id.country_id', store=True)
     product_uom_id = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]", ondelete="restrict")
     product_id = fields.Many2one('product.product', string='Product', ondelete='restrict')
     product_uom_category_id = fields.Many2one('uom.category', related='product_id.uom_id.category_id')


### PR DESCRIPTION

Add and Store the partner's country on both account.move and account.move.line to enable filtering and grouping by country.
This aim to help users manage their accounting and taxes when dealing with multiple countries

[Task 2469401](https://www.odoo.com/web#id=2469401&model=project.task)

Description of the issue/feature this PR addresses:

Current behavior before PR:
Unable to filter and group accounting entries by country

Desired behavior after PR is merged:
User is able to filter and group by partner country

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
