### PR TITLE
[MERGE][IMP] website_slides: refactor content management + vimeo support

### DIFF
--- a/addons/test_website_slides_full/tests/test_ui_wslides.py
+++ b/addons/test_website_slides_full/tests/test_ui_wslides.py
@@ -148,7 +148,7 @@ class TestUi(TestUICommon):
                 (0, 0, {
                     'name': 'DIY Furniture Certification',
                     'sequence': 1,
-                    'slide_type': 'certification',
+                    'slide_category': 'certification',
                     'category_id': False,
                     'is_published': True,
                     'is_preview': False,

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'eLearning',
-    'version': '2.4',
+    'version': '2.5',
     'sequence': 125,
     'summary': 'Manage and publish an eLearning platform',
     'website': 'https://www.odoo.com/app/elearning',

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -14,7 +14,7 @@ Featuring
 
  * Integrated course and lesson management
  * Fullscreen navigation
- * Support Youtube videos, Google documents, PDF, images, web pages
+ * Support Youtube videos, Google documents, PDF, images, articles
  * Test knowledge with quizzes
  * Filter and Tag
  * Statistics

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1083,7 +1083,7 @@ class WebsiteSlides(WebsiteProfile):
 
             if not slide.video_source_type:
                 slide.unlink()
-                return {'error': _('Please enter valid YouTube or Google Drive Link')}
+                return {'error': _('Please enter valid YouTube, Vimeo or Google Drive Link')}
 
             if slide.video_source_type == 'youtube':
                 identical_video = existing_videos.filtered(
@@ -1091,6 +1091,9 @@ class WebsiteSlides(WebsiteProfile):
             elif slide.video_source_type == 'google_drive':
                 identical_video = existing_videos.filtered(
                     lambda existing_video: slide.google_drive_id == existing_video.google_drive_id)
+            elif slide.video_source_type == 'vimeo':
+                identical_video = existing_videos.filtered(
+                    lambda existing_video: slide.vimeo_id == existing_video.vimeo_id)
             if identical_video:
                 identical_video_name = identical_video[0].name
                 return {'error': _('This video already exists in this channel on the following content: %s', identical_video_name)}

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1175,9 +1175,9 @@ class WebsiteSlides(WebsiteProfile):
         channel._resequence_slides(slide, force_category=category)
 
         redirect_url = "/slides/slide/%s" % (slide.id)
-        if channel.channel_type == "training" and slide.slide_category not in ["webpage", "quiz"]:
+        if channel.channel_type == "training" and slide.slide_category not in ["article", "quiz"]:
             redirect_url = "/slides/%s" % (slug(channel))
-        if slide.slide_category == 'webpage':
+        if slide.slide_category == 'article':
             redirect_url += "?enable_editor=1"
         return {
             'url': redirect_url,

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -67,7 +67,7 @@ class WebsiteSlides(WebsiteProfile):
 
     def _set_completed_slide(self, slide):
         # quiz use their specific mechanism to be marked as done
-        if slide.slide_type == 'quiz' or slide.question_ids:
+        if slide.slide_category == 'quiz' or slide.question_ids:
             raise werkzeug.exceptions.Forbidden(_("Slide with questions must be marked as done when submitting all good answers "))
         if slide.website_published and slide.channel_id.is_member:
             slide.action_set_completed()
@@ -331,12 +331,12 @@ class WebsiteSlides(WebsiteProfile):
         return request.render('website_slides.courses_home', values)
 
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True)
-    def slides_channel_all(self, slide_type=None, slug_tags=None, my=False, **post):
+    def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
         """ Home page displaying a list of courses displayed according to some
         criterion and search terms.
 
-          :param string slide_type: if provided, filter the course to contain at
-           least one slide of type 'slide_type'. Used notably to display courses
+          :param string slide_category: if provided, filter the course to contain at
+           least one slide of type 'slide_category'. Used notably to display courses
            with certifications;
           :param string slug_tags: if provided, filter the slide.channels having
             the tag(s) (in comma separated slugified form);
@@ -347,6 +347,10 @@ class WebsiteSlides(WebsiteProfile):
            * ``search``: filter on course description / name;
         """
 
+        # retro-compatibility for older links, 'slide_category' field was previously named 'slide_type'
+        # can be safely removed after 15.3 (I swear though, don't be afraid, remove it!)
+        slide_category = slide_category or post.get('slide_type')
+
         if slug_tags and request.httprequest.method == 'GET':
             # Redirect `tag-1,tag-2` to `tag-1` to disallow multi tags
             # in GET request for proper bot indexation;
@@ -355,7 +359,7 @@ class WebsiteSlides(WebsiteProfile):
             # request and so clearly it's not SEO bot.
             tag_list = slug_tags.split(',')
             if len(tag_list) > 1 and not post.get('search'):
-                url = QueryURL('/slides/all', ['tag'], tag=tag_list[0], my=my, slide_type=slide_type)()
+                url = QueryURL('/slides/all', ['tag'], tag=tag_list[0], my=my, slide_category=slide_category)()
                 return request.redirect(url, code=302)
 
         options = {
@@ -367,7 +371,7 @@ class WebsiteSlides(WebsiteProfile):
             'allowFuzzy': not post.get('noFuzzy'),
             'my': my,
             'tag': slug_tags or post.get('tag'),
-            'slide_type': slide_type,
+            'slide_category': slide_category,
         }
         search = post.get('search')
         order = self._channel_order_by_criterion.get(post.get('sorting'))
@@ -390,7 +394,7 @@ class WebsiteSlides(WebsiteProfile):
             'tag_groups': tag_groups,
             'search_term': fuzzy_search_term or search,
             'original_search': fuzzy_search_term and search,
-            'search_slide_type': slide_type,
+            'search_slide_category': slide_category,
             'search_my': my,
             'search_tags': search_tags,
             'top3_users': self._get_top3_users(),
@@ -416,15 +420,20 @@ class WebsiteSlides(WebsiteProfile):
         '/slides/<model("slide.channel"):channel>/category/<model("slide.slide"):category>',
         '/slides/<model("slide.channel"):channel>/category/<model("slide.slide"):category>/page/<int:page>',
     ], type='http', auth="public", website=True, sitemap=sitemap_slide)
-    def channel(self, channel, category=None, tag=None, page=1, slide_type=None, uncategorized=False, sorting=None, search=None, **kw):
+    def channel(self, channel, category=None, tag=None, page=1, slide_category=None, uncategorized=False, sorting=None, search=None, **kw):
         """
         Will return all necessary data to display the requested slide_channel along with a possible category.
         """
+
+        # retro-compatibility for older links, 'slide_category' field was previously named 'slide_type'
+        # can be safely removed after 15.3 (I swear though, don't be afraid, remove it!)
+        slide_category = slide_category or kw.get('slide_type')
+
         domain = self._get_channel_slides_base_domain(channel)
 
         pager_url = "/slides/%s" % (channel.id)
         pager_args = {}
-        slide_types = dict(request.env['slide.slide']._fields['slide_type']._description_selection(request.env))
+        slide_categories = dict(request.env['slide.slide']._fields['slide_category']._description_selection(request.env))
 
         if search:
             domain += [
@@ -443,9 +452,9 @@ class WebsiteSlides(WebsiteProfile):
             if uncategorized:
                 domain += [('category_id', '=', False)]
                 pager_args['uncategorized'] = 1
-            elif slide_type:
-                domain += [('slide_type', '=', slide_type)]
-                pager_url += "?slide_type=%s" % slide_type
+            elif slide_category:
+                domain += [('slide_category', '=', slide_category)]
+                pager_url += "?slide_category=%s" % slide_category
 
         # sorting criterion
         if channel.channel_type == 'documentation':
@@ -467,8 +476,8 @@ class WebsiteSlides(WebsiteProfile):
             query_string = "?search_category=%s" % category.id
         elif tag:
             query_string = "?search_tag=%s" % tag.id
-        elif slide_type:
-            query_string = "?search_slide_type=%s" % slide_type
+        elif slide_category:
+            query_string = "?search_slide_category=%s" % slide_category
         elif uncategorized:
             query_string = "?search_uncategorized=1"
 
@@ -479,10 +488,10 @@ class WebsiteSlides(WebsiteProfile):
             # search
             'search_category': category,
             'search_tag': tag,
-            'search_slide_type': slide_type,
+            'search_slide_category': slide_category,
             'search_uncategorized': uncategorized,
             'query_string': query_string,
-            'slide_types': slide_types,
+            'slide_categories': slide_categories,
             'sorting': actual_sorting,
             'search': search,
             # display data
@@ -704,8 +713,8 @@ class WebsiteSlides(WebsiteProfile):
         values.update({
             'search_category': slide.category_id if kwargs.get('search_category') else None,
             'search_tag': request.env['slide.tag'].browse(int(kwargs.get('search_tag'))) if kwargs.get('search_tag') else None,
-            'slide_types': dict(request.env['slide.slide']._fields['slide_type']._description_selection(request.env)) if kwargs.get('search_slide_type') else None,
-            'search_slide_type': kwargs.get('search_slide_type'),
+            'slide_categories': dict(request.env['slide.slide']._fields['slide_category']._description_selection(request.env)) if kwargs.get('search_slide_category') else None,
+            'search_slide_category': kwargs.get('search_slide_category'),
             'search_uncategorized': kwargs.get('search_uncategorized')
         })
 
@@ -724,7 +733,7 @@ class WebsiteSlides(WebsiteProfile):
                 type='http', auth="public", website=True, sitemap=False)
     def slide_get_pdf_content(self, slide):
         response = werkzeug.wrappers.Response()
-        response.data = slide.datas and base64.b64decode(slide.datas) or b''
+        response.data = slide.binary_content and base64.b64decode(slide.binary_content) or b''
         response.mimetype = 'application/pdf'
         return response
 
@@ -1064,8 +1073,8 @@ class WebsiteSlides(WebsiteProfile):
     @http.route(['/slides/add_slide'], type='json', auth='user', methods=['POST'], website=True)
     def create_slide(self, *args, **post):
         # check the size only when we upload a file.
-        if post.get('datas'):
-            file_size = len(post['datas']) * 3 / 4  # base64
+        if post.get('binary_content'):
+            file_size = len(post['binary_content']) * 3 / 4  # base64
             if (file_size / 1024.0 / 1024.0) > 25:
                 return {'error': _('File is too big. File size cannot exceed 25MB')}
 
@@ -1117,9 +1126,9 @@ class WebsiteSlides(WebsiteProfile):
         channel._resequence_slides(slide, force_category=category)
 
         redirect_url = "/slides/slide/%s" % (slide.id)
-        if channel.channel_type == "training" and not slide.slide_type == "webpage":
+        if channel.channel_type == "training" and not slide.slide_category == "webpage":
             redirect_url = "/slides/%s" % (slug(channel))
-        if slide.slide_type == 'webpage':
+        if slide.slide_category == 'webpage':
             redirect_url += "?enable_editor=1"
         return {
             'url': redirect_url,
@@ -1129,8 +1138,8 @@ class WebsiteSlides(WebsiteProfile):
         }
 
     def _get_valid_slide_post_values(self):
-        return ['name', 'url', 'tag_ids', 'slide_type', 'channel_id', 'is_preview',
-                'mime_type', 'datas', 'description', 'image_1920', 'is_published']
+        return ['name', 'url', 'tag_ids', 'slide_category', 'channel_id', 'is_preview',
+                'mime_type', 'binary_content', 'description', 'image_1920', 'is_published']
 
     @http.route(['/slides/tag/search_read'], type='json', auth='user', methods=['POST'], website=True)
     def slide_tag_search_read(self, fields, domain):

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -4,7 +4,7 @@
          <record id="slide_template_published" model="mail.template">
             <field name="name">Slide Published</field>
             <field name="model_id" ref="model_slide_slide"/>
-            <field name="subject">New {{ object.slide_type }} published on {{ object.channel_id.name }}</field>
+            <field name="subject">New {{ object.slide_category }} published on {{ object.channel_id.name }}</field>
             <field name="body_html" type="html">
                 <div style="margin: 0px; padding: 0px;">
                     <p style="margin: 0px; padding: 0px; font-size: 13px;">
@@ -36,14 +36,14 @@
         <record id="slide_template_shared" model="mail.template">
             <field name="name">Slide Shared</field>
             <field name="model_id" ref="model_slide_slide"/>
-            <field name="subject">{{ user.name }} shared a {{ object.slide_type }} with you!</field>
+            <field name="subject">{{ user.name }} shared a {{ object.slide_category }} with you!</field>
             <field name="email_from">{{ user.email_formatted }}</field>
             <field name="email_to">{{ ctx.get('email', '') }}</field>
             <field name="body_html" type="html">
                 <div style="margin: 0px; padding: 0px;">
                     <p style="margin: 0px; padding: 0px; font-size: 13px;">
                         Hello<br/><br/>
-                        <t t-out="user.name or ''">Mitchell Admin</t> shared the <t t-out="object.slide_type or ''">document</t> <strong t-out="object.name or ''">Trees</strong> with you!
+                        <t t-out="user.name or ''">Mitchell Admin</t> shared the <t t-out="object.slide_category or ''">document</t> <strong t-out="object.name or ''">Trees</strong> with you!
                         <div style="margin: 16px 8px 16px 8px; text-align: center;">
                             <a t-att-href="(object.website_url + '?fullscreen=1') if ctx.get('fullscreen') else object.website_url">
                                 <img t-att-alt="object.name" t-attf-src="{{ ctx.get('base_url') }}/web/image/slide.slide/{{ object.id }}/image_1024" style="height:auto; width:150px; margin: 16px;"/>

--- a/addons/website_slides/data/slide_slide_demo.xml
+++ b/addons/website_slides/data/slide_slide_demo.xml
@@ -8,7 +8,7 @@
         <field name="sequence">1</field>
         <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_category">presentation</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -211,7 +211,6 @@
         <field name="sequence">5</field>
         <field name="url">https://www.youtube.com/watch?v=QYmgrw0PgLU</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_QYmgrw0PgLU.jpg"/>
-        <field name="document_id">QYmgrw0PgLU</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
@@ -329,7 +328,7 @@
         <field name="sequence">6</field>
         <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_category">presentation</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -344,7 +343,6 @@
         <field name="sequence">7</field>
         <field name="url">https://www.youtube.com/watch?v=l0JZ25VvbwE</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_l0JZ25VvbwE.jpg"/>
-        <field name="document_id">l0JZ25VvbwE</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
@@ -380,7 +378,7 @@
         <field name="sequence">1</field>
         <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_2.jpg"/>
-        <field name="slide_category">presentation</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -512,7 +510,6 @@
         <field name="sequence">3</field>
         <field name="url">https://www.youtube.com/watch?v=ebBez6bcSEc</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_ebBez6bcSEc.jpg"/>
-        <field name="document_id">ebBez6bcSEc</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
@@ -529,7 +526,7 @@
         <field name="sequence">5</field>
         <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-documentation-default.jpg"/>
-        <field name="slide_category">presentation</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -576,7 +573,6 @@
         <field name="sequence">3</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_PYr1rK8pS30.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=PYr1rK8pS30</field>
-        <field name="document_id">PYr1rK8pS30</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_3_furn0"/>
         <field name="is_published" eval="True"/>
@@ -655,7 +651,6 @@
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_bvSe6r5BpaY.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=bvSe6r5BpaY</field>
-        <field name="document_id">bvSe6r5BpaY</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="is_published" eval="True"/>
@@ -741,7 +736,7 @@
         <field name="sequence">1</field>
         <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_category">presentation</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -768,7 +763,6 @@
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_5WMqwTnZ-qs.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=5WMqwTnZ-qs</field>
-        <field name="document_id">5WMqwTnZ-qs</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
@@ -783,7 +777,6 @@
         <field name="sequence">4</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_grrXe1QZNzQ.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=grrXe1QZNzQ</field>
-        <field name="document_id">grrXe1QZNzQ</field>
         <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>

--- a/addons/website_slides/data/slide_slide_demo.xml
+++ b/addons/website_slides/data/slide_slide_demo.xml
@@ -225,7 +225,7 @@
         <field name="name">A little chat with Harry Potted</field>
         <field name="sequence">6</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_1.jpg"/>
-        <field name="slide_category">webpage</field>
+        <field name="slide_category">article</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
@@ -462,7 +462,7 @@
         <field name="name">A Mighty Forest from Ages</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_3.jpg"/>
-        <field name="slide_category">webpage</field>
+        <field name="slide_category">article</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
@@ -605,7 +605,7 @@
         <field name="name">Foreword</field>
         <field name="sequence">1</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_furniture_2.jpg"/>
-        <field name="slide_category">webpage</field>
+        <field name="slide_category">article</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">

--- a/addons/website_slides/data/slide_slide_demo.xml
+++ b/addons/website_slides/data/slide_slide_demo.xml
@@ -6,9 +6,9 @@
     <record id="slide_slide_demo_0_0" model="slide.slide">
         <field name="name">Gardening: The Know-How</field>
         <field name="sequence">1</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_category">presentation</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -29,7 +29,7 @@
         <field name="name">Home Gardening</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_gardening_1.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -43,7 +43,7 @@
         <field name="name">Mighty Carrots</field>
         <field name="sequence">3</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_gardening_2.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -56,9 +56,9 @@
     <record id="slide_slide_demo_0_3" model="slide.slide">
         <field name="name">How to Grow and Harvest The Best Strawberries | Basics</field>
         <field name="sequence">4</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_l0JZ25VvbwE.jpg"/>
-        <field name="slide_type">document</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -72,7 +72,7 @@
         <field name="name">Test your knowledge</field>
         <field name="sequence">5</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_owl.jpg"/>
-        <field name="slide_type">quiz</field>
+        <field name="slide_category">quiz</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_0_gard_0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -149,7 +149,7 @@
         <field name="name">Tree Infographic</field>
         <field name="sequence">1</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_infographic_1.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -163,7 +163,7 @@
         <field name="name">Interesting Tree Facts</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_infographic_2.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -177,7 +177,7 @@
         <field name="name">Energy Efficiency Facts</field>
         <field name="sequence">3</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_infographic_3.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -212,7 +212,7 @@
         <field name="url">https://www.youtube.com/watch?v=QYmgrw0PgLU</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_QYmgrw0PgLU.jpg"/>
         <field name="document_id">QYmgrw0PgLU</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -226,7 +226,7 @@
         <field name="name">A little chat with Harry Potted</field>
         <field name="sequence">6</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_1.jpg"/>
-        <field name="slide_type">webpage</field>
+        <field name="slide_category">webpage</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
@@ -327,9 +327,9 @@
     <record id="slide_slide_demo_1_5" model="slide.slide">
         <field name="name">3 Main Methodologies</field>
         <field name="sequence">6</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_category">presentation</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -345,7 +345,7 @@
         <field name="url">https://www.youtube.com/watch?v=l0JZ25VvbwE</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_l0JZ25VvbwE.jpg"/>
         <field name="document_id">l0JZ25VvbwE</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -378,9 +378,9 @@
     <record id="slide_slide_demo_2_0" model="slide.slide">
         <field name="name">Main Trees Categories</field>
         <field name="sequence">1</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_2.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_category">presentation</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -464,7 +464,7 @@
         <field name="name">A Mighty Forest from Ages</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_tree_img_3.jpg"/>
-        <field name="slide_type">webpage</field>
+        <field name="slide_category">webpage</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
@@ -513,7 +513,7 @@
         <field name="url">https://www.youtube.com/watch?v=ebBez6bcSEc</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_ebBez6bcSEc.jpg"/>
         <field name="document_id">ebBez6bcSEc</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -527,9 +527,9 @@
     <record id="slide_slide_demo_2_3" model="slide.slide">
         <field name="name">Wood Characteristics</field>
         <field name="sequence">5</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-documentation-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_category">presentation</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -561,7 +561,7 @@
         <field name="name">Comparing Hardness of Wood Species</field>
         <field name="sequence">2</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_wood_infographic_1.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_3_furn0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -577,7 +577,7 @@
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_PYr1rK8pS30.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=PYr1rK8pS30</field>
         <field name="document_id">PYr1rK8pS30</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_3_furn0"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -609,7 +609,7 @@
         <field name="name">Foreword</field>
         <field name="sequence">1</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_furniture_2.jpg"/>
-        <field name="slide_type">webpage</field>
+        <field name="slide_category">webpage</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
@@ -656,7 +656,7 @@
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_bvSe6r5BpaY.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=bvSe6r5BpaY</field>
         <field name="document_id">bvSe6r5BpaY</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=3)"/>
@@ -670,7 +670,7 @@
         <field name="name">Drawing 1</field>
         <field name="sequence">11</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_furniture_img.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=4)"/>
@@ -684,7 +684,7 @@
         <field name="name">Drawing 2</field>
         <field name="sequence">12</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_furniture_img_1.jpg"/>
-        <field name="slide_type">infographic</field>
+        <field name="slide_category">infographic</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=4)"/>
@@ -697,9 +697,9 @@
     <record id="slide_slide_demo_4_12" model="slide.slide">
         <field name="name">Presentation</field>
         <field name="sequence">13</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-documentation-default.jpg"/>
-        <field name="slide_type">document</field>
+        <field name="slide_category">document</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=4)"/>
@@ -739,9 +739,9 @@
     <record id="slide_slide_demo_5_0" model="slide.slide">
         <field name="name">Unforgettable Tools</field>
         <field name="sequence">1</field>
-        <field name="datas" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
+        <field name="binary_content" type="base64" file="website_slides/static/src/img/presentation.pdf"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel-training-default.jpg"/>
-        <field name="slide_type">presentation</field>
+        <field name="slide_category">presentation</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -769,7 +769,7 @@
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_5WMqwTnZ-qs.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=5WMqwTnZ-qs</field>
         <field name="document_id">5WMqwTnZ-qs</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -784,7 +784,7 @@
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_thumb_grrXe1QZNzQ.jpg"/>
         <field name="url">https://www.youtube.com/watch?v=grrXe1QZNzQ</field>
         <field name="document_id">grrXe1QZNzQ</field>
-        <field name="slide_type">video</field>
+        <field name="slide_category">video</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>
@@ -797,7 +797,7 @@
         <field name="name">Test your knowledge !</field>
         <field name="sequence">6</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_owl.jpg"/>
-        <field name="slide_type">quiz</field>
+        <field name="slide_category">quiz</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="is_published" eval="True"/>
         <field name="date_published" eval="datetime.now() - timedelta(days=8)"/>

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -186,7 +186,7 @@ class Channel(models.Model):
     nbr_document = fields.Integer('Documents', compute='_compute_slides_statistics', store=True)
     nbr_video = fields.Integer('Videos', compute='_compute_slides_statistics', store=True)
     nbr_infographic = fields.Integer('Infographics', compute='_compute_slides_statistics', store=True)
-    nbr_webpage = fields.Integer("Webpages", compute='_compute_slides_statistics', store=True)
+    nbr_article = fields.Integer("Articles", compute='_compute_slides_statistics', store=True)
     nbr_quiz = fields.Integer("Number of Quizs", compute='_compute_slides_statistics', store=True)
     total_slides = fields.Integer('Number of Contents', compute='_compute_slides_statistics', store=True)
     total_views = fields.Integer('Visits', compute='_compute_slides_statistics', store=True)

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -183,7 +183,6 @@ class Channel(models.Model):
     )
     promoted_slide_id = fields.Many2one('slide.slide', string='Promoted Slide')
     access_token = fields.Char("Security Token", copy=False, default=_default_access_token)
-    nbr_presentation = fields.Integer('Presentations', compute='_compute_slides_statistics', store=True)
     nbr_document = fields.Integer('Documents', compute='_compute_slides_statistics', store=True)
     nbr_video = fields.Integer('Videos', compute='_compute_slides_statistics', store=True)
     nbr_infographic = fields.Integer('Infographics', compute='_compute_slides_statistics', store=True)

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -125,7 +125,7 @@ class Slide(models.Model):
     # content
     slide_category = fields.Selection([
         ('infographic', 'Image'),
-        ('webpage', 'Web Page'),
+        ('article', 'Article'),
         ('document', 'Document'),
         ('video', 'Video'),
         ('quiz', "Quiz")],
@@ -143,7 +143,7 @@ class Slide(models.Model):
     # google
     google_drive_id = fields.Char('Google Drive ID of the external URL', compute='_compute_google_drive_id')
     # content - webpage
-    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of category 'Web Page'.", translate=True, sanitize_attributes=False, sanitize_form=False)
+    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of category 'Article'.", translate=True, sanitize_attributes=False, sanitize_form=False)
     # content - images
     image_binary_content = fields.Binary('Image Content', related='binary_content', readonly=False,
         help="Used to filter file input to images only")
@@ -152,7 +152,7 @@ class Slide(models.Model):
     # content - documents
     slide_type = fields.Selection([
         ('image', 'Image'),
-        ('webpage', 'Web Page'),
+        ('article', 'Article'),
         ('quiz', 'Quiz'),
         ('pdf', 'PDF'),
         ('sheet', 'Sheet (Excel, Google Sheet, ...)'),
@@ -201,7 +201,7 @@ class Slide(models.Model):
     nbr_document = fields.Integer("Number of Documents", compute='_compute_slides_statistics', store=True)
     nbr_video = fields.Integer("Number of Videos", compute='_compute_slides_statistics', store=True)
     nbr_infographic = fields.Integer("Number of Images", compute='_compute_slides_statistics', store=True)
-    nbr_webpage = fields.Integer("Number of Webpages", compute='_compute_slides_statistics', store=True)
+    nbr_article = fields.Integer("Number of Articles", compute='_compute_slides_statistics', store=True)
     nbr_quiz = fields.Integer("Number of Quizs", compute="_compute_slides_statistics", store=True)
     total_slides = fields.Integer(compute='_compute_slides_statistics', store=True)
     is_published = fields.Boolean(tracking=1)
@@ -366,8 +366,8 @@ class Slide(models.Model):
                     slide.slide_type = False
             elif slide.slide_category == 'infographic':
                 slide.slide_type = 'image'
-            elif slide.slide_category == 'webpage':
-                slide.slide_type = 'webpage'
+            elif slide.slide_category == 'article':
+                slide.slide_type = 'article'
             elif slide.slide_category == 'quiz':
                 slide.slide_type = 'quiz'
             elif slide.slide_category == 'video' and slide.video_source_type == 'youtube':
@@ -1252,7 +1252,7 @@ class Slide(models.Model):
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         icon_per_category = {
             'infographic': 'fa-file-picture-o',
-            'webpage': 'fa-file-text',
+            'article': 'fa-file-text',
             'presentation': 'fa-file-pdf-o',
             'document': 'fa-file-pdf-o',
             'video': 'fa-play-circle',

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -90,6 +90,7 @@ class Slide(models.Model):
 
     YOUTUBE_VIDEO_ID_REGEX = r'^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*'
     GOOGLE_DRIVE_DOCUMENT_ID_REGEX = r'(^https:\/\/docs.google.com|^https:\/\/drive.google.com).*\/d\/([^\/]*)'
+    VIMEO_VIDEO_ID_REGEX = r'\/\/(player.)?vimeo.com\/(?:[a-z]*\/)*([0-9]{6,11})\/?([0-9a-z]{6,11})?[?]?.*'
 
     # description
     name = fields.Char('Title', required=True, translate=True)
@@ -158,7 +159,8 @@ class Slide(models.Model):
         ('doc', 'Document (Word, Google Doc, ...)'),
         ('slides', 'Slides (PowerPoint, Google Slides, ...)'),
         ('youtube_video', 'YouTube Video'),
-        ('google_drive_video', 'Google Drive Video')],
+        ('google_drive_video', 'Google Drive Video'),
+        ('vimeo_video', 'Vimeo Video')],
         string="Slide Type", compute='_compute_slide_type', store=True, readonly=False,
         help="Subtype of the slide category, allows more precision on the actual file type / source type.")
     document_google_url = fields.Char('Document Link', related='url', readonly=False,
@@ -167,12 +169,14 @@ class Slide(models.Model):
         help="Used to filter file input to PDF only")
     # content - videos
     video_url = fields.Char('Video URL', related='url', readonly=False,
-        help="Link of the video (we support YouTube and Google Drive as sources)")
+        help="Link of the video (we support YouTube, Google Drive and Vimeo as sources)")
     video_source_type = fields.Selection([
         ('youtube', 'YouTube'),
-        ('google_drive', 'Google Drive')],
+        ('google_drive', 'Google Drive'),
+        ('vimeo', 'Vimeo')],
         string='Video Source', compute="_compute_video_source_type")
     youtube_id = fields.Char('Video YouTube ID', compute='_compute_youtube_id')
+    vimeo_id = fields.Char('Video Vimeo ID', compute='_compute_vimeo_id')
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
     date_published = fields.Datetime('Publish Date', readonly=True, tracking=False)
@@ -370,6 +374,8 @@ class Slide(models.Model):
                 slide.slide_type = 'youtube_video'
             elif slide.slide_category == 'video' and slide.video_source_type == 'google_drive':
                 slide.slide_type = 'google_drive_video'
+            elif slide.slide_category == 'video' and slide.video_source_type == 'vimeo':
+                slide.slide_type = 'vimeo_video'
             else:
                 slide.slide_type = False
 
@@ -404,6 +410,19 @@ class Slide(models.Model):
                     embed_code = Markup('<iframe src="//www.youtube-nocookie.com/embed/%s?%s" allowFullScreen="true" frameborder="0"></iframe>') % (slide.youtube_id, query_params)
                 elif slide.video_source_type == 'google_drive':
                     embed_code = Markup('<iframe src="//drive.google.com/file/d/%s/preview" allowFullScreen="true" frameborder="0"></iframe>') % (slide.google_drive_id)
+                elif slide.video_source_type == 'vimeo':
+                    if '/' in slide.vimeo_id:
+                        # in case of privacy 'with URL only', vimeo adds a token after the video ID
+                        # the embed url needs to receive that token as a "h" parameter
+                        [vimeo_id, vimeo_token] = slide.vimeo_id.split('/')
+                        embed_code = Markup("""
+                            <iframe src="https://player.vimeo.com/video/%s?h=%s&badge=0&amp;autopause=0&amp;player_id=0"
+                                frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>""") % (
+                                vimeo_id, vimeo_token)
+                    else:
+                        embed_code = Markup("""
+                            <iframe src="https://player.vimeo.com/video/%s?badge=0&amp;autopause=0&amp;player_id=0"
+                                frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>""") % (slide.vimeo_id)
             elif slide.slide_category in ['infographic', 'document'] and slide.source_type == 'external' and slide.google_drive_id:
                 embed_code = Markup('<iframe src="//drive.google.com/file/d/%s/preview" allowFullScreen="true" frameborder="0"></iframe>') % (slide.google_drive_id)
             elif slide.slide_category == 'document' and slide.source_type == 'local_file':
@@ -425,6 +444,9 @@ class Slide(models.Model):
                 video_source_type = 'youtube'
             if slide.video_url and not video_source_type and re.match(self.GOOGLE_DRIVE_DOCUMENT_ID_REGEX, slide.video_url):
                 video_source_type = 'google_drive'
+            vimeo_match = re.search(self.VIMEO_VIDEO_ID_REGEX, slide.video_url) if slide.video_url else False
+            if not video_source_type and vimeo_match and len(vimeo_match.groups()) == 3:
+                video_source_type = 'vimeo'
 
             slide.video_source_type = video_source_type
 
@@ -439,6 +461,23 @@ class Slide(models.Model):
                     slide.youtube_id = False
             else:
                 slide.youtube_id = False
+
+    @api.depends('video_url', 'video_source_type')
+    def _compute_vimeo_id(self):
+        for slide in self:
+            if slide.video_url and slide.video_source_type == 'vimeo':
+                match = re.search(self.VIMEO_VIDEO_ID_REGEX, slide.video_url)
+                if match and len(match.groups()) == 3:
+                    if match.group(3):
+                        # in case of privacy 'with URL only', vimeo adds a token after the video ID
+                        # the share url is then 'vimeo_id/token'
+                        # the token will be captured in the third group of the regex (if any)
+                        slide.vimeo_id = '%s/%s' % (match.group(2), match.group(3))
+                    else:
+                        # regular video, we just capture the vimeo_id
+                        slide.vimeo_id = match.group(2)
+            else:
+                slide.vimeo_id = False
 
     @api.depends('url', 'document_google_url', 'image_google_url', 'video_url')
     def _compute_google_drive_id(self):
@@ -868,6 +907,8 @@ class Slide(models.Model):
             slide_metadata, error = self._fetch_youtube_metadata(image_url_only)
         elif self.slide_category == 'video' and self.video_source_type == 'google_drive':
             slide_metadata, error = self._fetch_google_drive_metadata(image_url_only)
+        elif self.slide_category == 'video' and self.video_source_type == 'vimeo':
+            slide_metadata, error = self._fetch_vimeo_metadata(image_url_only)
         elif self.slide_category in ['document', 'infographic'] and self.source_type == 'external':
             # external documents & google drive videos share the same method currently
             slide_metadata, error = self._fetch_google_drive_metadata(image_url_only)
@@ -1079,6 +1120,73 @@ class Slide(models.Model):
                 ) / (60 * 60 * 1000)  # millis to hours conversion
             if completion_time:
                 slide_metadata['completion_time'] = completion_time
+
+        return slide_metadata, None
+
+    def _fetch_vimeo_metadata(self, image_url_only=False):
+        """ Fetches video metadata from the Vimeo API.
+        See https://developer.vimeo.com/api/oembed/showcases for more information.
+
+        Returns a dict containing video metadata with the following keys (matching slide.slide fields):
+        - 'name' matching the video title
+        - 'description' matching the video description
+        - 'image_1920' binary data of the video thumbnail
+          OR 'image_url' containing an external link to the thumbnail when 'fetch_image' param is False
+        - 'completion_time' matching the video duration
+
+        :param image_url_only: if False, will return 'image_url' instead of binary data
+          Typically used when displaying a slide preview to the end user.
+        :return a tuple (values, error) containing the values of the slide and a potential error
+          (e.g: 'Video could not be found') """
+
+        self.ensure_one()
+        error_message = False
+        try:
+            response = requests.get(
+                'https://vimeo.com/api/oembed.json?%s' % urls.url_encode({'url': self.video_url}),
+                timeout=3
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            error_message = e.response.content
+            if e.response.status_code == 404:
+                return {}, _('Your video could not be found on Vimeo, please check the link and/or privacy settings')
+        except requests.exceptions.ConnectionError as e:
+            error_message = str(e)
+
+        if not error_message and 'application/json' in response.headers.get('content-type'):
+            response = response.json()
+            if response.get('error'):
+                error_message = response.get('error', {}).get('errors', [{}])[0].get('reason')
+
+            if not response:
+                error_message = _('Please enter a valid Vimeo video link')
+
+        if error_message:
+            _logger.warning('Could not fetch Vimeo metadata: %s', error_message)
+            return {}, error_message
+
+        vimeo_values = response
+        slide_metadata = {'slide_type': 'vimeo_video'}
+
+        if vimeo_values.get('title'):
+            slide_metadata['name'] = vimeo_values.get('title')
+
+        if vimeo_values.get('description'):
+            slide_metadata['description'] = vimeo_values.get('description')
+
+        if vimeo_values.get('duration'):
+            # seconds to hours conversion
+            slide_metadata['completion_time'] = vimeo_values.get('duration') / (60 * 60)
+
+        thumbnail_url = vimeo_values.get('thumbnail_url')
+        if thumbnail_url:
+            if image_url_only:
+                slide_metadata['image_url'] = thumbnail_url
+            else:
+                slide_metadata['image_1920'] = base64.b64encode(
+                    requests.get(thumbnail_url, timeout=3).content
+                )
 
         return slide_metadata, None
 

--- a/addons/website_slides/static/src/js/slides_category_add.js
+++ b/addons/website_slides/static/src/js/slides_category_add.js
@@ -19,7 +19,7 @@ var CategoryAddDialog = Dialog.extend({
                 classes: 'btn-primary',
                 click: this._onClickFormSubmit.bind(this)
             }, {
-                text: _t('Discard'),
+                text: _t('Back'),
                 close: true
             }]
         });

--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -548,7 +548,7 @@
         // Private
         //--------------------------------------------------------------------------
         /**
-         * Fetches content with an rpc call for slides of category "webpage"
+         * Fetches content with an rpc call for slides of category "article"
          *
          * @private
          */
