### PR TITLE
[FIX] stock_landed_costs: add an "onchange" to disable the "landed cost" option when we change the product type

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2668,6 +2668,14 @@ msgid "You cannot change the product of the value %s set on product %s."
 msgstr ""
 
 #. module: product
+#: code:addons/product/models/product_template.py:0
+#, python-format
+msgid ""
+"You cannot change the product type or disable landed cost option because the"
+" product is used in an account move line."
+msgstr ""
+
+#. module: product
 #: code:addons/product/models/product_attribute.py:0
 #, python-format
 msgid "You cannot change the value of the value %s set on product %s."

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -403,6 +403,11 @@ class ProductTemplate(models.Model):
         return templates
 
     def write(self, vals):
+        if (('type' in vals and vals['type'] != 'service') or ('landed_cost_ok' in vals and vals['landed_cost_ok'] == False)) and self.type == 'service' and self.landed_cost_ok:
+            if self.env['account.move.line'].search_count([('product_id', 'in', self.product_variant_ids.ids), ('is_landed_costs_line', '=', True)]):
+                raise UserError(_("You cannot change the product type or disable landed cost option because the product is used in an account move line."))
+            else:
+                vals['landed_cost_ok'] = False
         uom = self.env['uom.uom'].browse(vals.get('uom_id')) or self.uom_id
         uom_po = self.env['uom.uom'].browse(vals.get('uom_po_id')) or self.uom_po_id
         if uom and uom_po and uom.category_id != uom_po.category_id:


### PR DESCRIPTION
Steps to reproduce the bug:
- Install inventory and accounting app
- Enable the "Landed Costs" option in the inventory settings
- Go to inventory > Create a new "Storable Product" (e.g: "Product1")
- create a product category (e.g: "PC1") and specify an "income and expense account"
- Go to accounting > customers > invoice
- Create an invoice > add any customer > add the product "Product1" on the invoice line
- The income account specified in the product category "PC1" gets used on the invoice line.
- Go back to the product template and change the type to "Service"
- In the "Purchase" tab, enable "Is a Landed Cost" option
- Go back to the "General Information" tab and change the product type back to "Storable Product"
- Create a new invoice > add any customer > add the product "Product1"
- the expense account specified in the product category "PC1" gets used on the invoice line instead of the income account

Problem:
When we change the product type from "service" to another product type and the option "is a landed cost" is activated,
an “onchange” is not triggered to disable this option. So the invoice line will be treated as a landed cost line.

(FYI: https://github.com/odoo/odoo/blob/13.0/addons/stock_landed_costs/views/product_views.xml#L10
	https://github.com/odoo/odoo/blob/13.0/addons/stock_landed_costs/models/account_move.py#L70-L75)
	
Solution:
-Add a User Error if the user tries to disable the landed_cost_ok option or
  to change the product type when the product is used in an account move line.

Opw-2547663





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
