### PR TITLE
[FIX] account: prevent user to use a tax report with an empty tag name

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -10915,6 +10915,13 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account.py:0
+#, python-format
+msgid ""
+"The tax report line '%s' must have a tag name to be used in an Account tag."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_account_tag__tax_report_line_ids
 msgid "The tax report lines using this tag"
 msgstr ""

--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -68,7 +68,13 @@ class AccountAccountTag(models.Model):
             if record.applicability == 'taxes' and not record.country_id:
                 raise ValidationError(_("A tag defined to be used on taxes must always have a country set."))
 
+    @api.onchange('tax_report_line_ids')
+    def _onchange_tax_report_line_ids(self):
+        for line in self.tax_report_line_ids:
+            if not line.tag_name:
+                raise ValidationError(_("The tax report line '%s' must have a tag name to be used in an Account tag.") % (line.name))
 
+                
 class AccountTaxReportLine(models.Model):
     _name = "account.tax.report.line"
     _description = 'Account Tax Report Line'


### PR DESCRIPTION
Steps to reproduce the bug:
- Activate Developer Mode
- Go to accounting > Configuration > Management > Tax Report
- Create a new Tax report > do not define a tag name
- Go to configuration > Accounting > Account Tags
- Create a new Account Tag :
  - define a Tag name
  - In “Applicability” select “Taxes”
  - Choose the same country as that of the current company
  - Add the newly created Tax report
- Create a new invoice :
  - Add Any product
  - In Journal Items tab
  - In any line add the newly created Account Tag in the tax Grids
  - save the invoice

Problem:
An error is triggered because we try to access the empty name tag of the tax report

Solution:
Add a constraint so that you can’t use “account.tax.report.line” until there is a tag name

opw-2541071




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
