### PR TITLE
[FIX] POS: Add check to prevent posting a statement in opened session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -700,7 +700,7 @@ class PosSession(models.Model):
         for statement in self.statement_ids:
             if not self.config_id.cash_control:
                 statement.write({'balance_end_real': statement.balance_end})
-            statement.button_post()
+            statement.with_context(not_check_session_closed = True).button_post()
             all_lines = (
                   split_cash_statement_lines[statement].mapped('move_id.line_ids').filtered(lambda aml: aml.account_id.internal_type == 'receivable')
                 | combine_cash_statement_lines[statement].mapped('move_id.line_ids').filtered(lambda aml: aml.account_id.internal_type == 'receivable')


### PR DESCRIPTION
Before this commit, a customer was allowed to post
a statement related to an open pos session.
This was preventing the closing of the session.

Now, a statement cannot be posted if the related
pos session is not closed.

opw-2487628

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
