### PR TITLE
[FIX] Make blog post title and subtitle editable

### DIFF
--- a/addons/website_blog/static/src/js/wysiwyg.js
+++ b/addons/website_blog/static/src/js/wysiwyg.js
@@ -23,6 +23,7 @@ Wysiwyg.include({
     async start() {
         await this._super(...arguments);
         $('.js_tweet, .js_comment').off('mouseup').trigger('mousedown');
+        this.$editable.find('#o_wblog_post_name, #o_wblog_post_subtitle').attr('contentEditable', true)
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Cannot edit empty blog post and subtitle, e.g., a blog that is just created

Current behavior before PR:
Create a new blog; the title and subtitle are not editable

Desired behavior after PR is merged:
Empty blog title and subtitle should be editable



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
