### PR TITLE
[FIX] server: prevent inotify watches leak

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -290,6 +290,7 @@ class FSWatcherInotify(FSWatcherBase):
     def stop(self):
         self.started = False
         self.thread.join()
+        del self.watcher  # ensures inotify watches are freed up before reexec
 
 
 #----------------------------------------------------------


### PR DESCRIPTION
Before this commit the PyInotify filesystem watcher used by the code
autoreload feature (`--dev=reload`) would not get a chance to free
it's inotify watches before the reexec, hence at each reexec triggered
by a code reload the inotify watches where accumulated until potentially
reaching the kernel limit `fs.inotify.max_user_watches`.

This patch ensures that inotify properly closes it's file descriptor
before we reexec:
https://github.com/dsoprea/PyInotify/blob/f77596a/inotify/adapters.py#L79

--
I confirm I have sold my soul to the devil and read "The Exorcist"'s script at least 10 times
