### PR TITLE
[IMP] various: generic improvements for timesheets

### DIFF
--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -44,6 +44,13 @@
             <field name="act_window_id" ref="act_hr_timesheet_report"/>
         </record>
 
+        <record id="act_hr_timesheet_report_kanban" model="ir.actions.act_window.view">
+            <field name="sequence" eval="20"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="hr_timesheet.view_kanban_account_analytic_line"/>
+            <field name="act_window_id" ref="act_hr_timesheet_report"/>
+        </record>
+
         <record id="timesheet_action_report_by_project" model="ir.actions.act_window">
             <field name="name">Timesheets By Project</field>
             <field name="res_model">account.analytic.line</field>
@@ -87,6 +94,13 @@
             <field name="act_window_id" ref="timesheet_action_report_by_project"/>
         </record>
 
+        <record id="timesheet_action_view_report_by_project_kanban" model="ir.actions.act_window.view">
+            <field name="sequence" eval="20"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="hr_timesheet.view_kanban_account_analytic_line"/>
+            <field name="act_window_id" ref="timesheet_action_report_by_project"/>
+        </record>
+
         <record id="timesheet_action_report_by_task" model="ir.actions.act_window">
             <field name="name">Timesheets By Task</field>
             <field name="res_model">account.analytic.line</field>
@@ -127,6 +141,13 @@
             <field name="sequence" eval="15"/>
             <field name="view_mode">form</field>
             <field name="view_id" ref="hr_timesheet.hr_timesheet_line_form"/>
+            <field name="act_window_id" ref="timesheet_action_report_by_task"/>
+        </record>
+
+        <record id="timesheet_action_view_report_by_task_kanban" model="ir.actions.act_window.view">
+            <field name="sequence" eval="20"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="hr_timesheet.view_kanban_account_analytic_line"/>
             <field name="act_window_id" ref="timesheet_action_report_by_task"/>
         </record>
 

--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -1,4 +1,64 @@
 <odoo>
+    <template id="hr_timesheet.timesheet_table">
+        <div class="row" style="margin-top:10px;">
+            <div class="col-lg-12">
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th class="align-middle"><span>Date</span></th>
+                            <th class="align-middle"><span>Responsible</span></th>
+                            <th class="align-middle"><span>Description</span></th>
+                            <th class="align-middle" t-if="show_project"><span>Project</span></th>
+                            <th class="align-middle" t-if="show_task"><span>Task</span></th>
+                            <th class="text-right">
+                                <span t-if="is_uom_day">Time Spent (Days)</span>
+                                <span t-else="">Time Spent (Hours)</span>
+                            </th>
+                        </tr>
+                   </thead>
+                   <tbody>
+                        <tr t-foreach="lines" t-as="line">
+                            <td>
+                               <span t-field="line.date"/>
+                            </td>
+                            <td>
+                               <span t-field="line.user_id.partner_id.name"/>
+                               <span t-if="not line.user_id.partner_id.name" t-field="line.employee_id"/>
+                            </td>
+                            <td >
+                                <span t-field="line.name" t-options="{'widget': 'text'}"/>
+                            </td>
+                            <td t-if="show_project">
+                                <span t-field="line.project_id.sudo().name"/>
+                            </td>
+                            <td t-if="show_task">
+                                <t t-if="line.task_id"><span t-field="line.task_id.sudo().name"/></t>
+                            </td>
+                            <td class="text-right">
+                                <span t-if="is_uom_day" t-esc="line._get_timesheet_time_day()" t-options="{'widget': 'timesheet_uom'}"/>
+                                <span t-else="" t-field="line.unit_amount" t-options="{'widget': 'duration', 'digital': True, 'unit': 'hour', 'round': 'minute'}"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <t t-set="nbCols" t-value="4"/>
+                            <t t-if="show_project" t-set="nbCols" t-value="nbCols + 1"/>
+                            <t t-if="show_task" t-set="nbCols" t-value="nbCols + 1"/>
+                            <td class="text-right" t-attf-colspan="{{nbCols}}">
+                                <strong t-if="is_uom_day">
+                                    <span style="margin-right: 15px;">Total (Days)</span>
+                                    <t t-esc="lines._convert_hours_to_days(sum(lines.mapped('unit_amount')))" t-options="{'widget': 'timesheet_uom'}"/>
+                                </strong>
+                                <strong t-else="">
+                                    <span style="margin-right: 15px;">Total (Hours)</span>
+                                    <t t-esc="sum(lines.mapped('unit_amount'))" t-options="{'widget': 'duration', 'digital': True, 'unit': 'hour', 'round': 'minute'}"/>
+                                </strong>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </template>
     <template id="report_timesheet">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
