### PR TITLE
[FIX] account: fix taxes set on invoice sections & notes at creation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3160,6 +3160,8 @@ class AccountMoveLine(models.Model):
     @api.onchange('product_uom_id')
     def _onchange_uom_id(self):
         ''' Recompute the 'price_unit' depending of the unit of measure. '''
+        if self.display_type in ('line_section', 'line_note'):
+            return
         taxes = self._get_computed_taxes()
         if taxes and self.move_id.fiscal_position_id:
             taxes = self.move_id.fiscal_position_id.map_tax(taxes, partner=self.partner_id)


### PR DESCRIPTION
When adding a section or a note on an invoice, default taxes are set on
the account move line, making the corresponding Tax Group to appear on
the invoice.

opw-2541722

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
