### PR TITLE
[FIX] stock: Access right issue for "Own Document" Sales User

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -176,8 +176,8 @@ class StockMove(models.Model):
     next_serial = fields.Char('First SN')
     next_serial_count = fields.Integer('Number of SN')
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Original Reordering Rule', check_company=True)
-    forecast_availability = fields.Float('Forecast Availability', compute='_compute_forecast_information', digits='Product Unit of Measure')
-    forecast_expected_date = fields.Datetime('Forecasted Expected date', compute='_compute_forecast_information')
+    forecast_availability = fields.Float('Forecast Availability', compute='_compute_forecast_information', digits='Product Unit of Measure', compute_sudo=True)
+    forecast_expected_date = fields.Datetime('Forecasted Expected date', compute='_compute_forecast_information', compute_sudo=True)
     lot_ids = fields.Many2many('stock.production.lot', compute='_compute_lot_ids', inverse='_set_lot_ids', string='Serial Numbers', readonly=False)
 
     @api.onchange('product_id', 'picking_type_id')


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider that Reservation = manual (Inventory>Configuration)
- Let's consider two interna users I1 and I2 with the following access rights:
   -Sales: own document only
   -Inventory: user
- Login as I1 : Create sale order SO1 to sell a storable product P
- Confirm SO1 to create delivery order DO1
- SO1's Sales Person should be assigned to I1 and DO1's status should be "waiting"
- Login as I2 : Create sale order SO2 to sell P
- Confirm SO2 to create delivery order DO2
- SO2's Sales Person should be assigned to I2 and DO2's status should be "waiting"

Bug:

When I1 or I2 tried to access DO1 or DO2, an access error was raised due to personal order line record rule

opw:2530101