### PR TITLE
[FIX] point_of_sale: correct compute prices of order in OrderManagementScreen

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -13,7 +13,7 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
     class OrderManagementScreen extends ControlButtonsMixin(IndependentToOrderScreen) {
         constructor() {
             super(...arguments);
-            useListener('close-screen', this._close);
+            useListener('close-screen', this.close);
             useListener('set-numpad-mode', this._setNumpadMode);
             useListener('click-order', this._onClickOrder);
             useListener('next-page', this._onNextPage);
@@ -76,18 +76,8 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             OrderFetcher.fetch();
         }
         _onClickOrder({ detail: clickedOrder }) {
-            let currentPOSOrder = this.env.pos.get_order();
-            if (currentPOSOrder && (!clickedOrder || clickedOrder.locked)) {
+            if (!clickedOrder || clickedOrder.locked) {
                 this.orderManagementContext.selectedOrder = clickedOrder;
-                if (clickedOrder.attributes.client){
-                    currentPOSOrder.set_client(clickedOrder.attributes.client);
-                }
-                if (clickedOrder.fiscal_position){
-                    currentPOSOrder.fiscal_position = clickedOrder.fiscal_position;
-                }
-                if (clickedOrder.pricelist){
-                    currentPOSOrder.set_pricelist(clickedOrder.pricelist);
-                }
             } else {
                 this._setOrder(clickedOrder);
             }
@@ -100,15 +90,6 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             if (order === this.env.pos.get_order()) {
                 this.close();
             }
-        }
-        _close() {
-            let currentOrder = this.env.pos.get_order();
-            if (currentOrder){
-                currentOrder.set_client(false);
-                currentOrder.fiscal_position = false;
-                currentOrder.set_pricelist(this.env.pos.default_pricelist);
-            }
-            this.close();
         }
     }
     OrderManagementScreen.template = 'OrderManagementScreen';

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2076,9 +2076,9 @@ exports.Orderline = Backbone.Model.extend({
         }
         return taxes;
     },
-    _map_tax_fiscal_position: function(tax) {
+    _map_tax_fiscal_position: function(tax, order = false) {
         var self = this;
-        var current_order = this.pos.get_order();
+        var current_order = order || this.pos.get_order();
         var order_fiscal_position = current_order && current_order.fiscal_position;
         var taxes = [];
 
@@ -2284,7 +2284,7 @@ exports.Orderline = Backbone.Model.extend({
             var tax = _.detect(taxes, function(t){
                 return t.id === el;
             });
-            product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax));
+            product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax, self.order));
         });
         product_taxes = _.uniq(product_taxes, function(tax) { return tax.id; });
 
@@ -2315,7 +2315,7 @@ exports.Orderline = Backbone.Model.extend({
             var new_included_taxes = [];
             var self = this;
             _(taxes).each(function(tax) {
-                var line_taxes = self._map_tax_fiscal_position(tax);
+                var line_taxes = self._map_tax_fiscal_position(tax, order);
                 if (line_taxes.length && line_taxes[0].price_include){
                     new_included_taxes = new_included_taxes.concat(line_taxes);
                 }


### PR DESCRIPTION
When viewing an order in the order management screen that has customer
with fiscal position, the calculation of prices is based on the fiscal
position of the currently active order. This commit fixes the issue
by properly specifying the order in the calculation of taxes based
on the order's customer and/or fiscal position.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
