### PR TITLE
[FIX] portal: fix portal searchbar

### DIFF
--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -98,7 +98,7 @@ publicWidget.registry.portalSearchPanel = publicWidget.Widget.extend({
     events: {
         'click .search-submit': '_onSearchSubmitClick',
         'click .dropdown-item': '_onDropdownItemClick',
-        'keyup input[name="search"]': '_onSearchInputKeyup',
+        'keydown input[name="search"]': '_onSearchInputKeydown',
     },
 
     /**
@@ -156,8 +156,9 @@ publicWidget.registry.portalSearchPanel = publicWidget.Widget.extend({
     /**
      * @private
      */
-    _onSearchInputKeyup: function (ev) {
+    _onSearchInputKeydown: function (ev) {
         if (ev.keyCode === $.ui.keyCode.ENTER) {
+            ev.preventDefault();
             this._search();
         }
     },


### PR DESCRIPTION
Before this commit, trying to search for elements in a given category in the searchbar of the tasks portal sometimes lead to an issue when using the enter key, if the form was submitted before trigger the search for the data.

This commit adds a way to get rid of the form submission to avoid getting this issue.

# Steps to reproduce
1. Go to the portal and open the tasks
2. Select "Project" in the searchbar dropdown
3. Search for anything, such as "Office", by using the enter key instead of clicking on the search button
4. See that, at times, the output received does not match what was expected

Linked to task-2508883

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr