### PR TITLE
[IMP] website: autocorrect website domain

### DIFF
--- a/addons/website/tests/test_base_url.py
+++ b/addons/website/tests/test_base_url.py
@@ -57,12 +57,35 @@ class TestBaseUrl(TestUrlCommon):
         # Test URL is correct for the website itself when no domain is set
         self.assertEqual(self.website.get_base_url(), icp_base_url)
 
+        # Test URL is correctly auto fixed
+        domains = [
+            # trailing /
+            ("https://www.monsite.com/", "https://www.monsite.com"),
+            # no scheme
+            ("www.monsite.com", "https://www.monsite.com"),
+            ("monsite.com", "https://monsite.com"),
+            # respect scheme
+            ("https://www.monsite.com", "https://www.monsite.com"),
+            ("http://www.monsite.com", "http://www.monsite.com"),
+            # respect port
+            ("www.monsite.com:8069", "https://www.monsite.com:8069"),
+            ("www.monsite.com:8069/", "https://www.monsite.com:8069"),
+            # no guess wwww
+            ("monsite.com", "https://monsite.com"),
+            # mix
+            ("www.monsite.com/", "https://www.monsite.com"),
+        ]
+        for (domain, expected) in domains:
+            self.website.domain = domain
+            self.assertEqual(self.website.get_base_url(), expected)
+
     def test_02_canonical_url(self):
-        self._assertCanonical('/', self.domain + '/')
-        self._assertCanonical('/?debug=1', self.domain + '/')
-        self._assertCanonical('/a-page', self.domain + '/a-page')
-        self._assertCanonical('/en_US', self.domain + '/')
-        self._assertCanonical('/fr_FR', self.domain + '/fr/')
+        # test does not work in local due to port
+        self._assertCanonical('/', self.website.get_base_url() + '/')
+        self._assertCanonical('/?debug=1', self.website.get_base_url() + '/')
+        self._assertCanonical('/a-page', self.website.get_base_url() + '/a-page')
+        self._assertCanonical('/en_US', self.website.get_base_url() + '/')
+        self._assertCanonical('/fr_FR', self.website.get_base_url() + '/fr/')
 
 
 @odoo.tests.tagged('-at_install', 'post_install')

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -95,7 +95,7 @@ tour.register('shop_mail', {
     {
         content: "check it's the correct email, and the URL is correct too",
         trigger: 'div.oe_form_field_html[name="body_html"] p:contains("Your"):contains("order")',
-        extra_trigger: 'div.oe_form_field_html[name="body_html"] a[href^="http://my-test-domain.com"]',
+        extra_trigger: 'div.oe_form_field_html[name="body_html"] a[href^="https://my-test-domain.com"]',
     },
 ]);
 });


### PR DESCRIPTION
Before, get_http_domain make the job,
now we force website.domain to be valid

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
