### PR TITLE
[FIX] sale: grouped invoices

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -678,6 +678,7 @@ class SaleOrder(models.Model):
         if not grouped:
             new_invoice_vals_list = []
             invoice_grouping_keys = self._get_invoice_grouping_keys()
+            invoice_vals_list = sorted(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys])
             for grouping_keys, invoices in groupby(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys]):
                 origins = set()
                 payment_refs = set()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
Add **sorted()** before groupby invoice_vals in create invoice process, since it is required to ensure the grouping is correctly made.
Additional information: https://docs.python.org/3/library/itertools.html#itertools.groupby

**Current behavior before PR**:
Sale orders: Order Partner A + Order Partner B + Order Partner B + Order Partner A + Order Partner B
When the order invoicing process is executed, 4 invoices are created: Invoice Partner A + Invoice Partner B + Invoice Partner A + Invoice Partner B

**Desired behavior after PR is merged**:
Sale orders: Order Partner A + Order Partner B + Order Partner B + Order Partner A + Order Partner B
When the order invoicing process is executed, only 2 invoices are created: Invoice Partner A + Invoice Partner B

**Impacted versions**:
- 13.0
- 14.0

cc @Tecnativa TT30145

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr