### PR TITLE
[FIX] base: confusion between werkzeug.urls and urls local

### DIFF
--- a/odoo/addons/base/module/module.py
+++ b/odoo/addons/base/module/module.py
@@ -13,6 +13,7 @@ import tempfile
 import zipfile
 
 import requests
+import werkzeug.urls
 
 from odoo.tools import pycompat
 
@@ -748,7 +749,7 @@ class Module(models.Model):
             _logger.warning(msg)
             raise UserError(msg)
 
-        apps_server = urls.url_parse(self.get_apps_server())
+        apps_server = werkzeug.urls.url_parse(self.get_apps_server())
 
         OPENERP = odoo.release.product_name.lower()
         tmp = tempfile.mkdtemp()
@@ -759,7 +760,7 @@ class Module(models.Model):
                 if not url:
                     continue    # nothing to download, local version is already the last one
 
-                up = urls.url_parse(url)
+                up = werkzeug.urls.url_parse(url)
                 if up.scheme != apps_server.scheme or up.netloc != apps_server.netloc:
                     raise AccessDenied()
 


### PR DESCRIPTION
As part of the Python 3 compatibility effort,
01e35141479b8dfc4a390518f89fc52e7cec5396 moved all uses of urllib(2)
to werkzeug & requests as the packages were renamed and reorganised
between P2 and P3.

For `module.py`, it looks like I confused the `urls` local variable
for an already imported `werkzeug.urls` and just tried calling
`url_parse` on that. Which doesn't work, because `urls` is a
dict.

Fixes #71076