### PR TITLE
[ADD] l10n_fr_fec_import: added a module for import data from FEC

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -98,6 +98,8 @@ class ResConfigSettings(models.TransientModel):
              '-This installs the account_batch_payment module.')
     module_account_sepa = fields.Boolean(string='SEPA Credit Transfer (SCT)')
     module_account_sepa_direct_debit = fields.Boolean(string='Use SEPA Direct Debit')
+    module_l10n_fr_fec_import = fields.Boolean("Import FEC files",
+        help='Allows you to import FEC files.\n' '-This installs the l10n_fr_fec_import module.')
     module_account_bank_statement_import_qif = fields.Boolean("Import .qif files")
     module_account_bank_statement_import_ofx = fields.Boolean("Import in .ofx format")
     module_account_bank_statement_import_csv = fields.Boolean("Import in .csv format")

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -550,6 +550,26 @@
                                 </div>
                             </div>
                         </t>
+
+                        <t groups="account.group_account_user">
+                            <h2>Accounting Import</h2>
+                            <div class="row mt16 o_settings_container" id="accounting_import">
+                                <div class="col-12 col-lg-6 o_setting_box"
+                                    id="l10n_fr_fec_import"
+                                    title="This adds a menu item in the Accounting Configuration menu to import FEC files.">
+                                    <div class="o_setting_left_pane">
+                                        <field name="module_l10n_fr_fec_import" widget="upgrade_boolean"/>
+                                    </div>
+                                    <div class="o_setting_right_pane">
+                                        <label for="module_l10n_fr_fec_import" string="FEC Import"/>
+                                        <div class="text-muted">
+                                            Import your accounting data from FEC
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+
                         <t groups="account.group_account_user">
                             <h2>Fiscal Periods</h2>
                             <div class="row mt16 o_settings_container" id="accounting_reports">

--- a/addons/l10n_fr_fec/__manifest__.py
+++ b/addons/l10n_fr_fec/__manifest__.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
 
 {
-    'name': 'France - FEC',
+    'name': 'France - FEC Export',
     'icon': '/l10n_fr/static/description/icon.png',
     'category': 'Accounting/Localizations/Reporting',
     'summary': "Fichier d'Échange Informatisé (FEC) for France",


### PR DESCRIPTION
A FEC file (Fichier des Ecritures Comptables) contains all the accounting data and entries recorded
in all the accounting journals for a financial year. In order to make the onboarding of new users
easier, Odoo Enterprise's French fiscal localization includes access to the ``l10n_fr_fec_import``
module, that enables the import of existing FEC files from older software to the Odoo database.

The imported data are:

    * accounts
    * journals
    * partners
    * journal entries

Every entity is imported with a generator that reads the values from each line, ready to be loaded.
The entity (only accounts for the moment) is then completed with data from the CoA's templates
and imported in the database. Journal entries are posted and reconciled.

The Odoo branch implements the install checkbox in the Settings > Accounting page for an easy install.

Task 2515785: https://www.odoo.com/web#id=2515785model=project.task
Documentation PR: odoo/documentation#979

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
