### PR TITLE
[FIX] web: Fix flicker in editable list view

### DIFF
--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -244,10 +244,10 @@ var ListController = BasicController.extend({
      * @param {string} dataPointId a dataPoint of type 'list' (may be grouped)
      * @return {Promise}
      */
-    _addRecord: function (dataPointId) {
+    _addRecord: function (dataPointId, options) {
         var self = this;
         this._disableButtons();
-        return this.renderer.unselectRow().then(function () {
+        return this.renderer.unselectRow(options).then(function () {
             return self.model.addDefaultRecord(dataPointId, {
                 position: self.editable,
             });
@@ -560,8 +560,9 @@ var ListController = BasicController.extend({
     _onAddRecord: function (ev) {
         ev.stopPropagation();
         var dataPointId = ev.data.groupId || this.handle;
+        const stayInEdit = ev.data.stayInEdit;
         if (this.activeActions.create) {
-            this._addRecord(dataPointId);
+            this._addRecord(dataPointId, { stayInEdit: stayInEdit });
         } else if (ev.data.onFail) {
             ev.data.onFail();
         }
@@ -732,7 +733,7 @@ var ListController = BasicController.extend({
      * @param {OdooEvent} ev
      */
     _onSaveLine: function (ev) {
-        this.saveRecord(ev.data.recordID)
+        this.saveRecord(ev.data.recordID, { stayInEdit: ev.data.stayInEdit })
             .then(ev.data.onSuccess)
             .guardedCatch(ev.data.onFailure);
     },

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -484,7 +484,7 @@ ListRenderer.include({
      *   possibly removed). If may be rejected, when the row is dirty and the
      *   user refuses to discard its changes.
      */
-    unselectRow: function () {
+    unselectRow: function (options) {
         // Protect against calling this method when no row is selected
         if (this.currentRow === null) {
             return Promise.resolve();
@@ -502,6 +502,7 @@ ListRenderer.include({
         return new Promise((resolve, reject) => {
             this.trigger_up('save_line', {
                 recordID: recordID,
+                stayInEdit: options && options.stayInEdit,
                 onSuccess: resolve,
                 onFailure: reject,
             });
@@ -1015,8 +1016,9 @@ ListRenderer.include({
             } else if (this.editable) {
                 // if for some reason (e.g. create feature is disabled) we can't add a new
                 // record, select the first record row
-                this.unselectRow().then(this.trigger_up.bind(this, 'add_record', {
+                this.unselectRow({stayInEdit: true}).then(this.trigger_up.bind(this, 'add_record', {
                     groupId: groupId,
+                    stayInEdit: true,
                     onFail: this._selectCell.bind(this, borderRowIndex, cellIndex, cellOptions),
                 }));
             }


### PR DESCRIPTION
currently, When switching from one line to the next in create mode, save/create
buttons quickly flicker.

after this commit,When switching from one line to the next in create mode,
save/create buttons does not flicker. to fix flicker pass "stayInEdit: true"
parameter in create  mode.

id-2507247

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
