### PR TITLE
[IMP] website: remove progress bar title margin

### DIFF
--- a/addons/website/views/snippets/s_media_list.xml
+++ b/addons/website/views/snippets/s_media_list.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Media List" id="s_media_list">
-    <section class="s_media_list bg-200 pt32 pb32" data-vcss="001">
+    <section class="s_media_list pt32 pb32 o_cc o_cc2" data-vcss="001">
         <div class="container">
             <div class="row s_nb_column_fixed s_col_no_bgcolor">
                 <div class="col-lg-12 s_media_list_item pt16 pb16" data-name="Media item">

--- a/addons/website/views/snippets/s_picture.xml
+++ b/addons/website/views/snippets/s_picture.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_picture" name="Picture">
-    <section class="s_picture bg-200 pt48 pb24">
+    <section class="s_picture pt48 pb24 o_cc o_cc2">
         <div class="container">
             <h2 style="text-align: center;"><font style="font-size: 62px;">A punchy Headline</font></h2>
             <p style="text-align: center;">Choose a vibrant image and write an inspiring paragraph about it.<br/> It does not have to be long, but it should reinforce your image.</p>

--- a/addons/website/views/snippets/s_progress_bar.xml
+++ b/addons/website/views/snippets/s_progress_bar.xml
@@ -3,7 +3,7 @@
 
 <template name="Progress Bar" id="s_progress_bar">
     <div class="s_progress_bar" data-display="inline">
-        <h4>We are almost done!</h4>
+        <h4 class="mb-0">We are almost done!</h4>
         <div class="progress">
             <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%; min-width: 3%">
                 <span class="s_progress_bar_text">80% Development</span>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -3,7 +3,7 @@
 
 <template id="s_quotes_carousel" name="Quotes">
     <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="001">
-        <div id="myQuoteCarousel" class="s_quotes_carousel s_carousel_default carousel slide bg-200" data-interval="10000">
+        <div id="myQuoteCarousel" class="s_quotes_carousel s_carousel_default carousel slide o_cc o_cc2" data-interval="10000">
             <!-- Indicators -->
             <ol class="carousel-indicators">
                 <li data-target="#myQuoteCarousel" data-slide-to="0" class="active"/>

--- a/addons/website/views/snippets/s_three_columns.xml
+++ b/addons/website/views/snippets/s_three_columns.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_three_columns" name="Columns">
-    <section class="s_three_columns bg-200 pt32 pb32" data-vcss="001">
+    <section class="s_three_columns o_cc o_cc2 pt32 pb32" data-vcss="001">
         <div class="container">
             <div class="row d-flex align-items-stretch">
                 <div class="col-lg-4 s_col_no_bgcolor pt16 pb16">


### PR DESCRIPTION
The mb0 has been added to the h4 tag of the progress bar so that there
is not too much padding if it is changed to simple text.

task-2542318

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
