### PR TITLE
[FIX] sale: hide update_prices button correctly

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -444,7 +444,7 @@ class SaleOrder(models.Model):
                 }
             }
 
-    @api.onchange('pricelist_id')
+    @api.onchange('pricelist_id', 'order_line')
     def _onchange_pricelist_id(self):
         if self.order_line and self.pricelist_id and self._origin.pricelist_id != self.pricelist_id:
             self.show_update_pricelist = True


### PR DESCRIPTION
Steps:
 - Active Pricelist
 - Create SO --> add some lines
 - Change Pricelist and remove lines

Issue:
- Button to Update prices is still visible

Fix:
- Button should not be visible as there are no lines

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
