### PR TITLE
[IMP] hr_expense: use bank account defined on employee in payment

### DIFF
--- a/addons/hr_expense/wizard/account_payment_register.py
+++ b/addons/hr_expense/wizard/account_payment_register.py
@@ -9,6 +9,15 @@ class AccountPaymentRegister(models.TransientModel):
     # -------------------------------------------------------------------------
     # BUSINESS METHODS
     # -------------------------------------------------------------------------
+    
+    @api.model
+    def _get_line_batch_key(self, line):
+        # OVERRIDE to set the bank account defined on the employee
+        res = super()._get_line_batch_key(line)
+        expense_sheet = self.env['hr.expense.sheet'].search([('payment_mode', '=', 'own_account'), ('account_move_id', 'in', line.move_id.ids)])
+        if expense_sheet.employee_id.bank_account_id and not line.move_id.partner_bank_id:
+            res['partner_bank_id'] = expense_sheet.employee_id.bank_account_id.id
+        return res
 
     def _create_payments(self):
         # OVERRIDE to set the 'done' state on expense sheets.


### PR DESCRIPTION
When registering a payment on an expense, we are currently using the first
bank account set on the partner if no account is set on the account move.
We should use the bank account defined on the employee instead, and
fallback on the partner only if it is not set.

Description of the issue/feature this PR addresses:
opw-2496440

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
