### PR TITLE
[FIX] point_of_sale,pos_mrp: correctly generate COGS entries for invo…

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -359,12 +359,14 @@ class StockMove(models.Model):
     def _prepare_merge_moves_distinct_fields(self):
         distinct_fields = super()._prepare_merge_moves_distinct_fields()
         distinct_fields.append('created_production_id')
+        distinct_fields.append('bom_line_id')
         return distinct_fields
 
     @api.model
     def _prepare_merge_move_sort_method(self, move):
         keys_sorted = super()._prepare_merge_move_sort_method(move)
         keys_sorted.append(move.created_production_id.id)
+        keys_sorted.append(move.bom_line_id.id)
         return keys_sorted
 
     def _compute_kit_quantities(self, product_id, kit_qty, kit_bom, filters):

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -54,7 +54,7 @@ class ProductProduct(models.Model):
             bom_line = move.bom_line_id
             bom_line_data = bom_lines[bom_line]
             bom_line_qty = bom_line_data['qty']
-            value += move.product_id._compute_average_price(qty_invoiced * bom_line_qty, qty_to_invoice * bom_line_qty, move)
+            value += bom_line_qty * move.product_id._compute_average_price(qty_invoiced * bom_line_qty, qty_to_invoice * bom_line_qty, move)
         return value
 
     def _compute_bom_price(self, bom, boms_to_recompute=False):

--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -22,3 +22,8 @@ class StockMove(models.Model):
             return super()._get_dest_account(accounts_data)
         else:
             return self.location_id.valuation_in_account_id.id or accounts_data['stock_output'].id
+
+    def _filter_anglo_saxon_moves(self, product):
+        res = super(StockMove, self)._filter_anglo_saxon_moves(product)
+        res += self.filtered(lambda m: m.bom_line_id.bom_id.product_tmpl_id.id == product.product_tmpl_id.id)
+        return res

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -198,7 +198,7 @@ class PosOrder(models.Model):
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
         moves = self.filtered(lambda o: o.partner_id.id == partner_id)\
             .mapped('picking_ids.move_lines')\
-            .filtered(lambda m: m.product_id.id == product.id)\
+            ._filter_anglo_saxon_moves(product)\
             .sorted(lambda x: x.date)
         price_unit = product._compute_average_price(0, quantity, moves)
         return price_unit

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -19,6 +19,9 @@ class StockMove(models.Model):
     account_move_ids = fields.One2many('account.move', 'stock_move_id')
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'stock_move_id')
 
+    def _filter_anglo_saxon_moves(self, product):
+        return self.filtered(lambda m: m.product_id.id == product.id)
+
     def action_get_account_moves(self):
         self.ensure_one()
         action_data = self.env['ir.actions.act_window']._for_xml_id('account.action_move_journal_line')


### PR DESCRIPTION
…iced kit

Activate anglo saxon accounting
Have a [DEMO] KIT product in a category using automated
Inventory Valuation with costing method AVCO
The KIT is composed by C1 and C2 in the same product category
Define a cost on both C1 and C2
Open a POS session, order [DEMO], Invoice and complete the order
Close Session, Validate and display Journal Items

COGS entries will be missing.
This does not occur when making the order without invoicing

opw-2481518
opw-2545758

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
