### PR TITLE
[FIX] stock: avoid infinite loop in _procure_orderpoint_confirm

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -470,7 +470,7 @@ class StockWarehouseOrderpoint(models.Model):
                 cr = registry(self._cr.dbname).cursor()
                 self = self.with_env(self.env(cr=cr))
             orderpoints_batch = self.env['stock.warehouse.orderpoint'].browse(orderpoints_batch)
-            orderpoints_exceptions = []
+            all_orderpoints_exceptions = []
             while orderpoints_batch:
                 procurements = []
                 for orderpoint in orderpoints_batch:
@@ -486,8 +486,10 @@ class StockWarehouseOrderpoint(models.Model):
                     with self.env.cr.savepoint():
                         self.env['procurement.group'].with_context(from_orderpoint=True).run(procurements, raise_user_error=raise_user_error)
                 except ProcurementException as errors:
+                    orderpoints_exceptions = []
                     for procurement, error_msg in errors.procurement_exceptions:
                         orderpoints_exceptions += [(procurement.values.get('orderpoint_id'), error_msg)]
+                    all_orderpoints_exceptions += orderpoints_exceptions
                     failed_orderpoints = self.env['stock.warehouse.orderpoint'].concat(*[o[0] for o in orderpoints_exceptions])
                     if not failed_orderpoints:
                         _logger.error('Unable to process orderpoints')
@@ -505,7 +507,7 @@ class StockWarehouseOrderpoint(models.Model):
                     break
 
             # Log an activity on product template for failed orderpoints.
-            for orderpoint, error_msg in orderpoints_exceptions:
+            for orderpoint, error_msg in all_orderpoints_exceptions:
                 existing_activity = self.env['mail.activity'].search([
                     ('res_id', '=', orderpoint.product_id.product_tmpl_id.id),
                     ('res_model_id', '=', self.env.ref('product.model_product_template').id),


### PR DESCRIPTION
A security has been added to avoid an infinite loop due to custom
code if the failing orderpoints were not correctly return in order
to exclude them from the set to retry.

However after a first batch if some orderpoints were correctly exclude
orderpoints_exceptions will not be empty and during the second iteration
failed_orderpoints will be always filled from exceptions of previous
iterations and the infinite loop will not be detected.

opw-2525893
