### PR TITLE
[FIX] payment_stripe_sca: metadata exists in normal flow too

### DIFF
--- a/addons/payment_stripe_sca/models/payment.py
+++ b/addons/payment_stripe_sca/models/payment.py
@@ -253,7 +253,7 @@ class PaymentTransactionStripeSCA(models.Model):
     def _stripe_form_get_tx_from_data(self, data):
         """ Given a data dict coming from stripe, verify it and find the related
         transaction record. """
-        reference = data.get('metadata', data).get("reference")
+        reference = data.get('metadata', {}).get("reference") or data.get("reference")
         if not reference:
             stripe_error = data.get("error", {}).get("message", "")
             _logger.error(


### PR DESCRIPTION
...and is an empty dictionary which leads to denial of successful
payment.

**Description of the issue/feature this PR addresses:**
Self-explanatory I guess...

**Current behavior before PR:**
Successful payment not registered correctly

**Desired behavior after PR is merged:**
Work as expected...

Info: @wt-io-it




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