@@ -18,66 +78,9 @@
                             </h2>
                         </div>
                     </div>
-
-                    <div class="row" style="margin-top:10px;">
-                        <div class="col-lg-12">
-                            <t t-set='is_uom_day' t-value='docs._is_timesheet_encode_uom_day()'/>
-                            <table class="table table-sm">
-                                <thead>
-                                    <tr>
-                                        <th class="align-middle"><span>Date</span></th>
-                                        <th class="align-middle"><span>Responsible</span></th>
-                                        <th class="align-middle"><span>Description</span></th>
-                                        <th class="align-middle" t-if="show_project"><span>Project</span></th>
-                                        <th class="align-middle" t-if="show_task"><span>Task</span></th>
-                                        <th class="text-right">
-                                            <span t-if="is_uom_day">Time Spent (Days)</span>
-                                            <span t-else="">Time Spent (Hours)</span>
-                                        </th>
-                                    </tr>
-                               </thead>
-                               <tbody>
-                                    <tr t-foreach="docs" t-as="l">
-                                        <td>
-                                           <span t-field="l.date"/>
-                                        </td>
-                                        <td>
-                                           <span t-field="l.user_id.partner_id.name"/>
-                                           <span t-if="not l.user_id.partner_id.name" t-field="l.employee_id"/>
-                                        </td>
-                                        <td >
-                                            <span t-field="l.name" t-options="{'widget': 'text'}"/>
-                                        </td>
-                                        <td t-if="show_project">
-                                            <span t-field="l.project_id.sudo().name"/>
-                                        </td>
-                                        <td t-if="show_task">
-                                            <t t-if="l.task_id"><span t-field="l.task_id.sudo().name"/></t>
-                                        </td>
-                                        <td class="text-right">
-                                            <span t-if="is_uom_day" t-esc="l._get_timesheet_time_day()" t-options="{'widget': 'timesheet_uom'}"/>
-                                            <span t-else="" t-field="l.unit_amount" t-options="{'widget': 'duration', 'digital': True, 'unit': 'hour', 'round': 'minute'}"/>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <t t-set="nbCols" t-value="4"/>
-                                        <t t-if="show_project" t-set="nbCols" t-value="nbCols + 1"/>
-                                        <t t-if="show_task" t-set="nbCols" t-value="nbCols + 1"/>
-                                        <td class="text-right" t-attf-colspan="{{nbCols}}">
-                                            <strong t-if="is_uom_day">
-                                                <span style="margin-right: 15px;">Total (Days)</span>
-                                                <t t-esc="docs._convert_hours_to_days(sum(docs.mapped('unit_amount')))" t-options="{'widget': 'timesheet_uom'}"/>
-                                            </strong>
-                                            <strong t-else="">
-                                                <span style="margin-right: 15px;">Total (Hours)</span>
-                                                <t t-esc="sum(docs.mapped('unit_amount'))" t-options="{'widget': 'duration', 'digital': True, 'unit': 'hour', 'round': 'minute'}"/>
-                                            </strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                    <t t-set='is_uom_day' t-value='docs._is_timesheet_encode_uom_day()'/>
+                    <t t-set='lines' t-value='docs'/>
+                    <t t-call="hr_timesheet.timesheet_table"/>
                     <div class="oe_structure"/>
                 </div>
             </t>
@@ -91,6 +94,51 @@
         <field name="report_name">hr_timesheet.report_timesheet</field>
         <field name="report_file">report_timesheet</field>
         <field name="binding_model_id" ref="model_account_analytic_line"/>
