### PR TITLE
[IMP] mail_plugin: allow to upload attachments when  logging an email

### DIFF
--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -160,10 +160,26 @@ class MailPluginController(http.Controller):
         return response
 
     @http.route('/mail_plugin/log_mail_content', type="json", auth="outlook", cors="*")
-    def log_mail_content(self, model, res_id, message):
+    def log_mail_content(self, model, res_id, message, attachments=None):
+        """Log the email on the given record.
+
+        :param model: Model of the record on which we want to log the email
+        :param res_id: ID of the record
+        :param message: Body of the email
+        :param attachments: List of attachments of the email.
+            List of tuple: (filename, base 64 encoded content)
+        """
         if model not in self._mail_content_logging_models_whitelist():
             raise Forbidden()
-        request.env[model].browse(res_id).message_post(body=message)
+
+        if attachments:
+            attachments = [
+                (name, base64.b64decode(content))
+                for name, content in attachments
+            ]
+
+        request.env[model].browse(res_id).message_post(body=message, attachments=attachments)
+        return True
 
     def _iap_enrich(self, domain):
         enriched_data = {}


### PR DESCRIPTION
Purpose
=======
Allow to upload the attachments of the email when logging it on the
partner / lead / ticket.

Technical
=========
The attachments posted on this new endpoint are base 64 encoded and
added in the JSON data in a list (name, encoded content).

Links
=====
Task 2545048
See odoo/mail-client-extensions/pull/11