### PR TITLE
[FIX] web_editor, website: fix validation issue when saving LinkDialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -54,6 +54,7 @@ const _DialogLinkWidget = Link.extend({
         }
         this.data.isNewWindow = data.isNewWindow;
         this.final_data = this.data;
+        return Promise.resolve();
     },
 
     //--------------------------------------------------------------------------
@@ -196,15 +197,12 @@ const LinkDialog = Dialog.extend({
      * @override
      */
     save: function () {
-        this.linkWidget.save();
-        if (!this.linkWidget.final_data) {
-            // Invalid form content: do not proceed with save.
-            return;
-        }
-        this.final_data = this.linkWidget.final_data;
-        if (this.final_data) {
-            return this._super(...arguments);
-        }
+        const _super = this._super.bind(this);
+        const saveArguments = arguments;
+        return this.linkWidget.save().then(() => {
+            this.final_data = this.linkWidget.final_data;
+            return _super(...saveArguments);
+        });
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -243,7 +243,11 @@ const Wysiwyg = Widget.extend({
                 ev.preventDefault();
             }
 
-            if ($target.is(this.customizableLinksSelector) && $target.is('a') && !$target.attr('data-oe-model') && !$target.find('> [data-oe-model]').length) {
+            if ($target.is(this.customizableLinksSelector)
+                    && $target.is('a')
+                    && !$target.attr('data-oe-model')
+                    && !$target.find('> [data-oe-model]').length
+                    && !$target[0].closest('.o_extra_menu_items')) {
                 this.linkPopover = $target.data('popover-widget-initialized');
                 if (!this.linkPopover) {
                     // TODO this code is ugly maybe the mutex should be in the

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1431,7 +1431,9 @@ const Wysiwyg = Widget.extend({
                 if (!this.showTooltip || $target.attr('title') !== undefined) {
                     return;
                 }
+                this.odooEditor.observerUnactive();
                 $target.tooltip({title: _t('Double-click to edit'), trigger: 'manual', container: 'body'}).tooltip('show');
+                this.odooEditor.observerActive();
                 setTimeout(() => $target.tooltip('dispose'), 800);
             }, 400);
         }

--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -473,9 +473,9 @@ var MenuEntryDialog = weWidgets.LinkDialog.extend({
             if (!$e.val() || !$e[0].checkValidity()) {
                 $e.closest('.form-group').addClass('o_has_error').find('.form-control, .custom-select').addClass('is-invalid');
                 $e.focus();
-                return;
+                return Promise.reject();
             }
-            oldSave.bind(this.linkWidget)();
+            return oldSave.bind(this.linkWidget)();
         };
 
         this.menuType = data.menuType;

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -242,6 +242,19 @@ function registerThemeHomepageTour(name, steps) {
     ));
 }
 
+function clickOnExtraMenuItem(stepOptions) {
+    return Object.assign({}, {
+        content: "Click on the extra menu dropdown toggle if it is there",
+        trigger: '#top_menu',
+        run: function () {
+            console.log('click extra');
+            const extraMenuButton = this.$anchor[0].querySelector('.o_extra_menu_items a.nav-link');
+            if (extraMenuButton) {
+                extraMenuButton.click();
+            }
+        },
+    }, stepOptions);
+}
 
 return {
     addMedia,
@@ -263,7 +276,7 @@ return {
     selectHeader,
     selectNested,
     selectSnippetColumn,
-
     registerThemeHomepageTour,
+    clickOnExtraMenuItem,
 };
 });

--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -75,8 +75,10 @@ const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
                 method: 'save',
                 args: [websiteId, {'data': [data]}],
             }).then(function () {
+                self.options.wysiwyg.odooEditor.observerUnactive();
                 self.$target.attr('href', link.url);
                 $menu.text(link.content);
+                self.options.wysiwyg.odooEditor.observerActive();
             });
         });
         dialog.open();

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -2,6 +2,7 @@ odoo.define("website.tour.edit_megamenu", function (require) {
 "use strict";
 
 const tour = require('web_tour.tour');
+const wTourUtils = require('website.tour_utils');
 
 tour.register('edit_megamenu', {
     test: true,
@@ -37,6 +38,7 @@ tour.register('edit_megamenu', {
         trigger: '.modal-dialog .btn-primary span:contains("Save")',
         run: 'click',
     },
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'a[data-action=edit]'}),
     {
         content: "Menu should have a new megamenu item",
         trigger: '#top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -1,0 +1,107 @@
+/** @odoo-module */
+
+import wTourUtils from 'website.tour_utils';
+import tour from 'web_tour.tour';
+
+const clickOnSave = {
+   content: "Clicks on the menu edition dialog save button",
+   trigger: '.modal-dialog .btn-primary span:contains("Save")',
+};
+
+tour.register('edit_menus', {
+    test: true,
+    url: '/',
+}, [
+    // Add a megamenu item from the menu.
+    {
+        content: "Open Pages menu",
+        trigger: '.o_menu_sections a:contains("Pages")',
+    },
+    {
+        content: "Click on Edit Menu",
+        trigger: 'a.dropdown-item:contains("Edit Menu")',
+    },
+    {
+        content: "Trigger the link dialog (click 'Add Mega Menu Item')",
+        extra_trigger: '.o_web_editor_dialog:visible',
+        trigger: '.modal-body a.js_add_menu[data-type="mega"]',
+    },
+    {
+        content: "Write a label for the new menu item",
+        extra_trigger: '.o_link_dialog',
+        trigger: '.o_link_dialog #o_link_dialog_label_input',
+        run: 'text Megaaaaa!'
+    },
+    clickOnSave,
+    {
+        content: "Click save and wait for the page to be reloaded",
+        trigger: '.modal-dialog .btn-primary span:contains("Save")',
+        run: async function () {
+            await new Promise(resolve => {
+                window.onunload = () => {
+                    resolve();
+                };
+                this.$anchor.click();
+            });
+        },
+    },
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'body:not(:has(.oe_menu_editor))'}),
+    {
+        content: "There should be a new megamenu item.",
+        trigger: '#top_menu .nav-item a.o_mega_menu_toggle:contains("Megaaaaa!")',
+        run: () => {}, // It's a check.
+    },
+    // Add a menu item in edit mode.
+    wTourUtils.clickOnEdit(),
+    {
+        content: "Click on a menu item",
+        trigger: '#top_menu .nav-item a',
+        extra_trigger: '#oe_snippets.o_loaded',
+    },
+    {
+        content: "Click on Edit Menu",
+        trigger: '.o_edit_menu_popover a.js_edit_menu',
+    },
+    {
+        content: "Trigger the link dialog (click 'Add Menu Item')",
+        extra_trigger: '.o_web_editor_dialog:visible',
+        trigger: '.modal-body a.js_add_menu',
+    },
+    clickOnSave,
+    {
+        content: "It didn't save without a label. Fill label input.",
+        extra_trigger: '.o_link_dialog',
+        trigger: '.o_link_dialog #o_link_dialog_label_input',
+        run: 'text Random!',
+    },
+    clickOnSave,
+    {
+        content: "It didn't save without a url. Fill url input.",
+        extra_trigger: '.o_link_dialog',
+        trigger: '.o_link_dialog #o_link_dialog_url_input',
+        run: 'text #',
+    },
+    clickOnSave,
+    clickOnSave,
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: '#oe_snippets.o_loaded'}),
+    {
+        content: "Menu should have a new link item",
+        trigger: '#top_menu .nav-item a:contains("Random!")',
+    },
+    {
+        content: "Click on Edit Link",
+        trigger: '.o_edit_menu_popover a.o_we_edit_link',
+    },
+    {
+        content: "Change the label",
+        trigger: '.o_link_dialog #o_link_dialog_label_input',
+        run: 'text Modnar',
+    },
+    clickOnSave,
+    {
+        content: "Label should have changed",
+        trigger: '#top_menu .nav-item a:contains("Modnar")',
+        run: () => {}, // It's a check.
+    },
+]);

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -84,6 +84,7 @@ tour.register('edit_menus', {
     clickOnSave,
     clickOnSave,
     wTourUtils.clickOnEdit(),
+    // Edit the new menu item from the "edit link" popover button
     wTourUtils.clickOnExtraMenuItem({extra_trigger: '#oe_snippets.o_loaded'}),
     {
         content: "Menu should have a new link item",
@@ -99,9 +100,37 @@ tour.register('edit_menus', {
         run: 'text Modnar',
     },
     clickOnSave,
+    ...wTourUtils.clickOnSave(),
+    // Edit the menu item from the "edit menu" popover button
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: '#oe_snippets.o_loaded'}),
     {
         content: "Label should have changed",
         trigger: '#top_menu .nav-item a:contains("Modnar")',
+    },
+    {
+        content: "Click on the popover Edit Menu button",
+        trigger: '.o_edit_menu_popover a.js_edit_menu',
+    },
+    {
+        content: "Click on the dialog Edit Menu button",
+        trigger: '.oe_menu_editor .js_menu_label:contains("Modnar")',
+        run: function () {
+            const liEl = this.$anchor[0].closest('[data-menu-id]');
+            liEl.querySelector('button.js_edit_menu').click();
+        },
+    },
+    {
+        content: "Change the label",
+        trigger: '.o_link_dialog #o_link_dialog_label_input',
+        run: 'text Modnar !!',
+    },
+    clickOnSave,
+    clickOnSave,
+    wTourUtils.clickOnExtraMenuItem({extra_trigger: 'a[data-action=edit]'}),
+    {
+        content: "Label should have changed",
+        trigger: '#top_menu .nav-item a:contains("Modnar !!")',
         run: () => {}, // It's a check.
     },
 ]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -278,3 +278,9 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_15_website_link_tools(self):
         self.start_tour("/", "link_tools", login="admin")
+
+    def test_16_website_edit_megamenu(self):
+        self.start_tour("/", "edit_megamenu", login="admin")
+
+    def test_17_website_edit_menus(self):
+        self.start_tour("/", "edit_menus", login="admin")


### PR DESCRIPTION
There was an issue when saving the LinkDialog with invalid data.
The _DialogLinkWidget.save methods return values were not consistent.

Also, tests are added for the menu and mega menu edition.

task-2513588


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
