### PR TITLE
[IMP] mail: activity keyboard navigation improvement

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -56,6 +56,7 @@
             'mail/static/src/scss/variables.scss',
         ],
         'web.assets_backend': [
+            'mail/static/src/js/core/dialog.js',
             'mail/static/src/js/core/translation.js',
             'mail/static/src/js/many2many_tags_email.js',
             'mail/static/src/js/m2x_avatar_user.js',
@@ -338,6 +339,7 @@
             'mail/static/src/utils/throttle/throttle_tests.js',
             'mail/static/src/utils/timer/timer_tests.js',
             'mail/static/src/widgets/form_renderer/form_renderer_tests.js',
+            'mail/static/src/widgets/list_view/list_view_tests.js',
             'mail/static/src/widgets/notification_alert/notification_alert_tests.js',
         ],
         'web.qunit_mobile_suite_tests': [

--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -375,6 +375,7 @@ var BasicActivity = AbstractField.extend({
             this.$('.o_activity_selected').removeClass('o_activity_selected');
             $actLi.toggleClass('o_activity_selected');
             $panel.collapse('toggle');
+            $panel.find('#activity_feedback').focus();
 
         } else if (!$markDoneBtn.data('bs.popover')) {
             $markDoneBtn.popover({
@@ -416,6 +417,11 @@ var BasicActivity = AbstractField.extend({
     _onMarkActivityDoneActions: function ($btn, $form, activityID) {
         var self = this;
         $form.find('#activity_feedback').val(self._draftFeedback[activityID]);
+        $form.on('keydown', '#activity_feedback', function (ev) {
+            if (ev.key === 'Enter') {
+                ev.stopPropagation(); // Prevent list view actions
+            }
+        });
         $form.on('click', '.o_activity_popover_done', function (ev) {
             ev.stopPropagation();
             self._markActivityDone({
@@ -423,12 +429,32 @@ var BasicActivity = AbstractField.extend({
                 feedback: $form.find('#activity_feedback').val(),
             });
         });
+        $form.on('keydown', '.o_activity_popover_done', function (ev) {
+            if (ev.key === 'Enter') {
+                ev.stopPropagation(); // Prevent list view actions
+                ev.preventDefault();
+                self._markActivityDone({
+                    activityID: activityID,
+                    feedback: $form.find('#activity_feedback').val(),
+                });
+            }
+        });
         $form.on('click', '.o_activity_popover_done_next', function (ev) {
             ev.stopPropagation();
             self._markActivityDoneAndScheduleNext({
                 activityID: activityID,
                 feedback: $form.find('#activity_feedback').val(),
             });
+        });
+        $form.on('keydown', '.o_activity_popover_done_next', function (ev) {
+            if (ev.key === 'Enter') {
+                ev.stopPropagation(); // Prevent list view actions
+                ev.preventDefault();
+                self._markActivityDoneAndScheduleNext({
+                    activityID: activityID,
+                    feedback: $form.find('#activity_feedback').val(),
+                });
+            }
         });
         $form.on('click', '.o_activity_popover_discard', function (ev) {
             ev.stopPropagation();

--- a/addons/mail/static/src/js/core/dialog.js
+++ b/addons/mail/static/src/js/core/dialog.js
@@ -1,0 +1,22 @@
+/** @odoo-module **/
+
+import Dialog from 'web.Dialog';
+
+Dialog.include({
+    /**
+     * @private
+     * @override
+     * @param {jQueryEvent} ev
+     */
+    _onFooterButtonKeyDown(ev) {
+        switch(ev.key) {
+            case 'TAB':
+                const name = ev.target.getAttribute('name');
+                if (['action_close_dialog', 'action_done', 'action_done_schedule_next'].includes(name)) {
+                    return;
+                }
+                return this._super.apply(this, arguments);
+        }
+    },
+
+});

--- a/addons/mail/static/src/widgets/list_view/list_view_tests.js
+++ b/addons/mail/static/src/widgets/list_view/list_view_tests.js
@@ -1,0 +1,139 @@
+/** @odoo-module **/
+
+import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+
+import ListView from 'web.ListView';
+import testUtils from 'web.test_utils';
+
+QUnit.module('mail', {}, function () {
+QUnit.module('widgets', {}, function () {
+QUnit.module('list_view', {}, function () {
+QUnit.module('list_view_tests.js', {
+    beforeEach: function () {
+        beforeEach(this);
+
+        Object.assign(this.data['res.users'].fields, {
+            activity_ids: {
+                string: 'Activities',
+                type: 'one2many',
+                relation: 'mail.activity',
+                relation_field: 'res_id',
+            },
+            activity_state: {
+                string: 'State',
+                type: 'selection',
+                selection: [['overdue', 'Overdue'], ['today', 'Today'], ['planned', 'Planned']],
+            },
+            activity_summary: {
+                string: "Next Activity Summary",
+                type: 'char',
+            },
+            activity_type_id: {
+                string: "Activity type",
+                type: "many2one",
+                relation: "mail.activity.type",
+            }
+        });
+    },
+    afterEach() {
+        afterEach(this);
+    },
+});
+
+QUnit.test('list activity widget: done the acitivty with "ENTER" keyboard shortcut', async function (assert) {
+    assert.expect(2);
+
+    const currentUser = this.data['res.users'].records.find(user =>
+        user.id === this.data.currentUserId
+    );
+    Object.assign(currentUser, {
+        activity_ids: [1],
+        activity_state: 'today',
+        activity_summary: 'Call with Al',
+        activity_type_id: 3,
+    });
+    this.data['mail.activity'].records.push({
+        activity_type_id: 3,
+        can_write: true,
+        create_uid: this.data.currentUserId,
+        display_name: "Call with Al",
+        date_deadline: moment().format("YYYY-MM-DD"),
+        id: 1,
+        state: "today",
+        user_id: this.data.currentUserId,
+    });
+
+    const { widget: list } = await start({
+        hasView: true,
+        View: ListView,
+        model: 'res.users',
+        data: this.data,
+        arch: `
+            <list>
+                <field name="activity_ids" widget="list_activity"/>
+            </list>`,
+        mockRPC(route, args) {
+            if (args.method === 'action_feedback') {
+                assert.step('action_feedback');
+            }
+            return this._super(route, args);
+        },
+    });
+    await testUtils.dom.click(list.$('.o_activity_btn span'));
+    await testUtils.dom.click(list.$('.o_mark_as_done:first'));
+    await testUtils.fields.triggerKeydown(list.$('.o_activity_popover_done'), 'enter');
+    assert.verifySteps(['action_feedback']);
+
+    list.destroy();
+});
+
+QUnit.test('list activity widget: done and schedule the next acitivty with "ENTER" keyboard shortcut', async function (assert) {
+    assert.expect(2);
+
+    const currentUser = this.data['res.users'].records.find(user =>
+        user.id === this.data.currentUserId
+    );
+    Object.assign(currentUser, {
+        activity_ids: [1],
+        activity_state: 'today',
+        activity_summary: 'Call with Al',
+        activity_type_id: 3,
+    });
+    this.data['mail.activity'].records.push({
+        activity_type_id: 3,
+        can_write: true,
+        create_uid: this.data.currentUserId,
+        display_name: "Call with Al",
+        date_deadline: moment().format("YYYY-MM-DD"),
+        id: 1,
+        state: "today",
+        user_id: this.data.currentUserId,
+    });
+
+    const { widget: list } = await start({
+        hasView: true,
+        View: ListView,
+        model: 'res.users',
+        data: this.data,
+        arch: `
+            <list>
+                <field name="activity_ids" widget="list_activity"/>
+            </list>`,
+        mockRPC(route, args) {
+            if (args.method === 'action_feedback_schedule_next') {
+                assert.step('action_feedback_schedule_next');
+            }
+            return this._super(route, args);
+        },
+    });
+    await testUtils.dom.click(list.$('.o_activity_btn span'));
+    await testUtils.dom.click(list.$('.o_mark_as_done:first'));
+    await testUtils.fields.triggerKeydown(list.$('.o_activity_popover_done_next'), 'enter');
+    assert.verifySteps(['action_feedback_schedule_next']);
+
+    list.destroy();
+});
+
+});
+});
+});


### PR DESCRIPTION
**PURPOSE**

Improve some mail activity issues regarding keyboard navigation through forms.

**SPCIFICATION**

- When creating an activity using the form view, allowing user for the form and
  given access for TAB key to the four buttons at the footer.
- When done an activity using the record list view, allowing user ENTER key
  support on "Done" or "Done and Schedule Next" button to post feedback and
  mark the activity as done.

**Task**-2528109