### PR TITLE
[FIX] website_slides: Patch CSRF vulnerability

### DIFF
--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -27,7 +27,7 @@ class SlidesPortalChatter(PortalChatter):
     @http.route([
         '/slides/mail/update_comment',
         '/mail/chatter_update',
-        ], type='http', auth="user")
+        ], type='http', auth="user", methods=['POST'])
     def mail_update_message(self, res_model, res_id, message, message_id, redirect=None, attachment_ids='', attachment_tokens='', **post):
         # keep this mecanism intern to slide currently (saas 12.5) as it is
         # considered experimental

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -769,7 +769,7 @@ class WebsiteSlides(WebsiteProfile):
             'can_create': can_create,
         }
 
-    @http.route('/slides/category/add', type="http", website=True, auth="user")
+    @http.route('/slides/category/add', type="http", website=True, auth="user", methods=['POST'])
     def slide_category_add(self, channel_id, name):
         """ Adds a category to the specified channel. Slide is added at the end
         of slide list based on sequence. """

--- a/doc/cla/individual/sushiwushi.md
+++ b/doc/cla/individual/sushiwushi.md
@@ -1,0 +1,11 @@
+Malaysia, 2021-06-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+iamsushi 45194995+sushiwushi@users.noreply.github.com https://github.com/sushiwushi


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

CSRF vulnerability exists in ``/slides/category/add`` and ``/slides/mail/update_comment`` endpoint.

Current behavior before PR: 

HTTP request method can be sent as GET request to bypass CSRF protection.

Desired behavior after PR is merged:

Only allow POST request from client.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
