### PR TITLE
[FIX] hr_employee: remove duplicates from working_hours computation

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -158,7 +158,7 @@ class HrEmployeeBase(models.AbstractModel):
     def _get_employee_working_now(self):
         working_now = []
         # We loop over all the employee tz and the resource calendar_id to detect working hours in batch.
-        all_employee_tz = self.mapped('tz')
+        all_employee_tz = set(self.mapped('tz'))
         for tz in all_employee_tz:
             employee_ids = self.filtered(lambda e: e.tz == tz)
             resource_calendar_ids = employee_ids.mapped('resource_calendar_id')


### PR DESCRIPTION
Since the computation of employees work intervals is done in batch, i.e. 1 call to `resource.calendar._work_intervals` for each (tz, resource_calendar_id) pairs, removing tz duplicates from mapped results improves the perf of hr_presence_state/hr_icon_display computations.

This is especially true for grouped hr.employee kanban view as each column search_read triggers a recompute for these fields.

##### Some speedup data

###### Client DB, 3851 active employees, 6 tz, 52 resource_calendar, Employee Kanban grouped by country, search_read time averaged on kanban columns

| Before PR | After PR |
|:--------------:|:-----------:|
|400ms | 180ms |

###### _get_employee_working_now avg time by employees with 6tz, 52 resource_calendar

| Employees | Before PR | After PR |
|:---------------:|:-------------:|:------------:|
|1 | 0.01s | 0.01s |
|10 | 0.12s | 0.035s |
|100 | 4.15s | 0.1s |
|500 | 37s | 0.2s |
|1000 | 2m17s | 0.32s |

###### _get_employee_working_now avg time by distinct tz with 500 employees

| tz | Before PR | After PR|
|:--:|:--------------:|:-----------:|
|10| 8.59s | 0.26s |
|50| 3.37s | 0.41s |
|100| 2.53s | 0.58s |
|500| 1.71s | 1.71s |

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
