### PR TITLE
[MERGE][IMP] sale: clean sale core code

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -123,8 +123,8 @@ class SaleOrder(models.Model):
         return u' {pre}{0}{post}'.format(amount, pre=pre, post=post)
 
     @api.depends('order_line.is_delivery', 'order_line.is_downpayment')
-    def _get_invoice_status(self):
-        super()._get_invoice_status()
+    def _compute_invoice_status(self):
+        super()._compute_invoice_status()
         for order in self:
             if order.invoice_status in ['no', 'invoiced']:
                 continue

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -99,6 +99,7 @@ class SaleOrderLine(models.Model):
 
     @api.onchange('product_id')
     def _onchange_product_id(self):
+        super()._onchange_product_id()
         # We reset the event when keeping it would lead to an inconstitent state.
         # We need to do it this way because the only relation between the product and the event is through the corresponding tickets.
         if self.event_id and (not self.product_id or self.product_id.id not in self.event_id.mapped('event_ticket_ids.product_id.id')):
@@ -118,7 +119,7 @@ class SaleOrderLine(models.Model):
     @api.onchange('event_ticket_id')
     def _onchange_event_ticket_id(self):
         # we call this to force update the default name
-        self.product_id_change()
+        self._onchange_product_id()
 
     def get_sale_order_line_multiline_description_sale(self, product):
         """ We override this method because we decided that:

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -112,9 +112,9 @@ class SaleOrderLine(models.Model):
             self.event_ticket_id = None
 
     @api.onchange('product_uom', 'product_uom_qty')
-    def product_uom_change(self):
+    def _onchange_quantity(self):
         if not self.event_ticket_id:
-            super(SaleOrderLine, self).product_uom_change()
+            super()._onchange_quantity()
 
     @api.onchange('event_ticket_id')
     def _onchange_event_ticket_id(self):

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -207,5 +207,5 @@ class TestEventSale(TestEventSaleCommon):
             'event_id': event.id,
             'event_ticket_id': event_ticket.id,
         })
-        sol.product_id_change()
+        sol._onchange_product_id()
         self.assertEqual(so.amount_total, 660.0, "Ticket is $1000 but the event product is on a pricelist 10 -> 6. So, $600 + a 10% tax.")

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -478,11 +478,9 @@ class SaleOrder(models.Model):
             # Block if partner only has warning but parent company is blocked
             if partner.sale_warn != 'block' and partner.parent_id and partner.parent_id.sale_warn == 'block':
                 partner = partner.parent_id
-            title = ("Warning for %s") % partner.name
-            message = partner.sale_warn_msg
             warning = {
-                    'title': title,
-                    'message': message,
+                'title': _("Warning for %s", partner.name),
+                'message': partner.sale_warn_msg,
             }
             if partner.sale_warn == 'block':
                 self.update({'partner_id': False, 'partner_invoice_id': False, 'partner_shipping_id': False, 'pricelist_id': False})

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -615,11 +615,11 @@ class SaleOrder(models.Model):
     #################
 
     @api.model
-    def get_empty_list_help(self, help):
+    def get_empty_list_help(self, help_msg):
         self = self.with_context(
             empty_list_help_document_name=_("sale order"),
         )
-        return super(SaleOrder, self).get_empty_list_help(help)
+        return super(SaleOrder, self).get_empty_list_help(help_msg)
 
     @api.onchange('expected_date')
     def _onchange_commitment_date(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -547,6 +547,10 @@ class SaleOrder(models.Model):
                 }
             }
 
+    @api.onchange('expected_date')
+    def _onchange_expected_date(self):
+        self.commitment_date = self.expected_date
+
     @api.onchange('pricelist_id')
     def _onchange_pricelist_id(self):
         if self.order_line and self.pricelist_id and self._origin.pricelist_id != self.pricelist_id:
@@ -620,10 +624,6 @@ class SaleOrder(models.Model):
             empty_list_help_document_name=_("sale order"),
         )
         return super(SaleOrder, self).get_empty_list_help(help_msg)
-
-    @api.onchange('expected_date')
-    def _onchange_commitment_date(self):
-        self.commitment_date = self.expected_date
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_draft_or_cancel(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -366,7 +366,7 @@ class SaleOrder(models.Model):
         return super(SaleOrder, self)._track_subtype(init_values)
 
     @api.onchange('partner_shipping_id', 'partner_id', 'company_id')
-    def onchange_partner_shipping_id(self):
+    def _onchange_partner_shipping_id(self):
         """
         Trigger the change of fiscal position when the shipping address is modified.
         """
@@ -374,7 +374,7 @@ class SaleOrder(models.Model):
         return {}
 
     @api.onchange('partner_id')
-    def onchange_partner_id(self):
+    def _onchange_partner_id(self):
         """
         Update the following fields when the partner is changed:
         - Pricelist
