### PR TITLE
[FIX] sale: do not grant access to purchase invoices by default

### DIFF
--- a/addons/sale/security/sale_security.xml
+++ b/addons/sale/security/sale_security.xml
@@ -148,28 +148,28 @@
     <record id="account_move_personal_rule" model="ir.rule">
         <field name="name">Personal Invoice</field>
         <field ref="model_account_move" name="model_id"/>
-        <field name="domain_force">[('type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), '|', ('invoice_user_id', '=', user.id), ('invoice_user_id', '=', False)]</field>
+        <field name="domain_force">[('type', 'in', ('out_invoice', 'out_refund')), '|', ('invoice_user_id', '=', user.id), ('invoice_user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
     </record>
 
     <record id="account_move_see_all" model="ir.rule">
         <field name="name">All Invoices</field>
         <field ref="model_account_move" name="model_id"/>
-        <field name="domain_force">[('type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]</field>
+        <field name="domain_force">[('type', 'in', ('out_invoice', 'out_refund'))]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
     <record id="account_move_line_personal_rule" model="ir.rule">
         <field name="name">Personal Invoice Lines</field>
         <field ref="model_account_move_line" name="model_id"/>
-        <field name="domain_force">[('move_id.type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), '|', ('move_id.invoice_user_id', '=', user.id), ('move_id.invoice_user_id', '=', False)]</field>
+        <field name="domain_force">[('move_id.type', 'in', ('out_invoice', 'out_refund')), '|', ('move_id.invoice_user_id', '=', user.id), ('move_id.invoice_user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
     </record>
 
     <record id="account_move_line_see_all" model="ir.rule">
         <field name="name">All Invoices Lines</field>
         <field ref="model_account_move_line" name="model_id"/>
-        <field name="domain_force">[('move_id.type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]</field>
+        <field name="domain_force">[('move_id.type', 'in', ('out_invoice', 'out_refund'))]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 


### PR DESCRIPTION
Sales people should only access customer invoices by default.

Notice that the equivalent rule in the `purchase` module makes more sense: https://github.com/odoo/odoo/blob/e2247a860d3d4931d641928a6313bef4649e0edf/addons/purchase/security/purchase_security.xml#L62

@Tecnativa TT30228