### PR TITLE
[FIX] Use correct model for "Calendar Event"

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -201,7 +201,7 @@ class MergePartnerAutomatic(models.TransientModel):
         update_records = functools.partial(update_records)
 
         for partner in src_partners:
-            update_records('calendar', src=partner, field_model='model_id.model')
+            update_records('calendar.event', src=partner, field_model='res_model')
             update_records('ir.attachment', src=partner, field_model='res_model')
             update_records('mail.followers', src=partner, field_model='res_model')
             update_records('mail.message', src=partner)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
model "calendar" does not exist!

Current behavior before PR:
"calendar.event" records related to a partner are not correctly merged
Desired behavior after PR is merged:
"calendar.event" records related to a partner should be correctly merged



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
