### PR TITLE
[FIX] mrp: unarchive operations when re-activating the operation setting

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -677,7 +677,7 @@ class MrpProduction(models.Model):
 
     @api.onchange('bom_id')
     def _onchange_workorder_ids(self):
-        if self.bom_id:
+        if self.bom_id and self.env.user.has_group('mrp.group_mrp_routings'):
             self._create_workorder()
         else:
             self.workorder_ids = False

--- a/addons/mrp/models/res_config_settings.py
+++ b/addons/mrp/models/res_config_settings.py
@@ -34,10 +34,7 @@ class ResConfigSettings(models.TransientModel):
         # Work Orders' is deactivated.
         # Long story short: if 'mrp_workorder' is already installed, we don't uninstall it based on
         # group_mrp_routings
-        operations = self.env['mrp.routing.workcenter'].with_context({'active_test': False}).search([('company_id', '=', self.company_id.id)])
         if self.group_mrp_routings:
             self.module_mrp_workorder = True
-        else:
-            operations.action_archive()  # When deactivating workorders we want to archive all the operations linked to the company
-            if not self.env['ir.module.module'].search([('name', '=', 'mrp_workorder'), ('state', '=', 'installed')]):
-                self.module_mrp_workorder = False
+        elif not self.env['ir.module.module'].search([('name', '=', 'mrp_workorder'), ('state', '=', 'installed')]):
+            self.module_mrp_workorder = False

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -292,6 +292,7 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(sum(mo.move_finished_ids.mapped('quantity_done')), 5)
 
     def test_update_quantity_3(self):
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         bom = self.env['mrp.bom'].create({
             'product_id': self.product_6.id,
             'product_tmpl_id': self.product_6.product_tmpl_id.id,
@@ -1743,6 +1744,7 @@ class TestMrpOrder(TestMrpCommon):
 
     def test_multi_button_plan(self):
         """ Test batch methods (confirm/validate) of the MO with the same bom """
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         self.bom_2.type = "normal"  # avoid to get the operation of the kit bom
 
         mo_3 = Form(self.env['mrp.production'])
@@ -1786,6 +1788,7 @@ class TestMrpOrder(TestMrpCommon):
     def test_workcenter_timezone(self):
         # Workcenter is based in Bangkok
         # Possible working hours are Monday to Friday, from 8:00 to 12:00 and from 13:00 to 17:00 (UTC+7)
+        self.env.user.groups_id += self.env.ref('mrp.group_mrp_routings')
         workcenter = self.workcenter_1
         workcenter.resource_calendar_id.tz = 'Asia/Bangkok'
 

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -103,6 +103,7 @@
             <field name="res_model">mrp.routing.workcenter</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="mrp_routing_workcenter_tree_view"/>
+            <field name="context">{'search_default_active': 1}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a new operation
@@ -111,7 +112,6 @@
                 Each operation is done at a specific Work Center and has a specific duration.
               </p>
             </field>
-            <field name="domain">['|', ('bom_id', '=', False), ('bom_id.active', '=', True)]</field>
         </record>
 
         <record id="mrp_routing_workcenter_filter" model="ir.ui.view">
@@ -122,6 +122,8 @@
                     <field name="name"/>
                     <field name="bom_id"/>
                     <field name="workcenter_id"/>
+                    <filter string="Archived" name="inactive" domain="['|', ('bom_id.active', '=', False), ('active', '=', False)]"/>
+                    <filter string="Active" name="active" domain="['|', ('bom_id', '=', False), ('bom_id.active', '=', True)]"/>
                     <group>
                         <filter string="Bill of Material" name="bom" context="{'group_by': 'bom_id'}"/>
                         <filter string="Workcenter" name="workcenter" context="{'group_by': 'workcenter_id'}"/>


### PR DESCRIPTION
Following https://github.com/odoo/odoo/pull/66108/, de-activating the operation setting archives all operations. The problem is that after re-activation of the operation setting, operations that were active before were not un-archived.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
