### PR TITLE
[FIX] l10n_cl: do not override `_onchange_journal``

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -97,7 +97,7 @@ class AccountMove(models.Model):
                                             'the country should be different from Chile to register purchases.'))
 
     @api.onchange('journal_id')
-    def _onchange_journal(self):
+    def _l10n_cl_onchange_journal(self):
         self.l10n_latam_document_type_id = False
 
     def post(self):


### PR DESCRIPTION
This method was defined in `account` but overrided in `l10n_cl`. Prefix
the method to avoid that.

Backport of 4f43dda7cd690bea780a209f48240ecf07e2f198




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
