### PR TITLE
[FIX] l10n_ca: wrong predicate in xpath, missing fields in template p…

### DIFF
--- a/addons/l10n_ca/models/res_company.py
+++ b/addons/l10n_ca/models/res_company.py
@@ -6,3 +6,11 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     l10n_ca_pst = fields.Char(related='partner_id.l10n_ca_pst', string='PST', store=False)
+
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    l10n_ca_pst = fields.Char(related='company_id.l10n_ca_pst', readonly=True)
+    account_fiscal_country_id = fields.Many2one(related="company_id.account_fiscal_country_id", readonly=True)

--- a/addons/l10n_ca/views/report_template.xml
+++ b/addons/l10n_ca/views/report_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="l10n_ca_external_layout_standard" inherit_id="web.external_layout_standard">
-        <xpath expr="//div[@class='row'][last()]" position="after">
+        <xpath expr="//div[hasclass('row')][last()]" position="after">
             <t t-if="company.account_fiscal_country_id.code == 'CA' and company.l10n_ca_pst" class="mt16">
                 <div>PST: <span t-field="company.l10n_ca_pst"/></div>
             </t>
@@ -9,7 +9,7 @@
     </template>
 
     <template id="l10n_ca_external_layout_clean" inherit_id="web.external_layout_clean">
-        <xpath expr="//div[@class='row']" position="after">
+        <xpath expr="//div[hasclass('row')]" position="after">
             <t t-if="company.account_fiscal_country_id.code == 'CA' and company.l10n_ca_pst" class="mt16">
                 <div>PST: <span t-field="company.l10n_ca_pst"/></div>
             </t>
@@ -17,7 +17,7 @@
     </template>
 
     <template id="l10n_ca_external_layout_boxed" inherit_id="web.external_layout_boxed">
-        <xpath expr="//div[@class='row mb8']" position="after">
+        <xpath expr="//div[hasclass('row') and hasclass('mb8')]" position="after">
             <t t-if="company.account_fiscal_country_id.code == 'CA' and company.l10n_ca_pst" class="mt16">
                 <div>PST: <span t-field="company.l10n_ca_pst"/></div>
             </t>
@@ -25,7 +25,7 @@
     </template>
 
     <template id="l10n_ca_external_layout_background" inherit_id="web.external_layout_background">
-        <xpath expr="//div[@class='float-left company_address']" position="after">
+        <xpath expr="//div[hasclass('float-left') and hasclass('company_address')]" position="after">
             <t t-if="company.account_fiscal_country_id.code == 'CA' and company.l10n_ca_pst" class="mt16">
                 <div>PST: <span t-field="company.l10n_ca_pst"/></div>
             </t>


### PR DESCRIPTION
…review

* `hasclass` should be used instead of `@class`
* fields added to a template should be present in `base.document.layout`
in order to be able to display the preview.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
