### PR TITLE
support many2one_avatar_user widget on activity view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -498,7 +498,7 @@
                     <field name="company_currency"/>
                     <templates>
                         <div t-name="activity-box">
-                            <img t-att-src="activity_image('res.users', 'avatar_128', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
+                            <field name="user_id" widget="many2one_avatar_user"/>
                             <div>
                                 <field name="name" display="full"/>
                                 <field name="expected_revenue" widget="monetary" display="full" muted="1"/>

--- a/addons/mail/static/src/js/m2x_avatar_user.js
+++ b/addons/mail/static/src/js/m2x_avatar_user.js
@@ -97,4 +97,5 @@ export const Many2ManyAvatarUser = FieldMany2ManyTagsAvatar.extend(M2XAvatarMixi
 
 fieldRegistry.add('many2one_avatar_user', Many2OneAvatarUser);
 fieldRegistry.add('kanban.many2one_avatar_user', KanbanMany2OneAvatarUser);
+fieldRegistry.add('activity.many2one_avatar_user', KanbanMany2OneAvatarUser);
 fieldRegistry.add('many2many_avatar_user', Many2ManyAvatarUser);

--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -69,8 +69,9 @@
         padding: 8px 8px;
         cursor: pointer;
 
-        > img {
+        .o_m2o_avatar > img, > img {
             width: 32px;
+            height: 32px;
             max-height: 32px;
             margin-right: 16px;
         }

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1082,7 +1082,7 @@
                     <field name="user_id"/>
                     <templates>
                         <div t-name="activity-box">
-                            <img t-att-src="activity_image('res.users', 'avatar_128', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
+                            <field name="user_id" widget="many2one_avatar_user"/>
                             <div>
                                 <field name="name" display="full"/>
                                 <field name="project_id" muted="1" display="full" invisible="context.get('default_project_id', False)"/>


### PR DESCRIPTION
PURPOSE
The purpose of this task is to support the many2one_avatar widget in the activity view.
With this, users will be able to chat with users from their avatars in the activity view, just like they can from the formview, kanban, etc.

SPECIFICATION
    implement support for the many2one_avatar widget in the activity view
    replace the user avatar <img> by the many2one_avatar_user widget in the following activity views 

TASK 2554466


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
