### PR TITLE
[IMP] Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ _build/
 
 # dotfiles
 .*
+!.editorconfig
 !.gitignore
 !.github
 !.mailmap


### PR DESCRIPTION
Current behavior before PR:

I am tired of pushing a PR and having to amend it, remove the trimmed whitespace diff, and force-push it again. And I bet other contributors feel alike.

Desired behavior after PR is merged:

[EditorConfig](https://editorconfig.org/) is a pseudo-standard that is supported across [almost?] all decent code editors on earth. All you need is to drop this file, and everybody's IDE gets configured automatically with `trim_trailing_whitespace = false`. Contributors will be happier.

Other configurations are there because they fit current Odoo coding standards, and the shouldn't harm.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa

According to https://github.com/odoo/odoo/pull/5156#issuecomment-89100459, I guess @antonylesuisse and @KangOl will like the change.