### PR TITLE
[FIX] web: Prevent quick create from closing after text selection

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record_quick_create.js
@@ -22,7 +22,9 @@ var RecordQuickCreate = Widget.extend({
         'click .o_kanban_add': '_onAddClicked',
         'click .o_kanban_edit': '_onEditClicked',
         'click .o_kanban_cancel': '_onCancelClicked',
+        'mousedown': '_onMouseDown',
     },
+    mouseDownInside: false,
 
     /**
      * @override
@@ -257,6 +259,9 @@ var RecordQuickCreate = Widget.extend({
      * @param {MouseEvent} ev
      */
     _onWindowClicked: function (ev) {
+        var mouseDownInside = this.mouseDownInside;
+
+        this.mouseDownInside = false;
         // ignore clicks if the quick create is not in the dom
         if (!document.contains(this.el)) {
             return;
@@ -290,12 +295,21 @@ var RecordQuickCreate = Widget.extend({
         }
 
         // ignore clicks if target is inside the quick create
-        if (this.el.contains(ev.target) || this.el === ev.target) {
+        if (this.el.contains(ev.target) || this.el === ev.target || mouseDownInside) {
             return;
         }
 
         this.cancel();
     },
+    /**
+     * Detects if the click is originally from the quick create
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onMouseDown: function(ev){
+        this.mouseDownInside = true;
+    }
 });
 
 return RecordQuickCreate;

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -814,7 +814,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('quick create record: cancel and validate without using the buttons', function (assert) {
-        assert.expect(8);
+        assert.expect(9);
 
         var nbRecords = 4;
         var kanban = createView({
@@ -853,6 +853,14 @@ QUnit.module('Views', {
         kanban.$('.o_kanban_group .o_kanban_record:first').click();
         assert.strictEqual(kanban.$('.o_kanban_quick_create').length, 0,
             "the quick create should be destroyed when the user clicks outside");
+
+        // click to input and drag the mouse outside, should not cancel the quick creation
+        kanban.$('.o_kanban_header .o_kanban_quick_add i').first().click();
+        $quickCreate = kanban.$('.o_kanban_quick_create');
+        $quickCreate.find('input').trigger('mousedown');
+        kanban.$('.o_kanban_group .o_kanban_record:first').click();
+        assert.strictEqual(kanban.$('.o_kanban_quick_create').length , 1,
+        "the quick create should not have been destroyed after clicking outside");
 
         // click to really add an element
         kanban.$('.o_kanban_header .o_kanban_quick_add i').first().click();


### PR DESCRIPTION
There is a function allowing to close the quick create if we click outside the element.

`RecordQuickCreate._onWindowClicked`

https://github.com/odoo/odoo/blob/1942e3cb70726cbb14d609e26348f5c8695165fc/addons/web/static/src/js/views/kanban/kanban_record_quick_create.js#L261-L301

Except that this function is triggered in a "click" event, so if we click on the quick create element and drag the mouse outside, it will detect that we are outside and close the quick create.
This manipulation can happen when you want to select text with the mouse.

This PR prevents this behavior by detecting when a click is from the quick create

opw-2558932