### PR TITLE
[FIX] web: select colors per cycle in a calendar

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -520,7 +520,7 @@ return AbstractModel.extend({
             var fieldName = this.fieldColor;
             _.each(events, function (event) {
                 var value = event.record[fieldName];
-                event.color_index = _.isArray(value) ? value[0] : value;
+                event.color_index = _.isArray(value) ? value[0] % 30 : value % 30;
             });
             this.model_color = this.fields[fieldName].relation || element.model;
         }
@@ -630,7 +630,7 @@ return AbstractModel.extend({
                 _.each(data, function (_value) {
                     var value = _.isArray(_value) ? _value[0] : _value;
                     var f = {
-                        'color_index': self.model_color === (field.relation || element.model) ? value : false,
+                        'color_index': self.model_color === (field.relation || element.model) ? value % 30 : false,
                         'value': value,
                         'label': fieldUtils.format[field.type](_value, field) || _t("Undefined"),
                         'avatar_model': field.relation || element.model,


### PR DESCRIPTION
To reproduce the error:
1. Have a DB with > 24 users
2. Create an event for each user (in same week)
3. Open Week view in Calendar

Error: the first 24 users have a different color, but all the others
will have the same color.

30 colors are available:
https://github.com/odoo/odoo/blob/94b3e339ba45f664e8b892067a4dd3df134ec325/addons/web/static/src/scss/secondary_variables.scss#L9-L20
Therefore, each one should be used. Moreover, if the 30 colors are
already used once, the colors selection should cycle again on the 30
ones.

OPW-2532748
closes #70940