### PR TITLE
[IMP] Transientmodel vacuum advisory lock

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -64,6 +64,7 @@ from .tools import date_utils
 from .tools import populate
 from .tools import unique
 from .tools.lru import LRU
+from .tools.sql import pg_try_advisory_lock
 
 _logger = logging.getLogger(__name__)
 _schema = logging.getLogger(__name__ + '.schema')
@@ -6536,6 +6537,10 @@ class TransientModel(Model):
           would immediately cause the maximum to be reached again.
         - the 10 rows that have been created/changed the last 5 minutes will NOT be deleted
         """
+        # Ensure the vacuum for this model is not already running on a different worker
+        if not pg_try_advisory_lock(self.env.cr, "transient.vacuum." + self._name):
+            return
+
         if self._transient_max_hours:
             # Age-based expiration
             self._transient_clean_rows_older_than(self._transient_max_hours * 60 * 60)

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -3,8 +3,10 @@
 
 # pylint: disable=sql-injection
 
+import hashlib
 import logging
 import psycopg2
+import struct
 
 _schema = logging.getLogger('odoo.schema')
 
@@ -277,3 +279,19 @@ def increment_field_skiplock(record, field):
     cr.execute(query, {'ids': tuple(record.ids)})
 
     return bool(cr.fetchone())
+
+
+def pg_try_advisory_lock(cr, reference):
+    """Attempt to acquire a pg_try_advisory_xact_lock for the given reference.
+
+    Use this method to create database lock with a specific static reference. This
+    reference always resolves to the same hash so the lock cannot be set twice. Useful
+    to solve data concurrency issues where records are accessed and updated by
+    different processes.
+    """
+    hasher = hashlib.sha1(reference)
+    pglock = struct.unpack('q', hasher.digest()[:8])[0]
+    cr.execute("SELECT pg_try_advisory_xact_lock(%s);", (pglock,))
+    if not cr.fetchone()[0]:
+        return False
+    return True


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Simultaneous invocation of the _transient_vacuum method when creating new transient model records can create concurrency issues when called multiple times on the same set to be cleaned.

Current behavior before PR:
A concurrent update error is raised.
Desired behavior after PR is merged:
No concurrent update is raised since the cleaning is executed only once.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
