### PR TITLE
[FIX] [crm_]mail_plugin: fix multi_company access error

### DIFF
--- a/addons/crm_mail_plugin/controllers/crm_client.py
+++ b/addons/crm_mail_plugin/controllers/crm_client.py
@@ -45,9 +45,6 @@ class CrmClient(http.Controller):
         if not partner:
             return {'error': 'partner_not_found'}
 
-        # In a multi-company environment, we will not be able to create a lead if the user is connected to a different
-        # company then the one linked to the contact, this is not supported, and users are encouraged to check if they
-        # are connected to the right company before performing such operation.
         record = request.env['crm.lead'].create({
             'name': html2plaintext(email_subject),
             'partner_id': partner_id,

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -111,11 +111,6 @@ class MailPluginController(http.Controller):
         The method returns an array containing the dicts of the matched contacts.
         """
 
-        #In a multi-company environment, the method may return contacts not belonging to the company that the user
-        #is connected to, this may result in the user not being able to view the contact in Odoo, while this may happen
-        #it is not supported for now and users are encouraged to check if they are connected to the correct company before
-        # clicking on a contact.
-
         normalized_email = tools.email_normalize(search_term)
 
         if normalized_email:
@@ -293,7 +288,10 @@ class MailPluginController(http.Controller):
         else:  # no partner found
             partner_response = {}
 
-        return {'partner': partner_response}
+        return {
+            'partner': partner_response,
+            'user_companies': request.env['res.users'].browse(request.uid).company_ids.ids
+        }
 
     def _mail_content_logging_models_whitelist(self):
         """


### PR DESCRIPTION
This commit fixes the multi_company access error when the user is attempting to
see a record belonging to another company then the one he is logged in to from
the plugins, it returns the company_id with the record so that the plugin uses
it to make sure that the user is redirected to the record with the right
company ticked.

Task-2541205

PLUGIN-PR: odoo/mail-client-extensions#10

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
