### PR TITLE
[FIX] account: do not override accounting date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -367,9 +367,12 @@ class AccountMove(models.Model):
         if self.invoice_date:
             if not self.invoice_payment_term_id and (not self.invoice_date_due or self.invoice_date_due < self.invoice_date):
                 self.invoice_date_due = self.invoice_date
-            if self.date != self.invoice_date:  # Don't flag date as dirty if not needed
+            if (
+                self.is_sale_document() and self.date != self.invoice_date
+                or self.is_purchase_document() and not self.date
+            ):
                 self.date = self.invoice_date
-            self._onchange_currency()
+                self._onchange_currency()
 
     @api.onchange('journal_id')
     def _onchange_journal(self):

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -364,6 +364,7 @@ class AccountTestInvoicingCommon(SavepointCase):
     def init_invoice(cls, move_type, partner=None, invoice_date=None, post=False, products=[], amounts=[], taxes=None):
         move_form = Form(cls.env['account.move'].with_context(default_move_type=move_type, account_predictive_bills_disable_prediction=True))
         move_form.invoice_date = invoice_date or fields.Date.from_string('2019-01-01')
+        move_form.date = move_form.invoice_date
         move_form.partner_id = partner or cls.partner_a
 
         for product in products:


### PR DESCRIPTION
The accounting date must be today by default and changing the
Kind of followup after this change of behavior fcaa54939e9a4f0dd5e47cd0ccffe7aa24bd451c

[task-2550985](https://www.odoo.com/web#active_id=2550985&cids=1&id=2550985&model=project.task&menu_id=)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
