### PR TITLE
[FIX] stock_account: use “account_journal_id” only if the valuation is real_time

### DIFF
--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
@@ -16,12 +16,12 @@ class StockValuationLayerRevaluation(models.TransientModel):
         res = super().default_get(default_fields)
         if res.get('product_id'):
             product = self.env['product.product'].browse(res['product_id'])
-            accounts = product.product_tmpl_id.get_product_accounts()
             if product.categ_id.property_cost_method == 'standard':
                 raise UserError(_("You cannot revalue a product with a standard cost method."))
             if product.quantity_svl <= 0:
                 raise UserError(_("You cannot revalue a product with an empty or negative stock."))
-            if 'account_journal_id' not in res and 'account_journal_id' in default_fields:
+            if 'account_journal_id' not in res and 'account_journal_id' in default_fields and product.categ_id.property_valuation == 'real_time':               
+                accounts = product.product_tmpl_id.get_product_accounts()
                 res['account_journal_id'] = accounts['stock_journal'].id
         return res
 
@@ -39,7 +39,7 @@ class StockValuationLayerRevaluation(models.TransientModel):
     new_value_by_qty = fields.Monetary("New value by quantity", compute='_compute_new_value')
     reason = fields.Char("Reason", help="Reason of the revaluation")
 
-    account_journal_id = fields.Many2one('account.journal', "Journal", required=True, check_company=True)
+    account_journal_id = fields.Many2one('account.journal', "Journal", check_company=True)
     account_id = fields.Many2one('account.account', "Counterpart Account", domain=[('deprecated', '=', False)], check_company=True)
     date = fields.Date("Accounting Date")
 

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
@@ -25,7 +25,7 @@
                         <field name="property_valuation" invisible="1"/>
                         <group>
                             <field name="reason"/>
-                            <field name="account_journal_id" attrs="{'invisible':[('property_valuation', '!=', 'real_time')]}"/>
+                            <field name="account_journal_id" attrs="{'invisible':[('property_valuation', '!=', 'real_time')], 'required': [('property_valuation', '=', 'real_time')]}"/>
                         </group>
                         <group>
                             <field name="account_id" attrs="{'invisible':[('property_valuation', '!=', 'real_time')], 'required': [('property_valuation', '=', 'real_time')]}"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to inventory > create a new product
    -Create a new product category:
        * Select "Manual" inventory Valuation
        * Choose "First In First Out (FIFO)" costing Method
        * Be sure that in "Automated" inventory valuation, stock journal is not settled
- Save
- Update quantity of the product
- Go to Inventory > Inventory Valuation> Choose the product newly created
- Click on the "+" button to make manual valuation

Problem:
An error is triggered because we try to access stock_journal when it is false

Solution:
Use “account_journal_id” only if the valuation is real_time and relax the required constraint of `account_journal_id` in case of manual inventory Valuation (which is not used in that case)

Opw-2541497





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
