### PR TITLE
Fix warning about t-foreach missing a t-key

### DIFF
--- a/addons/web/static/src/xml/week_days.xml
+++ b/addons/web/static/src/xml/week_days.xml
@@ -4,14 +4,14 @@
         <div class="o_recurrent_weekdays border mt-2 mb-2">
             <table class="table table-responsive mb-0">
                 <tr>
-                    <th t-foreach="weekdaysShort" t-as="day" class="text-center border font-weight-bold">
+                    <th t-foreach="weekdaysShort" t-as="day" t-key="day" class="text-center border font-weight-bold">
                         <div class="o_recurrent_weekday_label" t-att-title="props.record.fields[day].string">
                             <t t-esc="props.record.fields[day].string"/>
                         </div>
                     </th>
                 </tr>
                 <tr>
-                    <td t-foreach="weekdaysShort" t-as="day">
+                    <td t-foreach="weekdaysShort" t-as="day" t-key="day">
                         <CustomCheckbox disabled="mode === 'readonly'"
                             value="state.days[day].value"
                             id="state.days[day].id"


### PR DESCRIPTION
Not sure this is correct but it seems about right?

`weekdaysShort` is a simple array of weekday name abbreviations: https://github.com/odoo/odoo/blob/8e299ec4b257c2d87e60cdc4d97a0dbd0c77543c/addons/web/static/src/js/widgets/week_days.js#L49-L59