### PR TITLE
[FIX] point_of_sale: Add possibility to execute odoo in IoT with alias

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/odoo
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+LOGLEVEL=$1
+DAEMON=/home/pi/odoo/odoo-bin
+CONFIG=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+MODULES=$(ls /home/pi/odoo/addons/ -m -w0 | tr -d ' ')
+[ -z $LOGLEVEL ] && LOGLEVEL='error --logfile=/var/log/odoo/odoo-server.log'
+
+$DAEMON --log-level $LOGLEVEL --load=$MODULES --config $CONFIG

--- a/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo.conf
@@ -1,5 +1,6 @@
 [options]
 data_dir = /var/run/odoo
-log_level = error
-logfile = /var/log/odoo/odoo-server.log
 pidfile = /var/run/odoo/odoo.pid
+limit_time_cpu = 600
+limit_time_real = 1200
+max_cron_threads = 0

--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
@@ -14,28 +14,33 @@
 . /lib/lsb/init-functions
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
-DAEMON=/home/pi/odoo/odoo-bin
 NAME=odoo
 DESC=odoo
-CONFIG=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf
-LOGFILE=/var/log/odoo/odoo-server.log
-PIDFILE=/var/run/${NAME}.pid
+DAEMON=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo
+PIDFILE_DAEMON=/var/run/${NAME}.pid
+PIDFILE_ODOO=/var/run/${NAME}/${NAME}.pid
 USER=pi
 
 test -x $DAEMON || exit 0
 set -e
 
 function _start() {
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$USER --background --make-pidfile --exec $DAEMON -- --config $CONFIG --logfile $LOGFILE --load=web,hw_proxy,hw_posbox_homepage,hw_escpos,hw_blackbox_be,hw_drivers --limit-time-cpu=600 --limit-time-real=1200
+    # Wait for time to be synced or AP to start or max 30 seconds
+    cnt=30
+    while ! test -a /run/systemd/timesync/synchronized && ! ip route | grep 10.11.12.1 && ((cnt--)); do
+        sleep 1
+    done
+    start-stop-daemon --start --quiet --pidfile $PIDFILE_DAEMON --chuid $USER:$USER --background --make-pidfile --exec $DAEMON
 }
 
 function _stop() {
-    start-stop-daemon --stop --quiet --pidfile $PIDFILE --oknodo --retry 3
-    rm -f $PIDFILE
+    start-stop-daemon --stop --quiet --pidfile $PIDFILE_DAEMON --oknodo --retry 3
+    kill -9 $(cat $PIDFILE_ODOO)
+    rm -f $PIDFILE_DAEMON $PIDFILE_ODOO
 }
 
 function _status() {
-    start-stop-daemon --status --quiet --pidfile $PIDFILE
+    start-stop-daemon --status --quiet --pidfile $PIDFILE_DAEMON
     return $?
 }
 

--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -173,6 +173,9 @@ create_ramdisk_dir () {
     mkdir -v "${1}_ram"
 }
 
+#alias iot_server can take log level in parameter. By default loglevel is error
+echo 'alias iot_server=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo' >> /home/pi/.bashrc
+
 create_ramdisk_dir "/var"
 create_ramdisk_dir "/etc"
 create_ramdisk_dir "/tmp"


### PR DESCRIPTION
Add a alias in the IoT to easily debug with same parameters as the service

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
