### PR TITLE
[FIX] mail: prevent useless write

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -748,10 +748,14 @@ class Channel(models.Model):
                     state = 'folded'
                 else:
                     state = 'open'
-            session_state.write({
-                'fold_state': state,
-                'is_minimized': bool(state != 'closed'),
-            })
+            is_minimized = bool(state != 'closed')
+            vals = {}
+            if session_state.fold_state != state:
+                vals['fold_state'] = state
+            if session_state.is_minimized != is_minimized:
+                vals['is_minimized'] = is_minimized
+            if vals:
+                session_state.write(vals)
             self.env['bus.bus'].sendone((self._cr.dbname, 'res.partner', self.env.user.partner_id.id), session_state.channel_id.channel_info()[0])
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In database with frontend and live chat there are lot of bad query error.
bad query: UPDATE "mail_channel_partner" SET "write_uid"=5,"write_date"=(now() at time zone 'UTC') WHERE id IN (328111)

Error: Could not serialize access due to concurrent update

In customer database 2000 events in 24h.

@tde-banana-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
