### PR TITLE
[IMP] project: do not display the archived sub-task in list

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -157,12 +157,12 @@ class Task(models.Model):
 
     @api.depends('child_ids.effective_hours', 'child_ids.subtask_effective_hours')
     def _compute_subtask_effective_hours(self):
-        for task in self:
+        for task in self.with_context(active_test=False):
             task.subtask_effective_hours = sum(child_task.effective_hours + child_task.subtask_effective_hours for child_task in task.child_ids)
 
     def action_view_subtask_timesheet(self):
         self.ensure_one()
-        tasks = self._get_all_subtasks()
+        tasks = self.with_context(active_test=False)._get_all_subtasks()
         return {
             'type': 'ir.actions.act_window',
             'name': _('Timesheets'),

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -646,7 +646,7 @@ class Task(models.Model):
     legend_normal = fields.Char(related='stage_id.legend_normal', string='Kanban Ongoing Explanation', readonly=True, related_sudo=False)
     is_closed = fields.Boolean(related="stage_id.is_closed", string="Closing Stage", readonly=True, related_sudo=False)
     parent_id = fields.Many2one('project.task', string='Parent Task', index=True)
-    child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", context={'active_test': False})
+    child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks")
     child_text = fields.Char(compute="_compute_child_text")
     allow_subtasks = fields.Boolean(string="Allow Sub-tasks", related="project_id.allow_subtasks", readonly=True)
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count')
@@ -1382,7 +1382,7 @@ class Task(models.Model):
     # If depth == 3, return children to third generation
     # If depth <= 0, return all children without depth limit
     def _get_all_subtasks(self, depth=0):
-        children = self.mapped('child_ids').filtered(lambda children: children.active)
+        children = self.mapped('child_ids')
         if not children:
             return self.env['project.task']
         if depth == 1:


### PR DESCRIPTION
Currently, when go to project > settings > enable 'sub-tasks', create a task >> add a sub-task and archive the sub-task
then the archived sub-task is still displayed in the sub-tasks list

so in this commit, removed the active_test context from the field to hide the archived sub-task.

PS: revert of the commit: https://github.com/odoo/odoo/commit/7a2cba3c8934064b311da4312ef2fbd07c6329ec As we would deduct archived tasks from the count and the number of planning hours, and keep them included in the timesheets.

TaskID: 2534898
