### PR TITLE
[IMP] mrp: lock MOs by default

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -69,7 +69,7 @@ class MrpProduction(models.Model):
 
     @api.model
     def _get_default_is_locked(self):
-        return self.user_has_groups('mrp.group_locked_by_default')
+        return not self.user_has_groups('mrp.group_unlocked_by_default')
 
     name = fields.Char(
         'Reference', copy=False, readonly=True, default=lambda x: _('New'))
@@ -502,7 +502,11 @@ class MrpProduction(models.Model):
     @api.depends('state')
     def _compute_show_lock(self):
         for order in self:
-            order.show_lock = self.env.user.has_group('mrp.group_locked_by_default') and order.id is not False and order.state not in {'cancel', 'draft'}
+            order.show_lock = order.state == 'done' or (
+                not self.env.user.has_group('mrp.group_unlocked_by_default')
+                and order.id is not False
+                and order.state not in {'cancel', 'draft'}
+            )
 
     @api.depends('state','move_raw_ids')
     def _compute_show_lot_ids(self):

--- a/addons/mrp/security/mrp_security.xml
+++ b/addons/mrp/security/mrp_security.xml
@@ -30,8 +30,8 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
-    <record id="group_locked_by_default" model="res.groups">
-        <field name="name">Locked by default</field>
+    <record id="group_unlocked_by_default" model="res.groups">
+        <field name="name">Unlocked by default</field>
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -396,6 +396,7 @@ class TestMrpOrder(TestMrpCommon):
         production = production_form.save()
         production.action_confirm()
         production.action_assign()
+        production.is_locked = False
         production_form = Form(production)
         # change the quantity producing and the initial demand
         # in the same transaction
@@ -1027,6 +1028,7 @@ class TestMrpOrder(TestMrpCommon):
 
         mo.bom_id.consumption = 'flexible'  # Because we'll over-consume with a product not defined in the BOM
         mo.action_assign()
+        mo.is_locked = False
 
         mo_form = Form(mo)
         mo_form.qty_producing = 3

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -467,6 +467,7 @@ class TestProcurement(TestMrpCommon):
 
         self.assertEqual(len(mo), 1, "Manufacture order was not automatically created")
         mo.action_assign()
+        mo.is_locked = False
         self.assertEqual(mo.move_raw_ids.reserved_availability, 0, "No components should be reserved yet")
         self.assertEqual(mo.product_qty, 15, "Quantity to produce should be picking demand + reordering rule max qty")
 

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -297,7 +297,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         production = production_form.save()
 
         production.action_confirm()
-
+        production.is_locked = False
         production_form = Form(production)
         with production_form.move_raw_ids.new() as move:
             move.product_id = new_product

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -65,12 +65,12 @@
                             </div>
                             <div class="col-lg-6 col-12 o_setting_box" id="mrp_lock" title="Makes confirmed manufacturing orders locked rather than unlocked by default. This only applies to new manufacturing orders, not previously created ones.">
                                 <div class="o_setting_left_pane">
-                                    <field name="group_locked_by_default"/>
+                                    <field name="group_unlocked_by_default"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="group_locked_by_default"/>
+                                    <label for="group_unlocked_by_default"/>
                                     <div class="text-muted">
-                                        Prevent manufacturing users from modifying quantities to consume, unless a manager has unlocked the document
+                                        Allow manufacturing users to modify quantities to consume, without the need for prior approval
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Previous specification of making MOs unlocked by default was confusing
for users and made it too easy to accidentally change the qty to consume
rather than the consumed amount. This fix makes it so MOs are now locked
by default and will be unlocked/locked (including existing draft /
confirmed / in progress MOs) automatically when setting is changed.
Previous setting (Lock Quantities To Consume) has been repurposed for
this. When setting is active, no lock/unlock button will be visible to
match the updated setting description (i.e. non-done MOs can
never be locked).

Task: 2518523
Upgrade PR: odoo/upgrade#2532
ENT PR (fixes tests only): odoo/enterprise#18850

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
