### PR TITLE
[FIX] point_of_sale: allow user to close session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -307,7 +307,7 @@ class PosSession(models.Model):
             # made thru cash in/out when sesion is in cash_control.
             if self.config_id.cash_control:
                 self.cash_register_id.button_confirm_bank()
-            self.move_id.unlink()
+            self.move_id.unlink() if not sudo else self.move_id.sudo().unlink()
         self.write({'state': 'closed'})
         return {
             'type': 'ir.actions.client',


### PR DESCRIPTION
If a user has no accounting permission, when he opens/closes a POS
session (without any sale), he will not be able to close the session

To reproduce the error:
(Use demo data)
1. Remove all Marc Demo's permissions for the Accounting module
2. Login with Marc Demo
3. Open a POS Session
4. Close the POS Session

Error: "Sorry, you are not allowed to delete documents of type 'Journal
Entries' (account.move) [...]"

Note: if the user processes at least one order during the POS session,
he will be able to close it thanks to sudo mode:
https://github.com/odoo/odoo/blob/369331dfdc144cf852c80c99d00ce8d5da843be1/addons/point_of_sale/models/pos_session.py#L302

OPW-2523187