### PR TITLE
[FIX] base: remove non-fictional number from demo data

### DIFF
--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -25,7 +25,7 @@
             <field name="zip">94134</field>
             <field name='country_id' ref='base.us'/>
             <field name='state_id' ref='state_us_5'/>
-            <field name="phone">+1 (650) 691-3277 </field>
+            <field name="phone">+1 (650) 555-0111 </field>
             <field name="email">info@yourcompany.example.com</field>
             <field name="website">www.example.com</field>
         </record>


### PR DESCRIPTION
Steps:
- Install Website
- Go to Website
- Click "Go to Website"

Bug:
The default phone number on the website is not fictional and may cause
unwanted spam.

Explanation:
In North America, only 555-0100 through 555-0199 are specifically
reserved for fictional use.
> The industry also reserved a block of 100 numbers as fictitious,
> non-working numbers (555-0100 through 0199) for use by the
> entertainment and advertising industries.

Source: https://www.nationalnanpa.com/pdf/NRUF/ATIS-0300115.pdf

opw:2530388