### PR TITLE
[13.0][FIX] sale_mrp: stock_account_get_anglo_saxon_price_unit on multicompany environments

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -11,8 +11,8 @@ class AccountMoveLine(models.Model):
 
         so_line = self.sale_line_ids and self.sale_line_ids[-1] or False
         if so_line:
-            bom = so_line.product_id.product_tmpl_id.bom_ids and so_line.product_id.product_tmpl_id.bom_ids[0]
-            if bom.type == 'phantom':
+            bom = so_line.product_id.product_tmpl_id.bom_ids.filtered(lambda b: not b.company_id or b.company_id == so_line.company_id)[:1]
+            if bom and bom.type == 'phantom':
                 qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
                 qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in so_line.invoice_lines if x.move_id.state == 'posted'])
                 moves = so_line.move_ids


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** price unit on stock journals for SO for kits products were the kit belongs to another company is not well calculated. Causing Stock Interim account (Output) to have discrepancies even when the invoice is issued at the same time as the delivery is performed.

**Current behavior before PR:** price unit on stock journals for SO for kits products are calculated based on the components price even if the kit does not belong to the company

**Desired behavior after PR is merged:** price unit on stock journals is calculated based on the delivered product, the kit, because, actually it is not a kit for the company.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
