### PR TITLE
[FIX] crm_iap_mine: combined search of countries with and without states

### DIFF
--- a/addons/crm_iap_mine/tests/common.py
+++ b/addons/crm_iap_mine/tests/common.py
@@ -86,6 +86,10 @@ class MockIAPReveal(MockIAPEnrich):
             self.assertEqual(payload['contact_number'], mine.contact_number)
         else:
             self.assertTrue('contact_number' not in payload)
-        self.assertEqual(payload['countries'], mine.mapped('country_ids.code'))
+        countries = [{
+            'code': country.code,
+            'states': mine.state_ids.filtered(lambda state: state in country.state_ids).mapped('code'),
+        } for country in mine.country_ids]
+        self.assertEqual(payload['countries'], countries)
         self.assertEqual(payload['lead_number'], mine.lead_number)
         self.assertEqual(payload['search_type'], mine.search_type)


### PR DESCRIPTION
Previously, when searching for leads from Belgium and from the state of California, in the US, only companies from California would be returned.

This was due to the way the query was built, it looked like this:

`country IN ('Belgium', 'United States') AND state = 'California'`

instead of :

`(country = 'United States' AND state = 'California') OR country = 'Belgium'`

Task: 2543169
