### PR TITLE
[14.0] stock_landed_costs: rounding issue

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -265,10 +265,10 @@ class StockLandedCost(models.Model):
                         else:
                             value = (line.price_unit / total_line)
 
-                        if digits:
-                            value = tools.float_round(value, precision_digits=digits, rounding_method='UP')
+                        if digits:                            
                             fnc = min if line.price_unit > 0 else max
                             value = fnc(value, line.price_unit - value_split)
+                            value = tools.float_round(value, precision_digits=digits, rounding_method='UP')
                             value_split += value
 
                         if valuation.id not in towrite_dict:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

`min` or `max` can bring a floating rounding issue. Small e.g., e-14, but still, that brings extra booking entries with "already out" labels.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
