### PR TITLE
[FIX] purchase: fix the issue of vendor reference getting duplicated

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -18,9 +18,9 @@ class AccountMove(models.Model):
 
     def _get_invoice_reference(self):
         self.ensure_one()
-        vendor_refs = [ref for ref in set(self.line_ids.mapped('purchase_line_id.order_id.partner_ref')) if ref]
+        vendor_refs = ', '.join(self.line_ids.purchase_line_id.order_id.filtered(lambda order: order.partner_ref != False).mapped('partner_ref')).split(', ')
         if self.ref:
-            return [ref for ref in self.ref.split(', ') if ref and ref not in vendor_refs] + vendor_refs
+            return set(self.ref.split(', ')).union(set(vendor_refs))
         return vendor_refs
 
     @api.onchange('purchase_vendor_bill_id', 'purchase_id')


### PR DESCRIPTION
Before this fix, if vendor bill is created from purchase order, then
reference got duplicated on bill if vendor reference had comma (, ) in
it.

Description of the issue/feature this PR addresses:
Please watch this video in which the issue is demonstrated:
https://drive.google.com/file/d/1gGlnNogO6B2gkjPiwdzEtYaUcOrjaGRc/view?usp=sharing



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
