### PR TITLE
[FIX] survey: fix certification for long names & uppercase

### DIFF
--- a/addons/survey/views/survey_report_templates.xml
+++ b/addons/survey/views/survey_report_templates.xml
@@ -15,7 +15,16 @@
                     <div class="certification-content">
                         <div t-if="user_input.scoring_success">
                             <p>This certificate is presented to
-                                <br/><span class="user-name" t-esc="user_input.partner_id.name or user_input.email"/>
+                                <br/>
+                                <t t-set="certif_style" t-value="''"/>
+                                <t t-set="certified_name" t-value="user_input.partner_id.name or user_input.email"/>
+                                <t t-if="certified_name.isupper()">
+                                    <t t-set="certif_style" t-value="certif_style + 'font-family: certification-serif;'"/>
+                                </t>
+                                <t t-if="len(certified_name) > 20">
+                                    <t t-set="certif_style" t-value="certif_style + 'font-size: 40px; line-height: 4;'"/>
+                                </t>
+                                <span t-att-style="certif_style" class="user-name" t-esc="certified_name"/>
 
                                 <br/>by <span class="certification-company" t-field="user_input.survey_id.create_uid.company_id.display_name"/> for successfully completing
                                 <br/><b><span class="certification-name" t-field="user_input.survey_id.display_name"/></b>
@@ -58,7 +67,18 @@
                     <div class="certification-content">
                         <div t-if="user_input.scoring_success">
                             <p>This certificate is presented to
-                                <br/><span class="user-name" t-esc="user_input.partner_id.name or user_input.email"/>
+                                 <t t-set="certif_style" t-value="''"/>
+                                <t t-set="certified_name" t-value="user_input.partner_id.name or user_input.email"/>
+                                <t t-if="certified_name.isupper()">
+                                    <t t-set="certif_style" t-value="certif_style + 'font-family: certification-serif;'"/>
+                                </t>
+                                <t t-if="len(certified_name) > 35">
+                                    <t t-set="certif_style" t-value="certif_style + 'font-size: 20px; line-height: 4; font-family: certification-serif; '"/>
+                                </t>
+                                <t t-elif="len(certified_name) > 20">
+                                    <t t-set="certif_style" t-value="certif_style + 'font-size: 30px; line-height: 4;'"/>
+                                </t>
+                                <span t-att-style="certif_style" class="user-name" t-esc="certified_name"/>
 
                                 <br/>by <span class="certification-company" t-field="user_input.survey_id.create_uid.company_id.display_name"/>
                                 for successfully completing


### PR DESCRIPTION
A client's name was too long (over 30char) and in uppercase, making the certificate's layout break.
A condition has been put in place for names over 20char and uppercase names


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
