### PR TITLE
[FIX] l10n_it_edi: The imported e-invoice was submitted to the wrong company, and the original XML wasn't attached

### DIFF
--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -135,7 +135,8 @@ class FetchmailServer(models.Model):
                     # we have a receipt
                     self._message_receipt_invoice(split_underscore[1], attachment)
                 else:
-                    match = re.search("([A-Z]{2}[A-Za-z0-9]{2,28}_[A-Za-z0-9]{0,5}.(xml.p7m|xml))", attachment.fname)
+                    att_filename = attachment.fname
+                    match = re.search("([A-Z]{2}[A-Za-z0-9]{2,28}_[A-Za-z0-9]{0,5}.(xml.p7m|xml))", att_filename)
                     # If match, we have an invoice.
                     if match:
                         # If it's signed, the content has a bytes type and we just remove the signature's envelope
@@ -143,12 +144,13 @@ class FetchmailServer(models.Model):
                             att_content_data = remove_signature(attachment.content)
                             # If the envelope cannot be removed, the remove_signature returns None, so we skip
                             if not att_content_data:
-                                _logger.warning("E-invoice couldn't be read: %s", attachment.fname)
+                                _logger.warning("E-invoice couldn't be read: %s", att_filename)
                                 continue
-                        # Otherwise, it should be an utf-8 encoded XML string
+                            att_filename = att_filename.replace('.xml.p7m', '.xml')
                         else:
+                            # Otherwise, it should be an utf-8 encoded XML string
                             att_content_data = attachment.content.encode()
-                    self._create_invoice_from_mail(att_content_data, attachment.fname, from_address)
+                    self._create_invoice_from_mail(att_content_data, att_filename, from_address)
             else:
                 if split_underscore[1] == 'AT':
                     # Attestazione di avvenuta trasmissione della fattura con impossibilità di recapito
@@ -174,7 +176,7 @@ class FetchmailServer(models.Model):
             return invoices
 
         # Create the new attachment for the file
-        self.env['ir.attachment'].create({
+        attachment = self.env['ir.attachment'].create({
             'name': att_name,
             'raw': att_content_data,
             'res_model': 'account.move',
@@ -195,6 +197,10 @@ class FetchmailServer(models.Model):
 
         invoices.l10n_it_send_state = 'new'
         invoices.invoice_source_email = from_address
+        for invoice in invoices:
+            invoice.with_context(no_new_invoice=True, default_res_id=invoice.id) \
+                    .message_post(body=(_("Original E-invoice XML file")), attachment_ids=[attachment.id])
+
         self._cr.commit()
 
         _logger.info('New E-invoices (%s), ids: %s', att_name, [x.id for x in invoices])

--- a/addons/l10n_it_edi/tests/test_ir_mail_server.py
+++ b/addons/l10n_it_edi/tests/test_ir_mail_server.py
@@ -44,8 +44,10 @@ class PecMailServerTests(AccountEdiTestCommon):
         super().setUpClass(chart_template_ref='l10n_it.l10n_it_chart_template_generic',
                            edi_format_ref='l10n_it_edi.edi_fatturaPA')
 
+        # Use the company_data_2 to test that the e-invoice is imported for the right company
+        cls.company = cls.company_data_2['company']
+
         # Initialize the company's codice fiscale
-        cls.company = cls.company_data['company']
         cls.company.l10n_it_codice_fiscale = 'IT01234560157'
 
         # Build test data.
@@ -108,6 +110,7 @@ class PecMailServerTests(AccountEdiTestCommon):
         """ Test a signed (P7M) sample e-invoice file from https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2/IT01234567890_FPR01.xml """
         invoices = self._create_invoice(self.signed_invoice_content, self.signed_invoice_filename)
         self.assertRecordValues(invoices, [{
+            'company_id': self.company.id,
             'name': 'BILL/2014/12/0001',
             'date': datetime.date(2014, 12, 18),
             'ref': '01234567890',


### PR DESCRIPTION
[FIX] The imported e-invoice was submitted to the wrong company, and the original XML wasn't attached

- The context used to create the Form used 'with_context' instead of 'with_company'.
- An additional message has been posted to the chatter with the original E-invoice XML from the email.
- Some code clarification were due where the e-invoice company is determined.

Ticket link: https://www.odoo.com/web#id=2460485&model=project.task

opw-2460485

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
