### PR TITLE
[FIX] mail: unblacklist with mass mailing


### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -306,7 +306,7 @@ class MailComposer(models.TransientModel):
         blacklisted_rec_ids = set()
         if mass_mail_mode and issubclass(type(self.env[self.model]), self.pool['mail.thread.blacklist']):
             self.env['mail.blacklist'].flush(['email'])
-            self._cr.execute("SELECT email FROM mail_blacklist")
+            self._cr.execute("SELECT email FROM mail_blacklist WHERE active=true")
             blacklist = {x[0] for x in self._cr.fetchall()}
             if blacklist:
                 targets = self.env[self.model].browse(res_ids).read(['email_normalized'])

--- a/addons/test_mass_mailing/tests/test_mass_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mass_mailing.py
@@ -282,17 +282,28 @@ class TestOnResPartner(TransactionCase):
             'name': 'test email 2',
             'email': 'test2@email.com',
         })
+        partner_c = partners.create({
+            'name': 'test email 3',
+            'email': 'test3@email.com',
+        })
 
         # Set Blacklist
         self.blacklist_contact_entry = self.env['mail.blacklist'].create({
             'email': 'Test2@email.com',
         })
+        self.env['mail.blacklist'].create({
+            'email': 'test3@email.com',
+        })
+
+        # Unblacklist
+        self.env['mail.blacklist']._remove('Test3@email.com')
+        self.env['mail.blacklist'].flush(['active'])
 
         # create mass mailing record
         self.mass_mailing = mass_mailing.create({
             'name': 'One',
             'subject': 'One',
-            'mailing_domain': [('id', 'in', [partner_a.id, partner_b.id])],
+            'mailing_domain': [('id', 'in', [partner_a.id, partner_b.id, partner_c.id])],
             'body_html': 'This is mass mail marketing demo'})
         self.mass_mailing.mailing_model_real = 'res.partner'
         self.mass_mailing.action_put_in_queue()


### PR DESCRIPTION

The optimization 2ccf0bd0dc does not take into account that to
"unblacklist" a user, you have the archive the mail.blacklist record so
only mail.blacklist active records need to be taken into account.

opw-2536304
