### PR TITLE
[FIX] base: do not overwrite context when upgrading

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2252,7 +2252,7 @@ class IrModelData(models.Model):
             return True
 
         bad_imd_ids = []
-        self = self.with_context({MODULE_UNINSTALL_FLAG: True})
+        self = self.with_context(**{MODULE_UNINSTALL_FLAG: True})
         loaded_xmlids = self.pool.loaded_xmlids
 
         query = """ SELECT id, module || '.' || name, model, res_id FROM ir_model_data


### PR DESCRIPTION
Just allow to pass flags to the context of `_process_end` method.

(the same is done in https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/ir_model.py#L2087)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr