### PR TITLE
Saas 14.3 web fix reference field length dht

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -3581,7 +3581,10 @@ var FieldReference = FieldMany2One.extend({
             this.$('.o_input_dropdown').show();
             if (!this.nodeOptions.model_field) {
                 // this class is used to display the two components (select & input) on the same line
-                this.$el.addClass('o_row');
+                if (this.nodeOptions.hide_model) {
+                    this.$el.addClass('o_row');
+                }
+                this.$el.find('.o_field_many2one_selection').addClass('o_row');
             }
         } else {
             // hide the many2one if the selection is empty

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -167,6 +167,10 @@ $o-form-label-margin-right: 0px;
                 }
             }
         }
+
+        .o_field_many2one .o_field_many2one_selection {
+            width: 100% !important;
+        }
     }
 
     // No sheet


### PR DESCRIPTION
PURPOSE

Fix the rendering glitch of reference field.

SPECIFICATION

Current
  The selection and many2one fields of reference
  field were rendering at same place. Due to which we are not able to see
  properly any of the field in edit mode.

To be
  It should render separately side by side as it was before

Task Id: 2453138
PR: #71799

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
