### PR TITLE
[FIX] point_of_sale: Load all existing Payment Method but displayed linked ones

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -31,6 +31,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             onChangeOrder(this._onPrevOrder, this._onNewOrder);
             useErrorHandlers();
             this.payment_interface = null;
+            this.payment_methods_from_config = this.env.pos.payment_methods.filter(method => this.env.pos.config.payment_method_ids.includes(method.id));
         }
         get currentOrder() {
             return this.env.pos.get_order();

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -505,9 +505,7 @@ exports.PosModel = Backbone.Model.extend({
     },{
         model:  'pos.payment.method',
         fields: ['name', 'is_cash_count', 'use_payment_terminal'],
-        domain: function(self, tmp) {
-            return [['id', 'in', tmp.payment_method_ids]];
-        },
+        domain: function(self){return ['|',['active', '=', false], ['active', '=', true]]; },
         loaded: function(self, payment_methods) {
             self.payment_methods = payment_methods.sort(function(a,b){
                 // prefer cash payment_method to be first in the list

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
@@ -29,7 +29,7 @@
                         <div class="paymentmethods-container">
                             <PaymentScreenPaymentLines paymentLines="paymentLines" />
                             <div class="paymentmethods">
-                                <t t-foreach="env.pos.payment_methods" t-as="paymentMethod"
+                                <t t-foreach="payment_methods_from_config" t-as="paymentMethod"
                                    t-key="paymentMethod.id">
                                     <PaymentMethodButton paymentMethod="paymentMethod" />
                                 </t>


### PR DESCRIPTION
Before, when using the manage order, if a payment method was used and then removed from the pos.config,
we couldn't load the old order anymore because of unknow reference.
To fix this, we load all methods at the opening of the pos but when we display the payment methods we only show those in the pos.config.

task-id: 2541708

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