@@ -419,14 +419,14 @@ class SaleOrder(models.Model):
         self.update(values)
 
     @api.onchange('user_id')
-    def onchange_user_id(self):
+    def _onchange_user_id(self):
         if self.user_id:
             self.team_id = self.env['crm.team'].with_context(
                 default_team_id=self.team_id.id
             )._get_default_team_id(user_id=self.user_id.id, domain=None)
 
     @api.onchange('partner_id')
-    def onchange_partner_id_warning(self):
+    def _onchange_partner_id_warning(self):
         if not self.partner_id:
             return
         warning = {}

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -624,20 +624,21 @@ class SaleOrderLine(models.Model):
             vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
         self.update(vals)
 
-        title = False
-        message = False
-        result = {}
-        warning = {}
-        if product.sale_line_warn != 'no-message':
-            title = _("Warning for %s", product.name)
-            message = product.sale_line_warn_msg
-            warning['title'] = title
-            warning['message'] = message
-            result = {'warning': warning}
+    @api.onchange('product_id')
+    def _onchange_product_id_warning(self):
+        product = self.product_id
+
+        if product and product.sale_line_warn != 'no-message':
+            result = {
+                'warning': {
+                    'title': _("Warning for %s", product.name),
+                    'message': product.sale_line_warn_msg,
+                }
+            }
             if product.sale_line_warn == 'block':
                 self.product_id = False
 
-        return result
+            return result
 
     @api.onchange('product_uom', 'product_uom_qty')
     def _onchange_quantity(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -640,7 +640,7 @@ class SaleOrderLine(models.Model):
         return result
 
     @api.onchange('product_uom', 'product_uom_qty')
-    def product_uom_change(self):
+    def _onchange_quantity(self):
         if not self.product_uom or not self.product_id:
             self.price_unit = 0.0
             return

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -20,7 +20,7 @@ class SaleOrderLine(models.Model):
 
     company_id = fields.Many2one(related='order_id.company_id', string='Company', store=True, readonly=True, index=True)
     currency_id = fields.Many2one(related='order_id.currency_id', depends=['order_id.currency_id'], store=True, string='Currency', readonly=True)
-    order_partner_id = fields.Many2one(related='order_id.partner_id', store=True, string='Customer', readonly=False)
+    order_partner_id = fields.Many2one(related='order_id.partner_id', store=True, string='Customer')
     salesman_id = fields.Many2one(related='order_id.user_id', store=True, string='Salesperson', readonly=True)
     state = fields.Selection(
         related='order_id.state', string='Order Status', readonly=True, copy=False, store=True, default='draft')

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -141,7 +141,7 @@ class SaleOrderLine(models.Model):
         onchange_fields = ['name', 'price_unit', 'product_uom', 'tax_id']
         if values.get('order_id') and values.get('product_id') and any(f not in values for f in onchange_fields):
             line = self.new(values)
-            line.product_id_change()
+            line._onchange_product_id()
             for field in onchange_fields:
                 if field not in values:
                     res[field] = line._fields[field].convert_to_write(line[field], line)
@@ -588,7 +588,7 @@ class SaleOrderLine(models.Model):
         return max(base_price, final_price)
 
     @api.onchange('product_id')
-    def product_id_change(self):
+    def _onchange_product_id(self):
         if not self.product_id:
             return
         valid_values = self.product_id.product_tmpl_id.valid_product_template_attribute_line_ids.product_template_value_ids

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -287,7 +287,7 @@ class TestOnchangeProductId(TransactionCase):
             'name': 'Test2', 'sale_warn': 'block', 'sale_warn_msg': 'Cannot afford our services'})
 
         sale_order = self.env['sale.order'].create({'partner_id': partner_with_warning.id})
