### PR TITLE
[FIX] l10n_it_edi: some vendor credit note fail import from xml

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -289,7 +289,7 @@ class AccountEdiFormat(models.Model):
                     if elements:
                         message_to_log.append("%s<br/>%s" % (
                             _("Bank account not found, useful informations from XML file:"),
-                            self._compose_info_message(body_tree, './/DatiPagamento')))
+                            invoice._compose_info_message(body_tree, './/DatiPagamento')))
 
                 # Invoice lines. <2.2.1>
                 elements = body_tree.xpath('.//DettaglioLinee')


### PR DESCRIPTION
When importing vendor credit note from an italian e-invoice xml file with a "DettaglioPagamento" section,
the data import will fail and you will have the "Unsupported image format" message on top of the invoice.

The use of '_compose_info_message' function is not possible on a 'account.edi.format' object and was
changed to use the 'invoice' parameter.

opw-2500569