### PR TITLE
[FIX] account: Allow the user to cash in/out

### DIFF
--- a/addons/account/wizard/pos_box.py
+++ b/addons/account/wizard/pos_box.py
@@ -34,7 +34,7 @@ class CashBox(models.TransientModel):
                 raise UserError(_("You cannot put/take money in/out for a bank statement which is closed."))
             values = box._calculate_values_for_statement_line(record)
             account = record.journal_id.company_id.transfer_account_id
-            self.env['account.bank.statement.line'].with_context(counterpart_account_id=account.id).create(values)
+            self.env['account.bank.statement.line'].sudo().with_context(counterpart_account_id=account.id).create(values)
 
 
 class CashBoxOut(CashBox):


### PR DESCRIPTION
An user wasn't able to put cash in/out before this commit due to security restriction.
The user needed at least "billing" as default value in accounting to be allowed to changed.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
