### PR TITLE
[FIX] mail: avoid unwanted scroll bar jump with mulitline message

### DIFF
--- a/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -2439,6 +2439,47 @@ QUnit.test('chat window should remain folded when new message is received', asyn
     );
 });
 
+QUnit.test('with conversation scrolled to end, when composer size changes, conversation should still be scrolled to end', async function(assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records.push({ id: 20 });
+    // Create enough message to make the scrollbar inside the chat window.
+    for (let i = 0; i < 10; i++) {
+        this.data['mail.message'].records.push({
+            body: "not empty",
+            model: "mail.channel",
+            res_id: 20,
+        });
+    }
+    await this.start();
+
+    await afterNextRender(() => document.querySelector(`.o_MessagingMenu_toggler`).click());
+    await this.afterEvent({
+        eventName: 'o-component-message-list-scrolled',
+        func: () => document.querySelector('.o_NotificationList_preview').click(),
+        message: "should wait until channel 20 scrolled to its last message after opening it from the messaging menu",
+        predicate: ({ scrollTop, thread }) => {
+            const messageList = document.querySelector('.o_ThreadView_messageList');
+            return (
+                thread &&
+                thread.model === 'mail.channel' &&
+                thread.id === 20 &&
+                scrollTop === messageList.scrollHeight - messageList.clientHeight
+            );
+        },
+    });
+
+    await afterNextRender(() => {
+        document.querySelector(`.o_ComposerTextInput_textarea`).focus();
+        document.execCommand('insertText', false, "\n");
+    });
+    assert.strictEqual(
+        document.querySelector(`.o_ThreadView_messageList`).scrollTop,
+        document.querySelector('.o_ThreadView_messageList').scrollHeight - document.querySelector('.o_ThreadView_messageList').clientHeight,
+        "scrollTop should still be the same after inserting a new line inside the composer. Composer resize will not push the scrollbar up"
+    );
+});
+
 });
 });
 });

--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -43,7 +43,6 @@
                             getScrollableElement="getScrollableElement"
                             hasComposer="false"
                             hasScrollAdjust="chatter.hasMessageListScrollAdjust"
-                            order="'desc'"
                             threadViewLocalId="chatter.threadView.localId"
                             t-ref="thread"
                         />

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -46,7 +46,7 @@ export class MessageList extends Component {
                 componentHintList: threadView ? [...threadView.componentHintList] : [],
                 hasAutoScrollOnMessageReceived: threadView && threadView.hasAutoScrollOnMessageReceived,
                 hasScrollAdjust: this.props.hasScrollAdjust,
-                order: this.props.order,
+                order: threadView && threadView.order,
                 orderedMessages: threadCache ? [...threadCache.orderedMessages] : [],
                 thread,
                 threadCache,
@@ -56,10 +56,33 @@ export class MessageList extends Component {
                 threadViewer: threadView && threadView.threadViewer,
             };
         });
+        /**
+         * This observer will trigger each time the root element is resized and
+         * adjust the scroll position.
+         */
+        this.resizeObserver = new ResizeObserver(elements => {
+            // In this case, this loop seems useless since we are really working
+            // on a single element, but it's required by the ResizeObserver to
+            // avoid error: ResizeObserver loop completed with undelivered
+            // notifications.
+            for (const element of elements) {
+                if (this.threadView && this.threadView.isAtEnd) {
+                    this._adjustScrollForExtraMessagesAtTheEnd();
+                }
+            }
+        });
         // useUpdate must be defined after useRenderedValues, indeed they both
         // use onMounted/onPatched, and the calls from useRenderedValues must
         // happen first to save the values before useUpdate accesses them.
         useUpdate({ func: () => this._update() });
