### PR TITLE
[IMP] mrp: Mass assignation of SN/Lot in MRP

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -23,6 +23,7 @@
         'wizard/mrp_production_backorder.xml',
         'wizard/mrp_consumption_warning_views.xml',
         'wizard/mrp_immediate_production_views.xml',
+        'wizard/stock_assign_serial_numbers.xml',
         'views/mrp_views_menus.xml',
         'views/stock_move_views.xml',
         'views/mrp_workorder_views.xml',

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -268,6 +268,7 @@ class MrpProduction(models.Model):
         ('late', 'Late')], compute='_compute_components_availability')
     show_lot_ids = fields.Boolean('Display the serial number shortcut on the moves', compute='_compute_show_lot_ids')
     forecasted_issue = fields.Boolean(compute='_compute_forecasted_issue')
+    show_serial_mass_produce = fields.Boolean('Display the serial mass product wizard action moves', compute='_compute_show_serial_mass_produce')
 
     @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_child_count(self):
@@ -527,6 +528,17 @@ class MrpProduction(models.Model):
     def _compute_show_lot_ids(self):
         for order in self:
             order.show_lot_ids = order.state != 'draft' and any(m.product_id.tracking == 'serial' for m in order.move_raw_ids)
+
+    @api.depends('state', 'move_raw_ids')
+    def _compute_show_serial_mass_produce(self):
+        self.show_serial_mass_produce = False
+        for order in self:
+            if order.state == 'confirmed' and order.product_id.tracking == 'serial' and \
+                    float_compare(order.product_qty, 1, precision_rounding=order.product_uom_id.rounding) > 0 and \
+                    float_compare(order.qty_producing, order.product_qty, precision_rounding=order.product_uom_id.rounding) < 0:
+                have_serial_components, dummy, dummy, dummy = order._check_serial_mass_produce_components()
+                if not have_serial_components:
+                    order.show_serial_mass_produce = True
 
     _sql_constraints = [
         ('name_uniq', 'unique(name, company_id)', 'Reference must be unique per Company!'),
@@ -1715,6 +1727,34 @@ class MrpProduction(models.Model):
             'target': 'new',
         }
 
+    def action_serial_mass_produce_wizard(self):
+        self.ensure_one()
+        self._check_company()
+        if self.state != 'confirmed':
+            return
+        if self.product_id.tracking != 'serial':
+            return
+        dummy, dummy, missing_components, multiple_lot_components = self._check_serial_mass_produce_components()
+        message = ""
+        if missing_components:
+            message += _("Make sure enough quantities of these components are reserved to carry on production:\n")
+            message += "\n".join(component.name for component in missing_components)
+        if multiple_lot_components:
+            if message:
+                message += "\n"
+            message += _("Component Lots must be unique for mass production. Please review consumption for:\n")
+            message += "\n".join(component.name for component in multiple_lot_components)
+        if message:
+            raise UserError(message)
+        next_serial = self.env['stock.production.lot'].get_next_serial(self.company_id, self.product_id)
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.act_assign_serial_numbers_production")
+        action['context'] = {
+            'default_production_id': self.id,
+            'default_expected_qty': self.product_qty,
+            'default_next_serial_number': next_serial,
+        }
+        return action
+
     @api.model
     def _prepare_procurement_group_vals(self, values):
         return {'name': values['name']}
@@ -1816,3 +1856,99 @@ class MrpProduction(models.Model):
                     ) and float_is_zero(production.qty_producing, precision_digits=pd):
                 immediate_productions |= production
         return immediate_productions
+
+    def _check_serial_mass_produce_components(self):
+        have_serial_components = False
+        have_lot_components = False
+        missing_components = set()
+        multiple_lot_components = set()
+        for production in self:
+            have_serial_components |= any(move.product_id.tracking == 'serial' for move in production.move_raw_ids)
+            have_lot_components |= any(move.product_id.tracking == 'lot' for move in production.move_raw_ids)
+            missing_components.update([move.product_id for move in production.move_raw_ids if float_compare(move.reserved_availability, move.product_uom_qty, precision_rounding=move.product_uom.rounding) < 0])
+            components = {}
+            for move in production.move_raw_ids:
+                if move.product_id.tracking != 'lot':
+                    continue
+                lot_ids = move.mapped('move_line_ids.lot_id.id')
+                if not lot_ids:
+                    continue
+                components.setdefault(move.product_id, set()).update(lot_ids)
+            multiple_lot_components.update([p for p, l in components.items() if len(l) != 1])
+        return (have_serial_components, have_lot_components, missing_components, multiple_lot_components)
+
+    def _generate_backorder_productions_multi(self, serial_numbers, cancel_remaining_quantities=False):
+        self.ensure_one()
+        if self.product_id.tracking != 'serial':
+            raise UserError(_('Expected product tracked by Serial Number.'))
+        if self.backorder_sequence == 0:
+            self.backorder_sequence = 1
+        result = []
+        production = self
+        for serial_number in serial_numbers:
+            production.qty_producing = 1
+            if production.product_qty > 1 and (serial_number != serial_numbers[-1] or not cancel_remaining_quantities):
+                backorder = production.copy(default=production._get_backorder_mo_vals())
+            else:
+                backorder = None
+            new_moves_origin = []
+            new_moves_quantity_to_split = []
+            new_moves_vals = []
+            for move in production.move_raw_ids | production.move_finished_ids:
+                if not move.additional:
+                    uom_qty_to_split = move.product_uom_qty - move.unit_factor * production.qty_producing
+                    qty_to_split = move.product_uom._compute_quantity(uom_qty_to_split, move.product_id.uom_id, rounding_method='HALF-UP')
+                    uom_qty_to_split = float_round(uom_qty_to_split, precision_rounding=move.product_uom.rounding, rounding_method='HALF-UP')
+                    move_vals = move._split(qty_to_split)
+                    if backorder:
+                        if not move_vals:
+                            continue
+                        if move.raw_material_production_id:
+                            move_vals[0]['raw_material_production_id'] = backorder.id
+                        else:
+                            move_vals[0]['production_id'] = backorder.id
+                        new_moves_origin.append(move)
+                        new_moves_vals.append(move_vals[0])
+                        new_moves_quantity_to_split.append(uom_qty_to_split)
+                    elif move.raw_material_production_id:
+                        move.move_line_ids.product_uom_qty = 0
+                        move.move_line_ids[0].product_uom_qty = move.product_uom_qty
+            if backorder:
+                new_moves = self.env['stock.move'].create(new_moves_vals)
+                for move, quantity_to_split, new_move in zip(new_moves_origin, new_moves_quantity_to_split, new_moves):
+                    if move.raw_material_production_id:
+                        move.move_line_ids[0].copy({
+                            'move_id': new_move.id,
+                            'product_uom_qty': quantity_to_split,
+                            'lot_id': move.move_line_ids[0].lot_id.id if move.move_line_ids[0].lot_id else 0,
+                        })
+                        move.with_context(bypass_reservation_update=True).move_line_ids.product_uom_qty = 0
+                        move.with_context(bypass_reservation_update=True).move_line_ids[0].product_uom_qty = move.product_uom_qty
+                for old_wo, wo in zip(production.workorder_ids, backorder.workorder_ids):
+                    wo.qty_produced = max(old_wo.qty_produced - old_wo.qty_producing, 0)
+                    wo.qty_producing = 1
+                ratio = production.qty_producing / production.product_qty
+                for workorder in production.workorder_ids:
+                    workorder.duration_expected = workorder.duration_expected * ratio
+                for workorder in backorder.workorder_ids:
+                    workorder.duration_expected = workorder.duration_expected * (1 - ratio)
+                backorder.action_confirm()
+            production.name = self._get_name_backorder(production.name, production.backorder_sequence)
+            production.product_qty = 1
+            production.lot_producing_id = self.env['stock.production.lot'].create({
+                'product_id': production.product_id.id,
+                'company_id': production.company_id.id,
+                'name': serial_number,
+            })
+            qty_producing_uom = production.product_uom_id._compute_quantity(production.qty_producing, production.product_id.uom_id, rounding_method='HALF-UP')
+            if qty_producing_uom != 1:
+                production.qty_producing = production.product_id.uom_id._compute_quantity(1, production.product_uom_id, rounding_method='HALF-UP')
+            for move in (production.move_raw_ids | production.move_finished_ids.filtered(lambda m: m.product_id != production.product_id)):
+                if not move.product_uom:
+                    continue
+                new_qty = float_round((production.qty_producing - production.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
+                move.move_line_ids.filtered(lambda ml: ml.state not in ('done', 'cancel')).qty_done = 0
+                move.move_line_ids = move._set_quantity_done_prepare_vals(new_qty)
+            result.append((production.lot_producing_id.id, production.id))
+            production = backorder
+        return result

--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_oee
 from . import test_traceability
 from . import test_multicompany
 from . import test_backorder
+from . import test_smp

--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mrp.tests.common import TestMrpCommon
+from odoo.tests import Form
+from odoo.exceptions import UserError
+
+class TestMrpSerialMassProduce(TestMrpCommon):
+
+    def test_smp_serial(self):
+        """Create a MO for a product not tracked by serial number.
+        The smp wizard should not open.
+        """
+        mo = self.generate_mo()[0]
+        self.assertEqual(mo.state, 'confirmed')
+        res = mo.action_serial_mass_produce_wizard()
+        self.assertFalse(res)
+
+    def test_smp_no_serial_component(self):
+        """Create a MO for a product tracked by serial number with a component also tracked by serial number.
+        An error should be throwed.
+        """
+        mo = self.generate_mo(tracking_final='serial', tracking_base_2='serial')[0]
+        with self.assertRaises(UserError):
+            mo.action_serial_mass_produce_wizard()
+
+    def test_smp_produce_all(self):
+        """Create a MO for a product tracked by serial number.
+        Open the smp wizard, generate all serial numbers to produce all quantitites.
+        """
+        mo = self.generate_mo(tracking_final='serial')[0]
+        count = mo.product_qty
+        # Make some stock and reserve
+        for product in mo.move_raw_ids.product_id:
+            self.env['stock.quant'].with_context(inventory_mode=True).create({
+                'product_id': product.id,
+                'inventory_quantity': 100,
+                'location_id': mo.location_src_id.id,
+            })._apply_inventory()
+        mo.action_assign()
+        # Open the wizard
+        action = mo.action_serial_mass_produce_wizard()
+        wizard = Form(self.env['stock.assign.serial'].with_context(**action['context']))
+        # Let the wizard generate all serial numbers
+        wizard.next_serial_number = "sn#1"
+        wizard.next_serial_count = count
+        action = wizard.save().generate_serial_numbers_production()
+        # Reload the wizard to apply generated serial numbers
+        wizard = Form(self.env['stock.assign.serial'].browse(action['res_id']))
+        wizard.save().apply()
+        # Initial MO should have a backorder-sequenced name and be in to_close state
+        self.assertTrue("-001" in mo.name)
+        self.assertEqual(mo.state, "to_close")
+        # Each generated serial number should have its own mo
+        self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), count)
+
+    def test_smp_produce_all_but_one(self):
+        """Create a MO for a product tracked by serial number.
+        Open the smp wizard, generate all but one serial numbers and create a back order.
+        """
+        mo = self.generate_mo(tracking_final='serial')[0]
+        count = mo.product_qty
+        # Make some stock and reserve
+        for product in mo.move_raw_ids.product_id:
+            self.env['stock.quant'].with_context(inventory_mode=True).create({
+                'product_id': product.id,
+                'inventory_quantity': 100,
+                'location_id': mo.location_src_id.id,
+            })._apply_inventory()
+        mo.action_assign()
+        action = mo.action_serial_mass_produce_wizard()
+        wizard = Form(self.env['stock.assign.serial'].with_context(**action['context']))
+        wizard.next_serial_number = "sn#1"
+        wizard.next_serial_count = count - 1
+        action = wizard.save().generate_serial_numbers_production()
+        # Reload the wizard to create backorder (applying generated serial numbers)
+        wizard = Form(self.env['stock.assign.serial'].browse(action['res_id']))
+        wizard.save().create_backorder()
+        # Last MO in sequence is the backorder
+        bo = mo.procurement_group_id.mrp_production_ids[-1]
+        self.assertEqual(bo.backorder_sequence, count)
+        self.assertEqual(bo.state, "confirmed")

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -102,6 +102,8 @@
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,progress,done"/>
                     <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', False)]}" string="Unlock" groups="mrp.group_mrp_manager" type="object" help="Unlock the manufacturing order to adjust what has been consumed or produced." data-hotkey="l"/>
                     <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', True)]}" string="Lock" groups="mrp.group_mrp_manager" type="object" help="Lock the manufacturing order to prevent changes to what has been consumed or produced." data-hotkey="l"/>
