### PR TITLE
[FIX] website: allow translation of cookie buttons

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -1069,6 +1069,13 @@ msgid "Action"
 msgstr ""
 
 #. module: website
+#. openerp-web
+#: code:addons/website/static/src/js/backend/res_config_settings.js:0
+#, python-format
+msgid "Activate anyway"
+msgstr ""
+
+#. module: website
 #: model:ir.model.fields,field_description:website.field_theme_ir_ui_view__active
 #: model:ir.model.fields,field_description:website.field_website_page__active
 #: model:ir.model.fields,field_description:website.field_website_rewrite__active
@@ -2822,6 +2829,13 @@ msgstr ""
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.res_config_settings_view_form
 msgid "Display this website when users visit this domain"
+msgstr ""
+
+#. module: website
+#. openerp-web
+#: code:addons/website/static/src/js/backend/res_config_settings.js:0
+#, python-format
+msgid "Do not activate"
 msgstr ""
 
 #. module: website

--- a/addons/website/static/src/js/backend/res_config_settings.js
+++ b/addons/website/static/src/js/backend/res_config_settings.js
@@ -54,13 +54,13 @@ const WebsiteCookiesbarField = FieldBoolean.extend({
             title: _t("Please confirm"),
             $content: QWeb.render('website.res_config_settings.cookies_modal_main'),
             buttons: [{
-                text: 'Do not activate',
+                text: _t('Do not activate'),
                 classes: 'btn-primary',
                 close: true,
                 click: cancelCallback,
             },
             {
-                text: 'Activate anyway',
+                text: _t('Activate anyway'),
                 close: true,
                 click: () => this._setValue(checked),
             }],


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Expand translations

Current behavior before PR: The terms "Do not activate" and "Activate anyway" cannot be translated

Desired behavior after PR is merged:The terms "Do not activate" and "Activate anyway" can be translated


Fixes https://github.com/odoo/odoo/issues/71902
Closes https://github.com/odoo/odoo/issues/71902 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
