### PR TITLE
[FIX] point_of_sale: random failure when reprint receipt

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -2973,6 +2973,10 @@ td {
     color: white;
 }
 
+.order-receipt-hidden {
+    display: none;
+}
+
 .order-receipt {
     color: white;
     font-size: medium;

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/ReprintReceiptButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/ReprintReceiptButton.js
@@ -6,7 +6,6 @@ odoo.define('point_of_sale.ReprintReceiptButton', function (require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const OrderManagementScreen = require('point_of_sale.OrderManagementScreen');
     const Registries = require('point_of_sale.Registries');
-    const OrderReceipt = require('point_of_sale.OrderReceipt');
     const contexts = require('point_of_sale.PosContext');
 
     class ReprintReceiptButton extends PosComponent {
@@ -20,10 +19,7 @@ odoo.define('point_of_sale.ReprintReceiptButton', function (require) {
             if (!order) return;
 
             if (this.env.pos.proxy.printer) {
-                const fixture = document.createElement('div');
-                const orderReceipt = new (Registries.Component.get(OrderReceipt))(this, { order });
-                await orderReceipt.mount(fixture);
-                const receiptHtml = orderReceipt.el.outerHTML;
+                const receiptHtml = this.props.hiddenOrderReceipt.el.outerHTML;
                 const printResult = await this.env.pos.proxy.printer.print_receipt(receiptHtml);
                 if (!printResult.successful) {
                     this.showTempScreen('ReprintReceiptScreen', { order: order });

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -1,7 +1,7 @@
 odoo.define('point_of_sale.OrderManagementScreen', function (require) {
     'use strict';
 
-    const { useContext } = owl.hooks;
+    const { useContext, useRef } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const ControlButtonsMixin = require('point_of_sale.ControlButtonsMixin');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
@@ -27,6 +27,7 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             OrderFetcher.setComponent(this);
             OrderFetcher.setConfigId(this.env.pos.config_id);
             this.orderManagementContext = useContext(contexts.orderManagement);
+            this.receiptRef = useRef('order-receipt');
         }
         mounted() {
             OrderFetcher.on('update', this, this.render);

--- a/addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderManagementScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderManagementScreen.xml
@@ -9,7 +9,7 @@
                     <div class="pads">
                         <div class="control-buttons">
                             <t t-foreach="controlButtons" t-as="cb" t-key="cb.name">
-                                <t t-component="cb.component" t-key="cb.name" />
+                                <t t-component="cb.component" t-key="cb.name" hiddenOrderReceipt="receiptRef"/>
                             </t>
                         </div>
                         <div class="subpads">
@@ -26,6 +26,9 @@
                 </div>
             </div>
             <MobileOrderManagementScreen t-else="" />
+            <div class="order-receipt-hidden">
+                <OrderReceipt t-if="orderManagementContext.selectedOrder" order="orderManagementContext.selectedOrder" t-ref="order-receipt" />
+            </div>
         </div>
     </t>
 


### PR DESCRIPTION
Because the `receiptHtml` was taken from a component which was mounted outside of the DOM, it was hardly ever destroyed for some unknown reasons and the `el.outerHTML` could not be taken to create the receipt.