### PR TITLE
Remove dynamic domain for performance

### DIFF
--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -116,7 +116,6 @@
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="has_tracking" invisible="1"/>
-                                <field name="allowed_mo_ids" invisible="1"/>
                                 <field name="lot_id" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                             </group>
@@ -155,7 +154,6 @@
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="has_tracking" invisible="1"/>
-                                <field name="allowed_mo_ids" invisible="1"/>
                                 <field name="lot_id" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
                                 <field name="company_id" groups="base.group_multi_company" readonly="1"/>
                             </group>

--- a/addons/mrp_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_landed_costs/models/stock_landed_cost.py
@@ -13,18 +13,6 @@ class StockLandedCost(models.Model):
     mrp_production_ids = fields.Many2many(
         'mrp.production', string='Manufacturing order',
         copy=False, states={'done': [('readonly', True)]}, groups='mrp.group_mrp_user')
-    allowed_mrp_production_ids = fields.Many2many(
-        'mrp.production', compute='_compute_allowed_mrp_production_ids', groups='mrp.group_mrp_user')
-
-    @api.depends('company_id')
-    def _compute_allowed_mrp_production_ids(self):
-        for cost in self:
-            moves = self.env['stock.move'].search([
-                ('stock_valuation_layer_ids', '!=', False),
-                ('production_id', '!=', False),
-                ('company_id', '=', cost.company_id.id)
-            ])
-            self.allowed_mrp_production_ids = moves.production_id
 
     @api.onchange('target_model')
     def _onchange_target_model(self):

--- a/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
+++ b/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
@@ -121,10 +121,12 @@ class TestStockLandedCostsMrp(ValuationReconciliationTestCommon):
         landed_cost = Form(self.env['stock.landed.cost'].with_user(self.allow_user)).save()
         landed_cost.target_model = 'manufacturing'
 
-        self.assertTrue(man_order.id in landed_cost.allowed_mrp_production_ids.ids)
+        # Check domain of the views
+        self.assertTrue(man_order in self.env['mrp.production'].search([
+            ('move_finished_ids.stock_valuation_layer_ids', '!=', False), ('company_id', '=', landed_cost.company_id.id)]))
+
         landed_cost.mrp_production_ids = [(6, 0, [man_order.id])]
         landed_cost.cost_lines = [(0, 0, {'product_id': self.landed_cost.id, 'price_unit': 5.0, 'split_method': 'equal'})]
-
         landed_cost.button_validate()
 
         self.assertEqual(landed_cost.state, 'done')

--- a/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
@@ -10,11 +10,10 @@
                 <attribute name="groups">mrp.group_mrp_user</attribute>
             </field>
             <field name="picking_ids" position="after">
-                <field name="allowed_mrp_production_ids" invisible="1"/>
                 <field name="mrp_production_ids" 
                     widget="many2many_tags" options="{'no_create_edit': True}"
-                    attrs="{'invisible': [('target_model', '!=', 'manufacturing')]}" 
-                    domain="[('id', 'in', allowed_mrp_production_ids)]"/>
+                    attrs="{'invisible': [('target_model', '!=', 'manufacturing')]}"
+                    domain="[('company_id', '=', company_id), ('move_finished_ids.stock_valuation_layer_ids', '!=', False)]"/>
             </field>
         </field>
     </record>

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -413,18 +413,17 @@ class PurchaseOrderLine(models.Model):
 
     def _get_stock_move_price_unit(self):
         self.ensure_one()
-        line = self[0]
-        order = line.order_id
-        price_unit = line.price_unit
+        order = self.order_id
+        price_unit = self.price_unit
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
-        if line.taxes_id:
-            qty = line.product_qty or 1
-            price_unit = line.taxes_id.with_context(round=False).compute_all(
-                price_unit, currency=line.order_id.currency_id, quantity=qty, product=line.product_id, partner=line.order_id.partner_id
+        if self.taxes_id:
+            qty = self.product_qty or 1
+            price_unit = self.taxes_id.with_context(round=False).compute_all(
+                price_unit, currency=self.order_id.currency_id, quantity=qty, product=self.product_id, partner=self.order_id.partner_id
             )['total_void']
             price_unit = float_round(price_unit / qty, precision_digits=price_unit_prec)
-        if line.product_uom.id != line.product_id.uom_id.id:
-            price_unit *= line.product_uom.factor / line.product_id.uom_id.factor
+        if self.product_uom.id != self.product_id.uom_id.id:
+            price_unit *= self.product_uom.factor / self.product_id.uom_id.factor
         if order.currency_id != order.company_id.currency_id:
             price_unit = order.currency_id._convert(
                 price_unit, order.company_id.currency_id, self.company_id, self.date_order or fields.Date.today(), round=False)

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -338,11 +338,9 @@ class PurchaseOrderLine(models.Model):
         return lines
 
     def write(self, values):
-        for line in self.filtered(lambda l: not l.display_type):
-            # PO date_planned overrides any PO line date_planned values
-            if values.get('date_planned'):
-                new_date = fields.Datetime.to_datetime(values['date_planned'])
-                self._update_move_date_deadline(new_date)
+        if values.get('date_planned'):
+            new_date = fields.Datetime.to_datetime(values['date_planned'])
+            self.filtered(lambda l: not l.display_type)._update_move_date_deadline(new_date)
         result = super(PurchaseOrderLine, self).write(values)
         if 'product_qty' in values:
             self.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -96,7 +96,8 @@ class Warehouse(models.Model):
     def _onchange_company_id(self):
         group_user = self.env.ref('base.group_user')
         group_stock_multi_warehouses = self.env.ref('stock.group_stock_multi_warehouses')
-        if group_stock_multi_warehouses not in group_user.implied_ids:
+        group_stock_multi_location = self.env.ref('stock.group_stock_multi_locations')
+        if group_stock_multi_warehouses not in group_user.implied_ids and group_stock_multi_location not in group_user.implied_ids:
             return {
                 'warning': {
                     'title': _('Warning'),

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -40,7 +40,6 @@
         <field name="arch" type="xml">
             <tree string="Reordering Rules" editable="bottom" js_class="stock_orderpoint_list" sample="1" multi_edit="1">
                 <field name="active" invisible="1"/>
-                <field name="allowed_route_ids" invisible="1"/>
                 <field name="product_category_id" invisible="1"/>
                 <field name="product_tmpl_id" invisible="1"/>
                 <field name="product_id" attrs="{'readonly': [('product_id', '!=', False)]}" invisible="context.get('default_product_id')" force_save="1"/>
@@ -74,7 +73,6 @@
         <field name="arch" type="xml">
             <tree string="Reordering Rules" editable="bottom">
                 <field name="active" invisible="1"/>
-                <field name="allowed_route_ids" invisible="1"/>
                 <field name="warehouse_id" invisible="1"/>
                 <field name="product_tmpl_id" invisible="1"/>
                 <field name="product_id" invisible="context.get('default_product_id')" force_save="1"/>
@@ -154,7 +152,6 @@
                     <group>
                         <group>
                             <field name="active" invisible="1"/>
-                            <field name="allowed_route_ids" invisible="1"/>
                             <field name="route_id" invisible="1"/>
                             <field name="product_id"/>
                             <label for="product_min_qty"/>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -29,9 +29,10 @@
                         <group>
                             <group>
                                 <field name="date"/>
-                                <field name="allowed_picking_ids" invisible="1"/>
                                 <field name="target_model" widget="radio" invisible="1"/>
-                                <field name="picking_ids" widget="many2many_tags" options="{'no_create_edit': True}" domain="[('id', 'in', allowed_picking_ids)]" attrs="{'invisible': [('target_model', '!=', 'picking')]}"/>
+                                <field name="picking_ids" widget="many2many_tags" 
+                                    options="{'no_create_edit': True}" attrs="{'invisible': [('target_model', '!=', 'picking')]}"
+                                    domain="[('company_id', '=', company_id), ('move_lines.stock_valuation_layer_ids', '!=', False)]"/>
                             </group>
                             <group>
                                 <label for="account_journal_id" string="Journal"/>


### PR DESCRIPTION
[FIX] stock: avoid raise a useless warning 

During the creation of the second warehouse,
a warning popup to tell that it will activate also the
Storage Locations setting even if this one is already activate.
Only raise this warning if the is Storage Locations not activate yet.
 
[FIX] purchase: don't break the prefetch 

Avoid breaking prefetch for `_get_stock_move_price_unit`

[REF] purchase: avoid useless loop in the write 
 
[FIX] mrp: make the unbuild form more scalable 

Making a dynamic domain with a `allowed_xxx_ids` field is a bad idea
when the domain doesn't filter out the most of records. It can create a
performance issue, if the `allowed_xxx_ids` contains too much ids, then
a lot of data will be exchange to/from server for each onchange which
slows down all the form views.
 
[FIX] stock/mrp_landed_cost: fix domain no scalable. 

Making a dynamic domain with a `allowed_xxx_ids` field is a bad idea
when the domain doesn't filter out the most of records. It can create a
performance issue, if the `allowed_xxx_ids` contains too much ids
(for 70K by example), then a lot of data will be exchange to/from server
for each onchange (500Ko, > 1 sec) which slows down all the form views.

Change it into a static domain, which slows down a little the
search of the picking but the onchange becomes very fast. Also the JS
won't parse anymore a huge `allowed_xxx_ids` fields (the form becomes
smoother).

[REF] stock: remove useless dynamic domain 

task-2558097
Enterprise: https://github.com/odoo/enterprise/pull/18849