### PR TITLE
[FIX] core, mass_mailing: preserve markup status in prepend_html_content

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -433,14 +433,11 @@ def append_content_to_html(html, content, plaintext=True, preserve=False, contai
 
 def prepend_html_content(html_body, html_content):
     """Prepend some HTML content at the beginning of an other HTML content."""
-    html_content = re.sub(r'(?i)(</?(?:html|body|head|!\s*DOCTYPE)[^>]*>)', '', html_content)
+    html_content = type(html_content)(re.sub(r'(?i)(</?(?:html|body|head|!\s*DOCTYPE)[^>]*>)', '', html_content))
     html_content = html_content.strip()
 
-    insert_index = next(re.finditer(r'<body[^>]*>', html_body), None)
-    if insert_index is None:
-        insert_index = next(re.finditer(r'<html[^>]*>', html_body), None)
-
-    insert_index = insert_index.end() if insert_index else 0
+    body_match = re.search(r'<body[^>]*>', html_body) or re.search(r'<html[^>]*>', html_body)
+    insert_index = body_match.end() if body_match else 0
 
     return html_body[:insert_index] + html_content + html_body[insert_index:]
 


### PR DESCRIPTION
In `prepend_html_content`, if body `html_body` and `html_content` are `Markup` objects, the processing of `html_content` through `re.sub` will strip away the `Markup` flag, leading to the later concatenation of the body and content first escaping the content (to safely convert it to a `Markup`) before performing the concatenation proper.

As a result, the `preview` of a `mailing.mailing` would be double-escaped, and the markup hiding it would instead be printed as part of the body.

Assume that the type of `html_content` is str-compatible, and immediately rewrap the value after processing it through `re.sub`. This should do nothing if `html_content` was an actual `str`, and will re-flag it as a `Markup` if it was one.

Also change the finding of the insertion point to use `re.search`, I don't understand why this uses `find_iter`, it just makes the code more complicated.
