### PR TITLE
[FIX] sale_timesheet: fix _compute_warning_employee_rate

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -87,7 +87,7 @@ class Project(models.Model):
         employees = self.env['account.analytic.line'].read_group([('task_id', 'in', tasks.ids), ('non_allow_billable', '=', False)], ['employee_id', 'project_id'], ['employee_id', 'project_id'], ['employee_id', 'project_id'], lazy=False)
         dict_project_employee = defaultdict(list)
         for line in employees:
-            dict_project_employee[line['project_id'][0]] += [line['employee_id'][0]]
+            dict_project_employee[line['project_id'][0]] += [line['employee_id'][0]] if line['employee_id'] else []
         for project in projects:
             project.warning_employee_rate = any(x not in project.sale_line_employee_ids.employee_id.ids for x in dict_project_employee[project.id])
 


### PR DESCRIPTION
On account analytic lines, employee_id can be null.
https://github.com/odoo/odoo/blob/c63af09774414a004ef34644b4f38b4fdb1d12bd/addons/hr_timesheet/models/hr_timesheet.py#L48

```
Traceback (most recent call last):
  File "/tmp/tmpowipzc_d/migrations/base/tests/test_mock_crawl.py", line 155, in crawl_menu
    self.mock_action(action_vals)
  File "/tmp/tmpowipzc_d/migrations/base/tests/test_mock_crawl.py", line 245, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
  File "/tmp/tmpowipzc_d/migrations/base/tests/test_mock_crawl.py", line 335, in mock_view_kanban
    self.mock_web_search_read(model, view, [domain], fields_list)
  File "/tmp/tmpowipzc_d/migrations/base/tests/test_mock_crawl.py", line 394, in mock_web_search_read
    data = model.search_read(domain=domain, fields=fields_list, limit=80)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4839, in search_read
    result = records.read(fields)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3020, in read
    return self._read_format(fnames=fields, load=load)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3040, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5666, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1019, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1175, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4061, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/odoo/src/odoo/14.0/addons/sale_timesheet/models/project.py", line 90, in _compute_warning_employee_rate
    dict_project_employee[line['project_id'][0]] += [line['employee_id'][0]]
TypeError: 'bool' object is not subscriptable
```

```
❯ psql test_14 -c '\d account_analytic_line' | grep employee_id
 employee_id            | integer                     |           |          |
    "account_analytic_line_employee_id_fkey" FOREIGN KEY (employee_id) REFERENCES hr_employee(id) ON DELETE SET NULL
```

Observed on upgrade request 16289
opw-2525553

Steps to reproduce on runbot (or local db with -i sale_timesheet and
deoma data)
1. Select Project > Office Design
2. Change project settings:
  Settings tab > Billable=True
  Invoicing tab > Invoice Tasks to=A unique customer
                > Pricing=Employee rate
3. Save
4. Delete Employees > Eli Lambert
5. Open Project main menu -> Traceback

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
