### PR TITLE
[FIX] mail:  Message from mailing channel should not make a notification in Odoo

### DIFF
--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -226,23 +226,6 @@ function factory(dependencies) {
                 return;
             }
 
-            // Message from mailing channel should not make a notification in
-            // Odoo for users with notification "Handled by Email".
-            // Channel has been marked as read server-side in this case, so
-            // it should not display a notification by incrementing the
-            // unread counter.
-            if (
-                channel.mass_mailing &&
-                this.env.session.notification_type === 'email'
-            ) {
-                this._handleNotificationChannelSeen(channelId, {
-                    last_message_id: messageData.id,
-                    partner_id: this.env.messaging.currentPartner.id,
-                });
-                return;
-            }
-            // In all other cases: update counter and notify if necessary
-
             // Chat from OdooBot is considered disturbing and should only be
             // shown on the menu, but no notification and no thread open.
             const isChatWithOdooBot = (

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1537,6 +1537,20 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {boolean}
+         */
+        _computeShouldBeSetAsSeen() {
+            if (
+                this.mass_mailing &&
+                this.env.session.notification_type === 'email' &&
+                this.lastMessage
+            ) {
+                return this.markAsSeen(this.lastMessage);
+            }
+        }
+
+        /**
+         * @private
          * @returns {mail.activity[]}
          */
         _computeTodayActivities() {
@@ -2279,6 +2293,17 @@ function factory(dependencies) {
          */
         serverMessageUnreadCounter: attr({
             default: 0,
+        }),
+        /**
+         * Not a real field, used to trigger `thread.markAsSeen` when
+         * notification "Handled by Email".
+         */
+        shouldBeSetAsSeen: attr({
+            compute: '_computeShouldBeSetAsSeen',
+            dependencies: [
+                'lastMessage',
+                'mass_mailing',
+            ],
         }),
         /**
          * Determines the `mail.suggested_recipient_info` concerning `this`.


### PR DESCRIPTION
currently,
Message from mailing channel make a notification in Odoo for users
with notification "Handled by Email" when user is not log-in. this is happening
because mailing channel is marked ans seen from
"messaging_notification_handler.js" which  is not executed when user is not
log-in and receive message so message counter is increase when user log-in. 

after this commit,
Message from mailing channel does not make a notification in Odoo for users with
notification "Handled by Email". to achieve that mark mailing channel as seen if
user has notification "Handled by Email" from "thread.js" when  unread-massage
counter is calculated.

ID - 2541660


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
