### PR TITLE
[FIX] point_of_sale: cash rounding on invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -376,16 +376,18 @@ class PosOrder(models.Model):
             rounding_applied = float_round(self.amount_paid - self.amount_total,
                                            precision_rounding=new_move.currency_id.rounding)
             rounding_line = new_move.line_ids.filtered(lambda line: line.is_rounding_line)
+            if rounding_line and rounding_line.debit > 0:
+                rounding_line_difference = rounding_line.debit + rounding_applied
+            elif rounding_line and rounding_line.credit > 0:
+                rounding_line_difference = -rounding_line.credit + rounding_applied
+            else:
+                rounding_line_difference = rounding_applied
             if rounding_applied:
                 if rounding_applied > 0.0:
                     account_id = new_move.invoice_cash_rounding_id.loss_account_id.id
                 else:
                     account_id = new_move.invoice_cash_rounding_id.profit_account_id.id
                 if rounding_line:
-                    if rounding_line.debit > 0:
-                        rounding_line_difference = rounding_line.debit + rounding_applied
-                    else:
-                        rounding_line_difference = -rounding_line.credit + rounding_applied
                     if rounding_line_difference:
                         rounding_line.with_context(check_move_validity=False).write({
                             'debit': rounding_applied < 0.0 and -rounding_applied or 0.0,
@@ -393,25 +395,9 @@ class PosOrder(models.Model):
                             'account_id': account_id,
                             'price_unit': rounding_applied,
                         })
-                        existing_terms_line = new_move.line_ids.filtered(
-                            lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
-                        if existing_terms_line.debit > 0:
-                            existing_terms_line_new_val = float_round(
-                                existing_terms_line.debit + rounding_line_difference,
-                                precision_rounding=new_move.currency_id.rounding)
-                        else:
-                            existing_terms_line_new_val = float_round(
-                                -existing_terms_line.credit + rounding_line_difference,
-                                precision_rounding=new_move.currency_id.rounding)
-                        existing_terms_line.write({
-                            'debit': existing_terms_line_new_val > 0.0 and existing_terms_line_new_val or 0.0,
-                            'credit': existing_terms_line_new_val < 0.0 and -existing_terms_line_new_val or 0.0,
-                        })
-
-                        new_move._recompute_payment_terms_lines()
 
                 else:
-                    self.env['account.move.line'].create({
+                    self.env['account.move.line'].with_context(check_move_validity=False).create({
                         'debit': rounding_applied < 0.0 and -rounding_applied or 0.0,
                         'credit': rounding_applied > 0.0 and rounding_applied or 0.0,
                         'quantity': 1.0,
@@ -428,7 +414,24 @@ class PosOrder(models.Model):
                     })
             else:
                 if rounding_line:
-                    rounding_line.unlink()
+                    rounding_line.with_context(check_move_validity=False).unlink()
+            if rounding_line_difference:
+                existing_terms_line = new_move.line_ids.filtered(
+                    lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
+                if existing_terms_line.debit > 0:
+                    existing_terms_line_new_val = float_round(
+                        existing_terms_line.debit + rounding_line_difference,
+                        precision_rounding=new_move.currency_id.rounding)
+                else:
+                    existing_terms_line_new_val = float_round(
+                        -existing_terms_line.credit + rounding_line_difference,
+                        precision_rounding=new_move.currency_id.rounding)
+                existing_terms_line.write({
+                    'debit': existing_terms_line_new_val > 0.0 and existing_terms_line_new_val or 0.0,
+                    'credit': existing_terms_line_new_val < 0.0 and -existing_terms_line_new_val or 0.0,
+                })
+
+                new_move._recompute_payment_terms_lines()
         return new_move
 
     def action_pos_order_paid(self):


### PR DESCRIPTION
When an invoice is created from pos having a cash rounding method, the
value of the rounding can depend on the payment methods.

When no rounding has been applied because of the order has been
partially paid by cash and bank, the rounding line should be deleted
from the invoice. We should also adapt the terms lines.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
