### PR TITLE
[IMP] sale: improve partner SO count performance

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -15,7 +15,7 @@ class ResPartner(models.Model):
 
     def _compute_sale_order_count(self):
         # retrieve all children partners and prefetch 'parent_id' on them
-        all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
+        all_partners = self.with_context(active_test=False).search(['|', ('id', 'in', self.ids), ('commercial_partner_id', 'in', self.ids)])
         all_partners.read(['parent_id'])
 
         sale_order_groups = self.env['sale.order'].read_group(


### PR DESCRIPTION
In v12, the `child_of` operator is quite heavy on the SQL level. In a database with many partners, this becomes slow. And the `sale_order_count`non-stored computed field appears on kanban views of `res.partner`, which makes performance worse.

By switching the domain to search for `id` and `commercial_partner_id`, we get the same results but with less queries.

@Tecnativa TT30390


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