+                    <field name="show_serial_mass_produce" invisible="1"/>
+                    <button name="action_serial_mass_produce_wizard" attrs="{'invisible': [('show_serial_mass_produce', '=', False)]}" string="Mass Produce" type="object"/>
                     <button name="action_cancel" type="object" string="Cancel" data-hotkey="z"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('state', 'in', ('done', 'cancel')), ('confirm_cancel', '=', True)]}"/>
                     <button name="action_cancel" type="object" string="Cancel" data-hotkey="z"

--- a/addons/mrp/wizard/__init__.py
+++ b/addons/mrp/wizard/__init__.py
@@ -6,3 +6,4 @@ from . import stock_warn_insufficient_qty
 from . import mrp_production_backorder
 from . import mrp_consumption_warning
 from . import mrp_immediate_production
+from . import stock_assign_serial_numbers

--- a/addons/mrp/wizard/stock_assign_serial_numbers.py
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import Counter
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class StockAssignSerialNumbers(models.TransientModel):
+    _inherit = 'stock.assign.serial'
+
+    production_id = fields.Many2one('mrp.production', 'Production')
+    expected_qty = fields.Float('Expected Quantity', digits='Product Unit of Measure')
+    serial_numbers = fields.Text('Produced Serial Numbers')
+    produced_qty = fields.Float('Produced Quantity', digits='Product Unit of Measure')
+    show_apply = fields.Boolean(help="Technical field to show the Apply button")
+    show_backorders = fields.Boolean(help="Technical field to show the Create Backorder and No Backorder buttons")
+
+    def generate_serial_numbers_production(self):
+        if self.next_serial_number and self.next_serial_count:
+            generated_serial_numbers = "\n".join(self.env['stock.production.lot'].generate_lot_names(self.next_serial_number, self.next_serial_count))
+            self.serial_numbers = "\n".join([self.serial_numbers, generated_serial_numbers]) if self.serial_numbers else generated_serial_numbers
+            self._onchange_serial_numbers()
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.act_assign_serial_numbers_production")
+        action['res_id'] = self.id
+        return action
+
+    def _get_serial_numbers(self):
+        if self.serial_numbers:
+            return list(filter(lambda serial_number: len(serial_number.strip()) > 0, self.serial_numbers.split('\n')))
+        return []
+
+    @api.onchange('serial_numbers')
+    def _onchange_serial_numbers(self):
+        self.show_apply = False
+        self.show_backorders = False
+        serial_numbers = self._get_serial_numbers()
+        duplicate_serial_numbers = [serial_number for serial_number, counter in Counter(serial_numbers).items() if counter > 1]
+        if duplicate_serial_numbers:
+            self.serial_numbers = ""
+            self.produced_qty = 0
+            raise UserError(_('Duplicate Serial Numbers (%s)') % ','.join(duplicate_serial_numbers))
+        existing_serial_numbers = self.env['stock.production.lot'].search([
+            ('company_id', '=', self.production_id.company_id.id),
+            ('product_id', '=', self.production_id.product_id.id),
+            ('name', 'in', serial_numbers),
+        ])
+        if existing_serial_numbers:
+            self.serial_numbers = ""
+            self.produced_qty = 0
+            raise UserError(_('Existing Serial Numbers (%s)') % ','.join(existing_serial_numbers.mapped('display_name')))
+        if len(serial_numbers) > self.expected_qty:
+            self.serial_numbers = ""
+            self.produced_qty = 0
+            raise UserError(_('There are more Serial Numbers than the Quantity to Produce'))
+        self.produced_qty = len(serial_numbers)
+        self.show_apply = self.produced_qty == self.expected_qty
+        self.show_backorders = self.produced_qty > 0 and self.produced_qty < self.expected_qty
+
+    def apply(self):
+        self.production_id._generate_backorder_productions_multi(self._get_serial_numbers())
+
+    def create_backorder(self):
+        self.production_id._generate_backorder_productions_multi(self._get_serial_numbers(), False)
+
+    def no_backorder(self):
+        self.production_id._generate_backorder_productions_multi(self._get_serial_numbers(), True)

