### PR TITLE
[FIX] point_of_sale: save default values for pos customer

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientDetailsEdit.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientDetailsEdit.xml
@@ -68,9 +68,10 @@
                         <span class="label">Language</span>
                         <select class="detail client-lang needsclick" name="lang"
                                 t-on-change="captureChange">
+                            <option value="">None</option>
                             <t t-foreach="env.pos.langs" t-as="lang" t-key="lang.id">
                                 <option t-att-value="lang.code"
-                                        t-att-selected="props.partner.lang ? ((lang.code === props.partner.lang) ? true : undefined) : lang.code === env.pos.user.lang? true : undefined">
+                                        t-att-selected="props.partner.lang ? ((lang.code === props.partner.lang) ? true : undefined) : undefined">
                                     <t t-esc="lang.name" />
                                 </option>
                             </t>


### PR DESCRIPTION
Issue

	- Install 'Point of Sale' module
	- Activate 'Dutch' language
	- Open any POS
	- Click on customer
	- Create new customer
	- Edit only 'Name' field
	  (Ensure country already set)
	- Save and exit POS
	- Go to 'Point of Sale -> Order -> Customer'
	- Open customer created in POS

	Country is not set.
	(Language has no "None" select option +
	no set to a default value)

Cause

	Default values on form are set in xml when
	select input matches partner default value.
	(+No default lang set on partner).

	Only changed values from ui are saved
	to new customer.

Solution

	- Add 'lang' field to 'defaultFields' + add
	  "None" select option
	- When saving a new customer, if fields in 'defaulFields'
	are not in 'processedChanges' (changed fields), update
	'processedChanges' with partner defaut values.

opw-2542901