@@ -574,7 +574,7 @@
         */
         _fetchSlideContent: function (){
             var slide = this.get('slide');
-            if (slide.category === 'webpage' && !slide.isQuiz) {
+            if (slide.category === 'article' && !slide.isQuiz) {
                 return this._fetchHtmlContent();
             }
             return Promise.resolve();
@@ -616,8 +616,8 @@
                 // technical settings for the Fullscreen to work
                 var autoSetDone = false;
                 if (!slideData.hasQuestion) {
-                    if (_.contains(['infographic', 'document', 'webpage'], slideData.category)) {
-                        autoSetDone = true;  // images, documents (local + external) and web pages are marked as completed when opened
+                    if (_.contains(['infographic', 'document', 'article'], slideData.category)) {
+                        autoSetDone = true;  // images, documents (local + external) and articles are marked as completed when opened
                     } else if (slideData.category === 'video' && slideData.videoSourceType === 'google_drive') {
                         autoSetDone = true;  // google drive videos do not benefit from the YouTube integration and are marked as completed when opened
                     }
@@ -646,7 +646,7 @@
         },
         /**
          * Render the current slide content using specific mecanism according to slide category:
-         * - simply append content (for webpage)
+         * - simply append content (for article)
          * - template rendering (for image, document, ....)
          * - using a sub widget (quiz and video)
          *
@@ -676,8 +676,8 @@
                 return this.videoPlayer.appendTo($content);
             } else if (slide.category === 'video' && slide.videoSourceType === 'google_drive') {
                 $content.html(QWeb.render('website.slides.fullscreen.video.google_drive', {widget: this}));
-            } else if (slide.category === 'webpage'){
-                var $wpContainer = $('<div>').addClass('o_wslide_fs_webpage_content bg-white block w-100 overflow-auto');
+            } else if (slide.category === 'article'){
+                var $wpContainer = $('<div>').addClass('o_wslide_fs_article_content bg-white block w-100 overflow-auto');
                 $(slide.htmlContent).appendTo($wpContainer);
                 $content.append($wpContainer);
                 this.trigger_up('widgets_start_request', {

--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -512,14 +512,22 @@
                     slideData.embedUrl = slideData.embedCode ? scheme + slideData.embedCode + separator + $.param(params) : "";
                 } else if (slideData.category === 'infographic') {
                     slideData.embedUrl = _.str.sprintf('/web/image/slide.slide/%s/image_1024', slideData.id);
-                } else if (_.contains(['document', 'presentation'], slideData.category)) {
+                } else if (slideData.category === 'document') {
                     slideData.embedUrl = $(slideData.embedCode).attr('src');
                 }
                 // fill empty property to allow searching on it with _.filter(list, matcher)
                 slideData.isQuiz = !!slideData.isQuiz;
                 slideData.hasQuestion = !!slideData.hasQuestion;
                 // technical settings for the Fullscreen to work
-                slideData._autoSetDone = _.contains(['infographic', 'presentation', 'document', 'webpage'], slideData.category) && !slideData.hasQuestion;
+                var autoSetDone = false;
+                if (!slideData.hasQuestion) {
+                    if (_.contains(['infographic', 'document', 'webpage'], slideData.category)) {
+                        autoSetDone = true;  // images, documents (local + external) and web pages are marked as completed when opened
+                    } else if (slideData.category === 'video' && slideData.videoSourceType === 'google_drive') {
+                        autoSetDone = true;  // google drive videos do not benefit from the YouTube integration and are marked as completed when opened
+                    }
+                }
+                slideData._autoSetDone = autoSetDone;
             });
             return slidesDataList;
         },
@@ -563,7 +571,7 @@
             }
 
             // render slide content
-            if (_.contains(['document', 'presentation', 'infographic'], slide.category)) {
+            if (_.contains(['document', 'infographic'], slide.category)) {
                 $content.html(QWeb.render('website.slides.fullscreen.content', {widget: this}));
             } else if (slide.category === 'video') {
                 this.videoPlayer = new VideoPlayer(this, slide);
@@ -627,7 +635,7 @@
                 return self._renderSlide();
             }).then(function() {
                 if (slide._autoSetDone && !session.is_website_user) {  // no useless RPC call
-                    if (['document', 'presentation'].includes(slide.category)) {
+                    if (slide.category === 'document') {
                         // only set the slide as completed after iFrame is loaded to avoid concurrent execution with 'embedUrl' controller
                         self.el.querySelector('iframe.o_wslides_iframe_viewer').addEventListener('load', () => self._setCompleted(slide.id));
                     } else {

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -18,7 +18,7 @@
      * This widget is responsible of displaying quiz questions and propositions. Submitting the quiz will fetch the
      * correction and decorate the answers according to the result. Error message or modal can be displayed.
      *
-     * This widget can be attached to DOM rendered server-side by `website_slides.slide_type_quiz` or
+     * This widget can be attached to DOM rendered server-side by `website_slides.slide_category_quiz` or
      * used client side (Fullscreen).
      *
      * Triggered events are :

--- a/addons/website_slides/static/src/js/slides_course_tag_add.js
+++ b/addons/website_slides/static/src/js/slides_course_tag_add.js
@@ -25,7 +25,7 @@ var TagCourseDialog = Dialog.extend({
                 classes: 'btn-primary',
                 click: this._onClickFormSubmit.bind(this)
             }, {
-                text: _t("Discard"),
+                text: _t("Back"),
                 click: this._onClickClose.bind(this)
             }]
         });

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -10,7 +10,7 @@ var SlideUploadDialog = Dialog.extend({
     template: 'website.slide.upload.modal',
     events: _.extend({}, Dialog.prototype.events, {
         'click .o_wslides_js_upload_install_button': '_onClickInstallModule',
-        'click .o_wslides_select_type': '_onClickSlideTypeIcon',
+        'click .o_wslides_select_category': '_onClickSlideCategoryIcon',
         'change input#upload': '_onChangeSlideUpload',
         'change input#url': '_onChangeSlideUrl',
     }),
@@ -120,7 +120,7 @@ var SlideUploadDialog = Dialog.extend({
         return form[0].checkValidity() && this.isValidUrl;
     },
     /**
-     * Extract values to submit from form, force the slide_type according to
+     * Extract values to submit from form, force the slide_category according to
      * filled values.
      *
      * @private
@@ -136,30 +136,30 @@ var SlideUploadDialog = Dialog.extend({
             'is_published': forcePublished,
         }, this._getSelect2DropdownValues()); // add tags and category
 
-        // default slide_type (for webpage for instance)
-        if (_.contains(this.slide_type_data), this.get('state')) {
-            values['slide_type'] = this.get('state');
+        // default slide_category (for webpage for instance)
+        if (_.contains(this.slide_category_data), this.get('state')) {
+            values['slide_category'] = this.get('state');
         }
 
         if (this.file.type === 'application/pdf') {
             _.extend(values, {
                 'image_1920': canvas.toDataURL().split(',')[1],
-                'slide_type': canvas.height > canvas.width ? 'document' : 'presentation',
+                'slide_category': canvas.height > canvas.width ? 'document' : 'presentation',
                 'mime_type': this.file.type,
-                'datas': this.file.data
+                'binary_content': this.file.data
             });
-        } else if (values['slide_type'] === 'webpage') {
+        } else if (values['slide_category'] === 'webpage') {
             _.extend(values, {
                 'mime_type': 'text/html',
                 'image_1920': this.file.type === 'image/svg+xml' ? await this._svgToPNG() : this.file.data,
             });
         } else if (/^image\/.*/.test(this.file.type)) {
             const fileData = this.file.type === 'image/svg+xml' ? await this._svgToPNG() : this.file.data;
-            if (values['slide_type'] === 'presentation') {
+            if (values['slide_category'] === 'presentation') {
                 _.extend(values, {
-                    'slide_type': 'infographic',
+                    'slide_category': 'infographic',
                     'mime_type': this.file.type === 'image/svg+xml' ? 'image/png' : this.file.type,
-                    'datas': fileData,
+                    'binary_content': fileData,
                 });
             } else {
                 _.extend(values, {
@@ -321,12 +321,12 @@ var SlideUploadDialog = Dialog.extend({
         return values;
     },
     /**
-     * Init the data relative to the support slide type to upload
+     * Init the data relative to the support slide category to upload
      *
      * @private
      */
     _setup: function () {
-        this.slide_type_data = {
+        this.slide_category_data = {
             presentation: {
                 icon: 'fa-file-pdf-o',
                 label: _t('Presentation'),
@@ -393,7 +393,7 @@ var SlideUploadDialog = Dialog.extend({
         } else if (currentType === '_import') {
             tmpl = 'website.slide.upload.modal.import';
         } else {
-            tmpl = this.slide_type_data[currentType]['template'];
+            tmpl = this.slide_category_data[currentType]['template'];
             this.$modal.find('.modal-dialog').addClass('modal-lg');
         }
         this.$('.o_w_slide_upload_modal_container').empty();
@@ -623,10 +623,10 @@ var SlideUploadDialog = Dialog.extend({
         }
     },
 
-    _onClickSlideTypeIcon: function (ev) {
+    _onClickSlideCategoryIcon: function (ev) {
         var $elem = this.$(ev.currentTarget);
-        var slideType = $elem.data('slideType');
-        this.set('state', slideType);
+        var slideCategory = $elem.data('slideCategory');
+        this.set('state', slideCategory);
 
         this._bindSelect2Dropdown();  // rebind select2 at each modal body rendering
     },

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -134,7 +134,7 @@ var SlideUploadDialog = Dialog.extend({
      */
     _formValidateGetValues: async function (forcePublished) {
         var slideCategory = 'document';
-        // default slide_category (for webpage for instance)
+        // default slide_category (for article for instance)
         if (_.contains(this.slide_category_data), this.get('state')) {
             slideCategory = this.get('state');
         }
@@ -165,7 +165,7 @@ var SlideUploadDialog = Dialog.extend({
                 'slide_category': 'document',
                 'binary_content': this.file.data
             });
-        } else if (values['slide_category'] === 'webpage') {
+        } else if (values['slide_category'] === 'article') {
             _.extend(values, {
                 'image_1920': this.file.type === 'image/svg+xml' ? await this._svgToPng() : this.file.data,
             });
@@ -345,10 +345,10 @@ var SlideUploadDialog = Dialog.extend({
                 label: _t('Image'),
                 template: 'website.slide.upload.modal.infographic',
             },
-            webpage: {
+            article: {
                 icon: 'fa-file-text',
-                label: _t('Web Page'),
-                template: 'website.slide.upload.modal.webpage',
+                label: _t('Article'),
+                template: 'website.slide.upload.modal.article',
             },
             video: {
                 icon: 'fa-file-video-o',

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -27,7 +27,7 @@ var SlideUploadDialog = Dialog.extend({
      */
     init: function (parent, options) {
         options = _.defaults(options || {}, {
-            title: _t("Upload new content"),
+            title: _t("Add Content"),
             size: 'medium',
         });
         this._super(parent, options);
@@ -63,10 +63,10 @@ var SlideUploadDialog = Dialog.extend({
      * @private
      * @param {string} message
      */
-    _alertDisplay: function (message) {
+    _alertDisplay: function (message, alertClass='alert-warning') {
         this._alertRemove();
         $('<div/>', {
-            "class": 'alert alert-warning',
+            "class": 'alert ' + alertClass,
             id: 'upload-alert',
             role: 'alert'
         }).text(message).insertBefore(this.$('form'));
@@ -113,7 +113,10 @@ var SlideUploadDialog = Dialog.extend({
         });
     },
     _formSetFieldValue: function (fieldId, value) {
-        this.$('form').find('#'+fieldId).val(value);
+        var $formField = this.$('form').find('#'+fieldId);
+        if (!$formField.val()) {  // update only if the user did not assign a value manually
+            $formField.val(value);
+        }
     },
     _formGetFieldValue: function (fieldId) {
         return this.$('#'+fieldId).val();
@@ -192,7 +195,7 @@ var SlideUploadDialog = Dialog.extend({
             if (! this.modulesToInstallStatus.installing) {
                 btnList.push({text: this.modulesToInstallStatus.failed ? _t("Retry") : _t("Install"), classes: 'btn-primary', click: this._onClickInstallModuleConfirm.bind(this)});
             }
-            btnList.push({text: _t("Discard"), classes: 'o_w_slide_go_back', click: this._onClickGoBack.bind(this)});
+            btnList.push({text: _t("Back"), classes: 'o_w_slide_go_back', click: this._onClickGoBack.bind(this)});
         } else if (state !== '_upload') { // no button when uploading
             if (this.canUpload) {
                 if (this.canPublish) {
@@ -202,7 +205,7 @@ var SlideUploadDialog = Dialog.extend({
                     btnList.push({text: _t("Save"), classes: 'btn-primary o_w_slide_upload', click: this._onClickFormSubmit.bind(this)});
                 }
             }
-            btnList.push({text: _t("Discard"), classes: 'o_w_slide_go_back', click: this._onClickGoBack.bind(this)});
+            btnList.push({text: _t("Back"), classes: 'o_w_slide_go_back', click: this._onClickGoBack.bind(this)});
         }
         return btnList;
     },
@@ -339,7 +342,7 @@ var SlideUploadDialog = Dialog.extend({
             },
             infographic: {
                 icon: 'fa-file-image-o',
-                label: _t('Infographic'),
+                label: _t('Image'),
                 template: 'website.slide.upload.modal.infographic',
             },
             webpage: {
@@ -348,7 +351,7 @@ var SlideUploadDialog = Dialog.extend({
                 template: 'website.slide.upload.modal.webpage',
             },
             video: {
-                icon: 'fa-video-camera',
+                icon: 'fa-file-video-o',
                 label: _t('Video'),
                 template: 'website.slide.upload.modal.video',
             },
@@ -407,11 +410,23 @@ var SlideUploadDialog = Dialog.extend({
                 self._alertDisplay(data.error);
                 self._hidePreviewColumn();
             } else {
+                if (data.info) {
+                    self._alertDisplay(data.info, 'alert-info');
+                } else {
+                    self._alertRemove();
+                }
+
                 self.isValidUrl = true;
 
                 if (data.name) {
                     self._formSetFieldValue('name', data.name);
+                    self.$('#slide-video-title')
+                        .text(data.name)
+                        .removeClass('d-none');
+                } else {
+                    self.$('#slide-video-title').addClass('d-none');
                 }
+
                 if (data.description) {
                     self._formSetFieldValue('description', data.description);
                 }
@@ -476,7 +491,7 @@ var SlideUploadDialog = Dialog.extend({
         if (currentType === '_import') {
             this.set_title(_t("New Certification"));
         } else {
-            this.set_title(_t("Upload new content"));
+            this.set_title(_t("Add Content"));
         }
     },
     _onChangeCanSubmitForm: function (ev) {

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -42,7 +42,7 @@ tour.register('slides_tour', {
     width: 260,
 }, {
     trigger: 'a.btn-primary.o_wslides_js_slide_upload',
-    content: Markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create a web page or link a video.")),
+    content: Markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create an article or link a video.")),
     position: 'bottom',
 }, {
     trigger: 'a[data-slide-category="document"]',

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -45,8 +45,8 @@ tour.register('slides_tour', {
     content: Markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create a web page or link a video.")),
     position: 'bottom',
 }, {
-    trigger: 'a[data-slide-category="presentation"]',
-    content: Markup(_t("First, let's add a <b>Presentation</b>. It can be a .pdf or an image.")),
+    trigger: 'a[data-slide-category="document"]',
+    content: Markup(_t("First, let's add a <b>Document</b>. It has to be a .pdf file.")),
     position: 'bottom',
 }, {
     trigger: 'input#upload',

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -45,7 +45,7 @@ tour.register('slides_tour', {
     content: Markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create a web page or link a video.")),
     position: 'bottom',
 }, {
-    trigger: 'a[data-slide-type="presentation"]',
+    trigger: 'a[data-slide-category="presentation"]',
     content: Markup(_t("First, let's add a <b>Presentation</b>. It can be a .pdf or an image.")),
     position: 'bottom',
 }, {

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -515,6 +515,25 @@ $truncate-limits: 2, 3, 10;
 // Modals
 // **************************************************
 
+.o_w_slide_upload_modal_container {
+    .o_slide_preview {
+        display: flex; // not using d-flex because it messes with d-none
+    }
+
+    .form-check {
+        line-height: 1.5rem; // necessary to align label correctly with radio button
+
+    }
+
+    .was-validated .form-check .form-check-label {
+        @include o-w-preserve-base; // avoid ugly green when form is marked as 'was-validated'
+    }
+}
+
+.o_wslides_slide_upload_loading {
+    background-color: rgba(0, 0, 0, .3);
+}
+
 .o_wslides_quiz_modal {
     @include media-breakpoint-up (sm) {
         .modal-body {

--- a/addons/website_slides/static/src/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/src/tests/tours/slides_tour_tools.js
@@ -56,16 +56,16 @@ var addVideoToSection = function (sectionName, saveAsDraft) {
 	return base_steps;
 };
 
-var addWebPageToSection = function (sectionName, pageName) {
+var addArticleToSection = function (sectionName, pageName) {
 	return [
 {
 	content: 'eLearning: add content to section',
 	trigger: 'div.o_wslides_slide_list_category_header:contains("' + sectionName + '") a:contains("Add Content")',
 }, {
-	content: 'eLearning: click on webpage',
-	trigger: 'a[data-slide-category=webpage]',
+	content: 'eLearning: click on article',
+	trigger: 'a[data-slide-category=article]',
 }, {
-	content: 'eLearning: fill webpage title',
+	content: 'eLearning: fill article title',
 	trigger: 'input[name=name]',
 	run: 'text ' + pageName,
 }, {
@@ -76,7 +76,7 @@ var addWebPageToSection = function (sectionName, pageName) {
     trigger: 'div.select2-result-label:contains("Theory")',
     in_modal: false,
 }, {
-	content: 'eLearning: fill webpage completion time',
+	content: 'eLearning: fill article completion time',
 	trigger: 'input[name=duration]',
 	run: 'text 4',
 }];
@@ -132,7 +132,7 @@ var addNewCourseTag = function (courseTagName) {
 export default {
 	addSection: addSection,
 	addVideoToSection: addVideoToSection,
-	addWebPageToSection: addWebPageToSection,
+	addArticleToSection: addArticleToSection,
 	addExistingCourseTag: addExistingCourseTag,
 	addNewCourseTag: addNewCourseTag,
 };

--- a/addons/website_slides/static/src/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/src/tests/tours/slides_tour_tools.js
@@ -29,7 +29,7 @@ var addVideoToSection = function (sectionName, saveAsDraft) {
 	trigger: 'div.o_wslides_slide_list_category_header:contains("' + sectionName + '") a:contains("Add Content")',
 }, {
 	content: 'eLearning: click on video',
-	trigger: 'a[data-slide-type=video]',
+	trigger: 'a[data-slide-category=video]',
 }, {
 	content: 'eLearning: fill video link',
 	trigger: 'input[name=url]',
@@ -63,7 +63,7 @@ var addWebPageToSection = function (sectionName, pageName) {
 	trigger: 'div.o_wslides_slide_list_category_header:contains("' + sectionName + '") a:contains("Add Content")',
 }, {
 	content: 'eLearning: click on webpage',
-	trigger: 'a[data-slide-type=webpage]',
+	trigger: 'a[data-slide-category=webpage]',
 }, {
 	content: 'eLearning: fill webpage title',
 	trigger: 'input[name=name]',

--- a/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
@@ -1,12 +1,12 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="website.slides.fullscreen.content">
-        <t t-if="_.contains(['document', 'presentation'], widget.get('slide').type)">
+        <t t-if="_.contains(['document', 'presentation'], widget.get('slide').category)">
             <div class="embed-responsive h-100">
                 <iframe t-att-src="widget.get('slide').embedUrl" class="o_wslides_iframe_viewer" allowFullScreen="true" frameborder="0"/>
             </div>
         </t>
-        <t t-if="widget.get('slide').type === 'infographic'">
+        <t t-if="widget.get('slide').category === 'infographic'">
             <div class="o_wslides_fs_player w-100 h-100 overflow-auto d-flex align-items-start justify-content-center">
                 <img t-att-src="'/web/image/slide.slide/'+ widget.get('slide').id +'/image_1024'" class="img-fluid position-relative m-auto" alt="Slide image"/>
             </div>

--- a/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="website.slides.fullscreen.content">
-        <t t-if="_.contains(['document', 'presentation'], widget.get('slide').category)">
+        <t t-if="widget.get('slide').category === 'document'">
             <div class="embed-responsive h-100">
                 <iframe t-att-src="widget.get('slide').embedUrl" class="o_wslides_iframe_viewer" allowFullScreen="true" frameborder="0"/>
             </div>

--- a/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
@@ -13,9 +13,21 @@
         </t>
     </t>
 
-    <t t-name="website.slides.fullscreen.video">
+    <t t-name="website.slides.fullscreen.video.google_drive">
+        <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
+            <iframe t-att-src="widget.get('slide').embedUrl" allowFullScreen="true" frameborder="0" autoplay="1" allow="autoplay"></iframe>
+        </div>
+    </t>
+
+    <t t-name="website.slides.fullscreen.video.youtube">
         <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
             <iframe t-att-id="'youtube-player' + widget.slide.id" t-att-src="widget.slide.embedUrl" allowFullScreen="true" frameborder="0" enablejsapi="1" autoplay="1" allow="autoplay"></iframe>
+        </div>
+    </t>
+
+    <t t-name="website.slides.fullscreen.video.vimeo">
+        <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
+            <t t-out="widget.slide.embedCode"/>
         </div>
     </t>
 

--- a/addons/website_slides/static/src/xml/website_slides_share.xml
+++ b/addons/website_slides/static/src/xml/website_slides_share.xml
@@ -52,7 +52,7 @@
             </form>
         </div>
         <div t-if="widget.session.is_website_user" class="alert alert-info d-inline-block">
-            <p class="mb-0">Please <a t-attf-href="/web?redirect=#{window.location.href}" class="font-weight-bold"> login </a> to share this <t t-esc="widget.slide.type"/> by email.</p>
+            <p class="mb-0">Please <a t-attf-href="/web?redirect=#{window.location.href}" class="font-weight-bold"> login </a> to share this <t t-esc="widget.slide.category"/> by email.</p>
         </div>
     </t>
 

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -10,17 +10,17 @@
     </t>
 
     <!--
-        Slide Type Selection template
+        Slide Category Selection template
     -->
     <t t-name="website.slide.upload.modal.select">
         <div class="row p-1 mt-4 mb-2">
-            <div t-foreach="widget.slide_type_data" t-as="slide_type" class="col-6 col-md-3">
-                <t t-set="type_data" t-value="widget.slide_type_data[slide_type]"/>
+            <div t-foreach="widget.slide_category_data" t-as="slide_category" class="col-6 col-md-3">
+                <t t-set="category_data" t-value="widget.slide_category_data[slide_category]"/>
 
-                <a href="#" t-att-data-slide-type="slide_type"
-                    class="content-type d-flex flex-column align-items-center mb-4 o_wslides_select_type btn rounded border text-600 p-3">
-                    <i t-attf-class="fa #{type_data['icon']} mb-2 fa-3x"/>
-                    <t t-esc="type_data['label']"/>
+                <a href="#" t-att-data-slide-category="slide_category"
+                    class="content-type d-flex flex-column align-items-center mb-4 o_wslides_select_category btn rounded border text-600 p-3">
+                    <i t-attf-class="fa #{category_data['icon']} mb-2 fa-3x"/>
+                    <t t-esc="category_data['label']"/>
                 </a>
             </div>
         </div>
@@ -55,7 +55,7 @@
     </t>
 
     <!--
-        Slide Type common form part template
+        Slide Category common form part template
     -->
     <t t-name="website.slide.upload.modal.common">
         <div class="form-group">
@@ -82,7 +82,7 @@
     </t>
 
     <!--
-        Slide Type templates
+        Slide Category templates
     -->
     <t t-name="website.slide.upload.modal.presentation">
         <div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -14,7 +14,7 @@
     -->
     <t t-name="website.slide.upload.modal.select">
         <div class="row p-1 mt-4 mb-2">
-            <div t-foreach="widget.slide_category_data" t-as="slide_category" class="col-6 col-md-3">
+            <div t-foreach="widget.slide_category_data" t-as="slide_category" class="col-6 col-md-4">
                 <t t-set="category_data" t-value="widget.slide_category_data[slide_category]"/>
 
                 <a href="#" t-att-data-slide-category="slide_category"
@@ -71,9 +71,9 @@
             <input id="tag_ids" name="tag_ids" type="hidden"/>
         </div>
         <div class="form-group">
-            <label for="duration" class="col-form-label">Duration</label>
+            <label for="duration" class="col-form-label">Estimated Completion Time</label>
             <div class="input-group">
-                <input type="number" id="duration" min="0" name="duration" placeholder="Estimated slide completion time" class="form-control" autocomplete="off"/>
+                <input type="number" id="duration" min="0" name="duration" placeholder='e.g. "15"' class="form-control" autocomplete="off"/>
                     <div class="input-group-prepend">
                     <span class="input-group-text">Minutes</span>
                 </div>
@@ -94,13 +94,13 @@
                             <div class="form-check ml-2">
                                 <input class="form-check-input" type="radio" name="source_type" id="source_type_local_file" data-value="local_file" checked="checked"/>
                                 <label class="form-check-label font-weight-normal" for="source_type_local_file">
-                                    Local File
+                                    Upload from Device
                                 </label>
                             </div>
                             <div class="form-check ml-2">
                                 <input class="form-check-input" type="radio" name="source_type" id="source_type_external" data-value="external"/>
                                 <label class="form-check-label font-weight-normal" for="source_type_external">
-                                    External
+                                    Retrieve from Google Drive
                                 </label>
                             </div>
                         </div>
@@ -110,7 +110,8 @@
                         </div>
                         <div class="form-group o_wslides_js_slide_upload_external d-none">
                             <label for="document_google_url" class="col-form-label">Document Link</label>
-                            <input id="document_google_url" name="document_google_url" class="form-control h-100"/>
+                            <input id="document_google_url" name="document_google_url" class="form-control h-100" autocomplete="off"
+                                placeholder='e.g "https://drive.google.com/file/..."'/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -120,7 +121,7 @@
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How do I add new content?</div>
                                 <div>
-                                    <span>You can either choose a local file from your computer or insert a valid Google Drive link.</span><br/>
+                                    <span>You can either upload a file from your computer or insert a Google Drive link.</span><br/>
                                 </div>
                                 <div class="o_wslides_js_slide_upload_local_file">
                                     <div class="h5 mt-3">What types of documents do we support?</div>
@@ -169,13 +170,13 @@
                             <div class="form-check ml-2">
                                 <input class="form-check-input" type="radio" name="source_type" id="source_type_local_file" data-value="local_file" checked="checked"/>
                                 <label class="form-check-label font-weight-normal" for="source_type_local_file">
-                                    Local File
+                                    Upload from Device
                                 </label>
                             </div>
                             <div class="form-check ml-2">
                                 <input class="form-check-input" type="radio" name="source_type" id="source_type_external" data-value="external"/>
                                 <label class="form-check-label font-weight-normal" for="source_type_external">
-                                    External
+                                    Retrieve from Google Drive
                                 </label>
                             </div>
                         </div>
@@ -185,7 +186,8 @@
                         </div>
                         <div class="form-group o_wslides_js_slide_upload_external d-none">
                             <label for="image_google_url" class="col-form-label">Image Link</label>
-                            <input id="image_google_url" name="image_google_url" class="form-control h-100"/>
+                            <input id="image_google_url" name="image_google_url" class="form-control h-100" autocomplete="off"
+                                placeholder='e.g "https://drive.google.com/file/..."'/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -195,7 +197,7 @@
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How do I add new content?</div>
                                 <div>
-                                    <span>You can either choose a local file from your computer or insert a valid Google Drive link.</span><br/>
+                                    <span>You can either upload a file from your computer or insert a Google Drive link.</span><br/>
                                     <span>The Google Drive link can be obtained by using the 'share' button in the Google interface.</span><br/>
                                     <span>It should look similar to
                                     <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
@@ -239,7 +241,8 @@
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
                             <label for="video_url" class="col-form-label">Video Link</label>
-                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube, Vimeo or Google Drive Link" required="required"/>
+                            <input id="video_url" name="video_url" class="form-control" autocomplete="off"
+                                placeholder='e.g "https://www.youtube.com/watch?v=ebBez6bcSEc"' required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -276,6 +279,7 @@
                             </div>
                             <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
                                 <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                                <div id="slide-video-title" class="d-none mt-1"/>
                             </div>
                         </div>
                     </div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -213,7 +213,7 @@
         </div>
     </t>
 
-    <t t-name="website.slide.upload.modal.webpage">
+    <t t-name="website.slide.upload.modal.article">
         <div>
             <form class="clearfix">
                 <div class="row">
@@ -224,7 +224,7 @@
                     <div id="o_wslides_js_slide_upload_preview_column" class="col-md-6">
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
-                                <div class="h5">How to create a Lesson as a Web Page?</div>
+                                <div class="h5">How to create a Lesson as an Article?</div>
                                 <div>First, create your lesson, then edit it with the website builder. You'll be able to drop building blocks on your page and edit them.</div>
                             </div>
                         </div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -239,7 +239,7 @@
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
                             <label for="video_url" class="col-form-label">Video Link</label>
-                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube or Google Drive Link" required="required"/>
+                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube, Vimeo or Google Drive Link" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -252,6 +252,20 @@
                                 <div>First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
                                 <div>What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
                                 <div><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <br/>
+                                <div class="h6">On Vimeo</div>
+                                <div>
+                                    <span>First, upload your videos on Vimeo and mark them as <strong>Private</strong>. This way, they will be secured.</span><br/>
+                                    <span>What does <strong>Private</strong> mean? The Vimeo "Private" privacy setting means it is a video which can be viewed only by the users with the link to it.
+                                    Your video will never come up in the search results nor on your channel.</span><br/>
+                                    <span><a href="https://vimeo.zendesk.com/hc/en-us/articles/224819527-Changing-the-privacy-settings-of-your-videos" target="_blank" >Change video privacy settings</a></span><br/><br/>
+                                    <span>The video link to input here can be obtained by using the 'share' button in the Vimeo interface.</span><br/>
+                                    <span>It should look similar to</span>
+                                    <span class="font-italic">https://vimeo.com/558907333/30da9ff3d8</span>
+                                    <span>for 'Private' videos and similar to</span>
+                                    <span class="font-italic">https://vimeo.com/558907555</span>
+                                    <span>for public ones.</span>
+                                </div>
                                 <br/>
                                 <div class="h6">On Google Drive</div>
                                 <div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -84,14 +84,33 @@
     <!--
         Slide Category templates
     -->
-    <t t-name="website.slide.upload.modal.presentation">
+    <t t-name="website.slide.upload.modal.document">
         <div>
             <form class="clearfix">
                 <div class="row">
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
-                            <label for="upload" class="col-form-label">Choose a PDF or an Image</label>
-                            <input id="upload" name="file" class="form-control h-100" accept="image/*,application/pdf" type="file" required="required"/>
+                            <label for="source_type" class="col-form-label">Document Source</label><br/>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_local_file" data-value="local_file" checked="checked"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_local_file">
+                                    Local File
+                                </label>
+                            </div>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_external" data-value="external"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_external">
+                                    External
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_local_file">
+                            <label for="upload" class="col-form-label">Choose a PDF</label>
+                            <input id="upload" name="file" class="form-control h-100" accept="application/pdf" type="file" required="required"/>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_external d-none">
+                            <label for="document_google_url" class="col-form-label">Document Link</label>
+                            <input id="document_google_url" name="document_google_url" class="form-control h-100"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -99,15 +118,91 @@
                     <div id="o_wslides_js_slide_upload_preview_column" class="col-md-6">
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
-                                <div class="h5">How to upload your PowerPoint Presentations or Word Documents?</div>
-                                <div class="mx-3 my-4">Save your presentations or documents as PDF files and upload them.</div>
-                                <div class="alert alert-warning" role="alert">
-                                    <i class="fa fa-info-circle pr-2"/>
-                                    Only JPG, PNG, PDF, files types are supported
+                                <div class="h5">How do I add new content?</div>
+                                <div>
+                                    <span>You can either choose a local file from your computer or insert a valid Google Drive link.</span><br/>
+                                </div>
+                                <div class="o_wslides_js_slide_upload_local_file">
+                                    <div class="h5 mt-3">What types of documents do we support?</div>
+                                    <div>
+                                        <span>When using local files, we only support PDF files.</span><br/>
+                                        <span>If you want to use other types of files, you may want to use an external source (Google Drive) instead.</span>
+                                    </div>
+                                    <div class="h5 mt-3">How to upload your PowerPoint Presentations or Word Documents?</div>
+                                    <div>
+                                        <span>Save your presentations or documents as PDF files and upload them.</span>
+                                    </div>
+                                </div>
+                                <div class="o_wslides_js_slide_upload_external d-none">
+                                    <div class="h5 mt-3">What types of documents do we support?</div>
+                                    <div>
+                                        Through Google Drive, we support most common types of documents.
+                                        Including regular documents (Google Doc, .docx), Sheets (Google Sheet, .xlsx), PowerPoints, ...
+                                    </div>
+                                    <div class="h5 mt-3">How to use Google Drive?</div>
+                                    <div>
+                                        <span>First, upload the file on your Google Drive account.</span><br/>
+                                        <span>Then, go into the file permissions and set it as "Anyone with the link".</span><br/>
+                                        <span>The Google Drive link to use here can be obtained by clicking the "Share" button in the Google interface.</span><br/>
+                                        <span>It should look similar to
+                                        <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="o_slide_preview d-none">
-                                <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                            <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
+                                <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </t>
+
+    <t t-name="website.slide.upload.modal.infographic">
+        <div>
+            <form class="clearfix">
+                <div class="row">
+                    <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
+                        <div class="form-group">
+                            <label for="source_type" class="col-form-label">Image Source</label><br/>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_local_file" data-value="local_file" checked="checked"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_local_file">
+                                    Local File
+                                </label>
+                            </div>
+                            <div class="form-check ml-2">
+                                <input class="form-check-input" type="radio" name="source_type" id="source_type_external" data-value="external"/>
+                                <label class="form-check-label font-weight-normal" for="source_type_external">
+                                    External
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_local_file">
+                            <label for="upload" class="col-form-label">Choose an Image</label>
+                            <input id="upload" name="file" class="form-control h-100" accept="image/*" type="file" required="required"/>
+                        </div>
+                        <div class="form-group o_wslides_js_slide_upload_external d-none">
+                            <label for="image_google_url" class="col-form-label">Image Link</label>
+                            <input id="image_google_url" name="image_google_url" class="form-control h-100"/>
+                        </div>
+                        <canvas id="data_canvas" class="d-none"></canvas>
+                        <t t-call="website.slide.upload.modal.common"/>
+                    </div>
+                    <div id="o_wslides_js_slide_upload_preview_column" class="col-md-6">
+                        <div class="img-thumbnail h-100">
+                            <div class="o_slide_tutorial p-3">
+                                <div class="h5">How do I add new content?</div>
+                                <div>
+                                    <span>You can either choose a local file from your computer or insert a valid Google Drive link.</span><br/>
+                                    <span>The Google Drive link can be obtained by using the 'share' button in the Google interface.</span><br/>
+                                    <span>It should look similar to
+                                    <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
+                                </div>
+                            </div>
+                            <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
+                                <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
@@ -128,7 +223,7 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How to create a Lesson as a Web Page?</div>
-                                <div class="mx-3 my-4">First, create your lesson, then edit it with the website builder. You'll be able to drop building blocks on your page and edit them.</div>
+                                <div>First, create your lesson, then edit it with the website builder. You'll be able to drop building blocks on your page and edit them.</div>
                             </div>
                         </div>
                     </div>
@@ -143,8 +238,8 @@
                 <div class="row">
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
-                            <label for="url" class="col-form-label">Youtube Link</label>
-                            <input id="url" name="url" class="form-control" placeholder="Youtube Video URL" required="required"/>
+                            <label for="video_url" class="col-form-label">Video Link</label>
+                            <input id="video_url" name="video_url" class="form-control" placeholder="Youtube or Google Drive Link" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -153,12 +248,20 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How to upload your videos ?</div>
-                                <div class="mx-3 my-4">First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
-                                <div class="mx-3 my-4">What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
-                                <div class="mx-3 my-4"><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <div class="h6">On YouTube</div>
+                                <div>First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
+                                <div>What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
+                                <div><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <br/>
+                                <div class="h6">On Google Drive</div>
+                                <div>
+                                    <span>The Google Drive link can be obtained by using the 'share' button in the Google interface.</span><br/>
+                                    <span>It should look similar to
+                                    <span class="font-italic">https://drive.google.com/file/d/ABC/view?usp=sharing</span></span>
+                                </div>
                             </div>
-                            <div class="o_slide_preview d-none">
-                                <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
+                            <div class="o_slide_preview d-none h-100 flex-column justify-content-center">
+                                <img referrerPolicy="no-referrer" src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
@@ -179,13 +282,23 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">Test your students with small Quizzes</div>
-                                <div class="mx-3 my-4">With Quizzes you can keep your students focused and motivated by answering some questions and gaining some karma points</div>
+                                <div>With Quizzes you can keep your students focused and motivated by answering some questions and gaining some karma points</div>
                                 <img src="/website_slides/static/src/img/onboarding-quiz.png" title="Quiz Demo Data" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
                 </div>
             </form>
+        </div>
+    </t>
+
+    <!-- Misc -->
+    <t t-name="website.slide.upload.modal.loading">
+        <div class="o_wslides_slide_upload_loading position-absolute h-100 w-100 text-center d-flex flex-column justify-content-center">
+            <h2 class="text-white">
+                <span class="fa fa-spinner fa-pulse"></span>
+                <span>Loading content...</span>
+            </h2>
         </div>
     </t>
 </templates>

--- a/addons/website_slides/tests/common.py
+++ b/addons/website_slides/tests/common.py
@@ -55,7 +55,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook Humans',
             'channel_id': cls.channel.id,
-            'slide_type': 'presentation',
+            'slide_category': 'presentation',
             'is_published': True,
             'completion_time': 2.0,
             'sequence': 1,
@@ -70,7 +70,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide_2 = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook For Humans',
             'channel_id': cls.channel.id,
-            'slide_type': 'presentation',
+            'slide_category': 'presentation',
             'is_published': True,
             'completion_time': 3.0,
             'sequence': 3,
@@ -78,7 +78,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide_3 = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook Humans For Humans',
             'channel_id': cls.channel.id,
-            'slide_type': 'document',
+            'slide_category': 'document',
             'is_published': True,
             'completion_time': 1.5,
             'sequence': 4,

--- a/addons/website_slides/tests/common.py
+++ b/addons/website_slides/tests/common.py
@@ -55,7 +55,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook Humans',
             'channel_id': cls.channel.id,
-            'slide_category': 'presentation',
+            'slide_category': 'document',
             'is_published': True,
             'completion_time': 2.0,
             'sequence': 1,
@@ -70,7 +70,7 @@ class SlidesCase(common.TransactionCase):
         cls.slide_2 = cls.env['slide.slide'].with_user(cls.user_officer).create({
             'name': 'How To Cook For Humans',
             'channel_id': cls.channel.id,
-            'slide_category': 'presentation',
+            'slide_category': 'document',
             'is_published': True,
             'completion_time': 3.0,
             'sequence': 3,

--- a/addons/website_slides/tests/test_karma.py
+++ b/addons/website_slides/tests/test_karma.py
@@ -28,14 +28,14 @@ class TestKarmaGain(common.SlidesCase):
         self.slide_2_0 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'How to travel through space and time',
             'channel_id': self.channel_2.id,
-            'slide_type': 'presentation',
+            'slide_category': 'presentation',
             'is_published': True,
             'completion_time': 2.0,
         })
         self.slide_2_1 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'How to duplicate yourself',
             'channel_id': self.channel_2.id,
-            'slide_type': 'presentation',
+            'slide_category': 'presentation',
             'is_published': True,
             'completion_time': 2.0,
         })

--- a/addons/website_slides/tests/test_karma.py
+++ b/addons/website_slides/tests/test_karma.py
@@ -28,14 +28,14 @@ class TestKarmaGain(common.SlidesCase):
         self.slide_2_0 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'How to travel through space and time',
             'channel_id': self.channel_2.id,
-            'slide_category': 'presentation',
+            'slide_category': 'document',
             'is_published': True,
             'completion_time': 2.0,
         })
         self.slide_2_1 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'How to duplicate yourself',
             'channel_id': self.channel_2.id,
-            'slide_category': 'presentation',
+            'slide_category': 'document',
             'is_published': True,
             'completion_time': 2.0,
         })

--- a/addons/website_slides/tests/test_slide_utils.py
+++ b/addons/website_slides/tests/test_slide_utils.py
@@ -168,7 +168,7 @@ class TestSequencing(slides_common.SlidesCase):
 
 
 class TestFromURL(slides_common.SlidesCase):
-    def test_video_urls(self):
+    def test_video_youtube(self):
         youtube_urls = {
             'W0JQcpGLSFw': [
                 'https://youtu.be/W0JQcpGLSFw',
@@ -203,12 +203,60 @@ class TestFromURL(slides_common.SlidesCase):
                     self.assertEqual('youtube', slide.video_source_type)
                     self.assertEqual(youtube_id, slide.youtube_id)
 
-        # test URL from Google Drive when user hits the "share" button (main use case)
-        slide = Slide.create({
-            'name': 'dummy',
-            'channel_id': self.channel.id,
-            'url': 'https://drive.google.com/file/d/1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR/view?usp=sharing',
-            'slide_category': 'video'
-        })
-        self.assertEqual('google_drive', slide.video_source_type)
-        self.assertEqual('1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR', slide.google_drive_id)
+    def test_video_google_drive(self):
+        google_drive_urls = {
+            '1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR': [
+                'https://drive.google.com/file/d/1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR/view?usp=sharing',
+                'https://drive.google.com/file/d/1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR',
+            ],
+        }
+
+        Slide = self.env['slide.slide'].with_context(website_slides_skip_fetch_metadata=True)
+
+        # test various Google Drive URL formats
+        for google_drive_id, urls in google_drive_urls.items():
+            for url in urls:
+                with self.subTest(url=url, id=google_drive_id):
+                    slide = Slide.create({
+                        'name': 'dummy',
+                        'channel_id': self.channel.id,
+                        'url': url,
+                        'slide_category': 'video'
+                    })
+                    self.assertEqual('google_drive', slide.video_source_type)
+                    self.assertEqual(google_drive_id, slide.google_drive_id)
+
+    def test_video_vimeo(self):
+        vimeo_urls = {
+            # regular URL from Vimeo
+            '545859999': [
+                'https://vimeo.com/545859999',
+                'https://vimeo.com/545859999?autoplay=1',
+            ],
+            # test channel URL from Vimeo
+            '551979139': [
+                'https://vimeo.com/channels/staffpicks/551979139',
+                'https://vimeo.com/channels/staffpicks/551979139?autoplay=1',
+            ],
+            # test URL from Vimeo with setting 'with URL only'
+            # we need to store both the ID and the token, see '_compute_embed_code' method for details
+            '545859999/94dd03ddb0': [
+                'https://vimeo.com/545859999/94dd03ddb0',
+                'https://vimeo.com/545859999/94dd03ddb0?autoplay=1',
+            ],
+        }
+
+        Slide = self.env['slide.slide'].with_context(website_slides_skip_fetch_metadata=True)
+
+        # test various Vimeo URL formats
+        for vimeo_id, urls in vimeo_urls.items():
+            for url in urls:
+                with self.subTest(url=url, id=vimeo_id):
+                    slide = Slide.create({
+                        'name': 'dummy',
+                        'channel_id': self.channel.id,
+                        'url': url,
+                        'slide_category': 'video'
+                    })
+                    self.assertEqual('vimeo', slide.video_source_type)
+                    self.assertEqual(vimeo_id, slide.vimeo_id)

--- a/addons/website_slides/tests/test_slide_utils.py
+++ b/addons/website_slides/tests/test_slide_utils.py
@@ -168,8 +168,8 @@ class TestSequencing(slides_common.SlidesCase):
 
 
 class TestFromURL(slides_common.SlidesCase):
-    def test_youtube_urls(self):
-        urls = {
+    def test_video_urls(self):
+        youtube_urls = {
             'W0JQcpGLSFw': [
                 'https://youtu.be/W0JQcpGLSFw',
                 'https://www.youtube.com/watch?v=W0JQcpGLSFw',
@@ -188,9 +188,27 @@ class TestFromURL(slides_common.SlidesCase):
             ],
         }
 
-        for id, urls in urls.items():
+        Slide = self.env['slide.slide'].with_context(website_slides_skip_fetch_metadata=True)
+
+        # test various YouTube URL formats
+        for youtube_id, urls in youtube_urls.items():
             for url in urls:
-                with self.subTest(url=url, id=id):
-                    document = self.env['slide.slide']._find_document_data_from_url(url)
-                    self.assertEqual(document[0], 'youtube')
-                    self.assertEqual(document[1], id)
+                with self.subTest(url=url, id=youtube_id):
+                    slide = Slide.create({
+                        'name': 'dummy',
+                        'channel_id': self.channel.id,
+                        'url': url,
+                        'slide_category': 'video'
+                    })
+                    self.assertEqual('youtube', slide.video_source_type)
+                    self.assertEqual(youtube_id, slide.youtube_id)
+
+        # test URL from Google Drive when user hits the "share" button (main use case)
+        slide = Slide.create({
+            'name': 'dummy',
+            'channel_id': self.channel.id,
+            'url': 'https://drive.google.com/file/d/1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR/view?usp=sharing',
+            'slide_category': 'video'
+        })
+        self.assertEqual('google_drive', slide.video_source_type)
+        self.assertEqual('1qU5nHVNbz_r84P_IS5kDzoCuC1h5ZAZR', slide.google_drive_id)

--- a/addons/website_slides/tests/test_statistics.py
+++ b/addons/website_slides/tests/test_statistics.py
@@ -39,12 +39,12 @@ class TestChannelStatistics(common.SlidesCase):
     @mute_logger('odoo.models')
     def test_channel_statistics(self):
         channel_publisher = self.channel.with_user(self.user_officer)
-        # slide type computation
+        # slide category computation
         self.assertEqual(channel_publisher.total_slides, len(channel_publisher.slide_content_ids))
-        self.assertEqual(channel_publisher.nbr_infographic, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'infographic')))
-        self.assertEqual(channel_publisher.nbr_presentation, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'presentation')))
-        self.assertEqual(channel_publisher.nbr_document, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'document')))
-        self.assertEqual(channel_publisher.nbr_video, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_type == 'video')))
+        self.assertEqual(channel_publisher.nbr_infographic, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'infographic')))
+        self.assertEqual(channel_publisher.nbr_presentation, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'presentation')))
+        self.assertEqual(channel_publisher.nbr_document, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'document')))
+        self.assertEqual(channel_publisher.nbr_video, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'video')))
         # slide statistics computation
         self.assertEqual(float_compare(channel_publisher.total_time, sum(s.completion_time for s in channel_publisher.slide_content_ids), 3), 0)
         # members computation
@@ -156,14 +156,14 @@ class TestSlideStatistics(common.SlidesCase):
         self.assertEqual(slide_emp.total_views, 5)
 
     @users('user_officer')
-    def test_slide_statistics_types(self):
+    def test_slide_statistics_categories(self):
         category = self.category.with_user(self.env.user)
         self.assertEqual(
             category.nbr_presentation,
-            len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_type == 'presentation')))
+            len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_category == 'presentation')))
         self.assertEqual(
             category.nbr_document,
-            len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_type == 'document')))
+            len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_category == 'document')))
 
         self.assertEqual(self.channel.total_slides, 3, 'The channel should contain 3 slides')
         self.assertEqual(category.total_slides, 2, 'The first category should contain 2 slides')

--- a/addons/website_slides/tests/test_statistics.py
+++ b/addons/website_slides/tests/test_statistics.py
@@ -42,7 +42,6 @@ class TestChannelStatistics(common.SlidesCase):
         # slide category computation
         self.assertEqual(channel_publisher.total_slides, len(channel_publisher.slide_content_ids))
         self.assertEqual(channel_publisher.nbr_infographic, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'infographic')))
-        self.assertEqual(channel_publisher.nbr_presentation, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'presentation')))
         self.assertEqual(channel_publisher.nbr_document, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'document')))
         self.assertEqual(channel_publisher.nbr_video, len(channel_publisher.slide_content_ids.filtered(lambda s: s.slide_category == 'video')))
         # slide statistics computation
@@ -158,9 +157,6 @@ class TestSlideStatistics(common.SlidesCase):
     @users('user_officer')
     def test_slide_statistics_categories(self):
         category = self.category.with_user(self.env.user)
-        self.assertEqual(
-            category.nbr_presentation,
-            len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_category == 'presentation')))
         self.assertEqual(
             category.nbr_document,
             len(category.channel_id.slide_ids.filtered(lambda s: s.category_id == category and s.slide_category == 'document')))

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -34,7 +34,7 @@ class TestUICommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
                     'name': 'Gardening: The Know-How',
                     'sequence': 1,
                     'binary_content': pdf_content,
-                    'slide_category': 'presentation',
+                    'slide_category': 'document',
                     'is_published': True,
                     'is_preview': True,
                 }), (0, 0, {

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -33,32 +33,32 @@ class TestUICommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
                 (0, 0, {
                     'name': 'Gardening: The Know-How',
                     'sequence': 1,
-                    'datas': pdf_content,
-                    'slide_type': 'presentation',
+                    'binary_content': pdf_content,
+                    'slide_category': 'presentation',
                     'is_published': True,
                     'is_preview': True,
                 }), (0, 0, {
                     'name': 'Home Gardening',
                     'sequence': 2,
                     'image_1920': img_content,
-                    'slide_type': 'infographic',
+                    'slide_category': 'infographic',
                     'is_published': True,
                 }), (0, 0, {
                     'name': 'Mighty Carrots',
                     'sequence': 3,
                     'image_1920': img_content,
-                    'slide_type': 'infographic',
+                    'slide_category': 'infographic',
                     'is_published': True,
                 }), (0, 0, {
                     'name': 'How to Grow and Harvest The Best Strawberries | Basics',
                     'sequence': 4,
-                    'datas': pdf_content,
-                    'slide_type': 'document',
+                    'binary_content': pdf_content,
+                    'slide_category': 'document',
                     'is_published': True,
                 }), (0, 0, {
                     'name': 'Test your knowledge',
                     'sequence': 5,
-                    'slide_type': 'quiz',
+                    'slide_category': 'quiz',
                     'is_published': True,
                     'question_ids': [
                         (0, 0, {

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -77,9 +77,9 @@
                                      <tree decoration-bf="is_category" editable="bottom">
                                         <field name="sequence" widget="handle"/>
                                         <field name="name"/>
-                                        <field name="slide_type" attrs="{'invisible': [('slide_type', '=', 'category')]}"/>
-                                        <field name="completion_time" attrs="{'invisible': [('slide_type', '=', 'category')]}" string="Duration" widget="float_time"/>
-                                        <field name="total_views" attrs="{'invisible': [('slide_type', '=', 'category')]}"/>
+                                        <field name="slide_category" attrs="{'invisible': [('slide_category', '=', 'category')]}"/>
+                                        <field name="completion_time" attrs="{'invisible': [('slide_category', '=', 'category')]}" string="Duration" widget="float_time"/>
+                                        <field name="total_views" attrs="{'invisible': [('slide_category', '=', 'category')]}"/>
                                         <field name="is_preview" string="Preview"/>
                                         <field name="is_published" string="Published"/>
                                         <field name="is_category" invisible="1"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -116,14 +116,14 @@
                                     <group name="lesson_details">
                                         <field name="active" invisible="1"/>
                                         <field name="channel_id"/>
-                                        <field name="slide_type" string="Content Type"/>
+                                        <field name="slide_category" string="Content Type"/>
                                         <field name="url" attrs="{
-                                            'required': [('slide_type', 'in', ('video'))],
-                                            'invisible': [('slide_type', 'not in', ('video'))]}" />
+                                            'required': [('slide_category', 'in', ('video'))],
+                                            'invisible': [('slide_category', 'not in', ('video'))]}" />
                                         <field name="document_id" invisible="1"/>
                                         <field name="mime_type" force_save="1" readonly="1" groups="base.group_no_one"/>
-                                        <field name="datas" string="Attachment"
-                                            attrs="{'invisible': [('slide_type', 'not in', ('document', 'presentation'))]}"/>
+                                        <field name="binary_content" string="Attachment"
+                                            attrs="{'invisible': [('slide_category', 'not in', ('document', 'presentation'))]}"/>
                                     </group>
                                     <group name="related_details">
                                         <field name="user_id" string="Responsible" widget="many2one_avatar"/>
@@ -133,7 +133,7 @@
                                             <span> hours</span>
                                         </div>
                                         <field name="is_preview"/>
-                                        <field name="slide_resource_downloadable" attrs="{'invisible': [('slide_type', 'not in', ['presentation', 'document'])]}"/>
+                                        <field name="slide_resource_downloadable" attrs="{'invisible': [('slide_category', 'not in', ['presentation', 'document'])]}"/>
                                         <field name="date_published" string="Published Date" attrs="{'invisible': [('date_published', '=', False)]}" groups="base.group_no_one"/>
                                     </group>
                                 </group>
@@ -211,7 +211,7 @@
                     sample="1">
                     <field name="id"/>
                     <field name="channel_id"/>
-                    <field name="slide_type"/>
+                    <field name="slide_category"/>
                     <field name="user_id"/>
                     <field name="image_128"/>
                     <templates>
@@ -242,20 +242,20 @@
                                     </div>
                                     <div class="o_kanban_record_bottom mt-auto d-flex justify-content-between align-items-end">
                                         <span>
-                                            <t t-if="record.slide_type.raw_value == 'infographic'">
+                                            <t t-if="record.slide_category.raw_value == 'infographic'">
                                                 <i class="fa fa-file-image-o mr-2" aria-label="Infographic" role="img" title="Infographic"/>
                                             </t>
-                                            <t t-elif="record.slide_type.raw_value == 'webpage'">
+                                            <t t-elif="record.slide_category.raw_value == 'webpage'">
                                                 <i class="fa fa-file-code-o mr-2" aria-label="Webpage" role="img" title="Webpage"/>
                                             </t>
-                                            <t t-elif="record.slide_type.raw_value == 'video'">
+                                            <t t-elif="record.slide_category.raw_value == 'video'">
                                                 <i class="fa fa-file-video-o mr-2" aria-label="Video" role="img" title="Video"/>
                                             </t>
-                                            <t t-elif="record.slide_type.raw_value == 'quiz'">
+                                            <t t-elif="record.slide_category.raw_value == 'quiz'">
                                                 <i class="fa fa-flag mr-2" aria-label="Quiz" role="img" title="Quiz"/>
                                             </t>
                                             <t t-else=""><i class="fa fa-file-pdf-o mr-2" aria-label="Document" role="img" title="Document"/></t>
-                                            <field name="slide_type"/>
+                                            <field name="slide_category"/>
                                         </span>
                                         <span>
                                             <i class="fa fa-clock-o mr-2" aria-label="Duration" role="img" title="Duration"/><field name="completion_time" widget="float_time"/>
@@ -324,7 +324,7 @@
                     <group expand="0" string="Group By">
                         <filter string="Course" name="groupby_channel" domain="[]" context="{'group_by': 'channel_id'}"/>
                         <filter string="Category" name="groupby_category" domain="[]" context="{'group_by': 'category_id'}"/>
-                        <filter string="Type" name="groupby_type" domain="[]" context="{'group_by': 'slide_type'}"/>
+                        <filter string="Type" name="groupby_type" domain="[]" context="{'group_by': 'slide_category'}"/>
                     </group>
                 </search>
             </field>
@@ -336,7 +336,7 @@
             <field name="arch" type="xml">
                 <graph string="Graph of Contents" stacked="0" sample="1">
                     <field name="channel_id"/>
-                    <field name="slide_type"/>
+                    <field name="slide_category"/>
                     <field name="total_views" type="measure"/>
                     <field name="quiz_first_attempt_reward" invisible="1"/>
                     <field name="quiz_second_attempt_reward" invisible="1"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -117,13 +117,32 @@
                                         <field name="active" invisible="1"/>
                                         <field name="channel_id"/>
                                         <field name="slide_category" string="Content Type"/>
-                                        <field name="url" attrs="{
-                                            'required': [('slide_category', 'in', ('video'))],
-                                            'invisible': [('slide_category', 'not in', ('video'))]}" />
-                                        <field name="document_id" invisible="1"/>
-                                        <field name="mime_type" force_save="1" readonly="1" groups="base.group_no_one"/>
-                                        <field name="binary_content" string="Attachment"
-                                            attrs="{'invisible': [('slide_category', 'not in', ('document', 'presentation'))]}"/>
+                                        <field name="slide_type" invisible="1"/>
+                                        <field name="source_type" widget="radio" attrs="{
+                                            'invisible': [('slide_category', 'not in', ['infographic', 'document'])]}" />
+                                        <field name="video_url" attrs="{
+                                            'required': [('slide_category', '=', 'video')],
+                                            'invisible': [('slide_category', '!=', 'video')],
+                                            'readonly': [('slide_category', '!=', 'video')]}"
+                                            widget="url"/>
+                                        <field name="document_google_url" attrs="{
+                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'document')],
+                                            'readonly': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'document')]}"
+                                            placeholder='e.g "https://drive.google.com/file/..."'
+                                            widget="url"/>
+                                        <field name="image_google_url" attrs="{
+                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'infographic')],
+                                            'readonly': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'infographic')]}"
+                                            placeholder='e.g "https://drive.google.com/file/..."'
+                                            widget="url"/>
+                                        <field name="document_binary_content" string="" options="{'accepted_file_extensions': '.pdf'}"
+                                            attrs="{
+                                                'invisible': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'document')],
+                                                'readonly': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'document')]}"/>
+                                        <field name="image_binary_content" string="" options="{'accepted_file_extensions': 'image/*'}"
+                                            attrs="{
+                                                'invisible': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'infographic')],
+                                                'readonly': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'infographic')]}"/>
                                     </group>
                                     <group name="related_details">
                                         <field name="user_id" string="Responsible" widget="many2one_avatar"/>
