### PR TITLE
[IMP] website: add connector options to step snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -202,6 +202,7 @@
             'website/static/src/snippets/s_embed_code/options.js',
             'website/static/src/snippets/s_website_form/options.js',
             'website/static/src/snippets/s_searchbar/options.js',
+            'website/static/src/snippets/s_process_steps/options.js',
             'website/static/src/js/editor/wysiwyg.js',
             'website/static/src/js/editor/widget_link.js',
             'website/static/src/js/widgets/media.js',

--- a/addons/website/static/src/snippets/s_process_steps/000.js
+++ b/addons/website/static/src/snippets/s_process_steps/000.js
@@ -1,0 +1,119 @@
+/** @odoo-module **/
+import publicWidget from 'web.public.widget';
+
+publicWidget.registry.StepSnippet = publicWidget.Widget.extend({
+    selector: '.s_process_steps',
+    disabledInEditableMode: false,
+
+    /**
+     * @override
+     */
+    willStart: function () {
+        this.resizeObserver = new ResizeObserver(this._adjustConnectors.bind(this));
+        this.mutationObserver = new MutationObserver((mutations) => {
+            const isClassMutation = mutations.some(m => m.type === 'attributes' && m.attributeName === 'class');
+            const isChildMutation = isClassMutation ? false : mutations.some(m => m.type === 'childList');
+            if (isClassMutation || isChildMutation) {
+                this._adjustConnectors();
+                if (isChildMutation) {
+                    if (this.$target[0].dataset.currentConnector === 'curved_arrow') {
+                        $('.s_process_step_curved_arrow path').attr('d', 'M 0 0 Q 10 3, 20 0');
+                        $('.s_process_step_curved_arrow:even path').attr('d', 'M 0 0 Q 10 -3, 20 0');
+                    }
+                    // We need to register added node to the observer
+                    for (const {addedNodes} of mutations) {
+                        for (const node of addedNodes) {
+                            this.mutationObserver.observe(node, { attributes: true, attributeFilter: ['class'] });
+                        }
+                    }
+                }
+            }
+        });
+        const container = this.$target.find('> div > .row')[0];
+        $.each($('.s_process_step'), (_, step) => {
+            this.mutationObserver.observe(step, { attributes: true, attributeFilter: ['class'] });
+        });
+        this.mutationObserver.observe(container, { childList: true });
+        this.resizeObserver.observe(container);
+        this.$target.on('connectorChange', this._adjustConnectors.bind(this));
+        // Add mandatory ID now because setting it in the template would lead
+        // to ID duplication given that snippet thumbnails contain a copy of the template
+        if ($('#arrowhead').length === 0) {
+            $('#wrap .s_process_step_arrow_head').attr('id', 'arrowhead');
+        }
+        return this._super.apply(this, arguments);
+    },
+    /**
+     * @override
+     */
+    destroy: function () {
+        this.$target.off('connectorChange');
+        this.resizeObserver.disconnect();
+        this.mutationObserver.disconnect();
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Connector width is based on the distance between the two icons
+     * @private
+     * @returns {{arrowPosition: number, width: number}} Width of connector and position of arrow
+     */
+    _computeConnectorWidth($step, $next) {
+        const stepIco = $step.find('i')[0];
+        const nextIco = $next.find('i')[0];
+        const { left: stepLeft, right: stepRight } = stepIco.getBoundingClientRect();
+        const { left: nextLeft, right: nextRight } = nextIco.getBoundingClientRect();
+        let width = nextLeft - stepRight;
+        // In most cases arrow position is 50% - 40px (half of the icon)
+        // But if the icon overflows, we need to compute the exact position
+        const parentPosition = $step[0].getBoundingClientRect().right;
+        let arrowPosition = stepRight + $step.width() / 2 - parentPosition;
+        if (width < 40 && this.$target[0].dataset.currentConnector === 'curved_arrow') {
+            width = 40;
+            const stepIcoCenter = (stepLeft + stepRight) / 2;
+            const nextIcoCenter = (nextLeft + nextRight) / 2;
+            arrowPosition = (nextIcoCenter - stepIcoCenter) / 2 - width / 2;
+        }
+        return {
+            arrowPosition,
+            width,
+        };
+    },
+    /**
+     * Adjust connector size and position
+     * If connector width is greater or equals to 70, add space between arrow and icons
+     * @private
+     */
+    _adjustConnector($connector, connectorWidth, arrowPosition) {
+        connectorWidth = connectorWidth > 0 ? connectorWidth : 0;
+        const currentConnector = this.$target[0].dataset.currentConnector;
+        if (currentConnector && currentConnector !== 'line' && connectorWidth - 30 >= 40) {
+            connectorWidth -= 30;
+            arrowPosition += 15;
+        }
+        $connector.attr('width', connectorWidth);
+        $connector.css('left', `calc(50% + ${arrowPosition}px)`);
+    },
+    /**
+     * @private
+     */
+    _adjustConnectors() {
+        if (this.$target[0].dataset.currentConnector !== 'none') {
+            const $steps = $('.s_process_step');
+            $.each($steps, (_, step) => {
+                const $step = $(step);
+                const $next = $step.next('.s_process_step');
+                const $connector = $step.find('.s_process_step_connector');
+                // Hide connector if there is no next step or if steps are on different lines
+                $connector.toggle($next.length > 0 && $next.offset().top === $step.offset().top);
+                if ($next.length > 0) {
+                    const { arrowPosition, width } = this._computeConnectorWidth($step, $next);
+                    this._adjustConnector($connector, width, arrowPosition);
+                }
+            });
+        }
+    },
+});

--- a/addons/website/static/src/snippets/s_process_steps/000.scss
+++ b/addons/website/static/src/snippets/s_process_steps/000.scss
@@ -1,10 +1,6 @@
 .s_process_steps {
     .s_process_step_icon {
         margin: $grid-gutter-width 0;
-        span {
-            display: block;
-            overflow: hidden;
-        }
         .fa {
             display: block;
         }
@@ -18,35 +14,26 @@
             .s_process_step_icon {
                 position: relative;
                 z-index: 1;
-                span:after {
-                    content: '';
-                    z-index: -1;
-                    border-top: 1px solid gray('500');
-                    @include o-position-absolute(50%, 0, 0, auto);
-                }
             }
-            .s_process_step_icon {
-                span:after {
-                    width: 100%;
-                }
-            }
-            &:first-child .s_process_step_icon,
-            &:last-child .s_process_step_icon {
-                span:after {
-                    width: 50%;
-                }
-            }
-            &:first-child .s_process_step_icon {
-                .fa:after { right: 0; }
-                .fa.float-right:after { width: 0; }
-            }
-            &:last-child .s_process_step_icon {
-                span:after { left: 0; }
-                .fa {
-                    &:after { left: 0; }
-                    &.float-left:after { width: 0; }
-                }
+
+            &:nth-child(odd) .s_process_step_curved_arrow {
+                top: -5%;
             }
         }
     }
+
+    .s_process_step_connector {
+        position: absolute;
+        top: 50%;
+        z-index: -1;
+        display: none;
+    }
+
+    .s_process_step_curved_arrow {
+        top: 105%;
+    }
+}
+
+svg {
+    overflow: visible;
 }

--- a/addons/website/static/src/snippets/s_process_steps/options.js
+++ b/addons/website/static/src/snippets/s_process_steps/options.js
@@ -1,0 +1,50 @@
+/** @odoo-module **/
+import options from 'web_editor.snippets.options';
+
+options.registry.ConnectorChoice = options.Class.extend({
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Change connector type
+     */
+    changeConnector: function (previewMode, widgetValue, params) {
+        this.$target[0].dataset.currentConnector = widgetValue;
+        // Lets notify the snippet that a connector has change in order
+        // to adjust connector width
+        this.$target.trigger('connectorChange');
+        this.$target.find('.s_process_step_connector').toggleClass('s_process_step_curved_arrow', widgetValue === 'curved_arrow');
+        const arrowPath = widgetValue === 'curved_arrow' ? 'M 0 0 Q 10 2, 20 0' : 'M 0 0 L 20 0';
+        const isArrow = widgetValue.includes('arrow');
+        this.$target.find('.s_process_step_connector path').attr({
+            d: arrowPath,
+            'stroke-width': isArrow ? 2 : 1,
+            'marker-end': isArrow ? 'url(#arrowhead)' : '',
+        }).toggle(widgetValue !== 'none');
+        $('.s_process_step_curved_arrow:even path').attr('d', 'M 0 0 Q 10 -2, 20 0');
+    },
+    /**
+     * Change arrow heads' fill color according to stroke color
+     */
+    changeColor: function (previewMode, widgetValue, params) {
+        const color = this.$target.closest('.s_process_step_connector path').css('stroke');
+        $('.s_process_step_arrow_head path').css('fill', color);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _computeWidgetState: function (methodName, params) {
+        switch (methodName) {
+            case "changeConnector":
+                return this.$target[0].dataset.currentConnector;
+        }
+        return this._super(...arguments);
+    },
+});

--- a/addons/website/views/snippets/s_process_steps.xml
+++ b/addons/website/views/snippets/s_process_steps.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
 <template name="Steps" id="s_process_steps">
-    <section class="s_process_steps pt24 pb24">
+    <section class="s_process_steps pt24 pb24" data-current-connector="line">
+        <svg xmlns="http://www.w3.org/2000/svg" class="s_process_step_svg_defs position-absolute">
+            <defs>
+                <marker class="s_process_step_arrow_head" markerWidth="15" markerHeight="10" refX="9" refY="6" orient="auto">
+                     <path d="M 2,2 L10,6 L2,10 L6,6 L2,2" vector-effect="non-scaling-size" stroke="transparent" style="fill: rgb(108, 117, 125);"/>
+                </marker>
+            </defs>
+        </svg>
         <div class="container">
             <div class="row no-gutters">
                 <div class="col-lg-3 s_process_step pt24 pb24">
                     <div class="s_process_step_icon">
-                        <span>
-                            <i class="fa fa-shopping-basket fa-2x mx-auto rounded-circle bg-primary"/>
-                        </span>
+                        <svg class="s_process_step_connector" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M 0 0 L 20 0" style="stroke: rgb(108, 117, 125);" stroke-width="1" fill="transparent" vector-effect="non-scaling-stroke"/>
+                        </svg>
+                        <i class="fa fa-shopping-basket fa-2x mx-auto rounded-circle bg-primary"/>
                     </div>
                     <div class="s_process_step_content text-center">
                         <h2>Add to cart</h2>
@@ -18,9 +25,10 @@
                 </div>
                 <div class="col-lg-3 s_process_step pt24 pb24">
                     <div class="s_process_step_icon">
-                        <span>
-                            <i class="fa fa-unlock-alt fa-2x mx-auto rounded-circle bg-o-color-5"/>
-                        </span>
+                        <svg class="s_process_step_connector" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M 0 0 L 20 0" style="stroke: rgb(108, 117, 125);" stroke-width="1" fill="transparent" vector-effect="non-scaling-stroke"/>
+                        </svg>
+                        <i class="fa fa-unlock-alt fa-2x mx-auto rounded-circle bg-o-color-5"/>
                     </div>
                     <div class="s_process_step_content text-center">
                         <h2>Sign in</h2>
@@ -29,9 +37,10 @@
                 </div>
                 <div class="col-lg-3 s_process_step pt24 pb24">
                     <div class="s_process_step_icon">
-                        <span>
-                            <i class="fa fa-paypal fa-2x mx-auto rounded-circle bg-secondary"/>
-                        </span>
+                        <svg class="s_process_step_connector" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M 0 0 L 20 0"  style="stroke: rgb(108, 117, 125);" stroke-width="1" fill="transparent" vector-effect="non-scaling-stroke"/>
+                        </svg>
+                        <i class="fa fa-paypal fa-2x mx-auto rounded-circle bg-secondary"/>
                     </div>
                     <div class="s_process_step_content text-center">
                         <h2>Pay</h2>
@@ -40,9 +49,10 @@
                 </div>
                 <div class="col-lg-3 s_process_step pt24 pb24">
                     <div class="s_process_step_icon">
-                        <span>
-                            <i class="fa fa-plane fa-2x mx-auto rounded-circle bg-o-color-3"/>
-                        </span>
+                        <svg class="s_process_step_connector" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M 0 0 L 20 0"  style="stroke: rgb(108, 117, 125);" stroke-width="1" fill="transparent" vector-effect="non-scaling-stroke"/>
+                        </svg>
+                        <i class="fa fa-plane fa-2x mx-auto rounded-circle bg-o-color-3"/>
                     </div>
                     <div class="s_process_step_content text-center">
                         <h2>Get Delivered</h2>
@@ -54,10 +64,33 @@
     </section>
 </template>
 
+<template id="s_process_steps_options" inherit_id="website.snippet_options">
+	<xpath expr="." position="inside">
+		<div data-js="ConnectorChoice" data-selector=".s_process_steps">
+			<we-row string="Connector">
+				<we-select>
+					<we-button data-change-connector="none">None</we-button>
+					<we-button data-change-connector="line" data-name="line">Line</we-button>
+					<we-button data-change-connector="arrow" data-name="arrow">Straight arrow</we-button>
+					<we-button data-change-connector="curved_arrow" data-name="curved_arrow">Curved arrow</we-button>
+				</we-select>
+				<we-colorpicker data-color-prefix="stroke-" data-select-style="" data-dependencies="line, arrow, curved_arrow" 
+                data-apply-to=".s_process_step_connector path" data-css-property="stroke" data-change-color=""/>
+			</we-row>
+		</div>
+	</xpath>
+</template>
+
 <record id="website.s_process_steps_000_scss" model="ir.asset">
     <field name="name">Process steps 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">website/static/src/snippets/s_process_steps/000.scss</field>
 </record>
 
+
+<record id="website.s_process_steps_000_js" model="ir.asset">
+    <field name="name">Process Steps 000 JS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_process_steps/000.js</field>
+</record>
 </odoo>


### PR DESCRIPTION
Currently, step snippets' connector is a line. Even if simplicity is the key to beauty, we wanted to add more options :

- No connector;
- Line
- Straight Arrows
- Curved Arrows

Moreover, an option has been added to select the color of the connector itself. 

_OLD PR : https://github.com/odoo/odoo/pull/69127/files_