### PR TITLE
[FIX] sql_db: RELEASE SAVEPOINT even in case of rollback

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -411,7 +411,7 @@ class Cursor(object):
         except Exception:
             self.execute('ROLLBACK TO SAVEPOINT "%s"' % name)
             raise
-        else:
+        finally:
             self.execute('RELEASE SAVEPOINT "%s"' % name)
 
     @check


### PR DESCRIPTION
`ROLLBACK TO SAVEPOINT` doesn't release/destroy the savepoint.

e.g.
```
13.0=# BEGIN;
BEGIN
13.0=*# SAVEPOINT test;
SAVEPOINT
13.0=*# INSERT INTO res_partner(name) VALUES('test');
INSERT 0 1
13.0=*# SELECT name FROM res_partner WHERE name = 'test';
    name
------
    test
(1 row)

13.0=*# ROLLBACK TO SAVEPOINT  test;
ROLLBACK
13.0=*# SELECT name FROM res_partner WHERE name = 'test';
    name
------
(0 rows)

13.0=*# INSERT INTO res_partner(name) VALUES('test');
INSERT 0 1
13.0=*# SELECT name FROM res_partner WHERE name = 'test';
    name
------
    test
(1 row)

13.0=*# ROLLBACK TO SAVEPOINT  test;
ROLLBACK
13.0=*# SELECT name FROM res_partner WHERE name = 'test';
    name
------
(0 rows)

13.0=*# INSERT INTO res_partner(name) VALUES('test');
INSERT 0 1
13.0=*# RELEASE SAVEPOINT test;
RELEASE
13.0=*# ROLLBACK TO SAVEPOINT  test;
ERROR:  savepoint "test" does not exist
```

Meaning, before this revision, the savepoint
remained (until the transaction commit/rollback)
in case of exception / rollback.

This is particularly problematic for upgrades,
where the leftover savepoints can be carried for a long-time,
as commits do not occur that often.
Having a lot of savepoints in a transaction alter significantly
the transaction performance.
See
https://www.cybertec-postgresql.com/en/subtransactions-and-performance-in-postgresql/
