### PR TITLE
[FIX] mail, hr, test_mail: correctly Markup-ize bounce notification e…

### DIFF
--- a/addons/hr/models/mail_alias.py
+++ b/addons/hr/models/mail_alias.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
+
 from odoo import fields, models, _
 
 
@@ -13,7 +15,9 @@ class Alias(models.Model):
 
     def _get_alias_bounced_body_fallback(self, message_dict):
         if self.alias_contact == 'employees':
-            return _("""Hi,<br/>
+            return Markup(
+                _("""<p>Hi,<br/>
 Your document has not been created because your email address is not recognized.<br/>
-Please send emails with the email address recorded on your employee information, or contact your HR manager.""")
+Please send emails with the email address recorded on your employee information, or contact your HR manager.</p>""")
+            )
         return super(Alias, self)._get_alias_bounced_body_fallback(message_dict)

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -4,6 +4,8 @@
 import ast
 import re
 
+from markupsafe import Markup
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import remove_accents, is_html_empty
@@ -227,9 +229,11 @@ class Alias(models.Model):
         }
 
     def _get_alias_bounced_body_fallback(self, message_dict):
-        return _("""Hi,<br/>
+        return Markup(
+            _("""<p>Hi,<br/>
 The following email sent to %s cannot be accepted because this is a private email address.
-Only allowed people can contact us at this address.""", self.display_name)
+Only allowed people can contact us at this address.</p>""")
+        ) % self.display_name
 
     def _get_alias_bounced_body(self, message_dict):
         """Get the body of the email return in case of bounced email.

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -419,13 +419,16 @@ class TestMailgateway(TestMailCommon):
             record = self.format_and_process(MAIL_TEMPLATE, self.email_from, 'groups@test.com', subject='Should Bounce')
         self.assertFalse(record, 'message_process: should have bounced')
         # Check if default (hardcoded) value is in the mail content
-        self.assertSentEmail('"MAILER-DAEMON" <bounce.test@test.com>', ['whatever-2a840@postmaster.twitter.com'], body_content='The following email sent to')
+        self.assertSentEmail(
+            '"MAILER-DAEMON" <bounce.test@test.com>', ['whatever-2a840@postmaster.twitter.com'],
+            body_content="<p>Hi,<br/>\nThe following email sent to groups@test.com"
+        )
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_message_process_alias_config_bounced_to(self):
         """ Check bounce message contains the bouncing alias, not a generic "to" """
         self.alias.write({'alias_contact': 'partners'})
-        bounce_message_with_alias = "The following email sent to %s cannot be accepted because this is a private email address." % self.alias.display_name.lower()
+        bounce_message_with_alias = "<p>Hi,<br/>\nThe following email sent to %s cannot be accepted because this is a private email address." % self.alias.display_name.lower()
 
         # Bounce is To
         with self.mock_mail_gateway():


### PR DESCRIPTION
…mail content

It is currently escaped as it is not Markup-ed.