### PR TITLE
[FIX] point_of_sale: fix back button when reprint

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -222,7 +222,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
 
             // 3. Save the screen to the order.
             //  - This screen is shown when the order is selected.
-            if (!(component.prototype instanceof IndependentToOrderScreen)) {
+            if (!(component.prototype instanceof IndependentToOrderScreen) && name !== "ReprintReceiptScreen") {
                 this._setScreenData(name, props);
             }
         }


### PR DESCRIPTION
Before we were unable to go back to the product screen when pressing back button after a reprint.
With this commit, we prevent the automatic setting of screen on the order.
This allow us to go back to the the screen relative to the current order we were.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
