### PR TITLE
[FIX] core: allow NewId to be used as an id when origin is defined

### DIFF
--- a/doc/cla/corporate/archeti.md
+++ b/doc/cla/corporate/archeti.md
@@ -1,0 +1,15 @@
+Canada, 2021-04-28
+
+ArcheTI agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Loïc Faure-Lacroix llacroix@archeti.com https://github.com/llacroix
+
+List of contributors:
+
+Loïc Faure-Lacroix llacroix@archeti.com https://github.com/llacroix

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -13,6 +13,7 @@ import base64
 import binascii
 import pytz
 import psycopg2
+from odoo.models import NewId
 
 from .tools import (
     float_repr, float_round, float_compare, float_is_zero, html_sanitize, human_size,
@@ -1222,7 +1223,10 @@ class Integer(Field):
     group_operator = 'sum'
 
     def convert_to_column(self, value, record, values=None, validate=True):
-        return int(value or 0)
+        if isinstance(value, NewId):
+            return int(value.get_id(0))
+        else:
+            return int(value or 0)
 
     def convert_to_cache(self, value, record, validate=True):
         if isinstance(value, dict):


### PR DESCRIPTION
In the past, NewId was used only for references and for some reasons
was designed as falsy. In lots of places, the test to check for
NewId is only `if not id:`. It doesn't mean that the id doesn't exist
when the NewId(origin=real_id) is defined but will be used in the code
as if it was False instead.

In other words, this explains why an onchange with `NewId(origin=id)`
will return `field_name: False`. Because that's what the
`convert_to_read` does when it gets a `NewId`.

The issue may be in many places of odoo.

This PR adds

A get_id method that would return either of the value origin,ref or a
default.

`__bool__` on `NewId` returns True when origin is not None.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
