### PR TITLE
[FIX] mass_mailing: properly set new background colors in snippets

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -14,6 +14,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
     xmlDependencies: (FieldHtml.prototype.xmlDependencies || []).concat(["/mass_mailing/static/src/xml/mass_mailing.xml"]),
     jsLibs: [
         '/mass_mailing/static/src/js/mass_mailing_link_dialog_fix.js',
+        '/mass_mailing/static/src/js/mass_mailing_snippets.js',
     ],
 
     custom_events: _.extend({}, FieldHtml.prototype.custom_events, {
@@ -33,9 +34,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         // All the code related to this __extraAssetsForIframe variable is an
         // ugly hack to restore mass mailing options in stable versions. The
         // whole logic has to be refactored as soon as possible...
-        this.__extraAssetsForIframe = [{
-            jsLibs: ['/mass_mailing/static/src/js/mass_mailing_snippets.js'],
-        }];
+        this.__extraAssetsForIframe = [{jsLibs: []}];
     },
 
     //--------------------------------------------------------------------------

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -576,7 +576,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
+                        <td class="o_mail_no_colorpicker">
                             <div class="bg-o-color-2">
                                 &amp;nbsp;
                             </div>
@@ -865,7 +865,7 @@
         data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
         data-exclude=".o_mail_no_resize, .o_mail_no_options"/>
 
-    <div data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
+    <div data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, td.o_mail_no_colorpicker div:first-child, th"
          data-exclude=".o_mail_no_colorpicker, .o_mail_no_options">
         <we-colorpicker string="Background Color"
             data-select-style="true"

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -865,7 +865,10 @@
         data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, th"
         data-exclude=".o_mail_no_resize, .o_mail_no_options"/>
 
-    <div data-selector=".note-editable > div:not(.o_layout), .note-editable .oe_structure > div, td, td.o_mail_no_colorpicker div:first-child, th"
+    <div data-selector=".note-editable > div:not(.o_layout),
+        .note-editable .oe_structure > div:not(:has(> .o_mail_snippet_general)),
+        .note-editable .oe_structure > div > .o_mail_snippet_general,
+        td, td.o_mail_no_colorpicker div:first-child, th"
          data-exclude=".o_mail_no_colorpicker, .o_mail_no_options">
         <we-colorpicker string="Background Color"
             data-select-style="true"


### PR DESCRIPTION
This fixes the cases where the colorpicker was not working as expected in mass mailing.

Enterprise PR: https://github.com/odoo/enterprise/pull/18619

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