@@ -133,7 +152,7 @@
                                             <span> hours</span>
                                         </div>
                                         <field name="is_preview"/>
-                                        <field name="slide_resource_downloadable" attrs="{'invisible': [('slide_category', 'not in', ['presentation', 'document'])]}"/>
+                                        <field name="slide_resource_downloadable" attrs="{'invisible': ['|', ('slide_category', '!=', 'document'), ('source_type', '!=', 'local_file')]}"/>
                                         <field name="date_published" string="Published Date" attrs="{'invisible': [('date_published', '=', False)]}" groups="base.group_no_one"/>
                                     </group>
                                 </group>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -271,8 +271,8 @@
                                             <t t-if="record.slide_category.raw_value == 'infographic'">
                                                 <i class="fa fa-file-image-o mr-2" aria-label="Infographic" role="img" title="Infographic"/>
                                             </t>
-                                            <t t-elif="record.slide_category.raw_value == 'webpage'">
-                                                <i class="fa fa-file-code-o mr-2" aria-label="Webpage" role="img" title="Webpage"/>
+                                            <t t-elif="record.slide_category.raw_value == 'article'">
+                                                <i class="fa fa-file-code-o mr-2" aria-label="article" role="img" title="Article"/>
                                             </t>
                                             <t t-elif="record.slide_category.raw_value == 'video'">
                                                 <i class="fa fa-file-video-o mr-2" aria-label="Video" role="img" title="Video"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -118,12 +118,19 @@
                                         <field name="channel_id"/>
                                         <field name="slide_category" string="Content Type"/>
                                         <field name="slide_type" invisible="1"/>
