### PR TITLE
[FIX] im_livechat: show chat to operator only after first message

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -4,7 +4,7 @@ import base64
 import random
 import re
 
-from odoo import api, fields, models, modules, _
+from odoo import api, Command, fields, models, modules, _
 
 
 class ImLivechatChannel(models.Model):
@@ -115,14 +115,14 @@ class ImLivechatChannel(models.Model):
     def _get_livechat_mail_channel_vals(self, anonymous_name, operator, user_id=None, country_id=None):
         # partner to add to the mail.channel
         operator_partner_id = operator.partner_id.id
-        channel_partner_to_add = [(4, operator_partner_id)]
+        channel_partner_to_add = [Command.create({'partner_id': operator_partner_id, 'is_pinned': False})]
         visitor_user = False
         if user_id:
             visitor_user = self.env['res.users'].browse(user_id)
             if visitor_user and visitor_user.active:  # valid session user (not public)
-                channel_partner_to_add.append((4, visitor_user.partner_id.id))
+                channel_partner_to_add.append(Command.create({'partner_id': visitor_user.partner_id.id}))
         return {
-            'channel_partner_ids': channel_partner_to_add,
+            'channel_last_seen_partner_ids': channel_partner_to_add,
             'livechat_active': True,
             'livechat_operator_id': operator_partner_id,
             'livechat_channel_id': self.id,

--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -76,7 +76,7 @@ class MailChannel(models.Model):
         values = super(MailChannel, self).channel_fetch_slot()
         livechat_channels = self.env['mail.channel'].search([
             ('channel_type', '=', 'livechat'),
-            ('channel_partner_ids', 'in', self.env['mail.channel.partner'].sudo()._search([
+            ('channel_last_seen_partner_ids', 'in', self.env['mail.channel.partner'].sudo()._search([
                 ('partner_id', '=', self.env.user.partner_id.id),
                 ('is_pinned', '=', True)])
             ),


### PR DESCRIPTION
Not sure exactly because of which change, but channel partner is now created
with its default is_pinned value (True) taken into account, which was not the
case before. This is a good change in general, but the livechat code relied on
the old behavior.

This commit makes it explicit that in this case the value should be False, and a
test is added to guarantee it once and for all.

This commit also fixes an issue during init messaging, where ids of res.partner
were searched instead of ids of channel.partner.

task-2547806