### PR TITLE
[FIX] core: origin of main record in onchange

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1472,6 +1472,22 @@ class TestFields(common.TransactionCase):
         self.assertNotEqual(new_disc.participants, disc.participants)
         self.assertEqual(new_disc.participants._origin, disc.participants)
 
+        # provide many2one field as a dict of values; the value is a new record
+        # with the given 'id' as origin (if given, of course)
+        new_msg = disc.messages.new({
+            'discussion': {'name': disc.name},
+        })
+        self.assertTrue(new_msg.discussion)
+        self.assertFalse(new_msg.discussion.id)
+        self.assertFalse(new_msg.discussion._origin)
+
+        new_msg = disc.messages.new({
+            'discussion': {'name': disc.name, 'id': disc.id},
+        })
+        self.assertTrue(new_msg.discussion)
+        self.assertFalse(new_msg.discussion.id)
+        self.assertEqual(new_msg.discussion._origin, disc)
+
         # check convert_to_write
         tag = self.env['test_new_api.multi.tag'].create({'name': 'Foo'})
         rec = self.env['test_new_api.multi'].create({

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2528,7 +2528,10 @@ class Many2one(_Relational):
             # value is either a pair (id, name), or a tuple of ids
             id_ = value[0] if value else None
         elif isinstance(value, dict):
-            id_ = record.env[self.comodel_name].new(value).id
+            # return a new record (with the given field 'id' as origin)
+            comodel = record.env[self.comodel_name]
+            origin = comodel.browse(value.get('id'))
+            id_ = comodel.new(value, origin=origin).id
         else:
             id_ = None
 


### PR DESCRIPTION
When invoking onchange() on a line in a one2many field, the inverse
many2one field is given as a dict of values.  Those values are the ones
of the "container" record in the form view, and they include the "id" of
the container record.  The method onchange() instantiates the container
record as a new record with the given values.  Fix the code to set the
expected "origin" of that record to the record with the given "id".