### PR TITLE
[IMP] base: allow arranging report actions by giving sequence

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -125,6 +125,10 @@ class IrActions(models.Model):
         # sort actions by their sequence if sequence available
         if result.get('action'):
             result['action'] = sorted(result['action'], key=lambda vals: vals.get('sequence', 0))
+
+        # sort report actions by their sequence if sequence available
+        if result.get('report'):
+            result['report'] = sorted(result['report'], key=lambda vals: vals.get('sequence', 0))
         return result
 
     @api.model

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -94,6 +94,7 @@ class IrActionsReport(models.Model):
     binding_type = fields.Selection(default='report')
     model = fields.Char(required=True, string='Model Name')
     model_id = fields.Many2one('ir.model', string='Model', compute='_compute_model_id', search='_search_model_id')
+    sequence = fields.Integer('Sequence', default=10)
 
     report_type = fields.Selection([
         ('qweb-html', 'HTML'),

--- a/odoo/addons/test_action_bindings/tests/test_bindings.py
+++ b/odoo/addons/test_action_bindings/tests/test_bindings.py
@@ -28,7 +28,7 @@ class TestActionBindings(common.TransactionCase):
         )
         self.assertItemsEqual(
             bindings['report'],
-            action3.read(['name', 'binding_view_types']),
+            action3.read(['name', 'sequence', 'binding_view_types']),
             "Wrong action bindings",
         )
 
@@ -45,7 +45,7 @@ class TestActionBindings(common.TransactionCase):
         )
         self.assertItemsEqual(
             bindings['report'],
-            action3.read(['name', 'binding_view_types']),
+            action3.read(['name', 'sequence', 'binding_view_types']),
             "Wrong action bindings",
         )
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Allow arrangement of report actions in Print button by giving sequence to those actions.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
