### PR TITLE
[FIX] point_of_sale: add tax grouping to have correct reports

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -205,12 +205,7 @@ class PosOrder(models.Model):
             tax_key = ('tax',
                        values['partner_id'],
                        values['tax_line_id'],
-                       values['debit'] > 0,
-                       values.get('currency_id'))
-            if options.get('rounding_method') == 'round_globally':
-                tax_key = ('tax',
-                           values['tax_line_id'],
-                           order_id)
+                       order_id)
             return tax_key
         elif data_type == 'counter_part':
             return ('counter_part',
@@ -317,7 +312,7 @@ class PosOrder(models.Model):
                     'move_id': move.id,
                 })
 
-                key = self._get_account_move_line_group_data_type_key(data_type, values, {'rounding_method': rounding_method})
+                key = self._get_account_move_line_group_data_type_key(data_type, values)
                 if not key:
                     return
 
@@ -333,7 +328,7 @@ class PosOrder(models.Model):
                         current_value['debit'] = current_value.get('debit', 0.0) + values.get('debit', 0.0)
                         if 'currency_id' in values:
                             current_value['amount_currency'] = current_value.get('amount_currency', 0.0) + values.get('amount_currency', 0.0)
-                        if key[0] == 'tax' and rounding_method == 'round_globally':
+                        if key[0] == 'tax':
                             if current_value['debit'] - current_value['credit'] > 0:
                                 current_value['debit'] = current_value['debit'] - current_value['credit']
                                 current_value['credit'] = 0


### PR DESCRIPTION
Have l10n_be installed and company localized in Belgium as current
company.
Make a POS transaction as follows:
- Product A (qty: 1, tax: 21%)
- Product B (qty: -1, tax: 21%)
Close POS and validate the session
Open accounting report "Déclaration périodique à la TVA"

Entry 64 will be populated with the tax from Product B.
This does not occur while invoicing in POS or via invoicing app.
The reason is in the way POS generate entries: without
grouping together tax data the negative entries appear like in a
credit note

opw-2517738

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
