### PR TITLE
[FIX] point_of_sale : prevent error if you close/open POS

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -323,7 +323,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             const isPaymentSuccessful = await payment_terminal.send_payment_request(line.cid);
             if (isPaymentSuccessful) {
                 line.set_payment_status('done');
-                line.can_be_reversed = this.payment_interface.supports_reversals;
+                line.can_be_reversed = payment_terminal.supports_reversals;
             } else {
                 line.set_payment_status('retry');
             }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- create a new order
- add payment with payment terminal (like adyen)
- close POS then Open POS (or refresh page)
- Send the payment
When the payment succeed it raise. Because after a refresh this.payment_interface is undefined.


@pimodoo @rhe-odoo 

https://user-images.githubusercontent.com/16716992/119818132-1db82280-beef-11eb-8a55-bca76ff35b1f.mov




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
