### PR TITLE
[FIX] point_of_sale : prevent wrong cutting

### DIFF
--- a/addons/point_of_sale/i18n/ar.po
+++ b/addons/point_of_sale/i18n/ar.po
@@ -2973,6 +2973,7 @@ msgstr "الطلب"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/bg.po
+++ b/addons/point_of_sale/i18n/bg.po
@@ -2963,6 +2963,7 @@ msgstr "Поръчка"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/bn.po
+++ b/addons/point_of_sale/i18n/bn.po
@@ -2915,6 +2915,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/ca.po
+++ b/addons/point_of_sale/i18n/ca.po
@@ -2959,6 +2959,7 @@ msgstr "Ordre"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/ckb.po
+++ b/addons/point_of_sale/i18n/ckb.po
@@ -2913,6 +2913,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/cs.po
+++ b/addons/point_of_sale/i18n/cs.po
@@ -2982,6 +2982,7 @@ msgstr "Objednávka"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Objednávka %s"

--- a/addons/point_of_sale/i18n/da.po
+++ b/addons/point_of_sale/i18n/da.po
@@ -3000,6 +3000,7 @@ msgstr "Ordre"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Ordre %s"

--- a/addons/point_of_sale/i18n/de.po
+++ b/addons/point_of_sale/i18n/de.po
@@ -3000,6 +3000,7 @@ msgstr "Auftrag"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Auftrag %s"

--- a/addons/point_of_sale/i18n/el.po
+++ b/addons/point_of_sale/i18n/el.po
@@ -2940,6 +2940,7 @@ msgstr "Παραγγελία"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/eo.po
+++ b/addons/point_of_sale/i18n/eo.po
@@ -2878,6 +2878,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/es.po
+++ b/addons/point_of_sale/i18n/es.po
@@ -2994,6 +2994,7 @@ msgstr "Pedido"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Orden %s"

--- a/addons/point_of_sale/i18n/et.po
+++ b/addons/point_of_sale/i18n/et.po
@@ -2962,6 +2962,7 @@ msgstr "Ost"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Tellimus %s"

--- a/addons/point_of_sale/i18n/eu.po
+++ b/addons/point_of_sale/i18n/eu.po
@@ -2932,6 +2932,7 @@ msgstr "Eskaera"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/fa.po
+++ b/addons/point_of_sale/i18n/fa.po
@@ -2932,6 +2932,7 @@ msgstr "سفارش"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "سفارش %s"

--- a/addons/point_of_sale/i18n/fi.po
+++ b/addons/point_of_sale/i18n/fi.po
@@ -2945,6 +2945,7 @@ msgstr "Tilaus"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Tilaus %s"

--- a/addons/point_of_sale/i18n/fr.po
+++ b/addons/point_of_sale/i18n/fr.po
@@ -3051,6 +3051,7 @@ msgstr "Commande"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Commande %s"

--- a/addons/point_of_sale/i18n/he.po
+++ b/addons/point_of_sale/i18n/he.po
@@ -2965,6 +2965,7 @@ msgstr "הזמנה"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "הזמנה %s"

--- a/addons/point_of_sale/i18n/hi.po
+++ b/addons/point_of_sale/i18n/hi.po
@@ -2910,6 +2910,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/hr.po
+++ b/addons/point_of_sale/i18n/hr.po
@@ -2935,6 +2935,7 @@ msgstr "Narudžba"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/hu.po
+++ b/addons/point_of_sale/i18n/hu.po
@@ -2940,6 +2940,7 @@ msgstr "Rendelés"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "%s rendelés"

--- a/addons/point_of_sale/i18n/id.po
+++ b/addons/point_of_sale/i18n/id.po
@@ -2966,6 +2966,7 @@ msgstr "Order"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/it.po
+++ b/addons/point_of_sale/i18n/it.po
@@ -2996,6 +2996,7 @@ msgstr "Ordine"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Ordine %s"

--- a/addons/point_of_sale/i18n/ja.po
+++ b/addons/point_of_sale/i18n/ja.po
@@ -2934,6 +2934,7 @@ msgstr "オーダ"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "注文%s"

--- a/addons/point_of_sale/i18n/ka.po
+++ b/addons/point_of_sale/i18n/ka.po
@@ -2911,6 +2911,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/km.po
+++ b/addons/point_of_sale/i18n/km.po
@@ -2928,6 +2928,7 @@ msgstr "បញ្ជាទិញ"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/ko.po
+++ b/addons/point_of_sale/i18n/ko.po
@@ -2938,6 +2938,7 @@ msgstr "주문"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "%s 주문"

