### PR TITLE
[FIX] point_of_sale: \n in ticket header doesn't work

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -33,7 +33,7 @@
                     <t t-raw="receipt.header_html" />
                 </t>
                 <t t-if="!receipt.header_html and receipt.header">
-                    <div><t t-esc="receipt.header" /></div>
+                    <div class="pos-receipt-center-align" style="white-space:pre-line"><t t-esc="receipt.header" /></div>
                 </t>
                 <t t-if="receipt.cashier">
                     <div class="cashier">


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
- in pos.config set an header with \n
--> during the render of the ticket \n is bypass

Apply the same logic than the footer

Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/119971014-bc588800-bfb0-11eb-8073-6922de8556b5.png)

![image](https://user-images.githubusercontent.com/16716992/119971135-e0b46480-bfb0-11eb-92ba-b0c623b89350.png)


Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/16716992/119971066-cbd7d100-bfb0-11eb-97c7-2b3bc2bdde79.png)


@pimodoo @rhe-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
