### PR TITLE
[FIX] web_editor: properly apply link to icon

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -4,7 +4,6 @@ odoo.define('wysiwyg.widgets.LinkTools', function (require) {
 const Link = require('wysiwyg.widgets.Link');
 const OdooEditorLib = require('web_editor.odoo-editor');
 
-const nodeSize = OdooEditorLib.nodeSize;
 const setCursor = OdooEditorLib.setCursor;
 
 /**
@@ -20,8 +19,12 @@ const LinkTools = Link.extend({
     /**
      * @override
      */
-    init: function (parent, options, editable, data, $button, link) {
-        link = link || this.getOrCreateLink(editable);
+    init: function (parent, options, editable, data, $button, node) {
+        if (node && !$(node).is('a')) {
+            $(node).wrap('<a href="#"/>');
+            node = node.parentElement;
+        }
+        const link = node || this.getOrCreateLink(editable);
         this._super(parent, options, editable, data, $button, link);
     },
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -544,7 +544,7 @@ const Wysiwyg = Widget.extend({
             }
             if (forceOpen || !this.linkTools) {
                 const $btn = this.toolbar.$el.find('#create-link');
-                this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this}, this.odooEditor.editable, {}, $btn, link);
+                this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this}, this.odooEditor.editable, {}, $btn, link || this.lastMediaClicked);
                 const _onMousedown = ev => {
                     if (!ev.target.closest('.oe-toolbar') && !ev.target.closest('.ui-autocomplete')) {
                         // Destroy the link tools on click anywhere outside the


### PR DESCRIPTION
Range.extractContents resulted in an icon being duplicated when trying to just apply a link to it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
