### PR TITLE
[FIX] product: touch impacted products upon updating product templates

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -441,6 +441,12 @@ class ProductTemplate(models.Model):
                 'image_128',
                 'can_image_1024_be_zoomed',
             ])
+            # Touch all products that will fall back on the template field
+            # This is done because __last_update is used to compute the 'unique' SHA in image URLs
+            # for making sure that images are not retrieved from the browser cache after a change
+            # Performance discussion outcome:
+            # Actually touch all variants to avoid using filtered on the image_variant_1920 field
+            self.product_variant_ids.write({})
         return res
 
     @api.returns('self', lambda value: value.id)


### PR DESCRIPTION
Before this commit, products relying on values of template fields (i.e.
image) were not considered updated when their fallback template field
was updated.

After this commit, upon update of a template field, all products that
would fallback on that template for that field are "touched".
This avoids side-effects such as displaying an outdated template image
in the e-commerce for a given product.

task-2477438

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