--- a/addons/point_of_sale/i18n/lv.po
+++ b/addons/point_of_sale/i18n/lv.po
@@ -2919,6 +2919,7 @@ msgstr "Maksājuma uzdevums"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/mn.po
+++ b/addons/point_of_sale/i18n/mn.po
@@ -2982,6 +2982,7 @@ msgstr "Захиалга"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Ордер%s"

--- a/addons/point_of_sale/i18n/nb.po
+++ b/addons/point_of_sale/i18n/nb.po
@@ -2967,6 +2967,7 @@ msgstr "Ordre"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Ordre %s"

--- a/addons/point_of_sale/i18n/nl.po
+++ b/addons/point_of_sale/i18n/nl.po
@@ -3004,6 +3004,7 @@ msgstr "Order"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Order %s"

--- a/addons/point_of_sale/i18n/pl.po
+++ b/addons/point_of_sale/i18n/pl.po
@@ -2979,6 +2979,7 @@ msgstr "Zamówienie"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -2906,6 +2906,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/pt.po
+++ b/addons/point_of_sale/i18n/pt.po
@@ -2936,6 +2936,7 @@ msgstr "Ordem"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/pt_BR.po
+++ b/addons/point_of_sale/i18n/pt_BR.po
@@ -3026,6 +3026,7 @@ msgstr "Pedido"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Pedido %s"

--- a/addons/point_of_sale/i18n/ro.po
+++ b/addons/point_of_sale/i18n/ro.po
@@ -3000,6 +3000,7 @@ msgstr "Comandă"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Comandă %s"

--- a/addons/point_of_sale/i18n/ru.po
+++ b/addons/point_of_sale/i18n/ru.po
@@ -2981,6 +2981,7 @@ msgstr "Заказ"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/si.po
+++ b/addons/point_of_sale/i18n/si.po
@@ -2906,6 +2906,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/sk.po
+++ b/addons/point_of_sale/i18n/sk.po
@@ -2967,6 +2967,7 @@ msgstr "Poradie"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/sl.po
+++ b/addons/point_of_sale/i18n/sl.po
@@ -2936,6 +2936,7 @@ msgstr "Vrstni red"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/sv.po
+++ b/addons/point_of_sale/i18n/sv.po
@@ -2931,6 +2931,7 @@ msgstr "Order"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Order %s"

--- a/addons/point_of_sale/i18n/th.po
+++ b/addons/point_of_sale/i18n/th.po
@@ -2923,6 +2923,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/i18n/tr.po
+++ b/addons/point_of_sale/i18n/tr.po
@@ -3011,6 +3011,7 @@ msgstr "Sipariş"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Order %s"

--- a/addons/point_of_sale/i18n/uk.po
+++ b/addons/point_of_sale/i18n/uk.po
@@ -2982,6 +2982,7 @@ msgstr "Замовлення"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Замовлення %s"

--- a/addons/point_of_sale/i18n/vi.po
+++ b/addons/point_of_sale/i18n/vi.po
@@ -2995,6 +2995,7 @@ msgstr "Lệnh"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "Đơn hàng %s"

--- a/addons/point_of_sale/i18n/zh_CN.po
+++ b/addons/point_of_sale/i18n/zh_CN.po
@@ -2950,6 +2950,7 @@ msgstr "订单"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr "订单 %s"

--- a/addons/point_of_sale/i18n/zh_TW.po
+++ b/addons/point_of_sale/i18n/zh_TW.po
@@ -2925,6 +2925,7 @@ msgstr "訂單"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:0
 #: code:addons/point_of_sale/static/src/js/models.js:0
+#: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Order %s"
 msgstr ""

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -682,7 +682,7 @@ class PosOrder(models.Model):
             'lines': [[0, 0, line] for line in order.lines.export_for_ui()],
             'statement_ids': [[0, 0, payment] for payment in order.payment_ids.export_for_ui()],
             'name': order.pos_reference,
-            'uid': order.pos_reference[6:],
+            'uid': order.pos_reference[len(_("Order %s")) - 2:],
             'amount_paid': order.amount_paid,
             'amount_total': order.amount_total,
             'amount_tax': order.amount_tax,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Use Pos in french
- Create a new order, pay
- in database pos_reference is `Commande 0001-0001-00001`
- Close POS
- Reopen
- Click on the search button
- The command number is now `1-0001-00001`
Because 6 is arbitrary : https://github.com/odoo/odoo/blob/14.0/addons/point_of_sale/models/pos_order.py#L685


FIX for master : https://github.com/odoo/odoo/pull/71182


@bfr-o 
@pimodoo

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
