### PR TITLE
[FIX] website: timeline widget has vertical line


### DIFF
--- a/addons/website/static/src/snippets/s_timeline/000.scss
+++ b/addons/website/static/src/snippets/s_timeline/000.scss
@@ -3,6 +3,7 @@
         position: relative;
         &:before {
             content: '';
+            display: block !important; // override portal '#wrap .container' value
             position: absolute;
             width: 1px;
             top: 0px;


### PR DESCRIPTION

In fb556ed09c7e the middle vertical line is removed from the timeline
widget because the display was changed to table which seems to require
having an height.

opw-2558670
