### PR TITLE
14.0 l10n cl boleta controller

### DIFF
--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -28,3 +28,10 @@ class L10nLatamDocumentType(models.Model):
             return False
 
         return document_number.zfill(6)
+
+    def _filter_taxes_included(self, taxes):
+        """ In Chile we include taxes depending on document type """
+        self.ensure_one()
+        if self.country_id.code == "CL" and self.code in ['39', '41', '110', '111', '112', '34']:
+            return taxes.filtered(lambda x: x.l10n_cl_sii_code == 14)
+        return super()._filter_taxes_included(taxes)

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -9,7 +9,6 @@
         <t t-set="pre_printed_report" t-value="report_type == 'pdf'"/>
         <t t-set="report_name" t-value="o.l10n_latam_document_type_id.name"/>
         <t t-set="header_address" t-value="o.company_id.partner_id"/>
-        <!--<t t-set="is_tax" t-value="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']"/>-->
         <t t-set="custom_footer">
             <t t-call="l10n_cl.custom_footer"/>
         </t>
@@ -144,10 +143,21 @@
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
             <attribute name="t-field">line.l10n_latam_price_unit</attribute>
         </xpath>
+        <!-- nuevo inicio -->
+        <xpath expr="//span[@id='line_tax_ids']" position="attributes">
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids))</attribute>
+        </xpath>
+        <!-- nuevo fin -->
 
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
             <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
         </t>
+
+        <!-- nuevo inicio -->
+        <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
+            <span groups="account.group_show_line_subtotals_tax_included">Amount</span>
+        </xpath>
+        <!-- nuevo fin -->
 
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
@@ -158,7 +168,8 @@
         </span>
 
         <!-- we remove the taxes column in boletas -->
-        <xpath expr="//th[@name='th_taxes']/span" position="replace">
+        <!-- comentar para ver si el approach que usan en l10n_ar funciona bien -->
+        <!--<xpath expr="//th[@name='th_taxes']/span" position="replace">
             <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
                 <span>Taxes</span>
             </t>
@@ -181,21 +192,6 @@
             </td>
         </xpath>
 
-        <!-- remove payment term, this is added on information section -->
-        <p name="payment_term" position="replace"/>
-
-
-        <xpath expr="//span[@t-field='o.payment_reference']/../.." position="replace"/>
-
-        <div id="informations" position="replace">
-            <t t-call="l10n_cl.informations"/>
-        </div>
-
-        <!--  we remove the ml auto and also give more space to avoid multiple lines on tax detail -->
-        <xpath expr="//div[@id='total']/div" position="attributes">
-            <attribute name="t-attf-class">#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'}</attribute>
-        </xpath>
-
         <xpath expr="//tr[hasclass('o_subtotal')]" position="replace">
             <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
                 <tr class="border-black o_subtotal" style="">
@@ -205,6 +201,41 @@
                     </td>
                 </tr>
             </t>
+        </xpath>
+
+        -->
+        <!-- aca lo pongo igual que argentina.. si no resulta, vuelvo al anterior comentado arriba -->
+        <xpath expr="//th[@name='th_taxes']/span" position="replace">
+            <span>% VAT</span>
+        </xpath>
+
+        <xpath expr="//th[@name='th_taxes']" position="attributes">
+            <attribute name="t-if">o.amount_by_group</attribute>
+        </xpath>
+
+        <!-- use column vat instead of taxes and only list vat taxes-->
+        <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
+            <attribute name="t-if">o.amount_by_group</attribute>
+        </xpath>
+        <span id="line_tax_ids" position="attributes">
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
+        </span>
+        <!--- aca termina la prueba como en argentina -->
+
+        <!-- remove payment term, this is added on information section -->
+        <p name="payment_term" position="replace"/>
+
+        <!-- we remove the payment reference not used in chile -->
+        <xpath expr="//span[@t-field='o.payment_reference']/../.." position="replace"/>
+
+        <!-- replace information section and usage chilean style -->
+        <div id="informations" position="replace">
+            <t t-call="l10n_cl.informations"/>
+        </div>
+
+        <!--  we remove the ml auto and also give more space to avoid multiple lines on tax detail -->
+        <xpath expr="//div[@id='total']/div" position="attributes">
+            <attribute name="t-attf-class">#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'}</attribute>
         </xpath>
 
         <t t-foreach="o.amount_by_group" t-as="amount_by_group" position="replace">

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -9,7 +9,7 @@
         <t t-set="pre_printed_report" t-value="report_type == 'pdf'"/>
         <t t-set="report_name" t-value="o.l10n_latam_document_type_id.name"/>
         <t t-set="header_address" t-value="o.company_id.partner_id"/>