-                                        <field name="source_type" widget="radio" attrs="{
+                                        <div class="text-muted" colspan="2" attrs="{
+                                            'invisible': [('slide_category', '!=', 'quiz')]}">
+                                            You can add questions to this quiz in the 'Quiz' tab.
+                                        </div>
+                                        <label for="source_type" string="" attrs="{
+                                            'invisible': [('slide_category', 'not in', ['infographic', 'document'])]}"/>
+                                        <field name="source_type" widget="radio" nolabel="1" attrs="{
                                             'invisible': [('slide_category', 'not in', ['infographic', 'document'])]}" />
                                         <field name="video_url" attrs="{
                                             'required': [('slide_category', '=', 'video')],
                                             'invisible': [('slide_category', '!=', 'video')],
                                             'readonly': [('slide_category', '!=', 'video')]}"
+                                            placeholder='e.g "www.youtube.com/watch?v=ebBez6bcSEc"'
                                             widget="url"/>
                                         <field name="document_google_url" attrs="{
                                             'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'document')],

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -504,7 +504,7 @@
             <a name="o_wslides_list_slide_add_quizz" t-if="channel.can_upload and not slide.question_ids" t-attf-href="/slides/slide/#{slug(slide)}?quiz_quick_create">
                 <span class="badge badge-light badge-hide border font-weight-normal px-2 py-1 m-1">Add Quiz</span>
             </a>
-            <a t-if="channel.can_upload" href="#">
+            <a t-if="channel.can_upload" href="#" name="o_wslides_slide_toggle_is_preview">
                 <span t-att-data-slide-id="slide.id" t-attf-class="o_wslides_js_slide_toggle_is_preview badge #{'badge-success' if slide.is_preview else 'badge-light badge-hide border'} font-weight-normal px-2 py-1 m-1"><span>Preview</span></span>
             </a>
             <t t-elif="slide.is_preview and not channel.is_member">
@@ -685,7 +685,7 @@
                     t-att-data-channel-id="channel.id"
                     t-att-data-can-upload="channel.can_upload"
                     t-att-data-can-publish="channel.can_publish">
-                    <i class="fa fa-cloud-upload mr-1"/>Upload new content
+                    <i class="fa fa-cloud-upload mr-1"/>Add Content
                 </a>
                 <a class="btn btn-secondary py-1 o_wslides_js_slide_section_add"
                     title="Add Section" role="button"

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -13,7 +13,7 @@
                             <a href="/slides">Courses</a>
                         </li>
                         <t t-set="breadcrumb_class" t-value="'breadcrumb-item %s' % ('active' if not slide else '')" />
-                        <li t-att-class="'breadcrumb-item %s' % ('active' if not search_category and not search_tag and not search_slide_type and not slide else '')">
+                        <li t-att-class="'breadcrumb-item %s' % ('active' if not search_category and not search_tag and not search_slide_category and not slide else '')">
                             <a t-att-href="'/slides/%s' % slug(channel)"><span t-esc="channel.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_category" t-if="search_category">
@@ -25,8 +25,8 @@
                         <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_uncategorized" t-if="search_uncategorized">
                             <a t-att-href="'/slides/%s?search_uncategorized=1' % (slug(channel))">Uncategorized</a>
                         </li>
