### PR TITLE
[IMP] purchase_requisition: Add archived in purchase agreement types

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -34,6 +34,7 @@ class PurchaseRequisitionType(models.Model):
     line_copy = fields.Selection([
         ('copy', 'Use lines of agreement'), ('none', 'Do not create RfQ lines automatically')],
         string='Lines', required=True, default='copy')
+    active = fields.Boolean(default=True, help="Set active to false to hide the Purchase Agreement Types without removing it.")
 
 
 class PurchaseRequisition(models.Model):

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -44,10 +44,12 @@
         <field name="arch" type="xml">
             <form string="Purchase Agreement Types">
             <sheet>
+                <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <group>
                     <group string="Agreement Type">
                         <field name="name"/>
                         <field name="exclusive" widget="radio"/>
+                        <field name="active" invisible="1"/>
                     </group>
                     <group string="Data for new quotations">
                         <field name="line_copy" widget="radio"/>
@@ -56,6 +58,17 @@
                 </group>
             </sheet>
             </form>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="view_purchase_requisition_type_search">
+        <field name="name">purchase.requisition.type.search</field>
+        <field name="model">purchase.requisition.type</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <separator/>
+                <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+            </search>
         </field>
     </record>
     <record id="tender_type_action" model="ir.actions.act_window">


### PR DESCRIPTION
This pr is add archive button for hide the Purchase Agreement Types without removing it.
![Peek 2021-05-25 16-44](https://user-images.githubusercontent.com/24691983/119476780-96e13980-bd78-11eb-9214-66a530dec3d1.gif)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
