### PR TITLE
[IMP] mrp: Add Productivity Losses Menu

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -626,5 +626,12 @@
           action="mrp_workcenter_productivity_report"
           groups="group_mrp_routings"
           sequence="12"/>
+
+    <menuitem id="menu_productivity_loss_action"
+            name="Productivity Losses"
+            action="mrp_workcenter_productivity_loss_action"
+            groups="group_mrp_routings"
+            parent="menu_mrp_configuration"
+            sequence="-1"/>
     </data>
 </odoo>


### PR DESCRIPTION
- Improve MRP user menu by Adding Productivity Losses

Current behavior before PR:

- If Productivity loss of type 'productivity' is not defined the user will get a warning to add it in Configuration / Productivity Losses but the menu is not there

Desired behavior after PR is merged:

- The user should add Productivity Losses by accessing it through Configuration / Productivity Losses menu

opw-2564819
