### PR TITLE
[FIX] purchase_stock: Add ir_rule to access only own PO

### DIFF
--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -11,6 +11,7 @@
     'depends': ['stock_account', 'purchase'],
     'data': [
         'security/ir.model.access.csv',
+        'security/purchase_stock_security.xml',
         'data/purchase_stock_data.xml',
         'data/mail_data.xml',
         'views/purchase_views.xml',

--- a/addons/purchase_stock/security/purchase_stock_security.xml
+++ b/addons/purchase_stock/security/purchase_stock_security.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data noupdate="1">
+    <record id="purchase_order_user_rule" model="ir.rule">
+        <field name="name">User access own purchase order only</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="domain_force">[('create_uid', '=', user.id) ]</field>
+        <field name="groups" eval="[(4, ref('stock.group_stock_user'))]"/>
+    </record>
+    <record id="purchase_order_line_user_rule" model="ir.rule">
+        <field name="name">User access own purchase order line only</field>
+        <field name="model_id" ref="purchase.model_purchase_order_line"/>
+        <field name="domain_force">[('create_uid', '=', user.id) ]</field>
+        <field name="groups" eval="[(4, ref('stock.group_stock_user'))]"/>
+    </record>
+    <record id="purchase_order_manager_rule" model="ir.rule">
+        <field name="name">Manager access all purchase order</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="groups" eval="[(4, ref('purchase.group_purchase_manager'))]"/>
+    </record>
+    <record id="purchase_order_line_manager_rule" model="ir.rule">
+        <field name="name">Manager access all purchase order line</field>
+        <field name="model_id" ref="purchase.model_purchase_order_line"/>
+        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="groups" eval="[(4, ref('purchase.group_purchase_manager'))]"/>
+    </record>
+</data>
+</odoo>


### PR DESCRIPTION
Steps to reproduce :

  1. Create a user A with the following acces rights
    - Sales - User: Own Documents Only
    - Inventory - User

  2. Create a Purchase Order with another user B which has access
  rights to Purchase and confirm it to create the inventory receipt.

  3. With user A, go to this receipt. In the chatter you will see a
  link to the purchase order (screenshot of link in the attachment)

Issue

    If you click on the link with user A,
    he gets redirected to the purchase order.

Cause

    'group_stock_user' has the access right to read any PO.

Solution

    Add ir rules for models purchase.order and purchase.order_line.
    For user with `group_stock_user`, let him see only his records.
    For user with `group_purchase_manager`, let him see all records.

opw-2556748