### PR TITLE
[FIX] website_slides: set PdfFileReader to strict=False

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -351,7 +351,7 @@ class Slide(models.Model):
         if self.datas:
             data = base64.b64decode(self.datas)
             if data.startswith(b'%PDF-'):
-                pdf = PyPDF2.PdfFileReader(io.BytesIO(data), overwriteWarnings=False)
+                pdf = PyPDF2.PdfFileReader(io.BytesIO(data), overwriteWarnings=False, strict=False)
                 self.completion_time = (5 * len(pdf.pages)) / 60
 
     @api.depends('name', 'channel_id.website_id.domain')


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to elearning app > Courses > content
- Create new slide > Upload a PDF file with faulty content

Problem :
Pypdf2 throws errors because it does not support some content or syntax.
In our case we are just trying to get the number of pages in the PDF, so if we put `strict = false`
we just determine that the user should not be informed of all the errors that pypdf2 encounters,
the flag `strict` is not a security indicator.

FYI: https://pythonhosted.org/PyPDF2/PdfFileReader.html
``` strict (bool) - Determines whether user should be warned of all problems and also causes some correctable problems to be fatal. Defaults to True.```

opw-2530829


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
