### PR TITLE
[IMP] *_event_*: revamp event template form

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Events Organization',
-    'version': '1.5',
+    'version': '1.6',
     'website': 'https://www.odoo.com/app/events',
     'category': 'Marketing/Events',
     'summary': 'Trainings, Conferences, Meetings, Exhibitions, Registrations',

--- a/addons/event/data/event_data.xml
+++ b/addons/event/data/event_data.xml
@@ -5,7 +5,6 @@
         <record id="event_type_data_ticket" model="event.type">
             <field name="name">Ticketing</field>
             <field name="auto_confirm" eval="False"/>
-            <field name="use_ticket" eval="True"/>
         </record>
         <record id="event_type_data_conference" model="event.type">
             <field name="name">Conference</field>

--- a/addons/event/data/event_demo_misc.xml
+++ b/addons/event/data/event_demo_misc.xml
@@ -5,22 +5,17 @@
     <record id="event_type_0" model="event.type">
         <field name="name">Exhibition</field>
         <field name="auto_confirm" eval="False"/>
-        <field name="use_mail_schedule" eval="False"/>
     </record>
     <record id="event_type_1" model="event.type">
         <field name="name">Training</field>
         <field name="auto_confirm" eval="False"/>
-        <field name="use_mail_schedule" eval="True"/>
     </record>
     <record id="event_type_2" model="event.type">
         <field name="name">Sport</field>
         <field name="auto_confirm" eval="False"/>
-        <field name="use_mail_schedule" eval="False"/>
-        <field name="use_timezone" eval="True"/>
         <field name="default_timezone">US/Pacific</field>
     </record>
     <record id="event_type_data_conference" model="event.type">
-        <field name="use_timezone" eval="True"/>
         <field name="default_timezone">Europe/Brussels</field>
     </record>
 

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -6,7 +6,7 @@ import pytz
 
 from odoo import _, api, Command, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
-from odoo.tools import format_datetime
+from odoo.tools import format_datetime, is_html_empty
 from odoo.exceptions import ValidationError
 from odoo.tools.translate import html_translate
 
@@ -25,13 +25,10 @@ class EventType(models.Model):
     _order = 'sequence, id'
 
     name = fields.Char('Event Template', required=True, translate=True)
+    note = fields.Html(string='Note')
     sequence = fields.Integer()
     # tickets
-    use_ticket = fields.Boolean('Ticketing')
-    event_type_ticket_ids = fields.One2many(
-        'event.type.ticket', 'event_type_id',
-        string='Tickets', compute='_compute_event_type_ticket_ids',
-        readonly=False, store=True)
+    event_type_ticket_ids = fields.One2many('event.type.ticket', 'event_type_id', string='Tickets')
     tag_ids = fields.Many2many('event.tag', string="Tags")
     # registration
     has_seats_limitation = fields.Boolean('Limited Seats')
@@ -43,46 +40,10 @@ class EventType(models.Model):
         'Automatically Confirm Registrations', default=True,
         help="Events and registrations will automatically be confirmed "
              "upon creation, easing the flow for simple events.")
-    # location
-    use_timezone = fields.Boolean('Use Default Timezone')
     default_timezone = fields.Selection(
         _tz_get, string='Timezone', default=lambda self: self.env.user.tz or 'UTC')
     # communication
-    use_mail_schedule = fields.Boolean(
-        'Automatically Send Emails', default=True)
-    event_type_mail_ids = fields.One2many(
-        'event.type.mail', 'event_type_id',
-        string='Mail Schedule', compute='_compute_event_type_mail_ids',
-        readonly=False, store=True)
-
-    @api.depends('use_mail_schedule')
-    def _compute_event_type_mail_ids(self):
-        for template in self:
-            if not template.use_mail_schedule:
-                template.event_type_mail_ids = [(5, 0)]
-            elif not template.event_type_mail_ids:
-                template.event_type_mail_ids = [(0, 0, {
-                    'notification_type': 'mail',
-                    'interval_unit': 'now',
-                    'interval_type': 'after_sub',
-                    'template_id': self.env.ref('event.event_subscription').id,
-                }), (0, 0, {
-                    'notification_type': 'mail',
-                    'interval_nbr': 10,
-                    'interval_unit': 'days',
-                    'interval_type': 'before_event',
-                    'template_id': self.env.ref('event.event_reminder').id,
-                })]
-
-    @api.depends('use_ticket')
-    def _compute_event_type_ticket_ids(self):
-        for template in self:
-            if not template.use_ticket:
-                template.event_type_ticket_ids = [(5, 0)]
-            elif not template.event_type_ticket_ids:
-                template.event_type_ticket_ids = [(0, 0, {
-                    'name': _('Registration'),
-                })]
+    event_type_mail_ids = fields.One2many('event.type.mail', 'event_type_id', string='Mail Schedule')
 
     @api.depends('has_seats_limitation')
     def _compute_default_registration(self):
@@ -106,7 +67,7 @@ class EventEvent(models.Model):
         return self.env['ir.ui.view']._render_template('event.event_default_descripton')
 
     name = fields.Char(string='Event', translate=True, required=True)
-    note = fields.Html(string='Note')
+    note = fields.Html(string='Note', store=True, compute="_compute_note", readonly=False)
     description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, default=_default_description)
     active = fields.Boolean(default=True)
     user_id = fields.Many2one(
@@ -355,7 +316,7 @@ class EventEvent(models.Model):
     @api.depends('event_type_id')
     def _compute_date_tz(self):
         for event in self:
-            if event.event_type_id.use_timezone and event.event_type_id.default_timezone:
+            if event.event_type_id.default_timezone:
                 event.date_tz = event.event_type_id.default_timezone
             if not event.date_tz:
                 event.date_tz = self.env.user.tz or 'UTC'
@@ -417,7 +378,7 @@ class EventEvent(models.Model):
                 lambda mail: not(mail._origin.mail_done) and not(mail._origin.mail_registration_ids)
             )
             command = [Command.unlink(mail.id) for mail in mails_to_remove]
-            if event.event_type_id.use_mail_schedule:
+            if event.event_type_id.event_type_mail_ids:
                 command += [
                     Command.create({
                         attribute_name: line[attribute_name] if not isinstance(line[attribute_name], models.BaseModel) else line[attribute_name].id
@@ -460,7 +421,7 @@ class EventEvent(models.Model):
             # lines to keep: those with existing registrations
             tickets_to_remove = event.event_ticket_ids.filtered(lambda ticket: not ticket._origin.registration_ids)
             command = [Command.unlink(ticket.id) for ticket in tickets_to_remove]
-            if event.event_type_id.use_ticket:
+            if event.event_type_id.event_type_ticket_ids:
                 command += [
                     Command.create({
                         attribute_name: line[attribute_name] if not isinstance(line[attribute_name], models.BaseModel) else line[attribute_name].id
@@ -468,6 +429,12 @@ class EventEvent(models.Model):
                     }) for line in event.event_type_id.event_type_ticket_ids
                 ]
             event.event_ticket_ids = command
+
+    @api.depends('event_type_id')
+    def _compute_note(self):
+        for event in self:
+            if event.event_type_id and not is_html_empty(event.event_type_id.note):
+                event.note = event.event_type_id.note
 
     @api.constrains('seats_max', 'seats_available', 'seats_limited')
     def _check_seats_limit(self):

--- a/addons/event/tests/common.py
+++ b/addons/event/tests/common.py
@@ -69,16 +69,13 @@ class TestEventCommon(common.TransactionCase):
             'auto_confirm': True,
             'has_seats_limitation': True,
             'seats_max': 30,
-            'use_timezone': True,
             'default_timezone': 'Europe/Paris',
-            'use_ticket': True,
             'event_type_ticket_ids': [(0, 0, {
                     'name': 'First Ticket',
                 }), (0, 0, {
                     'name': 'Second Ticket',
                 })
             ],
-            'use_mail_schedule': True,
             'event_type_mail_ids': [
                 (0, 0, {  # right at subscription
                     'interval_unit': 'now',

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -81,12 +81,6 @@ class TestEventData(TestEventCommon):
         # ------------------------------------------------------------
 
         event_type = self.env['event.type'].browse(self.event_type_complex.id)
-        event_type.write({
-            'use_mail_schedule': False,
-            'use_ticket': False,
-        })
-        self.assertEqual(event_type.event_type_mail_ids, self.env['event.type.mail'])
-        self.assertEqual(event_type.event_type_ticket_ids, self.env['event.type.ticket'])
 
         event = self.env['event.event'].create({
             'name': 'Event Update Type',
@@ -108,11 +102,9 @@ class TestEventData(TestEventCommon):
 
         # change template to a one with mails -> fill event as it is void
         event_type.write({
-            'use_mail_schedule': True,
             'event_type_mail_ids': [(5, 0), (0, 0, {
                 'interval_nbr': 1, 'interval_unit': 'days', 'interval_type': 'before_event',
                 'template_id': self.env['ir.model.data'].xmlid_to_res_id('event.event_reminder')})],
-            'use_ticket': True,
             'event_type_ticket_ids': [(5, 0), (0, 0, {'name': 'TestRegistration'})],
         })
         event.write({'event_type_id': event_type.id})
@@ -155,7 +147,6 @@ class TestEventData(TestEventCommon):
         # setup test records
         event_type_default = self.env['event.type'].create({
             'name': 'Type Default',
-            'use_mail_schedule': False,
             'auto_confirm': True
         })
         event_type_mails = self.env['event.type'].create({
@@ -163,7 +154,6 @@ class TestEventData(TestEventCommon):
             'auto_confirm': False
         })
         event_type_mails.write({
-            'use_mail_schedule': True,
             'event_type_mail_ids': [
                 Command.clear(),
                 Command.create({
@@ -228,6 +218,28 @@ class TestEventData(TestEventCommon):
         )
 
     @users('user_eventmanager')
+    def test_event_configuration_note_from_type(self):
+        event_type = self.env['event.type'].browse(self.event_type_complex.id)
+
+        event = self.env['event.event'].create({
+            'name': 'Event Update Type Note',
+            'date_begin': FieldsDatetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': FieldsDatetime.to_string(datetime.today() + timedelta(days=15)),
+        })
+
+        # verify that note is not propagated if the event type contains blank html
+        event.write({'note': '<p>Event Note</p>'})
+        event_type.write({'note': '<p><br></p>'})
+        event.write({'event_type_id': event_type.id})
+        self.assertEqual(event.note, '<p>Event Note</p>')
+
+        # verify that note is correctly propagated if it contains non empty html
+        event.write({'event_type_id': False})
+        event_type.write({'note': '<p>Event Type Note</p>'})
+        event.write({'event_type_id': event_type.id})
+        self.assertEqual(event.note, '<p>Event Type Note</p>')
+
+    @users('user_eventmanager')
     def test_event_configuration_tickets_from_type(self):
         """ Test data computation (related to tickets) of event coming from its event.type template.
         This test uses pretty low level Form data checks, as manipulations in a non-saved Form are
@@ -238,7 +250,6 @@ class TestEventData(TestEventCommon):
         # setup test records
         event_type_default = self.env['event.type'].create({
             'name': 'Type Default',
-            'use_ticket': False,
             'auto_confirm': True
         })
         event_type_tickets = self.env['event.type'].create({
@@ -246,7 +257,6 @@ class TestEventData(TestEventCommon):
             'auto_confirm': False
         })
         event_type_tickets.write({
-            'use_ticket': True,
             'event_type_ticket_ids': [
                 Command.clear(),
                 Command.create({
@@ -614,17 +624,11 @@ class TestEventTypeData(TestEventCommon):
             'name': 'Testing fields computation',
             'has_seats_limitation': True,
             'seats_max': 30,
-            'use_ticket': True,
         })
         self.assertTrue(event_type.has_seats_limitation)
         self.assertEqual(event_type.seats_max, 30)
-        self.assertEqual(event_type.event_type_ticket_ids.mapped('name'), ['Registration'])
 
         # reset seats limitation
         event_type.write({'has_seats_limitation': False})
         self.assertFalse(event_type.has_seats_limitation)
         self.assertEqual(event_type.seats_max, 0)
-
-        # reset tickets
-        event_type.write({'use_ticket': False})
-        self.assertEqual(event_type.event_type_ticket_ids, self.env['event.type.ticket'])

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -9,116 +9,63 @@
             <field name="arch" type="xml">
                 <form string="Event Category">
                    <sheet>
-                        <div class="oe_title">
-                            <label for="name"/>
-                            <h1><field name="name" placeholder="e.g. Exhibition"/></h1>
+                        <div class="oe_title" name="event_type_title">
+                            <label for="name" string="Event Template"/>
+                            <h1><field name="name" placeholder="e.g. Online Conferences" class="mb-2"/></h1>
                         </div>
-                        <h2>Location</h2>
-                        <div class="row mt16 o_settings_container" name="event_type_location">
-                            <div class="col-12 col-lg-6 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="use_timezone"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="use_timezone"/>
-                                    <div class="row">
-                                        <div class="col-lg-8 mt16" attrs="{'invisible': [('use_timezone', '=', False)]}">
-                                            <label for="default_timezone"/>
-                                            <field name="default_timezone"
-                                                attrs="{'required': [('use_timezone', '=', True)]}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Communication</h2>
-                        <div class="row mt16 o_settings_container" name="event_type_communication">
-                            <div class="col-12 col-lg-12 o_setting_box">
-                                <div class="o_setting_left_pane">
-                                    <field name="use_mail_schedule"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="use_mail_schedule"/>
-                                    <div class="row mt16" attrs="{'invisible': [('use_mail_schedule', '=', False)]}">
-                                        <div class="col-12">
-                                            <field name="event_type_mail_ids" style="width: 100%;">
-                                                <tree string="Communication" editable="bottom">
-                                                    <field name="notification_type" invisible="1"/>
-                                                    <field name="template_id" attrs="{'required': [('notification_type', '=', 'mail')]}"/>
-                                                    <field name="interval_nbr" attrs="{'readonly':[('interval_unit', '=', 'now')]}"/>
-                                                    <field name="interval_unit"/>
-                                                    <field name="interval_type"/>
-                                                </tree>
-                                            </field>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Visibility</h2>
-                        <div class="row mt16 o_settings_container" name="event_type_visibility">
-                            <div class="col-12 col-lg-6 o_setting_box" name="event_type_visibility_seats">
-                                <div class="o_setting_left_pane">
-                                    <field name="has_seats_limitation"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="has_seats_limitation"/>
-                                    <div class="row">
-                                        <div class="col-lg-8 mt16" attrs="{'invisible': [('has_seats_limitation', '=', False)]}">
-                                            <div>
-                                                <label for="seats_max"/> <field name="seats_max"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" name="event_type_visibility_tags">
-                                <div class="o_setting_left_pane"/>
-                                <div class="o_setting_right_pane">
-                                    <label for="tag_ids" string="Tags"/>
-                                    <div class="row">
-                                        <div class="col-12 mt16">
-                                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <h2>Attendees</h2>
-                        <div class="row mt16 o_settings_container" name="event_type_attendees">
-                            <div class="col-12 o_setting_box" name="event_type_attendees_tickets">
-                                <div class="o_setting_left_pane">
-                                    <field name="use_ticket"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="use_ticket"/>
-                                    <div class="row mt16" attrs="{'invisible': [('use_ticket', '=', False)]}">
-                                        <div class="col">
-                                            <field name="event_type_ticket_ids"
-                                                class="w-100"
-                                                context="{
-                                                    'tree_view_ref': 'event.event_type_ticket_view_tree_from_type',
-                                                    'form_view_ref': 'event.event_type_ticket_view_form_from_type'
-                                                }"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" name="event_type_attendees_auto_confirm">
-                                <div class="o_setting_left_pane">
-                                    <field name="auto_confirm"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="auto_confirm"/>
-                                    <div class="row">
-                                        <div class="col-lg-8 mt16 text-muted">
-                                            Events and registrations will automatically be confirmed
-                                            upon creation, easing the flow for simple events.
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+
+                       <group>
+                           <group>
+                               <div colspan="2" class="o_checkbox_optional_field">
+                                   <label for="default_timezone"/>
+                                   <field name="default_timezone" class="w-100"/>
+                               </div>
+                               <div colspan="2" class="o_checkbox_optional_field">
+                                   <label for="tag_ids"/>
+                                   <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
+                               </div>
+                           </group>
+                           <group>
+                               <div colspan="2" class="o_checkbox_optional_field">
+                                   <label for="has_seats_limitation" string="Limit Registrations"/>
+                                   <field name="has_seats_limitation"/>
+                                   <span attrs="{'invisible': [('has_seats_limitation', '=', False)], 'required': [('has_seats_limitation', '=', False)]}">
+                                       to <field name="seats_max" class="oe_inline"/>
+                                       Attendees
+                                   </span>
+                               </div>
+                               <div colspan="2" class="o_checkbox_optional_field">
+                                   <label for="auto_confirm" string="Autoconfirmation"/>
+                                   <field name="auto_confirm"/>
+                               </div>
+                           </group>
+                       </group>
+
+                       <notebook>
+                           <page string="Tickets">
+                               <field name="event_type_ticket_ids"
+                                      class="w-100"
+                                      context="{
+                                         'tree_view_ref': 'event.event_type_ticket_view_tree_from_type',
+                                         'form_view_ref': 'event.event_type_ticket_view_form_from_type'
+                                      }"
+                               />
+                           </page>
+                           <page string="Communication" name="event_type_communication">
+                               <field name="event_type_mail_ids" class="w-100">
+                                   <tree string="Communication" editable="bottom">
+                                       <field name="notification_type" invisible="1"/>
+                                       <field name="template_id" attrs="{'required': [('notification_type', '=', 'mail')]}"/>
+                                       <field name="interval_nbr" attrs="{'readonly':[('interval_unit', '=', 'now')]}"/>
+                                       <field name="interval_unit"/>
+                                       <field name="interval_type"/>
+                                   </tree>
+                               </field>
+                           </page>
+                           <page string="Notes">
+                               <field name="note"/>
+                           </page>
+                       </notebook>
                     </sheet>
                 </form>
             </field>

--- a/addons/event_sale/tests/test_event_internals.py
+++ b/addons/event_sale/tests/test_event_internals.py
@@ -16,11 +16,6 @@ class TestEventData(TestEventSaleCommon):
         """ In addition to event test, also test tickets configuration coming
         from event_sale capabilities. """
         event_type = self.event_type_complex.with_user(self.env.user)
-        event_type.write({
-            'use_mail_schedule': False,
-            'use_ticket': False,
-        })
-        self.assertEqual(event_type.event_type_ticket_ids, self.env['event.type.ticket'])
 
         event = self.env['event.event'].create({
             'name': 'Event Update Type',
@@ -28,10 +23,7 @@ class TestEventData(TestEventSaleCommon):
             'date_begin': FieldsDatetime.to_string(datetime.today() + timedelta(days=1)),
             'date_end': FieldsDatetime.to_string(datetime.today() + timedelta(days=15)),
         })
-        self.assertEqual(event.event_ticket_ids, self.env['event.event.ticket'])
-
         event_type.write({
-            'use_ticket': True,
             'event_type_ticket_ids': [(5, 0), (0, 0, {
                 'name': 'First Ticket',
                 'product_id': self.event_product.id,

--- a/addons/test_event_full/tests/test_event_security.py
+++ b/addons/test_event_full/tests/test_event_security.py
@@ -92,7 +92,6 @@ class TestEventSecurity(TestEventCommon):
         with self.assertRaises(AccessError):
             self.env['event.type'].create({
                 'name': 'ManagerEventType',
-                'use_mail_schedule': True,
                 'event_type_mail_ids': [(5, 0), (0, 0, {
                     'interval_nbr': 1, 'interval_unit': 'days', 'interval_type': 'before_event',
                     'template_id': self.env['ir.model.data'].xmlid_to_res_id('event.event_reminder')})]
@@ -104,7 +103,6 @@ class TestEventSecurity(TestEventCommon):
         # Event Type
         event_type = self.env['event.type'].create({
             'name': 'ManagerEventType',
-            'use_mail_schedule': True,
             'event_type_mail_ids': [(5, 0), (0, 0, {
                 'interval_nbr': 1, 'interval_unit': 'days', 'interval_type': 'before_event',
                 'template_id': self.env['ir.model.data'].xmlid_to_res_id('event.event_reminder')})]

--- a/addons/website_event/views/event_type_views.xml
+++ b/addons/website_event/views/event_type_views.xml
@@ -6,31 +6,20 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="event.view_event_type_form"/>
         <field name="arch" type="xml">
-            <div name="event_type_visibility_seats" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" name="event_type_visibility_website">
-                    <div class="o_setting_left_pane">
+            <xpath expr="//div[hasclass('oe_title')]" position="after">
+                    <span name="website_menu">
+                        <label for="website_menu" string="Website Submenu"/>
                         <field name="website_menu"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="website_menu"/>
-                        <div class="row" name="website_menu">
-                            <div class="col-lg-8 mt16 text-muted">
-                                Check this option to have menus for your event on the
-                                website: registrations, schedule, map, ...
-                            </div>
-                        </div>
-                        <div class="row mt16" name="menu_register_cta"
-                            groups="base.group_no_one">
-                            <label class="col" for="menu_register_cta"/> <field name="menu_register_cta"/>
-                        </div>
-                        <div class="row mt16" name="community_menu"
-                            id="community-menu"
-                            attrs="{'invisible': [('website_menu', 'in', (True, False))]}">
-                            <label class="col" for="community_menu"/> <field name="community_menu"/>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </span>
+                    <span name="community_menu" invisible="1">
+                        <label for="community_menu" string="Community"/>
+                        <field name="community_menu"/>
+                    </span>
+                    <span name="menu_register_cta">
+                        <label for="menu_register_cta" string="Register Button"/>
+                        <field name="menu_register_cta"/>
+                    </span>
+            </xpath>
         </field>
     </record>
 

--- a/addons/website_event_exhibitor/views/event_event_views.xml
+++ b/addons/website_event_exhibitor/views/event_event_views.xml
@@ -15,7 +15,7 @@
                     <field name="sponsor_count" string="Sponsors" widget="statinfo"/>
                 </button>
             </field>
-            <xpath expr="//field[@name='website_menu']" position="after">
+            <xpath expr="//label[@for='community_menu']" position="before">
                 <label for="exhibitor_menu"/>
                 <field name="exhibitor_menu"/>
             </xpath>

--- a/addons/website_event_exhibitor/views/event_type_views.xml
+++ b/addons/website_event_exhibitor/views/event_type_views.xml
@@ -5,10 +5,11 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='website_menu']" position='after'>
-                <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col" for="exhibitor_menu"/> <field name="exhibitor_menu"/>
-                </div>
+                <xpath expr="//span[@name='community_menu']" position='before'>
+                <span name="exhibitor_menu">
+                    <label for="exhibitor_menu" string="Exhibitors Menu Item"/>
+                    <field name="exhibitor_menu"/>
+                </span>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_meet/views/event_type_views.xml
+++ b/addons/website_event_meet/views/event_type_views.xml
@@ -5,13 +5,14 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='community-menu']" position='after'>
-                <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col" for="meeting_room_allow_creation"/> <field name="meeting_room_allow_creation"/>
-                </div>
+            <xpath expr="//field[@name='community_menu']" position='after'>
+                <span attrs="{'invisible': [('community_menu', '=', False)]}">
+                    <label for="meeting_room_allow_creation"/>
+                    <field name="meeting_room_allow_creation"/>
+                </span>
             </xpath>
-            <xpath expr="//div[@id='community-menu']" position="attributes">
-                <attribute name="attrs">{'invisible': [('website_menu', '=', False)]}</attribute>
+            <xpath expr="//span[@name='community_menu']" position="attributes">
+                <attribute name="invisible">0</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_questions/__manifest__.py
+++ b/addons/website_event_questions/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Questions on Events',
     'description': 'Questions on Events',
     'category': 'Marketing',
-    'version': '1.1',
+    'version': '1.2',
     'depends': ['website_event'],
     'data': [
         'views/event_views.xml',

--- a/addons/website_event_questions/data/event_demo.xml
+++ b/addons/website_event_questions/data/event_demo.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data>
     <record id="event.event_type_data_conference" model="event.type">
-        <field name="use_timezone" eval="True"/>
         <field name="default_timezone">Europe/Brussels</field>
-        <field name="use_questions" eval="True"/>
     </record>
 </data></odoo>

--- a/addons/website_event_questions/models/event_event.py
+++ b/addons/website_event_questions/models/event_event.py
@@ -7,7 +7,6 @@ from odoo import api, fields, models
 class EventType(models.Model):
     _inherit = 'event.type'
 
-    use_questions = fields.Boolean('Questions to Attendees')
     question_ids = fields.One2many(
         'event.question', 'event_type_id',
         string='Questions', copy=True)
@@ -53,7 +52,7 @@ class EventEvent(models.Model):
                 command = [(3, question.id) for question in questions_toremove]
             else:
                 command = [(5, 0)]
-            if event.event_type_id.use_mail_schedule:
+            if event.event_type_id.event_type_mail_ids:
                 command += [
                     (0, 0, {
                         'title': question.title,

--- a/addons/website_event_questions/tests/common.py
+++ b/addons/website_event_questions/tests/common.py
@@ -36,4 +36,3 @@ class TestEventQuestionCommon(TestEventCommon):
             'event_type_id': cls.event_type_complex.id,
             'once_per_order': True,
         })
-        cls.event_type_complex.write({'use_questions': True})

--- a/addons/website_event_questions/views/event_views.xml
+++ b/addons/website_event_questions/views/event_views.xml
@@ -5,26 +5,17 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-            <div name="event_type_attendees_auto_confirm" position="after">
-                <div class="col-12 col-lg-12 o_setting_box">
-                    <div class="o_setting_left_pane">
-                        <field name="use_questions"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="use_questions"/>
-                        <div class="row mt16" attrs="{'invisible': [('use_questions', '=', False)]}">
-                            <div class="col-lg-9">
-                                <field name="question_ids">
-                                    <tree>
-                                        <field name="title"/>
-                                        <field name="question_type" />
-                                    </tree>
-                                </field>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <page name="event_type_communication" position="after">
+                <page string="Questions">
+                     <field name="question_ids" class="w-100">
+                         <tree sample="1">
+                             <field name="title"/>
+                             <field name="question_type" />
+                             <field name="answer_ids" widget = "many2many_tags"/>
+                         </tree>
+                     </field>
+                </page>
+            </page>
         </field>
     </record>
 

--- a/addons/website_event_track/views/event_type_views.xml
+++ b/addons/website_event_track/views/event_type_views.xml
@@ -6,13 +6,15 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='website_menu']" position='after'>
-                <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col" for="website_track"/> <field name="website_track"/>
-                </div>
-                <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col" for="website_track_proposal"/> <field name="website_track_proposal"/>
-                </div>
+                <xpath expr="//span[@name='website_menu']" position='after'>
+                <span>
+                    <label for="website_track" string="Tracks Menu Item"/>
+                    <field name="website_track"/>
+                </span>
+                <span name="website_track_proposal">
+                    <label for="website_track_proposal" string="Track Proposals Menu Item"/>
+                    <field name="website_track_proposal"/>
+                </span>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_track_quiz/views/event_type_views.xml
+++ b/addons/website_event_track_quiz/views/event_type_views.xml
@@ -5,8 +5,8 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='community-menu']" position="attributes">
-                <attribute name="attrs">{'invisible': [('website_menu', '=', False)]}</attribute>
+            <xpath expr="//span[@name='community_menu']" position="attributes">
+                <attribute name="invisible">0</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This commit revamps the event template form to be similar to the event form
itself and removes unecessary fields, purpose is to give more clarity to the
user.

It also fixes the order of the fields in the event form to be exactly
the same as in the front-end, so that the user don't get confused.

Task-2541208

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
