### PR TITLE
[REF] account_edi: remove test_mode from _post_invoice_edi and _cance…

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -157,8 +157,6 @@ class AccountEdiDocument(models.Model):
             # supposed to have any traceability from the user.
             attachments_to_unlink.unlink()
 
-        test_mode = self._context.get('edi_test_mode', False)
-
         documents.edi_format_id.ensure_one()  # All account.edi.document of a job should have the same edi_format_id
         documents.move_id.company_id.ensure_one()  # All account.edi.document of a job should be from the same company
         if len(set(doc.state for doc in documents)) != 1:
@@ -168,18 +166,18 @@ class AccountEdiDocument(models.Model):
         state = documents[0].state
         if doc_type == 'invoice':
             if state == 'to_send':
-                edi_result = edi_format._post_invoice_edi(documents.move_id, test_mode=test_mode)
+                edi_result = edi_format._post_invoice_edi(documents.move_id)
                 _postprocess_post_edi_results(documents, edi_result)
             elif state == 'to_cancel':
-                edi_result = edi_format._cancel_invoice_edi(documents.move_id, test_mode=test_mode)
+                edi_result = edi_format._cancel_invoice_edi(documents.move_id)
                 _postprocess_cancel_edi_results(documents, edi_result)
 
         elif doc_type == 'payment':
             if state == 'to_send':
-                edi_result = edi_format._post_payment_edi(documents.move_id, test_mode=test_mode)
+                edi_result = edi_format._post_payment_edi(documents.move_id)
                 _postprocess_post_edi_results(documents, edi_result)
             elif state == 'to_cancel':
-                edi_result = edi_format._cancel_payment_edi(documents.move_id, test_mode=test_mode)
+                edi_result = edi_format._cancel_payment_edi(documents.move_id)
                 _postprocess_cancel_edi_results(documents, edi_result)
 
     def _process_documents_no_web_services(self):

--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -154,11 +154,10 @@ class AccountEdiFormat(models.Model):
         # TO OVERRIDE
         return []
 
-    def _post_invoice_edi(self, invoices, test_mode=False):
+    def _post_invoice_edi(self, invoices):
         """ Create the file content representing the invoice (and calls web services if necessary).
 
         :param invoices:    A list of invoices to post.
-        :param test_mode:   A flag indicating the EDI should only simulate the EDI without sending data.
         :returns:           A dictionary with the invoice as key and as value, another dictionary:
         * attachment:       The attachment representing the invoice in this edi_format if the edi was successfully posted.
         * error:            An error if the edi was not successfully posted.
@@ -168,11 +167,10 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         return {}
 
-    def _cancel_invoice_edi(self, invoices, test_mode=False):
+    def _cancel_invoice_edi(self, invoices):
         """Calls the web services to cancel the invoice of this document.
 
         :param invoices:    A list of invoices to cancel.
-        :param test_mode:   A flag indicating the EDI should only simulate the EDI without sending data.
         :returns:           A dictionary with the invoice as key and as value, another dictionary:
         * success:          True if the invoice was successfully cancelled.
         * error:            An error if the edi was not successfully cancelled.
@@ -182,11 +180,10 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         return {invoice: {'success': True} for invoice in invoices}  # By default, cancel succeeds doing nothing.
 
-    def _post_payment_edi(self, payments, test_mode=False):
+    def _post_payment_edi(self, payments):
         """ Create the file content representing the payment (and calls web services if necessary).
 
         :param payments:   The payments to post.
-        :param test_mode:   A flag indicating the EDI should only simulate the EDI without sending data.
         :returns:           A dictionary with the payment as key and as value, another dictionary:
         * attachment:       The attachment representing the payment in this edi_format if the edi was successfully posted.
         * error:            An error if the edi was not successfully posted.
@@ -196,11 +193,10 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         return {}
 
-    def _cancel_payment_edi(self, payments, test_mode=False):
+    def _cancel_payment_edi(self, payments):
         """Calls the web services to cancel the payment of this document.
 
         :param payments:  A list of payments to cancel.
