### PR TITLE
[FIX] pos_cash_rounding: fix sign, up and down rounding.

### DIFF
--- a/addons/pos_cash_rounding/models/pos_order.py
+++ b/addons/pos_cash_rounding/models/pos_order.py
@@ -26,16 +26,18 @@ class PosOrder(models.Model):
         if self.config_id.cash_rounding:
             rounding_applied = float_round(self.amount_paid - self.amount_total, precision_rounding=new_move.currency_id.rounding)
             rounding_line = new_move.line_ids.filtered(lambda line: line.is_rounding_line)
+            if rounding_line and rounding_line.debit > 0:
+                rounding_line_difference = rounding_line.debit + rounding_applied
+            elif rounding_line and rounding_line.credit > 0:
+                rounding_line_difference = -rounding_line.credit + rounding_applied
+            else:
+                rounding_line_difference = rounding_applied
             if rounding_applied:
                 if rounding_applied > 0.0:
                     account_id = new_move.invoice_cash_rounding_id._get_loss_account_id().id
                 else:
                     account_id = new_move.invoice_cash_rounding_id._get_profit_account_id().id
                 if rounding_line:
-                    if rounding_line.debit > 0:
-                        rounding_line_difference = rounding_line.debit + rounding_applied
-                    else:
-                        rounding_line_difference = -rounding_line.credit + rounding_applied
                     if rounding_line_difference:
                         rounding_line.with_context(check_move_validity=False).write({
                             'debit': rounding_applied < 0.0 and -rounding_applied or 0.0,
@@ -43,20 +45,8 @@ class PosOrder(models.Model):
                             'account_id': account_id,
                             'price_unit': rounding_applied,
                         })
-                        existing_terms_line = new_move.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
-                        if existing_terms_line.debit > 0:
-                            existing_terms_line_new_val = float_round(existing_terms_line.debit + rounding_line_difference, precision_rounding=new_move.currency_id.rounding)
-                        else:
-                            existing_terms_line_new_val = float_round(-existing_terms_line.credit + rounding_line_difference, precision_rounding=new_move.currency_id.rounding)
-                        existing_terms_line.write({
-                            'debit': existing_terms_line_new_val > 0.0 and existing_terms_line_new_val or 0.0,
-                            'credit': existing_terms_line_new_val < 0.0 and -existing_terms_line_new_val or 0.0,
-                        })
-
-                        new_move._recompute_payment_terms_lines()
-
                 else:
-                     self.env['account.move.line'].create({
+                    self.env['account.move.line'].with_context(check_move_validity=False).create({
                          'debit': rounding_applied < 0.0 and -rounding_applied or 0.0,
                          'credit': rounding_applied > 0.0 and rounding_applied or 0.0,
                          'quantity': 1.0,
@@ -73,7 +63,24 @@ class PosOrder(models.Model):
                      })
             else:
                 if rounding_line:
-                    rounding_line.unlink()
+                    rounding_line.with_context(check_move_validity=False).unlink()
+            if rounding_line_difference:
+                existing_terms_line = new_move.line_ids.filtered(
+                    lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
+                if existing_terms_line.debit > 0:
+                    existing_terms_line_new_val = float_round(
+                        existing_terms_line.debit + rounding_line_difference,
+                        precision_rounding=new_move.currency_id.rounding)
+                else:
+                    existing_terms_line_new_val = float_round(
+                        -existing_terms_line.credit + rounding_line_difference,
+                        precision_rounding=new_move.currency_id.rounding)
+                existing_terms_line.write({
+                    'debit': existing_terms_line_new_val > 0.0 and existing_terms_line_new_val or 0.0,
+                    'credit': existing_terms_line_new_val < 0.0 and -existing_terms_line_new_val or 0.0,
+                })
+
+                new_move._recompute_payment_terms_lines()
         return new_move
 
     def _get_amount_receivable(self):


### PR DESCRIPTION
This commit includes 3 fix from 14:

Before 0302552 rounding applied was eg. for these numbers and UP and
DOWN rounding methods to multiple of 10:

```
Numbers | -8 | -2 |  2 |  8 | 12
DOWN    | -2 | -8 | -2 | -8 | -2
UP      |  8 |  2 |  8 |  2 |  8
```

which is correct for positive numbers but UP and DOWN are inversed for
negatives numbers.

After 0302552 this became:

```
Numbers | -8 | -2 |  2 |  8 | 12
DOWN    |  8 |  2 |  8 | -8 | -2
UP      | -2 | -8 | -2 |  2 |  8
```

which is correct for all cases except for positive numbers that are
before HALF of the precision (eg. number 2) for which UP and DOWN are
inversed.

This is happening because 0302552 uses the sign of the rounded value
=> this does not work for 0 so number 2 is broken (and if fixed number
-2 would be broken).

With this commit, the adjustement of sign is done based on original
number, so we get the equivalent of python equivalent methods:

```
Numbers | -8 | -2 |  2 |  8 | 12
DOWN    |  8 |  2 | -2 | -8 | -2
UP      | -2 | -8 |  8 |  2 |  8

---

The method that computs what is due and the change of an order is based
on the selected payment line which is wrong, because if you add and
remove a payment line, none will be seleced, that lead to issue in this
case because a change is computed, and it won't match the invoices
because an amount_return is sent to server.

To reproduce you can follow this simply procedure:
    - set rounding half-up to 0.05
    - create a product at 0.98
    - open POS and create an order with the product
    - go to payment screen
    - add cash payment (1€ auto filled)
    - add bank payment (It'll autofill -0.02 not really a problem)
    - remove the bank payment => It'll show 0.02 due (it is caused because of no payment method is selected)
    - Set a customer and check the invoice => unbalanced (0.02 probably because it is set in amount_return of the request)

 ---

While using the cash rounding, there were issues when rounding up and down.
The pre filled amount was correct but the rest of the transaction was wrong. (Wrong due, wrong change,...)
This commit re calculate the rounding applied when using up or down payment.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
