### PR TITLE
[IMP] core: allow using routes with a wrong type

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -322,8 +322,7 @@ class WebRequest(object):
         if self.endpoint.routing['type'] != self._request_type:
             msg = "%s, %s: Function declared as capable of handling request of type '%s' but called with a request of type '%s'"
             params = (self.endpoint.original, self.httprequest.path, self.endpoint.routing['type'], self._request_type)
-            _logger.info(msg, *params)
-            raise werkzeug.exceptions.BadRequest(msg % params)
+            _logger.warning(msg, *params)
 
         if self.endpoint_arguments:
             kwargs.update(self.endpoint_arguments)


### PR DESCRIPTION
It should be allowed to specify route as type='json', but use as
type='http' (and vise versa) for the following reason at least: on webhook
verification API provider send test query without json headers even though
the address will be used in json mode.

close #57133

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
