### PR TITLE
[IMP] website_event_[exhibitor|meet|track]: add link for no content s…

### DIFF
--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -124,7 +124,9 @@
                 <p class="m-0">We did not find any exhibitor matching your <strong t-esc="search_key"/> search.</p>
             </div>
             <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
-                <p class="m-0">Add some exhibitors to get started !</p>
+                <a target="_blank" t-att-href="'/web?#action=website_event_exhibitor.event_sponsor_action_from_event&amp;active_id=%s' % event.id">
+                    <p class="m-0">Add some exhibitors to get started !</p>
+                </a>
             </div>
         </div>
     </t>

--- a/addons/website_event_meet/static/src/js/customize_options.js
+++ b/addons/website_event_meet/static/src/js/customize_options.js
@@ -61,7 +61,7 @@ EventSpecificOptions.include({
             }],
         });
 
-        this._reloadEventPage();
+        location.reload();
     },
 
 });

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -48,7 +48,11 @@
             </t>
             <div t-if="not meeting_rooms" class="m-auto text-center text-muted">
                 <h3 class="mt8">No Room Open</h3>
-                <p>Create one to get conversations going</p>
+                <div groups="event.group_event_user">
+                    <a target="_blank" t-att-href="'/web?#action=website_event_meet.action_meeting_room_from_event&amp;active_id=%s' % event.id">
+                        <p>Create one to get conversations going</p>
+                    </a>
+                </div>
             </div>
         </div>
     </div>

--- a/addons/website_event_meet/views/event_meeting_room_views.xml
+++ b/addons/website_event_meet/views/event_meeting_room_views.xml
@@ -4,6 +4,14 @@
         <field name="name">Meeting Room</field>
         <field name="res_model">event.meeting.room</field>
         <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a Room
+            </p>
+            <p>
+                Rooms allow your event attendees to meet up and chat on different topics.
+            </p>
+        </field>
     </record>
     <record id="event_meeting_room_view_search" model="ir.ui.view">
         <field name="name">event.meeting.room.search</field>
@@ -58,7 +66,7 @@
         <field name="name">event.meeting.room.tree</field>
         <field name="model">event.meeting.room</field>
         <field name="arch" type="xml">
-            <tree string="Meeting Room" multi_edit="1">
+            <tree string="Meeting Room" multi_edit="1" sample="1">
                 <field name="name"/>
                 <field name="summary"/>
                 <field name="target_audience"/>
@@ -87,4 +95,20 @@
             </search>
         </field>
     </record>
+
+    <record id="action_meeting_room_from_event" model="ir.actions.act_window">
+        <field name="res_model">event.meeting.room</field>
+        <field name="name">Event Rooms</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_event_id': active_id, 'default_event_id': active_id}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a Room
+            </p>
+            <p>
+                Rooms allow your event attendees to meet up and chat on different topics.
+            </p>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -66,7 +66,9 @@
             <p class="m-0">We did not find any track matching your <strong t-esc="search_key"/> search.</p>
         </div>
         <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
-            <p class="m-0">Schedule some tracks to get started !</p>
+            <a target="_blank" t-att-href="'/web?#action=website_event_track.action_event_track_from_event&amp;active_id=%s' % event.id">
+                <p class="m-0">Schedule some tracks to get started</p>
+            </a>
         </div>
     </div>
 

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -124,7 +124,9 @@
                 <p class="m-0">We did not find any track matching your <strong t-esc="search_key"/> search.</p>
             </div>
             <div t-else="" class="alert alert-info text-center" groups="event.group_event_user">
-                <p class="m-0">Schedule some tracks to get started !</p>
+                <a target="_blank" t-att-href="'/web?#action=website_event_track.action_event_track_from_event&amp;active_id=%s' % event.id">
+                    <p class="m-0">Schedule some tracks to get started</p>
+                </a>
             </div>
         </div>
     </t>


### PR DESCRIPTION
…ubmenu buttons

This commit modifies texts proposing to the users to create new
exhibitor/meeting_room/tracks by adding links redirecting the user to the
backend allowing them to easily create new records without having to go to
the backend again.

It also prevents the user from being redirected to the main event page when
toggling the allow room creation submenu, instead it will only reload the
current page, thus preventing the user from losing the community page.

Task-2531104

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
