### PR TITLE
[IMP] mail_plugin: allow to upload attachments when  logging an email

### DIFF
--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -160,10 +160,17 @@ class MailPluginController(http.Controller):
         return response
 
     @http.route('/mail_plugin/log_mail_content', type="json", auth="outlook", cors="*")
-    def log_mail_content(self, model, res_id, message):
+    def log_mail_content(self, model, res_id, message, attachments=None):
         if model not in self._mail_content_logging_models_whitelist():
             raise Forbidden()
-        request.env[model].browse(res_id).message_post(body=message)
+
+        if attachments:
+            attachments = [
+                (name, base64.b64decode(content))
+                for name, content in attachments
+            ]
+
+        request.env[model].browse(res_id).message_post(body=message, attachments=attachments)
 
     def _iap_enrich(self, domain):
         enriched_data = {}


### PR DESCRIPTION
Purpose
=======
Allow to upload the attachments when logging the email on the partner /
lead / ticket.

Technical
=========
The attachments are base 64 encoded and then added in the JSON posted
on the Odoo endpoint.

The maximum POST request size on the Gmail side is 50 MB. So they're 2
limits implemented.
- Maximum 10 MB per files
- Maximum 40 MB for the sum of the files size

When the limit is overcome, the new files are just ignored to not have
a quota issue.

N.B.: when creating an email from Gmail, if the sum of the file size if
more than 25 MB, they are automatically uploaded on GDrive and the link
to those files are added in the email.

Links
=====
Task 2545048