### PR TITLE
float_time formatting improvement

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -1273,23 +1273,24 @@ var FieldFloatTime = FieldFloat.extend({
         }
     },
 
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
     /**
-     * Ensure the widget is re-rendered after being edited s.t. the value is
-     * directly formatted (without waiting for the record to be saved, as we do
-     * by default).
-     *
-     * See InputField@reset: we skip the call to _render if this widget initiated
-     * the change.
-     *
-     * Note: the default behavior could be changed s.t. all fields are formatted
-     * directly on blur.
-     *
+     * Formats the value on field blur
      * @override
+     * @private
      */
-    async reset() {
-        await this._super(...arguments);
-        if (!this.isDirty) {
-            await this._render();
+    _onBlur() {
+        let parsedValue;
+        let isValid = false;
+        try {
+            parsedValue = this._parseValue(this.$input.val());
+            isValid = true;
+        } catch { }
+        if (isValid) {
+            this.$input.val(this._formatValue(parsedValue));
         }
     },
 });

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -1256,6 +1256,23 @@ var FieldFloatTime = FieldFloat.extend({
         this._super.apply(this, arguments);
         this.formatType = 'float_time';
     },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _parseValue: function (value) {
+        try {
+            return this._super(...arguments);
+        } catch (error) {
+            this.$input.val("00:00");
+            return 0;
+        }
+    },
+
     /**
      * Ensure the widget is re-rendered after being edited s.t. the value is
      * directly formatted (without waiting for the record to be saved, as we do

--- a/addons/web/static/src/legacy/js/fields/field_utils.js
+++ b/addons/web/static/src/legacy/js/fields/field_utils.js
@@ -648,8 +648,19 @@ function parseFloatTime(value) {
         factor = -1;
     }
     var float_time_pair = value.split(":");
-    if (float_time_pair.length !== 2)
+    if (float_time_pair.length !== 2) {
+        // if value is integer with all digits e.g. 1234 should be converted to 12:34
+        if (value.length > 2 && value.toString().indexOf('.') === -1) {
+            var parsed = parseNumber(value);
+            if (isNaN(parsed)) {
+                throw new Error(_.str.sprintf(core._t("'%s' is not a correct float"), value));
+            }
+            const hours = parseInt(String(value).slice(0, -2));
+            const minutes = parseInt(String(value).slice(-2));
+            return factor * (hours + (minutes / 60));
+        }
         return factor * parseFloat(value);
+    }
     var hours = parseInteger(float_time_pair[0]);
     var minutes = parseInteger(float_time_pair[1]);
     return factor * (hours + (minutes / 60));

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -5809,7 +5809,7 @@ QUnit.module('basic_fields', {
             'The formatted time value should be displayed properly.');
 
         await testUtils.form.clickEdit(form);
-        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), '9.5', ['change']);
+        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), '9.5', ['blur', 'change']);
         assert.strictEqual(form.$('input[name=qux]').val(), '09:30',
             'The new value should be displayed properly in the input.');
 
@@ -5821,7 +5821,7 @@ QUnit.module('basic_fields', {
     });
 
     QUnit.test('float_time field with invalid value', async function (assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         const form = await createView({
             View: FormView,
@@ -5833,11 +5833,16 @@ QUnit.module('basic_fields', {
                 </form>`,
         });
 
-        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), 'blabla', ['change']);
+        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), 'blabla', ['blur']);
         assert.strictEqual(form.$('input[name=qux]').val(), "00:00",
             "invalid value should reset value");
 
-        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), '6.5', ['change']);
+        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), '6.5', ['blur']);
+        assert.strictEqual(form.$('input[name=qux]').val(), "06:30",
+            "valid value should set value");
+
+        // again add same value and blur the input
+        await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), '6.5', ['blur']);
         assert.strictEqual(form.$('input[name=qux]').val(), "06:30",
             "valid value should set value");
 

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -5821,7 +5821,7 @@ QUnit.module('basic_fields', {
     });
 
     QUnit.test('float_time field with invalid value', async function (assert) {
-        assert.expect(5);
+        assert.expect(2);
 
         const form = await createView({
             View: FormView,
@@ -5831,24 +5831,15 @@ QUnit.module('basic_fields', {
                 `<form>
                     <field name="qux" widget="float_time"/>
                 </form>`,
-            interceptsPropagate: {
-                call_service: function (ev) {
-                    if (ev.data.service === 'notification') {
-                        assert.strictEqual(ev.data.method, 'notify');
-                        assert.strictEqual(ev.data.args[0].title, 'Invalid fields:');
-                        assert.strictEqual(ev.data.args[0].message, '<ul><li>Qux</li></ul>');
-                    }
-                }
-            },
         });
 
         await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), 'blabla', ['change']);
-        await testUtils.form.clickSave(form);
-        assert.hasClass(form.$('input[name=qux]'), 'o_field_invalid');
+        assert.strictEqual(form.$('input[name=qux]').val(), "00:00",
+            "invalid value should reset value");
 
         await testUtils.fields.editAndTrigger(form.$('input[name=qux]'), '6.5', ['change']);
-        assert.doesNotHaveClass(form.$('input[name=qux]'), 'o_field_invalid',
-            "date field should not be displayed as invalid now");
+        assert.strictEqual(form.$('input[name=qux]').val(), "06:30",
+            "valid value should set value");
 
         form.destroy();
     });

--- a/addons/web/static/tests/legacy/fields/field_utils_tests.js
+++ b/addons/web/static/tests/legacy/fields/field_utils_tests.js
@@ -219,6 +219,28 @@ QUnit.test('parse float', function(assert) {
     _.extend(core._t.database.parameters, originalParameters);
 });
 
+QUnit.test('parse float_time', function(assert) {
+    assert.expect(13);
+
+    assert.strictEqual(fieldUtils.parse.float_time(""), 0);
+    assert.strictEqual(fieldUtils.parse.float_time("0"), 0);
+    assert.strictEqual(fieldUtils.parse.float_time("100.00"), 100);
+    assert.strictEqual(fieldUtils.parse.float_time("-100.00"), -100);
+    assert.strictEqual(fieldUtils.parse.float_time("1,000.00"), 1000);
+    assert.strictEqual(fieldUtils.parse.float_time("1000000.00"), 1000000);
+    // Insert only digits
+    assert.strictEqual(fieldUtils.parse.float_time("12"), 12);
+    assert.strictEqual(parseFloat(fieldUtils.parse.float_time("123").toFixed(2)), 1.38);
+    assert.strictEqual(parseFloat(fieldUtils.parse.float_time("1234").toFixed(2)), 12.57);
+    assert.strictEqual(parseFloat(fieldUtils.parse.float_time("1295").toFixed(2)), 13.58);
+    assert.strictEqual(parseFloat(fieldUtils.parse.float_time("12395").toFixed(2)), 124.58);
+
+    assert.strictEqual(parseFloat(fieldUtils.parse.float_time('1234567').toFixed(2)), 12346.12);
+    assert.throws(function () {
+        fieldUtils.parse.float_time("blabla");
+    }, "Throw an exception if it's not a valid number");
+});
+
 QUnit.test('parse integer', function(assert) {
     assert.expect(11);
 


### PR DESCRIPTION
PURPOSE

Improve the encoding of time durations by formatting:
    formatting digits-only inputs as hh:mm
    clearing invalid inputs
Currently, if the user inputs only digits in a float_time widget, it will set those as hours, and none as minutes.
e.g. 1245 will be formatted as 12:45

SPECIFICATION

The formatting rule for digit-only inputs is as follows (where X is the number of digits in the input)
    If X<3, set the whole input as hours
        3 becomes 03:00
        11 becomes 11:00
        05 becomes 05:00
        etc.
    If X>2, set the last two digits of the input as minutes, and the previous ones as hours
        115 becomes 01:15
        050 becomes 00:50
        1245 becomes 12:45
        0730 becomes 07:30
        12345 becomes 123:45

TASK 2487542


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