-                        <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_slide_type" t-if="search_slide_type">
-                            <a t-att-href="'/slides/%s?slide_type=%s' % (slug(channel), search_slide_type)"><span t-esc="slide_types[search_slide_type]"/></a>
+                        <li t-att-class="breadcrumb_class" t-att-aria-current="'page' and search_slide_category" t-if="search_slide_category">
+                            <a t-att-href="'/slides/%s?slide_category=%s' % (slug(channel), search_slide_category)"><span t-esc="slide_categories[search_slide_category]"/></a>
                         </li>
                         <li t-if="slide" class="breadcrumb-item active">
                             <a t-att-href="'/slides/slide/%s' % slug(slide)"><span t-esc="slide.name"/></a>
@@ -58,7 +58,7 @@
                             <div class="dropdown-menu">
                                 <a class="dropdown-item" href="/slides">Home</a>
                                 <t t-set="dropdown_class" t-value="'dropdown-item %s' % ('active' if not slide else '')"/>
-                                <a t-att-class="'dropdown-item %s' % ('active' if not search_category and not search_tag and not search_slide_type else '')" t-att-href="'/slides/%s' % slug(channel)">
+                                <a t-att-class="'dropdown-item %s' % ('active' if not search_category and not search_tag and not search_slide_category else '')" t-att-href="'/slides/%s' % slug(channel)">
                                     &#9492;<span class="ml-1" t-esc="channel.name"/>
                                 </a>
                                 <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_category" t-if="search_category" t-att-href="'/slides/%s/category/%s' % (slug(channel), slug(search_category))">
@@ -70,8 +70,8 @@
                                 <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_uncategorized" t-if="search_uncategorized" t-att-href="'/slides/%s?search_uncategorized=1' % (slug(channel))">
                                     &#9492;<span class="ml-1">Uncategorized</span>
                                 </a>
-                                <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_slide_type" t-if="search_slide_type" t-att-href="'/slides/%s?slide_type=%s' % (slug(channel), search_slide_type)">
-                                    &#9492;<span class="ml-1" t-esc="slide_types[search_slide_type]"/>
+                                <a t-att-class="dropdown_class" t-att-aria-current="'page' and search_slide_category" t-if="search_slide_category" t-att-href="'/slides/%s?slide_category=%s' % (slug(channel), search_slide_category)">
+                                    &#9492;<span class="ml-1" t-esc="slide_categories[search_slide_category]"/>
                                 </a>
                                  <a t-if="slide" class="dropdown-item active" t-att-href="'/slides/slide/%s' % (slug(slide))">
                                     &#9492;<span class="ml-1" t-esc="slide.name"/>
@@ -526,7 +526,7 @@
                 <i t-else="" class="check-done text-success fa fa-check-circle px-2"></i>
             </t>
             <span t-if="channel.can_publish" class="d-none d-md-flex">
-                <a t-if="slide.slide_type == 'webpage'" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1"><span class="fa fa-pencil"/></a>
+                <a t-if="slide.slide_category == 'webpage'" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1"><span class="fa fa-pencil"/></a>
                 <a t-else="" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/web#id=#{slide.id}&amp;action=#{slide_action}&amp;model=slide.slide&amp;view_type=form" title="Edit in backend"><span class="fa fa-pencil"/></a>
                 <a href="#" t-att-data-slide-id="slide.id" class="o_text_link text-danger px-2 o_wslides_js_slide_archive"><span class="fa fa-trash"/></a>
             </span>
@@ -537,7 +537,7 @@
 <!-- ======= Documentation Course content: cards / categories=======  -->
 <template id="course_promoted_slide" name="Documentation Course content: promoted slide">
     <div class="o_wslides_promoted_slide">
-        <div t-if="not search and not search_slide_type and slide_promoted" class="container py-1 mb-2">
+        <div t-if="not search and not search_slide_category and slide_promoted" class="container py-1 mb-2">
             <div class="card flex-column flex-lg-row">
                 <t t-set="image_url" t-value="website.image_url(slide_promoted, 'image_1024')"/>
 
@@ -574,7 +574,7 @@
                 <nav class="navbar navbar-expand-lg navbar-light bg-transparent col">
                     <a class="navbar-brand d-lg-none" href="#">Filter &amp; order</a>
 
-                    <div class="form-inline ml-auto d-lg-none" t-if="search_slide_type or search">
+                    <div class="form-inline ml-auto d-lg-none" t-if="search_slide_category or search">
                         <a t-att-href="'/slides/%s' % (slug(channel))" class="btn btn-info mr-3">
                             <i class="fa fa-eraser mr-1"/>Clear filters
                         </a>
@@ -588,23 +588,23 @@
                         <div class="col-12">
                             <ul class="navbar-nav mr-lg-auto align-items-lg-center">
 
-                                <t t-set="slide_type_keys" t-value="slide_types.keys()"/>
-                                <t t-foreach="slide_type_keys" t-as="slide_type_key">
+                                <t t-set="slide_category_keys" t-value="slide_categories.keys()"/>
+                                <t t-foreach="slide_category_keys" t-as="slide_category_key">
                                     <t t-if="search_category">
-                                        <li t-if="search_category['nbr_%s' % slide_type_key] > 0" class="nav-item">
-                                            <a t-att-href="'/slides/%s/category/%s?%s' % (slug(channel), slug(search_category), keep_query(slide_type=slide_type_key))"
-                                               t-att-class="'nav-link d-flex align-items-center justify-content-between mr-1 %s' % ('active' if search_slide_type == slide_type_key else '')">
-                                               <t t-esc="slide_types[slide_type_key]"/>
-                                               <span t-attf-class="badge badge-pill ml-1 #{'badge-info' if search_slide_type == slide_type_key else 'bg-400'}" t-esc="search_category['nbr_%s' % slide_type_key]"/>
+                                        <li t-if="search_category['nbr_%s' % slide_category_key] > 0" class="nav-item">
+                                            <a t-att-href="'/slides/%s/category/%s?%s' % (slug(channel), slug(search_category), keep_query(slide_category=slide_category_key))"
+                                               t-att-class="'nav-link d-flex align-items-center justify-content-between mr-1 %s' % ('active' if search_slide_category == slide_category_key else '')">
+                                               <t t-esc="slide_categories[slide_category_key]"/>
+                                               <span t-attf-class="badge badge-pill ml-1 #{'badge-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="search_category['nbr_%s' % slide_category_key]"/>
                                             </a>
                                         </li>
                                     </t>
                                     <t t-else="">
-                                        <li t-if="channel['nbr_%s' % slide_type_key] > 0" class="nav-item">
-                                            <a t-att-href="'/slides/%s?%s' % (slug(channel), keep_query(slide_type=slide_type_key))"
-                                               t-att-class="'nav-link d-flex align-items-center justify-content-between mr-1 %s' % ('active' if search_slide_type == slide_type_key else '')">
-                                               <t t-esc="slide_types[slide_type_key]"/>
-                                               <span t-attf-class="badge badge-pill ml-1 #{'badge-info' if search_slide_type == slide_type_key else 'bg-400'}" t-esc="channel['nbr_%s' % slide_type_key]"/>
+                                        <li t-if="channel['nbr_%s' % slide_category_key] > 0" class="nav-item">
+                                            <a t-att-href="'/slides/%s?%s' % (slug(channel), keep_query(slide_category=slide_category_key))"
+                                               t-att-class="'nav-link d-flex align-items-center justify-content-between mr-1 %s' % ('active' if search_slide_category == slide_category_key else '')">
+                                               <t t-esc="slide_categories[slide_category_key]"/>
+                                               <span t-attf-class="badge badge-pill ml-1 #{'badge-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="channel['nbr_%s' % slide_category_key]"/>
                                             </a>
                                         </li>
                                     </t>
@@ -626,18 +626,18 @@
                                     </a>
                                     <div class="dropdown-menu" aria-labelledby="slidesChannelDropdownSort" role="menu">
                                         <h6 class="dropdown-header">Sort by</h6>
-                                        <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_type', sorting='latest'))"
+                                        <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_category', sorting='latest'))"
                                            t-att-class="'dropdown-item %s' % ('active' if sorting and sorting == 'latest' else '')">Newest</a>
-                                        <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_type', sorting='most_voted'))"
+                                        <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_category', sorting='most_voted'))"
                                            t-att-class="'dropdown-item %s' % ('active' if sorting and sorting == 'most_voted' else '')">Most Voted</a>
-                                        <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_type', sorting='most_viewed'))"
+                                        <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_category', sorting='most_viewed'))"
                                            t-att-class="'dropdown-item %s' % ('active' if sorting and sorting == 'most_viewed' else '')">Most Viewed</a>
                                     </div>
                                 </li>
                             </ul>
 
                             <div class="form-inline mr-3 d-none d-lg-inline-block">
-                                <a t-if="search_slide_type or search" t-att-href="'/slides/%s' % (slug(channel))" class="btn btn-sm btn-info ml-1">
+                                <a t-if="search_slide_category or search" t-att-href="'/slides/%s' % (slug(channel))" class="btn btn-sm btn-info ml-1">
                                     <i class="fa fa-eraser mr-1"/>Clear filters
                                 </a>
                             </div>
@@ -805,13 +805,13 @@
 
 <template id="slide_icon">
     <t t-set="icon_class" t-value="icon_class if icon_class else 'mr-2 text-muted'"/>
-    <i t-if="slide.slide_type == 'document'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'presentation'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'infographic'" t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'link'" t-att-class="'fa fa-file-code-o %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'document'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'presentation'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'infographic'" t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'link'" t-att-class="'fa fa-file-code-o %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
+    <i t-if="slide.slide_category == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>
 </template>
 
 </data></odoo>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -812,6 +812,7 @@
     <i t-if="slide.slide_type == 'image'" t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'youtube_video'" t-att-class="'fa fa-youtube-play %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'google_drive_video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'vimeo_video'" t-att-class="'fa fa-vimeo %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>
     <i t-if="not slide.slide_type" t-att-class="'fa fa-file-o %s' % icon_class"></i>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -367,7 +367,7 @@
                             <a  t-if="channel.can_upload"
                                 class="o_text_link o_wslides_js_slide_upload px-3 py-2"
                                 role="button"
-                                aria-label="Upload Presentation"
+                                aria-label="Upload Document"
                                 href="#"
                                 t-att-data-modules-to-install="modules_to_install"
                                 t-att-data-channel-id="channel.id"
@@ -393,7 +393,7 @@
         <div t-if="channel.can_upload" class="o_wslides_content_actions btn-group">
             <a  class="o_wslides_js_slide_upload mr-1 border btn btn-primary"
                 role="button"
-                aria-label="Upload Presentation"
+                aria-label="Upload Document"
                 href="#"
                 t-att-data-open-modal="enable_slide_upload"
                 t-att-data-modules-to-install="modules_to_install"
@@ -680,8 +680,8 @@
 
             <div t-if="channel.can_upload" class="text-right pb-2 col-auto">
                 <a class="btn btn-primary py-1 o_wslides_js_slide_upload"
-                    title="Upload Presentation" role="button"
-                    aria-label="Upload Presentation" href="#"
+                    title="Upload Document" role="button"
+                    aria-label="Upload Document" href="#"
                     t-att-data-channel-id="channel.id"
                     t-att-data-can-upload="channel.can_upload"
                     t-att-data-can-publish="channel.can_publish">
@@ -796,7 +796,7 @@
                     </span>
                 </div>
                 <t t-if="channel.is_member and channel_progress[slide.id].get('completed')">
-                    <span class="badge badge-pill badge-success"><i class="fa fa-check"/> Completed</span>
+                    <span class="badge badge-pill badge-success"><i class="fa fa-check"/> Done</span>
                 </t>
             </div>
         </div>
@@ -805,13 +805,16 @@
 
 <template id="slide_icon">
     <t t-set="icon_class" t-value="icon_class if icon_class else 'mr-2 text-muted'"/>
-    <i t-if="slide.slide_category == 'document'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
-    <i t-if="slide.slide_category == 'presentation'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
-    <i t-if="slide.slide_category == 'infographic'" t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
-    <i t-if="slide.slide_category == 'video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
-    <i t-if="slide.slide_category == 'link'" t-att-class="'fa fa-file-code-o %s' % icon_class"></i>
-    <i t-if="slide.slide_category == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
-    <i t-if="slide.slide_category == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'pdf'" t-att-class="'fa fa-file-pdf-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'sheet'" t-att-class="'fa fa-file-excel-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'doc'" t-att-class="'fa fa-file-word-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'slides'" t-att-class="'fa fa-file-powerpoint-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'image'" t-att-class="'fa fa-file-picture-o %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'youtube_video'" t-att-class="'fa fa-youtube-play %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'google_drive_video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>
+    <i t-if="not slide.slide_type" t-att-class="'fa fa-file-o %s' % icon_class"></i>
 </template>
 
 </data></odoo>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -526,7 +526,7 @@
                 <i t-else="" class="check-done text-success fa fa-check-circle px-2"></i>
             </t>
             <span t-if="channel.can_publish" class="d-none d-md-flex">
-                <a t-if="slide.slide_category == 'webpage'" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1"><span class="fa fa-pencil"/></a>
+                <a t-if="slide.slide_category == 'article'" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1"><span class="fa fa-pencil"/></a>
                 <a t-else="" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/web#id=#{slide.id}&amp;action=#{slide_action}&amp;model=slide.slide&amp;view_type=form" title="Edit in backend"><span class="fa fa-pencil"/></a>
                 <a href="#" t-att-data-slide-id="slide.id" class="o_text_link text-danger px-2 o_wslides_js_slide_archive"><span class="fa fa-trash"/></a>
             </span>
@@ -813,7 +813,7 @@
     <i t-if="slide.slide_type == 'youtube_video'" t-att-class="'fa fa-youtube-play %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'google_drive_video'" t-att-class="'fa fa-play-circle %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'vimeo_video'" t-att-class="'fa fa-vimeo %s' % icon_class"></i>
-    <i t-if="slide.slide_type == 'webpage'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
+    <i t-if="slide.slide_type == 'article'" t-att-class="'fa fa-file-text %s' % icon_class"></i>
     <i t-if="slide.slide_type == 'quiz'" t-att-class="'fa fa-question-circle %s' % icon_class"></i>
     <i t-if="not slide.slide_type" t-att-class="'fa fa-file-o %s' % icon_class"></i>
 </template>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -173,7 +173,7 @@
             <section class="s_banner bg-900" style="background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%" data-snippet="s_banner">
                 <div class="container py-5">
                     <h1 t-if="search_my" class="display-3 mb-0">My Courses</h1>
-                    <h1 t-elif="search_slide_type=='certification'" class="display-3 mb-0">Certifications</h1>
+                    <h1 t-elif="search_slide_category=='certification'" class="display-3 mb-0">Certifications</h1>
                     <h1 t-else="" class="display-3 mb-0">All Courses</h1>
                 </div>
             </section>
@@ -184,7 +184,7 @@
                         <a class="nav-link nav-item px-3" href="/slides"><i class="fa fa-chevron-left"/></a>
                     </div>
                     <!-- Clear filtering (mobile)-->
-                    <div class="form-inline text-nowrap ml-auto d-md-none" t-if="search_slide_type or search_my or search_tags">
+                    <div class="form-inline text-nowrap ml-auto d-md-none" t-if="search_slide_category or search_my or search_tags">
                         <a href="/slides/all" class="btn btn-info mr-2" role="button" title="Clear filters">
                             <i class="fa fa-eraser"/> Clear filters
                         </a>
@@ -199,7 +199,7 @@
                         <t t-set="placeholder">Search courses</t>
                         <t t-set="search" t-value="original_search or search_term"/>
                         <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
-                        <input t-if="search_slide_type" type="hidden" name="slide_type" t-att-value="search_slide_type" />
+                        <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
                     </t>
                     <button class="navbar-toggler px-1" type="button"
                         data-toggle="collapse" data-target="#navbarTagGroups"
@@ -221,7 +221,7 @@
                                     <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
                                         <t t-foreach="group_frontend_tags" t-as="tag">
                                             <a rel="nofollow" t-att-class="'dropdown-item post_link %s' % ('active' if tag in search_tags else '')"
-                                                t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_type=search_slide_type)"
+                                                t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)"
                                                 t-esc="tag.name"/>
                                         </t>
                                     </div>
@@ -229,7 +229,7 @@
                             </t>
                         </ul>
                         <!-- Clear filtering (desktop)-->
-                        <div class="form-inline ml-auto d-none d-md-flex" t-if="search_slide_type or search_my or search_tags">
+                        <div class="form-inline ml-auto d-none d-md-flex" t-if="search_slide_category or search_my or search_tags">
                             <a href="/slides/all" class="btn btn-info text-nowrap mr-2" role="button" title="Clear filters">
                                 <i class="fa fa-eraser"/> Clear filters
                             </a>
@@ -244,7 +244,7 @@
                             <t t-set="placeholder">Search courses</t>
                             <t t-set="search" t-value="original_search or search_term"/>
                             <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
-                            <input t-if="search_slide_type" type="hidden" name="slide_type" t-att-value="search_slide_type" />
+                            <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
                         </t>
                     </div>
                 </nav>
@@ -267,19 +267,19 @@
                       <span class="align-items-baseline border d-inline-flex pl-2 rounded mb-2">
                       <i class="fa fa-tag mr-2 text-muted"/>
                       <t t-esc="search_term"/>
-                      <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_type=search_slide_type)" class="btn border-0 py-1 post_link" t-att-rel="search_tags and 'nofollow'">&#215;</a>
+                      <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category)" class="btn border-0 py-1 post_link" t-att-rel="search_tags and 'nofollow'">&#215;</a>
                     </span>
                 </t>
                 <t t-foreach="search_tags" t-as="tag">
                     <span class="align-items-baseline border d-inline-flex pl-2 rounded mb-2">
                         <i class="fa fa-tag mr-2 text-muted"/>
                         <t t-esc="tag.display_name"/>
-                        <a t-att-href='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_type=search_slide_type)' class="btn border-0 py-1 post_link" t-att-rel="search_tags and 'nofollow'">&#215;</a>
+                        <a t-att-href='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category)' class="btn border-0 py-1 post_link" t-att-rel="search_tags and 'nofollow'">&#215;</a>
                     </span>
                 </t>
             </div>
             <div class="container o_wslides_home_main pb-5">
-                <div t-if="not channels and not search_term and not search_slide_type and not search_my and not search_tags">
+                <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
                     <p class="h2">No Course created yet.</p>
                     <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
                 </div>
@@ -333,10 +333,10 @@
                 <div t-if="channel_frontend_tags" class="mt-2 pt-1 o_wslides_desc_truncate_2">
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
-                            <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_type=search_slide_type)" t-attf-class="badge post_link #{'badge-primary' if tag in search_tags else 'o_wslides_channel_tag o_tag_color_0'}" t-att-rel="search_tags and 'nofollow'" t-esc="tag.name"/>
+                            <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)" t-attf-class="badge post_link #{'badge-primary' if tag in search_tags else 'o_wslides_channel_tag o_tag_color_0'}" t-att-rel="search_tags and 'nofollow'" t-esc="tag.name"/>
                         </t>
                         <t t-else="">
-                            <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_type=search_slide_type)" t-attf-class="badge post_link o_wslides_channel_tag #{'o_tag_color_'+str(tag.color)}" t-att-rel="search_tags and 'nofollow'" t-esc="tag.name"/>
+                            <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)" t-attf-class="badge post_link o_wslides_channel_tag #{'o_tag_color_'+str(tag.color)}" t-att-rel="search_tags and 'nofollow'" t-esc="tag.name"/>
                         </t>
                     </t>
                 </div>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -144,17 +144,15 @@
                 <t t-set="can_access" t-value="aside_slide.is_preview or is_member or slide.channel_id.can_publish"/>
                 <li class="p-0 pb-1">
                     <a t-att-href="'/slides/slide/%s' % (slug(aside_slide)) if can_access else '#'"