--- a/addons/mrp/wizard/stock_assign_serial_numbers.xml
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_assign_serial_numbers_production" model="ir.ui.view">
+        <field name="name">mrp_assign_serial_numbers</field>
+        <field name="model">stock.assign.serial</field>
+        <field name="arch" type="xml">
+            <form string="Serial Mass Produce">
+                <group>
+                    <field name="production_id" readonly="True"/>
+                </group>
+                <group>
+                    <group>
+                        <field name="next_serial_number"/>
+                    </group>
+                    <group>
+                        <label for="next_serial_count"/>
+                        <div class="o_row">
+                            <span><field name="next_serial_count"/></span>
+                            <button name="generate_serial_numbers_production" type="object" class="btn btn-secondary" title="Generate Serial Numbers">
+                                <span>Generate</span>
+                            </button>
+                        </div>
+                    </group>
+                </group>
+                <group>
+                    <field name="serial_numbers" placeholder="copy paste a list and/or use Generate"/>
+                </group>
+                <field name="show_apply" invisible="1" />
+                <field name="show_backorders" invisible="1" />
+                <group>
+                    <group>
+                        <field name="produced_qty" readonly="True" force_save="True"/>
+                    </group>
+                    <group>
+                        <field name="expected_qty" readonly="True"/>
+                    </group>
+                    <p class="o_form_label oe_inline" attrs="{'invisible': [('show_backorders', '=', False)]}">
+                        You have entered less serial numbers than the quantity to produce.<br/>
+                        Create a backorder if you expect to process the remaining quantities later.<br/>
+                        Do not create a backorder if you will not process the remaining products.
+                    </p>
+                </group>
+                <footer>
+                    <button name="apply" string="Apply" type="object" class="btn-primary" attrs="{'invisible': [('show_apply', '=', False)]}"/>
+                    <button name="create_backorder" string="Create Backorder" type="object" class="btn-primary" attrs="{'invisible': [('show_backorders', '=', False)]}"/>
+                    <button name="no_backorder" string="No Backorder" type="object" class="btn-primary" attrs="{'invisible': [('show_backorders', '=', False)]}"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="act_assign_serial_numbers_production" model="ir.actions.act_window">
+        <field name="name">Assign Serial Numbers</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.assign.serial</field>
+        <field name="view_id" ref="view_assign_serial_numbers_production"/>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -93,7 +93,7 @@ class StockPicking(models.Model):
         return self.move_lines.filtered(lambda move: move.is_subcontract).move_orig_ids.production_id
 
     def _get_warehouse(self, subcontract_move):
