### PR TITLE
[FIX] sale: retrieve correct reinvoice pricelist price

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -183,12 +183,16 @@ class AccountMoveLine(models.Model):
         amount = (self.credit or 0.0) - (self.debit or 0.0)
 
         if self.product_id.expense_policy == 'sales_price':
-            return self.product_id.with_context(
+            product = self.product_id.with_context(
                 partner=order.partner_id.id,
                 date_order=order.date_order,
                 pricelist=order.pricelist_id.id,
-                uom=self.product_uom_id.id
-            ).price
+                uom=self.product_uom_id.id,
+                quantity=unit_amount
+            )
+            if order.pricelist_id.discount_policy == 'with_discount':
+                return product.price
+            return product.lst_price
 
         uom_precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         if float_is_zero(unit_amount, precision_digits=uom_precision_digits):


### PR DESCRIPTION
- Install Sale, Project, Purchase, Timesheet, Accounting
- Enable pricelists, discount, analytic accounting
- Create a pricelist [PRICELIST]:
  * Discount all product by 50%
  * Discount Policy: Show public price & discount to the customer
- Create a product [SERVICE]:
  * Type: Service
  * Timesheet on task
  * Create a task in sales order project
- Create another product [TEST]:
  * Price: 100
  * Re-Invoice Expenses: At cost
- Create a SO with pricelist [PRICELIST], product [SERVICE], confirm
- Create a PO with [TEST], specify analytic account from SO
- Receive the product, create the bill & confirm

Back to the SO, the unit price of [TEST] is set to 50, when invoicing it
will be cut of another 50%, resulting in 25

opw-2491693

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
