### PR TITLE
[FIX] l10n_it_edi_sdicoop: do not make request in demo mode

### DIFF
--- a/addons/account_edi_proxy_client/__manifest__.py
+++ b/addons/account_edi_proxy_client/__manifest__.py
@@ -18,6 +18,9 @@ Odoo database.
     'data': [
         'security/ir.model.access.csv',
     ],
+    'demo': [
+        'data/config_demo.xml',
+    ],
     'installable': True,
     'application': False,
 }

--- a/addons/account_edi_proxy_client/data/config_demo.xml
+++ b/addons/account_edi_proxy_client/data/config_demo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <record id="account_edi_proxy_client_demo" model="ir.config_parameter">
+        <field name="key">account_edi_proxy_client.demo</field>
+        <field name="value">True</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
When demo data is installed, all request are successful by default and the proxy is not contacted.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
