### PR TITLE
[FIX] crm: rearrange settings

### DIFF
--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -136,8 +136,7 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row mt16 o_settings_container" name="generate_lead_setting_container">
+
                         <div class="col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="module_crm_iap_lead"/>
@@ -151,6 +150,9 @@
                                 </div>
                             </div>
                         </div>
+
+                    </div>
+                    <div class="row mt16 o_settings_container" name="generate_lead_setting_container">
                         <div class="col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="module_crm_iap_lead_website"/>


### PR DESCRIPTION
move the lead mining section to the top right as we now have more space after
the removal of the outlook plugin settings

Task-2531032