### PR TITLE
[FIX] website_sale_stock: allow user to show qty from locations

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
         if combination_info['product_id']:
             product = self.env['product.product'].sudo().browse(combination_info['product_id'])
             website = self.env['website'].get_current_website()
-            virtual_available = product.with_context(warehouse=website.warehouse_id.id).virtual_available
+            virtual_available = product.with_context(warehouse=website.warehouse_id.id, location=website.stock_location_ids.ids).virtual_available
             combination_info.update({
                 'virtual_available': virtual_available,
                 'virtual_available_formatted': self.env['ir.qweb.field.float'].value_to_html(virtual_available, {'decimal_precision': 'Product Unit of Measure'}),

--- a/addons/website_sale_stock/models/res_config_settings.py
+++ b/addons/website_sale_stock/models/res_config_settings.py
@@ -15,6 +15,7 @@ class ResConfigSettings(models.TransientModel):
     ], string='Inventory Availability', default='never')
     available_threshold = fields.Float(string='Availability Threshold')
     website_warehouse_id = fields.Many2one('stock.warehouse', related='website_id.warehouse_id', domain="[('company_id', '=', website_company_id)]", readonly=False)
+    website_stock_location_ids = fields.Many2many('stock.location', related='website_id.stock_location_ids', domain="[('company_id', '=', website_company_id)]", readonly=False)
 
     def set_values(self):
         super(ResConfigSettings, self).set_values()
@@ -34,3 +35,6 @@ class ResConfigSettings(models.TransientModel):
     def _onchange_website_company_id(self):
         if self.website_warehouse_id.company_id != self.website_company_id:
             return {'value': {'website_warehouse_id': False}}
+        # Checking against first location is enough, as website_stock_location_ids can't have different companies (forced domain)
+        if self.website_stock_location_ids and self.website_stock_location_ids[0].company_id != self.website_company_id:
+            return {'value': {'website_stock_location_ids': False}}

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -20,8 +20,12 @@ class SaleOrder(models.Model):
                 # The quantity should be computed based on the warehouse of the website, not the
                 # warehouse of the SO.
                 website = self.env['website'].get_current_website()
-                if cart_qty > line.product_id.with_context(warehouse=website.warehouse_id.id).virtual_available and (line_id == line.id):
-                    qty = line.product_id.with_context(warehouse=website.warehouse_id.id).virtual_available - cart_qty
+                line_product_with_context = line.product_id.with_context(
+                    warehouse=website.warehouse_id.id,
+                    location=website.stock_location_ids.ids,
+                )
+                if cart_qty > line_product_with_context.virtual_available and (line_id == line.id):
+                    qty = line_product_with_context.virtual_available - cart_qty
                     new_val = super(SaleOrder, self)._cart_update(line.product_id.id, line.id, qty, 0, **kwargs)
                     values.update(new_val)
 

--- a/addons/website_sale_stock/models/website.py
+++ b/addons/website_sale_stock/models/website.py
@@ -1,11 +1,31 @@
 # -*- coding: utf-8 -*-
+
+from ast import literal_eval
+
 from odoo import api, fields, models
 
 
 class Website(models.Model):
     _inherit = 'website'
 
+    # Deprecated, will be removed in master/saas-14.4 in favor of `stock_location_ids`
     warehouse_id = fields.Many2one('stock.warehouse', string='Warehouse')
