### PR TITLE
[IMP] hr_work_entry_holidays: half day outside of working hours

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -200,7 +200,10 @@ class HrLeave(models.Model):
             contracts = employee.sudo()._get_contracts(date_from, date_to, states=['open'])
             contracts |= employee.sudo()._get_incoming_contracts(date_from, date_to)
             calendar = contracts[:1].resource_calendar_id if contracts else None # Note: if len(contracts)>1, the leave creation will crash because of unicity constaint
-            return employee._get_work_days_data_batch(date_from, date_to, calendar=calendar)[employee.id]
+            result = employee._get_work_days_data_batch(date_from, date_to, calendar=calendar)[employee.id]
+            if self.request_unit_half and result['hours'] > 0:
+                result['days'] = 0.5
+            return result
 
         return days
 


### PR DESCRIPTION
Fixes taking a half day outside of working hours counting as half a day
instead of nothing.

Since hr_work_entry_holidays has been moved to community in 14.3 also apply it here

See odoo/odoo#68977
See odoo/enterprise#18454