### PR TITLE
[FIX] website: allow editing empty non-arch fields

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -305,7 +305,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
     },
 
     _getContentEditableAreas () {
-        return $(this.savableSelector).not('input, [data-oe-readonly],[data-oe-type="monetary"],[data-oe-many2one-id], :empty').filter((_, el) => {
+        return $(this.savableSelector).not('input, [data-oe-readonly],[data-oe-type="monetary"],[data-oe-many2one-id], [data-oe-field="arch"]:empty').filter((_, el) => {
             return !$(el).closest('.o_not_editable').length;
         }).toArray();
     },


### PR DESCRIPTION
987fc1190abaef33666620957fec42f6d011f148 had added a rule that made empty fields non-editable so that a snippetless website would not be editable. This makes empty t-fields non-editable as well which is - to say the least - not welcome.
This commit fixes that problem by making the rule more restrictive: what we don't want to be able to edit are empty _arch_ field specifically.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
