### PR TITLE
[FIX] website_crm_partner_assign: allow editing contact from portal

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -4,7 +4,7 @@
 import random
 
 from odoo import api, fields, models, _
-from odoo.exceptions import AccessDenied, AccessError
+from odoo.exceptions import AccessDenied, AccessError, UserError
 from odoo.tools import html_escape
 
 
@@ -236,6 +236,14 @@ class CrmLead(models.Model):
                         'date_deadline': values['activity_date_deadline'],
                     })
             lead.write(lead_values)
+
+    def update_contact_details_from_portal(self, values):
+        self.check_access_rights('write')
+        fields = ['partner_name', 'phone', 'mobile', 'email_from', 'street', 'street2',
+            'city', 'zip', 'state_id', 'country_id']
+        if any([key not in fields for key in values]):
+            raise UserError(_("Not allowed to update the following field(s) : %s.") % ", ".join([key for key in values if not key in fields]))
+        return self.sudo().write(values)
 
     @api.model
     def create_opp_portal(self, values):

--- a/addons/website_crm_partner_assign/static/src/js/crm_partner_assign.js
+++ b/addons/website_crm_partner_assign/static/src/js/crm_partner_assign.js
@@ -93,7 +93,7 @@ publicWidget.registry.crmPartnerAssign = publicWidget.Widget.extend({
     _editContact: function () {
         return this._rpc({
             model: 'crm.lead',
-            method: 'write',
+            method: 'update_contact_details_from_portal',
             args: [[parseInt($('.edit_contact_form .opportunity_id').val())], {
                 partner_name: $('.edit_contact_form .partner_name').val(),
                 phone: $('.edit_contact_form .phone').val(),


### PR DESCRIPTION
Issue

	- Install 'addons/website_crm_partner_assign' module
	- Create a partner X without a phone number (edit only name).
	- Save and click on "Opportunities" stat button
	- Create an opportunity Y and set X as customer
	- Edit it and set "Joel Willis" as assigned partner
	- Logout then login with portal user (Joel Willis)
	- Go to "My account" page and click on "Opportunities"
	- Select the opportunity Y and edit "Contact"
	- Change phone number then save

	Access error message.

Cause

	When editing the opportunity (OPP) phone (or email_from) field,
	if a partner is linked to the OPP and the phone is different,
	we will update also the phone of the partner.
	User portal is not allowed to edit phone partner.

Solution

	Override `_inverse_phone` and `_inverse_email_from`:
	If assigned partner on opportunity is same
	as env.user commercial partner, then use
	sudo() on lead.partner_id to update phone or email_from.

opw-2530744