### PR TITLE
[13.0] Make stock move reservation overiddable (backport)

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1167,6 +1167,11 @@ class StockMove(models.Model):
         self.ensure_one()
         return self.location_id.should_bypass_reservation() or self.product_id.type != 'product'
 
+    # necessary hook to be able to override move reservation to a restrict lot, owner, pack, location...
+    def _get_available_quantity(self, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, allow_negative=False):
+        self.ensure_one()
+        return self.env['stock.quant']._get_available_quantity(self.product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict, allow_negative=allow_negative)
+
     def _action_assign(self):
         """ Reserve stock moves by creating their stock move lines. A stock move is
         considered reserved once the sum of `product_qty` for all its move lines is
@@ -1215,7 +1220,7 @@ class StockMove(models.Model):
                         continue
                     # Reserve new quants and create move lines accordingly.
                     forced_package_id = move.package_level_id.package_id or None
-                    available_quantity = self.env['stock.quant']._get_available_quantity(move.product_id, move.location_id, package_id=forced_package_id)
+                    available_quantity = move._get_available_quantity(move.location_id, package_id=forced_package_id)
                     if available_quantity <= 0:
                         continue
                     taken_quantity = move._update_reserved_quantity(need, available_quantity, move.location_id, package_id=forced_package_id, strict=False)
@@ -1282,8 +1287,7 @@ class StockMove(models.Model):
                         # partially `quantity`. When this happens, we chose to reserve the maximum
                         # still available. This situation could not happen on MTS move, because in
                         # this case `quantity` is directly the quantity on the quants themselves.
-                        available_quantity = self.env['stock.quant']._get_available_quantity(
-                            move.product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True)
+                        available_quantity = move._get_available_quantity(location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True)
                         if float_is_zero(available_quantity, precision_rounding=rounding):
                             continue
                         taken_quantity = move._update_reserved_quantity(need, min(quantity, available_quantity), location_id, lot_id, package_id, owner_id)


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/57574 (14.0)

**Description of the issue/feature this PR addresses:**

Make possible to override the stock move reservation. This would allow to introduce new features like restrict a move reservation to a specific lot, a specific package or even a specific sublocation...

**Current behavior before PR:**

The stock move reservation is not overridable at all.

**Desired behavior after PR is merged:**

Make possible to override the stock move reservation in submodules to introduce new features like restricting the reservation to a specific lot, like it was possible to do with restrict_lot_id field in version 10.

ping @florian-dacosta @amoyaux is it OK to merge this in 13.0? No drawback to do so?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
