### PR TITLE
[FIX] account: remove tags records without unlinking them

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -150,7 +150,7 @@ class AccountTaxReportLine(models.Model):
         """
         all_tags = self.mapped('tag_ids')
         tags_to_unlink = all_tags.filtered(lambda x: not (x.tax_report_line_ids - self))
-        self.write({'tag_ids': [(2, tag.id, 0) for tag in tags_to_unlink]})
+        self.write({'tag_ids': [(3, tag.id, 0) for tag in tags_to_unlink]})
         self._delete_tags_from_taxes(tags_to_unlink.ids)
 
     def _delete_tags_from_taxes(self, tag_ids_to_delete):


### PR DESCRIPTION
In `_remove_tax_used_only_by_self`, as tags will be properly removed in `_delete_tags_from_taxes`, we should only remove them from the `self.tag_ids` set without unlinking them (unlink them at this step, might lead to issues if these tags are still linked to `account.move.line` for example).

As stated in https://github.com/odoo/odoo/blob/7444857b631e4c26ac1f13e6c29dfaa6b4c66359/odoo/models.py#L3549-L3555
we use the command `3` instead of `2` to achieve this.

upg-61375

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
