### PR TITLE
[FIX] web_editor : remove duplicate focus() declaration

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -411,9 +411,6 @@ const Wysiwyg = Widget.extend({
     redo: function () {
         this.odooEditor.historyRedo();
     },
-    focus() {
-        this.odooEditor.resetCursorOnLastHistoryCursor();
-    },
     /**
      * Focus inside the editor.
      *


### PR DESCRIPTION
wrongly introduced in #69471 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
