### PR TITLE
[FIX] point_of_sale: tax not aligned on order receipt

### DIFF
--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -55,6 +55,12 @@
     text-align: center;
 }
 
+.pos-receipt .pos-receipt-tax-line {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+}
+
 .pos-receipt .pos-order-receipt-cancel {
     color: red;
 }

--- a/addons/point_of_sale/static/src/xml/pos.xml
+++ b/addons/point_of_sale/static/src/xml/pos.xml
@@ -959,7 +959,7 @@
                 <br/>
                 <div>Subtotal<span t-esc='widget.format_currency(receipt.subtotal)' class="pos-receipt-right-align"/></div>
                 <t t-foreach='receipt.tax_details' t-as='tax'>
-                    <div>
+                    <div class="pos-receipt-tax-line">
                         <t t-esc='tax.name' />
                         <span t-esc='widget.format_currency_no_symbol(tax.amount)' class="pos-receipt-right-align"/>
                     </div>


### PR DESCRIPTION
It can happen that the amount of a tax is not properly aligned on the receipt (e.g.: Indian Localization), this fix should prevent any misaligned value.

related task id: 2372852