### PR TITLE
[FIX] payment_ingenico,portal_rating: fix typo in route kw

### DIFF
--- a/addons/payment_ingenico/controllers/main.py
+++ b/addons/payment_ingenico/controllers/main.py
@@ -23,7 +23,7 @@ class OgoneController(http.Controller):
         '/payment/ogone/decline', '/payment/ogone/test/decline',
         '/payment/ogone/exception', '/payment/ogone/test/exception',
         '/payment/ogone/cancel', '/payment/ogone/test/cancel',
-    ], type='http', auth='public', csrf=False, method=['GET', 'POST'])
+    ], type='http', auth='public', csrf=False, methods=['GET', 'POST'])
     def ogone_form_feedback(self, **post):
         """ Handle both redirection from Ingenico (GET) and s2s notification (POST/GET) """
         _logger.info('Ogone: entering form_feedback with post data %s', pprint.pformat(post))  # debug

--- a/addons/portal_rating/controllers/portal_rating.py
+++ b/addons/portal_rating/controllers/portal_rating.py
@@ -7,7 +7,7 @@ from odoo.http import request
 
 class PortalRating(http.Controller):
 
-    @http.route(['/website/rating/comment'], type='json', auth="user", method=['POST'], website=True)
+    @http.route(['/website/rating/comment'], type='json', auth="user", methods=['POST'], website=True)
     def publish_rating_comment(self, rating_id, publisher_comment):
         rating = request.env['rating.rating'].search([('id', '=', int(rating_id))])
         if not rating:


### PR DESCRIPTION
The common mistake of method instead of method leads to the parameter being ignored.
A warning will be added in master
