### PR TITLE
[IMP] web: list: allow to multi edit daterange field

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -846,26 +846,28 @@
 <t t-name="ListView.confirmModal">
     <main role="alert">
         <p>
-            <t t-if="changes.isDomainSelected">This update will only consider the records of the current page.<br/><br/></t>
-            <t t-if="changes.nbRecords != changes.nbValidRecords">
-                Among the <t t-esc="changes.nbRecords"/> selected records,
-                <t t-esc="changes.nbValidRecords"/> are valid for this update.<br/>
+            <t t-if="isDomainSelected">This update will only consider the records of the current page.<br/><br/></t>
+            <t t-if="nbRecords != nbValidRecords">
+                Among the <t t-esc="nbRecords"/> selected records,
+                <t t-esc="nbValidRecords"/> are valid for this update.<br/>
             </t>
-            Are you sure you want to perform the following update on those <t t-esc="changes.nbValidRecords"/> records ?
+            Are you sure you want to perform the following update on those <t t-esc="nbValidRecords"/> records ?
         </p>
         <div class="table-responsive">
             <table class="o_modal_changes">
                 <tbody>
-                    <tr>
-                        <td>Field:</td>
-                        <td><t t-esc="changes.fieldLabel"/></td>
-                    </tr>
-                    <tr>
-                        <td>Update to:</td>
-                        <td>
-                            <div class="o_changes_widget"/>
-                        </td>
-                    </tr>
+                    <t t-foreach="fields" t-as="field">
+                        <tr>
+                            <td>Field:</td>
+                            <td><t t-esc="field.label"/></td>
+                        </tr>
+                        <tr>
+                            <td>Update to:</td>
+                            <td>
+                                <div class="o_changes_widget" t-att-data-name="field.name"/>
+                            </td>
+                        </tr>
+                    </t>
                 </tbody>
             </table>
         </div>

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -3686,6 +3686,7 @@ QUnit.module('basic_fields', {
                 '</form>',
             res_id: 1,
             session: {
+                // #tzoffset_daterange
                 // Date field should not have an offset as they are ignored. 
                 // However, in the test environement, a UTC timezone is set to run all tests. And if any code does not use the safe timezone method
                 // provided by the framework (which happens in this case inside the date range picker lib), unexpected behavior kicks in as the timezone


### PR DESCRIPTION
Before this commit, the multi edition of a field using the daterange
widget wasn't really handled: only the field that was used for doing
the change (i.e. only the start or end date) was actually saved.

With this commit, the multi edit feature now supports the case where
editing a field actually triggers changes on other fields. All those
changes are displayed in the confirmation dialog.

Task 2555178