+    # Stable fix, no compute/inverse in master/saas-14.4
+    stock_location_ids = fields.Many2many('stock.location', string='Locations', compute='_compute_stock_location_ids', inverse='_inverse_stock_location_ids')
+
+    def _compute_stock_location_ids(self):
+        ICP = self.env['ir.config_parameter']
+        for website in self:
+            key = 'website_%s_stock_location_ids' % website.id
+            location_ids = literal_eval(ICP.sudo().get_param(key, "[]"))
+            website.stock_location_ids = self.env['stock.location'].browse(location_ids)
+
+    def _inverse_stock_location_ids(self):
+        for website in self:
+            self.env['ir.config_parameter'].sudo().set_param(
+                'website_%s_stock_location_ids' % website.id,
+                website.stock_location_ids.ids,
+            )
 
     def _prepare_sale_order_values(self, partner, pricelist):
         self.ensure_one()

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -72,3 +72,74 @@ class TestWebsiteSaleStockProductWarehouse(TestWebsiteSaleProductAttributeValueC
 
         # Check available quantity of product is according to warehouse
         self.assertEqual(combination_info['virtual_available'], 0, "Product B should not be available in warehouse 1.")
+
+    def test_02_get_combination_info_locations(self):
+        """ Checked that correct product quantity is shown in website according
+        to the stock locations set on the current website.
+            - Create a warehouse with 2 locations
+            - Create two stockable products
+            - Update quantity of Product A in Location 1
+            - Update quantity of Product A in Location 2
+            - Update quantity of Product B in Location 2
+            - Set Location 1 in website
+            - Check available quantity of Product A and Product B in website
+        Product A should be available in the website as it is available in Location 1 but Product B
+        should not be available in website as it is stored in Location 2.
+        Also, only quantity of Location 1 should be used on website.
+        """
+        # Setup
+        warehouse = self.env['stock.warehouse'].create({
+            'name': 'Warehouse 1',
+            'code': 'WH1',
+        })
+        location_1 = self.env['stock.location'].create({
+            'name': 'Room A',
+            'location_id': warehouse.lot_stock_id.id,
+        })
+        location_2 = self.env['stock.location'].create({
+            'name': 'Room B',
+            'location_id': warehouse.lot_stock_id.id,
+        })
+        product_1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'inventory_availability': 'always',
+            'type': 'product',
+            'default_code': 'E-COM1',
+        })
+        product_2 = self.env['product.product'].create({
+            'name': 'Product B',
+            'inventory_availability': 'always',
+            'type': 'product',
+            'default_code': 'E-COM2',
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product_1.id,
+            'inventory_quantity': 10.0,
+            'location_id': location_1.id,
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product_1.id,
+            'inventory_quantity': 10.0,
+            'location_id': location_2.id,
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product_2.id,
+            'inventory_quantity': 10.0,
+            'location_id': location_2.id,
+        })
+        current_website = self.env['website'].get_current_website()
+        current_website.stock_location_ids = location_1
+
+        # Tests
+        product = product_1.with_context(website_id=current_website.id)
+        combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
+        self.assertEqual(combination_info['virtual_available'], 10, "10 units of Product A should be available in Location 1. Location 2 should be ignored.")
+
+        product = product_2.with_context(website_id=current_website.id)
+        combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
+        self.assertEqual(combination_info['virtual_available'], 0, "Product B should not be available in Location 1.")
+
+        current_website.stock_location_ids = location_1 + location_2
+        product = product_1.with_context(website_id=current_website.id)
+        combination_info = product.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info()
+        self.assertEqual(combination_info['virtual_available'], 20, "10 units in Location 1 and 10 units in Location 2.")

--- a/addons/website_sale_stock/views/res_config_settings_views.xml
+++ b/addons/website_sale_stock/views/res_config_settings_views.xml
@@ -16,6 +16,10 @@
                         <label for="website_warehouse_id" string="Warehouse" class="col-lg-3 o_light_label" />
                         <field name="website_warehouse_id"/>
                     </div>
+                    <div class="row mt16" attrs="{'invisible': [('group_stock_multi_warehouses', '=', False)]}">
+                        <label for="website_stock_location_ids" string="Inventory Locations" class="col-lg-3 o_light_label" />
+                        <field name="website_stock_location_ids" widget="many2many_tags" options="{'no_create': True, 'no_open': True}"/>
+                    </div>
                     <div class="row mt16" title="Default availability mode set on newly created storable products. This can be changed at the product level.">
                         <label for="inventory_availability" string="Mode" class="col-lg-3 o_light_label" />
                         <field name="inventory_availability" string="Inventory"/>


### PR DESCRIPTION
Before this commit, one could set a warehouse ID on his website to restrict the
product quantity computation to that warehouse only. This was introduced with
2b484317ff01.

That behavior is not enough, as one might want to use more than one warehouse
to compute the available quantity.
This commit allows that by setting some stock locations to a website. Then only
those locations will be used to compute the quantity.

It will allow more flexible configuration than replacing `warehouse_id` by
`warehouse_ids`, for instance, one could have this setup:

```
  warehouse 1
     Location ecommerce 1
        shelf 1
        shelf 2
     Location Retail 1
        shelf 3
        shelf 4
  warehouse 2
     Location ecommerce 2
        shelf 5
        shelf 6
     Location Retail 2
        shelf 7
        shelf 8
```

Note that we can't just restrict the computation to the website's company, as
it would break such flows (which is not legal in every country):

```
  - odoo.fr, linked to a French company
  - odoo.nl, linked to a Dutch company
  - odoo.es, linked to a Spanish company

  The 3 companies resupply from some Belgian company, which handles all the stock.
```

Closes #60190, closes #70455
opw-2363507
