### PR TITLE
[FIX] mrp: send additional components to backorder

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -975,7 +975,7 @@ class MrpProduction(models.Model):
             if production.state in ('done', 'cancel'):
                 continue
             additional_moves = production.move_raw_ids.filtered(
-                lambda move: move.state == 'draft' and move.additional
+                lambda move: move.state == 'draft'
             )
             additional_moves.write({
                 'group_id': production.procurement_group_id.id,
@@ -983,7 +983,7 @@ class MrpProduction(models.Model):
             additional_moves._adjust_procure_method()
             moves_to_confirm |= additional_moves
             additional_byproducts = production.move_finished_ids.filtered(
-                lambda move: move.state == 'draft' and move.additional
+                lambda move: move.state == 'draft'
             )
             moves_to_confirm |= additional_byproducts
 

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -190,8 +190,8 @@ class StockMove(models.Model):
                     defaults['state'] = 'draft'
                 else:
                     defaults['state'] = 'done'
+                    defaults['additional'] = True
                 defaults['product_uom_qty'] = 0.0
-                defaults['additional'] = True
         return defaults
 
     def write(self, vals):


### PR DESCRIPTION
Following https://github.com/odoo/odoo/pull/64911, components that are added in the
simplified view of an MO are not transferred to the backorder, which is not aligned
with the behavior of the tablet view.

Enterprise PR: https://github.com/odoo/enterprise/pull/18897
Task: 2566749

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
