### PR TITLE
[FIX] website_form_editor: don't save disable send


### DIFF
--- a/addons/website_form/static/src/js/website_form_editor.js
+++ b/addons/website_form/static/src/js/website_form_editor.js
@@ -419,6 +419,9 @@ odoo.define('website_form_editor', function (require) {
             // Prevent saving of the status message  // TODO: would be better on Edit
             this.$target.find('#o_website_form_result').empty();
 
+            // Prevent saving disabled state of send button  // TODO: would be better on Edit
+            this.$target.find('.o_website_form_send').removeClass('disabled').removeAttr('disabled')
+
             // Update values of custom inputs to mirror their labels
             var custom_inputs = this.$target.find('.o_website_form_custom .o_website_form_input');
             _.each(custom_inputs, function (input, index) {


### PR DESCRIPTION

Scenario:

- send form without "Thank You Page" => "Send" is disabled

- edit the form without refreshing

- save

=> the "Send" button no longer work until the view is edited manually to
remove `disabled="disabled"`.

note: 13.0 community forward-port of odoo/enterprise#18693

opw-2471875
