### PR TITLE
[13.0][FIX] mrp: Consumption and picking type are not seen for subcontracted BoMs

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -108,10 +108,10 @@
                             <group>
                                 <group>
                                     <field name="ready_to_produce" attrs="{'invisible': [('type','!=','normal')]}" string="Manufacturing Readiness" groups="mrp.group_mrp_routings"/>
-                                    <field name="consumption" attrs="{'invisible': [('type','!=','normal')], 'required': [('type','=','normal')]}"/>
+                                    <field name="consumption" attrs="{'invisible': [('type','=','phantom')], 'required': [('type','!=','phantom')]}"/>
                                 </group>
                                 <group>
-                                    <field name="picking_type_id" attrs="{'invisible': [('type','!=','normal')]}" string="Operation" groups="stock.group_adv_location"/>
+                                    <field name="picking_type_id" attrs="{'invisible': [('type','=','phantom')]}" string="Operation" groups="stock.group_adv_location"/>
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
The consumption feature is used as well for subcontracting, but we can't select other value from the default, as was hidden for all BoM types except normal ones.

As the only BoM type that doesn't apply the consumption feature are the kits, then let's hide the field only on that case.

Similar can be applied to picking type, as it's at least used here:

https://github.com/odoo/odoo/blob/cc0e63561f310b21511b8005c34fe99c88854cb0/addons/mrp_subcontracting/models/stock_move.py#L172

@Tecnativa TT30389