### PR TITLE
[FIX] point_of_sale: load missing products

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderFetcher.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderFetcher.js
@@ -133,6 +133,7 @@ odoo.define('point_of_sale.OrderFetcher', function (require) {
             const idsNotInCache = ids.filter((id) => !(id in this.cache));
             if (idsNotInCache.length > 0) {
                 const fetchedOrders = await this._fetchOrders(idsNotInCache);
+                await this.comp.env.pos._loadMissingProducts(fetchedOrders);
                 // Cache these fetched orders so that next time, no need to fetch
                 // them again, unless invalidated. See `invalidateCache`.
                 fetchedOrders.forEach((order) => {

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -363,7 +363,9 @@ var PosDB = core.Class.extend({
         var list = [];
         if (product_ids) {
             for (var i = 0, len = Math.min(product_ids.length, this.limit); i < len; i++) {
-                list.push(this.product_by_id[product_ids[i]]);
+                const product = this.product_by_id[product_ids[i]];
+                if (!(product.active && product.available_in_pos)) continue;
+                list.push(product);
             }
         }
         return list;
@@ -385,7 +387,9 @@ var PosDB = core.Class.extend({
             var r = re.exec(this.category_search_string[category_id]);
             if(r){
                 var id = Number(r[1]);
-                results.push(this.get_product_by_id(id));
+                const product = this.get_product_by_id(id);
+                if (!(product.active && product.available_in_pos)) continue;
+                results.push(product);
             }else{
                 break;
             }

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -108,8 +108,8 @@ exports.PosModel = Backbone.Model.extend({
             return self.after_load_server_data();
         });
     },
-    after_load_server_data: function(){
-        this.load_orders();
+    after_load_server_data: async function(){
+        await this.load_orders();
         this.set_start_order();
         if(this.config.use_proxy){
             if (this.config.iface_customer_facing_display) {
@@ -420,7 +420,7 @@ exports.PosModel = Backbone.Model.extend({
         model:  'product.product',
         fields: ['display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_id', 'taxes_id',
                  'barcode', 'default_code', 'to_weight', 'uom_id', 'description_sale', 'description',
-                 'product_tmpl_id','tracking', 'write_date', 'available_in_pos', 'attribute_line_ids'],
+                 'product_tmpl_id','tracking', 'write_date', 'available_in_pos', 'attribute_line_ids', 'active'],
         order:  _.map(['sequence','default_code','name'], function (name) { return {name: name}; }),
         domain: function(self){
             var domain = ['&', '&', ['sale_ok','=',true],['available_in_pos','=',true],'|',['company_id','=',self.config.company_id[0]],['company_id','=',false]];
@@ -769,8 +769,9 @@ exports.PosModel = Backbone.Model.extend({
      * Second load all orders belonging to the same config but from other sessions,
      * Only if tho order has orderlines.
      */
-    load_orders: function(){
+    load_orders: async function(){
         var jsons = this.db.get_unpaid_orders();
+        await this._loadMissingProducts(jsons);
         var orders = [];
 
         for (var i = 0; i < jsons.length; i++) {
@@ -802,7 +803,27 @@ exports.PosModel = Backbone.Model.extend({
             this.get('orders').add(orders);
         }
     },
-
+    async _loadMissingProducts(orders) {
+        const missingProductIds = new Set([]);
+        for (const order of orders) {
+            for (const line of order.lines) {
+                const productId = line[2].product_id;
+                if (missingProductIds.has(productId)) continue;
+                if (!this.db.get_product_by_id(productId)) {
+                    missingProductIds.add(productId);
+                }
+            }
+        }
+        const productModel = _.find(this.models, function(model){return model.model === 'product.product';});
+        const fields = productModel.fields;
+        const products = await this.rpc({
+            model: 'product.product',
+            method: 'read',
+            args: [[...missingProductIds], fields],
+            context: Object.assign(this.session.user_context, { display_default_code: false }),
+        });
+        productModel.loaded(this, products);
+    },
     set_start_order: function(){
         var orders = this.get('orders').models;
 


### PR DESCRIPTION
When loading pos, orders saved from the local storage is loaded. There
is, however, a chance that the products used in the loaded orders
are missing during the loading of pos. (Which can be caused by backend
changes such as archiving a product.) This situation is similar when
loading paid orders from the backend in the order management screen.
This results to crashing of the pos app and force clearance of the
local storage in order for pos to work again.

In this commit, we try to rectify the issue by loading the unloaded
products. The product remain inactive if it was archived, however,
they can still be visible in the orderlines.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
