### PR TITLE
[FIX] point_of_sale: use correct product's location

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -960,7 +960,7 @@ class PosOrder(models.Model):
                             if stock_production_lot.product_id.tracking == 'lot':
                                 qty = abs(pos_pack_lot.pos_order_line_id.qty)
                             qty_done += qty
-                            quant = stock_production_lot.quant_ids.filtered(lambda q: q.quantity > 0.0 or q.location_id.parent_path.startswith(move.location_id.parent_path))[-1:]
+                            quant = stock_production_lot.quant_ids.filtered(lambda q: q.quantity > 0.0 and q.location_id.parent_path.startswith(move.location_id.parent_path))[-1:]
                             pack_lots.append({'lot_id': stock_production_lot.id, 'quant_location_id': quant.location_id.id, 'qty': qty})
                         else:
                             has_wrong_lots = True

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -280,6 +280,70 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         # I close the session to generate the journal entries
         self.pos_config.current_session_id.action_pos_session_closing_control()
 
+    def test_order_to_picking02(self):
+        """ This test is similar to test_order_to_picking except that this time, the product is tracked and its
+         location is a sublocation of the main warehouse
+        """
+        product = self.env['product.product'].create({
+            'name': 'SuperProduct',
+            'type': 'product',
+            'tracking': 'lot',
+            'available_in_pos': True,
+        })
+        wh_location = self.env['ir.model.data'].xmlid_to_object('stock.warehouse0').lot_stock_id
+        shelf1_location = self.env['stock.location'].create({
+            'name': 'shelf1',
+            'usage': 'internal',
+            'location_id': wh_location.id,
+        })
+        lot = self.env['stock.production.lot'].create({
+            'name': 'SuperLot',
+            'product_id': product.id,
+        })
+        qty = 2
+        self.env['stock.quant']._update_available_quantity(product, shelf1_location, qty, lot_id=lot)
+
+        self.pos_config.open_session_cb()
+
+        untax, atax = self.compute_tax(product, 1.15, 1)
+
+        for i in range(qty):
+            pos_order = self.PosOrder.create({
+                'company_id': self.company_id,
+                'pricelist_id': self.partner1.property_product_pricelist.id,
+                'partner_id': self.partner1.id,
+                'lines': [(0, 0, {
+                    'name': "OL/0001",
+                    'product_id': product.id,
+                    'price_unit': untax + atax,
+                    'discount': 0.0,
+                    'qty': 1.0,
+                    'tax_ids': [(6, 0, product.taxes_id.ids)],
+                    'price_subtotal': untax,
+                    'price_subtotal_incl': untax + atax,
+                    'pack_lot_ids': [[0, 0, {'lot_name': lot.name}]],
+                })],
+                'amount_tax': atax,
+                'amount_total': untax + atax,
+                'amount_paid': 0,
+                'amount_return': 0,
+            })
+
+            context_make_payment = {
+                "active_ids": [pos_order.id],
+                "active_id": pos_order.id,
+            }
+            pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
+                'amount': untax + atax,
+            })
+            context_payment = {'active_id': pos_order.id}
+            pos_make_payment.with_context(context_payment).check()
+
+            self.assertEqual(pos_order.state, 'paid')
+            self.assertEqual(pos_order.picking_id.move_line_ids.lot_id, lot)
+            self.assertEqual(pos_order.picking_id.move_line_ids.location_id, shelf1_location)
+
+        self.pos_config.current_session_id.action_pos_session_closing_control()
 
     def test_order_to_invoice(self):
 


### PR DESCRIPTION
When selling a tracked product, if the latter has already been sold
once, the source location of the associated stock move will be
incorrect.

To reproduce the error:
1. Create a product P
    - Product Type: Storable Product
    - Available in POS: True
    - Inventory: By Lots
2. Update P's quantity > 0 with lot L
3. Start POS session
4. Sell one P with lot L (Register payment + Validate)
5. Repeat 4
6. Go to Inventory > Reporting > Product Moves and apply one filter:
    - Product: P
Error: There are 3 product moves:
    - One from Inventory adjustment to Stock
    - One from Stock to Customers
    - One from Customers to Customers
The third one is incorrect and should be from Stock to Customers.

Because of the first sale, a `stock.quant` is created and indicates that
one P from lot L is at location "Customers". When selling the second
one, because of the OR-condition, this `stock.quant` is selected. The
condition should be an AND-condition.

This fix is an improvement of #69750. The new test checks the above flow
and the one described in the related PR.

closes #71435