### PR TITLE
[FIX] purchase_requisition: Delete Purchase Orders Action

### DIFF
--- a/addons/purchase_requisition/views/product_views.xml
+++ b/addons/purchase_requisition/views/product_views.xml
@@ -38,13 +38,4 @@
         </field>
     </record>
 
-    <record id="act_res_partner_2_purchase_order" model="ir.actions.act_window">
-        <field name="name">Purchase orders</field>
-        <field name="res_model">purchase.order</field>
-        <field name="domain">[('requisition_id', '=', active_id)]</field>
-        <field name="context">{'default_requisition_id': active_id}</field>
-        <field name="binding_model_id" ref="model_purchase_requisition"/>
-        <field name="binding_view_types">form</field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
Delete purchase orders action on purchase agreements (PA)
![Selection_096](https://user-images.githubusercontent.com/24691983/120308299-26996180-c2fe-11eb-9212-969a1edfe2d9.png)

On this document have New Quotation button which will create RFQ and can create when PA's state is Ongoing, Confirmed, Bid Selection
![Selection_097](https://user-images.githubusercontent.com/24691983/120308873-c5be5900-c2fe-11eb-8ebb-867cfa67ebf1.png)

and Purchase orders action will create RFQ with all PA's state, this is my video
![Peek 2021-06-01 17-32](https://user-images.githubusercontent.com/24691983/120309483-7cbad480-c2ff-11eb-9b45-7a7cd6a97cb7.gif)

My reason should delete this action
1. RFQ should create when PA's state is Ongoing, Confirmed, Bid Selection
2. If create RFQ with this action and PA's state = draft, No have smart button link to RFQ

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
