### PR TITLE
[13.0][FIX] mail: ignore accents when searching for partners

### DIFF
--- a/addons/mail/static/src/js/services/mail_manager.js
+++ b/addons/mail/static/src/js/services/mail_manager.js
@@ -1152,7 +1152,7 @@ var MailManager =  AbstractService.extend({
             if (values.length < limit) {
                 values = values.concat(_.filter(partners, function (partner) {
                     return (session.partner_id !== partner.id) &&
-                            searchRegexp.test(partner.name);
+                            searchRegexp.test(utils.unaccent(partner.name));
                 })).splice(0, limit);
             }
         });


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** When searching for partners, the search query is parsed to strip any accents from it, but it is then compared with the partner's name without stripping any accent. This leads to false negatives in the search, which can cause extra RPC calls to fetch partners from ORM or the return of a set of partners for some query that is not complete.

**Current behavior before PR:** When you have a set of partners already cached and search for a partner whose name contains accents which is on that list, the search query won't find it. As you have a cached list, it won't perform a RPC/ORM search (which would find the partner correctly), and will return a set of partners that doesn't include the one we are looking for. 

**Desired behavior after PR is merged:** The partner search in the cached list takes into account the accents and avoids false negatives and extra RPC calls.

@Tecnativa
TT30219

cc @pedrobaeza @Yajo @Tardo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
