### PR TITLE
[REF] base: modernise ir.ui.view

### DIFF
--- a/addons/auth_totp_portal/views/templates.xml
+++ b/addons/auth_totp_portal/views/templates.xml
@@ -8,7 +8,7 @@
                 bit ridiculous
             -->
             <div class="d-none" id="totp_wizard_view">
-                <t t-esc="env.ref('auth_totp.view_totp_wizard').sudo().read_combined(['arch'])['arch']"/>
+                <t t-esc="env.ref('auth_totp.view_totp_wizard').sudo().get_combined_arch()"/>
             </div>
             <section>
                 <h3>Two-factor authentication</h3>

--- a/addons/web_editor/tests/test_views.py
+++ b/addons/web_editor/tests/test_views.py
@@ -60,7 +60,7 @@ class TestViews(TransactionCase):
         self.assertEqual(base.inherit_children_ids.mode, 'extension')
         self.assertIn(
             '<p>Hello World!</p>',
-            base.inherit_children_ids.read_combined(['arch'])['arch'],
+            base.inherit_children_ids.get_combined_arch(),
         )
 
     def test_find_available_name(self):

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -378,7 +378,7 @@ class Http(models.AbstractModel):
                 # There might be 2 cases where the exception code can't be found
                 # in the view, either the error is in a child view or the code
                 # contains branding (<div t-att-data="request.browse('ok')"/>).
-                et = etree.fromstring(view.with_context(inherit_branding=False).read_combined(['arch'])['arch'])
+                et = view.with_context(inherit_branding=False)._get_combined_arch()
                 node = et.xpath(exception.path)
                 line = node is not None and etree.tostring(node[0], encoding='unicode')
                 if line:

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -294,8 +294,8 @@ class View(models.Model):
             return view_id if view_id._name == 'ir.ui.view' else self.env['ir.ui.view']
 
     @api.model
-    def _get_inheriting_views_arch_domain(self, model):
-        domain = super(View, self)._get_inheriting_views_arch_domain(model)
+    def _get_inheriting_views_domain(self):
+        domain = super(View, self)._get_inheriting_views_domain()
         current_website = self.env['website'].browse(self._context.get('website_id'))
         website_views_domain = current_website.website_domain()
         # when rendering for the website we have to include inactive views
@@ -305,11 +305,11 @@ class View(models.Model):
         return expression.AND([website_views_domain, domain])
 
     @api.model
-    def get_inheriting_views_arch(self, model):
+    def _get_inheriting_views(self):
         if not self._context.get('website_id'):
-            return super(View, self).get_inheriting_views_arch(model)
+            return super(View, self)._get_inheriting_views()
 
-        views = super(View, self.with_context(active_test=False)).get_inheriting_views_arch(model)
+        views = super(View, self.with_context(active_test=False))._get_inheriting_views()
         # prefer inactive website-specific views over active generic ones
         return views.filter_duplicate().filtered('active')
 

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2020,7 +2020,7 @@ class NameManager:
         self.mandatory_names_or_ids = dict()
         self.available_names_or_ids = set()
         self.validate = validate
-        self.Model = Model
+        self.Model = Model.with_context(lang=False)
         self.fields_get = self.Model.fields_get()
 
     def has_field(self, name, info=()):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -74,18 +74,25 @@ def transfer_node_to_modifiers(node, modifiers, context=None, current_node_path=
         else:
             modifiers['invisible'] = [('state', 'not in', node.get('states').split(','))]
 
-    for a in ('invisible', 'readonly', 'required'):
-        if node.get(a):
-            v = bool(safe_eval.safe_eval(node.get(a), {'context': context or {}}))
+    for attr in ('invisible', 'readonly', 'required'):
+        value_str = node.get(attr)
+        if value_str:
+            # most (~95%) elements are 0/1/True/False
+            if value_str == '1' or value_str == 'True':
+                value = True
+            elif value_str == '0' or value_str == 'False':
+                value = False
+            else:
+                value = bool(safe_eval.safe_eval(value_str, {'context': context or {}}))
             node_path = current_node_path or ()
-            if 'tree' in node_path and 'header' not in node_path and a == 'invisible':
+            if 'tree' in node_path and 'header' not in node_path and attr == 'invisible':
                 # Invisible in a tree view has a specific meaning, make it a
                 # new key in the modifiers attribute.
-                modifiers['column_invisible'] = v
-            elif v or (a not in modifiers or not isinstance(modifiers[a], list)):
+                modifiers['column_invisible'] = value
+            elif value or (attr not in modifiers or not isinstance(modifiers[attr], list)):
                 # Don't set the attribute to False if a dynamic value was
                 # provided (i.e. a domain from attrs or states).
-                modifiers[a] = v
+                modifiers[attr] = value
 
 
 def simplify_modifiers(modifiers):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -390,7 +390,7 @@ actual arch.
         for view in self:
             try:
                 # verify the view is valid xml and that the inheritance resolves
-                view_arch = etree.fromstring(view.arch.encode('utf-8'))
+                view_arch = etree.fromstring(view.arch)
                 view._valid_inheritance(view_arch)
                 combined_arch = view._get_combined_arch()
                 if view.type == 'qweb':
@@ -400,7 +400,7 @@ actual arch.
                     "Error while validating view:\n\n%(error)s",
                     error=tools.ustr(e),
                 )).with_traceback(e.__traceback__)
