### PR TITLE
[IMP] base,mail,sms,calendar_sms: add accounting firm to company data and xml exports

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -438,7 +438,7 @@
                     <field name="invoice_origin" optional="hide" string="Source Document"/>
                     <field name="payment_reference" optional="hide" invisible="context.get('default_move_type') in ('out_invoice', 'out_refund','out_receipt')"/>
                     <field name="ref" optional="hide"/>
-                    <field name="invoice_user_id" optional="hide" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Sales Person" widget="many2one_avatar_user"/>
+                    <field name="invoice_user_id" optional="hide" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Salesperson" widget="many2one_avatar_user"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="hide"/>
                     <field name="amount_untaxed_signed" string="Tax Excluded" sum="Total" optional="show"/>

--- a/addons/calendar_sms/views/calendar_views.xml
+++ b/addons/calendar_sms/views/calendar_views.xml
@@ -33,8 +33,8 @@
             <xpath expr="//div[@name='send_buttons']" position="inside">
                 <button name="action_send_sms" help="Send SMS to attendees" type="object" string="SMS" icon="fa-mobile"/>
             </xpath>
-            <xpath expr="//field[@name='phone']" position="replace">
-                <field name="phone" widget="phone" options="{'enable_sms': false}"/>
+            <xpath expr="//field[@name='phone']" position="attributes">
+                <attribute name="options">{'enable_sms': false}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The goal is to be able to add a required attribute to the fields :
phone, mobile and email when necessary in l10n modules.
    
But this was not possible due to the use of position="replace"
in modules that are installed after account_report.
    
So instead of replacing the entire field, the attributes are added
when and where they are needed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
