### PR TITLE
[FIX] l10n_in: fix invoice report

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -18,7 +18,7 @@
                 </t>
             </t>
         </xpath>
-        <xpath expr="//p[@t-if='o.narration']" position="before">
+        <xpath expr="//p[@t-if='not is_html_empty(o.narration)']" position="before">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
                 <p id="total_in_words" class="mb16">
                     <strong>Total (In Words): </strong>


### PR DESCRIPTION
- before this commit,
it was raising an error when trying to install the l10n_in module, due
to unavailability of report element

- after this commit,
l10n_in module can be installed successfully


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
