### PR TITLE
[FIX] Delete id_document, is the same that national_citizen_id

### DIFF
--- a/addons/l10n_co/models/res_partner.py
+++ b/addons/l10n_co/models/res_partner.py
@@ -7,15 +7,14 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     l10n_co_document_type = fields.Selection([('rut', 'NIT'),
-                                              ('id_document', 'Cédula'),
-                                              ('id_card', 'Tarjeta de Identidad'),
+                                              ('national_citizen_id', 'Cédula de ciudadanía'),
                                               ('passport', 'Pasaporte'),
                                               ('foreign_id_card', 'Cédula Extranjera'),
+                                              ('id_card', 'Tarjeta de Identidad'),
                                               ('external_id', 'ID del Exterior'),
                                               ('diplomatic_card', 'Carné Diplomatico'),
                                               ('residence_document', 'Salvoconducto de Permanencia'),
-                                              ('civil_registration', 'Registro Civil'),
-                                              ('national_citizen_id', 'Cédula de ciudadanía')], string='Document Type',
+                                              ('civil_registration', 'Registro Civil')], string='Document Type',
                                              help='Indicates to what document the information in here belongs to.')
     l10n_co_verification_code = fields.Char(compute='_compute_verification_code', string='VC',  # todo remove this field in master
                                             help='Redundancy check to verify the vat number has been typed in correctly.')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In Colombia (l10n_co module), the document type id_document = 'Cédula' and national_citizen_id = 'Cédula de ciudadanía' is the same document and is not necesary show 2 items.

Current behavior before PR:
 l10n_co_document_type = fields.Selection([('rut', 'NIT'),
                                              ('id_document', 'Cédula'),
                                              ('id_card', 'Tarjeta de Identidad'),
                                              ('passport', 'Pasaporte'),
                                              ('foreign_id_card', 'Cédula Extranjera'),
                                              ('external_id', 'ID del Exterior'),
                                              ('diplomatic_card', 'Carné Diplomatico'),
                                              ('residence_document', 'Salvoconducto de Permanencia'),
                                              ('civil_registration', 'Registro Civil'),
                                              ('national_citizen_id', 'Cédula de ciudadanía')], string='Document Type',
                                             help='Indicates to what document the information in here belongs to.')

Desired behavior after PR is merged:
l10n_co_document_type = fields.Selection([('rut', 'NIT'),
                                              ('national_citizen_id', 'Cédula de ciudadanía'),
                                              ('passport', 'Pasaporte'),
                                              ('foreign_id_card', 'Cédula Extranjera'),
                                              ('id_card', 'Tarjeta de Identidad'),
                                              ('external_id', 'ID del Exterior'),
                                              ('diplomatic_card', 'Carné Diplomatico'),
                                              ('residence_document', 'Salvoconducto de Permanencia'),
                                              ('civil_registration', 'Registro Civil')], string='Document Type',
                                             help='Indicates to what document the information in here belongs to.')



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
