### PR TITLE
[IMP] l10n_ar: Exportation Document reports

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Argentinian Accounting',
-    'version': "3.3",
+    'version': "3.4",
     'description': """
 Functional
 ----------

--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -910,8 +910,8 @@ msgstr "No Cero"
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.custom_header
-msgid "Nro:"
-msgstr ""
+msgid "No:"
+msgstr "Nro:"
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.view_company_form

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -882,7 +882,7 @@ msgstr ""
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.custom_header
-msgid "Nro:"
+msgid "No:"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/l10n_latam_document_type.py
+++ b/addons/l10n_ar/models/l10n_latam_document_type.py
@@ -50,7 +50,7 @@ class L10nLatamDocumentType(models.Model):
     def _filter_taxes_included(self, taxes):
         """ In argentina we include taxes depending on document letter """
         self.ensure_one()
-        if self.country_id == self.env.ref('base.ar') and self.l10n_ar_letter in ['B', 'C', 'X', 'R']:
+        if self.country_id == self.env.ref('base.ar') and self.l10n_ar_letter in ['B', 'C', 'X', 'R', 'E']:
             return taxes.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
         return super()._filter_taxes_included(taxes)
 

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -50,7 +50,7 @@
 
                     <t t-if="not pre_printed_report">
                         <!-- (7) Numero punto venta - (8) numero de documento -->
-                        <span t-att-style="'color: %s;' % o.company_id.secondary_color">Nro: </span><span t-esc="report_number"/>
+                        <span t-att-style="'color: %s;' % o.company_id.secondary_color">No: </span><span t-esc="report_number"/>
                     </t>
                     <br/>
 

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -82,7 +82,7 @@
             <t t-set="pre_printed_report" t-value="report_type == 'pdf' and o.journal_id.l10n_ar_afip_pos_system == 'II_IM'"/>
             <t t-set="document_letter" t-value="o.l10n_latam_document_type_id.l10n_ar_letter"/>
             <t t-set="document_legend" t-value="o.l10n_latam_document_type_id.code and 'Cod. %02d' % int(o.l10n_latam_document_type_id.code) or ''"/>
-            <t t-set="report_name" t-value="o.l10n_latam_document_type_id.report_name"/>
+            <t t-set="report_name" t-value="('es_' not in lang[0:3] and (o.l10n_latam_document_type_id.code == '19' and 'INVOICE' or o.l10n_latam_document_type_id.code == '20' and 'DEBIT NOTE' or o.l10n_latam_document_type_id.code == '21' and 'CREDIT NOTE')) or o.l10n_latam_document_type_id.report_name"/>
             <t t-set="header_address" t-value="o.journal_id.l10n_ar_afip_pos_partner_id"/>
 
             <t t-set="custom_footer">
@@ -252,7 +252,7 @@
             <t t-set="pre_printed_report" t-value="report_type == 'pdf' and o.journal_id.l10n_ar_afip_pos_system == 'II_IM'"/>
             <t t-set="document_letter" t-value="o.l10n_latam_document_type_id.l10n_ar_letter"/>
             <t t-set="document_legend" t-value="o.l10n_latam_document_type_id.code and 'Cod. %02d' % int(o.l10n_latam_document_type_id.code) or ''"/>
-            <t t-set="report_name" t-value="o.l10n_latam_document_type_id.report_name"/>
+            <t t-set="report_name" t-value="('es_' not in lang[0:3] and (o.l10n_latam_document_type_id.code == '19' and 'INVOICE' or o.l10n_latam_document_type_id.code == '20' and 'DEBIT NOTE' or o.l10n_latam_document_type_id.code == '21' and 'CREDIT NOTE')) or o.l10n_latam_document_type_id.report_name"/>
             <t t-set="header_address" t-value="o.journal_id.l10n_ar_afip_pos_partner_id"/>
 
             <t t-set="custom_footer">


### PR DESCRIPTION
latam task 559 /  adhoc ticket 40153
---

* Use the customer lang to print the report name.
* do not show the % VAT column this one is not needed for exportation documents.
* fixup report words in Spanish to English and update the proper Spanish translation: Number abbreviation No instead of Nro.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