-        :param test_mode: A flag indicating the EDI should only simulate the EDI without sending data.
         :returns:         A dictionary with the payment as key and as value, another dictionary:
         * success:        True if the payment was successfully cancelled.
         * error:          An error if the edi was not successfully cancelled.

--- a/addons/account_edi/tests/common.py
+++ b/addons/account_edi/tests/common.py
@@ -30,7 +30,7 @@ def _mocked_check_move_configuration_fail(edi_format, move):
     return ['Fake error (mocked)']
 
 
-def _mocked_post(edi_format, invoices, test_mode):
+def _mocked_post(edi_format, invoices):
     res = {}
     for invoice in invoices:
         attachment = edi_format.env['ir.attachment'].create({
@@ -42,7 +42,7 @@ def _mocked_post(edi_format, invoices, test_mode):
     return res
 
 
-def _mocked_post_two_steps(edi_format, invoices, test_mode):
+def _mocked_post_two_steps(edi_format, invoices):
     # For this test, we use the field ref to know if the first step is already done or not.
     # Typically, a technical field for the reference of the upload to the web-service will
     # be saved on the invoice.
@@ -64,11 +64,11 @@ def _mocked_post_two_steps(edi_format, invoices, test_mode):
         raise ValueError('wrong use of "_mocked_post_two_steps"')
 
 
-def _mocked_cancel_success(edi_format, invoices, test_mode):
+def _mocked_cancel_success(edi_format, invoices):
     return {invoice: {'success': True} for invoice in invoices}
 
 
-def _mocked_cancel_failed(edi_format, invoices, test_mode):
+def _mocked_cancel_failed(edi_format, invoices):
     return {invoice: {'error': 'Faked error (mocked)'} for invoice in invoices}
 
 
@@ -134,7 +134,7 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
             pass
 
     def edi_cron(self):
-        self.env['account.edi.document'].sudo().with_context(edi_test_mode=True).search([('state', 'in', ('to_send', 'to_cancel'))])._process_documents_web_services(with_commit=False)
+        self.env['account.edi.document'].sudo().search([('state', 'in', ('to_send', 'to_cancel'))])._process_documents_web_services(with_commit=False)
 
     def _create_empty_vendor_bill(self):
         invoice = self.env['account.move'].create({
@@ -203,7 +203,7 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
         the formats we want to return the files for (in case we want to test specific formats).
         Other formats will still generate documents, they simply won't be returned.
         """
-        moves.edi_document_ids.with_context(edi_test_mode=True)._process_documents_web_services(with_commit=False)
+        moves.edi_document_ids._process_documents_web_services(with_commit=False)
 
         documents_to_return = moves.edi_document_ids
         if formats_to_return != None:

--- a/addons/account_edi/tests/test_edi.py
+++ b/addons/account_edi/tests/test_edi.py
@@ -45,7 +45,7 @@ class TestAccountEdi(AccountEdiTestCommon, CronMixinCase):
             to_process = edi_docs._prepare_jobs()
             self.assertEqual(len(to_process), 2)
 
-    @patch('odoo.addons.account_edi.models.account_edi_format.AccountEdiFormat._post_invoice_edi')
+    @patch('odoo.addons.account_edi.models.account_edi_format.AccountEdiFormat._post_invoice_edi', return_value={})
     def test_warning_is_retried(self, patched):
         with patch('odoo.addons.account_edi.models.account_edi_format.AccountEdiFormat._needs_web_services',
                    new=lambda edi_format: True):
@@ -132,7 +132,7 @@ class TestAccountEdi(AccountEdiTestCommon, CronMixinCase):
             self.assertIsNotNone(doc.error)
 
     def test_edi_flow_two_step_cancel_with_call_off_request(self):
-        def _mock_cancel(edi_format, invoices, test_mode):
+        def _mock_cancel(edi_format, invoices):
             invoices_no_ref = invoices.filtered(lambda i: not i.ref)
             if len(invoices_no_ref) == len(invoices):  # first step
                 invoices_no_ref.ref = 'test_ref_cancel'

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -23,10 +23,10 @@ DEFAULT_FACTURX_DATE_FORMAT = '%Y%m%d'
 class AccountEdiFormat(models.Model):
     _inherit = 'account.edi.format'
 
-    def _post_invoice_edi(self, invoices, test_mode=False):
+    def _post_invoice_edi(self, invoices):
         self.ensure_one()
         if self.code != 'facturx_1_0_05':
-            return super()._post_invoice_edi(invoices, test_mode=test_mode)
+            return super()._post_invoice_edi(invoices)
         res = {}
         for invoice in invoices:
             attachment = self._export_facturx(invoice)

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -246,11 +246,11 @@ class AccountEdiFormat(models.Model):
             return super()._is_enabled_by_default_on_journal(journal)
         return False
 
-    def _post_invoice_edi(self, invoices, test_mode=False):
+    def _post_invoice_edi(self, invoices):
         # OVERRIDE
         self.ensure_one()
         if self.code != 'ubl_2_1':
-            return super()._post_invoice_edi(invoices, test_mode=test_mode)
+            return super()._post_invoice_edi(invoices)
         res = {}
         for invoice in invoices:
             attachment = self._export_ubl(invoice)

--- a/addons/l10n_be_edi/models/account_edi_format.py
+++ b/addons/l10n_be_edi/models/account_edi_format.py
@@ -52,10 +52,10 @@ class AccountEdiFormat(models.Model):
             return super()._is_compatible_with_journal(journal)
         return journal.type == 'sale' and journal.country_code == 'BE'
 
-    def _post_invoice_edi(self, invoices, test_mode=False):
+    def _post_invoice_edi(self, invoices):
         self.ensure_one()
         if self.code != 'efff_1':
-            return super()._post_invoice_edi(invoices, test_mode=test_mode)
+            return super()._post_invoice_edi(invoices)
         res = {}
         for invoice in invoices:
             attachment = self._export_efff(invoice)

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -45,10 +45,10 @@ class AccountEdiFormat(models.Model):
         # Determine on which invoices the Mexican CFDI must be generated.
         return invoice.is_sale_document() and invoice.l10n_it_send_state not in ['sent', 'delivered', 'delivered_accepted'] and invoice.country_code == 'IT'
 
-    def _post_invoice_edi(self, invoices, test_mode=False):
+    def _post_invoice_edi(self, invoices):
         # OVERRIDE
         self.ensure_one()
-        edi_result = super()._post_invoice_edi(invoices, test_mode=test_mode)
+        edi_result = super()._post_invoice_edi(invoices)
         if self.code != 'fattura_pa':
             return edi_result
 

--- a/addons/l10n_nl_edi/models/account_edi_format.py
+++ b/addons/l10n_nl_edi/models/account_edi_format.py
@@ -120,10 +120,10 @@ class AccountEdiFormat(models.Model):
             return super()._is_compatible_with_journal(journal)
         return journal.type == 'sale' and journal.country_code == 'NL'
 
-    def _post_invoice_edi(self, invoices, test_mode=False):
+    def _post_invoice_edi(self, invoices):
         self.ensure_one()
         if self.code != 'nlcius_1':
-            return super()._post_invoice_edi(invoices, test_mode=test_mode)
+            return super()._post_invoice_edi(invoices)
 
         invoice = invoices  # no batch ensure that there is only one invoice
         attachment = self._export_nlcius(invoice)


### PR DESCRIPTION
…l_invoice_edi

Before this commit, business logic was mixed with tests. This commit aims to replace the test_mode with mocks for all account_edi tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