-                        t-att-class="'o_wslides_lesson_aside_list_link d-flex align-items-top px-2 pt-1 text-decoration-none %s%s' % (('bg-100 py-1 active' if aside_slide == slide else ''), 'text-muted' if not can_access else '')">
-                        <div t-if="is_member" >
-                            <i t-att-id="'o_wslides_lesson_aside_slide_check_%s' % (aside_slide.id)"
-                                t-att-class="'mr-1 fa fa-fw %s' % ('text-success fa-check-circle' if channel_progress[aside_slide.id].get('completed') else 'text-600 fa-circle')">
-                            </i>
-                        </div>
-                        <div class="o_wslides_lesson_link_name">
-                            <t t-call="website_slides.slide_icon">
-                                <t t-set="slide" t-value="aside_slide"/>
-                            </t>
-                            <span t-esc="aside_slide.name" class="mr-2"/>
+                        t-att-class="'o_wslides_lesson_aside_list_link d-flex align-items-center px-2 py-1 text-decoration-none %s%s' % (('bg-100 active' if aside_slide == slide else ''), 'text-muted' if not can_access else '')">
+                        <i t-if="is_member" t-att-id="'o_wslides_lesson_aside_slide_check_%s' % (aside_slide.id)"
+                            t-att-class="'mr-2 fa text-left %s' % ('text-success fa-check-circle' if channel_progress[aside_slide.id].get('completed') else 'text-600 fa-circle')">
+                        </i>
+                        <t t-call="website_slides.slide_icon">
+                            <t t-set="slide" t-value="aside_slide"/>
+                        </t>
+                        <div class="o_wslides_lesson_link_name text-truncate" t-att-title="aside_slide.name">
+                            <span t-esc="aside_slide.name" class="mr-2 text-truncate"/>
                         </div>
                         <div class="ml-auto" t-if="aside_slide.question_ids">
                             <span t-att-class="'badge badge-pill %s' % ('badge-success' if channel_progress[aside_slide.id].get('completed') else 'badge-light text-600')">
@@ -231,7 +229,7 @@
                     t-att-href="'/slides/slide/%s' % (slug(previous_slide)) if previous_slide else '#'">
                     <i class="fa fa-chevron-left mr-2"></i> <span class="d-none d-sm-inline-block">Prev</span>
                 </a>
-                <t t-set="allow_done_btn" t-value="slide.slide_category in ['infographic', 'presentation', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
+                <t t-set="allow_done_btn" t-value="slide.slide_category in ['infographic', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
                 <a t-att-class="'btn btn-primary border text-white %s' % ('disabled' if not allow_done_btn else '')"
                     role="button" t-att-aria-disabled="'true' if not allow_done_btn else None"
                     t-att-href="'/slides/slide/%s/set_completed?%s' % (slide.id, 'next_slide_id=%s' % (next_slide.id) if next_slide else '') if allow_done_btn else '#'">
@@ -257,10 +255,10 @@
     <div class="o_wslides_lesson_content_type">
         <img t-if="slide.slide_category == 'infographic'"
             t-att-src="website.image_url(slide, 'image_1024')" class="img-fluid" style="width:100%" t-att-alt="slide.name"/>
-        <div t-if="slide.slide_category in ('presentation', 'document')" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
+        <div t-if="slide.slide_category == 'document'" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
             <t t-out="slide.embed_code"/>
         </div>
-        <div t-if="slide.slide_category == 'video' and slide.document_id" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
+        <div t-if="slide.slide_category == 'video'" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
             <t t-out="slide.embed_code"/>
         </div>
         <div t-if="slide.slide_category == 'webpage'" class="bg-white p-3">
@@ -557,7 +555,7 @@
                 <t t-esc="slide.embed_code_external"/>
             </textarea>
         </div>
-        <div t-if="slide.slide_category in ('presentation', 'document') and not embed_hide_starting_page" class="form-group d-flex">
+        <div t-if="slide.slide_category == 'document' and not embed_hide_starting_page" class="form-group d-flex">
             <div class="form-text p-0 col-xs-5 col-sm-5 col-md-5 col-lg-5">Select page to start with</div>
             <div class="input-group col-xs-3 col-sm-2 col-md-2 col-lg-3">
                 <input type="number" value="1" class="form-control"/>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -261,8 +261,13 @@
         <div t-if="slide.slide_category == 'video'" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
             <t t-out="slide.embed_code"/>
         </div>
-        <div t-if="slide.slide_category == 'webpage'" class="bg-white p-3">
-            <div t-field="slide.html_content"/>
+        <div t-if="slide.slide_category == 'webpage'">
+            <div t-if="is_html_empty(slide.html_content)" class="alert alert-info">
+                Click on the "Edit" button on the top-right of the screen to edit your slide content.
+            </div>
+            <div class="bg-white p-3">
+                <div t-field="slide.html_content"/>
+            </div>
         </div>
     </div>
 

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -187,10 +187,10 @@
                             </li>
                         </div>
                         <li class="pl-4">
-                            <a t-if="can_access and aside_slide.question_ids and aside_slide.slide_type != 'quiz'" t-att-href="'/slides/slide/%s#lessonQuiz' % (slug(aside_slide))" class="o_wslides_lesson_aside_list_link text-decoration-none small text-600">
+                            <a t-if="can_access and aside_slide.question_ids and aside_slide.slide_category != 'quiz'" t-att-href="'/slides/slide/%s#lessonQuiz' % (slug(aside_slide))" class="o_wslides_lesson_aside_list_link text-decoration-none small text-600">
                                 <i class="fa fa-flag text-warning"/> Quiz
                             </a>
-                            <span t-elif="not can_access and aside_slide.question_ids and aside_slide.slide_type != 'quiz'"
+                            <span t-elif="not can_access and aside_slide.question_ids and aside_slide.slide_category != 'quiz'"
                                 class="o_wslides_lesson_aside_list_link text-decoration-none small text-600 text-muted">
                                 <i class="fa fa-flag text-warning"/> Quiz
                             </span>
@@ -231,7 +231,7 @@
                     t-att-href="'/slides/slide/%s' % (slug(previous_slide)) if previous_slide else '#'">
                     <i class="fa fa-chevron-left mr-2"></i> <span class="d-none d-sm-inline-block">Prev</span>
                 </a>
-                <t t-set="allow_done_btn" t-value="slide.slide_type in ['infographic', 'presentation', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
+                <t t-set="allow_done_btn" t-value="slide.slide_category in ['infographic', 'presentation', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
                 <a t-att-class="'btn btn-primary border text-white %s' % ('disabled' if not allow_done_btn else '')"
                     role="button" t-att-aria-disabled="'true' if not allow_done_btn else None"
                     t-att-href="'/slides/slide/%s/set_completed?%s' % (slide.id, 'next_slide_id=%s' % (next_slide.id) if next_slide else '') if allow_done_btn else '#'">
@@ -255,15 +255,15 @@
         </t>
     </div>
     <div class="o_wslides_lesson_content_type">
-        <img t-if="slide.slide_type == 'infographic'"
+        <img t-if="slide.slide_category == 'infographic'"
             t-att-src="website.image_url(slide, 'image_1024')" class="img-fluid" style="width:100%" t-att-alt="slide.name"/>
-        <div t-if="slide.slide_type in ('presentation', 'document')" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
+        <div t-if="slide.slide_category in ('presentation', 'document')" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
             <t t-out="slide.embed_code"/>
         </div>
-        <div t-if="slide.slide_type == 'video' and slide.document_id" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
+        <div t-if="slide.slide_category == 'video' and slide.document_id" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
             <t t-out="slide.embed_code"/>
         </div>
-        <div t-if="slide.slide_type == 'webpage'" class="bg-white p-3">
+        <div t-if="slide.slide_category == 'webpage'" class="bg-white p-3">
             <div t-field="slide.html_content"/>
         </div>
     </div>
@@ -400,7 +400,7 @@
         </div>
     </div>
     <div class="o_wslides_js_quiz_container" t-att-data-slide-id="slide.id">
-        <div class="row" t-if="slide.slide_type != 'certification'">
+        <div class="row" t-if="slide.slide_category != 'certification'">
             <t t-if="slide.question_ids">
                 <t t-call="website_slides.lesson_content_quiz"/>
             </t>
@@ -444,7 +444,7 @@
     <div class="o_wslides_js_lesson_quiz col" id="lessonQuiz"
         t-att-data-id="slide.id"
         t-att-data-name="slide.name"
-        t-att-data-slide-type="slide.slide_type"
+        t-att-data-slide-category="slide.slide_category"
         t-att-data-is-member="slide.channel_id.is_member"
         t-att-data-completed="1 if slide_completed else 0"
         t-att-data-quiz-attempts-count="quiz_attempts_count"
@@ -543,7 +543,7 @@
         </form>
     </div>
     <div t-if="is_public_user" class="alert alert-info d-inline-block">
-        <p class="mb-0">Please <a t-attf-href="/web?redirect=#{request.httprequest.url}" class="font-weight-bold"> login </a> to share this <t t-esc="slide.slide_type"/> by email.</p>
+        <p class="mb-0">Please <a t-attf-href="/web?redirect=#{request.httprequest.url}" class="font-weight-bold"> login </a> to share this <t t-esc="slide.slide_category"/> by email.</p>
     </div>
 </template>
 
@@ -557,7 +557,7 @@
                 <t t-esc="slide.embed_code_external"/>
             </textarea>
         </div>
-        <div t-if="slide.slide_type in ('presentation', 'document') and not embed_hide_starting_page" class="form-group d-flex">
+        <div t-if="slide.slide_category in ('presentation', 'document') and not embed_hide_starting_page" class="form-group d-flex">
             <div class="form-text p-0 col-xs-5 col-sm-5 col-md-5 col-lg-5">Select page to start with</div>
             <div class="input-group col-xs-3 col-sm-2 col-md-2 col-lg-3">
                 <input type="number" value="1" class="form-control"/>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -229,7 +229,7 @@
                     t-att-href="'/slides/slide/%s' % (slug(previous_slide)) if previous_slide else '#'">
                     <i class="fa fa-chevron-left mr-2"></i> <span class="d-none d-sm-inline-block">Prev</span>
                 </a>
-                <t t-set="allow_done_btn" t-value="slide.slide_category in ['infographic', 'document', 'webpage', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
+                <t t-set="allow_done_btn" t-value="slide.slide_category in ['infographic', 'document', 'article', 'video'] and not slide.question_ids and not channel_progress[slide.id].get('completed') and slide.channel_id.is_member"/>
                 <a t-att-class="'btn btn-primary border text-white %s' % ('disabled' if not allow_done_btn else '')"
                     role="button" t-att-aria-disabled="'true' if not allow_done_btn else None"
                     t-att-href="'/slides/slide/%s/set_completed?%s' % (slide.id, 'next_slide_id=%s' % (next_slide.id) if next_slide else '') if allow_done_btn else '#'">
@@ -261,7 +261,7 @@
         <div t-if="slide.slide_category == 'video'" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
             <t t-out="slide.embed_code"/>
         </div>
-        <div t-if="slide.slide_category == 'webpage'">
+        <div t-if="slide.slide_category == 'article'">
             <div t-if="is_html_empty(slide.html_content)" class="alert alert-info">
                 Click on the "Edit" button on the top-right of the screen to edit your slide content.
             </div>

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -71,7 +71,7 @@
                                     </t>
                                 </div>
                             </div>
-                            <t t-if="slide.slide_type in ('presentation', 'document')">
+                            <t t-if="slide.slide_category in ('presentation', 'document')">
                                 <div id="PDFViewerLoader" class="oe_slides_loader mt-3 mx-2 w-100">
                                     <div class="toast show mx-auto">
                                         <div class="toast-header">
@@ -84,12 +84,12 @@
                                 </div>
                                 <canvas id="PDFViewerCanvas" class="mx-auto" style="display: none;"></canvas>
                             </t>
-                            <t t-if="slide.slide_type == 'infographic'">
+                            <t t-if="slide.slide_category == 'infographic'">
                                 <img t-att-src="website.image_url(slide, 'image_1024')" class="img-fluid" style="width: 100%" alt="Slide image"/>
                             </t>
                         </div>
                         <!-- Fixed bottom navbar -->
-                        <div id="PDFViewerNav" class="pt-2 pb-2 bg-light text-white" role="navigation" t-if="slide.slide_type in ('presentation', 'document')">
+                        <div id="PDFViewerNav" class="pt-2 pb-2 bg-light text-white" role="navigation" t-if="slide.slide_category in ('presentation', 'document')">
                             <div class="container-fluid oe_slides_panel_footer">
                                 <div class="row align-items-center">
                                     <div class="col-3 d-flex align-items-center">
@@ -111,7 +111,7 @@
                                         <span id="previous" class="mx-1 mx-sm-2" title="Previous slide" aria-label="Previous slide" role="button"><i class="fa fa-arrow-circle-left"/></span>
                                         <span id="next" class="mx-1 mx-sm-2" title="Next slide" aria-label="Next slide" role="button"><i class="fa fa-arrow-circle-right"/></span>
                                         <span id="last" class="mx-1 mx-sm-2" title="Last slide" aria-label="Last slide" role="button"><i class="fa fa-step-forward"/></span>
-                                        <a t-if="slide.slide_resource_downloadable" id="download" t-attf-href="/web/content/slide.slide/#{slide.id}/datas?download=true"
+                                        <a t-if="slide.slide_resource_downloadable" id="download" t-attf-href="/web/content/slide.slide/#{slide.id}/binary_content?download=true"
                                            class="ml-1 ml-sm-2" title="Download Content" aria-label="Download" role="button">
                                             <i class="fa fa-download" />
                                         </a>

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -71,7 +71,7 @@
                                     </t>
                                 </div>
                             </div>
-                            <t t-if="slide.slide_category in ('presentation', 'document')">
+                            <t t-if="slide.slide_category == 'document'">
                                 <div id="PDFViewerLoader" class="oe_slides_loader mt-3 mx-2 w-100">
                                     <div class="toast show mx-auto">
                                         <div class="toast-header">
@@ -89,7 +89,7 @@
                             </t>
                         </div>
                         <!-- Fixed bottom navbar -->
-                        <div id="PDFViewerNav" class="pt-2 pb-2 bg-light text-white" role="navigation" t-if="slide.slide_category in ('presentation', 'document')">
+                        <div id="PDFViewerNav" class="pt-2 pb-2 bg-light text-white" role="navigation" t-if="slide.slide_category == 'document'">
                             <div class="container-fluid oe_slides_panel_footer">
                                 <div class="row align-items-center">
                                     <div class="col-3 d-flex align-items-center">

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -109,12 +109,12 @@
                     t-att-data-id="slide.id"
                     t-att-data-can-access="can_access"
                     t-att-data-name="slide.name"
-                    t-att-data-type="slide.slide_type"
+                    t-att-data-category="slide.slide_category"
                     t-att-data-slug="slug(slide)"
                     t-att-data-has-question="1 if slide.question_ids else 0"
                     t-att-data-is-quiz="0"
                     t-att-data-completed="1 if slide_completed else 0"
-                    t-att-data-embed-code="slide.embed_code if slide.slide_type in ['video', 'document', 'presentation', 'infographic'] else False"
+                    t-att-data-embed-code="slide.embed_code if slide.slide_category in ['video', 'document', 'presentation', 'infographic'] else False"
                     t-att-data-is-member="is_member"
                     t-att-data-session-answers="session_answers">
                     <span class="ml-3">
@@ -135,7 +135,7 @@
                                 <div class="o_wslides_fs_slide_name text-600" t-esc="slide.name"/>
                             </div>
                         </span>
-                        <ul class="list-unstyled w-100 pt-2 small" t-if="slide.slide_resource_ids or (slide.question_ids and not slide.slide_type =='quiz')" >
+                        <ul class="list-unstyled w-100 pt-2 small" t-if="slide.slide_resource_ids or (slide.question_ids and not slide.slide_category =='quiz')" >
                             <t t-set="links" t-value="slide.slide_resource_ids.filtered(lambda res: res.resource_type == 'url')"/>
                             <li t-if="links" t-foreach="links" t-as="link" class="pl-0 mb-1">
                                 <a t-if="can_access" class="o_wslides_fs_slide_link" t-att-href="link.link" target="_blank">
@@ -159,11 +159,11 @@
                                     <t t-call="website_slides.join_course_link"/>
                                 </li>
                             </div>
-                            <li class="o_wslides_fs_sidebar_list_item pl-0 mb-1" t-if="slide.question_ids and not slide.slide_type == 'quiz'"
+                            <li class="o_wslides_fs_sidebar_list_item pl-0 mb-1" t-if="slide.question_ids and not slide.slide_category == 'quiz'"
                                 t-att-data-id="slide.id"
                                 t-att-data-can-access="can_access"
                                 t-att-data-name="slide.name"
-                                t-att-data-type="slide.slide_type"
+                                t-att-data-category="slide.slide_category"
                                 t-att-data-slug="slug(slide)"
                                 t-att-data-has-question="1 if slide.question_ids else 0"
                                 t-att-data-is-quiz="1"

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -110,11 +110,12 @@
                     t-att-data-can-access="can_access"
                     t-att-data-name="slide.name"
                     t-att-data-category="slide.slide_category"
+                    t-att-data-video-source-type="slide.video_source_type"
                     t-att-data-slug="slug(slide)"
                     t-att-data-has-question="1 if slide.question_ids else 0"
                     t-att-data-is-quiz="0"
                     t-att-data-completed="1 if slide_completed else 0"
-                    t-att-data-embed-code="slide.embed_code if slide.slide_category in ['video', 'document', 'presentation', 'infographic'] else False"
+                    t-att-data-embed-code="slide.embed_code if slide.slide_category in ['video', 'document', 'infographic'] else False"
                     t-att-data-is-member="is_member"
                     t-att-data-session-answers="session_answers">
                     <span class="ml-3">
@@ -124,6 +125,7 @@
                     <div class="ml-2">
                         <a t-if="can_access" class="d-block pt-1" href="#">
                             <div class="d-flex ">
+                                <t t-set="icon_class" t-value="'mr-2'"/>
                                 <t t-call="website_slides.slide_icon"/>
                                 <div class="o_wslides_fs_slide_name" t-esc="slide.name"/>
                             </div>
@@ -162,6 +164,7 @@
                             <li class="o_wslides_fs_sidebar_list_item pl-0 mb-1" t-if="slide.question_ids and not slide.slide_category == 'quiz'"
                                 t-att-data-id="slide.id"
                                 t-att-data-can-access="can_access"
+                                t-att-data-video-source-type="slide.video_source_type"
                                 t-att-data-name="slide.name"
                                 t-att-data-category="slide.slide_category"
                                 t-att-data-slug="slug(slide)"

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -123,14 +123,14 @@
                         <i t-if="not slide_completed and is_member" class="fa fa-circle-thin fa-fw" t-att-data-slide-id="slide.id"/>
                     </span>
                     <div class="ml-2">
-                        <a t-if="can_access" class="d-block pt-1" href="#">
+                        <a t-if="can_access" class="d-block" href="#">
                             <div class="d-flex ">
                                 <t t-set="icon_class" t-value="'mr-2'"/>
                                 <t t-call="website_slides.slide_icon"/>
                                 <div class="o_wslides_fs_slide_name" t-esc="slide.name"/>
                             </div>
                         </a>
-                        <span t-else="" class="d-block pt-1" href="#">
+                        <span t-else="" class="d-block" href="#">
                             <div class="d-flex ">
                                 <t t-set="icon_class" t-value="'mr-2 text-600'"/>
                                 <t t-call="website_slides.slide_icon"/>

--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -43,7 +43,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
 
     @http.route(['/slides/add_slide'], type='json', auth='user', methods=['POST'], website=True)
     def create_slide(self, *args, **post):
-        create_new_survey = post['slide_type'] == "certification" and post.get('survey') and not post['survey']['id']
+        create_new_survey = post['slide_category'] == "certification" and post.get('survey') and not post['survey']['id']
         linked_survey_id = int(post.get('survey', {}).get('id') or 0)
 
         if create_new_survey:
@@ -87,7 +87,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
     # Utils
     # ---------------------------------------------------
     def _set_completed_slide(self, slide):
