### PR TITLE
[FIX] website: override footer company name in a separate template

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -172,9 +172,6 @@
     <xpath expr="//footer[@id='bottom']" position="attributes">
         <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'footer_visible' in main_object and not main_object.footer_visible else ''}" separator=" "/>
     </xpath>
-    <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
-        <span class="o_footer_copyright_name mr-2">Copyright &amp;copy; Company name</span>
-    </xpath>
 </template>
 
 <template id="custom_code_layout" name="Custom Code Layout" inherit_id="website.layout" priority="55">
@@ -1746,6 +1743,12 @@
 <template id="footer_no_copyright" inherit_id="website.layout" name="Footer No Copyright" active="False">
     <xpath expr="//div[hasclass('o_footer_copyright')]" position="before">
         <t t-set="no_copyright" t-value="True"/>
+    </xpath>
+</template>
+
+<template id="footer_copyright_company_name" inherit_id="website.layout">
+    <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
+        <span class="o_footer_copyright_name mr-2">Copyright &amp;copy; Company name</span>
     </xpath>
 </template>
 


### PR DESCRIPTION
The footer company name override from the website is done in a separate
template from website.layout in order to avoid duplicating it when
edited.

Related to https://github.com/odoo/odoo/pull/69943
task-2468472

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
