### PR TITLE
[FIX] survey: Unescape characters in mail subject

### DIFF
--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -196,7 +196,7 @@ class SurveyInvite(models.TransientModel):
 
     def _send_mail(self, answer):
         """ Create mail specific for recipient containing notably its access token """
-        subject = self.env['mail.template']._render_template(self.subject, 'survey.user_input', answer.id, post_process=True)
+        subject = self.env['mail.template'].with_context(safe=True)._render_template(self.subject, 'survey.user_input', answer.id, post_process=True)
         body = self.env['mail.template']._render_template(self.body, 'survey.user_input', answer.id, post_process=True)
         # post the message
         mail_values = {


### PR DESCRIPTION
To reproduce the error:
Create a survey (title must contain ") and send it

Error:
The mail subject is incorrect: the character " is replaced with `&#34;`

OPW-2536206