### PR TITLE
[IMP] website_event_[exhibitor|meet|track]: hide "others" section whe…

### DIFF
--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -12,8 +12,10 @@
             <div id="oe_structure_wesponsor_index_1" class="oe_structure"/>
             <!-- Content -->
             <div t-att-class="'o_wevent_online_page_container %s' % ('container pb-3' if not option_widescreen else 'pb-3')">
-                <div class="row mb-5 mx-0">
-                    <t t-call="website_event_exhibitor.exhibitor_aside"/>
+                <div t-att-class="'row mb-5 mx-0 %s' % ('justify-content-center' if not sponsors_other else '')">
+                    <t t-if="sponsors_other">
+                        <t t-call="website_event_exhibitor.exhibitor_aside"/>
+                    </t>
                     <t t-call="website_event_exhibitor.exhibitor_main"/>
                 </div>
             </div>

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -12,8 +12,10 @@
             <div id="oe_structure_wemeet_index_1" class="oe_structure"/>
             <!-- Content -->
             <div t-att-class="'o_wevent_online_page_container %s' % ('container pb-3' if not option_widescreen else 'pb-3')">
-                <div class="row mb-5 mx-0">
-                    <t t-call="website_event_meet.meeting_room_aside"/>
+                <div t-att-class="'row mb-5 mx-0 %s' % ('justify-content-center' if not meeting_rooms_other else '')">
+                    <t t-if="meeting_rooms_other">
+                        <t t-call="website_event_meet.meeting_room_aside"/>
+                    </t>
                     <t t-call="website_event_meet.meeting_room_main"/>
                 </div>
             </div>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -11,8 +11,10 @@
             <div id="oe_structure_wesession_track_index_1" class="oe_structure"/>
             <!-- Content -->
             <div t-att-class="'o_wevent_online_page_container %s' % ('container pb-3' if not option_widescreen else 'pb-3')">
-                <div class="row mb-5 mx-0">
-                    <t t-call="website_event_track.event_track_aside"/>
+                <div t-att-class="'row mb-5 mx-0 %s' % ('justify-content-center' if not tracks_other else '')">
+                    <t t-if="tracks_other">
+                        <t t-call="website_event_track.event_track_aside"/>
+                    </t>
                     <t t-call="website_event_track.event_track_content"/>
                 </div>
             </div>


### PR DESCRIPTION
…n there is a single item

This commit hides "other" tracks/rooms and exhibitor sections if there is only
a single record for these.

Purpose is:
Allow users to handle events that do not have a ton of things happening at the
same time without showing empty sections.
Example: I use Odoo events to broadcast my concert/zoom conference/... online
and want my website to look neat.

Task-2531084

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
