### PR TITLE
[FIX] web_editor: fix overlay handles display

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -157,7 +157,7 @@ var SnippetEditor = Widget.extend({
         this.isTargetParentEditable = false;
         this.isTargetMovable = false;
         this.$scrollingElement = $().getScrollingElement(this.ownerDocument);
-        this.displayHandles = false;
+        this.displayOverlayOptions = false;
 
         this.__isStarted = new Promise(resolve => {
             this.__isStartedResolveFunc = resolve;
@@ -176,6 +176,7 @@ var SnippetEditor = Widget.extend({
         this.isTargetParentEditable = this.$target.parent().is(':o_editable');
         this.isTargetMovable = this.isTargetParentEditable && this.isTargetMovable;
         this.isTargetRemovable = this.isTargetParentEditable && !this.$target.parent().is('[data-oe-type="image"]');
+        this.displayOverlayOptions = this.displayOverlayOptions || this.isTargetMovable || !this.isTargetParentEditable;
 
         // Initialize move/clone/remove buttons
         if (this.isTargetMovable) {
@@ -504,7 +505,7 @@ var SnippetEditor = Widget.extend({
             // sticky class is added/removed when toggling/untoggling
             this.$el.removeClass('o_we_overlay_preview');
             this.$el.toggleClass('o_we_overlay_sticky', show);
-            if (!this.displayHandles) {
+            if (!this.displayOverlayOptions) {
                 this.$el.find('.o_handle').addClass('d-none');
                 this.$el.find('.o_overlay_options_wrap').addClass('o_inside_parent');
             }
@@ -686,8 +687,8 @@ var SnippetEditor = Widget.extend({
                 this.$el.add($optionsSection).find('.oe_snippet_remove').addClass('d-none');
             }
 
-            if (option.displayHandles) {
-                this.displayHandles = true;
+            if (option.displayOverlayOptions) {
+                this.displayOverlayOptions = true;
             }
 
             return option.appendTo(document.createDocumentFragment());
@@ -1732,8 +1733,8 @@ var SnippetsMenu = Widget.extend({
                 // enabled previously by a click
                 if (editorToEnable) {
                     editorToEnable.toggleOverlay(true, previewMode);
-                    if (!previewMode && !editorToEnable.displayHandles) {
-                        const parentEditor = editorToEnableHierarchy.find(ed => ed.displayHandles);
+                    if (!previewMode && !editorToEnable.displayOverlayOptions) {
+                        const parentEditor = editorToEnableHierarchy.find(ed => ed.displayOverlayOptions);
                         if (parentEditor) {
                             parentEditor.toggleOverlay(true, previewMode);
                         }

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2769,7 +2769,7 @@ const SnippetOptionWidget = Widget.extend({
      *
      * @type {boolean}
      */
-    displayHandles: false,
+    displayOverlayOptions: false,
 
     /**
      * The option `$el` is supposed to be the associated DOM UI element.
@@ -3846,7 +3846,7 @@ const registry = {};
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 registry.sizing = SnippetOptionWidget.extend({
-    displayHandles: true,
+    displayOverlayOptions: true,
 
     /**
      * @override

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4216,7 +4216,10 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     /**
      * @see this.selectClass for parameters
      */
-    setQuality(previewMode, widgetValue, params) {
+    async setQuality(previewMode, widgetValue, params) {
+        if (previewMode) {
+            return;
+        }
         this._getImg().dataset.quality = widgetValue;
         return this._applyOptions();
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -3,6 +3,7 @@ odoo.define('wysiwyg.widgets.LinkTools', function (require) {
 
 const Link = require('wysiwyg.widgets.Link');
 const OdooEditorLib = require('web_editor.odoo-editor');
+const dom = require('web.dom');
 
 const setCursor = OdooEditorLib.setCursor;
 
@@ -34,7 +35,9 @@ const LinkTools = Link.extend({
         this.options.wysiwyg.odooEditor.observerUnactive();
         this.$link.addClass('oe_edited_link');
         this.$button.addClass('active');
-        return this._super(...arguments);
+        return this._super(...arguments).then(() => {
+            dom.scrollTo(this.$(':visible:last')[0], {duration: 0});
+        });
     },
     destroy: function () {
         $('.oe_edited_link').removeClass('oe_edited_link');

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2667,7 +2667,7 @@ options.registry.ContainerWidth = options.Class.extend({
  * Allows snippets to be moved before the preceding element or after the following.
  */
 options.registry.SnippetMove = options.Class.extend({
-    displayHandles: true,
+    displayOverlayOptions: true,
 
     /**
      * @override


### PR DESCRIPTION
A new parameter displayHandles was introduced on SnippetOptions to
display or not the handles on a snippet. If a snippet had no option
needing the handles overlay, the overlay (and handles) from its closest
parent with such option was.

Two use cases were not tackled correctly and should display overlay,
even with no option with displayHandles:
- root containers (which have no editable parent)
- inline snippets (movable snippets)

task-2542318

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
