### PR TITLE
[FIX] point_of_sale: default state/country are not saved on creating

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
@@ -10,7 +10,11 @@ odoo.define('point_of_sale.ClientDetailsEdit', function(require) {
         constructor() {
             super(...arguments);
             this.intFields = ['country_id', 'state_id', 'property_product_pricelist'];
-            this.changes = {};
+            const partner = this.props.partner;
+            this.changes = {
+                'country_id': partner.country_id && partner.country_id[0],
+                'state_id': partner.state_id && partner.state_id[0],
+            };
         }
         mounted() {
             this.env.bus.on('save-customer', this, this.saveChanges);


### PR DESCRIPTION
STEPS:
* set state/country for current company
* open POS
* create partner without changing default state/country values

BEFORE: the values are not saved
AFTER:  the values are saved

WHY: the values are set, but not copied to `changes` variable:

https://github.com/odoo/odoo/blob/2a8f777c04bdbdce77dc44d92e099612f158cbef/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js#L43-L44

---

opw-2519788

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
