### PR TITLE
[IMP] website: hide link preview when typing on mega menu

### DIFF
--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -4,6 +4,25 @@ import contentMenu from 'website.contentMenu';
 import weWidgets from 'wysiwyg.widgets';
 import {_t} from 'web.core';
 
+weWidgets.LinkPopoverWidget.include({
+    /**
+     * @override
+     */
+    start() {
+        // hide popover while typing on mega menu
+        if (this.target.closest('.o_mega_menu')) {
+            let timeoutID = undefined;
+            this.$target.on('keydown.link_popover', () => {
+                this.$target.popover('hide');
+                clearTimeout(timeoutID);
+                timeoutID = setTimeout(() => this.$target.popover('show'), 1500);
+            });
+        }
+
+        return this._super(...arguments);
+    },
+});
+
 const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
     events: _.extend({}, weWidgets.LinkPopoverWidget.prototype.events, {
         'click .js_edit_menu': '_onEditMenuClick',


### PR DESCRIPTION
The link preview is a bit messy inside a mega menu.
Hiding it during typing clears the UI.

task-2566651

See https://github.com/odoo/odoo/pull/72009#discussion_r651768270 for reason to target only mega_menu