### PR TITLE
[FIX] account: set default_partner_id to bank_partner_id for partner_bank_id

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -660,7 +660,7 @@
                                 <field name="payment_reference"
                                        attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))], 'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="partner_bank_id"
-                                       context="{'default_partner_id': commercial_partner_id}"
+                                       context="{'default_partner_id': bank_partner_id}"
                                        domain="[('partner_id', '=', bank_partner_id)]"
                                        attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))], 'readonly': [('state', '!=', 'draft')]}"/>
                                 <label name="invoice_vendor_bill_id_label" for="invoice_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
@@ -1060,7 +1060,7 @@
                                         <field name="invoice_user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                                         <field name="invoice_origin" string="Source Document" force_save="1" invisible="1"/>
                                         <field name="partner_bank_id"
-                                               context="{'default_partner_id': commercial_partner_id}"
+                                               context="{'default_partner_id': bank_partner_id}"
                                                domain="[('partner_id', '=', bank_partner_id)]"
                                                attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                         <field name="qr_code_method"


### PR DESCRIPTION
Change “default_partner_id” from “commercial_partner_id” to “bank_partner_id”
for “partner_bank_id” field in from view. If not, on an invoice, a newly created
partner bank (via “Recipient Bank” field) would be created for the partner
instead of the current company.

Task: 2524441