### PR TITLE
[FIX] all: grant py39 support

### DIFF
--- a/addons/base_import_module/models/base_import_module.py
+++ b/addons/base_import_module/models/base_import_module.py
@@ -18,7 +18,7 @@ class BaseImportModule(models.TransientModel):
     def import_module(self):
         self.ensure_one()
         IrModule = self.env['ir.module.module']
-        zip_data = base64.decodestring(self.module_file)
+        zip_data = base64.decodebytes(self.module_file)
         fp = BytesIO()
         fp.write(zip_data)
         res = IrModule.import_zipfile(fp, force=self.force)

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -358,7 +358,7 @@ class AccountFrFec(models.TransientModel):
             suffix = '-NONOFFICIAL'
 
         self.write({
-            'fec_data': base64.encodestring(fecvalue),
+            'fec_data': base64.encodebytes(fecvalue),
             # Filename = <siren>FECYYYYMMDD where YYYMMDD is the closing date
             'filename': '%sFEC%s%s.csv' % (company_legal_data['siren'], end_date, suffix),
             })

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -164,7 +164,7 @@ class AccountInvoice(models.Model):
                 'name': report_name,
                 'res_id': invoice.id,
                 'res_model': invoice._name,
-                'datas': base64.encodestring(data),
+                'datas': base64.encodebytes(data),
                 'datas_fname': report_name,
                 'description': description,
                 'type': 'binary',
@@ -785,7 +785,7 @@ class ImportInvoiceImportWizard(models.TransientModel):
                 # invoice already exist
                 raise UserError(_('E-invoice already exist: %s') % attachment.name)
             self = self.with_context(default_journal_id= self.journal_id.id)
-            invoice = self.env['account.invoice']._import_xml_invoice(base64.decodestring(attachment.datas), attachment)
+            invoice = self.env['account.invoice']._import_xml_invoice(base64.decodebytes(attachment.datas), attachment)
         else:
             invoice = super(ImportInvoiceImportWizard, self)._create_invoice_from_file(attachment)
         return invoice

--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -135,7 +135,7 @@ class FetchmailServer(models.Model):
 
         invoice_attachment = self.env['ir.attachment'].create({
                 'name': att_name,
-                'datas': base64.encodestring(att_content),
+                'datas': base64.encodebytes(att_content),
                 'datas_fname': att_name,
                 'type': 'binary',
                 })

--- a/addons/pos_cache/models/pos_cache.py
+++ b/addons/pos_cache/models/pos_cache.py
@@ -30,7 +30,7 @@ class pos_cache(models.Model):
                                          lang=self.compute_user_id.lang)
         res = prod_ctx.read(self.get_product_fields())
         datas = {
-            'cache': base64.encodestring(json.dumps(res).encode('utf-8')),
+            'cache': base64.encodebytes(json.dumps(res).encode('utf-8')),
         }
 
         self.write(datas)
@@ -50,7 +50,7 @@ class pos_cache(models.Model):
             self.product_fields = str(fields)
             self.refresh_cache()
 
