### PR TITLE
[FIX] sale_coupon: align stat button with act_window results

### DIFF
--- a/addons/sale_coupon/models/coupon_program.py
+++ b/addons/sale_coupon/models/coupon_program.py
@@ -23,9 +23,10 @@ class CouponProgram(models.Model):
             'name': _('Sales Orders'),
             'view_mode': 'tree,form',
             'res_model': 'sale.order',
+            'search_view_id': [self.env.ref('sale.sale_order_view_search_inherit_quotation').id],
             'type': 'ir.actions.act_window',
-            'domain': [('id', 'in', orders.ids), ('state', 'not in', ('draft', 'sent', 'cancel'))],
-            'context': dict(self._context, create=False)
+            'domain': [('id', 'in', orders.ids)],
+            'context': dict(self._context, create=False),
         }
 
     def _check_promo_code(self, order, coupon_code):


### PR DESCRIPTION
Before this commit, the number you saw on the stat button was not always
the same as the number of sale order you would see when you clicked on it.
Indeed, there was a domain force on the action to only show confirmed orders,
while the stat button was counting quotations too.

Fixed #70911 