### PR TITLE
[FIX] purchase: send email on RFQ confirmation

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -189,7 +189,9 @@ class PurchaseOrder(models.Model):
     def _track_subtype(self, init_values):
         self.ensure_one()
         if 'state' in init_values and self.state == 'purchase':
-            return 'purchase.mt_rfq_approved'
+            if init_values['state'] == 'to approve':
+                return 'purchase.mt_rfq_approved'
+            return 'purchase.mt_rfq_confirmed'
         elif 'state' in init_values and self.state == 'to approve':
             return 'purchase.mt_rfq_confirmed'
         elif 'state' in init_values and self.state == 'done':


### PR DESCRIPTION
When confirming a RfQ, even if a follower is subscribed to "RFQ
Confirmed", he will not receive any email.

To reproduce the error:
(Need a mail catcher)
1. Create a PO
2. Add a follower and edit his subscriptions:
    - Check 'RFQ Confirmed'
3. Confirm the PO

Error: No mail has been sent. The user should have been subscribed to
"RFQ Approved" to receive an email.

OPW-2447234