-        return json.loads(base64.decodestring(self.cache).decode('utf-8'))
+        return json.loads(base64.decodebytes(self.cache).decode('utf-8'))
 
 
 class pos_config(models.Model):

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1169,7 +1169,7 @@ class Binary(http.Controller):
             try:
                 attachment = Model.create({
                     'name': filename,
-                    'datas': base64.encodestring(ufile.read()),
+                    'datas': base64.encodebytes(ufile.read()),
                     'datas_fname': filename,
                     'res_model': model,
                     'res_id': int(id)

--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -224,7 +224,7 @@ class WebsiteForm(http.Controller):
             custom_field = file.field_name not in authorized_fields
             attachment_value = {
                 'name': file.filename,
-                'datas': base64.encodestring(file.read()),
+                'datas': base64.encodebytes(file.read()),
                 'datas_fname': file.filename,
                 'res_model': model_name,
                 'res_id': record.id,

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -203,7 +203,7 @@ class IrActionsReport(models.Model):
             return None
         attachment_vals = {
             'name': attachment_name,
-            'datas': base64.encodestring(buffer.getvalue()),
+            'datas': base64.encodebytes(buffer.getvalue()),
             'datas_fname': attachment_name,
             'res_model': self.model,
             'res_id': record.id,
@@ -563,7 +563,7 @@ class IrActionsReport(models.Model):
 
         # Check special case having only one record with existing attachment.
         if len(save_in_attachment) == 1 and not pdf_content:
-            return base64.decodestring(list(save_in_attachment.values())[0].datas)
+            return base64.decodebytes(list(save_in_attachment.values())[0].datas)
 
         # Create a list of streams representing all sub-reports part of the final result
         # in order to append the existing attachments and the potentially modified sub-reports
@@ -633,7 +633,7 @@ class IrActionsReport(models.Model):
         # are not been rendered by wkhtmltopdf. So, create a new stream for each of them.
         if self.attachment_use:
             for attachment_id in save_in_attachment.values():
-                content = base64.decodestring(attachment_id.datas)
+                content = base64.decodebytes(attachment_id.datas)
                 streams.append(io.BytesIO(content))
 
         # Build the final pdf.

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -67,7 +67,7 @@ class IrUiMenu(models.Model):
         icon_image = False
         if icon_path:
             with tools.file_open(icon_path, 'rb') as icon_file:
-                icon_image = base64.encodestring(icon_file.read())
+                icon_image = base64.encodebytes(icon_file.read())
         return icon_image
 
     @api.constrains('parent_id')

--- a/odoo/addons/base/wizard/base_export_language.py
+++ b/odoo/addons/base/wizard/base_export_language.py
@@ -37,7 +37,7 @@ class BaseLanguageExport(models.TransientModel):
 
         with contextlib.closing(io.BytesIO()) as buf:
             tools.trans_export(lang, mods, buf, this.format, self._cr)
-            out = base64.encodestring(buf.getvalue())
+            out = base64.encodebytes(buf.getvalue())
 
         filename = 'new'
         if lang:

--- a/odoo/addons/base/wizard/base_import_language.py
+++ b/odoo/addons/base/wizard/base_import_language.py
@@ -36,7 +36,7 @@ class BaseLanguageImport(models.TransientModel):
 
         with TemporaryFile('wb+') as buf:
             try:
-                buf.write(base64.decodestring(this.data))
+                buf.write(base64.decodebytes(this.data))
 
                 # now we determine the file format
                 buf.seek(0)

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -137,7 +137,7 @@ class TestTermCount(common.TransactionCase):
     def test_import_from_po_file(self):
         """Test the import from a single po file works"""
         with file_open('test_translation_import/i18n/tlh.po', 'rb') as f:
-            po_file = base64.encodestring(f.read())
+            po_file = base64.encodebytes(f.read())
 
         import_tlh = self.env["base.language.import"].create({
             'name': 'Klingon',
@@ -160,7 +160,7 @@ class TestTermCount(common.TransactionCase):
     def test_import_from_csv_file(self):
         """Test the import from a single CSV file works"""
         with file_open('test_translation_import/i18n/dot.csv', 'rb') as f:
-            po_file = base64.encodestring(f.read())
+            po_file = base64.encodebytes(f.read())
 
         import_tlh = self.env["base.language.import"].create({
             'name': 'Dothraki',

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -88,6 +88,8 @@ _EXPR_OPCODES = _CONST_OPCODES.union(set(opmap[x] for x in [
     # comprehensions
     'LIST_APPEND', 'MAP_ADD', 'SET_ADD',
     'COMPARE_OP',
+    # py39
+    'LIST_EXTEND', 'CONTAINS_OP'
 ] if x in opmap))
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(set(opmap[x] for x in [


### PR DESCRIPTION
There are new opcodes with py39 and base64.{en,de}codestring have been
replaced by base64.{en,de}codebytes.

Closes: #71352