### PR TITLE
[REM] stock, website_sale: remove occurences of digital type

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -109,9 +109,9 @@
                 <xpath expr="//group[@name='group_lots_and_weight']" position="before">
                     <field name="has_available_route_ids" invisible="1"/>
                     <group string="Operations" name="operations">
-                        <label for="route_ids" attrs="{'invisible': [('type', 'in', ['service', 'digital'])]}"/>
+                        <label for="route_ids" attrs="{'invisible': [('type', '=', 'service')]}"/>
                         <div>
-                            <field name="route_ids" class="mb-0" widget="many2many_checkboxes" attrs="{'invisible': ['|', ('has_available_route_ids', '=', False), ('type', 'in', ['service', 'digital'])]}"/>
+                            <field name="route_ids" class="mb-0" widget="many2many_checkboxes" attrs="{'invisible': ['|', ('has_available_route_ids', '=', False), ('type', '=', 'service')]}"/>
                             <button id="stock.view_diagram_button" string="View Diagram" type="action" name="%(action_open_routes)d" icon="fa-arrow-right"
                                  attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}"
                                  class="btn btn-link pt-0" context="{'default_product_tmpl_id': id}"/>
@@ -122,7 +122,7 @@
                 <xpath expr="//group[@name='group_lots_and_weight']" position="after">
                     <group string="Traceability" name="traceability" groups="stock.group_production_lot"
                            attrs="{'invisible': [('type', '=', 'consu')]}">
-                        <field name="tracking" widget="radio" attrs="{'invisible': [('type', 'in', ['service', 'digital'])]}"/>
+                        <field name="tracking" widget="radio" attrs="{'invisible': [('type', '=', 'service')]}"/>
                     </group>
                      <group string="Counterpart Locations" name="stock_property" groups="base.group_no_one">
                         <field name="property_stock_production"/>

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -45,7 +45,7 @@ class SaleOrder(models.Model):
     def _compute_cart_info(self):
         for order in self:
             order.cart_quantity = int(sum(order.mapped('website_order_line.product_uom_qty')))
-            order.only_services = all(l.product_id.type in ('service', 'digital') for l in order.website_order_line)
+            order.only_services = all(l.product_id.type == 'service' for l in order.website_order_line)
 
     @api.depends('website_id', 'date_order', 'order_line', 'state', 'partner_id')
     def _compute_abandoned_cart(self):

--- a/addons/website_sale_digital/controllers/main.py
+++ b/addons/website_sale_digital/controllers/main.py
@@ -10,18 +10,6 @@ from werkzeug.utils import redirect
 from odoo import http
 from odoo.http import request
 from odoo.addons.sale.controllers.portal import CustomerPortal
-from odoo.addons.website_sale.controllers.main import WebsiteSale
-
-
-class WebsiteSaleDigitalConfirmation(WebsiteSale):
-
-    @http.route()
-    def shop_payment_confirmation(self, **post):
-        response = super().shop_payment_confirmation(**post)
-        order_lines = response.qcontext['order'].order_line
-        digital_content = any(x.product_id.type == 'digital' for x in order_lines)
-        response.qcontext.update(digital=digital_content)
-        return response
 
 
 class WebsiteSaleDigital(CustomerPortal):


### PR DESCRIPTION
The product type value `digital` is gone since long time, see 1a1efe3fce12.
This commit removes the leftover occurences of it.

Relatedt to https://github.com/odoo/odoo/issues/25651