### PR TITLE
[FIX] point_of_sale: Set max cron for IoT to 0

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
@@ -32,7 +32,7 @@ function _start() {
     while ! test -a /run/systemd/timesync/synchronized && ! ip route | grep 10.11.12.1 && ((cnt--)); do
         sleep 1
     done
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$USER --background --make-pidfile --exec $DAEMON -- --config $CONFIG --logfile $LOGFILE --load=$MODULES --limit-time-cpu=600 --limit-time-real=1200
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$USER --background --make-pidfile --exec $DAEMON -- --config $CONFIG --logfile $LOGFILE --load=$MODULES --limit-time-cpu=600 --limit-time-real=1200 --max-cron-threads=0
 }
 
 function _stop() {


### PR DESCRIPTION
From commit 42f292af93bc1e77b079fb0a934e6724f3e13d5e the default
max cron is setted to 2.

But we don't need cron on the IoT and need to explicitly set it to 0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
