### PR TITLE
[FIX] website: correctly destroy autohideMenu widget  

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -451,7 +451,7 @@ publicWidget.registry.autohideMenu = publicWidget.Widget.extend({
      */
     destroy() {
         this._super(...arguments);
-        if (!this.noAutohide) {
+        if (!this.noAutohide && this.$topMenu) {
             $(window).off('.autohideMenu');
             dom.destroyAutoMoreMenu(this.$topMenu);
         }


### PR DESCRIPTION
When changing the color of the header with the custom colorpicker and
saving the changes, the autohideMenu widget was destroyed before
finishing the rendering.

The commit fixes the destroy method of this widget, testing if the 
variables are defined before using them.

task-2519545

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
