### PR TITLE
[FIX] point_of_sale: duplicated reference in POS

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -57,7 +57,9 @@ class PosController(http.Controller):
             'session_info': session_info,
             'login_number': pos_session.login(),
         }
-        return request.render('point_of_sale.index', qcontext=context)
+        response = request.render('point_of_sale.index', context)
+        response.headers['Cache-Control'] = 'no-store'
+        return response
 
     @http.route('/pos/ui/tests', type='http', auth="user")
     def test_suite(self, mod=None, **kwargs):


### PR DESCRIPTION
When you are opening a POS session, a number corresponding to count of
connection to this session is incremented, to be sure to have a unique
identifier on receipts.

In recent browsers, when you are reopening a recent tab (Ctrl+Shift+t)
the browser will load the response of last request and won't perform the
request. So the count of login won't be incremented, and this will
result of duplication of receipt number.

To avoid this behavior, we are explicitly say to the browser (through
the response header) that we don't want to cache the request result.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
