### PR TITLE
[FIX] stock: add button to remove lines in SN detailed operations form

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -599,6 +599,19 @@ class StockMove(models.Model):
         self._generate_serial_numbers()
         return self.action_show_details()
 
+    def action_clear_lines_show_details(self):
+        """ Unlink `self.move_line_ids` before returning `self.action_show_details`.
+        Useful for if a user creates too many SNs by accident via action_assign_serial_show_details
+        since there's no way to undo the action.
+        """
+        self.ensure_one()
+        if self.picking_type_id.show_reserved:
+            move_lines = self.move_line_ids
+        else:
+            move_lines = self.move_line_nosuggest_ids
+        move_lines.unlink()
+        return self.action_show_details()
+
     def action_assign_serial(self):
         """ Opens a wizard to assign SN's name on each move lines.
         """

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -208,6 +208,12 @@
                                         title="Assign Serial Numbers">
                                     <span>Assign Serial Numbers</span>
                                 </button>
+                                <button name="action_clear_lines_show_details" type="object"
+                                        class="btn-link"
+                                        title="Clear Lines"
+                                        attrs="{'invisible': [('display_assign_serial', '=', False)]}">
+                                    <span>Clear All</span>
+                                </button>
                             </div>
                         </group>
                     </group>


### PR DESCRIPTION
Currently there is an action_assign_serial_show_details button within
the detailed operations form of a serial tracked product move.
Unfortunately there is no way to undo the assigning/creating of move
lines from this action (including via clicking the "Discard" button).
This can lead to a lot of manual work (e.g. 500 SNs produced instead of
50) to remove unwanted move lines. To remedy this, we add in a button
to unlink all of the move's move lines whenever the Assign Serial
Numbers button is visible.

Task: 2426281

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
