### PR TITLE
[FIX] l10n_cl: module category

### DIFF
--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -10,7 +10,7 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes
     """,
     'author': 'Blanco Martín & Asociados',
     'website': 'https://www.odoo.com/documentation/14.0/applications/finance/accounting/fiscal_localizations/localizations/chile.html',
-    'category': 'Localization',
+    'category': 'Accounting/Localizations/Account Charts',
     'depends': [
         'contacts',
         'base_address_city',


### PR DESCRIPTION
Localization modules need to be `Accounting/Localizations/Account Charts`
Because this will install `l10n_generic_coa` otherwise
https://github.com/odoo/odoo/blob/36a9e761c8d6c1c6e9611cc410ecca82ff2b1659/addons/account/__init__.py#L28

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
