### PR TITLE
[FIX] base_vat: improve space handling in vat formatting

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -77,7 +77,8 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     def _split_vat(self, vat):
-        vat_country, vat_number = vat[:2].lower(), vat[2:].replace(' ', '')
+        vat = vat.replace(' ','')
+        vat_country, vat_number = vat[:2].lower(), vat[2:]
         return vat_country, vat_number
 
     @api.model

--- a/doc/cla/individual/TheMule71.md
+++ b/doc/cla/individual/TheMule71.md
@@ -1,0 +1,11 @@
+Italy, 2021-06-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Marco Colombo marco.colombo@gmail.com https://github.com/TheMule71


### PR DESCRIPTION
Prior to this fix, the _split_vat method would return (' i', 'T05979361218')
if called with the string " IT 05979361218 ", that is, it would fail to
remove the leading space(s) and thus wouldn't return the correct country
code. It seems better to remove all spaces first, then split the
vat string.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
