### PR TITLE
[FIX] mass_mailing: ensure mailing snippets are in same window as others

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -14,6 +14,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
     xmlDependencies: (FieldHtml.prototype.xmlDependencies || []).concat(["/mass_mailing/static/src/xml/mass_mailing.xml"]),
     jsLibs: [
         '/mass_mailing/static/src/js/mass_mailing_link_dialog_fix.js',
+        '/mass_mailing/static/src/js/mass_mailing_snippets.js',
     ],
 
     custom_events: _.extend({}, FieldHtml.prototype.custom_events, {
@@ -33,9 +34,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         // All the code related to this __extraAssetsForIframe variable is an
         // ugly hack to restore mass mailing options in stable versions. The
         // whole logic has to be refactored as soon as possible...
-        this.__extraAssetsForIframe = [{
-            jsLibs: ['/mass_mailing/static/src/js/mass_mailing_snippets.js'],
-        }];
+        this.__extraAssetsForIframe = [{jsLibs: []}];
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Mass Mailing needs to extend the registry of wysiwyg snippets but couldn't do so because they didn't live in the same window. This moves the mass mailing snippets to the top window.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
