### PR TITLE
[MERGE] various: improve list views by fine tuning decorations

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -398,7 +398,7 @@
             <field name="name">account.move.tree</field>
             <field name="model">account.move</field>
             <field name="arch" type="xml">
-                <tree string="Journal Entries" sample="1">
+                <tree string="Journal Entries" sample="1" decoration-info="state == 'draft'">
                     <field name="date"/>
                     <field name="name"/>
                     <field name="partner_id" optional="show"/>
@@ -419,6 +419,7 @@
             <field name="arch" type="xml">
                 <tree string="Invoices"
                       js_class="account_tree"
+                      decoration-info="state == 'draft'"
                       sample="1">
                     <header>
                         <button name="action_register_payment" type="object" string="Register Payment"

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -8,7 +8,7 @@
             <field name="name">account.payment.tree</field>
             <field name="model">account.payment</field>
             <field name="arch" type="xml">
-                <tree edit="false" sample="1">
+                <tree edit="false" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'">
                     <header>
                         <button name="action_post" type="object" string="Confirm"/>
                     </header>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -44,7 +44,7 @@
             <field name="name">hr.expense.tree</field>
             <field name="model">hr.expense</field>
             <field name="arch" type="xml">
-                <tree string="Expenses" multi_edit="1" sample="1" js_class="hr_expense_tree_dashboard_upload">
+                <tree string="Expenses" multi_edit="1" sample="1" js_class="hr_expense_tree_dashboard_upload" decoration-info="state == 'draft'">
                     <header>
                         <button name="action_submit_expenses" type="object" string="Create Report"/>
                     </header>
@@ -603,7 +603,7 @@
             <field name="name">hr.expense.sheet.tree</field>
             <field name="model">hr.expense.sheet</field>
             <field name="arch" type="xml">
-                <tree string="Expense Reports" multi_edit="1" js_class="hr_expense_tree_dashboard_upload" sample="1">
+                <tree string="Expense Reports" multi_edit="1" js_class="hr_expense_tree_dashboard_upload" sample="1" decoration-info="state == 'draft'">
                     <header>
                         <button name="approve_expense_sheets" string="Approve Report" type="object"
                                 groups="hr_expense.group_hr_expense_team_approver"

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -190,7 +190,7 @@
         <field name="model">hr.leave.allocation</field>
         <field name="priority">16</field>
         <field name="arch" type="xml">
-            <tree string="Allocation Requests" sample="1">
+            <tree string="Allocation Requests" sample="1" decoration-info="state == 'draft'">
                 <field name="employee_id"/>
                 <field name="department_id" optional="hide"/>
                 <field name="holiday_status_id" class="font-weight-bold"/>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -30,7 +30,7 @@
             <field name="model">mailing.mailing</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <tree string="Mailings" sample="1">
+                <tree string="Mailings" sample="1" decoration-info="state in ['draft', 'in_queue']">
                     <field name="subject" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                     <field name="mailing_type" invisible="1"/>
                     <field name="mailing_model_id" string="Recipients"/>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -212,7 +212,7 @@
         <field name="model">mailing.mailing</field>
         <field name="priority">20</field>
         <field name="arch" type="xml">
-            <tree string="SMS Marketing" sample="1">
+            <tree string="SMS Marketing" sample="1" decoration-info="state == 'draft'">
                 <field name="subject"/>
                 <field name="mailing_type" invisible="1"/>
                 <field name="mailing_model_id" string="Recipients"/>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -228,7 +228,7 @@
         <field name="name">pos.order.tree</field>
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
-            <tree string="POS Orders" create="0" sample="1">
+            <tree string="POS Orders" create="0" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'">
                 <field name="currency_id" invisible="1"/>
                 <field name="name" decoration-bf="1"/>
                 <field name="session_id" />

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -545,8 +545,9 @@
             <field name="model">purchase.order</field>
             <field name="priority" eval="10"/>
             <field name="arch" type="xml">
-                <tree string="Purchase Order" decoration-bf="message_unread==True"
-                      class="o_purchase_order" js_class="purchase_list_dashboard" sample="1">
+                <tree string="Purchase Order" decoration-info="state in ['draft', 'sent']" 
+                decoration-muted="state == 'cancel'" decoration-bf="message_unread==True" 
+                class="o_purchase_order" js_class="purchase_list_dashboard" sample="1">
                     <header>
                         <button name="action_create_invoice" type="object" string="Create Bills"/>
                     </header>
