### PR TITLE
[IMP] stock: added graph view for product moves

### DIFF
--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -26,6 +26,7 @@
                     <separator/>
                     <filter string="Manufactured Products" name="manufactured_products" domain="[('bom_ids', '!=', False)]"/>
                     <filter string="BoM Components" name="components" domain="[('bom_line_ids', '!=', False)]"/>
+                    <field string="Used in" name="bom_ids" filter_domain="[('bom_ids.bom_line_ids.product_id.product_tmpl_id.name', 'ilike', self)]"/>
                 </xpath>
             </field>
         </record>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -130,11 +130,22 @@
         </field>
     </record>
 
+    <record id="view_stock_move_line_graph" model="ir.ui.view">
+        <field name="name">stock.move.line.graph</field>
+        <field name="model">stock.move.line</field>
+        <field name="arch" type="xml">
+            <graph string="Stock Move Lines Analysis" type="line" sample="1">
+                <field name="qty_done" type="measure"/>
+                <field name="date"/>
+            </graph>
+        </field>
+    </record>
+
     <record id="stock_move_line_action" model="ir.actions.act_window">
             <field name="name">Product Moves</field>
             <field name="res_model">stock.move.line</field>
             <field name="type">ir.actions.act_window</field>
-            <field name="view_mode">tree,kanban,pivot,form</field>
+            <field name="view_mode">tree,kanban,pivot,form,graph</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="context">{'search_default_filter_last_12_months': 1, 'search_default_done': 1, 'search_default_groupby_product_id': 1, 'create': 0}</field>
             <field name="help" type="html">


### PR DESCRIPTION
In this commit, added graph view and dashboard view for
stock move line which can be open from MRP MPS

TaskID - 2351645

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
