### PR TITLE
[FIX] point_of_sale: restore old total computation

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1342,7 +1342,7 @@ exports.PosModel = Backbone.Model.extend({
             i -= 1;
         });
 
-        var total_excluded = recompute_base(base, incl_fixed_amount, incl_percent_amount, incl_division_amount, currency_rounding);
+        var total_excluded = recompute_base(base, incl_fixed_amount, incl_percent_amount, incl_division_amount, this.currency.rounding);
         var total_included = total_excluded;
 
         // 5) Iterate the taxes in the sequence order to fill missing base/amount values.


### PR DESCRIPTION
Enable rounding method: Globally
Have a [TAX] computed as 21% amount, included in price
Have 3 products:
* A, price 3.15, using [TAX], available in POS
* B, price 3.60, using [TAX], available in POS
* C, price 0.05, using [TAX], available in POS

Open POS session, add in cart 2*A, 1*B, 1*C
Total is computed as 9.96, but should be 9.95.
This occur because after b4f305aa74819f30d8ecd27630dbf35e1338be13
the amount used as base in section '5) Iterate the taxes in the sequence
order to fill missing base/amount values' is rounded with higher
precision rather than the base currency rounding, altering the
computation of the total with included tax

opw-2522180

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
