### PR TITLE
[FIX] payment: don't send customer IP address when running a cron

### DIFF
--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -155,4 +155,4 @@ def split_partner_name(partner_name):
 # Security
 
 def get_customer_ip_address():
-    return request and request.httprequest.remote_addr
+    return request and request.httprequest.remote_addr or ''


### PR DESCRIPTION
If a payment request is made from a cron (e.g., Subscriptions' cron for
recurring payments), the worker is not bound to an HTTP request and
therefore the value of `request.httprequest.remote_addr` is an instance
of the 'LocalProxy' object, which is not serializable.
If we're in this scenario, don't send the customer's IP address.

task-2494916

Co-authored-by: Toufik Ben Jaa <tbe@odoo.com>
