### PR TITLE
[FIX] website: make get_http_domain more smart

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -942,15 +942,19 @@ class Website(models.Model):
 
     def _get_http_domain(self):
         """Get the domain of the current website, prefixed by http if no
-        scheme is specified.
+        scheme is specified and withtout trailing /.
 
         Empty string if no domain is specified on the website.
         """
         self.ensure_one()
         if not self.domain:
             return ''
-        res = urls.url_parse(self.domain)
-        return 'http://' + self.domain if not res.scheme else self.domain
+
+        domain = self.domain
+        if not self.domain.startswith('http'):
+            domain = 'http://%s' % domain
+
+        return domain.rstrip('/')
 
     def get_base_url(self):
         self.ensure_one()


### PR DESCRIPTION
Autocorrect self.domain if wrong

website.domain should contains scheme and not trialing /

Else a several bugs like urls:
   //my/ => homepage
   wrong canonical url
   wrong hreflang
   ...

opw-2486918

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