-        warning = sale_order.onchange_partner_id_warning()
+        warning = sale_order._onchange_partner_id_warning()
         self.assertDictEqual(warning, {
             'warning': {
                 'title': "Warning for Test",
@@ -296,7 +296,7 @@ class TestOnchangeProductId(TransactionCase):
         })
 
         sale_order.partner_id = partner_with_block_warning
-        warning = sale_order.onchange_partner_id_warning()
+        warning = sale_order._onchange_partner_id_warning()
         self.assertDictEqual(warning, {
             'warning': {
                 'title': "Warning for Test2",

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -158,7 +158,7 @@ class TestOnchangeProductId(TransactionCase):
         })
 
         # force compute uom and prices
-        order_line.product_id_change()
+        order_line._onchange_product_id()
         order_line.product_uom_change()
         order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 90, "Christmas discount pricelist rule not applied")
@@ -216,7 +216,7 @@ class TestOnchangeProductId(TransactionCase):
         })
 
         # force compute uom and prices
-        order_line.product_id_change()
+        order_line._onchange_product_id()
         order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 81, "Second pricelist rule not applied")
         self.assertEqual(order_line.discount, 19, "Second discount not applied")
@@ -273,7 +273,7 @@ class TestOnchangeProductId(TransactionCase):
         })
 
         # force compute uom and prices
-        order_line.product_id_change()
+        order_line._onchange_product_id()
         self.assertEqual(order_line.price_unit, 180, "First pricelist rule not applied")
         order_line.product_uom = new_uom
         order_line.product_uom_change()
@@ -321,7 +321,7 @@ class TestOnchangeProductId(TransactionCase):
             'order_id': sale_order.id,
             'product_id': product_with_warning.id,
         })
-        warning = sale_order_line.product_id_change()
+        warning = sale_order_line._onchange_product_id()
         self.assertDictEqual(warning, {
             'warning': {
                 'title': "Warning for Test Product",
@@ -330,7 +330,7 @@ class TestOnchangeProductId(TransactionCase):
         })
 
         sale_order_line.product_id = product_with_block_warning
-        warning = sale_order_line.product_id_change()
+        warning = sale_order_line._onchange_product_id()
 
         self.assertDictEqual(warning, {
             'warning': {

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -159,12 +159,12 @@ class TestOnchangeProductId(TransactionCase):
 
         # force compute uom and prices
         order_line._onchange_product_id()
-        order_line.product_uom_change()
+        order_line._onchange_quantity()
         order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 90, "Christmas discount pricelist rule not applied")
         self.assertEqual(order_line.discount, 10, "Christmas discount not equalt to 10%")
         order_line.product_uom = new_uom
-        order_line.product_uom_change()
+        order_line._onchange_quantity()
         order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 900, "Christmas discount pricelist rule not applied")
         self.assertEqual(order_line.discount, 10, "Christmas discount not equalt to 10%")
@@ -276,7 +276,7 @@ class TestOnchangeProductId(TransactionCase):
         order_line._onchange_product_id()
         self.assertEqual(order_line.price_unit, 180, "First pricelist rule not applied")
         order_line.product_uom = new_uom
-        order_line.product_uom_change()
+        order_line._onchange_quantity()
         self.assertEqual(order_line.price_unit, 1800, "First pricelist rule not applied")
 
     def test_sale_warnings(self):

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -321,7 +321,7 @@ class TestOnchangeProductId(TransactionCase):
             'order_id': sale_order.id,
             'product_id': product_with_warning.id,
         })
