### PR TITLE
[IMP] point_of_sale: added `customer_note` field on orderlines

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -149,6 +149,7 @@
             'point_of_sale/static/src/js/Popups/OrderImportPopup.js',
             'point_of_sale/static/src/js/Popups/ProductConfiguratorPopup.js',
             'point_of_sale/static/src/js/Popups/CashOpeningPopup.js',
+            'point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.js',
             'point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/SetPricelistButton.js',
             'point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/SetFiscalPositionButton.js',
             'point_of_sale/static/src/js/ChromeWidgets/ClientScreenButton.js',

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -130,6 +130,7 @@ class PosConfig(models.Model):
     iface_print_via_proxy = fields.Boolean(string='Print via Proxy', help="Bypass browser printing and prints via the hardware proxy.")
     iface_scan_via_proxy = fields.Boolean(string='Scan via Proxy', help="Enable barcode scanning with a remotely connected barcode scanner and card swiping with a Vantiv card reader.")
     iface_big_scrollbars = fields.Boolean('Large Scrollbars', help='For imprecise industrial touchscreens.')
+    iface_orderline_customer_notes = fields.Boolean(string='Customer Notes', help='Allow to write notes for customer on Orderlines. This will be shown in the receipt.')
     iface_print_auto = fields.Boolean(string='Automatic Receipt Printing', default=False,
         help='The receipt will automatically be printed at the end of each order.')
     iface_print_skip_screen = fields.Boolean(string='Skip Preview Screen', default=True,

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -2163,6 +2163,17 @@ td {
     font-style:normal;
 }
 
+/* ------ ORDER NOTES ------- */
+
+.pos .order .orderline-note {
+    margin: 8px;
+    word-break: break-all;
+}
+.orderline-note .fa {
+    opacity: 0.5;
+    margin-right: 4px;
+}
+
 /*  ********* SplitBill ********* */
 
 .splitbill-screen .order-info {

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -59,6 +59,10 @@
     color: red;
 }
 
+.pos-receipt .pos-receipt-customer-note {
+    word-break: break-all;
+}
+
 .pos-payment-terminal-receipt {
     text-align: center;
     font-size: 75%;

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderlineDetails.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderlineDetails.js
@@ -46,6 +46,9 @@ odoo.define('point_of_sale.OrderlineDetails', function (require) {
         get pricePerUnit() {
             return ` ${this.unit} at ${this.unitPrice} / ${this.unit}`;
         }
+        get customerNote() {
+            return this.props.line.get_customer_note();
+        }
     }
     OrderlineDetails.template = 'OrderlineDetails';
 

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.js
@@ -1,0 +1,40 @@
+odoo.define('point_of_sale.OrderlineCustomerNoteButton', function(require) {
+    'use strict';
+
+    const PosComponent = require('point_of_sale.PosComponent');
+    const ProductScreen = require('point_of_sale.ProductScreen');
+    const { useListener } = require('web.custom_hooks');
+    const Registries = require('point_of_sale.Registries');
+
+    class OrderlineCustomerNoteButton extends PosComponent {
+        constructor() {
+            super(...arguments);
+            useListener('click', this.onClick);
+        }
+        async onClick() {
+            const selectedOrderline = this.env.pos.get_order().get_selected_orderline();
+            if (!selectedOrderline) return;
+
+            const { confirmed, payload: inputNote } = await this.showPopup('TextAreaPopup', {
+                startingValue: selectedOrderline.get_customer_note(),
+                title: this.env._t('Add Customer Note'),
+            });
+
+            if (confirmed) {
+                selectedOrderline.set_customer_note(inputNote);
+            }
+        }
+    }
+    OrderlineCustomerNoteButton.template = 'OrderlineCustomerNoteButton';
+
+    ProductScreen.addControlButton({
+        component: OrderlineCustomerNoteButton,
+        condition: function() {
+            return this.env.pos.config.iface_orderline_customer_notes;
+        },
+    });
+
+    Registries.Component.add(OrderlineCustomerNoteButton);
+
+    return OrderlineCustomerNoteButton;
+});

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/Orderline.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/Orderline.js
@@ -16,6 +16,9 @@ odoo.define('point_of_sale.Orderline', function(require) {
                 selected: this.props.line.selected,
             };
         }
+        get customerNote() {
+            return this.props.line.get_customer_note();
+        }
     }
     Orderline.template = 'Orderline';
 

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1634,6 +1634,7 @@ exports.Orderline = Backbone.Model.extend({
         this.full_product_name = '';
         this.id = orderline_id++;
         this.price_manually_set = false;
+        this.customerNote = this.customerNote || '';
 
         if (options.price) {
             this.set_unit_price(options.price);
@@ -1658,6 +1659,7 @@ exports.Orderline = Backbone.Model.extend({
             var pack_lot_line = new exports.Packlotline({}, {'json': _.extend(packlotline, {'order_line':this})});
             this.pack_lot_lines.add(pack_lot_line);
         }
+        this.set_customer_note(json.customer_note);
     },
     clone: function(){
         var orderline = new exports.Orderline({},{
@@ -1673,6 +1675,7 @@ exports.Orderline = Backbone.Model.extend({
         orderline.price = this.price;
         orderline.selected = false;
         orderline.price_manually_set = this.price_manually_set;
+        orderline.customerNote = this.customerNote;
         return orderline;
     },
     getPackLotLinesToEdit: function(isAllowOnlyOneLot) {
@@ -1877,6 +1880,8 @@ exports.Orderline = Backbone.Model.extend({
             return false;
         }else if (this.description !== orderline.description) {
             return false;
+        }else if (orderline.get_customer_note() !== this.get_customer_note()) {
+            return false;
         }else{
             return true;
         }
@@ -1905,6 +1910,7 @@ exports.Orderline = Backbone.Model.extend({
             description: this.description,
             full_product_name: this.get_full_product_name(),
             price_extra: this.get_price_extra(),
+            customer_note: this.get_customer_note(),
         };
     },
     //used to create a json of the ticket, to be sent to the printer
@@ -1928,7 +1934,8 @@ exports.Orderline = Backbone.Model.extend({
             tax:                this.get_tax(),
             product_description:      this.get_product().description,
             product_description_sale: this.get_product().description_sale,
-            pack_lot_lines:      this.get_lot_lines()
+            pack_lot_lines:      this.get_lot_lines(),
+            customer_note:      this.get_customer_note(),
         };
     },
     generate_wrapped_product_name: function() {
@@ -2345,6 +2352,12 @@ exports.Orderline = Backbone.Model.extend({
 
         return !selectedLine ? false : last_id === selectedLine.cid;
     },
+    set_customer_note: function(note) {
+        this.customerNote = note;
+    },
+    get_customer_note: function() {
+        return this.customerNote;
+    }
 });
 
 var OrderlineCollection = Backbone.Collection.extend({

--- a/addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderlineDetails.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderlineDetails.xml
@@ -15,6 +15,12 @@
                 </strong>
                 <span><t t-esc="pricePerUnit" /></span>
             </li>
+            <t t-if="customerNote">
+                <li class="info orderline-note">
+                    <i class="fa fa-sticky-note" role="img" aria-label="Customer Note" title="Customer Note"/>
+                    <t t-esc="customerNote" />
+                </li>
+            </t>
         </li>
     </t>
 

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderlineNoteButton" owl="1">
+    <t t-name="OrderlineCustomerNoteButton" owl="1">
         <div class="control-button">
-            <i class="fa fa-tag" />
+            <i class="fa fa-sticky-note" />
             <span> </span>
-            <span>Internal Note</span>
+            <span>Customer Note</span>
         </div>
     </t>
 

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -59,6 +59,12 @@
                         discount
                     </li>
                 </t>
+                <t t-if="customerNote">
+                    <li class="info orderline-note">
+                        <i class="fa fa-sticky-note" role="img" aria-label="Customer Note" title="Customer Note"/>
+                        <t t-esc="customerNote" />
+                    </li>
+                </t>
             </ul>
             <t t-if="props.line.get_lot_lines()">
                 <ul class="info-list">

--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -197,6 +197,11 @@
                     </span>
                 </div>
             </t>
+            <t t-if="line.customer_note">
+                <div class="pos-receipt-left-padding pos-receipt-customer-note">
+                    <t t-esc="line.customer_note"/>
+                </div>
+            </t>
             <t t-if="line.pack_lot_lines">
                 <div class="pos-receipt-left-padding">
                     <ul>

--- a/addons/point_of_sale/static/tests/tours/OrderManagementScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/OrderManagementScreen.tour.js
@@ -20,7 +20,7 @@ odoo.define('point_of_sale.tour.OrderManagementScreen', function (require) {
 
     // make one order and check if it can be seen from the management screen.
     // order 0001
-    makeFullOrder({ orderlist: [['Whiteboard Pen', '5', '6']], payment: ['Cash', '30'] });
+    makeFullOrder({ orderlist: [['Whiteboard Pen', '5', '6']], payment: ['Cash', '30'], customerNote: 'Customer Note' });
     Chrome.do.clickOrderManagementButton();
     OrderManagementScreen.check.isShown();
     OrderManagementScreen.check.orderlistHas({ orderName: '-0001', total: '30' });
@@ -108,7 +108,14 @@ odoo.define('point_of_sale.tour.OrderManagementScreen', function (require) {
     OrderManagementScreen.check.orderDetailsHas({
         lines: [{ product: 'Whiteboard Pen', quantity: '5' }],
         total: '30',
+        customerNote: 'Customer Note',
     });
+    //verify the customer note in the receipt
+    OrderManagementScreen.do.clickPrintReceiptButton();
+    OrderManagementScreen.check.reprintReceiptIsShown();
+    OrderManagementScreen.check.receiptCustomerNoteIs('Customer Note');
+    OrderManagementScreen.do.closeReceipt();
+
 
     // Select a paid order then invoice it. The selected order should remain selected
     // and will contain a new customer. After invoice, the current customer should be removed.

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -2,6 +2,7 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
     'use strict';
 
     const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
+    const { TextAreaPopup } = require('point_of_sale.tour.TextAreaPopupTourMethods');
     const { getSteps, startSteps } = require('point_of_sale.tour.utils');
     var Tour = require('web_tour.tour');
 
@@ -100,6 +101,15 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
     ProductScreen.check.selectedOrderlineHas('Monitor Stand', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
     ProductScreen.check.orderIsEmpty();
+
+    // Test OrderlineCustomerNoteButton
+    ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+    ProductScreen.do.clickOrderlineCustomerNoteButton();
+    TextAreaPopup.check.isShown();
+    TextAreaPopup.do.inputText('Test customer note');
+    TextAreaPopup.do.clickConfirm();
+    ProductScreen.check.orderlineHasCustomerNote('Desk Organizer', '1', 'Test customer note');
+
 
     Tour.register('ProductScreenTour', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
@@ -57,5 +57,13 @@ odoo.define('point_of_sale.tour.ReceiptScreen', function (require) {
     ReceiptScreen.check.totalAmountContains('$ 30.00 + $ 1.00 tip');
     ReceiptScreen.do.clickNextOrder();
 
+    // Test customer note in receipt
+    ProductScreen.exec.addOrderline('Desk Pad', '1', '5');
+    ProductScreen.exec.addCustomerNote('Test customer note')
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.do.clickPaymentMethod('Bank');
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.check.customerNoteIsThere('Test customer note');
+
     Tour.register('ReceiptScreenTour', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/CompositeTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/CompositeTourMethods.js
@@ -6,12 +6,15 @@ odoo.define('point_of_sale.tour.CompositeTourMethods', function (require) {
     const { PaymentScreen } = require('point_of_sale.tour.PaymentScreenTourMethods');
     const { ClientListScreen } = require('point_of_sale.tour.ClientListScreenTourMethods');
 
-    function makeFullOrder({ orderlist, customer, payment, ntimes = 1 }) {
+    function makeFullOrder({ orderlist, customer, payment, ntimes = 1 , customerNote}) {
         for (let i = 0; i < ntimes; i++) {
             ProductScreen.exec.addMultiOrderlines(...orderlist);
             if (customer) {
                 ProductScreen.do.clickCustomerButton();
                 ClientListScreen.exec.setClient(customer);
+            }
+            if (customerNote) { // this will add a note to the last selected order line
+                ProductScreen.exec.addCustomerNote(customerNote);
             }
             ProductScreen.do.clickPayButton();
             PaymentScreen.exec.pay(...payment);

--- a/addons/point_of_sale/static/tests/tours/helpers/OrderManagementScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/OrderManagementScreenTourMethods.js
@@ -102,7 +102,7 @@ odoo.define('point_of_sale.tour.OrderManagementScreenTourMethods', function (req
                 },
             ];
         }
-        orderDetailsHas({ lines, total }) {
+        orderDetailsHas({ lines, total, customerNote }) {
             const steps = [];
             for (let { product, quantity } of lines) {
                 steps.push({
@@ -117,6 +117,13 @@ odoo.define('point_of_sale.tour.OrderManagementScreenTourMethods', function (req
                     trigger: `.order-container .summary .total .value:contains("${total}")`,
                     run: () => {},
                 });
+            }
+            if (customerNote) {
+                steps.push({
+                    content: `order details has a line with a customer note: ${customerNote}`,
+                    trigger: `.orderlines .orderline-note:contains("${customerNote}")`,
+                    run: () => {},
+                })
             }
             return steps;
         }
@@ -170,6 +177,15 @@ odoo.define('point_of_sale.tour.OrderManagementScreenTourMethods', function (req
                 {
                     content: 'order management screen is not hidden',
                     trigger: `.order-management-screen:not(:has(.oe_hidden))`,
+                    run: () => {},
+                }
+            ]
+        }
+        receiptCustomerNoteIs(note) {
+            return [
+                {
+                    content: `receipt has customer note: ${note}`,
+                    trigger: `.orderlines .pos-receipt-left-padding:contains("${note}")`,
                     run: () => {},
                 }
             ]

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -2,6 +2,7 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
     'use strict';
 
     const { createTourMethods } = require('point_of_sale.tour.utils');
+    const { TextAreaPopup } = require('point_of_sale.tour.TextAreaPopupTourMethods');
 
     class Do {
         clickDisplayedProduct(name) {
@@ -123,6 +124,15 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 },
             ];
         }
+
+        clickOrderlineCustomerNoteButton() {
+            return [
+                {
+                    content: 'click customer note button',
+                    trigger: '.control-buttons .control-button span:contains("Customer Note")',
+                }
+            ]
+        }
     }
 
     class Check {
@@ -202,6 +212,20 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 },
             ];
         }
+        orderlineHasCustomerNote(name, quantity, note) {
+            return [
+                {
+                    content: `line has ${quantity} quantity`,
+                    trigger: `.order .orderline .product-name:contains("${name}") ~ .info-list em:contains("${quantity}")`,
+                    run: function () {}, // it's a check
+                },
+                {
+                    content: `line has '${note}' as customer note`,
+                    trigger: `.order .orderline .info-list .orderline-note:contains("${note}")`,
+                    run: function () {}, // it's a check
+                },
+            ]
+        }
     }
 
     class Execute {
@@ -247,6 +271,13 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 steps.push(...this.addOrderline(product, qty, price));
             }
             return steps;
+        }
+        addCustomerNote(note) {
+            const res = [];
+            res.push(...this._do.clickOrderlineCustomerNoteButton());
+            res.push(...TextAreaPopup._do.inputText(note));
+            res.push(...TextAreaPopup._do.clickConfirm());
+            return res;
         }
     }
 

--- a/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
@@ -67,6 +67,14 @@ odoo.define('point_of_sale.tour.ReceiptScreenTourMethods', function (require) {
                 },
             ];
         }
+
+        customerNoteIsThere(note) {
+            return [
+                {
+                    trigger: `.receipt-screen .orderlines .pos-receipt-left-padding:contains("${note}")`
+                }
+            ]
+        }
     }
 
     class Execute {

--- a/addons/point_of_sale/static/tests/tours/helpers/TextAreaPopupTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TextAreaPopupTourMethods.js
@@ -1,4 +1,4 @@
-odoo.define('pos_restaurant.tour.TextAreaPopupTourMethods', function (require) {
+odoo.define('point_of_sale.tour.TextAreaPopupTourMethods', function (require) {
     'use strict';
 
     const { createTourMethods } = require('point_of_sale.tour.utils');

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -37,6 +37,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         cls.main_pos_config = env['pos.config'].create({
             'name': 'Shop',
             'barcode_nomenclature_id': env.ref('barcodes.default_barcode_nomenclature').id,
+            'iface_orderline_customer_notes': True,
         })
 
         env['res.partner'].create({

--- a/addons/point_of_sale/views/point_of_sale_report.xml
+++ b/addons/point_of_sale/views/point_of_sale_report.xml
@@ -27,5 +27,4 @@
     </record>
 
     <template id="report_invoice" inherit_id="account.report_invoice" primary="True"/>
-
 </odoo>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -116,6 +116,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="iface_orderline_customer_notes">
+                            <div class="o_setting_left_pane">
+                                <field name="iface_orderline_customer_notes"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="iface_orderline_customer_notes"/>
+                                <div class="text-muted">
+                                    Add notes on order lines to be printed on receipt and invoice
+                                </div>
+                            </div>
+                        </div>
                         <div id="category_reference" class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="iface_display_categ_images"/>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -48,6 +48,7 @@
                                 <field name="full_product_name"/>
                                 <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
                                 <field name="qty"/>
+                                <field name="customer_note" optional="hide"/>
                                 <field name="product_uom_id" string="UoM" groups="uom.group_uom"/>
                                 <field name="price_unit" widget="monetary"/>
                                 <field name="discount" string="Disc.%" widget="monetary"/>

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -9,7 +9,7 @@ class PosConfig(models.Model):
 
     iface_splitbill = fields.Boolean(string='Bill Splitting', help='Enables Bill Splitting in the Point of Sale.')
     iface_printbill = fields.Boolean(string='Bill Printing', help='Allows to print the Bill before payment.')
-    iface_orderline_notes = fields.Boolean(string='Notes', help='Allow custom notes on Orderlines.')
+    iface_orderline_notes = fields.Boolean(string='Internal Notes', help='Allow custom internal notes on Orderlines.')
     floor_ids = fields.One2many('restaurant.floor', 'pos_config_id', string='Restaurant Floors', help='The restaurant floors served by this point of sale.')
     printer_ids = fields.Many2many('restaurant.printer', 'pos_config_printer_rel', 'config_id', 'printer_id', string='Order Printers')
     is_table_management = fields.Boolean('Floors & Tables')

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -10,7 +10,7 @@ from odoo import api, fields, models
 class PosOrderLine(models.Model):
     _inherit = 'pos.order.line'
 
-    note = fields.Char('Note added by the waiter.')
+    note = fields.Char('Internal Note added by the waiter.')
     mp_skip = fields.Boolean('Skip line when sending ticket to kitchen printers.')
     mp_dirty = fields.Boolean()
 
@@ -59,6 +59,7 @@ class PosOrder(models.Model):
             'mp_skip',
             'mp_dirty',
             'full_product_name',
+            'customer_note',
         ]
 
     def _get_order_lines(self, orders):

--- a/addons/pos_restaurant/static/src/css/restaurant.css
+++ b/addons/pos_restaurant/static/src/css/restaurant.css
@@ -307,17 +307,6 @@
     padding-left: 9px;
 }
 
-
-/* ------ ORDER NOTES ------- */
-
-.pos .order .orderline-note {
-    margin: 8px;
-}
-.orderline-note .fa {
-    opacity: 0.5;
-    margin-right: 4px;
-}
-
 /* ------ SPLIT BILL SCREEN ------- */
 
 .splitbill-screen.screen .contents {

--- a/addons/pos_restaurant/static/src/js/Screens/ProductScreen/ControlButtons/OrderlineNoteButton.js
+++ b/addons/pos_restaurant/static/src/js/Screens/ProductScreen/ControlButtons/OrderlineNoteButton.js
@@ -19,7 +19,7 @@ odoo.define('pos_restaurant.OrderlineNoteButton', function(require) {
 
             const { confirmed, payload: inputNote } = await this.showPopup('TextAreaPopup', {
                 startingValue: this.selectedOrderline.get_note(),
-                title: this.env._t('Add Note'),
+                title: this.env._t('Add Internal Note'),
             });
 
             if (confirmed) {
@@ -32,7 +32,7 @@ odoo.define('pos_restaurant.OrderlineNoteButton', function(require) {
     ProductScreen.addControlButton({
         component: OrderlineNoteButton,
         condition: function() {
-            return this.env.pos.config.module_pos_restaurant;
+            return this.env.pos.config.iface_orderline_notes;
         },
     });
 

--- a/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
@@ -1,7 +1,7 @@
 odoo.define('pos_restaurant.tour.ControlButtons', function (require) {
     'use strict';
 
-    const { TextAreaPopup } = require('pos_restaurant.tour.TextAreaPopupTourMethods');
+    const { TextAreaPopup } = require('point_of_sale.tour.TextAreaPopupTourMethods');
     const { NumberPopup } = require('point_of_sale.tour.NumberPopupTourMethods');
     const { Chrome } = require('pos_restaurant.tour.ChromeTourMethods');
     const { FloorScreen } = require('pos_restaurant.tour.FloorScreenTourMethods');

--- a/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -25,7 +25,7 @@ odoo.define('pos_restaurant.tour.ProductScreenTourMethods', function (require) {
             return [
                 {
                     content: 'click note button',
-                    trigger: '.control-buttons .control-button span:contains("Note")',
+                    trigger: '.control-buttons .control-button span:contains("Internal Note")',
                 },
             ];
         }

--- a/addons/pos_restaurant/views/pos_config_views.xml
+++ b/addons/pos_restaurant/views/pos_config_views.xml
@@ -103,7 +103,7 @@
                         <label for="iface_orderline_notes"/>
                         <span class="fa fa-lg fa-cutlery" title="For bars and restaurants" role="img" aria-label="For bars and restaurants"/>
                         <div class="text-muted">
-                            Add notes on order lines
+                            Add internal notes on order lines
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR allows the user to add a "Customer note" on a order line. This specific note will be visible to the customer through the receipt and invoice.

related task id: 2556994