### PR TITLE
[FIX] stock_account: do not create aml when updating cost of consumable

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -226,7 +226,7 @@ class ProductProduct(models.Model):
             product = stock_valuation_layer.product_id
             value = stock_valuation_layer.value
 
-            if product.valuation != 'real_time':
+            if product.type != 'product' or product.valuation != 'real_time':
                 continue
 
             # Sanity check.


### PR DESCRIPTION
- Create a Product Category: (i.e. Category X)
  * Costing Method: Average Cost (AVCO)
  * Inventory Valuation: Automated
- Create a Consumable Product with Category X (i.e. Product X)
- Create PO with Product X and receive products
- On Product X form, update Cost
- In debug mode, go to Accounting > Accounting > Journal Items
Account move lines have been created for stock valuation on cost change,
but it shouldn't for a consumable product.

opw-2510315

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
