### PR TITLE
[REM] base_vat: delete check_vat_nl

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -312,61 +312,6 @@ class ResPartner(models.Model):
         # Valid format and valid date
         return True
 
-    # Netherlands VAT verification
-    __check_vat_nl_re = re.compile("(?:NL)?[0-9A-Z+*]{10}[0-9]{2}")
-
-    def check_vat_nl(self, vat):
-        """
-        Temporary Netherlands VAT validation to support the new format introduced in January 2020,
-        until upstream is fixed.
-
-        Algorithm detail: http://kleineondernemer.nl/index.php/nieuw-btw-identificatienummer-vanaf-1-januari-2020-voor-eenmanszaken
-
-        TODO: remove when fixed upstream
-        """
-
-        try:
-            from stdnum.util import clean
-            from stdnum.nl.bsn import checksum
-        except ImportError:
-            return True
-
-        vat = clean(vat, ' -.').upper().strip()
-
-        if not (len(vat) == 14):
-            return False
-
-        # Check the format
-        match = self.__check_vat_nl_re.match(vat)
-        if not match:
-            return False
-
-        # Match letters to integers
-        char_to_int = {k: str(ord(k) - 55) for k in string.ascii_uppercase}
-        char_to_int['+'] = '36'
-        char_to_int['*'] = '37'
-
-        # Remove the prefix
-        vat = vat[2:]
-
-        # 2 possible checks:
-        # - For natural persons
-        # - For non-natural persons and combinations of natural persons (company)
-
-        # Natural person => mod97 full checksum
-        check_val_natural = '2321'
-        for x in vat:
-            check_val_natural += x if x.isdigit() else char_to_int[x]
-        if int(check_val_natural) % 97 == 1:
-            return True
-
-        # Company => weighted(9->2) mod11 on bsn
-        vat = vat[:-3]
-        if vat.isdigit() and checksum(vat) == 0:
-            return True
-
-        return False
-
     # Norway VAT validation, contributed by Rolv Råen (adEgo) <rora@adego.no>
     # Support for MVA suffix contributed by Bringsvor Consulting AS (bringsvor@bringsvor.com)
     def check_vat_no(self, vat):

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ reportlab==3.5.13; python_version < '3.8'
 reportlab==3.5.55; python_version >= '3.8'
 requests==2.21.0
 zeep==3.2.0
-python-stdnum==1.8
+python-stdnum==1.16
 vobject==0.9.6.1
 Werkzeug==0.16.1
 XlsxWriter==1.1.2


### PR DESCRIPTION
the algorithm is obsolete and doesn't always work

STEPS:
* create a partner without country
* past NL... code from the support ticket below

BEFORE: The VAT number [NL...] for partner [...] does not seem to be valid.
AFTER: No error

---

https://github.com/odoo/odoo/pull/42681
opw-2555357

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
