### PR TITLE
[FIX] point_of_sale: reload order with negative price

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2735,7 +2735,7 @@ exports.Order = Backbone.Model.extend({
             amount_paid: this.get_total_paid() - this.get_change(),
             amount_total: this.get_total_with_tax(),
             amount_tax: this.get_total_tax(),
-            amount_return: this.amount_return ? this.amount_return : this.get_change(),
+            amount_return: this.get_change(),
             lines: orderLines,
             statement_ids: paymentLines,
             pos_session_id: this.pos_session_id,


### PR DESCRIPTION
Steps:
- Go to Point of Sale
- Open a new session
- Add an item to the cart
- Click [+/-], [1] to get a negative price
- Reload the page
- Click Payment
- Click Cash
- Validate
- Close the UI and go back to the backend
- Click the three dots on the POS
- Click View / Orders
- Open the last order

Bug:
The order is still in "New" state and two payments of the same amount
have been registered. This results in the order not being fully paid.

Explanation:
`get_change()` returns the amount to be given back to the customer. It's
usually set back to 0 when the payment lines are created (e.g. when
clicking "Cash"). `amount_return` is then sent to the backend with the
order.
However, when reloading the page before clicking "Cash", no payment
lines are made and `amount_return` has been saved in LocalStorage with
the result of `get_change()`. `amount_return`, which is usually
undefined is now set back to its old value when reloading from the saved
JSON.
Because `amount_return` is not undefined in this case, it doesn't change
the result sent in the JSON when clicking "Cash"; it's not updated with
0 from `get_change()`. This results in two payments being recorded in
the order after validating and sending it to the backend.

This commit always uses the result of `get_change()` when sending the
order to the backend.

opw:2446563