### PR TITLE
[FIX] account: use default bank account in batch payments

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -128,7 +128,7 @@ class AccountPaymentRegister(models.TransientModel):
             'partner_id': line.partner_id.id,
             'account_id': line.account_id.id,
             'currency_id': (line.currency_id or line.company_currency_id).id,
-            'partner_bank_id': line.move_id.partner_bank_id.id,
+            'partner_bank_id': (line.move_id.partner_bank_id or line.partner_id.commercial_partner_id.bank_ids[:1]).id,
             'partner_type': 'customer' if line.account_internal_type == 'receivable' else 'supplier',
             'payment_type': 'inbound' if line.balance > 0.0 else 'outbound',
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In case we register one payment on a single accounting entry, we can manually
specify the bank account that will be used. In case we register one global payment
for several entries, the bank account is not visible in the payment register wizard.
We should use the first bank account set on the partner as a default case to allow
it and not block the whole process.

opw-2496440

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
