### PR TITLE
[FIX] fields: use `SAVEPOINT` when really creating the index

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -999,8 +999,7 @@ class Field(MetaField('DummyField', (object,), {})):
         indexname = '%s_%s_index' % (model._table, self.name)
         if self.index:
             try:
-                with model._cr.savepoint():
-                    sql.create_index(model._cr, indexname, model._table, ['"%s"' % self.name])
+                sql.create_index(model._cr, indexname, model._table, ['"%s"' % self.name])
             except psycopg2.OperationalError:
                 _schema.error("Unable to add index for %s", self)
         else:

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -195,7 +195,8 @@ def create_index(cr, indexname, tablename, expressions):
     if index_exists(cr, indexname):
         return
     args = ', '.join(expressions)
-    cr.execute('CREATE INDEX "{}" ON "{}" ({})'.format(indexname, tablename, args))
+    with cr.savepoint():
+        cr.execute('CREATE INDEX "{}" ON "{}" ({})'.format(indexname, tablename, args))
     _schema.debug("Table %r: created index %r (%s)", tablename, indexname, args)
 
 def create_unique_index(cr, indexname, tablename, expressions):


### PR DESCRIPTION
`update_db_index` is meant
to skip the creation of the index if it fails.

It therefore uses `with cr.savepoint()` for that purpose

But, before this revision, it surrounds `create_index`,
in which the index creation is skipped if it already exists.

Meaning, if the index already exists,
a savepoint was created for nothing.

Creating a savepoint has a cost.
Therefore, avoiding to create one when it's not necessary
is better for the performances.

In addition, during an installation / upgrades,
a lot of index are attempted to be created,
and the performance of postgresql are degraded
when there are more than 64 savepoints within the same transaction,
which could easily happen when installing/updating a module,
while attempting to create all its indexes (despite they already existed).

Moving only the `with cr.savepoint`, without moving the `try..except`
will have no impact on the API. It's still the role
of the method calling `create_index` to catch the exception
if it wants to.
Besides, for the methods which are calling `create_index`
without a `try..except` block, the transaction will still
be rollbacked, as it's the case for any uncatched exception
in Odoo.

There is therefore no downside to move `cr.savepoint` into `create_index`.
