### PR TITLE
[IMP] stock: Inventory adjustments improvements

### DIFF
--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -32,7 +32,7 @@
         <field name="model">stock.quant</field>
         <field name="inherit_id" ref="stock.view_stock_quant_tree_editable"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='inventory_quantity']" position="before">
+            <xpath expr="//field[@name='inventory_quantity_auto_apply']" position="before">
                 <field name="use_expiration_date" invisible="1"/>
                 <field name="removal_date" optional="show"
                     invisible="context.get('hide_removal_date')" attrs="{'readonly': ['|', ('tracking', '=', 'none'), ('use_expiration_date', '=', False)]}"/>

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -60,6 +60,8 @@
         'wizard/stock_track_confirmation_views.xml',
         'wizard/stock_orderpoint_snooze_views.xml',
         'wizard/stock_package_destination_views.xml',
+        'wizard/stock_inventory_adjustment_name.xml',
+        'wizard/stock_inventory_warning.xml',
 
         'views/res_partner_views.xml',
         'views/product_strategy_views.xml',
@@ -110,6 +112,7 @@
             'stock/static/src/js/stock_traceability_report_widgets.js',
             'stock/static/src/js/popover_widget.js',
             'stock/static/src/js/forecast_widget.js',
+            'stock/static/src/js/counted_quantity_widget.js',
             'stock/static/src/js/basic_model.js',
             'stock/static/src/js/stock_rescheduling_popover.js',
             'stock/static/tests/tours/stock_report_tests.js',

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -84,4 +84,6 @@ access_stock_storage_category_manager,stock.storage.category.manager,model_stock
 access_stock_storage_category_capacity_user,stock.storage.category.capacity.user,model_stock_storage_category_capacity,base.group_user,1,0,0,0
 access_stock_storage_category_capacity_manager,stock.storage.category.capacity.manager,model_stock_storage_category_capacity,stock.group_stock_manager,1,1,1,1
 access_stock_inventory_conflict,stock.inventory.conflict,model_stock_inventory_conflict,stock.group_stock_manager,1,1,1,0
+access_stock_inventory_warning,stock.inventory.warning,model_stock_inventory_warning,stock.group_stock_manager,1,1,1,0
+access_stock_inventory_adjustment_name,stock.inventory.adjustment.name,model_stock_inventory_adjustment_name,stock.group_stock_manager,1,1,1,0
 access_stock_request_count,stock.request.count,model_stock_request_count,stock.group_stock_manager,1,1,1,0

--- a/addons/stock/static/src/js/counted_quantity_widget.js
+++ b/addons/stock/static/src/js/counted_quantity_widget.js
@@ -1,0 +1,36 @@
+/** @odoo-module alias=stock.counted_quantity_widget **/
+
+import BasicFields from 'web.basic_fields';
+import fieldRegistry from 'web.field_registry';
+
+const CountedQuantityWidgetField = BasicFields.FieldFloat.extend({
+    supportedFieldTypes: ['float'],
+
+     _renderReadonly: function () {
+        if (this.recordData.inventory_quantity_set) {
+            this.el.textContent = this._formatValue(this.recordData.inventory_quantity);
+        } else {
+            this.el.textContent = "";
+        }
+    },
+
+    _onChange: function () {
+        if (!this.recordData.inventory_quantity_set) {
+            this.recordData.inventory_quantity_set = true;
+        }
+        this._super.apply(this);
+    },
+
+    _isSameValue: function(value) {
+        // We want to trigger the update of the view when inserting 0
+        if (value == 0) {
+            return false;
+        }
+        return this._super(...arguments);
+    }
+
+});
+
+fieldRegistry.add('counted_quantity_widget', CountedQuantityWidgetField);
+
+export default CountedQuantityWidgetField;

