### PR TITLE
[FIX] website_sale : don't hide Send quotation

### DIFF
--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -60,6 +60,10 @@
                     class="btn-primary"
                     attrs="{'invisible': ['|', ('is_abandoned_cart', '=', False), ('cart_recovery_email_sent', '=', True)]}"/>
             </xpath>
+            <xpath expr="//button[@name='action_quotation_send' and @states='sent,sale']" position="after">
+                <button name="action_quotation_send" string="Send by Email" type="object"
+                    attrs="{'invisible': ['|', '|', ('is_abandoned_cart', '=', False), ('cart_recovery_email_sent', '=', True), ('state', '!=', 'draft')]}"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- A customer start an order on website
- A few days later the back office call the customer to finalize the order. And try to send the quotation.
--> Issue the button "Send Quotation" is remplaced by "Send a Recovery Email"


**Desired behavior after PR is merged:**
With this PR both button are show.

It is more user friendly.

@JKE-be 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
