### PR TITLE
[FIX] website_slides: hide the "Go to website" button if the course is not saved

### DIFF
--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -42,7 +42,7 @@
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <field name="is_published" widget="website_redirect_button"
-                                   attrs="{'invisible': [('is_category', '=', True)]}"/>
+                                   attrs="{'invisible': ['|',('is_category', '=', True), ('channel_id', '=', False)]}"/>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="image_1920" widget="image" class="oe_avatar" options='{"preview_image": "image_256"}'
@@ -151,7 +151,10 @@
             <field name="mode">primary</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <field name="channel_id" position="replace"/>
+                <field name="channel_id" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                    <attribute name="required">0</attribute>
+                </field>
             </field>
         </record>
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Elearning > choose any course or create a new one
- Click on “add content” :
    - Add a title to slide
    - Click on "Go to Website"

Problem:
An error is triggered because we call the "create" method to save the slide, which tries to access the “channel_id”, the course ID in which the slide will be added. However, the field is not set in values.
The "create" or "write" function in "slide_channel" must first be called to save the course, which will then call the create function in "slide_slide"

Solution :
Hide the "Go to website" button as long as the course is not created and therefore has no id

opw-2526541

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
