### PR TITLE
[IMP] mail_plugin: add the translation for the attachment related message

### DIFF
--- a/addons/mail_plugin/i18n/mail_plugin.pot
+++ b/addons/mail_plugin/i18n/mail_plugin.pot
@@ -21,6 +21,15 @@ msgid "Allow"
 msgstr ""
 
 #. module: mail_plugin
+#. openerp-web
+#: code:addons/mail_plugin/static/src/to_translate/translations_gmail.xml:0
+#, python-format
+msgid ""
+"Attachments could not be logged in Odoo because their total size exceeded "
+"the allowed maximum."
+msgstr ""
+
+#. module: mail_plugin
 #: code:addons/mail_plugin/controllers/mail_plugin.py:0
 #, python-format
 msgid "Bad Email."
@@ -67,6 +76,20 @@ msgstr ""
 #. module: mail_plugin
 #: model:ir.model.fields,help:mail_plugin.field_res_partner_iap__iap_search_domain
 msgid "Domain used to find the company"
+msgstr ""
+
+#. module: mail_plugin
+#. openerp-web
+#: code:addons/mail_plugin/static/src/to_translate/translations_gmail.xml:0
+#, python-format
+msgid "From:"
+msgstr ""
+
+#. module: mail_plugin
+#. openerp-web
+#: code:addons/mail_plugin/static/src/to_translate/translations_gmail.xml:0
+#, python-format
+msgid "Gmail Inbox"
 msgstr ""
 
 #. module: mail_plugin
@@ -127,6 +150,13 @@ msgstr ""
 #. module: mail_plugin
 #: model_terms:ir.ui.view,arch_db:mail_plugin.app_auth
 msgid "Let"
+msgstr ""
+
+#. module: mail_plugin
+#. openerp-web
+#: code:addons/mail_plugin/static/src/to_translate/translations_gmail.xml:0
+#, python-format
+msgid "Logged from"
 msgstr ""
 
 #. module: mail_plugin

--- a/addons/mail_plugin/static/src/to_translate/translations_gmail.xml
+++ b/addons/mail_plugin/static/src/to_translate/translations_gmail.xml
@@ -43,6 +43,10 @@
     <string>Something bad happened. Please, try again later.</string>
     <string>Invalid URL</string>
     <string>No company attached to this contact.</string>
+    <string>Attachments could not be logged in Odoo because their total size exceeded the allowed maximum.</string>
+    <string>Logged from</string>
+    <string>Gmail Inbox</string>
+    <string>From: </string>
     <string>Debug Zone</string>
     <string>Debug zone for development purpose.</string>
     <string>Odoo Server URL</string>


### PR DESCRIPTION
Purpose
=======
In 14.3 we added the possibility to upload attachments when logging
an email. In the commit, we add the translation for the corresponding
error message.

Task 2545048
See odoo/odoo/pull/71543
See odoo/mail-client-extensions/pull/11