### PR TITLE
[IMP] web_editor, website: not display edit link popover if not needed

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -185,8 +185,10 @@ const LinkPopoverWidget = Widget.extend({
 });
 
 LinkPopoverWidget.createFor = async function (parent, targetEl) {
+    const noLinkPopoverClass = ".o_no_link_popover, .carousel-control-prev, .carousel-control-next";
     // Target might already have a popover, eg cart icon in navbar
-    if ($(targetEl).data('bs.popover')) {
+    const alreadyPopover = $(targetEl).data('bs.popover');
+    if (alreadyPopover || $(targetEl).is(noLinkPopoverClass) || !!$(targetEl).parents(noLinkPopoverClass).length) {
         return null;
     }
     const popoverWidget = new this(parent, targetEl);

--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-lg-3 s_table_of_content_navbar_wrap s_table_of_content_navbar_sticky                         s_table_of_content_vertical_navbar d-print-none d-none d-lg-block o_not_editable o_cc o_cc1" data-name="Navbar">
-                    <div class="s_table_of_content_navbar list-group"/>
+                    <div class="s_table_of_content_navbar list-group o_no_link_popover"/>
                 </div>
                 <div class="col-lg-9 s_table_of_content_main oe_structure oe_empty" data-name="Content">
                     <section class="pb16">

--- a/addons/website/views/snippets/s_tabs.xml
+++ b/addons/website/views/snippets/s_tabs.xml
@@ -5,7 +5,7 @@
     <section class="s_tabs pt48 pb48" data-vcss="001">
         <div class="container">
             <div class="s_tabs_main">
-                <div class="s_tabs_nav mb-3">
+                <div class="s_tabs_nav mb-3 o_no_link_popover">
                     <ul class="nav nav-pills justify-content-center" role="tablist">
                         <li class="nav-item">
                             <a class="nav-link active" id="nav_tabs_link_1" data-toggle="tab" href="#nav_tabs_content_1" role="tab" aria-controls="nav_tabs_content_1" aria-selected="true">Home</a>


### PR DESCRIPTION
This commit allows not to display the popover where we don't need it.
Like on the next or prev buttons of the carousel for example.

task-2537840

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
