### PR TITLE
[FIX] point_of_sale: automatic printing via web not loading images on…

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -1631,12 +1631,13 @@ var ReceiptScreenWidget = ScreenWidget.extend({
         };
     },
     print_web: function() {
-        if ($.browser.safari) {
-            document.execCommand('print', false, null);
-        } else {
+        var self = this;
+
+        setTimeout(function () {
             try {
                 window.print();
-            } catch(err) {
+                self.pos.get_order()._printed = true;
+            } catch (err) {
                 if (navigator.userAgent.toLowerCase().indexOf("android") > -1) {
                     this.gui.show_popup('error',{
                         'title':_t('Printing is not supported on some android browsers'),
@@ -1646,8 +1647,7 @@ var ReceiptScreenWidget = ScreenWidget.extend({
                     throw err;
                 }
             }
-        }
-        this.pos.get_order()._printed = true;
+        }, 500);
     },
     print_xml: function() {
         var receipt = QWeb.render('XmlReceipt', this.get_receipt_render_env());


### PR DESCRIPTION
… Chrome 91.

Tested on Firefox 89, Chrome 91, IOS 14 (Safari), Android 9 (Chrome 90 and Firefox 89).

Description of the issue/feature this PR addresses:
Point of Sale automatic printing via web not loading images on Chrome 91.

Current behavior before PR:
Images not loading on printing wizard

Desired behavior after PR is merged:
Print report from the browser with the images loaded



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
