### PR TITLE
[FIX] pos: render header and footer of a receipt

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1720,7 +1720,7 @@ td {
         margin-left: auto !important;
         margin-right: auto !important;
         border: none !important;
-        font-size: 13px !important;
+        font-size: 14px !important;
         width: 266px !important;
     }
 }

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -7,7 +7,7 @@
     top: 0;
     text-align: left;
     direction: ltr;
-    font-size: 28px;
+    font-size: 27px;
     color: #000000;
 }
 

--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -33,7 +33,7 @@
                     <t t-raw="receipt.header_html" />
                 </t>
                 <t t-if="!receipt.header_html and receipt.header">
-                    <div><t t-esc="receipt.header" /></div>
+                    <div style="white-space:pre-line"><t t-esc="receipt.header" /></div>
                 </t>
                 <t t-if="receipt.cashier">
                     <div class="cashier">


### PR DESCRIPTION
To reproduce the error:
1. In the settings of a POS, enable "Header & Footer"
2. Add:
    - a header (with at least one line break)
    - this footer: "0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5"
3. Start a session
4. Validate an order
    - Error: The header of the receipt is incorrect, line breaks are not
applied
    - Note that in the footer, there is a line break after the third '3'
6. Print Receipt
    - Error: in footer, the line break is after the third '5'. In header, 
    still not any line breaks
7. Send the receipt by email
    - Error: in the receipt of the mail, the line break is after the
third '2' (footer). In header, still not any line breaks

For the header:
A style is missing

For the footer:
The appearance should be the same in the three cases. On step 5, here
are the values used to display the receipt:
https://github.com/odoo/odoo/blob/6c1172922505cd955d278bc80d327423fc6867a6/addons/point_of_sale/static/src/css/pos.css#L1680-L1692
This fix applies the same ratio `width/font-size = 18.75` on values used
to print the receipt (`266 / 18.75 = +-14`) and the ones used to
generate the receipt in the mail (`512 / 18.75 = +-27`). That way, the
appearance of the receipts remains similar.

OPW-2528558