### PR TITLE
[FIX] base: ir_action_report update context in _get_report_from_name …

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -489,7 +489,7 @@ class IrActionsReport(models.Model):
         report_obj = self.env['ir.actions.report']
         conditions = [('report_name', '=', report_name)]
         context = self.env['res.users'].context_get()
-        return report_obj.with_context(context).search(conditions, limit=1)
+        return report_obj.with_context(**context).search(conditions, limit=1)
 
     @api.model
     def barcode(self, barcode_type, value, width=600, height=100, humanreadable=0, quiet=1):


### PR DESCRIPTION
…instead of overriding

Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/71259

Current behavior before PR: Context is lost using _get_report_from_name method

Desired behavior after PR is merged: context is preserved and just updated with the user's one




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