-        warning = sale_order_line._onchange_product_id()
+        warning = sale_order_line._onchange_product_id_warning()
         self.assertDictEqual(warning, {
             'warning': {
                 'title': "Warning for Test Product",
@@ -330,7 +330,7 @@ class TestOnchangeProductId(TransactionCase):
         })
 
         sale_order_line.product_id = product_with_block_warning
-        warning = sale_order_line._onchange_product_id()
+        warning = sale_order_line._onchange_product_id_warning()
 
         self.assertDictEqual(warning, {
             'warning': {

--- a/addons/sale/tests/test_reinvoice.py
+++ b/addons/sale/tests/test_reinvoice.py
@@ -57,7 +57,7 @@ class TestReInvoice(TestSaleCommon):
         })
         sale_order_line2.product_id_change()
 
-        self.sale_order.onchange_partner_id()
+        self.sale_order._onchange_partner_id()
         self.sale_order._compute_tax_id()
         self.sale_order.action_confirm()
 
@@ -247,7 +247,7 @@ class TestReInvoice(TestSaleCommon):
         })
         so_line2.product_id_change()
 
-        self.sale_order.onchange_partner_id()
+        self.sale_order._onchange_partner_id()
         self.sale_order._compute_tax_id()
         self.sale_order.action_confirm()
 

--- a/addons/sale/tests/test_reinvoice.py
+++ b/addons/sale/tests/test_reinvoice.py
@@ -45,7 +45,7 @@ class TestReInvoice(TestSaleCommon):
             'price_unit': self.company_data['product_order_cost'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line1.product_id_change()
+        sale_order_line1._onchange_product_id()
         sale_order_line2 = self.env['sale.order.line'].create({
             'name': self.company_data['product_delivery_cost'].name,
             'product_id': self.company_data['product_delivery_cost'].id,
@@ -55,7 +55,7 @@ class TestReInvoice(TestSaleCommon):
             'price_unit': self.company_data['product_delivery_cost'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line2.product_id_change()
+        sale_order_line2._onchange_product_id()
 
         self.sale_order._onchange_partner_id()
         self.sale_order._compute_tax_id()
@@ -129,7 +129,7 @@ class TestReInvoice(TestSaleCommon):
             'price_unit': self.company_data['product_delivery_sales_price'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line1.product_id_change()
+        sale_order_line1._onchange_product_id()
         sale_order_line2 = self.env['sale.order.line'].create({
             'name': self.company_data['product_order_sales_price'].name,
             'product_id': self.company_data['product_order_sales_price'].id,
@@ -139,7 +139,7 @@ class TestReInvoice(TestSaleCommon):
             'price_unit': self.company_data['product_order_sales_price'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line2.product_id_change()
+        sale_order_line2._onchange_product_id()
         self.sale_order._compute_tax_id()
         self.sale_order.action_confirm()
 
@@ -235,7 +235,7 @@ class TestReInvoice(TestSaleCommon):
             'discount': 100.00,
             'order_id': self.sale_order.id,
         })
-        so_line1.product_id_change()
+        so_line1._onchange_product_id()
         so_line2 = self.env['sale.order.line'].create({
             'name': self.company_data['product_delivery_sales_price'].name,
             'product_id': self.company_data['product_delivery_sales_price'].id,
@@ -245,7 +245,7 @@ class TestReInvoice(TestSaleCommon):
             'discount': 100.00,
             'order_id': self.sale_order.id,
         })
-        so_line2.product_id_change()
+        so_line2._onchange_product_id()
 
         self.sale_order._onchange_partner_id()
         self.sale_order._compute_tax_id()

--- a/addons/sale/tests/test_sale_flow.py
+++ b/addons/sale/tests/test_sale_flow.py
@@ -72,7 +72,7 @@ class TestSaleFlow(TestSaleCommonBase):
         for line in sale_order.order_line:
             line.product_id_change()
 
-        sale_order.onchange_partner_id()
+        sale_order._onchange_partner_id()
         sale_order._compute_tax_id()
         sale_order.action_confirm()
 

--- a/addons/sale/tests/test_sale_flow.py
+++ b/addons/sale/tests/test_sale_flow.py
@@ -70,7 +70,7 @@ class TestSaleFlow(TestSaleCommonBase):
             ],
         })
         for line in sale_order.order_line:
-            line.product_id_change()
+            line._onchange_product_id()
 
         sale_order._onchange_partner_id()
         sale_order._compute_tax_id()

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -512,7 +512,7 @@ class TestSaleOrder(TestSaleCommon):
         sale_order = self.env['sale.order'].create({
             'partner_id': partner.id,
         })
-        sale_order.onchange_partner_id()
+        sale_order._onchange_partner_id()
         self.assertEqual(sale_order.team_id.id, self.crm_team0.id, 'Should assign to team of sales person')
 
     def test_assign_sales_team_from_partner_team(self):
@@ -525,7 +525,7 @@ class TestSaleOrder(TestSaleCommon):
         sale_order = self.env['sale.order'].create({
             'partner_id': partner.id,
         })
-        sale_order.onchange_partner_id()
+        sale_order._onchange_partner_id()
         self.assertEqual(sale_order.team_id.id, self.crm_team1.id, 'Should assign to team of partner')
 
     def test_assign_sales_team_when_changing_user(self):
@@ -536,7 +536,7 @@ class TestSaleOrder(TestSaleCommon):
             'team_id': self.crm_team1.id
         })
         sale_order.user_id = self.user_in_team
-        sale_order.onchange_user_id()
+        sale_order._onchange_user_id()
         self.assertEqual(sale_order.team_id.id, self.crm_team0.id, 'Should assign to team of sales person')
 
     def test_keep_sales_team_when_changing_user_with_no_team(self):
@@ -546,7 +546,7 @@ class TestSaleOrder(TestSaleCommon):
             'team_id': self.crm_team1.id
         })
         sale_order.user_id = self.user_not_in_team
