### PR TITLE
[FIX] web: add the context in the parameters of the rpc in the _renderBanner

### DIFF
--- a/addons/web/static/src/js/views/abstract_controller.js
+++ b/addons/web/static/src/js/views/abstract_controller.js
@@ -350,7 +350,10 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
         if (this.bannerRoute !== undefined) {
             var self = this;
             return this.dp
-                .add(this._rpc({route: this.bannerRoute}))
+                .add(this._rpc({
+                    route: this.bannerRoute,
+                    params: {context: session.user_context},
+                }))
                 .then(function (response) {
                     if (!response.html) {
                         self.$el.removeClass('o_has_banner');


### PR DESCRIPTION
Steps to reproduce the bug:
- Install Accounting
- Connect with a user who has a default company (e.g: Company A) and allowed companies (e.g: “Company A” and “Company B”)
- Choose in the company selector “Company B”
- Make sure that the onboarding panel in the default company has not been closed
- Go to accounting and close the onboarding panel
- Refresh the page

Problem:
The onboarding panel is still open because in the `account/account_dashboard_onboarding` method we check the`account_dashboard_onboarding_state` field of the default company instead of the current company because "allowed_company_ids" is not in the context
This problem is also present in all the other views where an onboarding panel is present

Solution:
Add the context in the parameters of the controller so that it adds them to the rpc

opw-2477148




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
