### PR TITLE
[FIX] sale_coupon: singleton when reward product in multiple lines


### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -89,7 +89,7 @@ class SaleOrder(models.Model):
             # multipled by the reward qty
             reward_product_qty = program.reward_product_quantity * program_in_order
             # do not give more free reward than products
-            reward_product_qty = min(reward_product_qty, self.order_line.filtered(lambda x: x.product_id == program.reward_product_id).product_uom_qty)
+            reward_product_qty = min(reward_product_qty, sum(self.order_line.filtered(lambda x: x.product_id == program.reward_product_id).mapped("product_uom_qty")))
             if program.rule_minimum_amount:
                 order_total = sum(order_lines.mapped('price_total')) - (program.reward_product_quantity * program.reward_product_id.lst_price)
                 reward_product_qty = min(reward_product_qty, order_total // program.rule_minimum_amount)


### PR DESCRIPTION

Steps to reproduce:

- Create a promotion program:
  - auto apply
  - reward type: product
  - rewarded product: bolt (or any other)

- Create a quotation:
  - add two bolts (the reward product)
  - add two products (the products fulfilling the promotion domain)
  - Update promotions: the promotion gets applied
  - add another line with a bolt (reward product)
  - Update promotions: singleton error!

This commit takes into consideration any reward product line to sum the
quantities altogether.

note: forward-port of 12.0 enterprise PR

opw-2556805