-                err.context = None
+                err.context = getattr(e, 'context', None)
                 raise err from None
 
             try:

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -679,7 +679,7 @@ class TestTemplating(ViewCase):
             """
         })
 
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
 
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
@@ -722,7 +722,7 @@ class TestTemplating(ViewCase):
             """
         })
 
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
 
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
@@ -777,7 +777,7 @@ class TestTemplating(ViewCase):
             """
         })
 
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
 
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
@@ -832,7 +832,7 @@ class TestTemplating(ViewCase):
                 </xpath>
             """
         })
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
 
@@ -872,7 +872,7 @@ class TestTemplating(ViewCase):
                 </data>
             """
         })
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
 
@@ -902,7 +902,7 @@ class TestTemplating(ViewCase):
             """
         })
 
-        arch_string = view2.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view2.with_context(inherit_branding=True).get_combined_arch()
 
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
@@ -949,7 +949,7 @@ class TestTemplating(ViewCase):
             </xpath>"""
         })
 
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
 
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
@@ -986,7 +986,7 @@ class TestTemplating(ViewCase):
             </root>""",
         })
 
-        arch_string = view.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view.with_context(inherit_branding=True).get_combined_arch()
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
 
@@ -1007,7 +1007,7 @@ class TestTemplating(ViewCase):
             </root>""",
         })
 
-        arch_string = view.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view.with_context(inherit_branding=True).get_combined_arch()
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
 
@@ -1022,7 +1022,7 @@ class TestTemplating(ViewCase):
             </root>""",
         })
 
-        arch_string = view.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view.with_context(inherit_branding=True).get_combined_arch()
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
 
