### PR TITLE
[FIX] sale: improve compute expected date performance

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -274,6 +274,7 @@ class SaleOrder(models.Model):
         """ For service and consumable, we only take the min dates. This method is extended in sale_stock to
             take the picking_policy of SO into account.
         """
+        self.mapped("order_line")  # Prefetch indication
         for order in self:
             dates_list = []
             confirm_date = fields.Datetime.from_string((order.confirmation_date or order.write_date) if order.state == 'sale' else fields.Datetime.now())


### PR DESCRIPTION
Without this patch, each time the compute reaches the line with `.filtered()`, it needs a new fetch from the database. With too many sale orders, this becomes a bottleneck.

Now, before getting to that line, Odoo knows that it'll need all sale.order.line records, so it can fetch them all at once.

In a production database, loading the sale.order list goes down from 7s to 500ms with this patch.

@Tecnativa TT30390



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
