### PR TITLE
[FIX] portal: fix portal searchbar

### DIFF
--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -96,9 +96,8 @@ publicWidget.registry.PortalHomeCounters = publicWidget.Widget.extend({
 publicWidget.registry.portalSearchPanel = publicWidget.Widget.extend({
     selector: '.o_portal_search_panel',
     events: {
-        'click .search-submit': '_onSearchSubmitClick',
         'click .dropdown-item': '_onDropdownItemClick',
-        'keyup input[name="search"]': '_onSearchInputKeyup',
+        'submit': '_onSubmit',
     },
 
     /**
@@ -139,12 +138,6 @@ publicWidget.registry.portalSearchPanel = publicWidget.Widget.extend({
     /**
      * @private
      */
-    _onSearchSubmitClick: function () {
-        this._search();
-    },
-    /**
-     * @private
-     */
     _onDropdownItemClick: function (ev) {
         ev.preventDefault();
         var $item = $(ev.currentTarget);
@@ -156,10 +149,9 @@ publicWidget.registry.portalSearchPanel = publicWidget.Widget.extend({
     /**
      * @private
      */
-    _onSearchInputKeyup: function (ev) {
-        if (ev.keyCode === $.ui.keyCode.ENTER) {
-            this._search();
-        }
+    _onSubmit: function (ev) {
+        ev.preventDefault();
+        this._search();
     },
 });
 

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -310,7 +310,7 @@
                         </div>
                         <input type="text" class="form-control form-control-sm" placeholder="Search" t-att-value='search' name="search"/>
                         <span class="input-group-append">
-                            <button class="btn btn-secondary search-submit" type="button">
+                            <button class="btn btn-secondary o_wait_lazy_js" type="submit">
                                 <span class="fa fa-search"/>
                             </button>
                         </span>


### PR DESCRIPTION
Before this commit, trying to search for elements in a given category in the searchbar of the tasks portal sometimes lead to an issue when using the enter key, if the form was submitted before trigger the search for the data.

This commit adds a way to get rid of the form submission to avoid getting this issue.

# Steps to reproduce
1. Go to the portal and open the tasks
2. Select "Project" in the searchbar dropdown
3. Search for anything, such as "Office", by using the enter key instead of clicking on the search button
4. See that, at times, the output received does not match what was expected

task-2508883
Related PR: #70305 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr