### PR TITLE
[IMP] account: prevent edition of tax_negate, country_id and tax_report_line_ids in account.account.tag's form view

### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -394,9 +394,9 @@ action = model.setting_init_bank_account_action()
                         <group>
                             <field name="name"/>
                             <field name="applicability"/>
-                            <field name="tax_negate" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
-                            <field name="country_id" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
-                            <field name="tax_report_line_ids" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
+                            <field name="tax_negate" readonly="1" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
+                            <field name="country_id" readonly="1" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
+                            <field name="tax_report_line_ids" readonly="1" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
Those field are all handled by the account.tax.report.line creating the tax tag. They should never manually be changed by the user.

OPW 2541071