-        if slide.slide_type == 'certification':
+        if slide.slide_category == 'certification':
             raise werkzeug.exceptions.Forbidden(_("Certification slides are completed when the survey is succeeded."))
         return super(WebsiteSlidesSurvey, self)._set_completed_slide(slide)
 

--- a/addons/website_slides_survey/data/gamification_data.xml
+++ b/addons/website_slides_survey/data/gamification_data.xml
@@ -6,7 +6,7 @@
     <record id="website_slides.badge_data_certification_goal" model="gamification.goal.definition">
         <field name="domain">[
             ('survey_scoring_success', '=', True),
-            ('slide_id.slide_type', '=', 'certification')
+            ('slide_id.slide_category', '=', 'certification')
         ]</field>
     </record>
 </data></odoo>

--- a/addons/website_slides_survey/data/slide_slide_demo.xml
+++ b/addons/website_slides_survey/data/slide_slide_demo.xml
@@ -7,7 +7,7 @@
         <field name="name">Furniture Creation Certification</field>
         <field name="sequence">7</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_furniture.jpg"/>
-        <field name="slide_type">certification</field>
+        <field name="slide_category">certification</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_5_furn2"/>
         <field name="category_id" ref="website_slides.slide_category_demo_5_0"/>
         <field name="survey_id" ref="website_slides_survey.furniture_certification"/>
@@ -23,7 +23,7 @@
         <field name="name">DIY Furniture Certification</field>
         <field name="sequence">1</field>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/slide_demo_furniture.jpg"/>
-        <field name="slide_type">certification</field>
+        <field name="slide_category">certification</field>
         <field name="channel_id" ref="website_slides.slide_channel_demo_6_furn3"/>
         <field name="category_id" eval="False"/>
         <field name="survey_id" ref="website_slides_survey.furniture_certification"/>

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -33,6 +33,9 @@ class Slide(models.Model):
     slide_category = fields.Selection(selection_add=[
         ('certification', 'Certification')
     ], ondelete={'certification': 'set default'})
+    slide_type = fields.Selection(selection_add=[
+        ('certification', 'Certification')
+    ], ondelete={'certification': 'set null'})
     survey_id = fields.Many2one('survey.survey', 'Certification')
     nbr_certification = fields.Integer("Number of Certifications", compute='_compute_slides_statistics', store=True)
 
@@ -45,6 +48,13 @@ class Slide(models.Model):
     def _on_change_survey_id(self):
         if self.survey_id:
             self.slide_category = 'certification'
+
+    @api.depends('slide_category', 'source_type')
+    def _compute_slide_type(self):
+        super(Slide, self)._compute_slide_type()
+        for slide in self:
+            if slide.slide_category == 'certification':
+                slide.slide_type = 'certification'
 
     @api.model
     def create(self, values):

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -30,27 +30,27 @@ class SlidePartnerRelation(models.Model):
 class Slide(models.Model):
     _inherit = 'slide.slide'
 
-    slide_type = fields.Selection(selection_add=[
+    slide_category = fields.Selection(selection_add=[
         ('certification', 'Certification')
     ], ondelete={'certification': 'set default'})
     survey_id = fields.Many2one('survey.survey', 'Certification')
     nbr_certification = fields.Integer("Number of Certifications", compute='_compute_slides_statistics', store=True)
 
     _sql_constraints = [
-        ('check_survey_id', "CHECK(slide_type != 'certification' OR survey_id IS NOT NULL)", "A slide of type 'certification' requires a certification."),
-        ('check_certification_preview', "CHECK(slide_type != 'certification' OR is_preview = False)", "A slide of type certification cannot be previewed."),
+        ('check_survey_id', "CHECK(slide_category != 'certification' OR survey_id IS NOT NULL)", "A slide of type 'certification' requires a certification."),
+        ('check_certification_preview', "CHECK(slide_category != 'certification' OR is_preview = False)", "A slide of type certification cannot be previewed."),
     ]
 
     @api.onchange('survey_id')
     def _on_change_survey_id(self):
         if self.survey_id:
-            self.slide_type = 'certification'
+            self.slide_category = 'certification'
 
     @api.model
     def create(self, values):
         rec = super(Slide, self).create(values)
         if rec.survey_id:
-            rec.slide_type = 'certification'
+            rec.slide_category = 'certification'
         if 'survey_id' in values:
             rec._ensure_challenge_category()
         return rec
@@ -90,7 +90,7 @@ class Slide(models.Model):
             course can be enrolled multiple times.
         """
         certification_urls = {}
-        for slide in self.filtered(lambda slide: slide.slide_type == 'certification' and slide.survey_id):
+        for slide in self.filtered(lambda slide: slide.slide_category == 'certification' and slide.survey_id):
             if slide.channel_id.is_member:
                 user_membership_id_sudo = slide.user_membership_id.sudo()
                 if user_membership_id_sudo.user_input_ids:

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -38,11 +38,19 @@ class Slide(models.Model):
     ], ondelete={'certification': 'set null'})
     survey_id = fields.Many2one('survey.survey', 'Certification')
     nbr_certification = fields.Integer("Number of Certifications", compute='_compute_slides_statistics', store=True)
+    # small override of 'is_preview' to uncheck it automatically for slides of type 'certification'
+    is_preview = fields.Boolean(compute='_compute_is_preview', readonly=False, store=True)
 
     _sql_constraints = [
         ('check_survey_id', "CHECK(slide_category != 'certification' OR survey_id IS NOT NULL)", "A slide of type 'certification' requires a certification."),
         ('check_certification_preview', "CHECK(slide_category != 'certification' OR is_preview = False)", "A slide of type certification cannot be previewed."),
     ]
+
+    @api.depends('slide_category')
+    def _compute_is_preview(self):
+        for slide in self:
+            if slide.slide_category == 'certification' or not slide.is_preview:
+                slide.is_preview = False
 
     @api.onchange('survey_id')
     def _on_change_survey_id(self):

--- a/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
@@ -11,7 +11,7 @@ Fullscreen.include({
     ),
 
     /**
-     * Extend the _renderSlide method so that slides of type "certification"
+     * Extend the _renderSlide method so that slides of category "certification"
      * are also taken into account and rendered correctly
      *
      * @private
@@ -20,7 +20,7 @@ Fullscreen.include({
     _renderSlide: function (){
         var def = this._super.apply(this, arguments);
         var $content = this.$('.o_wslides_fs_content');
-        if (this.get('slide').type === "certification"){
+        if (this.get('slide').category === "certification"){
             $content.html(QWeb.render('website.slides.fullscreen.certification',{widget: this}));
         }
         return Promise.all([def]);

--- a/addons/website_slides_survey/static/src/js/slides_upload.js
+++ b/addons/website_slides_survey/static/src/js/slides_upload.js
@@ -7,7 +7,7 @@ var sessionStorage = window.sessionStorage;
 var SlidesUpload = require('@website_slides/js/slides_upload')[Symbol.for("default")];
 
 /**
- * Management of the new 'certification' slide_type
+ * Management of the new 'certification' slide_category
  */
 SlidesUpload.SlideUploadDialog.include({
     events: _.extend({}, SlidesUpload.SlideUploadDialog.prototype.events || {}, {
@@ -32,14 +32,14 @@ SlidesUpload.SlideUploadDialog.include({
     //--------------------------------------------------------------------------
 
     /**
-     * Overridden to add the "certification" slide type
+     * Overridden to add the "certification" slide category
      *
      * @override
      * @private
      */
     _setup: function () {
         this._super.apply(this, arguments);
-        this.slide_type_data['certification'] = {
+        this.slide_category_data['certification'] = {
             icon: 'fa-trophy',
             label: _t('Certification'),
             template: 'website.slide.upload.modal.certification',

--- a/addons/website_slides_survey/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides_survey/static/src/xml/website_slides_fullscreen.xml
@@ -3,14 +3,14 @@
 
     <t t-name="website.slides.fullscreen.certification">
         <div class="justify-content-center align-self-center">
-            <div t-if="widget.get('slide').type === 'certification' &amp;&amp; !widget.get('slide').completed" class="">
+            <div t-if="widget.get('slide').category === 'certification' &amp;&amp; !widget.get('slide').completed" class="">
                 <a class="btn btn-primary" t-att-href="'/slides_survey/slide/get_certification_url?slide_id=' + widget.get('slide').id" target="_blank">
                     <i class="fa fa-trophy"/>
                     <span t-if="widget.get('slide').isMember"> Pass Certification</span>
                     <span t-else="">Test Certification</span>
                 </a>
             </div>
-            <div class="" t-if="widget.get('slide').type === 'certification' &amp;&amp; widget.get('slide').completed">
+            <div class="" t-if="widget.get('slide').category === 'certification' &amp;&amp; widget.get('slide').completed">
                 <a role="button" class="btn btn-primary" t-att-href="'/survey/' + widget.get('slide').certificationId + '/get_certification'">
                     <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/> Download certification
                 </a>
@@ -20,7 +20,7 @@
 
     <t t-extend="website.slides.fullscreen.title">
         <t t-jquery=".o_wslides_fs_slide_title_span" t-operation="before">
-            <i t-if="widget.get('slide').type === 'certification'" class="fa fa-trophy mr-2 text"></i>
+            <i t-if="widget.get('slide').category === 'certification'" class="fa fa-trophy mr-2 text"></i>
         </t>
     </t>
 </templates>

--- a/addons/website_slides_survey/tests/test_course_certification_failure.py
+++ b/addons/website_slides_survey/tests/test_course_certification_failure.py
@@ -47,11 +47,11 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
             'is_published': True,
         })
 
-        # Step 2: link the certification to a slide of type 'certification'
+        # Step 2: link the certification to a slide of category 'certification'
         self.slide_certification = self.env['slide.slide'].sudo().create({
             'name': 'Certification slide',
             'channel_id': self.channel.id,
-            'slide_type': 'certification',
+            'slide_category': 'certification',
             'survey_id': certification.id,
             'is_published': True,
         })

--- a/addons/website_slides_survey/views/slide_channel_views.xml
+++ b/addons/website_slides_survey/views/slide_channel_views.xml
@@ -10,11 +10,11 @@
                 <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '>', 0)]}">Finished</span>
                 <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '=', 0)]}">Certified</span>
             </xpath>
-            <xpath expr="//field[@name='slide_type']" position="after">
+            <xpath expr="//field[@name='slide_category']" position="after">
                 <field name="survey_id"/>
             </xpath>
             <xpath expr="//create[@name='add_slide_lesson']" position="after">
-                <create name="add_slide_certificate" string="Add Certification" groups="survey.group_survey_user" context="{'default_slide_type': 'certification'}"/>
+                <create name="add_slide_certificate" string="Add Certification" groups="survey.group_survey_user" context="{'default_slide_category': 'certification'}"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_slides_survey/views/slide_slide_views.xml
+++ b/addons/website_slides_survey/views/slide_slide_views.xml
@@ -10,6 +10,9 @@
                     attrs="{'invisible': [('slide_category', '!=', 'certification')], 'required': [('slide_category', '=', 'certification')]}"
                     domain="[('certification', '=', True)]" context="{'default_certification': True, 'default_scoring_type': 'scoring_without_answers'}"/>
             </xpath>
+            <xpath expr="//field[@name='is_preview']" position="attributes">
+                <attribute name="attrs">{'invisible': [('slide_category', '=', 'certification')]}</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/addons/website_slides_survey/views/slide_slide_views.xml
+++ b/addons/website_slides_survey/views/slide_slide_views.xml
@@ -5,9 +5,9 @@
         <field name="model">slide.slide</field>
         <field name="inherit_id" ref="website_slides.view_slide_slide_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='slide_type']" position="after">
+            <xpath expr="//field[@name='slide_category']" position="after">
                 <field name="survey_id"
-                    attrs="{'invisible': [('slide_type', '!=', 'certification')], 'required': [('slide_type', '=', 'certification')]}"
+                    attrs="{'invisible': [('slide_category', '!=', 'certification')], 'required': [('slide_category', '=', 'certification')]}"
                     domain="[('certification', '=', True)]" context="{'default_certification': True, 'default_scoring_type': 'scoring_without_answers'}"/>
             </xpath>
         </field>
@@ -17,8 +17,8 @@
         <field name="name">Certifications</field>
         <field name="res_model">slide.slide</field>
         <field name="view_mode">tree,form,graph</field>
-        <field name="domain">[('slide_type', '=', 'certification')]</field>
-        <field name="context">{'default_slide_type': 'certification'}</field>
+        <field name="domain">[('slide_category', '=', 'certification')]</field>
+        <field name="context">{'default_slide_category': 'certification'}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Add a new certification

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -45,7 +45,7 @@
             <div class="text-muted d-inline-block">No certifications yet!</div>
         </t>
         <div class="text-right d-inline-block pull-right">
-            <a href="/slides/all?slide_type=certification" class="btn btn-link btn-sm"><i class="fa fa-arrow-right mr-1"/>All Certifications</a>
+            <a href="/slides/all?slide_category=certification" class="btn btn-link btn-sm"><i class="fa fa-arrow-right mr-1"/>All Certifications</a>
         </div>
     </template>
 

--- a/addons/website_slides_survey/views/website_slides_templates_course.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_course.xml
@@ -31,7 +31,7 @@
             <xpath expr="//a[@name='o_wslides_list_slide_add_quizz']" position="attributes">
                 <attribute name="t-if">channel.can_upload and not slide.question_ids and slide.slide_category != 'certification'</attribute>
             </xpath>
-            <xpath expr="//a[@t-if='channel.can_upload']" position="attributes">
+            <xpath expr="//a[@name='o_wslides_slide_toggle_is_preview']" position="attributes">
                 <attribute name="t-attf-class">#{'d-none' if slide.slide_type == 'certification' else ''}</attribute>
             </xpath>
         </template>

--- a/addons/website_slides_survey/views/website_slides_templates_course.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_course.xml
@@ -11,7 +11,7 @@
                 <div t-if="channel.nbr_certification > 0 and channel.is_member and channel.completion == 0" class="alert alert-success d-flex align-items-center justify-content-between flex-wrap">
                     <div>Begin your <b>certification</b> today!</div>
 
-                    <a t-attf-href="#{'/slides_survey/slide/get_certification_url?slide_id=%s' %(first_slide.id) if first_slide.slide_type == 'certification' and channel.total_slides == 1 else '/slides/slide/%s?fullscreen=1' %(slug(first_slide))}" class="btn btn-success mt-2 mt-sm-0">
+                    <a t-attf-href="#{'/slides_survey/slide/get_certification_url?slide_id=%s' %(first_slide.id) if first_slide.slide_category == 'certification' and channel.total_slides == 1 else '/slides/slide/%s?fullscreen=1' %(slug(first_slide))}" class="btn btn-success mt-2 mt-sm-0">
                         <span>Start Now</span><i class="fa fa-chevron-right ml-2 align-middle"/>
                     </a>
                 </div>
@@ -20,16 +20,16 @@
 
         <template id="slide_icon_inherit_survey" inherit_id="website_slides.slide_icon">
             <xpath expr="//i[last()]" position="after">
-                <i t-if="slide.slide_type == 'certification'" t-att-class="'fa fa-trophy %s' % icon_class"></i>
+                <i t-if="slide.slide_category == 'certification'" t-att-class="'fa fa-trophy %s' % icon_class"></i>
             </xpath>
         </template>
 
         <template id="course_slides_list_slide_inherit_survey" inherit_id="website_slides.course_slides_list_slide">
             <xpath expr="//a[hasclass('o_wslides_js_slides_list_slide_link')]" position="attributes">
-                <attribute name="t-attf-href">#{'/slides_survey/slide/get_certification_url?slide_id=%s' %(slide.id) if slide.slide_type == 'certification' and slide.channel_id.total_slides == 1 else '/slides/slide/%s' %(slug(slide))}</attribute>
+                <attribute name="t-attf-href">#{'/slides_survey/slide/get_certification_url?slide_id=%s' %(slide.id) if slide.slide_category == 'certification' and slide.channel_id.total_slides == 1 else '/slides/slide/%s' %(slug(slide))}</attribute>
             </xpath>
             <xpath expr="//a[@name='o_wslides_list_slide_add_quizz']" position="attributes">
-                <attribute name="t-if">channel.can_upload and not slide.question_ids and slide.slide_type != 'certification'</attribute>
+                <attribute name="t-if">channel.can_upload and not slide.question_ids and slide.slide_category != 'certification'</attribute>
             </xpath>
             <xpath expr="//a[@t-if='channel.can_upload']" position="attributes">
                 <attribute name="t-attf-class">#{'d-none' if slide.slide_type == 'certification' else ''}</attribute>

--- a/addons/website_slides_survey/views/website_slides_templates_course.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_course.xml
@@ -20,7 +20,7 @@
 
         <template id="slide_icon_inherit_survey" inherit_id="website_slides.slide_icon">
             <xpath expr="//i[last()]" position="after">
-                <i t-if="slide.slide_category == 'certification'" t-att-class="'fa fa-trophy %s' % icon_class"></i>
+                <i t-if="slide.slide_type == 'certification'" t-att-class="'fa fa-trophy %s' % icon_class"></i>
             </xpath>
         </template>
 

--- a/addons/website_slides_survey/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_homepage.xml
@@ -3,7 +3,7 @@
     <data>
         <template id="courses_home_inherit_survey" inherit_id="website_slides.courses_home">
             <xpath expr="//a[hasclass('o_wslides_home_all_slides')]" position="after">
-                <a class="nav-link nav-link d-flex" href="/slides/all?slide_type=certification">
+                <a class="nav-link nav-link d-flex" href="/slides/all?slide_category=certification">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                     <span class="ml-1">Certifications</span>
                 </a>

--- a/addons/website_slides_survey/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_lesson.xml
@@ -3,7 +3,7 @@
     <data>
         <template id="slide_content_detailed" inherit_id="website_slides.slide_content_detailed">
             <xpath expr="//div[hasclass('o_wslides_lesson_content_type')]" position="inside">
-                <div t-if="slide.slide_type == 'certification' and not channel_progress[slide.id].get('completed')" class="col mt32 mb8 d-flex justify-content-center">
+                <div t-if="slide.slide_category == 'certification' and not channel_progress[slide.id].get('completed')" class="col mt32 mb8 d-flex justify-content-center">
                     <a role="button"
                         class="btn btn-primary btn-lg"
                         t-att-href="'/slides_survey/slide/get_certification_url?slide_id=%s' %(slide.id)">
@@ -12,7 +12,7 @@
                         <t t-else="">Test Certification</t>
                     </a>
                 </div>
-                <div t-if="slide.slide_type == 'certification' and channel_progress[slide.id].get('completed')" class="col mt32 mb8 d-flex justify-content-center">
+                <div t-if="slide.slide_category == 'certification' and channel_progress[slide.id].get('completed')" class="col mt32 mb8 d-flex justify-content-center">
                     <a role="button" class="btn btn-primary btn-lg" t-att-href="'/survey/%s/get_certification' % slide.survey_id.id">
                         <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/> Download certification
                     </a>


### PR DESCRIPTION
This merge commit has five sub-sections:

1. Rename 'slide_type' and 'datas' fields

To 'slide_category' and 'binary_content', in order to ease the following
changes.

See underlying commits for detailed information about those points.

2. Completely refactor the way we handle external content in the course slides.

This includes both technical (new fields, ...) and functional (forms) changes.
With these changes, we aim to make it much clearer for the end user on how to
introduce new content to its course, both for local files and external links.

3. Introduce support for Vimeo

Vimeo is a platform for professionals that manage video content, similarly to
YouTube.
The changes include allowing to introduce Vimeo links in your slides, correctly
embed the video, automatically set it as completed in the last 30 seconds,
fetch video metadata to autocomplete fields when URL is input, ...

4. Slightly improve e-learning views

See underlying commits for detailed information about those points.

5. Rename 'webpage' to 'article'

Indeed, 'webpage' was confusing because it was leading you to believe that you
would have to link external content from another website.

See underlying commits for detailed information about those points.

LINKS

Task-2510174
UPG PR odoo/upgrade#2498