### PR TITLE
[FIX] crm: res_partner._compute_meeting perf imp.

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -72,7 +72,7 @@ class Partner(models.Model):
 
             # Keep only valid meeting data based on record rules of events
             events = [row[1] for row in meeting_data]
-            events = self.env['calendar.event'].search([('id', 'in', events)]).ids
+            events = set(self.env['calendar.event'].search([('id', 'in', events)]).ids)
             meeting_data = [m for m in meeting_data if m[1] in events]
 
             # Create a dict {partner_id: event_ids} and fill with events linked to the partner


### PR DESCRIPTION
Cast ids `list` to `set` before meeting_data list comprehension to reduce complexity
of "in" operator.

In a customer database with len(events) = 60k, 
line `meeting_data = [m for m in meeting_data if m[1] in events]` averaged exe time
goes from 28s -> 0.01s

NB: should be `up-to 14.3` (not sure I have the rights to do it myself) because calendar meeting statsinfo got moved
to calendar module in master. Or leave `up-to master` and I'll move it in the forward branch.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
