### PR TITLE
[FIX] point_of_sale : prevent error if order is not finalized

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -199,7 +199,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                 }
             }
 
-            this.showScreen(this.nextScreen);
+            this.showTempScreen(this.nextScreen);
 
             // If we succeeded in syncing the current order, and
             // there are still other orders that are left unsynced,

--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -79,10 +79,15 @@ odoo.define('point_of_sale.ReceiptScreen', function (require) {
                     }
                 }
             }
+            confirm() {
+                this.props.resolve({ confirmed: true, payload: null });
+                this.trigger('close-temp-screen');
+            }
             orderDone() {
                 this.currentOrder.finalize();
                 const { name, props } = this.nextScreen;
                 this.showScreen(name, props);
+                this.confirm();
             }
             async printReceipt() {
                 const isPrinted = await this._printReceipt();


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- go to runbot
- open POS (active before "Manager order")
- add product
- click Pay
- add cash payment
- click on validate
- open order manager and select an order
--> Raise

This commit block the header on receipt screen to force the user to click to "Next Order".

Current behavior before PR:

https://user-images.githubusercontent.com/16716992/119955416-5401aa80-bfa0-11eb-93b8-dc4430730e38.mov



Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/16716992/119955553-71367900-bfa0-11eb-8c37-c753f1c04063.png)


@pimodoo @rhe-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
