### PR TITLE
[FIX] project: ensure only stage_id field is used in ir_model_fields

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -68,6 +68,7 @@ class ReportProjectTaskBurndownChart(models.Model):
             INNER JOIN ir_model_fields imf
                     ON mtv.field = imf.id
                    AND imf.model = 'project.task'
+                   AND imf.name = 'stage_id'
             INNER JOIN project_task_type current_stage
                     ON mtv.old_value_integer = current_stage.id
             INNER JOIN project_task_type next_stage


### PR DESCRIPTION
Before this commit, the ir_model_fields used in the query could be
another field than the one expected, that is the stage_id field.
Indeed, since we don't check if the name column in the ir_model_fields
is right the stage_id field then we could have the user_id or another
many2one field.

This commit adds a check to be sure we only use the stage_id.

Related PR: #68343

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
