### PR TITLE
[IMP][Localization] Change Portugal address format

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1323,6 +1323,7 @@
             <field name="name">Portugal</field>
             <field name="code">pt</field>
             <field file="base/static/img/country_flags/pt.png" name="image" type="base64" />
+            <field name="address_format" eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s\n%(country_name)s'"/>
             <field name="currency_id" ref="EUR" />
             <field eval="351" name="phone_code" />
             <field name="vat_label">VAT</field>


### PR DESCRIPTION
The Portugal res_country record doesn't have an address_format field set, so Odoo uses the one by default.
Default Odoo address format adds the state code to addresses, which is not used in Portugal.
We propose adding a default address_format to the Portugal record in country data that removes this state code while keeping the rest of the address format intact.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr