### PR TITLE
[FIX] web_editor, mass_mailing, project: restore the codeview as option

### DIFF
--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -44,7 +44,7 @@
                             <page string="Content" name="content">
                                 <label for="subject"/>
                                 <h2 style="display: inline-block;"><field name="subject" placeholder="Subject (placeholders may be used here)"/></h2>
-                                <field name="body_html" widget="html" options="{'style-inline': true}"/>
+                                <field name="body_html" widget="html" options="{'style-inline': true, 'codeview': true }"/>
                                 <field name="attachment_ids" widget="many2many_binary"/>
                             </page>
                             <page string="Email Configuration" name="email_configuration">

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -300,24 +300,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
     },
 
     /**
-     * Toggle the code view.
-     */
-    _toggleCodeView: function () {
-        this.wysiwyg.odooEditor.observerUnactive();
-        const $codeview = this.$content.parent().find('textarea.o_codeview');
-        $codeview.toggleClass('d-none');
-        this.$content.toggleClass('d-none');
-        if ($codeview.hasClass('d-none')) {
-            this.wysiwyg.odooEditor.observerActive();
-            this.wysiwyg.setValue($codeview.val());
-            this.wysiwyg.odooEditor.historyStep();
-        } else {
-            $codeview.val(this.$content.html());
-            this.wysiwyg.odooEditor.observerActive();
-        }
-    },
-
-    /**
      * @override
      */
     _getWysiwygOptions: function () {
@@ -383,8 +365,8 @@ var MassMailingFieldHtml = FieldHtml.extend({
         if (!odoo.debug) {
             $snippetsSideBar.find('.o_codeview_btn').hide();
         }
-
-        $snippetsSideBar.on('click', '.o_codeview_btn', this._toggleCodeView.bind(this));
+        const $codeview = this.$content.parent().find('textarea.o_codeview');
+        $snippetsSideBar.on('click', '.o_codeview_btn', () => this._toggleCodeView($codeview));
 
         if ($themes.length === 0) {
             return;

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -2,6 +2,12 @@
     position: relative;
     word-wrap: break-word;
 
+    .odoo-editor #codeview-btn-group {
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
+
     .note-editable {
         font: inherit !important;
         font-family: inherit !important;


### PR DESCRIPTION
HTML fields used to have a toggle button for a "code view" (which came from the Summernote library), in debug mode. This allowed the advanced user to edit content with jinja conditions. This was lost with the new editor but reintroduced for Mass Mailing. As it turns out it was needed elsewhere so this makes the code view available as a node option, and already activates it for mail templates.

To activate the code view in an html field:
```xml
<field type="html" options="'codeview': True"/>
```

Task #2561300

![image](https://user-images.githubusercontent.com/24205914/121182506-7084c900-c863-11eb-9ca5-453e0d4e4abb.png)
![image](https://user-images.githubusercontent.com/24205914/121182549-7d092180-c863-11eb-84bb-376acde858b7.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
