### PR TITLE
[FIX] website: share snippet bug is fixed.

### DIFF
--- a/addons/website/static/src/snippets/s_share/000.js
+++ b/addons/website/static/src/snippets/s_share/000.js
@@ -20,6 +20,11 @@ const ShareWidget = publicWidget.Widget.extend({
                 return href.replace(urlRegex, function (match, a, b, c) {
                     return a + url + c;
                 }).replace(titleRegex, function (match, a, b, c) {
+                    if (href.indexOf('https://wa.me/?text') !== -1) {
+                        // For WhatsApp, everything needs to be sent via 'text' parameter. Page URL will
+                        // be parsed and converted into hyperlink automatically by the platform
+                        return a + title + url + c;
+                    }
                     return a + title + c;
                 });
             });

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -13,7 +13,7 @@
         <a t-if="not _exclude_share_links or not 'linkedin' in _exclude_share_links" href="http://www.linkedin.com/sharing/share-offsite/?url={url}" t-attf-class="s_share_linkedin #{_link_classes}" target="_blank">
             <i t-attf-class="fa fa-linkedin #{not _link_classes and 'rounded shadow-sm'}"/>
         </a>
-        <a t-if="not _exclude_share_links or not 'whatsapp' in _exclude_share_links" href="whatsapp://send?text={title}&amp;url={url}" t-attf-class="s_share_whatsapp #{_link_classes}" target="_blank">
+        <a t-if="not _exclude_share_links or not 'whatsapp' in _exclude_share_links" href="https://wa.me/?text={url}" t-attf-class="s_share_whatsapp #{_link_classes}" target="_blank">
             <i t-attf-class="fa fa-whatsapp #{not _link_classes and 'rounded shadow-sm'}"/>
         </a>
         <a t-if="not _exclude_share_links or not 'pinterest' in _exclude_share_links" href="http://pinterest.com/pin/create/button/?url={url}&amp;description={title}" t-attf-class="s_share_pinterest #{_link_classes}" target="_blank">

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -1,4 +1,4 @@
-.o_wevent_social_link {
+.o_wevent_sidebar_social > .o_wevent_social_link {
     $o_link_size: 3em;
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
PURPOSE

   1. whats-app option was not working properly in
      share snippet and On click, Whats-app opens
      but only sends the text without link of
      shared record.

   2. in the social share template Buttons aren't
      centred.

SPECIFICATION

in this commit, on whats-app share button link
replace the old link (whatsapp://send?text=) with
new one (https://web.whatsapp.com/send?text=) and
in share snippet add one condition for shared record
URL. For button displayed properly centred remove the 
display: inline-block property of button.

Task Id: 2557077

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