--- a/addons/stock/static/src/js/inventory_singleton_list_controller.js
+++ b/addons/stock/static/src/js/inventory_singleton_list_controller.js
@@ -21,20 +21,6 @@ var _t = core._t;
  */
 
 var SingletonListController = InventoryReportListController.extend({
-    buttons_template: 'StockQuant.Buttons',
-
-    // -------------------------------------------------------------------------
-    // Public
-    // -------------------------------------------------------------------------
-    /**
-     * @override
-     */
-    renderButtons: function ($node) {
-        this._super.apply(this, arguments);
-        this.$buttons.on('click', '.o_button_apply_inventory', this._onApplyInventory.bind(this));
-        this.$buttons.on('click', '.o_button_request_count_inventory', this._onRequestCountInventory.bind(this));
-        this.$buttons.on('click', '.o_button_set_inventory', this._onSetInventory.bind(this));
-    },
 
     // -------------------------------------------------------------------------
     // Private
@@ -85,53 +71,9 @@ var SingletonListController = InventoryReportListController.extend({
         }
     },
 
-    /**
-     * Override to show/hide inventory adjustment specific buttons.
-     * Maybe a bit too hacky since it's not the intended purpose of this function,
-     * but for some reason `_updateControlPanel` isn't called during reload action
-     * after triggering any of these buttons.
-     *
-     * @override
-     */
-    _renderHeaderButtons() {
-        this._super.apply(this, arguments);
-
-        if (this.selectedRecords.length > 0 && !this.context.inventory_report_mode) {
-            $('.o_button_apply_inventory').removeClass('d-none');
-            $('.o_button_request_count_inventory').removeClass('d-none');
-            $('.o_button_set_inventory').removeClass('d-none');
-        } else {
-            $('.o_button_apply_inventory').addClass('d-none');
-            $('.o_button_request_count_inventory').addClass('d-none');
-            $('.o_button_set_inventory').addClass('d-none');
-        }
-    },
-
     // -------------------------------------------------------------------------
     // Handlers
     // -------------------------------------------------------------------------
-
-    _onApplyInventory: function (ev) {
-        var self = this;
-        var ids = this.getSelectedIds();
-        if (!ids.length) {
-            var modified_records = this.initialState.data.filter(record => record.data.inventory_diff_quantity != 0)
-            ids = modified_records.map(record => record.data.id)
-        }
-        if (ids.length) {
-            return this._rpc({
-                model: 'stock.quant',
-                method: 'action_apply_inventory',
-                args: [ids],
-                context: this.context,
-            }).then((result) => {
-                if (!result) {
-                    return self.trigger_up('reload');
-                }
-                return self.do_action(result, {on_close: () => this.reload(),});
-            })
-        }
-    },
 
     /**
      *
@@ -152,34 +94,6 @@ var SingletonListController = InventoryReportListController.extend({
         }).then(function () {
             self._enableButtons();
         }).guardedCatch(this._enableButtons.bind(this));
-    },
-
-    _onRequestCountInventory: function (ev) {
-        var ids = this.getSelectedIds();
-        if ( ids.length ) {
-            return this.do_action('stock.action_stock_request_count',
-            {
-                additional_context: {
-                        default_quant_ids: ids,
-                },
-                on_close: () => this.reload(),
-            });
-        }
-    },
-
-    _onSetInventory: function (ev) {
-        var self = this;
-        var ids = this.getSelectedIds();
-        if (ids.length) {
-            return this._rpc({
-                model: 'stock.quant',
-                method: 'action_set_inventory_quantity',
-                args: [ids],
-                context: this.context,
-            }).then(() => {
-                return self.trigger_up('reload');
-            });
-        }
     },
 });
 

--- a/addons/stock/static/src/xml/inventory_report.xml
+++ b/addons/stock/static/src/xml/inventory_report.xml
@@ -9,18 +9,4 @@
     </t>
 </t>
 
-<t t-extend="StockInventoryReport.Buttons" t-name="StockQuant.Buttons">
-    <t t-jquery="button.o_button_at_date" t-operation="after">
-        <button class="btn btn-primary d-none o_button_apply_inventory" type="button">
-            Apply
-        </button>
-        <button class="btn btn-primary d-none o_button_set_inventory" type="button">
-            Set
-        </button>
-        <button class="btn btn-primary d-none o_button_request_count_inventory" type="button">
-            Request a Count
-        </button>
-    </t>
-</t>
-
 </templates>

--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -354,7 +354,7 @@ class TestInventory(TransactionCase):
         conflict_wizard_form = Form(self.env['stock.inventory.conflict'].with_context(conflict_wizard_values['context']))
         conflict_wizard = conflict_wizard_form.save()
         conflict_wizard.quant_to_fix_ids.inventory_quantity = 5
-        conflict_wizard.action_validate()
+        conflict_wizard.action_keep_counted_quantity()
         self.assertEqual(inventory_quant.inventory_diff_quantity, 0)
         self.assertEqual(inventory_quant.inventory_quantity, 0)
         self.assertEqual(inventory_quant.quantity, 5)

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -18,9 +18,9 @@
                     <filter name='internal_loc' string="Internal Locations" domain="[('location_id.usage','=', 'internal')]"/>
                     <filter name='transit_loc' string="Transit Locations" domain="[('location_id.usage' ,'=', 'transit')]"/>
                     <filter name="on_hand" string="On Hand" domain="[('on_hand', '=', True)]"/>
+                    <filter name="to_apply" string="To Apply" domain="[('inventory_quantity_set', '=', True)]"/>
                     <separator/>
                     <filter name="negative" string="Negative Stock" domain="[('quantity', '&lt;', 0.0)]"/>
-                    <filter name="positive" string="Positive Stock" domain="[('quantity', '&gt;', 0.0)]"/>
                     <filter name="reserved" string="Reservations" domain="[('reserved_quantity', '&gt;', 0.0)]"/>
                     <separator/>
                     <filter name="filter_in_date" date="in_date"/>
@@ -143,9 +143,7 @@
                 <field name="owner_id" groups="stock.group_tracking_owner"
                        attrs="{'readonly': [('id', '!=', False)]}"
                        options="{'no_create': True}"/>
-                <field name="inventory_quantity" string="Updated On Hand Quantity" decoration-danger="inventory_quantity &lt; 0"
-                       readonly="0"/>
-                <field name="quantity" string="On Hand Quantity"/>
+                <field name="inventory_quantity_auto_apply" string="On Hand Quantity" readonly="0"/>
                 <field name="available_quantity" optional="show"/>
                 <field name="product_uom_id" groups="uom.group_uom"/>
                 <field name='company_id' groups="base.group_multi_company" optional="show"/>
@@ -340,9 +338,17 @@
         <field name="model">stock.quant</field>
         <field eval="10" name="priority"/>
         <field name="arch" type="xml">
-            <tree default_order="location_id, inventory_date, product_id, package_id, lot_id, owner_id" editable="bottom" create="1" edit="1" import="0" js_class="singleton_list" sample="1">
+            <tree default_order="location_id, inventory_date, product_id, package_id, lot_id, owner_id" decoration-warning='is_outdated' editable="bottom" create="1" edit="1" import="0" js_class="singleton_list" sample="1">
+                <header>
+                    <button name="stock.action_stock_inventory_adjustement_name" groups="stock.group_stock_manager" type="action" string="Apply"/>
+                    <button name="action_set_inventory_quantity" type="object" string="Set"/>
+                    <button name="action_reset" type="object" string="Clear"/>
+                    <button name="stock.action_stock_request_count" groups="stock.group_stock_manager" type="action" string="Request a Count"/>
+                </header>
                 <field name="id" invisible="1"/>
+                <field name="is_outdated" invisible="1"/>
                 <field name="tracking" invisible="1"/>
+                <field name="inventory_quantity_set" invisible="1"/>
                 <field name="location_id" domain="[('usage', 'in', ['internal', 'transit'])]" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)" options="{'no_create': True}"/>
                 <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}" readonly="context.get('single_product', False)" force_save="1" options="{'no_create': True}"/>
                 <field name="lot_id" groups="stock.group_production_lot"
@@ -354,15 +360,15 @@
                 <field name="available_quantity" string="Available Quantity" decoration-danger="available_quantity &lt; 0" optional="hidden"/>
                 <field name="quantity" optional="show" string="On Hand Quantity"/>
                 <field name="product_uom_id" groups="uom.group_uom" string="UoM"/>
-                <field name="inventory_quantity" decoration-muted="inventory_quantity == 0"/>
-                <field name="inventory_diff_quantity" string="Difference" decoration-muted="inventory_quantity == 0" decoration-danger="inventory_diff_quantity &lt; 0" decoration-success="inventory_diff_quantity &gt; 0" decoration-bf="inventory_diff_quantity != 0"/>
+                <field name="inventory_quantity" widget="counted_quantity_widget"/>
+                <field name="inventory_diff_quantity" string="Difference"  attrs="{'invisible': [('inventory_quantity_set', '=', False)]}" decoration-muted="inventory_quantity == 0" decoration-danger="inventory_diff_quantity &lt; 0" decoration-success="inventory_diff_quantity &gt; 0" decoration-bf="inventory_diff_quantity != 0"/>
                 <field name="inventory_date" optional="show"/>
                 <field name="user_id" string="User" optional="show"/>
                 <field name='company_id' groups="base.group_multi_company" optional="hide"/>
-                <button name="action_apply_inventory" groups="stock.group_stock_manager" type="object" string="Apply" class="btn btn-link" icon="fa-save" attrs="{'invisible': [('inventory_diff_quantity', '=', 0), ('inventory_quantity', '=', 0), ('quantity', '!=', 0)]}"/>
-                <button name="action_set_inventory_quantity" type="object" string="Set" class="btn btn-link" icon="fa-bullseye" attrs="{'invisible': ['|',  '|', ('quantity', '=', 0.0), ('inventory_diff_quantity', '!=', 0), ('inventory_quantity', '!=', 0)]}"/>
-                <button name="action_inventory_history" type="object" class="btn btn-link" icon="fa-history" string="History"/>
-                <button name="action_set_inventory_quantity_to_zero" type="object" string="Reset" class="btn" icon="fa-times" attrs="{'invisible': [('inventory_diff_quantity', '=', 0), ('inventory_quantity', '=', 0), ('quantity', '!=', 0)]}"/>
+                <button name="action_inventory_history" type="object" class="btn btn-link text-info" icon="fa-history" string="History"/>
+                <button name="action_apply_inventory" groups="stock.group_stock_manager" type="object" string="Apply" class="btn btn-link text-success" icon="fa-save" attrs="{'invisible': [('inventory_quantity_set', '=', False)]}"/>
+                <button name="action_set_inventory_quantity" type="object" string="Set" class="btn btn-link" icon="fa-bullseye" attrs="{'invisible': [('inventory_quantity_set', '=', True)]}"/>
+                <button name="action_set_inventory_quantity_to_zero" type="object" string="Clear" class="btn text-warning" icon="fa-times" attrs="{'invisible': [('inventory_quantity_set', '=', False)]}"/>
             </tree>
         </field>
     </record>

--- a/addons/stock/wizard/__init__.py
+++ b/addons/stock/wizard/__init__.py
@@ -5,6 +5,8 @@ from . import stock_assign_serial_numbers
 from . import stock_picking_return
 from . import stock_change_product_qty
 from . import stock_inventory_conflict
+from . import stock_inventory_warning
+from . import stock_inventory_adjustment_name
 from . import stock_scheduler_compute
 from . import stock_immediate_transfer
 from . import stock_backorder_confirmation

--- a/addons/stock/wizard/stock_inventory_adjustment_name.py
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class StockInventoryAdjustmentName(models.TransientModel):
+    _name = 'stock.inventory.adjustment.name'
+    _description = 'Inventory Adjustment Name'
+
+    def _default_inventory_adjustment_name(self):
+        return _("Inventory Adjustment") + " - " + fields.Date.to_string(fields.Date.today())
+
+    quant_ids = fields.Many2many('stock.quant')
+    inventory_adjustment_name = fields.Char(default=_default_inventory_adjustment_name)
+
+    def action_apply(self):
+        return self.quant_ids.with_context(
+            inventory_name=self.inventory_adjustment_name).action_apply_inventory()

--- a/addons/stock/wizard/stock_inventory_adjustment_name.xml
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_inventory_adjustment_name_form_view" model="ir.ui.view">
+        <field name="name">stock.inventory.adjustment.name.form.view</field>
+        <field name="model">stock.inventory.adjustment.name</field>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    <group>
+                        <field name="inventory_adjustment_name" string="Inventory Reference"/>
+                    </group>
+                </div>
+                <footer>
+                    <button name="action_apply" string="Apply" type="object" class="btn-primary"/>
+                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="action_stock_inventory_adjustement_name" model="ir.actions.act_window">
+        <field name="name">Name Inventory Adjustement</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.inventory.adjustment.name</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="stock_inventory_adjustment_name_form_view"/>
+        <field name="context">{
+            'default_quant_ids': active_ids
+        }</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/addons/stock/wizard/stock_inventory_conflict.xml
+++ b/addons/stock/wizard/stock_inventory_conflict.xml
@@ -7,12 +7,20 @@
         <field name="arch" type="xml">
             <form>
                 <div>
-                    <strong>Some moves were made since your last inventory count. Plese count the inventory quantity again.</strong>
+                    <strong>Due to some stock moves done between your initial update of the quantity and now, the difference of quantity is not consistent anymore.</strong>
+                </div>
+                <div>
+                    You can either :
+                    <ul>
+                        <li>Keep the <strong>Counted Quantity</strong> (the Difference will be updated)</li>
+                        <li>Keep the <strong>Difference</strong> (the Counted Quantity will be updated to reflect the same difference as when you counted)</li>
+                        <li>Discard and manually resolve the conflict</li>
+                    </ul>
                 </div>
                 <div>
                     <br/>
                     <field name="quant_ids" invisible="1"/>
-                    <field name="quant_to_fix_ids" style="margin-top:10px;">
+                    <field name="quant_to_fix_ids" readonly="1" style="margin-top:10px;">
                         <tree editable="bottom" create="0" delete="0">
                             <field name="id" invisible="1"/>
                             <field name="tracking" invisible="1"/>
@@ -33,7 +41,8 @@
                     </field>
                 </div>
                 <footer>
-                    <button name="action_validate" string="Confirm" type="object" class="btn-primary"/>
+                    <button name="action_keep_counted_quantity" string="Keep Counted Quantity" type="object" class="btn-primary"/>
+                    <button name="action_keep_difference" string="Keep Difference" type="object" class="btn-primary"/>
                     <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel"/>
                 </footer>
             </form>

--- a/addons/stock/wizard/stock_inventory_warning.py
+++ b/addons/stock/wizard/stock_inventory_warning.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class StockInventoryWarning(models.TransientModel):
+    _name = 'stock.inventory.warning'
+    _description = 'Inventory Adjustment Warning'
+
+    quant_ids = fields.Many2many('stock.quant')
+
+    def action_apply(self):
+        return self.quant_ids.filtered(lambda q: q.inventory_quantity_set).action_apply_inventory()
+
+    def action_reset(self):
+        return self.quant_ids.action_set_inventory_quantity_to_zero()
+
+    def action_set(self):
+        valid_quants = self.quant_ids.filtered(lambda quant: not quant.inventory_quantity_set)
+        return valid_quants.action_set_inventory_quantity()

--- a/addons/stock/wizard/stock_inventory_warning.xml
+++ b/addons/stock/wizard/stock_inventory_warning.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="inventory_warning_reset_view" model="ir.ui.view">
+        <field name="name">inventory.reset.warning.view</field>
+        <field name="model">stock.inventory.warning</field>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    This will discard all unapplied counts, do you want to proceed?
+                </div>
+                <footer>
+                    <button name="action_reset" string="Continue" type="object" class="btn-primary"/>
+                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="inventory_warning_set_view" model="ir.ui.view">
+        <field name="name">inventory.set.warning.view</field>
+        <field name="model">stock.inventory.warning</field>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    Some selected lines already have quantities set, they will be ignored.
+                </div>
+                <footer>
+                    <button name="action_set" string="Continue" type="object" class="btn-primary"/>
+                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="inventory_warning_apply_view" model="ir.ui.view">
+        <field name="name">inventory.apply.warning.view</field>
+        <field name="model">stock.inventory.warning</field>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    Some selected lines don't have any quantities set, they will be ignored.
+                </div>
+                <footer>
+                    <button name="action_apply" string="Continue" type="object" class="btn-primary"/>
+                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock/wizard/stock_request_count.xml
+++ b/addons/stock/wizard/stock_request_count.xml
@@ -25,6 +25,9 @@
         <field name="res_model">stock.request.count</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="stock_inventory_request_count_form_view"/>
+        <field name="context">{
+            'default_quant_ids': active_ids
+        }</field>
         <field name="target">new</field>
     </record>
 </odoo>


### PR DESCRIPTION
General improvements of the new Inventory Adjustment mechanism, among which:
- From the Inventory Adjustment page
  - A new `inventory_quantity_set` Boolean field is used to hide the Counted Quantity when not set instead of showing 0.
  - Possibile to set 0 as a Counted Quantity directly (not using the set button).
  - Allows to provide a name for the Inventory Adjustment when using the Apply button at the top of the tree view. This name is applied on the corresponding stock moves.
  - Add warnings when trying to Apply/Set on multiple records when some records are not set/already set.
  - Highlight lines when there is a mismatch between Quantity / Counted Quantity / Difference. If the user still tries to Apply, shows the option to either keep the current Difference or the current Counted Quantity for all records.
  - Set the user when directly inserting a Counted Quantity (before only when using the Set button)
  - Add the possibility to import records.
  - Add "To Apply" filter.
  - Add a 'Reset' button at the top of the tree view for multiple records.
- From the Update Quantity page of a product
  - Remove the "Updated on Hand Quantity" and can directly change "On Hand" quantity
  - Pre-fill a default location (Last used location for tracked products or default destination location in single WH environment)
- From the Inventory Report
  - Remove the "Updated on Hand Quantity" and can directly change "On Hand" quantity

Task-ID: 2495664


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
