### PR TITLE
Fix state_selection dropdown in editable listview

### DIFF
--- a/addons/web/static/src/scss/list_view.scss
+++ b/addons/web/static/src/scss/list_view.scss
@@ -233,6 +233,12 @@
             }
         }
 
+        .o_data_row .o_data_cell {
+            &.o_state_selection_cell, &.o_kanban_state_selection_cell {
+                overflow: visible;
+            }
+        }
+
         .o_data_row:not(.o_selected_row) {
             .o_list_many2one,
             .o_list_char,


### PR DESCRIPTION
PURPOSE
state_selection widget is added in editable listview and dropdown is opened in state_selection hides behind list table.

SPEC
state_selection widget dropdown inside editable listview should be visible over table.

TASK 2556761


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
