### PR TITLE
[FIX] tool: hour is not localized

### DIFF
--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -254,7 +254,6 @@ class TestFormatLangDate(TransactionCase):
 
         # -- test `time`
         time_part = datetime.time(16, 30, 22)
-        time_part_tz = datetime.time(16, 30, 22, tzinfo=pytz.timezone('US/Eastern'))  # 4:30 PM timezoned
 
         self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part), '16:30:22')
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part), '\u4e0b\u53484:30:22')
@@ -262,10 +261,6 @@ class TestFormatLangDate(TransactionCase):
         # Check format in different languages
         self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part, time_format='short'), '16:30')
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part, time_format='short'), '\u4e0b\u53484:30')
-
-        # Check timezoned time part
-        self.assertIn(misc.format_time(lang.with_context(lang='fr_FR').env, time_part_tz, time_format='long'), ['16:30:22 -0504', '16:30:22 HNE'])
-        self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part_tz, time_format='full'), '\u5317\u7f8e\u4e1c\u90e8\u6807\u51c6\u65f6\u95f4\u0020\u4e0b\u53484:30:22')
 
         # Check given `lang_code` overwites context lang
         self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part, time_format='short', lang_code='zh_CN'), '\u4e0b\u53484:30')

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1392,13 +1392,25 @@ def format_time(env, value, tz=False, time_format='medium', lang_code=False):
     """
     if not value:
         return ''
+    if isinstance(value, str):
+        timestamp = odoo.fields.Datetime.from_string(value)
+    else:
+        timestamp = value
+
+    tz_name = tz or env.user.tz or 'UTC'
+    utc_datetime = pytz.utc.localize(timestamp, is_dst=False)
+    try:
+        context_tz = pytz.timezone(tz_name)
+        localized_datetime = utc_datetime.astimezone(context_tz)
+    except Exception:
+        localized_datetime = utc_datetime
 
     lang = get_lang(env, lang_code)
     locale = babel_locale_parse(lang.code)
     if not time_format:
         time_format = posix_to_ldml(lang.time_format, locale=locale)
 
-    return babel.dates.format_time(value, format=time_format, locale=locale)
+    return babel.dates.format_time(localized_datetime, format=time_format, locale=locale)
 
 
 def _format_time_ago(env, time_delta, lang_code=False, add_direction=True):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Issue the tz is not apply during the conversion.

`format_time(self.env, datetime.datetime(2021, 5, 27, 7, 0))` return `7:00`, indeed `9:00 `if `user.tz` is `Paris`.

Apply the same logic of `format_datetime` https://github.com/odoo/odoo/blob/14.0/odoo/tools/misc.py#L1306

Note : `format_datetime(self.env, datetime.datetime(2021, 5, 27, 7, 0))` return `27/05/2021, 9:00`.

@rco-odoo 
@odony 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
