### PR TITLE
[FIX] account: fix Average Price measure

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -107,7 +107,11 @@ class AccountInvoiceReport(models.Model):
                 line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                                                                             AS quantity,
                 -line.balance                                               AS price_subtotal,
-                -line.balance / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)
+                -COALESCE(line.balance
+                   / NULLIF(line.quantity, 0.0)
+                   / NULLIF(COALESCE(uom_line.factor, 1), 0.0)
+                   / NULLIF(COALESCE(uom_template.factor, 1), 0.0),
+                   0.0)
                                                                             AS price_average,
                 COALESCE(partner.country_id, commercial_partner.country_id) AS country_id,
                 1                                                           AS nbr_lines

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -24,7 +24,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
                     (0, None, {
                         'product_id': cls.product_a.id,
                         'quantity': 3,
-                        'price_unit': 1000,
+                        'price_unit': 750,
                     }),
                     (0, None, {
                         'product_id': cls.product_a.id,
@@ -115,7 +115,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             # amount_total  price_average   price_subtotal  residual    quantity
             [2000,          2000,           2000,           2000,       1],
             [1000,          1000,           1000,           1000,       1],
-            [1000,          1000,           1000,           1000,       3],
+            [750,           250,            750,            750,        3],
             [6,             6,              6,              6,          1],
             [-20,           -20,            -20,            -20,        -1],
             [-20,           -20,            -20,            -20,        -1],


### PR DESCRIPTION
Open Accounting>Reporting>Invoices
Add measure 'Average Price'

The reported amount will be wrong, as it will not consider the quantity,
making an average of the price subtotal

opw-2522621

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