+        <field name="binding_type">report</field>
+    </record>
+
+    <!-- Project Task Timesheet Report -->
+    <template id="report_project_task_timesheet">
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <t t-set="show_Task" t-value="len(docs.mapped('id')) == 1"/>
+                <div class="page">
+                    <t t-foreach="docs" t-as="doc">
+                        <div class="oe_structure"/>
+                        <div class="row" style="margin-top:10px;">
+                            <div class="col-lg-12">
+                                <t t-if="doc.allow_timesheets and doc.timesheet_ids">
+                                    <h1 class="mt-4 mb-4">
+                                        <t t-if="not show_Task">
+                                            Task: <span t-field="doc.name"/>
+                                        </t>
+                                    </h1>
+                                    <h2>
+                                        <span>Timesheet Entries
+                                            <t t-if="show_Task">
+                                                for the <t t-esc="doc.name"/> Task
+                                            </t>
+                                        </span>
+                                    </h2>
+                                    <t t-set='is_uom_day' t-value='doc.encode_uom_in_days'/>
+                                    <t t-set='lines' t-value='doc.timesheet_ids'/>
+                                    <t t-call="hr_timesheet.timesheet_table"/>
+                                </t>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
+    </template>
+
+    <record id="timesheet_report_task" model="ir.actions.report">
+        <field name="name">Timesheet Entries</field>
+        <field name="model">project.task</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">hr_timesheet.report_project_task_timesheet</field>
+        <field name="report_file">report_timesheet_task</field>
+        <field name="binding_model_id" ref="model_project_task"/>
         <field name="binding_type">report</field>
     </record>
 </odoo>

