### PR TITLE
[FIX] hr_holidays: correct pot content

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -91,7 +91,7 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_holidays.py:643
 #, python-format
 msgid "%s on Time Off : %.2f day(s)"
-msgstr "%s on Time Off : %.2f day(s)"
+msgstr ""
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave.py:643


### PR DESCRIPTION
A pot should never contain translation, it's the template

Fixes odoo/odoo#71082
