### PR TITLE
[IMP] mail: allow user to freely resize composer height

### DIFF
--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -141,8 +141,10 @@ export class ComposerTextInput extends Component {
      * @private
      */
     _updateHeight() {
-        this._mirroredTextareaRef.el.value = this.composerView.composer.textInputContent;
-        this._textareaRef.el.style.height = (this._mirroredTextareaRef.el.scrollHeight) + "px";
+        if (!this.composerView.composer.isUserResizable) {
+            this._mirroredTextareaRef.el.value = this.composerView.composer.textInputContent;
+            this._textareaRef.el.style.height = (this._mirroredTextareaRef.el.scrollHeight) + "px";
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -10,13 +10,13 @@
                         isBelow="props.hasMentionSuggestionsBelowPosition"
                     />
                 </t>
-                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
+                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea" t-attf-style="resize: {{ composerView.composer.isUserResizable and 'vertical' or 'none' }}"/>
                 <!--
                      This is an invisible textarea used to compute the composer
                      height based on the text content. We need it to downsize
                      the textarea properly without flicker.
                 -->
-                <textarea class="o_ComposerTextInput_mirroredTextarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-ref="mirroredTextarea" disabled="1"/>
+                <textarea t-if="!composerView.composer.isUserResizable" class="o_ComposerTextInput_mirroredTextarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-ref="mirroredTextarea" disabled="1"/>
             </div>
         </t>
     </t>

--- a/addons/mail/static/src/models/composer.js
+++ b/addons/mail/static/src/models/composer.js
@@ -39,6 +39,13 @@ registerModel({
             return this.attachments.some(attachment => attachment.isUploading);
         },
         /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsUserResizable() {
+            return this.thread && this.thread.model !== 'mail.channel';
+        },
+        /**
          * Detects if mentioned partners are still in the composer text input content
          * and removes them if not.
          *
@@ -185,6 +192,12 @@ registerModel({
          * Determines whether a post_message request is currently pending.
          */
         isPostingMessage: attr(),
+        /**
+         * Determines whether the composer is resizable or not.
+         */
+        isUserResizable: attr({
+            compute: '_computeIsUserResizable',
+        }),
         mentionedChannels: many('Thread', {
             compute: '_computeMentionedChannels',
         }),


### PR DESCRIPTION
PURPOSE

With a small screen, message history becomes invisible when attachments are
added in the composer.

SPECIFICATIONS

Removed `mirroredTextarea` that is invisible textarea which is used to compute
the composer height. Hence, the user can freely resize the composer height.

LINKS

Task: 2531149

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