+    }
+
+    mounted() {
+        this.resizeObserver.observe(this._getScrollableElement());
+    }
+
+    willUnmount() {
+        this.resizeObserver.disconnect();
     }
 
     willPatch() {
@@ -240,7 +263,7 @@ export class MessageList extends Component {
      */
     get orderedMessages() {
         const threadCache = this.threadView.threadCache;
-        if (this.props.order === 'desc') {
+        if (this.threadView.order === 'desc') {
             return [...threadCache.orderedMessages].reverse();
         }
         return threadCache.orderedMessages;
@@ -485,6 +508,13 @@ export class MessageList extends Component {
      * @param {ScrollEvent} ev
      */
     onScroll(ev) {
+        if (this.threadView) {
+            this.threadView.update({
+                clientHeight: this._getScrollableElement().clientHeight,
+                scrollHeight: this._getScrollableElement().scrollHeight,
+                scrollTop: this._getScrollableElement().scrollTop,
+            });
+        }
         this._onScrollThrottled(ev);
     }
 
@@ -494,11 +524,9 @@ export class MessageList extends Component {
      */
     _onScrollThrottled(ev) {
         const {
-            order,
             orderedMessages,
             thread,
             threadCache,
-            threadView,
             threadViewer,
         } = this._lastRenderedValues();
         if (!this._getScrollableElement()) {
@@ -512,17 +540,6 @@ export class MessageList extends Component {
             thread,
             threadViewer,
         });
-        if (!this._isLastScrollProgrammatic && threadView && threadView.exists()) {
-            // Margin to compensate for inaccurate scrolling to bottom and height
-            // flicker due height change of composer area.
-            const margin = 30;
-            // Automatically scroll to new received messages only when the list is
-            // currently fully scrolled.
-            const hasAutoScrollOnMessageReceived = (order === 'asc')
-                ? scrollTop >= this._getScrollableElement().scrollHeight - this._getScrollableElement().clientHeight - margin
-                : scrollTop <= margin;
-            threadView.update({ hasAutoScrollOnMessageReceived });
-        }
         if (threadViewer && threadViewer.exists()) {
             threadViewer.saveThreadCacheScrollHeightAsInitial(this._getScrollableElement().scrollHeight, threadCache);
             threadViewer.saveThreadCacheScrollPositionsAsInitial(scrollTop, threadCache);
@@ -542,7 +559,6 @@ Object.assign(MessageList, {
         hasSquashCloseMessages: false,
         haveMessagesMarkAsReadIcon: false,
         haveMessagesReplyIcon: false,
-        order: 'asc',
     },
     props: {
         /**
@@ -557,10 +573,6 @@ Object.assign(MessageList, {
         haveMessagesMarkAsReadIcon: Boolean,
         haveMessagesReplyIcon: Boolean,
         hasScrollAdjust: Boolean,
-        order: {
-            type: String,
-            validate: prop => ['asc', 'desc'].includes(prop),
-        },
         threadViewLocalId: String,
     },
     template: 'mail.MessageList',

--- a/addons/mail/static/src/components/message_list/message_list.xml
+++ b/addons/mail/static/src/components/message_list/message_list.xml
@@ -41,7 +41,7 @@
                         </button>
                     </div>
                 </t>
-                <t t-elif="props.order === 'asc' and orderedMessages.length > 0">
+                <t t-elif="threadView.order === 'asc' and orderedMessages.length > 0">
                     <t t-call="mail.MessageList.loadMore"/>
                 </t>
                 <!-- MESSAGES -->
@@ -78,7 +78,7 @@
                     </t>
                 </t>
                 <!-- LOADING (if order desc)-->
-                <t t-if="!threadView.threadCache.hasLoadingFailed and props.order === 'desc' and orderedMessages.length > 0">
+                <t t-if="!threadView.threadCache.hasLoadingFailed and threadView.order === 'desc' and orderedMessages.length > 0">
                     <t t-call="mail.MessageList.loadMore"/>
                 </t>
             </t>

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -134,10 +134,11 @@ QUnit.test('message list desc order', async function (assert) {
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'desc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => this.createThreadViewComponent(threadViewer.threadView, { order: 'desc' }, { isFixedSize: true }),
+        func: () => this.createThreadViewComponent(threadViewer.threadView, undefined, { isFixedSize: true }),
         message: "should wait until channel 100 loaded initial messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -231,10 +232,11 @@ QUnit.test('message list asc order', async function (assert) {
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => this.createThreadViewComponent(threadViewer.threadView, { order: 'asc' }, { isFixedSize: true }),
+        func: () => this.createThreadViewComponent(threadViewer.threadView, undefined, { isFixedSize: true }),
         message: "should wait until channel 100 loaded initial messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -340,6 +342,7 @@ QUnit.test('mark channel as fetched when a new message is loaded and as seen whe
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     await afterNextRender(async () => this.env.services.rpc({
@@ -409,6 +412,7 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -462,6 +466,7 @@ QUnit.test('show message subject when subject is not the same as the thread name
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView);
 
@@ -505,6 +510,7 @@ QUnit.test('do not show message subject when subject is the same as the thread n
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: [['link', thread]],
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView);
 
@@ -541,6 +547,7 @@ QUnit.test('[technical] new messages separator on posting message', async functi
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc'
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -611,6 +618,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -704,6 +712,7 @@ QUnit.test('new messages separator on posting message', async function (assert) 
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -763,6 +772,7 @@ QUnit.test('basic rendering of canceled notification', async function (assert) {
             id: 11,
             model: 'mail.channel',
         }),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
@@ -854,12 +864,13 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => this.createThreadViewComponent(
             threadViewer.threadView,
-            { order: 'asc' },
+            undefined,
             { isFixedSize: true },
         ),
         message: "should wait until channel 20 scrolled initially",
@@ -926,12 +937,13 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => this.createThreadViewComponent(
             threadViewer.threadView,
-            { order: 'asc' },
+            undefined,
             { isFixedSize: true },
         ),
         message: "should wait until channel 20 scrolled initially",
@@ -1001,6 +1013,7 @@ QUnit.test("delete all attachments of message without content should no longer d
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: insert({ id: 11, model: 'mail.channel' }),
+        order: 'asc',
     });
     // wait for messages of the thread to be loaded
     await this.afterEvent({
@@ -1060,6 +1073,7 @@ QUnit.test('delete all attachments of a message with some text content should st
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: insert({ id: 11, model: 'mail.channel' }),
+        order: 'asc',
     });
     // wait for messages of the thread to be loaded
     await this.afterEvent({
@@ -1126,6 +1140,7 @@ QUnit.test('delete all attachments of a message with tracking fields should stil
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: insert({ id: 11, model: 'mail.channel' }),
+        order: 'asc',
     });
     // wait for messages of the thread to be loaded
     await this.afterEvent({
@@ -1180,6 +1195,7 @@ QUnit.test('Post a message containing an email address followed by a mention on 
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -1223,6 +1239,7 @@ QUnit.test(`Mention a partner with special character (e.g. apostrophe ')`, async
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -1271,6 +1288,7 @@ QUnit.test('mention 2 different partners that have the same name', async functio
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -1323,6 +1341,7 @@ QUnit.test('mention a channel with space in the name', async function (assert) {
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -1367,6 +1386,7 @@ QUnit.test('mention a channel with "&" in the name', async function (assert) {
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -1411,6 +1431,7 @@ QUnit.test('mention a channel on a second line when the first line contains #', 
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -1455,6 +1476,7 @@ QUnit.test('mention a channel when replacing the space after the mention by anot
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -1515,6 +1537,7 @@ QUnit.test('mention 2 different channels that have the same name', async functio
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -1563,6 +1586,7 @@ QUnit.test('show empty placeholder when thread contains no message', async funct
             id: 11,
             model: 'mail.channel',
         }),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
@@ -1608,6 +1632,7 @@ QUnit.test('show empty placeholder when thread contains only empty messages', as
             id: 11,
             model: 'mail.channel',
         }),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
@@ -1658,6 +1683,7 @@ QUnit.test('message with subtype should be displayed (and not considered as empt
             id: 11,
             model: 'mail.channel',
         }),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
@@ -1715,11 +1741,12 @@ QUnit.test('[technical] message list with a full page of empty messages should s
             id: 11,
             model: 'mail.channel',
         }),
+        order: 'asc',
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
         func: () => {
-            this.createThreadViewComponent(threadViewer.threadView, { order: 'asc' }, { isFixedSize: true });
+            this.createThreadViewComponent(threadViewer.threadView, undefined, { isFixedSize: true });
         },
         message: "should wait until thread becomes loaded with messages",
         predicate: ({ hint, threadViewer }) => {
@@ -1774,6 +1801,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     // send a command that leads to receiving a transient message
@@ -1900,6 +1928,7 @@ QUnit.test('failure on loading messages should prompt retry button', async funct
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView);
 
@@ -1948,6 +1977,7 @@ QUnit.test('failure on loading more messages should not alter message list displ
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -1999,6 +2029,7 @@ QUnit.test('failure on loading more messages should display error and prompt ret
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
 
@@ -2059,6 +2090,7 @@ QUnit.test('Retry loading more messages on failed load more messages should load
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
     messageFetchShouldFail = true;
@@ -2109,6 +2141,7 @@ QUnit.test("highlight the message mentioning the current user inside the channel
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView);
     assert.hasClass(
@@ -2149,6 +2182,7 @@ QUnit.test("not highlighting the message if not mentioning the current user insi
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         thread: link(thread),
+        order: 'asc',
     });
     await this.createThreadViewComponent(threadViewer.threadView);
     assert.doesNotHaveClass(

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -116,7 +116,6 @@ Object.assign(ThreadView, {
         haveMessagesMarkAsReadIcon: false,
         haveMessagesReplyIcon: false,
         isDoFocus: false,
-        order: 'asc',
         showComposerAttachmentsExtensions: true,
         showComposerAttachmentsFilenames: true,
     },
@@ -162,10 +161,6 @@ Object.assign(ThreadView, {
          * Determines whether this should become focused.
          */
         isDoFocus: Boolean,
-        order: {
-            type: String,
-            validate: prop => ['asc', 'desc'].includes(prop),
-        },
         showComposerAttachmentsExtensions: Boolean,
         showComposerAttachmentsFilenames: Boolean,
         threadViewLocalId: String,

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -25,7 +25,6 @@
                                 hasSquashCloseMessages="props.hasSquashCloseMessages"
                                 haveMessagesMarkAsReadIcon="props.haveMessagesMarkAsReadIcon"
                                 haveMessagesReplyIcon="props.haveMessagesReplyIcon"
-                                order="props.order"
                                 threadViewLocalId="threadView.localId"
                                 t-ref="messageList"
                             />

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -270,6 +270,7 @@ function factory(dependencies) {
                 compact: true,
                 hasThreadView: this.hasThreadView,
                 thread: this.thread ? link(this.thread) : unlink(),
+                order: 'asc',
             };
             if (!this.threadViewer) {
                 return create(threadViewerData);

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -221,6 +221,7 @@ function factory(dependencies) {
             const threadViewerData = {
                 hasThreadView: this.hasThreadView,
                 thread: this.thread ? link(this.thread) : unlink(),
+                order: 'desc',
             };
             if (!this.threadViewer) {
                 return create(threadViewerData);

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -406,6 +406,7 @@ function factory(dependencies) {
                 hasTopbar: true,
                 selectedMessage: this.replyingToMessage ? link(this.replyingToMessage) : unlink(),
                 thread: this.thread ? link(this.thread) : unlink(),
+                order: 'asc',
             };
             if (!this.threadViewer) {
                 return create(threadViewerData);

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -101,6 +101,65 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {boolean}
+         */
+        _computeHasAutoScrollOnMessageReceived() {
+            return (this.order === 'asc') ? this.isAtEnd : this.isAtStart;
+        }
+
+        /**
+         * States whether the threadview is scrolled at the bottom.
+         *
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtBottom() {
+            return (this.scrollTop >=
+                this.scrollHeight -
+                this.clientHeight - 30);
+        }
+
+        /**
+         * States whether the threadview is at the end of the conversation
+         * regardeless of the order.
+         *
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtEnd() {
+            if (this.order === 'asc') {
+                return this.isAtBottom;
+            }
+            return this.isAtTop;
+        }
+
+        /**
+         * states whether the threadview is at the beginning of the conversation
+         * regardeless of the order.
+         *
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtStart() {
+            if (this.order === 'asc') {
+                return this.isAtTop;
+            }
+            return this.isAtBottom;
+        }
+
+
+        /**
+         * States whether the threadview is scrolled at the top.
+         *
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtTop() {
+            return this.scrollTop <= 30;
+        }
+
+        /**
+         * @private
          * @returns {string[]}
          */
         _computeTextInputSendShortcuts() {
@@ -337,7 +396,7 @@ function factory(dependencies) {
          * hint `message-received`.
          */
         hasAutoScrollOnMessageReceived: attr({
-            default: true,
+            compute: '_computeHasAutoScrollOnMessageReceived',
         }),
         /**
          * Last message in the context of the currently displayed thread cache.
@@ -423,6 +482,44 @@ function factory(dependencies) {
             inverse: 'threadView',
             isCausal: true,
             readonly: true,
+        }),
+        order: attr({
+            related: 'threadViewer.order',
+        }),
+        scrollTop: attr(),
+        scrollHeight: attr(),
+        clientHeight: attr(),
+        /**
+         * States whether the message list scroll position is at the bottom of the
+         * message list.
+         */
+        isAtBottom: attr({
+            compute: '_computeIsAtBottom',
+        }),
+        /**
+         * States whether the message list scroll position is at the end of the
+         * message list. Depending of the message list order, this could be the
+         * top or the bottom.
+         */
+        isAtEnd: attr({
+            compute: '_computeIsAtEnd',
+            default: false,
+        }),
+        /**
+         * States whether the message list scroll position is at the start of the
+         * message list. Depending of the message list order, this could be the
+         * top or the bottom.
+         */
+        isAtStart: attr({
+            compute: '_computeIsAtStart',
+            default: false,
+        }),
+        /**
+         * States whether the message list scroll position is at the top of the
+         * message list.
+         */
+        isAtTop: attr({
+            compute: '_computeIsAtTop',
         }),
     };
     ThreadView.onChanges = [

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -108,6 +108,13 @@ function factory(dependencies) {
             default: false,
         }),
         /**
+         * States the sorting direction.
+         * Possible value: asc, desc
+         */
+        order: attr({
+            required: true,
+        }),
+        /**
          * Determines the selected `mail.message`.
          */
         selectedMessage: many2one('mail.message'),

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -67,6 +67,7 @@ export async function boot() {
             hasThreadView: true,
             hasTopbar: true,
             thread: insert(messaging.models['mail.thread'].convertData(channelData)),
+            order: 'asc',
         });
         const ThreadView = getMessagingComponent('ThreadView');
         const threadViewComponent = new ThreadView(null, {
@@ -74,6 +75,7 @@ export async function boot() {
             hasComposer: true,
             hasComposerThreadTyping: true,
             threadViewLocalId: threadViewer.threadView.localId,
+            order: 'asc',
         });
         await threadViewComponent.mount(document.body);
         if (threadViewer.thread.defaultDisplayMode === 'video_full_screen') {


### PR DESCRIPTION
Before this commit, when the what window composer was multi line, the message
list scroll bar jumped over the content.
This PR prevent this jump by listening to resize event and restore the chat
window scroll position if needed.

task-2377824