### PR TITLE
[FIX] web: render graph in comparison mode

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_model.js
+++ b/addons/web/static/src/js/views/graph/graph_model.js
@@ -206,12 +206,22 @@ return AbstractModel.extend({
 
         var context = _.extend({fill_temporal: true}, this.chart.context);
         var defs = [];
+        var needEntireRange = "timeRangeMenuData" in context && "timeRange" in context["timeRangeMenuData"] && "comparisonTimeRange" in context["timeRangeMenuData"]
 
         domains.forEach(function (domain, originIndex) {
+            var context_extension = {}
+            if (needEntireRange) {
+                var range = originIndex == 0 ? context["timeRangeMenuData"]["timeRange"] : context["timeRangeMenuData"]["comparisonTimeRange"]
+                var start = moment(range[1][2])
+                var end = moment(range[2][2])
+                // end is exclusive in the domain, we need an inclusive value
+                end = end.subtract(1, 's')
+                context_extension = {start_fill_range: start.format("YYYY-MM-DD"), end_fill_range: end.format("YYYY-MM-DD"), fill_entire_range: true}
+            }
             defs.push(self._rpc({
                 model: self.modelName,
                 method: 'read_group',
-                context: context,
+                context: _.extend(context, context_extension),
                 domain: domain,
                 fields: fields,
                 groupBy: groupBy,

--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -208,7 +208,14 @@ return AbstractRenderer.extend({
      */
     _filterDataPoints: function () {
         var dataPoints = [];
-        if (_.contains(['bar', 'pie'], this.state.mode)) {
+        if (this.state.compare && this.state.mode == 'bar') {
+            // Keep the pair of points if at least one of them has a positive count
+            var groups = _.zip(..._.values(_.groupBy(this.state.dataPoints, 'originIndex'))).filter(
+                group => _.reduce(group, (memo, dp) => memo + (dp && dp.count || 0), 0)
+            );
+            dataPoints = [].concat(...groups).filter(datapoint => datapoint);
+        }
+        else if (_.contains(['bar', 'pie'], this.state.mode)) {
             dataPoints = this.state.dataPoints.filter(function (dataPt) {
                 return dataPt.count > 0;
             });


### PR DESCRIPTION
In CRM, the pipeline reporting may be wrong when comparing two different
periods. The data of the previous period won't be showed with the
correct label.

To reproduce the error:
1. In CRM, create 6 opportunities and always define the Expected Closing
Date:
    - May 2021, June 2021, October 2021, March 2020, April 2020, May
2020
2. CRM > Reporting > Pipeline
3. Remove all filters and set this one:
4. Times Ranges, Based On "Expected Closing" Range "This Year" Compare
To "Previous Year"
5. In Group By, disable "Stage"
Error: The comparison is wrong. The graph compares May 2021 with March
2020, June 2021 with April 2020 and October 2021 with May 2020

Technical analysis:
Since we are comparing two periods, 2 RPC calls are made (2 read_group).
This gives us two datasets where each item is like:
```
    {
        "0": {
                "__count": 1,
                "date_deadline:month": "May 2021",
                "__domain": [...]
        }
    }
```
When rendering the graph, JS first creates two dates sets, see
'dateClasses' creation on L762 in [1]
In the above example, the sets would be:
```
dateClasses: {
    dateSets: [
        ["May 2021", "June 2021", "October 2021"],
        ["March 2020", "April 2020", "May 2020"],
    ]
}
```
And here is the problem: the months are not the same. As a result,
later, when getting the label for each bar in the graph, the method
_getLabel ([2]) returns the index of the label to be used. But:
For each data point, _getLabel will call this.dateClasses.dateClass
(L363 in [2]). The latter will return the index of the month in its
dateSet (see [3]). So, for the data point "March 2020", it will return 0
(i.e. the index of "March 2020" in dateClasses.dateSets[1]). However,
the dateSet used to display the labels on the graph is
dateClasses.dateSets[0] => This is the reason why the data point "March
2020" will be display with the label "May 2021"

OPW-2530500

[1]
https://github.com/odoo/odoo/blob/a77086f8bcb4498361d1183ba8af3d0663cd031b/addons/web/static/src/js/views/graph/graph_renderer.js#L724-L775
[2]
https://github.com/odoo/odoo/blob/a77086f8bcb4498361d1183ba8af3d0663cd031b/addons/web/static/src/js/views/graph/graph_renderer.js#L352-L375
[3]
https://github.com/odoo/odoo/blob/49a97305b1f214b7d27f3de3bd0a91b6c551f8cd/addons/web/static/src/js/core/data_comparison_utils.js#L33-L43
