### PR TITLE
[IMP] website: change CTA based on website main objective 

### DIFF
--- a/addons/website/models/website_configurator_feature.py
+++ b/addons/website/models/website_configurator_feature.py
@@ -16,7 +16,7 @@ class WebsiteConfiguratorFeature(models.Model):
     description = fields.Char(translate=True)
     icon = fields.Char()
     iap_page_code = fields.Char(help='Page code used to tell IAP website_service for which page a snippet list should be generated')
-    website_types_preselection = fields.Char(help='Comma-separated list of website type for which this feature should be pre-selected')
+    website_types_preselection = fields.Char(help='Comma-separated list of website type/purpose for which this feature should be pre-selected')
     type = fields.Selection([('page', "Page"), ('app', "App")], compute='_compute_type')
     page_view_id = fields.Many2one('ir.ui.view', ondelete='cascade')
     module_id = fields.Many2one('ir.module.module', ondelete='cascade')

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -24,7 +24,8 @@ const WEBSITE_PURPOSES = {
     1: {id: 1, label: _lt("get leads"), name: 'get_leads'},
     2: {id: 2, label: _lt("develop the brand"), name: 'develop_brand'},
     3: {id: 3, label: _lt("sell more"), name: 'sell_more'},
-    4: {id: 4, label: _lt("inform customers"), name: 'inform_customers'}
+    4: {id: 4, label: _lt("inform customers"), name: 'inform_customers'},
+    5: {id: 5, label: _lt("schedule appointments"), name: 'schedule_appointments'}
 };
 
 const PALETTE_NAMES = [
@@ -354,6 +355,10 @@ const actions = {
         state.selectedType = id;
     },
     selectWebsitePurpose({state}, id) {
+        Object.values(state.features).filter((feature) => feature.module_state !== 'installed').forEach((feature) => {
+            // need to check id, since we set to undefined in mount() to avoid the auto next screen on back button
+            feature.selected |= id && feature.website_types_preselection.includes(WEBSITE_PURPOSES[id].name);
+        });
         state.selectedPurpose = id;
     },
     selectIndustry({state}, id) {
@@ -475,6 +480,8 @@ async function applyConfigurator(self, themeName) {
             industry_id: self.state.selectedIndustry,
             selected_palette: selectedPalette,
             theme_name: themeName,
+            website_purpose: WEBSITE_PURPOSES[self.state.selectedPurpose].name,
+            website_type: WEBSITE_TYPES[self.state.selectedType].name,
         };
         const resp = await rpc.query({
             model: 'website',

--- a/addons/website/views/snippets/s_banner.xml
+++ b/addons/website/views/snippets/s_banner.xml
@@ -9,7 +9,7 @@
                 <div class="col-lg-6 jumbotron rounded o_cc o_cc1 pt32 pb32" data-name="Box">
                     <h1><font style="font-size: 62px;">Sell Online. Easily.</font></h1>
                     <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-                    <a href="#" class="btn btn-primary mb-2">Contact Us</a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">Contact Us</t></a>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_call_to_action.xml
+++ b/addons/website/views/snippets/s_call_to_action.xml
@@ -11,7 +11,7 @@
                 </div>
                 <div class="col-lg-3 pt8">
                     <p style="text-align: right;">
-                        <a href="/contactus" class="btn btn-primary btn-lg mb-2">Contact us</a>
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text">Contact us</t></a>
                     </p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -9,7 +9,7 @@
             <h1 style="text-align: center;"><font style="font-size: 62px; font-weight: bold;">Catchy Headline</font></h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a href="/contactus" class="btn btn-primary mb-2">Contact us</a>
+                <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">Contact us</t></a>
             </p>
         </div>
     </section>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -11,6 +11,8 @@
     </xpath>
     <xpath expr="//t[@id='default_snippets']" position="replace">
         <t id="default_snippets">
+            <t t-set="cta_btn_text" t-value="False"/>
+            <t t-set="cta_btn_href">/contactus</t>
             <div id="snippet_mega_menu" class="o_panel d-none">
                 <div class="o_panel_header">Mega Menu</div>
                 <div class="o_panel_body">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -125,6 +125,11 @@
         <attribute name="data-name">Header</attribute>
     </xpath>
 
+    <xpath expr="//header" position="before">
+        <t t-set="cta_btn_text" t-value="False"/>
+        <t t-set="cta_btn_href">/contactus</t>
+    </xpath>
+
     <xpath expr="//footer" position="attributes">
         <attribute name="data-name">Footer</attribute>
         <!-- Background now controlled by css configuration, using color combinations -->
@@ -273,7 +278,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_default_1">
             <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <a href="/contactus" class="btn btn-primary ml-4">Contact Us</a>
+                    <a href="/contactus" class="btn btn-primary ml-4 btn_cta">Contact Us</a>
                 </div>
             </section>
         </div>
@@ -349,7 +354,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_hamburger_1">
             <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <a href="/contactus" class="btn btn-primary ml-4">Contact Us</a>
+                    <a href="/contactus" class="btn btn-primary ml-4 btn_cta">Contact Us</a>
                 </div>
             </section>
         </div>
@@ -697,7 +702,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_slogan_2">
             <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <a href="/contactus" class="btn btn-primary ml-4">Contact Us</a>
+                    <a href="/contactus" class="btn btn-primary ml-4 btn_cta">Contact Us</a>
                 </div>
             </section>
         </div>
@@ -926,7 +931,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_boxed_2">
             <section class="s_text_block" data-snippet="s_text_block" name="Text">
                 <div class="container">
-                     <a href="/contactus" class="btn btn-primary ml-lg-4">Contact Us</a>
+                    <a href="/contactus" class="btn btn-primary ml-lg-4 btn_cta">Contact Us</a>
                 </div>
             </section>
         </div>
@@ -1043,7 +1048,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_image_2">
             <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <a href="/contactus" class="btn btn-primary mt-3 mt-lg-0 ml-lg-3">Contact Us</a>
+                    <a href="/contactus" class="btn btn-primary mt-3 mt-lg-0 ml-lg-3 btn_cta">Contact Us</a>
                 </div>
             </section>
         </div>

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -12,3 +12,10 @@ class Website(models.Model):
         suggested_controllers = super(Website, self).get_suggested_controllers()
         suggested_controllers.append((_('Events'), url_for('/event'), 'website_event'))
         return suggested_controllers
+
+    def get_cta_data(self, website_purpose, website_type):
+        cta_data = super(Website, self).get_cta_data(website_purpose, website_type)
+        if website_purpose == 'sell_more' and website_type == 'event':
+            cta_btn_text = _('Next Events')
+            return {'cta_btn_text': cta_btn_text, 'cta_btn_href': '/event'}
+        return cta_data


### PR DESCRIPTION
If user selects 'schedule appointments' as main objective in the configurator
and if the website_calendar module is installed then the Call To Action of
snippets s_banner, s_cover and s_call_to_action is changed to 'Schedule an
appointment' and redirect user to '/calendar' on click.

task-2518565

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
