### PR TITLE
[FIX] models.py: fill group desc order kept


### DIFF
--- a/odoo/addons/test_read_group/tests/test_group_expand.py
+++ b/odoo/addons/test_read_group/tests/test_group_expand.py
@@ -87,3 +87,13 @@ class TestGroupOnSelection(common.TransactionCase):
                 '__domain': [('state', '=', False)],
             },
         ])
+
+    def test_reverse_order(self):
+        self.Model.create({'state': 'a', 'value': 1})
+        self.Model.create({'state': 'b', 'value': 2})
+
+        groups = self.Model.read_group([], fields=['state'], groupby=['state'], orderby='state DESC')
+        self.assertEqual(groups, [
+            {'__domain': [('state', '=', 'b')], 'state': 'b', 'state_count': 1},
+            {'__domain': [('state', '=', 'a')], 'state': 'a', 'state_count': 1},
+        ])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1753,6 +1753,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         # determine all groups that should be returned
         values = [line[groupby] for line in read_group_result if line[groupby]]
 
+        read_group_order = read_group_order and read_group_order.lower()
         if field.relational:
             # groups is a recordset; determine order on groups's model
             groups = self.env[field.comodel_name].browse([value[0] for value in values])


### PR DESCRIPTION

Scenario:

- group mail.mass_mailing.campaign list view by stage_id
- sort by reverse stage_id

=> the reverse does not work since we compare DESC (js) and desc (orm)

opw-2565810
