### PR TITLE
[IMP] account: move the type field on account.account form view

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -52,15 +52,11 @@
                                 <field name="company_id" invisible="1"/>
                             </h1>
                         </div>
-                        <group>
-                            <group>
-                                <field name="user_type_id" widget="account_hierarchy_selection"/>
-                            </group>
-                        </group>
                         <notebook>
                             <page name="accounting" string="Accounting">
                                 <group>
                                     <group>
+                                        <field name="user_type_id" widget="account_hierarchy_selection"/>
                                         <field name="tax_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]" attrs="{'invisible': [('internal_group', '=', 'off_balance')]}"/>
                                         <field name="tag_ids" widget="many2many_tags" domain="[('applicability', '!=', 'taxes')]" context="{'default_applicability': 'accounts'}" options="{'no_create_edit': True}"/>
                                         <field name="allowed_journal_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]" options="{'no_create_edit': True}"/>


### PR DESCRIPTION
The user_type_id field seems a bit out of place at the moment in the header of the form view.
We will move it to the accounting tab with other fields in order to improve that.

Task id #2563472

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
