### PR TITLE
[FIX] mail.py: keep image option related attributes

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -38,7 +38,7 @@ safe_attrs = clean.defs.safe_attrs | frozenset(
      'data-o-mail-quote',  # quote detection
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-id', 'data-oe-nodeid',
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
-     'data-class', 'data-mimetype',
+     'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      ])
 
 


### PR DESCRIPTION
Scenario:

- Change an image option in mass mailing editor (e.g. Quality)
- save
- edit > The option can't get the new applied value.

The body_arch's field used in mass mailing editor is
sanitizing attributes and as a consequence, option related data
attrs are removed on save.

task-2327045