-        return subcontract_move.warehouse_id or self.picking_type_id.warehouse_id
+        return subcontract_move.warehouse_id or self.picking_type_id.warehouse_id or subcontract_move.move_dest_ids.picking_type_id.warehouse_id
 
     def _prepare_subcontract_mo_vals(self, subcontract_move, bom):
         subcontract_move.ensure_one()

--- a/addons/mrp_subcontracting_dropshipping/__manifest__.py
+++ b/addons/mrp_subcontracting_dropshipping/__manifest__.py
@@ -10,6 +10,10 @@
         This bridge module allows to manage subcontracting with the dropshipping module.
     """,
     'depends': ['mrp_subcontracting', 'stock_dropshipping'],
+    'data': [
+        'data/mrp_subcontracting_dropshipping_data.xml',
+        'views/stock_warehouse_views.xml',
+    ],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/mrp_subcontracting_dropshipping/data/mrp_subcontracting_dropshipping_data.xml
+++ b/addons/mrp_subcontracting_dropshipping/data/mrp_subcontracting_dropshipping_data.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="route_subcontracting_dropshipping" model='stock.location.route'>
+            <field name="name">Dropship Subcontractor on Order</field>
+            <field name="sequence">5</field>
+            <field name="company_id"></field>
+            <field name="product_selectable" eval="True"/>
+        </record>
+
+        <function model="res.company" name="create_missing_subcontracting_dropshipping_rules"/>
+
+        <function model="stock.warehouse" name="write">
+            <value model="stock.warehouse" eval="obj().env['stock.warehouse'].search([]).ids"/>
+            <value eval="{'subcontracting_dropshipping_to_resupply': True}"/>
+        </function>
+
+    </data>
+</odoo>

--- a/addons/mrp_subcontracting_dropshipping/models/__init__.py
+++ b/addons/mrp_subcontracting_dropshipping/models/__init__.py
@@ -2,3 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import stock_picking
+from . import res_company
+from . import stock_warehouse

--- a/addons/mrp_subcontracting_dropshipping/models/__init__.py
+++ b/addons/mrp_subcontracting_dropshipping/models/__init__.py
@@ -4,3 +4,4 @@
 from . import stock_picking
 from . import res_company
 from . import stock_warehouse
+from . import purchase

--- a/addons/mrp_subcontracting_dropshipping/models/purchase.py
+++ b/addons/mrp_subcontracting_dropshipping/models/purchase.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def _get_destination_location(self):
+        self.ensure_one()
+        if not self.dest_address_id:
+            return super()._get_destination_location()
+
+        if self.mrp_production_count:
+            mrp_production_ids = self._get_mrp_productions()
+            if self.dest_address_id in mrp_production_ids.bom_id.subcontractor_ids:
+                return self.dest_address_id.property_stock_subcontractor.id
+        elif self.sale_order_count:
+            return super()._get_destination_location()
+
+        in_bom_products = False
+        not_in_bom_products = False
+        for order_line in self.order_line:
+            if any(bom_line.bom_id.type == 'subcontract' and self.dest_address_id in bom_line.bom_id.subcontractor_ids for bom_line in order_line.product_id.bom_line_ids.filtered(lambda line: line.company_id == self.company_id)):
+                in_bom_products = True
+            else:
+                not_in_bom_products = True
+        if in_bom_products and not_in_bom_products:
+            raise UserError(_("It appears some components in this RFQ are not meant for subcontracting. Please create a separate order for these."))
+        elif in_bom_products:
+            return self.dest_address_id.property_stock_subcontractor.id
+        return super()._get_destination_location()

--- a/addons/mrp_subcontracting_dropshipping/models/res_company.py
+++ b/addons/mrp_subcontracting_dropshipping/models/res_company.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def _create_subcontracting_dropshipping_rules(self):
+        route = self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping')
+        supplier_location = self.env.ref('stock.stock_location_suppliers')
+        vals = []
+        for company in self:
+            subcontracting_location = company.subcontracting_location_id
+            dropship_picking_type = self.env['stock.picking.type'].search([
+                ('company_id', '=', company.id),
+                ('default_location_src_id.usage', '=', 'supplier'),
+                ('default_location_dest_id.usage', '=', 'customer'),
+            ], limit=1, order='sequence')
+            if dropship_picking_type:
+                vals.append({
+                    'name': '%s → %s' % (supplier_location.name, subcontracting_location.name),
+                    'action': 'buy',
+                    'location_id': subcontracting_location.id,
+                    'location_src_id': supplier_location.id,
+                    'procure_method': 'make_to_stock',
+                    'route_id': route.id,
+                    'picking_type_id': dropship_picking_type.id,
+                    'company_id': company.id,
+                })
+        if vals:
+            self.env['stock.rule'].create(vals)
+
+    @api.model
+    def create_missing_subcontracting_dropshipping_rules(self):
+        route = self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping')
+        company_ids = self.env['res.company'].search([])
+        company_has_rules = self.env['stock.rule'].search([('route_id', '=', route.id)]).mapped('company_id')
+        company_todo_rules = company_ids - company_has_rules
+        company_todo_rules._create_subcontracting_dropshipping_rules()
+
+    def _create_per_company_rules(self):
+        res = super()._create_per_company_rules()
+        self.create_missing_subcontracting_dropshipping_rules()
+        return res

--- a/addons/mrp_subcontracting_dropshipping/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_warehouse.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class StockWarehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    subcontracting_dropshipping_to_resupply = fields.Boolean(
+        'Dropship Subcontractors', default=True,
+        help="Dropship subcontractors with components")
+
+    subcontracting_dropshipping_pull_id = fields.Many2one(
+        'stock.rule', 'Subcontracting-Dropshipping MTS Rule'
+    )
+
+    def _get_global_route_rules_values(self):
+        rules = super()._get_global_route_rules_values()
+        subcontract_location_id = self._get_subcontracting_location()
+        production_location_id = self._get_production_location()
+        rules.update({
+            'subcontracting_dropshipping_pull_id': {
+                'depends': ['subcontracting_dropshipping_to_resupply'],
+                'create_values': {
+                    'procure_method': 'make_to_order',
+                    'company_id': self.company_id.id,
+                    'action': 'pull',
+                    'auto': 'manual',
+                    'route_id': self._find_global_route('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping',
+                                                        _('Dropship Subcontractor on Order')).id,
+                    'name': self._format_rulename(subcontract_location_id, production_location_id, False),
+                    'location_id': production_location_id.id,
+                    'location_src_id': subcontract_location_id.id,
+                    'picking_type_id': self.subcontracting_type_id.id
+                },
+                'update_values': {
+                    'active': self.subcontracting_dropshipping_to_resupply
+                }
+            },
+        })
+        return rules

--- a/addons/mrp_subcontracting_dropshipping/views/stock_warehouse_views.xml
+++ b/addons/mrp_subcontracting_dropshipping/views/stock_warehouse_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warehouse_inherit_mrp_subcontracting_dropshipping" model="ir.ui.view">
+        <field name="name">Stock Warehouse Inherit Subcontracting Dropshipping</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="mrp_subcontracting.view_warehouse_inherit_mrp_subcontracting"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='subcontracting_to_resupply']" position="before">
+                <field name="subcontracting_dropshipping_to_resupply" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -90,7 +90,7 @@ class PurchaseOrder(models.Model):
         help="Depicts the date within which the Quotation should be confirmed and converted into a purchase order.")
     date_approve = fields.Datetime('Confirmation Date', readonly=1, index=True, copy=False)
     partner_id = fields.Many2one('res.partner', string='Vendor', required=True, states=READONLY_STATES, change_default=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
-    dest_address_id = fields.Many2one('res.partner', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Drop Ship Address', states=READONLY_STATES,
+    dest_address_id = fields.Many2one('res.partner', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Dropship Address', states=READONLY_STATES,
         help="Put an address if you want to deliver directly from the vendor to the customer. "
              "Otherwise, keep empty to deliver to your own company.")
     currency_id = fields.Many2one('res.currency', 'Currency', required=True, states=READONLY_STATES,

--- a/addons/purchase_requisition_stock_dropshipping/views/purchase_views.xml
+++ b/addons/purchase_requisition_stock_dropshipping/views/purchase_views.xml
@@ -7,7 +7,6 @@
             <field name="inherit_id" ref="purchase.purchase_order_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='origin']" position="after">
-                    <field name="picking_type_id"/>
                     <field name="group_id" invisible="1"/>
                 </xpath>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -54,10 +54,12 @@
                 <attribute name="attrs">{'column_invisible': [('parent.state', 'not in', ('purchase', 'done'))], 'readonly': [('product_type', 'in', ('consu', 'product'))]}</attribute>
             </xpath>
             <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
-                <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                <field name="dest_address_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('default_location_dest_id_usage', '!=', 'customer')], 'required': [('default_location_dest_id_usage', '=', 'customer')]}"/>
                 <field name="default_location_dest_id_usage" invisible="1"/>
                 <field name="incoterm_id"/>
+            </xpath>
+            <xpath expr="//field[@name='origin']" position="after">
+                <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                <field name="dest_address_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('default_location_dest_id_usage', '!=', 'customer')], 'required': [('default_location_dest_id_usage', '=', 'customer')]}"/>
             </xpath>
         </field>
     </record>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -897,7 +897,7 @@ class StockMove(models.Model):
         warehouse = self.location_dest_id.warehouse_id
         forecast_availability = self.product_id.with_context(warehouse=warehouse.id, to_date=self.date).virtual_available
         if self.state == 'draft':
-            forecast_availability += self.product_uom_qty
+            forecast_availability += self.product_qty
         return forecast_availability
 
     @api.onchange('product_id', 'picking_type_id')

--- a/addons/stock/wizard/stock_assign_serial_numbers.py
+++ b/addons/stock/wizard/stock_assign_serial_numbers.py
@@ -16,8 +16,8 @@ class StockAssignSerialNumbers(models.TransientModel):
             return len(filtered_move_lines)
 
     product_id = fields.Many2one('product.product', 'Product',
-        related='move_id.product_id', required=True)
-    move_id = fields.Many2one('stock.move', required=True)
+        related='move_id.product_id')
+    move_id = fields.Many2one('stock.move')
     next_serial_number = fields.Char('First SN', required=True)
     next_serial_count = fields.Integer('Number of SN',
         default=_default_next_serial_count, required=True)

--- a/addons/stock/wizard/stock_assign_serial_views.xml
+++ b/addons/stock/wizard/stock_assign_serial_views.xml
@@ -24,6 +24,7 @@
         <field name="name">Assign Serial Numbers</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">stock.assign.serial</field>
+        <field name="view_id" ref="view_assign_serial_numbers"/>
         <field name="view_mode">form</field>
         <field name="context">{}</field>
         <field name="target">new</field>

--- a/addons/stock_dropshipping/models/res_company.py
+++ b/addons/stock_dropshipping/models/res_company.py
@@ -53,6 +53,7 @@ class ResCompany(models.Model):
                 'default_location_src_id': self.env.ref('stock.stock_location_suppliers').id,
                 'default_location_dest_id': self.env.ref('stock.stock_location_customers').id,
                 'sequence_code': 'DS',
+                'use_existing_lots': False,
             })
         if dropship_vals:
             self.env['stock.picking.type'].create(dropship_vals)


### PR DESCRIPTION
Allow to produce several serial numbers at once.
Only when BoM do not contain any component tracked by unique serial number
and lot ones are from 1 lot.
Also allow to copy/paste serial numbers.
This applies to manufacturing orders and subcontracting receipts, dropshipping handled.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
