### PR TITLE
[FIX] crm: fix UserError message while merging leads

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1390,7 +1390,7 @@ class Lead(models.Model):
             raise UserError(_('Please select more than one element (lead or opportunity) from the list view.'))
 
         if max_length and len(self.ids) > max_length and not self.env.is_superuser():
-            raise UserError(_("To prevent data loss, Leads and Opportunities can only be merged by groups of %(max_length)s."))
+            raise UserError(_("To prevent data loss, Leads and Opportunities can only be merged by groups of %(max_length)s.", max_length=max_length))
 
         opportunities = self._sort_by_confidence_level(reverse=True)
 

--- a/addons/crm/wizard/crm_merge_opportunities_views.xml
+++ b/addons/crm/wizard/crm_merge_opportunities_views.xml
@@ -17,8 +17,8 @@
                                 <field name="name"/>
                                 <field name="type"/>
                                 <field name="contact_name"/>
-                                <field name="email_from"/>
-                                <field name="phone" class="o_force_ltr"/>
+                                <field name="email_from" optional="hide"/>
+                                <field name="phone" class="o_force_ltr" optional="hide"/>
                                 <field name="stage_id"/>
                                 <field name="user_id"/>
                                 <field name="team_id"/>


### PR DESCRIPTION
PURPOSE

Fix UserError message and hide 'email_from' and 'phone' fields in merge wizard

SPECIFICATION

Current:
Currently, in usererror  message max_number is not able to display number rather it is visible as a string %(max_number)s.
In, merge opportunity wizard we need to scroll horizontally for 'x' icon to cancel it.

TODo:
Now, we improve the message of UserError.
And hide the 'email_from' and 'phone' field to display 'x' icon without scrolling. 

TaskID-2542260

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
