### PR TITLE
[FIX] web_editor: libsass warning and also incorrect / confusing @extend

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -5,7 +5,7 @@
 }
 
 .o_wysiwyg_loader {
-    @extend .form-control:disabled;
+    @extend :disabled;
     pointer-events: none;
     min-height: 100px;
     color: transparent;


### PR DESCRIPTION
Apparently libsass has never actually supported compound selectors (or at least never the way people interpreted it should work).

Therefore since libsass 3.5 (July 2017) that is deprecated and emits a warning. Which is problematic because libsass is also hard-coded to emit its deprecation warning to stderr[^1], resulting in a few issues:

* because it's not decorated (let alone as a warning) it's not really noticeable on the runbot or in most dev logs
* but because it's not associated with a logger it's basically the only thing which shows up when running in `--log-level=warn` (as it's printed at least once per tour)
* and it's pretty gnarly to get the information back in Python as, again, hard-coded to stdout

odoo/odoo#70927 explored messing around with fds to intercept the writes and re-emit them to the proper location, but that was considered a bit too iffy.

And of course the intent was always to eventually fix the warning itself, which qsm provided for in [a comment][fix-extend], the important bit was the extension of `:disabled` so that's what's left here to fix the warning. The logic of the fix is that the loader is always used with the `form-control` class (internally) and the `:disabled` part of the `form-control` styling is what we really want to copy over. It's possible that third-party lose the styling if they use `o_wysiwyg_loader` alone (without an explicit `form-control` next to it) but that seems like an unlikely situation.

Alternatively we could just add the `,` and reproduce the existing behavior (just clarifying what the behaviour *is*), at the cost of a larger CSS (as today). That would be certain to not cause issues, while the current fix is only *unlikely* to cause issues, but saves some file-size in the final asset.

[^1] libsass 4 (sass/libsass#3135) surfaces warnings at the API level,
     and removes the hardcoded / direct stream writing

[fix-extend]: https://github.com/odoo/odoo/pull/70927#issuecomment-847964413
