### PR TITLE
[FIX][IMP] mass_mailing: make document fields required on trace model

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Email Marketing',
     'summary': 'Design, send and track emails',
     'description': "",
-    'version': '2.4',
+    'version': '2.5',
     'sequence': 60,
     'website': 'https://www.odoo.com/page/mailing',
     'category': 'Marketing/Email Marketing',

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -66,8 +66,8 @@ class MailingTrace(models.Model):
     medium_id = fields.Many2one(related='mass_mailing_id.medium_id')
     source_id = fields.Many2one(related='mass_mailing_id.source_id')
     # document
-    model = fields.Char(string='Document model')
-    res_id = fields.Many2oneReference(string='Document ID', model_field='model')
+    model = fields.Char(string='Document model', required=True)
+    res_id = fields.Many2oneReference(string='Document ID', model_field='model', required=True)
     # campaign / wave data
     mass_mailing_id = fields.Many2one('mailing.mailing', string='Mailing', index=True, ondelete='cascade')
     campaign_id = fields.Many2one(

--- a/addons/test_mass_mailing/tests/test_link_tracker.py
+++ b/addons/test_mass_mailing/tests/test_link_tracker.py
@@ -45,10 +45,14 @@ class TestLinkTracker(common.TestMassMailCommon):
 
     @users('user_marketing')
     def test_add_link_mail_stat(self):
-        mailing = self.env['mailing.mailing'].create({'name': 'Test Mailing', "subject": "Hi!"})
+        record = self.env['mailing.test.blacklist'].create({})
         code = self.link.code
         self.assertEqual(self.link.count, 1)
-        stat = self.env['mailing.trace'].create({'mass_mailing_id': mailing.id})
+        stat = self.env['mailing.trace'].create({
+            'mass_mailing_id': self.mailing_bl.id,
+            'model': record._name,
+            'res_id': record.id,
+        })
         self.assertFalse(stat.opened)
         self.assertFalse(stat.clicked)
 
@@ -60,6 +64,6 @@ class TestLinkTracker(common.TestMassMailCommon):
             mailing_trace_id=stat.id
         )
         self.assertEqual(self.link.count, 2)
-        self.assertEqual(click.mass_mailing_id, mailing)
+        self.assertEqual(click.mass_mailing_id, self.mailing_bl)
         self.assertTrue(stat.opened)
         self.assertTrue(stat.clicked)


### PR DESCRIPTION
Traces are always linked to documents as mailings are sent on
documents. Those fields should be required to ensure database
coherency.

Task ID-2525759
