### PR TITLE
[IMP] codeowners: add rd-security watch for auth_* modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,13 +31,14 @@
 # Generic fallback rules
 
 /addons/account*/ @odoo/rd-accounting
+/addons/auth_*/ @odoo/rd-security
 /addons/crm*/ @odoo/rd-sm
 /addons/event*/ @odoo/rd-sm
 /addons/l10n_*/ @odoo/rd-accounting
 /addons/*/data/mail_template_data.xml @odoo/rd-sm
-/addons/*/models/ir_http.py @odoo/rd-website
-/addons/*/models/ir_qweb.py @odoo/rd-website
-/addons/*/models/ir_qweb_fields.py @odoo/rd-website
+/addons/*/models/ir_http.py @odoo/rd-website @odoo/rd-security
+/addons/*/models/ir_qweb.py @odoo/rd-website @odoo/rd-security
+/addons/*/models/ir_qweb_fields.py @odoo/rd-website @odoo/rd-security
 /addons/website*/ @odoo/rd-website
 /addons/website_event*/ @odoo/rd-notif-muted @odoo/rd-sm
 /addons/website_slides*/ @odoo/rd-notif-muted @odoo/rd-sm


### PR DESCRIPTION
all auth_* modules are sensitive and changes should be monitored more carefully
