### PR TITLE
[FIX] web_editor: inlining style no safari error


### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -3,7 +3,7 @@ odoo.define('web_editor.convertInline', function (require) {
 
 var FieldHtml = require('web_editor.field.html');
 
-const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/g;
+const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
 /**
  * Returns the css rules which applies on an element, tweaked so that they are
  * browser/mail client ok.


### PR DESCRIPTION

On safari in saas-14.2, opening the full mail editor cause an error:

    Traceback: Error: The string did not match the expected pattern.
    matches@[native code]
    getMatchedCSSRules

This is happening because this cause an error in safari:

    document.body.matches(".custom-range::-webkit-slider-thumb");

and we get selector with :: that we should ignore because in d50c3b07f1
we use a global regex with `test` and multiple call of the regex on the
same string iterates over the string, for example:

    var x = /a/g;
    [x.test('a'), x.test('a'), x.test('a')]

gives [true, false, true]

opw-2489730
opw-2489515
opw-2502066
opw-2504051
opw-2518635
opw-2532695
