### PR TITLE
[FIX] core: block creating meaningless related field

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -11879,6 +11879,12 @@ msgid "Field %r used in attributes must be present in view but is missing:"
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:0
+#, python-format
+msgid "Field %s (%s) cannot be used in stored related field."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,field_description:base.field_ir_model_fields__help
 msgid "Field Help"
 msgstr ""

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -470,10 +470,12 @@ class IrModelFields(models.Model):
                 raise UserError(_("Unknown field name '%s' in related field '%s'") % (name, self.related))
             if index < last and not field.relational:
                 raise UserError(_("Non-relational field name '%s' in related field '%s'") % (name, self.related))
+            if self.store and index < last and not field._description_searchable:
+                raise UserError(_("Field %s (%s) cannot be used in stored related field.") % (field.string, field.name))
             model = model[name]
         return field
 
-    @api.constrains('related')
+    @api.constrains('related', 'store')
     def _check_related(self):
         for rec in self:
             if rec.state == 'manual' and rec.related:


### PR DESCRIPTION
There maybe fields that are not storable and not computed. Example: purchase_vendor_bill_id
https://github.com/odoo/odoo/blob/2b4ae68892bf963f5170651e4ca4a9983ea18af9/addons/purchase/models/account_invoice.py#L10

If related field has such a field in its chain, it would lead to recomputing all
records in field's model.

---

opw-2524010

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