@@ -1049,7 +1049,7 @@ class TestTemplating(ViewCase):
             </xpath>"""
         })
 
-        arch_string = view1.with_context(inherit_branding=True).read_combined(['arch'])['arch']
+        arch_string = view1.with_context(inherit_branding=True).get_combined_arch()
 
         arch = etree.fromstring(arch_string)
         self.View.distribute_branding(arch)
@@ -2742,7 +2742,7 @@ class TestViewCombined(ViewCase):
 
     def test_basic_read(self):
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.a1.with_context(context).read_combined(['arch'])['arch']
+        arch = self.a1.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2753,7 +2753,7 @@ class TestViewCombined(ViewCase):
 
     def test_read_from_child(self):
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.a3.with_context(context).read_combined(['arch'])['arch']
+        arch = self.a3.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2764,7 +2764,7 @@ class TestViewCombined(ViewCase):
 
     def test_read_from_child_primary(self):
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.a4.with_context(context).read_combined(['arch'])['arch']
+        arch = self.a4.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2776,7 +2776,7 @@ class TestViewCombined(ViewCase):
 
     def test_cross_model_simple(self):
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.c2.with_context(context).read_combined(['arch'])['arch']
+        arch = self.c2.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2790,7 +2790,7 @@ class TestViewCombined(ViewCase):
 
     def test_cross_model_double(self):
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.d1.with_context(context).read_combined(['arch'])['arch']
+        arch = self.d1.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2841,7 +2841,7 @@ class TestOptionalViews(ViewCase):
         """ mandatory and enabled views should be applied
         """
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.v0.with_context(context).read_combined(['arch'])['arch']
+        arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2857,7 +2857,7 @@ class TestOptionalViews(ViewCase):
         """
         self.v2.toggle_active()
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.v0.with_context(context).read_combined(['arch'])['arch']
+        arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2868,7 +2868,7 @@ class TestOptionalViews(ViewCase):
 
         self.v3.toggle_active()
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.v0.with_context(context).read_combined(['arch'])['arch']
+        arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(
@@ -2880,7 +2880,7 @@ class TestOptionalViews(ViewCase):
 
         self.v2.toggle_active()
         context = {'check_view_ids': self.View.search([]).ids}
-        arch = self.v0.with_context(context).read_combined(['arch'])['arch']
+        arch = self.v0.with_context(context).get_combined_arch()
         self.assertEqual(
             etree.fromstring(arch),
             E.qweb(

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1667,13 +1667,13 @@ class BaseModel(metaclass=MetaModel):
 
         if view_id:
             # read the view with inherited views applied
-            root_view = View.browse(view_id).read_combined(['id', 'name', 'field_parent', 'type', 'model', 'arch'])
-            result['arch'] = root_view['arch']
-            result['name'] = root_view['name']
-            result['type'] = root_view['type']
-            result['view_id'] = root_view['id']
-            result['field_parent'] = root_view['field_parent']
-            result['base_model'] = root_view['model']
+            view = View.browse(view_id)
+            result['arch'] = view.get_combined_arch()
+            result['name'] = view.name
+            result['type'] = view.type
+            result['view_id'] = view.id
+            result['field_parent'] = view.field_parent
+            result['base_model'] = view.model
         else:
             # fallback on default views methods if no ir.ui.view could be found
             try:

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -688,7 +688,7 @@ form: module.record_id""" % (xml_id,)
                     err=err.args[0],
                 )
                 _logger.debug(msg, exc_info=True)
-                raise ParseError(msg) from None  # Restart with "--log_handler odoo.tools.convert:DEBUG" for complete traceback
+                raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
             except Exception as e:
                 raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
                     rec.getroottree().docinfo.URL,

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -91,6 +91,8 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
     architecture) given by an inheriting view.
 
     :param Element source: a parent architecture to modify
+    :param Element specs_tree: a modifying architecture in an inheriting view
+    :param bool inherit_branding:
     :param pre_locate: function that is executed before locating a node.
                         This function receives an arch as argument.
                         This is required by studio to properly handle group_ids.


### PR DESCRIPTION
Aggregation of all the changes related to [Task 2463632](https://www.odoo.com/web#id=2463632&model=project.task&view_type=form&cids=1&menu_id=5195) and its sub-tasks.

### [IMP] base: fields_view_get() benchmark

Because our task is performance-related, we added a way to quickly benchmark the changes. We used py-spy to generate a speedscope (because the new `profile` was not merged yet) out of the benchmark and measure the functions but the new profiler can be used instead. All the commit that are mentioning performance improvements have been realized thanks to this benchmark with the following modules installed: `website_sale,mrp,contacts,crm,timesheet`.

py-spy cli:

    py-spy record -F -r 200 --format speedscope -o speedscope.json -- python3 odoo-bin -d <yourdatabase> --test-tags render_all_views --stop-after-init

To use the new built-in profiler (see #66590) instead:

     diff --git a/odoo/addons/base/tests/test_views.py b/odoo/addons/base/tests/test_views.py
     index b04fdd981bb..05b0c2da617 100644
     --- a/odoo/addons/base/tests/test_views.py
     +++ b/odoo/addons/base/tests/test_views.py
     @@ -3094,6 +3094,7 @@ class TestRenderAllViews(common.TransactionCase):

          @common.users('demo', 'admin')
          def test_render_all_views(self):
     +      with self.profile():
              env = self.env(context={'lang': 'en_US'})
              count = 0
              elapsed = 0

###  [REF] base: introduce view._get_combined_arch()

Also: [IMP] all: read_combined(['arch']['arch'] => get_combined_arch()

The only public API available to retrieve a combined view arch is `read_combined()` which is a `read` function where the `arch` field contains the combined views as a string.

We suggest to provide a way to get the combined architecture outside of a read. If possible, there should be a way to retrieve the combined arch either as string either as a low level etree.Element object. There are codes that re-parse the combined view in a etree Element and that would benefit to get an etree Element right away.

Two new methods were added:

* `get_combined_arch()` takes no argument and returns the combined arch as string
* `_get_combined_arch()` takes no argument and returns the combined arch as an etree Element.

Because the `read_combined` function was basically only used to get the combined arch (`read_combined(['arch'])['arch']` almost everywhere), we adapted all modules to use either of the two new method instead and deprecated `read_combined`.

### [REF] base: view hierarchy retrieval and combination

The current view combination mechanism involves multiple steps: (i) find all the primary views that are ancestors to the current view, for each primary view (starting with the oldest one) (ii) combine the primary view (iii) find all its extensions, (iv) order them in combination order, (v) combine them.

_Example_

In the hierarchy below, the views (1, 4) marked with a * are primary views, the view (6) marked with a ! is the view we want to combine.

              1*
             / \
            2   3
           / \
          4*  5
         /   / \
        6!  7   8

The primary views are ordered as follow (first to combine first): 1, 4.
The views are ordered as follow (first to combine first): 1, 2, 5, 7, 8, 3, 4, 6.

The current implementation uses a recursive approach: for every primary view, it queries the database to retrieve its descendants and merge them together. We argue that the recursion is sub-efficient because it queries the database more. We also argue that it is difficult to work with the current implementation and suggest to refactor it.

The view methods `_get_combined_arch()`, `get_inheriting_views_arch()`, `apply_view_inheritance()`, `_apply_view_inheritance()` and were responsible to combine the views together:

* `_get_combined_arch()`: implemented the above-mentioned recursion, it was responsible to find the nearest primary view ancestor, delegate the combination of the primary view's parent view thanks to a recursive _get_combined_arch() call.
* `get_inheriting_views_arch()`: big fat sql query to find all the extensions of the current primary view
* `apply_view_inheritance()`: build the above-mentioned hierarchy (only with 1 primary view)
* `_apply_view_inheritance()`: traverse in-order depth-first the hierarchy to combine the views

We changed the structure as follow:

* `_get_combined_arch()`: find all the views that are parent to the current view
* `_get_inheriting_views()`: find all the descendants for all the views
* `_get_combined_arch()` (again): build the above-mentioned hierarchy (with all primary views)
* `_combine()`: traverse the hierarchy in a clever order to combine the views

### Other commits

They are primary optimizations, please refer to the commit message of each commit.