### PR TITLE
[FIX] account: fix infinite looping in prepare_reconciliation_partials

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2338,13 +2338,17 @@ class AccountMove(models.Model):
         if cancel:
             reverse_moves.with_context(move_reverse_cancel=cancel)._post(soft=False)
             for move, reverse_move in zip(self, reverse_moves):
-                accounts = move.mapped('line_ids.account_id') \
-                    .filtered(lambda account: account.reconcile or account.internal_type == 'liquidity')
-                for account in accounts:
-                    (move.line_ids + reverse_move.line_ids)\
-                        .filtered(lambda line: line.account_id == account and not line.reconciled)\
-                        .with_context(move_reverse_cancel=cancel)\
-                        .reconcile()
+                lines = move.line_ids.filtered(
+                    lambda x: (x.account_id.reconcile or x.account_id.internal_type == 'liquidity')
+                              and not x.reconciled
+                )
+                for line in lines:
+                    counterpart_lines = reverse_move.line_ids.filtered(
+                        lambda x: x.account_id == line.account_id
+                                  and x.currency_id == line.currency_id
+                                  and not x.reconciled
+                    )
+                    (line + counterpart_lines).with_context(move_reverse_cancel=cancel).reconcile()
 
         return reverse_moves
 
@@ -4235,12 +4239,16 @@ class AccountMoveLine(models.Model):
             if debit_line_currency == credit_line_currency:
                 # Reconcile on the same currency.
 
-                # The debit line is now fully reconciled.
+                # The debit line is now fully reconciled because:
+                # - either amount_residual & amount_residual_currency are at 0.
+                # - either the credit_line is not an exchange difference one.
                 if not has_debit_residual_curr_left and (has_credit_residual_curr_left or not has_debit_residual_left):
                     debit_line = None
                     continue
 
-                # The credit line is now fully reconciled.
+                # The credit line is now fully reconciled because:
+                # - either amount_residual & amount_residual_currency are at 0.
+                # - either the debit is not an exchange difference one.
                 if not has_credit_residual_curr_left and (has_debit_residual_curr_left or not has_credit_residual_left):
                     credit_line = None
                     continue
@@ -4252,13 +4260,13 @@ class AccountMoveLine(models.Model):
             else:
                 # Reconcile on the company's currency.
 
-                # The debit line is now fully reconciled.
-                if not has_debit_residual_left and (has_credit_residual_left or not has_debit_residual_curr_left):
+                # The debit line is now fully reconciled since amount_residual is 0.
+                if not has_debit_residual_left:
                     debit_line = None
                     continue
 
-                # The credit line is now fully reconciled.
-                if not has_credit_residual_left and (has_debit_residual_left or not has_credit_residual_curr_left):
+                # The credit line is now fully reconciled since amount_residual is 0.
+                if not has_credit_residual_left:
                     credit_line = None
                     continue
 

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -679,6 +679,232 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         self.assertFullReconcile(res['full_reconcile'], line_1 + line_2 + line_3 + line_4 + line_5)
 
