### PR TITLE
[FIX] mail: fix the sending of mail in a channel

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2183,7 +2183,7 @@ class MailThread(models.AbstractModel):
                 for channel in channels.filtered(lambda c: c.email_send):
                     users = channel.channel_partner_ids.mapped('user_ids')
                     for user in users.filtered(lambda u: u.notification_type == 'email'):
-                        channel.with_user(user).channel_seen(message.id)
+                        channel.with_user(user).with_context(allowed_company_ids=[]).channel_seen(message.id)
 
         if bus_notifications:
             self.env['bus.bus'].sudo().sendmany(bus_notifications)


### PR DESCRIPTION
Steps to reproduce the bug:
- Connect as admin and choose in the company selector (e.g: Company A)
- Install Discuss app
- Create a new user (e.g: User B) with default company (e.g: Company B) and no other allowed company
- Go to discuss app
- Edit any channel (public or private) > enable “Send message by email” and add “User B” as member
- Send a message in the channel
- An access Error is triggered: “Access to unauthorized or invalid companies.”

Problem:
The current company (“company A) is not in the companies allowed for "User B”

Solution:
we don't use the company selector for that part, but the companies set on the user directly

opw-2537675



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
