### PR TITLE
[FIX] l10n_in: do not specify payment method in demo data

### DIFF
--- a/addons/l10n_in/demo/account_payment_demo.xml
+++ b/addons/l10n_in/demo/account_payment_demo.xml
@@ -11,10 +11,6 @@
             eval="obj().search([
                 ('type', '=', 'cash'),
                 ('company_id', '=', ref('l10n_in.demo_company_in'))], limit=1).id"/>
-        <field name="payment_method_id" model="account.journal"
-            eval="obj().search([
-                ('type', '=', 'cash'),
-                ('company_id', '=', ref('l10n_in.demo_company_in'))], limit=1).inbound_payment_method_line_ids[0].id"/>
     </record>
 
     <function model="account.payment" name="action_post">


### PR DESCRIPTION
This is computed automatically since
04522f01e6fdbf82a657b32b312449fd7d756f79



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
