### PR TITLE
[FIX] web: save operator for m2o fields in pivot view

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_model.js
+++ b/addons/web/static/src/js/views/pivot/pivot_model.js
@@ -975,15 +975,14 @@ var PivotModel = AbstractModel.extend({
                     acc.push(measure);
                     return acc;
                 }
-                var type = self.fields[measure].type;
-                var groupOperator = self.fields[measure].group_operator;
-                if (type === 'many2one') {
-                    groupOperator = 'count_distinct';
+                var field = self.fields[measure];
+                if (field.type === 'many2one') {
+                    field.group_operator = 'count_distinct';
                 }
-                if (groupOperator === undefined) {
+                if (field.group_operator === undefined) {
                     throw new Error("No aggregate function has been provided for the measure '" + measure + "'");
                 }
-                acc.push(measure + ':' + groupOperator);
+                acc.push(measure + ':' + field.group_operator);
                 return acc;
             },
             []


### PR DESCRIPTION
When generating a spreadsheet from a pivot view, the values of m2o
fields are added up instead of being counted.

To reproduce the error:
(Need point_of_sale,documents_spreadsheet)
1. Open a POS session
2. Process 3 orders
3. Close the session
4. Point of Sale > Reporting > Orders - Pivot View
    (Note: the number of orders is 3, which is correct)
5. Insert in Spreadsheet

Error: On spreadsheet, the number of orders is incorrect (the value
corresponds to the sum of the order identifier of each POS order line)

When generating the spreadsheet, here is how the operator for each field
is computed:
https://github.com/odoo/enterprise/blob/06bf2b0e2def3445cdd21d5b6fccc58e3015e0b5/documents_spreadsheet/static/src/js/o-spreadsheet/pivot_utils.js#L217-L225
If there is not any `group_operator`, the `operator` will be defined to
`sum`.

In the above case, the attribute `group_operator` is indeed not defined
for the field `order_id`:
https://github.com/odoo/odoo/blob/1ddbcb4860ee220e9f826e8b6f6b85b6c22fb2b7/addons/point_of_sale/report/pos_order_report.py#L14

However, when generating the pivot view, if the field is m2o, its
`group_operator` value is not considered and the operator is directly
defined to `count_distinct`:
https://github.com/odoo/odoo/blob/7cf8f6f40e5769d2f22620ac425208c4ad9ae80b/addons/web/static/src/js/views/pivot/pivot_model.js#L979-L987

Since the spreadsheet is based on the pivot view, this fix suggests
saving this decision so the spreadsheet will behave in the same way.

OPW-2551030