### PR TITLE
[FIX] mail: fix className can be null in mixin

### DIFF
--- a/addons/mail/static/src/js/m2x_avatar_user.js
+++ b/addons/mail/static/src/js/m2x_avatar_user.js
@@ -29,7 +29,7 @@ const M2XAvatarMixin = {
         if (!this.supportedModels.includes(this.field.relation)) {
             throw new Error(`This widget is only supported on many2one and many2many fields pointing to ${JSON.stringify(this.supportedModels)}`);
         }
-        this.className += ' o_clickable_m2x_avatar';
+        this.className = `${this.className || ''} o_clickable_m2x_avatar`.trim();
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Before this commit, the className can be null and then this processing:
`this.className += ' o_clickable_m2x_avatar';` gives
'null o_clickable_m2x_avatar' in the class of the element classList.

This commit checks if the className is not null if yes, then we add the
the class otherwise the className is created in this mixins.

X-original-commit: d25459e6cbfc1dbe92350bc5b17bb33062ac4f12

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
