### PR TITLE
[FIX] point_of_sale: show COGS entries among Journal Items

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -54,7 +54,7 @@ class ProductProduct(models.Model):
             bom_line = move.bom_line_id
             bom_line_data = bom_lines[bom_line]
             bom_line_qty = bom_line_data['qty']
-            value += move.product_id._compute_average_price(qty_invoiced * bom_line_qty, qty_to_invoice * bom_line_qty, move)
+            value += bom_line_qty * move.product_id._compute_average_price(qty_invoiced * bom_line_qty, qty_to_invoice * bom_line_qty, move)
         return value
 
     def _compute_bom_price(self, bom, boms_to_recompute=False):

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -199,7 +199,8 @@ class PosOrder(models.Model):
         moves = self.filtered(lambda o: o.partner_id.id == partner_id)\
             .mapped('picking_ids.move_lines')\
             .sorted(lambda x: x.date)
-        price_unit = product._compute_average_price(0, quantity, moves)
+        product_moves = moves.filtered(lambda m: m.product_id.id == product.id)
+        price_unit = product._compute_average_price(0, quantity, product_moves or moves)
         return price_unit
 
     name = fields.Char(string='Order Ref', required=True, readonly=True, copy=False, default='/')

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -198,7 +198,6 @@ class PosOrder(models.Model):
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
         moves = self.filtered(lambda o: o.partner_id.id == partner_id)\
             .mapped('picking_ids.move_lines')\
-            .filtered(lambda m: m.product_id.id == product.id)\
             .sorted(lambda x: x.date)
         price_unit = product._compute_average_price(0, quantity, moves)
         return price_unit

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1036,7 +1036,16 @@ class PosSession(models.Model):
                 + sum(partially_reconciled_lines.mapped(get_matched_move_lines), partially_reconciled_lines.ids)
                 + cash_move_lines.ids)
 
-        return self.env['account.move.line'].browse(ids).mapped('move_id')
+        res = self.env['account.move.line'].browse(ids).mapped('move_id')
+
+        if self.company_id.anglo_saxon_accounting:
+            anglo_saxon_moves = self.picking_ids.move_lines.filtered(lambda m:
+                m.product_id.type == 'product' and
+                m.product_id.valuation=='real_time'
+            ).mapped('account_move_ids')
+            res += anglo_saxon_moves
+
+        return res
 
     def action_show_payments_list(self):
         return {


### PR DESCRIPTION
Activate anglo saxon accounting
Have a [DEMO] KIT product in a category using automated
Inventory Valuation with costing method AVCO
The KIT is composed by C1 and C2 in the same product category
Define a cost on both C1 and C2
Open a POS session, order [DEMO] and complete the order
Close Session, Validate and display Journal Items

COGS entries will be missing

opw-2481518

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
