### PR TITLE
fix active filter not working in activity view

### DIFF
--- a/addons/mail/static/src/js/views/activity/activity_renderer.js
+++ b/addons/mail/static/src/js/views/activity/activity_renderer.js
@@ -187,7 +187,7 @@ class ActivityRenderer extends AbstractRendererOwl {
             this.activeFilter.activityTypeId = ev.detail.columnID;
             this.activeFilter.resIds = Object.entries(this.props.grouped_activities)
                 .filter(([, resIds]) => ev.detail.columnID in resIds &&
-                    resIds[ev.detail.columnID].state === ev.detail.values.activeFilter)
+                    resIds[ev.detail.columnID].state === ev.detail.values.activeFilter.value)
                 .map(([key]) => parseInt(key));
         } else {
             this.activeFilter.state = null;

--- a/addons/mail/static/src/xml/activity_view.xml
+++ b/addons/mail/static/src/xml/activity_view.xml
@@ -6,7 +6,7 @@
         <tr>
             <th></th>
             <th t-foreach="props.activity_types" t-as="type" t-key="type[0]"
-                class="o_activity_type_cell" t-attf-class="{{ activeFilter.activityTypeId === type[0] ? 'o_activity_filter_' + activeFilter.state : '' }}"
+                class="o_activity_type_cell" t-attf-class="{{ activeFilter.activityTypeId === type[0] ? 'o_activity_filter_' + activeFilter.state.value : '' }}"
                 t-att-data-activity-type-id="type[0]" t-attf-width="{{100/props.activity_types.length}}%">
                 <div>
                     <span t-esc="type[1]"/>
@@ -46,7 +46,7 @@
 <t t-name="mail.ActivityViewRow" owl="1">
     <tr class="o_data_row" t-att-data-res-id="resId">
         <t t-set="record" t-value="props.data.find(data => data.res_id === resId)"/>
-        <td t-attf-class="{{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state : '' }}">
+        <td t-attf-class="{{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state.value : '' }}">
             <ActivityRecordAdapter Component="widgetComponents.ActivityRecord"
                 widgetArgs="[record, { qweb: qweb }]"/>
         </td>
@@ -58,14 +58,15 @@
 
 <t t-name="mail.ActivityViewCell" owl="1">
     <t t-set="activityGroup" t-value="props.grouped_activities[resId] and props.grouped_activities[resId][type[0]] or {count: 0, ids: [], state: false}"/>
-    <td t-if="activityGroup.state" t-att-data-res-id="resId" t-att-data-activity-type-id="type[0]"
-        t-attf-class="o_activity_summary_cell {{activityGroup.state}} {{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state : '' }}">
+    <t t-set="isCellHidden" t-value="activeFilter.resIds.length and !activeFilter.resIds.includes(resId) and activeFilter.activityTypeId === type[0]"/>
+    <td t-if="activityGroup.state and !isCellHidden" t-att-data-res-id="resId" t-att-data-activity-type-id="type[0]"
+        t-attf-class="o_activity_summary_cell {{activityGroup.state}} {{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state.value : '' }}">
         <ActivityCellAdapter Component="widgetComponents.ActivityCell"
             widgetArgs="['activity_ids', props.getKanbanActivityData(activityGroup, resId)]"/>
     </td>
     <td t-else="" t-att-data-res-id="resId" t-att-data-activity-type-id="type[0]"
         class="o_activity_summary_cell o_activity_empty_cell"
-        t-attf-class="{{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state : '' }}"
+        t-attf-class="{{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state.value : '' }}"
         t-on-click.prevent.stop="_onEmptyCellClicked">
         <i title="Create" class="text-center fa fa-plus"/>
     </td>


### PR DESCRIPTION
PURPOSE
When applying active filter using progressbar in activity view, records are not displayed based on active filter, row was not getting highlighted based on active filter, row should be highlighted based on active filter and records should be sorted based on active filter.

SPEC
When applying active filter in activity view using progressbar, highlight row and sort records based on active filter.

TASK 2550959


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
