### PR TITLE
[REM] calendar: delete auto_join=False

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -153,8 +153,6 @@ class Meeting(models.Model):
         'Document Model Name', related='res_model_id.model', readonly=True, store=True)
     # messaging
     activity_ids = fields.One2many('mail.activity', 'calendar_event_id', string='Activities')
-    #redifine message_ids to remove autojoin to avoid search to crash in get_recurrent_ids
-    message_ids = fields.One2many(auto_join=False)
     # attendees
     attendee_ids = fields.One2many(
         'calendar.attendee', 'event_id', 'Participant')


### PR DESCRIPTION
it was made for old implementation that is changed since Odoo 14.0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
