### PR TITLE
[IMP] adyen_platforms: replace web.base.url by get_base_url

### DIFF
--- a/addons/adyen_platforms/models/adyen_account.py
+++ b/addons/adyen_platforms/models/adyen_account.py
@@ -370,7 +370,7 @@ class AdyenAccount(models.Model):
             url = self.env['ir.config_parameter'].sudo().get_param('adyen_platforms.onboarding_url')
             params = {
                 'creation_token': request.session.get('adyen_creation_token'),
-                'base_url': self.env['ir.config_parameter'].sudo().get_param('web.base.url'),
+                'base_url': self.get_base_url(),
                 'adyen_data': adyen_data,
             }
             auth = None


### PR DESCRIPTION
Use the helper method introduced in odoo/odoo#68201 instead of the
`web.base.url` ICP.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
