### PR TITLE
[FIX] account: fix reference to currency object

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -762,7 +762,7 @@ class AccountMove(models.Model):
                 'amount_currency': diff_amount_currency,
                 'partner_id': self.partner_id.id,
                 'move_id': self.id,
-                'currency_id': self.currency_id if self.currency_id != self.company_id.currency_id else False,
+                'currency_id': self.currency_id.id if self.currency_id != self.company_id.currency_id else False,
                 'company_id': self.company_id.id,
                 'company_currency_id': self.company_id.currency_id.id,
                 'is_rounding_line': True,


### PR DESCRIPTION
rounding_line_vals is invoked directly with a .create(), so the "currency_id" key's value should be an integer. See line 810.

This is hard to catch, i use Sentry on my servers and i found this bug. I cannot provide steps to reproduce, as i just see this bug report in Sentry.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