--- a/addons/hr_timesheet/static/src/js/task_with_hours.js
+++ b/addons/hr_timesheet/static/src/js/task_with_hours.js
@@ -17,7 +17,7 @@ const TaskWithHours = FieldMany2One.extend({
      * @override
      */
     _getDisplayNameWithoutHours: function (value) {
-        return value.split(' ‒ ')[0];
+        return value && value.split(' ‒ ')[0];
     },
     /**
      * @override

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -53,7 +53,7 @@
             <field name="name">account.analytic.line.pivot</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <pivot string="Timesheet" sample="1">
+                <pivot string="Timesheets" sample="1">
                     <field name="employee_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
@@ -78,7 +78,7 @@
             <field name="name">account.analytic.line.graph</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <graph string="Timesheet" sample="1" js_class="hr_timesheet_graphview">
+                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview">
                     <field name="task_id" type="row"/>
                     <field name="project_id" type="row"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -71,12 +71,19 @@
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('module_project_timesheet_synchro', '=', False), ('is_encode_uom_days', '=', True)]}">
                             <div class="o_setting_right_pane">
-                                <strong>Round Timesheets</strong>
-                                <div class="o_row w-30">
-                                    <span class="o_light_label"><label for="timesheet_min_duration"/><field name="timesheet_min_duration" class="col-lg-2 text-center"/> minutes</span>
+                                <strong>Time Rounding</strong>
+                                <div class="text-muted">
+                                    Minimal duration and rounding applied when using the timer
                                 </div>
-                                <div class="o_row">
-                                    <span class="o_light_label"><label for="timesheet_rounding"/><field name="timesheet_rounding" class="col-lg-2 text-center"/> minutes</span>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <div class="o_row w-30">
+                                            <span class="o_light_label"><label for="timesheet_min_duration"/><field name="timesheet_min_duration" class="col-lg-2 text-center"/> minutes</span>
+                                        </div>
+                                        <div class="o_row">
+                                            <span class="o_light_label"><label for="timesheet_rounding"/><field name="timesheet_rounding" class="col-lg-2 text-center"/> minutes</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/addons/sale_timesheet/views/account_invoice_views.xml
+++ b/addons/sale_timesheet/views/account_invoice_views.xml
@@ -2,12 +2,55 @@
 <odoo>
 
     <record id="action_timesheet_from_invoice" model="ir.actions.act_window">
-        <field name="name">Timesheet</field>
+        <field name="name">Timesheets</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">account.analytic.line</field>
-        <field name="view_mode">tree,form,graph</field>
-        <field name="context">{}</field>
+        <field name="view_mode">tree,form,graph,pivot,kanban,grid</field>
+        <field name="context">{'create': False, 'edit': False, 'delete': False}</field>
         <field name="domain">[('timesheet_invoice_id', '=', active_id)]</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No activities found
+            </p>
+            <p>
+                Track your working hours by projects every day and invoice this time to your customers.
+            </p>
+        </field>
+    </record>
+
+    <record id="action_timesheet_from_invoice_view_tree" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
+        <field name="act_window_id" ref="action_timesheet_from_invoice"/>
+    </record>
+
+    <record id="action_timesheet_from_invoice_view_form" model="ir.actions.act_window.view">
+        <field name="sequence" eval="4"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="hr_timesheet.hr_timesheet_line_form"/>
+        <field name="act_window_id" ref="action_timesheet_from_invoice"/>
+    </record>
+
+    <record id="action_timesheet_from_invoice_view_kanban" model="ir.actions.act_window.view">
+        <field name="sequence" eval="5"/>
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="hr_timesheet.view_kanban_account_analytic_line"/>
+        <field name="act_window_id" ref="action_timesheet_from_invoice"/>
+    </record>
+
+    <record id="action_timesheet_from_invoice_view_pivot" model="ir.actions.act_window.view">
+        <field name="sequence" eval="6"/>
+        <field name="view_mode">pivot</field>
+        <field name="view_id" ref="hr_timesheet.view_hr_timesheet_line_pivot"/>
+        <field name="act_window_id" ref="action_timesheet_from_invoice"/>
+    </record>
+
+    <record id="action_timesheet_from_invoice_view_graph" model="ir.actions.act_window.view">
+        <field name="sequence" eval="7"/>
+        <field name="view_mode">graph</field>
+        <field name="view_id" ref="hr_timesheet.view_hr_timesheet_line_graph"/>
+        <field name="act_window_id" ref="action_timesheet_from_invoice"/>
     </record>
 
     <record id="account_invoice_view_form_inherit_sale_timesheet" model="ir.ui.view">
@@ -16,8 +59,15 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="%(sale_timesheet.action_timesheet_from_invoice)d" type="action" class="oe_stat_button" icon="fa-calendar" attrs="{'invisible':[('timesheet_count','=', 0)]}">
-                    <field name="timesheet_count" widget="statinfo" string="Timesheets"/>
+                <field name="timesheet_count" invisible="1"/>
+                <button name="%(sale_timesheet.action_timesheet_from_invoice)d" type="action" class="oe_stat_button" icon="fa-clock-o" attrs="{'invisible': [('timesheet_count', '=', 0)]}" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="timesheet_total_duration" class="mr4" widget="statinfo" nolabel="1"/>
+                            <field name="timesheet_encode_uom_id" options="{'no_open': True}"/>
+                        </span>
+                        <span class="o_stat_text">Recorded</span>
+                    </div>
                 </button>
             </xpath>
         </field>

--- a/addons/sale_timesheet/views/sale_order_views.xml
+++ b/addons/sale_timesheet/views/sale_order_views.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//button[@name='action_view_invoice']" position="before">
-                        <field name="timesheet_count" invisible="1" />
+                        <field name="timesheet_count" invisible="1"/>
                         <button type="object"
                            name="action_view_timesheet"
                            class="oe_stat_button"
@@ -17,7 +17,7 @@
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="timesheet_total_duration" class="mr4" widget="statinfo" nolabel="1"/>
-                                    <field name="timesheet_encode_uom_id" options="{'no_open' : True}"/>
+                                    <field name="timesheet_encode_uom_id" options="{'no_open': True}"/>
                                 </span>
                                 <span class="o_stat_text">Recorded</span>
                             </div>


### PR DESCRIPTION
Purpose of the commit is to do the generic improvement for the
timesheets app.

So in this commit, done the following changes:
- added the "Timesheet Entries" report for the project.task object in project app.
- added the "Minimal duration and rounding applied when using the timer"
  description for 'round timesheets' in the setting of the timesheets app.
- added the kanban view for the "reporting" menus in the timesheets app.
- change the 'x Timesheets' stat button into 'x Hours recorded' and icon to
  'fa-clock-o' in invoice form view.

TaskID: 2464407

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
