### PR TITLE
[FIX] point_of_sale: fix order management infinite recursive loop

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -2976,10 +2976,6 @@ td {
     color: white;
 }
 
-.order-receipt-hidden {
-    display: none;
-}
-
 .order-receipt {
     color: white;
     font-size: medium;

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/ReprintReceiptButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/ReprintReceiptButton.js
@@ -6,7 +6,6 @@ odoo.define('point_of_sale.ReprintReceiptButton', function (require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const OrderManagementScreen = require('point_of_sale.OrderManagementScreen');
     const Registries = require('point_of_sale.Registries');
-    const OrderReceipt = require('point_of_sale.OrderReceipt');
     const contexts = require('point_of_sale.PosContext');
 
     class ReprintReceiptButton extends PosComponent {
@@ -19,18 +18,7 @@ odoo.define('point_of_sale.ReprintReceiptButton', function (require) {
             const order = this.orderManagementContext.selectedOrder;
             if (!order) return;
 
-            if (this.env.pos.proxy.printer) {
-                const fixture = document.createElement('div');
-                const orderReceipt = new (Registries.Component.get(OrderReceipt))(this, { order });
-                await orderReceipt.mount(fixture);
-                const receiptHtml = orderReceipt.el.outerHTML;
-                const printResult = await this.env.pos.proxy.printer.print_receipt(receiptHtml);
-                if (!printResult.successful) {
-                    this.showTempScreen('ReprintReceiptScreen', { order: order });
-                }
-            } else {
-                this.showTempScreen('ReprintReceiptScreen', { order: order });
-            }
+            this.showScreen('ReprintReceiptScreen', { order: order });
         }
     }
     ReprintReceiptButton.template = 'ReprintReceiptButton';

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/ReprintReceiptButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/ReprintReceiptButton.js
@@ -6,6 +6,7 @@ odoo.define('point_of_sale.ReprintReceiptButton', function (require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const OrderManagementScreen = require('point_of_sale.OrderManagementScreen');
     const Registries = require('point_of_sale.Registries');
+    const OrderReceipt = require('point_of_sale.OrderReceipt');
     const contexts = require('point_of_sale.PosContext');
 
     class ReprintReceiptButton extends PosComponent {
@@ -19,7 +20,10 @@ odoo.define('point_of_sale.ReprintReceiptButton', function (require) {
             if (!order) return;
 
             if (this.env.pos.proxy.printer) {
-                const receiptHtml = this.props.hiddenOrderReceipt.el.outerHTML;
+                const fixture = document.createElement('div');
+                const orderReceipt = new (Registries.Component.get(OrderReceipt))(this, { order });
+                await orderReceipt.mount(fixture);
+                const receiptHtml = orderReceipt.el.outerHTML;
                 const printResult = await this.env.pos.proxy.printer.print_receipt(receiptHtml);
                 if (!printResult.successful) {
                     this.showTempScreen('ReprintReceiptScreen', { order: order });

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -77,9 +77,9 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             OrderFetcher.fetch();
         }
         _onClickOrder({ detail: clickedOrder }) {
-            if (!clickedOrder || clickedOrder.locked) {
+            let currentPOSOrder = this.env.pos.get_order();
+            if (currentPOSOrder && (!clickedOrder || clickedOrder.locked)) {
                 this.orderManagementContext.selectedOrder = clickedOrder;
-                let currentPOSOrder = this.env.pos.get_order();
                 if (clickedOrder.attributes.client){
                     currentPOSOrder.set_client(clickedOrder.attributes.client);
                 }

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -1,7 +1,7 @@
 odoo.define('point_of_sale.OrderManagementScreen', function (require) {
     'use strict';
 
-    const { useContext, useRef } = owl.hooks;
+    const { useContext } = owl.hooks;
     const { useListener } = require('web.custom_hooks');
     const ControlButtonsMixin = require('point_of_sale.ControlButtonsMixin');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
@@ -27,7 +27,6 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             OrderFetcher.setComponent(this);
             OrderFetcher.setConfigId(this.env.pos.config_id);
             this.orderManagementContext = useContext(contexts.orderManagement);
-            this.receiptRef = useRef('order-receipt');
         }
         mounted() {
             OrderFetcher.on('update', this, this.render);

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ReprintReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ReprintReceiptScreen.js
@@ -6,12 +6,18 @@ odoo.define('point_of_sale.ReprintReceiptScreen', function (require) {
 
     const ReprintReceiptScreen = (AbstractReceiptScreen) => {
         class ReprintReceiptScreen extends AbstractReceiptScreen {
-            confirm() {
-                this.props.resolve({ confirmed: true, payload: null });
-                this.trigger('close-temp-screen');
+            mounted() {
+                this.tryReprint();
             }
-            tryReprint() {
-                this._printReceipt();
+            confirm() {
+                this.showScreen('OrderManagementScreen');
+            }
+            async tryReprint() {
+                if(this.env.pos.proxy.printer && this.env.pos.config.iface_print_skip_screen) {
+                    let result = await this._printReceipt();
+                    if(result)
+                        this.showScreen('OrderManagementScreen');
+                }
             }
         }
         ReprintReceiptScreen.template = 'ReprintReceiptScreen';

--- a/addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderManagementScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderManagementScreen.xml
@@ -9,7 +9,7 @@
                     <div class="pads">
                         <div class="control-buttons">
                             <t t-foreach="controlButtons" t-as="cb" t-key="cb.name">
-                                <t t-component="cb.component" t-key="cb.name" hiddenOrderReceipt="receiptRef"/>
+                                <t t-component="cb.component" t-key="cb.name" />
                             </t>
                         </div>
                         <div class="subpads">
@@ -26,9 +26,6 @@
                 </div>
             </div>
             <MobileOrderManagementScreen t-else="" />
-            <div class="order-receipt-hidden">
-                <OrderReceipt t-if="orderManagementContext.selectedOrder" order="orderManagementContext.selectedOrder" t-ref="order-receipt" />
-            </div>
         </div>
     </t>
 


### PR DESCRIPTION
The were few times where we ended up with a infinite recursion while clicking on an order in the order management screen.
This lead to a browser in a frozen state.
Now we don't use a temporary screen anymore and use the same mechanism of the receiptScreen to print the order.

We also fix an issue in pos restaurant when there wasn't any current order, we couldn't load the order management screen.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
