### PR TITLE
[FIX] event_sale: ticket price with pricelist and currency

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -100,11 +100,6 @@ class SaleOrderLine(models.Model):
 
     def _get_display_price(self, product):
         if self.event_ticket_id and self.event_id:
-            company = self.event_id.company_id or self.env.user.company_id
-            currency = company.currency_id or self.env.user.company_id.currency_id
-            return currency._convert(
-                self.event_ticket_id.price_reduce, self.order_id.currency_id,
-                self.order_id.company_id or self.env.user.company_id,
-                self.order_id.date_order or fields.Date.today())
+            return self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id).price_reduce
         else:
             return super()._get_display_price(product)

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -69,9 +69,7 @@ class EventSaleTest(common.TransactionCase):
 
     def test_01_ticket_price_with_pricelist_and_tax(self):
         self.env.user.partner_id.country_id = False
-        pricelists = self.env['product.pricelist'].search([])
-        pricelist = pricelists[0]
-        (pricelists - pricelist).write({'active': False})
+        pricelist = self.env['product.pricelist'].search([], limit=1)
 
         tax = self.env['account.tax'].create({
             'name': "Tax 10",
@@ -109,8 +107,9 @@ class EventSaleTest(common.TransactionCase):
 
         so = self.env['sale.order'].create({
             'partner_id': self.env.user.partner_id.id,
+            'pricelist_id': pricelist.id,
         })
-        sol = self.env['sale.order.line'].with_context(pricelist=pricelist.id).create({
+        sol = self.env['sale.order.line'].create({
             'name': event.name,
             'product_id': event_product.product_variant_id.id,
             'product_uom_qty': 1,

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -12,7 +12,6 @@
                             ('event_ticket_ids.product_id','=', product_id),
                             ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00'))
                         ]"
-                        context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
                         attrs="{'invisible': [('event_ok', '=', False)], 'required': [('event_ok', '!=', False)]}"
                         options="{'no_open': True, 'no_create': True}"
                     />
@@ -23,7 +22,6 @@
                             ('product_id','=',product_id),
                             '|', ('seats_availability', '=', 'unlimited'), ('seats_available', '>', 0)
                         ]"
-                        context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
                         attrs="{
                             'invisible': ['|', ('event_ok', '=', False), ('event_id', '=', False)],
                             'required': [('event_ok', '!=', False), ('event_id', '!=', False)],


### PR DESCRIPTION
Steps:
- Install Events
- Go to Events / Configuration / Settings
- Enable Tickets
- Go to Sales / Configuration / Settings
- Enable Multiple Sales Prices per Product
- Go to Sales / Products
- Edit Event Registration
  - Sales tab
    - Pricing
      - Pricelist: Public Pricelist (USD)
      - Price: $6
- Go to Sales
- Create a new quotation
  - Pricelist: Public Pricelist (USD)
  - Product: Event Registration
  - Event: Design Fair
  - Ticket: VIP

Bug:
The pricelist is not taken into account. Unit price should be $900 but
is $1500.

Explanation:
The original issue comes from this commit: https://github.com/odoo/odoo/commit/379f1490c93dc599a74add2d678c18fbba1efa62
The advertised amount was not the one showing up in the cart. This is
because the pricelist was not taken into account anymore when entering
the payment process.

Using `price_reduce` instead of `price` enables all kinds of discounts
on the final price.
However, `price_reduce` relies on the context to find the current
pricelist.
This commit adds the context needed to compute the price of the tickets.
This context is the same as the one in the sales module since pricelists
are working fine there: https://github.com/odoo/odoo/blob/b208570ce8399bc6d3e4a8ba02eef6558e0a6ccc/addons/sale/models/sale.py#L1494

The currency conversion is done in `product.price`. It's therefore
already done when calling `price_reduce`.

opw:2519453

Backport-Of: https://github.com/odoo/odoo/commit/de800c5cc3782d86cf07eac762af2dc62c760465