### PR TITLE
[IMP] mail: make mail.template name translatable

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -26,7 +26,7 @@ class MailTemplate(models.Model):
         return res
 
     # description
-    name = fields.Char('Name')
+    name = fields.Char('Name', translate=True)
     model_id = fields.Many2one('ir.model', 'Applies to', help="The type of document this template can be used with")
     model = fields.Char('Related Document Model', related='model_id.model', index=True, store=True, readonly=True)
     subject = fields.Char('Subject', translate=True, help="Subject (placeholders may be used here)")


### PR DESCRIPTION
This commit simply makes the mail.template name field translatable.

It had not been done yet since the model is quite technical but it's still
displayed for the end users within the composer so it's better to have it
translated if need be.

Task-2543495

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
