### PR TITLE
[FIX] website_blog: fix cover display on posts list page 

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -152,11 +152,11 @@ $o-wblog-loader-size: 50px;
         // ==============================================
         &.o_wblog_post_page_cover_regular {
             &.o_full_screen_height {
-                min-height: 350px;
+                min-height: 70vh !important;
             }
 
             &.o_half_screen_height {
-                min-height: 250px;
+                min-height: 40vh !important;
             }
 
             &.cover_auto {

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -248,6 +248,9 @@ $o-wblog-loader-size: 50px;
 
             padding-top: 33%;
             height: auto!important;
+            // This is mandatory as we do not want the CoverProperties 
+            // sizing classes to be applied here
+            min-height: auto!important;
 
             &:hover .o_record_cover_image {
                 opacity: 0.8;

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -244,7 +244,6 @@ $o-wblog-loader-size: 50px;
     #o_wblog_posts_loop {
         .o_record_cover_container {
             box-shadow: inset 0 0 0 1px rgba(white, 0.3);
-            background: rgba(black, 0.1);
 
             padding-top: 33%;
             height: auto!important;


### PR DESCRIPTION
Before, cover sizing classes .cover_mid and .cover_full were declared as
nested in containers. Therefore, adding such class in another container
that did not define it had no effect.
Now, we use globally declared css variables .o_full_screen_height and
.o_half_screen_height that declare min-height as !important and it was
mandatory to override that property in places where we don't want to
use the cover sizing classes.

Also, the cover background color was not displayed correctly.

task-2497846

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
