### PR TITLE
[FIX] l10n_fr_pos_cert: hash doesn't appear in ticket during reprint

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -127,6 +127,11 @@ class pos_order(models.Model):
             if order.company_id._is_accounting_unalterable():
                 raise UserError(_("According to French law, you cannot delet a point of sale order."))
         return super(pos_order, self).unlink()
+    
+    def _export_for_ui(self, order):
+        res = super()._export_for_ui(order)
+        res['l10n_fr_hash'] = order.l10n_fr_hash
+        return res
 
 
 class PosOrderLine(models.Model):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create a pos order, pay and valide
- Close Pos
- reopen pos
- search this order
- click print ticket

--> Issue the hash doesn't appear on the ticket


@oco-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
