### PR TITLE
[FIX] point_of_sale: delete cash statement if no sale

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -321,6 +321,10 @@ class PosSession(models.Model):
                 self.env['pos.order'].search([('session_id', '=', self.id), ('state', '=', 'paid')]).write({'state': 'done'})
             else:
                 self.move_id.unlink()
+        elif not self.cash_register_id.difference:
+            cash_register = self.cash_register_id
+            cash_register.pos_session_id = False
+            cash_register.unlink()
         self.write({'state': 'closed'})
         return {
             'type': 'ir.actions.client',


### PR DESCRIPTION
Suppose a POS with setting 'Advanced Cash Control' enabled. The user
starts/closes a POS session (no sale, no cash difference). In
Accounting > Cash, a bank statement exists, has no line and its starting
balance is equal to its ending balance.

The user has then to add a zero line, post and validate the bank
statement.

In such situation, the bank statement should be automatically deleted
when closing the session

OPW-2507394