### PR TITLE
 [FIX] web: wrong condition in time helpers

### DIFF
--- a/addons/web/static/src/js/core/time.js
+++ b/addons/web/static/src/js/core/time.js
@@ -306,7 +306,7 @@ const dateFormatWoZeroCache = {};
  */
 function getLangDateFormatWoZero() {
     const dateFormat = getLangDateFormat();
-    if (!dateFormat in dateFormatWoZeroCache) {
+    if (!(dateFormat in dateFormatWoZeroCache)) {
         dateFormatWoZeroCache[dateFormat] = dateFormat
             .replace('MM', 'M')
             .replace('DD', 'D');
@@ -320,7 +320,7 @@ const timeFormatWoZeroCache = {};
  */
 function getLangTimeFormatWoZero() {
     const timeFormat = getLangTimeFormat();
-    if (!timeFormat in timeFormatWoZeroCache) {
+    if (!(timeFormat in timeFormatWoZeroCache)) {
         timeFormatWoZeroCache[timeFormat] = timeFormat
             .replace('HH', 'H')
             .replace('mm', 'm')

--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -467,7 +467,7 @@ function parseDate(value, field, options) {
         return false;
     }
     var datePattern = time.getLangDateFormat();
-    var datePatternWoZero = datePattern.replace('MM', 'M').replace('DD', 'D');
+    var datePatternWoZero = time.getLangDateFormatWoZero();
     var date;
     const smartDate = parseSmartDateInput(value);
     if (smartDate) {

--- a/addons/web/static/tests/core/time_tests.js
+++ b/addons/web/static/tests/core/time_tests.js
@@ -1,6 +1,7 @@
 odoo.define('web.time_tests', function (require) {
 "use strict";
 
+const core = require('web.core');
 var time = require('web.time');
 
 QUnit.module('core', {}, function () {
@@ -143,6 +144,20 @@ QUnit.module('core', {}, function () {
         date.setMinutes(34);
         date.setSeconds(23);
         assert.strictEqual(time.time_to_str(date), "12:34:23");
+    });
+
+    QUnit.test("Get lang datetime format", (assert) => {
+        assert.expect(4);
+        const originalParameters = Object.assign({}, core._t.database.parameters);
+        Object.assign(core._t.database.parameters, {
+            date_format: '%m/%d/%Y',
+            time_format: '%H:%M:%S',
+        });
+        assert.strictEqual(time.getLangDateFormat(), "MM/DD/YYYY");
+        assert.strictEqual(time.getLangDateFormatWoZero(), "M/D/YYYY");
+        assert.strictEqual(time.getLangTimeFormat(), "HH:mm:ss");
+        assert.strictEqual(time.getLangTimeFormatWoZero(), "H:m:s");
+        Object.assign(core._t.database.parameters, originalParameters);
     });
 
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

some conditions in time helpers are wrong for getting the date/time formats.

Current behavior before PR:

some conditions in time helpers are wrong for getting the date/time formats.

Desired behavior after PR is merged:

corrected and tested



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
