### PR TITLE
[FIX] mass_mailing: subject and preview should not be user translatable

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -77,9 +77,9 @@ class MassMailing(models.Model):
             return False
 
     active = fields.Boolean(default=True, tracking=True)
-    subject = fields.Char('Subject', help='Subject of your Mailing', required=True, translate=True)
+    subject = fields.Char('Subject', help='Subject of your Mailing', required=True, translate=False)
     preview = fields.Char(
-        'Preview', translate=True,
+        'Preview', translate=False,
         help='Catchy preview sentence that encourages recipients to open this email.\n'
              'In most inboxes, this is displayed next to the subject.\n'
              'Keep it empty if you prefer the first characters of your email content to appear instead.')


### PR DESCRIPTION
Having those fields as translatable lead people to think those will be
translated into recipient's language. This is incorrect as translations
in Odoo are based on current user, not about any recipient who would
see the field value.

In this commit we therefore remove translation capabilities for
subject and preview. Indeed mailings currently offer no multi languages
support. Instead people should create separate mailings targetting
some specific recipients, based on lang or country for example.

Task ID-2535807