-        <t t-set="is_tax" t-value="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']"/>
+        <!--<t t-set="is_tax" t-value="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']"/>-->
         <t t-set="custom_footer">
             <t t-call="l10n_cl.custom_footer"/>
         </t>
@@ -153,23 +153,32 @@
             <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
         </span>
 
-
         <span t-field="o.amount_untaxed" position="attributes">
             <attribute name="t-field">o.l10n_latam_amount_untaxed</attribute>
         </span>
 
-
         <!-- we remove the taxes column in boletas -->
         <xpath expr="//th[@name='th_taxes']/span" position="replace">
-            <t t-if="is_tax">
+            <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
                 <span>Taxes</span>
             </t>
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']" position="replace">
-            <t t-if="is_tax">
+            <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
                 <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
             </t>
+        </xpath>
+
+        <xpath expr="//td[hasclass('o_price_total')]" position="replace">
+            <td class="text-right o_price_total">
+                <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
+                    <span class="text-nowrap" t-field="line.price_subtotal"/>
+                </t>
+                <t t-else="else">
+                    <span class="text-nowrap" t-field="line.price_total"/>
+                </t>
+            </td>
         </xpath>
 
         <!-- remove payment term, this is added on information section -->
@@ -186,6 +195,43 @@
         <xpath expr="//div[@id='total']/div" position="attributes">
             <attribute name="t-attf-class">#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'}</attribute>
         </xpath>
+
+        <xpath expr="//tr[hasclass('o_subtotal')]" position="replace">
+            <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
+                <tr class="border-black o_subtotal" style="">
+                    <td><strong>Subtotal</strong></td>
+                    <td class="text-right">
+                    <span t-field="o.amount_untaxed"/>
+                    </td>
+                </tr>
+            </t>
+        </xpath>
+
+        <t t-foreach="o.amount_by_group" t-as="amount_by_group" position="replace">
+            <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
+                <t t-foreach="o.amount_by_group" t-as="amount_by_group">
+                    <tr style="">
+                        <t t-if="len(o.line_ids.filtered(lambda line: line.tax_line_id)) in [0, 1] and o.amount_untaxed == amount_by_group[2]">
+                            <td><span class="text-nowrap" t-esc="amount_by_group[0]"/></td>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-esc="amount_by_group[3]"/>
+                            </td>
+                        </t>
+                        <t t-else="">
+                            <td>
+                                <span t-esc="amount_by_group[0]"/>
+                                <span class="text-nowrap"> on
+                                    <t t-esc="amount_by_group[4]"/>
+                                </span>
+                            </td>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-esc="amount_by_group[3]"/>
+                            </td>
+                        </t>
+                    </tr>
+                </t>
+            </t>
+        </t>
 
         <xpath expr="//div[@id='total']/div" position="before">
             <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'}"/>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -205,21 +205,17 @@
 
         -->
         <!-- aca lo pongo igual que argentina.. si no resulta, vuelvo al anterior comentado arriba -->
-        <xpath expr="//th[@name='th_taxes']/span" position="replace">
-            <span>% VAT</span>
-        </xpath>
+        <xpath expr="//th[@name='th_taxes']" position="replace"/>
 
-        <xpath expr="//th[@name='th_taxes']" position="attributes">
-            <attribute name="t-if">o.amount_by_group</attribute>
-        </xpath>
+        <xpath expr="//span[@id='line_tax_ids']/.." position="replace"/>
 
-        <!-- use column vat instead of taxes and only list vat taxes-->
-        <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
-            <attribute name="t-if">o.amount_by_group</attribute>
-        </xpath>
-        <span id="line_tax_ids" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
-        </span>
+
+        <!--<xpath expr="//span[@id='line_tax_ids']" position="replace">
+            <t t-if="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']">
+                <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
+            </t>
+        </xpath>-->
+
         <!--- aca termina la prueba como en argentina -->
 
         <!-- remove payment term, this is added on information section -->


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The "boleta" document type is printed with taxes not included, while it should be with taxes included

Current behavior before PR:
boleta items are printed in pdf or preview with taxes not included

Desired behavior after PR is merged:
boleta items are printed in pdf or preview with taxes included as it should be.






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