@@ -565,7 +566,7 @@
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="origin" optional="show"/>
                     <field name="amount_untaxed" sum="Total Untaxed amount" string="Untaxed" widget="monetary" optional="hide"/>
-                    <field name="amount_total" sum="Total amount" widget="monetary" optional="show" decoration-bf="1"/>
+                    <field name="amount_total" sum="Total amount" widget="monetary" optional="show" decoration-bf="state in ['purchase', 'done']"/>
                     <field name="currency_id" invisible="1"/>
                     <field name="state" optional="show" widget="badge" decoration-success="state == 'purchase' or state == 'done'"
                         decoration-warning="state == 'to approve'" decoration-info="state == 'draft' or state == 'sent'"/>
@@ -579,7 +580,8 @@
             <field name="model">purchase.order</field>
             <field name="arch" type="xml">
                 <tree decoration-bf="message_unread==True"
-                    decoration-muted="state=='cancel'"
+                    decoration-muted="state == 'cancel'"
+                    decoration-info="invoice_status == 'to invoice'"
                     string="Purchase Order"
                     class="o_purchase_order"
                     sample="1">

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -195,7 +195,7 @@
             <field name="model">sale.order</field>
             <field name="priority">2</field>
             <field name="arch" type="xml">
-                <tree string="Sales Orders" sample="1">
+                <tree string="Sales Orders" sample="1" decoration-info="invoice_status == 'to invoice'" decoration-muted="state == 'cancel'">
                     <field name="message_needaction" invisible="1"/>
                     <field name="name" string="Number" readonly="1" decoration-bf="1"/>
                     <field name="date_order" string="Order Date" widget="date" optional="show"/>
@@ -222,7 +222,7 @@
             <field name="model">sale.order</field>
             <field name="priority">4</field>
             <field name="arch" type="xml">
-                <tree string="Quotation" class="o_sale_order" sample="1">
+                <tree string="Quotation" class="o_sale_order" sample="1" decoration-info="state in ['draft', 'sent']" decoration-muted="state == 'cancel'">
                     <field name="name" string="Number" readonly="1" decoration-bf="1"/>
                     <field name="create_date" string="Creation Date" widget="date" optional="show"/>
                     <field name="commitment_date" widget="date" optional="hide"/>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -118,7 +118,7 @@
             <field name="name">stock.scrap.tree</field>
             <field name="model">stock.scrap</field>
             <field name="arch" type="xml">
-                <tree multi_edit="1" sample="1">
+                <tree multi_edit="1" sample="1" decoration-info="state == 'draft'">
                     <field name="name" decoration-bf="1"/>
                     <field name="date_done"/>
                     <field name="product_id" readonly="1"/>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -121,7 +121,7 @@
             <field name="name">stock.landed.cost.tree</field>
             <field name="model">stock.landed.cost</field>
             <field name="arch" type="xml">
-                <tree string="Landed Costs">
+                <tree string="Landed Costs" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'">
                     <field name="name" decoration-bf="1"/>
                     <field name="date"/>
                     <field name="company_id" groups="base.group_multi_company"/>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -143,7 +143,7 @@
             <field name="name">ir.module.module.tree</field>
             <field name="model">ir.module.module</field>
             <field name="arch" type="xml">
-                <tree create="false" string="Apps">
+                <tree create="false" string="Apps" decoration-info="state == 'uninstalled'" decoration-muted="state == 'uninstallable'">
                     <header>
                         <button name="button_immediate_install" type="object" string="Install"/>
                     </header>
@@ -154,9 +154,8 @@
                     <field name="installed_version"/>
                     <field name="state" widget="badge"
                         decoration-muted="state == 'uninstallable'"
-                        decoration-info="state in ['to upgrade', 'to install']"
-                        decoration-success="state == 'installed'"
-                        decoration-danger="state == 'uninstalled'"/>
+                        decoration-info="state  == 'uninstalled'"
+                        decoration-success="state == 'installed'"/>
                     <field name="category_id" invisible="1"/>
                 </tree>
             </field>


### PR DESCRIPTION
Currently, to identify records based on state, in most of the list views we
use 'badge' widget on 'state' fields which can be decorated as needed.

However, for the list views, best approach would be to also add list
decoration along with 'badge' widget so that the whole line is colored
and it's easy for user to 'scan' the information.

This PR improves the behavior adding decorations to several list-views.
To check the list of changes, kindly see the task specification.

Task ID-2527119
