### PR TITLE
[FIX] web_editor, website: properly display checklist items

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -121,10 +121,11 @@ ul.o_checklist {
     list-style: none;
 
     >li {
+        list-style: none;
         position: relative;
         margin-left: $o-checklist-margin-left;
 
-        &::before {
+        &:not(.oe-nested)::before {
             content: '';
             position: absolute;
             left: - $o-checklist-margin-left;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1405,3 +1405,8 @@ $ribbon-padding: 100px;
         display: none;
     }
 }
+
+ul.o_checklist > li.o_checked::after {
+    left: - ($o-checklist-margin-left - $o-checklist-checkmark-width) - 1;
+    top: 0;
+}


### PR DESCRIPTION
Indenting a checklist item duplicated its checkbox. This properly copies the css from the editor that was lost in translation.
The style of website requires that the checkmarks of checklists be offseted a little bit differently in website that in field html. This
acknowledges that difference so that they're properly centered in both cases.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
