### PR TITLE
[FIX] Merge "Activity" when merging partners

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -204,6 +204,7 @@ class MergePartnerAutomatic(models.TransientModel):
             update_records('calendar', src=partner, field_model='model_id.model')
             update_records('ir.attachment', src=partner, field_model='res_model')
             update_records('mail.followers', src=partner, field_model='res_model')
+            update_records('mail.activity', src=partner, field_model='res_model')
             update_records('mail.message', src=partner)
             update_records('ir.model.data', src=partner)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Activity (mail.activity) records are not merged when partners are merged into another one.

Current behavior before PR:
Activity (mail.activity) records are not merged when partners are merged into another one.

Desired behavior after PR is merged:
Activity (mail.activity) records should be merged when partners are merged into another one.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
