### PR TITLE
[IMP] account: unhide cancelled journal items and improve bank statement line search

### DIFF
--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -289,6 +289,8 @@
                     <field name="journal_id" domain="[('type', 'in', ('bank', 'cash'))]" />
                     <field name="narration" string="Notes"/>
                     <field name="transaction_type"/>
+                    <field name="move_id"/>
+                    <field name="amount"/>
                 </search>
             </field>
         </record>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1404,7 +1404,7 @@
             <field name="context">{'journal_type':'general', 'search_default_posted':1}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note')), ('move_id.state', '!=', 'cancel')]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="view_mode">tree,pivot,graph,form,kanban</field>
         </record>


### PR DESCRIPTION
[IMP] account: improve bank statement line search view
Enable searching for a bank statement line by amount and journal entry
part 1 of task [2486685](https://www.odoo.com/web#id=2486685&model=project.task)

[IMP] account: enable visibility of cancelled journal items
The default tree view action (debug mode) for account.move.line currently hides lines in the cancelled state. This commit modifies the default domain on the action.
Users can now filter and group all `account.move.line` including cancelled lines
part 3 of task (2486685)[https://www.odoo.com/web#id=2486685&model=project.task]

Description of the issue/feature this PR addresses:
Back2basics improvement task (2486685)

Current behavior before PR:
-unable to search bank statement lines by amount & journal entry
-unable to view cancelled journal items from the Journal Items menu

Desired behavior after PR is merged:
Both of the above are now available

See Task (2486685)[https://www.odoo.com/web#id=2486685&model=project.task]

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
