### PR TITLE
[FIX] account: name in reconciliation tour

### DIFF
--- a/addons/account/static/tests/tours/reconciliation.js
+++ b/addons/account/static/tests/tours/reconciliation.js
@@ -28,7 +28,7 @@ Tour.register('bank_statement_reconciliation', {
         },
         {
             content: "select the right line to match",
-            trigger: '.o_reconciliation_line:nth-child(4) .o_notebook .cell_label:contains("' + currentYear + '/0001")'
+            trigger: '.o_reconciliation_line:nth-child(4) .o_notebook .line_amount:contains("4,610.00")'
         },
         {
             content: "click on partial reconcile",


### PR DESCRIPTION
The name of the invoice we wanted changed from `INV/YYYY/0001` to
`INV/YYYY/0002` for some reason. Let's use the amount instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
