### PR TITLE
[FIX] account: error in reconcile rule percentage calculation

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -884,7 +884,8 @@ class AccountReconcileModel(models.Model):
         # Statement line amount is equal to the total residual.
         if line_currency.is_zero(line_residual_after_reconciliation):
             return True
-        reconciled_percentage = 100 - abs(line_residual_after_reconciliation) / abs(line_residual - line_residual_after_reconciliation) * 100
+        residual_difference = line_residual - line_residual_after_reconciliation
+        reconciled_percentage = 100 - abs(line_residual_after_reconciliation) / abs(residual_difference) * 100 if (residual_difference != 0) else 0
         return reconciled_percentage >= self.match_total_amount_param
 
     def _filter_candidates(self, candidates, aml_ids_to_exclude, reconciled_amls_ids):


### PR DESCRIPTION
Small fixup of recent commit 5800f20ccf63ef8482d1460f46c8c5fe30eac822.

It can happen that line_residual is equal to line_residual_after_reconciliation.
This should lead to a zero reconciled percentage instead of a ZeroDivisionError.

Description of the issue/feature this PR addresses:
opw-2542307
opw-2562947
opw-2558428
opw-2565906

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
