### PR TITLE
[FIX] point_of_sale: perform stock operation only when necessary

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -149,14 +149,15 @@ class StockPicking(models.Model):
                             self.env['stock.move.line'].create(ml_vals)
 
                 else:
-                    move._action_assign()
-                    for move_line in move.move_line_ids:
-                        move_line.qty_done = move_line.product_uom_qty
-                    if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
-                        remaining_qty = move.product_uom_qty - move.quantity_done
-                        ml_vals = move._prepare_move_line_vals()
-                        ml_vals.update({'qty_done':remaining_qty})
-                        self.env['stock.move.line'].create(ml_vals)
+                    if self.user_has_groups('stock.group_tracking_owner'):
+                        move._action_assign()
+                        for move_line in move.move_line_ids:
+                            move_line.qty_done = move_line.product_uom_qty
+                        if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
+                            remaining_qty = move.product_uom_qty - move.quantity_done
+                            ml_vals = move._prepare_move_line_vals()
+                            ml_vals.update({'qty_done':remaining_qty})
+                            self.env['stock.move.line'].create(ml_vals)
                     move.quantity_done = move.product_uom_qty
 
     def _send_confirmation_email(self):

--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -207,6 +207,8 @@ class TestPoSStock(TestPoSCommon):
         Test order via POS a product having stock owner.
         """
 
+        group_owner = self.env.ref('stock.group_tracking_owner')
+        self.env.user.write({'groups_id': [(4, group_owner.id)]})
         self.product4 = self.create_product('Product 3', self.categ_basic, 30.0, 15.0)
         inventory = self.env['stock.inventory'].create({
             'name': 'Inventory adjustment'


### PR DESCRIPTION
Fine tuning of
https://github.com/odoo/odoo/commit/bdd36f7ce68999576dfc30298f4ddf2572b4c7ec
to perform the assignment and related operation only when 'consignment' is
enabled

opw-2508371

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