+    def test_reconcile_asymetric_rate_change(self):
+        account_id = self.company_data['default_account_receivable'].id
+
+        # Rate is 3.0 in 2016, 2.0 in 2017.
+        currency1_id = self.currency_data['currency'].id
+        # Rate is 6.0 in 2016, 4.0 in 2017.
+        currency2_id = self.currency_data_2['currency'].id
+
+        # Create rate changes for 2018: currency1 rate increases while currency2 rate decreases.
+        self.env['res.currency.rate'].create({
+            'name': '2018-01-01',
+            'rate': 8.0,
+            'currency_id': currency1_id,
+            'company_id': self.company_data['company'].id,
+        })
+
+        self.env['res.currency.rate'].create({
+            'name': '2018-01-01',
+            'rate': 2.0,
+            'currency_id': currency2_id,
+            'company_id': self.company_data['company'].id,
+        })
+
+        moves = self.env['account.move'].create([
+            {
+                'move_type': 'entry',
+                'date': '2018-01-01',
+                'line_ids': [
+                    (0, 0, {
+                        'debit': 1200.0,
+                        'credit': 0.0,
+                        'amount_currency': 9600.0,
+                        'account_id': account_id,
+                        'currency_id': currency1_id,
+                    }),
+                    (0, 0, {
+                        'debit': 960.0,
+                        'credit': 0.0,
+                        'amount_currency': 1920.0,
+                        'account_id': account_id,
+                        'currency_id': currency2_id,
+                    }),
+                    (0, 0, {
+                        'debit': 0.0,
+                        'credit': 2160.0,
+                        'account_id': account_id,
+                    }),
+                ]
+            },
+            {
+                'move_type': 'entry',
+                'date': '2017-01-01',
+                'line_ids': [
+                    (0, 0, {
+                        'debit': 0.0,
+                        'credit': 1200.0,
+                        'amount_currency': -4800.0,
+                        'account_id': account_id,
+                        'currency_id': currency2_id,
+                    }),
+                    (0, 0, {
+                        'debit': 0.0,
+                        'credit': 960.0,
+                        'amount_currency': -1920.0,
+                        'account_id': account_id,
+                        'currency_id': currency1_id,
+                    }),
+                    (0, 0, {
+                        'debit': 2160.0,
+                        'credit': 0.0,
+                        'account_id': account_id,
+                    }),
+                ]
+            }
+        ])
+
+        moves.action_post()
+
+        line_1 = moves.line_ids.filtered(lambda line: line.debit == 1200.0)
+        line_2 = moves.line_ids.filtered(lambda line: line.debit == 960.0)
+        line_3 = moves.line_ids.filtered(lambda line: line.credit == 1200.0)
+        line_4 = moves.line_ids.filtered(lambda line: line.credit == 960.0)
+
+        self.assertRecordValues(line_1 + line_2 + line_3 + line_4, [
+            {'amount_residual': 1200.0,     'amount_residual_currency': 9600.0,     'reconciled': False},
+            {'amount_residual': 960.0,      'amount_residual_currency': 1920.0,     'reconciled': False},
+            {'amount_residual': -1200.0,    'amount_residual_currency': -4800.0,    'reconciled': False},
+            {'amount_residual': -960.0,     'amount_residual_currency': -1920.0,    'reconciled': False},
+        ])
+
+        # Reconcile with debit_line currency rate increased and credit_line currency rate decreased between
+        # credit_line.date and debit_line.date.
+
+        res = (line_1 + line_3).reconcile()
+
+        exchange_diff = res['full_reconcile'].exchange_move_id
+        exchange_diff_lines = exchange_diff.line_ids.sorted(lambda line: (line.currency_id, abs(line.amount_currency), -line.amount_currency))
+
+        self.assertRecordValues(exchange_diff_lines, [
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': 2400.0,
+                'currency_id': currency2_id,
+                'account_id': account_id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': -2400.0,
+                'currency_id': currency2_id,
+                'account_id': exchange_diff.journal_id.company_id.income_currency_exchange_account_id.id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': 7200.0,
+                'currency_id': currency1_id,
+                'account_id': exchange_diff.journal_id.company_id.expense_currency_exchange_account_id.id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': -7200.0,
+                'currency_id': currency1_id,
+                'account_id': account_id,
+            }
+        ])
+
+        self.assertPartialReconcile(res['partials'], [
+            {
+                'amount': 0.0,
+                'debit_amount_currency': 2400.0,
+                'credit_amount_currency': 2400.0,
+                'debit_move_id': exchange_diff_lines[0].id,
+                'credit_move_id': line_3.id,
+            },
+            {
+                'amount': 0.0,
+                'debit_amount_currency': 7200.0,
+                'credit_amount_currency': 7200.0,
+                'debit_move_id': line_1.id,
+                'credit_move_id': exchange_diff_lines[3].id,
+            },
+            {
+                'amount': 1200.0,
+                'debit_amount_currency': 2400.0,
+                'credit_amount_currency': 2400.0,
+                'debit_move_id': line_1.id,
+                'credit_move_id': line_3.id,
+            },
+        ])
+
+        self.assertRecordValues(line_1 + line_3, [
+            {'amount_residual': 0.0, 'amount_residual_currency': 0.0, 'reconciled': True},
+            {'amount_residual': 0.0, 'amount_residual_currency': 0.0, 'reconciled': True},
+        ])
+
+        # Reconcile with debit_line currency rate decreased and credit_line currency rate increased between
+        # credit_line.date and debit_line.date.
+
+        res = (line_2 + line_4).reconcile()
+
+        exchange_diff = res['full_reconcile'].exchange_move_id
+        exchange_diff_lines = exchange_diff.line_ids.sorted(lambda line: (line.currency_id, abs(line.amount_currency), -line.amount_currency))
+
+        self.assertRecordValues(exchange_diff_lines, [
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': 5760.0,
+                'currency_id': currency1_id,
+                'account_id': exchange_diff.journal_id.company_id.expense_currency_exchange_account_id.id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': -5760.0,
+                'currency_id': currency1_id,
+                'account_id': account_id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': 1920.0,
+                'currency_id': currency2_id,
+                'account_id': account_id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.0,
+                'amount_currency': -1920.0,
+                'currency_id': currency2_id,
+                'account_id': exchange_diff.journal_id.company_id.income_currency_exchange_account_id.id,
+            }
+        ])
+
+        self.assertPartialReconcile(res['partials'], [
+            {
+                'amount': 0.0,
+                'debit_amount_currency': 1920.0,
+                'credit_amount_currency': 1920.0,
+                'debit_move_id': exchange_diff_lines[2].id,
+                'credit_move_id': line_2.id,
+            },
+            {
+                'amount': 0.0,
+                'debit_amount_currency': 5760.0,
+                'credit_amount_currency': 5760.0,
+                'debit_move_id': line_4.id,
+                'credit_move_id': exchange_diff_lines[1].id,
+            },
+            {
+                'amount': 960.0,
+                'debit_amount_currency': 3840.0,
+                'credit_amount_currency': 7680.0,
+                'debit_move_id': line_2.id,
+                'credit_move_id': line_4.id,
+            },
+        ])
+
+        self.assertRecordValues(line_2 + line_4, [
+            {'amount_residual': 0.0, 'amount_residual_currency': 0.0, 'reconciled': True},
+            {'amount_residual': 0.0, 'amount_residual_currency': 0.0, 'reconciled': True},
+        ])
+
     def test_reverse_exchange_difference_same_foreign_currency(self):
         move_2016 = self.env['account.move'].create({
             'move_type': 'entry',


### PR DESCRIPTION
Given the following situation: reconciling two lines, one debit and one credit.
`debit_line.date > credit_line.date`, `debit_line.currency_id != credit_line.currency_id != self.currency_id`. 
If there have been the following rate changes in between `credit_line.date, debit_line.date`:
  - `debit_line.currency_id` rate increased
  - `credit_line.currency_id` rate decreased

The system currently enters an infinite while loop in `account.move.line._prepare_reconciliation_partials`.

This PR fixes this issue. Both lines are now properly reconciled.

Changes to `account.move` done by las.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
