### PR TITLE
[FIX] account: fix infinite loop when reversing moves in multi-currencies

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4262,6 +4262,12 @@ class AccountMoveLine(models.Model):
                     credit_line = None
                     continue
 
+                # To prevent an infinite loop
+                if not has_debit_residual_left and not has_credit_residual_left:
+                    debit_line = None
+                    credit_line = None
+                    continue
+
                 min_debit_amount_residual_currency = credit_line.company_currency_id._convert(
                     min_amount_residual,
                     debit_line.currency_id,


### PR DESCRIPTION
In a multi-currency environment, when reversing a bank statement reconciled
with "Currency exchange rate difference" move lines, it can happen that
_prepare_reconciliation_partials method is stuck in an infinite loop, because
it is processing a debit line and a credit line with different currency where
amount_residual is equal to 0.0 but amount_residual_currency is not for both.
As currency of debit line is different from currency of credit line,
ammount_residual (which is equal to 0.0) will be used to reduce amount_residual_currency
of debit and credit lines, which will lead to an infinite loop as the value
of amount_residual_currency for both lines will never reach 0.

opw-2521627
opw-2519400

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
