### PR TITLE
[FIX] mrp: Unbuild serial number

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1715,7 +1715,9 @@ class MrpProduction(models.Model):
                 ])
                 if duplicates:
                     # Maybe some move lines have been compensated by unbuild
-                    duplicates_unbuild = self.env['stock.move.line'].search_count(domain_unbuild)
+                    duplicates_unbuild = self.env['stock.move.line'].search_count(domain_unbuild + [
+                        ('move_id.unbuild_id', '!=', False)
+                    ])
                     if not (duplicates_unbuild and duplicates - duplicates_unbuild == 0):
                         raise UserError(message)
                 # Check presence of same sn in current production
@@ -1749,7 +1751,9 @@ class MrpProduction(models.Model):
                 ])
                 if duplicates:
                     # Maybe some move lines have been compensated by unbuild
-                    duplicates_unbuild = self.env['stock.move.line'].search_count(domain_unbuild)
+                    duplicates_unbuild = self.env['stock.move.line'].search_count(domain_unbuild + [
+                            ('move_id.unbuild_id', '!=', False)
+                        ])
                     if not (duplicates_unbuild and duplicates - duplicates_unbuild == 0):
                         raise UserError(message)
                 # Check presence of same sn in current production


### PR DESCRIPTION
When a serial number SN is trying to be consumed and has been unbuilt in the past,
an evaluation is used to check that the # of times SN was unbuilt is equal to
the # of times SN was consumed. However, it did not take into account if SN was the product
of its own MO.

opw:2510294