### PR TITLE
[FIX] hr_timesheet: fix date issue in activity report

### DIFF
--- a/addons/hr_timesheet/models/project_update.py
+++ b/addons/hr_timesheet/models/project_update.py
@@ -28,10 +28,10 @@ class ProjectUpdate(models.Model):
     def _get_activities(self, project):
         if not self.user_has_groups('hr_timesheet.group_hr_timesheet_user'):
             return []
-        today = fields.Datetime.today()
+        today = fields.Date.context_today(self)
         query = """
                 SELECT timesheet.employee_id as employee_id,
-                       gs as period,
+                       gs::date as period,
                        sum(timesheet.unit_amount) as unit_amount,
                        employee.name as name
                   FROM project_project p
@@ -40,8 +40,8 @@ class ProjectUpdate(models.Model):
             INNER JOIN hr_employee employee
                     ON timesheet.employee_id = employee.id
             CROSS JOIN generate_series(
-                        %(today)s::date - '180 days'::interval,
-                        %(today)s::date,
+                        %(today)s - '180 days'::interval,
+                        %(today)s,
                         '30 days'::interval
                        ) gs
                  WHERE p.id = %(project_id)s


### PR DESCRIPTION
Before this commit, the date taken into account to retrieve people
activities in the project update description was the UTC date. The
activities just recorded with the context_today date wasn't taken into
account.

Failing unit tests during nightly build (when date UTC < date GMT+2):
- `TestProjectUpdateHrTimesheet.test_project_update_description_people`
"AssertionError: 0 != 1 : The number of recorded timesheet activities
is 1"
- `TestProjectUpdateHrTimesheet.test_project_update_form_people`
"AssertionError: False is not true : The description should contain
'People'"

This commit fixes the issue using the context_today(self) date as a
reference.

Fixes PR : #68899
task-2393768

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
