### PR TITLE
[FIX] point_of_sale: use correct product's location

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -117,7 +117,7 @@ class StockPicking(models.Model):
                                             'product_id': line.product_id.id,
                                             'name': lot.lot_name,
                                         })
-                                    quant = existing_lot.quant_ids.filtered(lambda q: q.quantity > 0.0 or q.location_id.parent_path.startswith(move.location_id.parent_path))[-1:]
+                                    quant = existing_lot.quant_ids.filtered(lambda q: q.quantity > 0.0 and q.location_id.parent_path.startswith(move.location_id.parent_path))[-1:]
                                     ml_vals.update({
                                         'lot_id': existing_lot.id,
                                         'location_id': quant.location_id.id or move.location_id.id


### PR DESCRIPTION
When selling a tracked product, if the latter has already been sold
once, the source location of the associated stock move will be
incorrect.

To reproduce the error:
1. Create a product P
    - Product Type: Storable Product
    - Available in POS: True
    - Inventory: By Lots
2. Update P's quantity > 0 with lot L
3. Start POS session
4. Sell one P with lot L (Register payment + Validate)
5. Repeat 4
6. Go to Inventory > Reporting > Product Moves and apply one filter:
    - Product: P
Error: There are 3 product moves:
    - One from Inventory adjustment to Stock
    - One from Stock to Customers
    - One from Customers to Customers
The third one is incorrect and should be from Stock to Customers.

Because of the first sale, a `stock.quant` is created and indicates that
one P from lot L is at location "Customers". When selling the second
one, because of the OR-condition, this `stock.quant` is selected. The
condition should be an AND-condition.

This fix is an improvement of #69750. The new test checks the above flow
and the one described in the related PR.

closes #71435

closes odoo/odoo#71573

X-original-commit: fe5deb4ee4c8e07aed2f2cff6210271bfaa61476
Signed-off-by: pimodoo <pimodoo@users.noreply.github.com>
Signed-off-by: Adrien Widart <adwid@users.noreply.github.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
