### PR TITLE
[Fix] Ensure message is translatable

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -915,7 +915,7 @@ class HolidaysRequest(models.Model):
         # Post a second message, more verbose than the tracking message
         for holiday in self.filtered(lambda holiday: holiday.employee_id.user_id):
             holiday.message_post(
-                body=_('Your %s planned on %s has been accepted' % (holiday.holiday_status_id.display_name, holiday.date_from)),
+                body=_('Your %s planned on %s has been accepted') % (holiday.holiday_status_id.display_name, holiday.date_from),
                 partner_ids=holiday.employee_id.user_id.partner_id.ids)
 
         self.filtered(lambda hol: not hol.validation_type == 'both').action_validate()

--- a/doc/cla/individual/janikvonrotz.md
+++ b/doc/cla/individual/janikvonrotz.md
@@ -1,0 +1,11 @@
+Switzerland, 2021-05-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Janik von Rotz login@janikvonrotz.ch https://github.com/janikvonrotz


### PR DESCRIPTION
The closing bracket for the translation key is at the wrong position.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Translation key `Your %s planned on %s has been refused` is not translatable.

Desired behavior after PR is merged:

Translation key `Your %s planned on %s has been refused` is translatable.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
