### PR TITLE
[FIX] wait for images before receipt print

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -1731,7 +1731,7 @@ var ReceiptScreenWidget = ScreenWidget.extend({
         this.pos.proxy.printer.print_receipt(receipt);
         this.pos.get_order()._printed = true;
     },
-    print: function() {
+    _print: function() {
         var self = this;
 
         if (!this.pos.proxy.printer) { // browser (html) printing
@@ -1763,6 +1763,9 @@ var ReceiptScreenWidget = ScreenWidget.extend({
             this.print_html();
             this.lock_screen(false);
         }
+    },
+    print: function() {
+        $(window.document).ready(this._print.bind(this));
     },
     click_next: function() {
         this.pos.get_order().finalize();


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
> **File:** `addons/point_of_sale/static/src/js/screens.js`
> **Function:** `ReceiptScreenWidget::print` (line 1734)
> **Overview:** 
> The function could be called before the receipt fully loads. I did experience a case where the screen would print without a logo if automatic printing is selected.

 
### Current behavior before PR:
> Possible to print receipts while missing the logo

### Desired behavior after PR is merged:
> Waits for the document to be fully loaded before calling the print function



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