-        sale_order.onchange_user_id()
+        sale_order._onchange_user_id()
         self.assertEqual(sale_order.team_id.id, self.crm_team1.id, 'Should not reset the team to default')
 
     def test_onchange_packaging_00(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -283,7 +283,7 @@ class TestSaleOrder(TestSaleCommon):
 
         # Trigger onchange to reset discount, unit price, subtotal, ...
         for line in self.sale_order.order_line:
-            line.product_id_change()
+            line._onchange_product_id()
             line._onchange_discount()
 
         for line in self.sale_order.order_line:

--- a/addons/sale/tests/test_sale_pricelist.py
+++ b/addons/sale/tests/test_sale_pricelist.py
@@ -121,7 +121,7 @@ class TestSaleOrder(TestSaleCommon):
         self.sale_order.write({'pricelist_id': self.pricelist_discount_incl.id})
         # Trigger onchange to reset discount, unit price, subtotal, ...
         for line in self.sale_order.order_line:
-            line.product_id_change()
+            line._onchange_product_id()
             line._onchange_discount()
         # Check that pricelist of the SO has been applied on the sale order lines or not
         for line in self.sale_order.order_line:
@@ -145,7 +145,7 @@ class TestSaleOrder(TestSaleCommon):
         self.sale_order.write({'pricelist_id': self.pricelist_discount_excl.id})
         # Trigger onchange to reset discount, unit price, subtotal, ...
         for line in self.sale_order.order_line:
-            line.product_id_change()
+            line._onchange_product_id()
             line._onchange_discount()
 
         # Check pricelist of the SO apply or not on order lines where pricelist contains formula that add 15% on the cost price

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -440,12 +440,12 @@ class SaleOrder(models.Model):
         """
         return self.code_promo_program_id + self.no_code_promo_program_ids + self.applied_coupon_ids.mapped('program_id')
 
-    def _get_invoice_status(self):
+    def _compute_invoice_status(self):
         # Handling of a specific situation: an order contains
         # a product invoiced on delivery and a promo line invoiced
         # on order. We would avoid having the invoice status 'to_invoice'
         # if the created invoice will only contain the promotion line
-        super()._get_invoice_status()
+        super()._compute_invoice_status()
         for order in self.filtered(lambda order: order.invoice_status == 'to invoice'):
             paid_lines = order._get_paid_order_lines()
             if not any(line.invoice_status == 'to invoice' for line in paid_lines):

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -50,8 +50,8 @@ class SaleOrder(models.Model):
         return super(SaleOrder, self).copy(default=default)
 
     @api.onchange('partner_id')
-    def onchange_partner_id(self):
-        super(SaleOrder, self).onchange_partner_id()
+    def _onchange_partner_id(self):
+        super()._onchange_partner_id()
         template = self.sale_order_template_id.with_context(lang=self.partner_id.lang)
         self.note = template.note or self.note
 

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -178,8 +178,8 @@ class SaleOrderLine(models.Model):
 
     # Take the description on the order template if the product is present in it
     @api.onchange('product_id')
-    def product_id_change(self):
-        domain = super(SaleOrderLine, self).product_id_change()
+    def _onchange_product_id(self):
+        domain = super()._onchange_product_id()
         if self.product_id and self.order_id.sale_order_template_id:
             for line in self.order_id.sale_order_template_id.sale_order_template_line_ids:
                 if line.product_id == self.product_id:

--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -112,7 +112,7 @@ class SaleOrder(models.Model):
                 res = False
                 self.update(dict(order_line=new_lines))
                 for line in self.order_line.filtered(lambda line: line.product_template_id == product_template):
-                    res = line.product_id_change() or res
+                    res = line._onchange_product_id() or res
                     line._onchange_discount()
                     line._onchange_product_id_set_customer_lead()
                 return res

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -158,8 +158,8 @@ class SaleOrder(models.Model):
             self.warehouse_id = warehouse_id or self.user_id.with_company(self.company_id.id)._get_default_warehouse_id().id
 
     @api.onchange('user_id')
-    def onchange_user_id(self):
-        super().onchange_user_id()
+    def _onchange_user_id(self):
+        super()._onchange_user_id()
         self.warehouse_id = self.user_id.with_company(self.company_id.id)._get_default_warehouse_id().id
 
     @api.onchange('partner_shipping_id')

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -69,7 +69,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
         })
         sale_order_line2.product_id_change()
 
-        self.sale_order.onchange_partner_id()
+        self.sale_order._onchange_partner_id()
         self.sale_order._compute_tax_id()
         self.sale_order.action_confirm()
 

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -58,7 +58,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'price_unit': self.company_data['product_order_cost'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line1.product_id_change()
+        sale_order_line1._onchange_product_id()
         sale_order_line2 = self.env['sale.order.line'].create({
             'name': self.company_data['product_delivery_cost'].name,
             'product_id': self.company_data['product_delivery_cost'].id,
@@ -67,7 +67,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'price_unit': self.company_data['product_delivery_cost'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line2.product_id_change()
+        sale_order_line2._onchange_product_id()
 
         self.sale_order._onchange_partner_id()
         self.sale_order._compute_tax_id()
@@ -161,7 +161,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'price_unit': self.company_data['product_delivery_sales_price'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line1.product_id_change()
+        sale_order_line1._onchange_product_id()
         sale_order_line2 = self.env['sale.order.line'].create({
             'name': self.company_data['product_order_sales_price'].name,
             'product_id': self.company_data['product_order_sales_price'].id,
@@ -171,7 +171,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'price_unit': self.company_data['product_order_sales_price'].list_price,
             'order_id': self.sale_order.id,
         })
-        sale_order_line2.product_id_change()
+        sale_order_line2._onchange_product_id()
         self.sale_order._compute_tax_id()
         self.sale_order.action_confirm()
 

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -141,7 +141,7 @@ class TestSaleService(TestCommonSaleTimesheet):
             'price_unit': self.product_delivery_timesheet2.list_price,
             'order_id': self.sale_order.id,
         })
-        so_line_deliver_global_project.product_id_change()
+        so_line_deliver_global_project._onchange_product_id()
         self.sale_order.action_confirm()
         task_serv2 = self.env['project.task'].search([('sale_line_id', '=', so_line_deliver_global_project.id)])
 
@@ -187,7 +187,7 @@ class TestSaleService(TestCommonSaleTimesheet):
             'price_unit': self.product_delivery_timesheet3.list_price,
             'order_id': self.sale_order.id,
         })
-        so_line_deliver_new_task_project.product_id_change()
+        so_line_deliver_new_task_project._onchange_product_id()
         self.sale_order.action_confirm()
         task_serv2 = self.env['project.task'].search([('sale_line_id', '=', so_line_deliver_new_task_project.id)])
 
@@ -510,8 +510,8 @@ class TestSaleService(TestCommonSaleTimesheet):
             'price_unit': self.product_delivery_timesheet3.list_price,
             'order_id': self.sale_order.id,
         })
-        so_line_deliver_new_task_project.product_id_change()
-        so_line_deliver_new_task_project_2.product_id_change()
+        so_line_deliver_new_task_project._onchange_product_id()
+        so_line_deliver_new_task_project_2._onchange_product_id()
         self.sale_order.action_confirm()
 
         project = so_line_deliver_new_task_project.project_id

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -50,8 +50,8 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'price_unit': self.product_order_timesheet2.list_price,
             'order_id': sale_order.id,
         })
-        so_line_ordered_project_only.product_id_change()
-        so_line_ordered_global_project.product_id_change()
+        so_line_ordered_project_only._onchange_product_id()
+        so_line_ordered_global_project._onchange_product_id()
         sale_order.action_confirm()
         task_serv2 = self.env['project.task'].search([('sale_line_id', '=', so_line_ordered_global_project.id)])
         project_serv1 = self.env['project.project'].search([('sale_line_id', '=', so_line_ordered_project_only.id)])
@@ -188,8 +188,8 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'price_unit': self.product_delivery_timesheet3.list_price,
             'order_id': sale_order.id,
         })
-        so_line_deliver_global_project.product_id_change()
-        so_line_deliver_task_project.product_id_change()
+        so_line_deliver_global_project._onchange_product_id()
+        so_line_deliver_task_project._onchange_product_id()
 
         # confirm SO
         sale_order.action_confirm()
@@ -415,8 +415,8 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'price_unit': self.product_delivery_timesheet3.list_price,
             'order_id': sale_order.id,
         })
-        so_line_deliver_global_project.product_id_change()
-        so_line_deliver_task_project.product_id_change()
+        so_line_deliver_global_project._onchange_product_id()
+        so_line_deliver_task_project._onchange_product_id()
 
         # confirm SO
         sale_order.action_confirm()

--- a/addons/sale_timesheet/tests/test_upsell_warning.py
+++ b/addons/sale_timesheet/tests/test_upsell_warning.py
@@ -70,8 +70,8 @@ class TestUpsellWarning(TestCommonSaleTimesheet):
         timesheet._compute_so_line()
         so.order_line._compute_qty_delivered()
         so.order_line._compute_invoice_status()
-        so._get_invoice_status()
-        # Normally this method is called at the end of _get_invoice_status and other compute method. Here, we simulate for invoice_status field
+        so._compute_invoice_status()
+        # Normally this method is called at the end of _compute_invoice_status and other compute method. Here, we simulate for invoice_status field
         so._compute_field_value(so._fields['invoice_status'])
 
         self.assertEqual(len(so.activity_search(['sale.mail_act_sale_upsell'])), 0, 'No upsell warning should appear in the SO.')
@@ -81,8 +81,8 @@ class TestUpsellWarning(TestCommonSaleTimesheet):
         timesheet._compute_so_line()
         so.order_line._compute_qty_delivered()
         so.order_line._compute_invoice_status()
-        so._get_invoice_status()
-        # Normally this method is called at the end of _get_invoice_status and other compute method. Here, we simulate for invoice_status field
+        so._compute_invoice_status()
+        # Normally this method is called at the end of _compute_invoice_status and other compute method. Here, we simulate for invoice_status field
         so._compute_field_value(so._fields['invoice_status'])
 
         # 5) Check if the SO has an 'sale.mail_act_sale_upsell' activity.

--- a/addons/sale_timesheet/wizard/project_create_sale_order.py
+++ b/addons/sale_timesheet/wizard/project_create_sale_order.py
@@ -117,11 +117,11 @@ class ProjectCreateSalesOrder(models.TransientModel):
             'client_order_ref': self.project_id.name,
             'company_id': self.project_id.company_id.id,
         })
-        sale_order.onchange_partner_id()
-        sale_order.onchange_partner_shipping_id()
+        sale_order._onchange_partner_id()
+        sale_order._onchange_partner_shipping_id()
         # rewrite the user as the onchange_partner_id erases it
         sale_order.write({'user_id': self.project_id.user_id.id})
-        sale_order.onchange_user_id()
+        sale_order._onchange_user_id()
 
         # create the sale lines, the map (optional), and assign existing timesheet to sale lines
         self._make_billable(sale_order)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -732,7 +732,7 @@ class WebsiteSale(http.Controller):
                 partner_id = self._checkout_form_save(mode, post, kw)
                 if mode[1] == 'billing':
                     order.partner_id = partner_id
-                    order.with_context(not_self_saleperson=True).onchange_partner_id()
+                    order.with_context(not_self_saleperson=True)._onchange_partner_id()
                     # This is the *only* thing that the front end user will see/edit anyway when choosing billing address
                     order.partner_invoice_id = partner_id
                     if not kw.get('use_same'):
@@ -821,7 +821,7 @@ class WebsiteSale(http.Controller):
         if redirection:
             return redirection
 
-        order.onchange_partner_shipping_id()
+        order._onchange_partner_shipping_id()
         order.order_line._compute_tax_id()
         request.session['sale_last_order_id'] = order.id
         request.website.sale_get_order(update_pricelist=True)

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -297,7 +297,7 @@ class Website(models.Model):
 
             # set fiscal position
             if request.website.partner_id.id != partner.id:
-                sale_order.onchange_partner_shipping_id()
+                sale_order._onchange_partner_shipping_id()
             else: # For public user, fiscal position based on geolocation
                 country_code = request.session['geoip'].get('country_code')
                 if country_code:
@@ -305,7 +305,7 @@ class Website(models.Model):
                     sale_order.fiscal_position_id = request.env['account.fiscal.position'].sudo().with_company(request.website.company_id.id)._get_fpos_by_region(country_id)
                 else:
                     # if no geolocation, use the public user fp
-                    sale_order.onchange_partner_shipping_id()
+                    sale_order._onchange_partner_shipping_id()
 
             request.session['sale_order_id'] = sale_order.id
 
@@ -325,9 +325,9 @@ class Website(models.Model):
 
             # change the partner, and trigger the onchange
             sale_order.write({'partner_id': partner.id})
-            sale_order.with_context(not_self_saleperson=True).onchange_partner_id()
+            sale_order.with_context(not_self_saleperson=True)._onchange_partner_id()
             sale_order.write({'partner_invoice_id': partner.id})
-            sale_order.onchange_partner_shipping_id() # fiscal position
+            sale_order._onchange_partner_shipping_id() # fiscal position
             sale_order['payment_term_id'] = self.sale_get_payment_term(partner)
 
             # check the pricelist : update it if the pricelist is not the 'forced' one

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -185,7 +185,7 @@ class TestWebsiteSaleProductPricelist(TestSaleProductAttributeValueCommon):
         self.assertEqual(round(sol.price_total), 110.0, "110$ with 10% included tax")
         so.pricelist_id = pricelist
         so.fiscal_position_id = fpos
-        sol.product_id_change()
+        sol._onchange_product_id()
         with MockRequest(self.env, website=current_website, sale_order_id=so.id):
             so._cart_update(product_id=test_product.product_variant_id.id, line_id=sol.id, set_qty=1)
         self.assertEqual(round(sol.price_total), 50, "100$ with 50% discount + 0% tax (mapped from fp 10% -> 0%)")


### PR DESCRIPTION
To ease future tasks related to `sale`, this PR cleans up the core code of sale, `sale_order.py` & `sale_order_line.py`:

* Follow guidelines for code organisation (defaults, fields, computes, constraints, onchanges, crud, ...)
* Follow guidelines for methods naming conventions (`_onchange`, `_compute`, ...)
* Make code more readable by splitting up overly long lines
* Remove/simplify useless code 
    * Related / computed fields are readonly by default
    * Stored computed fields are compute_sudo by default
* Fix some little issues found during code review
   See dedicated [FIX] commits


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
