### PR TITLE
[FIX] project,{hr,sale}_timesheet: fix update description glitch

### DIFF
--- a/addons/hr_timesheet/views/project_update_templates.xml
+++ b/addons/hr_timesheet/views/project_update_templates.xml
@@ -1,34 +1,29 @@
 <?xml version="1.0"?>
 <odoo>
     <template id="project_update_default_description" inherit_id="project.project_update_default_description">
+        <!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
         <xpath expr="//div[@name='milestone']" position="after">
-            <t t-if="project.allow_timesheets and people['activities'] and user.has_group('hr_timesheet.group_hr_timesheet_approver')">
-                <hr/>
-                <div name="people">
-                    <h1>People</h1>
+<t t-if="project.allow_timesheets and people['activities'] and user.has_group('hr_timesheet.group_hr_timesheet_approver')">
+<hr/>
+<div name="people">
+<h1>People</h1>
 
-                    Activities of the past 30 days:
-                    <ul>
-                        <t t-foreach="people['activities']" t-as="activity">
-                            <li><span class="fa-li"><i class="fa" t-att-class="{'fa-check-square': activity['worked'], 'fa-square-o': not activity['worked']}"></i></span>
-                                <t t-if="activity['worked']">
-                                    <t t-esc="activity['name']"/>:
-                                    <t t-esc="activity['unit_amount']" />
-                                    <t t-esc="people['uom']"/>
-                                    <span t-if="activity['new']" class="text-success">
-                                        <font style="color: rgb(0, 128, 0);">
-                                            <b>(new this month)</b>
-                                        </font>
-                                    </span>
-                                </t>
-                                <t t-else="">
-                                    <s><t t-esc="activity['name']"/></s> <span class="text-muted"><font style="color: rgb(128, 128, 128);"><b>(no activity in past 30 days)</b></font></span>
-                                </t>
-                            </li>
-                        </t>
-                    </ul>
-                </div>
-            </t>
+Activities of the past 30 days:
+<ul>
+<t t-foreach="people['activities']" t-as="activity">
+<li>
+<t t-if="activity['worked']">
+<t t-esc="activity['name']"/>: <t t-esc="activity['unit_amount']" /> <t t-esc="people['uom']"/>
+<span t-if="activity['new']" class="text-success"><font style="color: rgb(0, 128, 0);"><b>(new this month)</b></font></span>
+</t>
+<t t-else="">
+<s><t t-esc="activity['name']"/></s> <span class="text-muted"><font style="color: rgb(128, 128, 128);"><b>(no activity in past 30 days)</b></font></span>
+</t>
+</li>
+</t>
+</ul>
+</div>
+</t>
         </xpath>
     </template>
 

--- a/addons/project/views/project_update_templates.xml
+++ b/addons/project/views/project_update_templates.xml
@@ -1,94 +1,77 @@
 <?xml version="1.0"?>
 <odoo>
     <template id="project.milestone_deadline">
-        <t t-if="milestone['deadline']">
-            (due on <t t-esc="milestone['deadline']" t-options='{"widget": "date"}'/><t t-if="not milestone['is_reached'] or not milestone['reached_date']">)</t>
-            <t t-else="">
-                - reached on
-                <t t-if="milestone['reached_date'] &gt; milestone['deadline']">
-                    <font t-att-style="'color: rgb(' + str(color_level) + ', 0, 0)'"><b><t t-esc="milestone['reached_date']" t-options='{"widget": "date"}'/></b></font>)
-                </t>
-                <t t-else="">
-                    <font t-att-style="'color: rgb(0, ' + str(color_level) + ', 0)'"><b><t t-esc="milestone['reached_date']" t-options='{"widget": "date"}'/></b></font>)
-                </t>
-            </t>
-        </t>
+<t t-if="milestone['deadline']">
+(due on <t t-esc="milestone['deadline']" t-options='{"widget": "date"}'/><t t-if="not milestone['is_reached'] or not milestone['reached_date']">)</t><t t-else=""> - reached on<t t-if="milestone['reached_date'] &gt; milestone['deadline']">
+<font t-att-style="'color: rgb(' + str(color_level) + ', 0, 0)'"><b><t t-esc="milestone['reached_date']" t-options='{"widget": "date"}'/></b></font>)</t><t t-else="">
+<font t-att-style="'color: rgb(0, ' + str(color_level) + ', 0)'"><b><t t-esc="milestone['reached_date']" t-options='{"widget": "date"}'/></b></font>)</t></t>
+</t>
     </template>
 
     <template id="project_update_default_description" name="Project Update Description">
-        <div name="tasks">
-            <h1>Tasks</h1>
+<!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
+<div name="tasks">
+<h1>Tasks</h1>
 
-            <a t-if="user.has_group('project.group_project_manager')" type="object" t-att-href="tasks['action']['url_default']" t-att-name="tasks['action']['name']"><t t-esc="tasks['open_tasks']"/> tasks are open</a><t t-else=""><t t-esc="tasks['open_tasks']"/> tasks are open</t>, out of <t t-esc="tasks['total_tasks']"/>.
-            In the last 30 days,
-            <ul>
-                <li t-if="tasks['created_tasks'] > 1"><t t-esc="tasks['created_tasks']"/> were created</li>
-                <li t-else=""><t t-esc="tasks['created_tasks']"/> was created</li>
-                <li t-if="tasks['closed_tasks'] > 1"><t t-esc="tasks['closed_tasks']"/> were closed (folded stage)</li>
-                <li t-else=""><t t-esc="tasks['closed_tasks']"/> was closed (folded stage)</li>
-            </ul>
-        </div>
+<a t-if="user.has_group('project.group_project_manager')" type="object" t-att-href="tasks['action']['url_default']" t-att-name="tasks['action']['name']"><t t-esc="tasks['open_tasks']"/> tasks are open</a><t t-else=""><t t-esc="tasks['open_tasks']"/> tasks are open</t>, out of <t t-esc="tasks['total_tasks']"/>. In the last 30 days,
+<ul>
+<li t-if="tasks['created_tasks'] > 1"><t t-esc="tasks['created_tasks']"/> were created</li>
+<li t-else=""><t t-esc="tasks['created_tasks']"/> was created</li>
+<li t-if="tasks['closed_tasks'] > 1"><t t-esc="tasks['closed_tasks']"/> were closed (folded stage)</li>
+<li t-else=""><t t-esc="tasks['closed_tasks']"/> was closed (folded stage)</li>
+</ul>
+</div>
 
-        <hr t-if="milestones['show_section']"/>
+<hr t-if="milestones['show_section']"/>
 
-        <div name="milestone">
-            <t t-if="milestones['show_section']">
-                <h1>Milestones</h1>
+<div name="milestone">
+<t t-if="milestones['show_section']">
+<h1>Milestones</h1>
 
-                <ul class="fa-ul" t-if="milestones['list']">
-                    <t t-foreach="milestones['list']" t-as="milestone" t-key="milestone['id']">
-                        <li><span class="fa-li"><i t-attf-class="fa {{milestone['is_reached'] and 'fa-check-square' or 'fa-square-o'}}"></i></span>
-                            <t t-esc="milestone['name']"/>
-                            <span t-if="milestone['is_deadline_future'] and not milestone['is_reached']">
-                                <font style="color: rgb(190, 190, 190);">
-                                    <t t-set="color_level" t-value="64"/>
-                                    <t t-call="project.milestone_deadline"/>
-                                </font>
-                            </span>
-                            <span t-else="">
-                                <t t-set="color_level" t-value="128"/>
-                                <t t-call="project.milestone_deadline"/>
-                            </span>
-                        </li>
-                    </t>
-                </ul>
+<ul class="o_checklist" t-if="milestones['list']">
+<t t-foreach="milestones['list']" t-as="milestone" t-key="milestone['id']">
+<li t-attf-class="{{milestone['is_reached'] and 'o_checked' or ''}}">
+<t t-esc="milestone['name']"/>
+<span t-if="milestone['is_deadline_future'] and not milestone['is_reached']"><font style="color: rgb(190, 190, 190);"><t t-set="color_level" t-value="64"/><t t-call="project.milestone_deadline"/></font></span>
+<span t-else=""><t t-set="color_level" t-value="128"/><t t-call="project.milestone_deadline"/></span>
+</li>
+</t>
+</ul>
 
-                <t t-if="milestones['updated']">
-                    <t t-if="len(milestones['updated']) > 1">Over the last 30 days, the deadline of the following milestones has been updated :</t>
-                    <t t-else="">Over the last 30 days, the deadline of the following milestone has been updated :</t>
-                    <ul>
-                        <t t-foreach="milestones['updated']" t-as="milestone" t-key="milestone['id']">
-                            <li>
-                                <t t-esc="milestone['name']"/>
-                                (<t t-esc="milestone['old_value']" t-options='{"widget": "date"}'/> =&gt; <t t-esc="milestone['new_value']"  t-options='{"widget": "date"}'/>)
-                            </li>
-                        </t>
-                    </ul>
-                </t>
+<t t-if="milestones['updated']">
+<t t-if="len(milestones['updated']) > 1">Over the last 30 days, the deadline of the following milestones has been updated :</t>
+<t t-else="">Over the last 30 days, the deadline of the following milestone has been updated :</t>
+<ul>
+<t t-foreach="milestones['updated']" t-as="milestone" t-key="milestone['id']">
+<li>
+<t t-esc="milestone['name']"/> (<t t-esc="milestone['old_value']" t-options='{"widget": "date"}'/> =&gt; <t t-esc="milestone['new_value']"  t-options='{"widget": "date"}'/>)
+</li>
+</t>
+</ul>
+</t>
 
-                <t t-if="milestones['created']">
-                    <t t-if="len(milestones['created']) > 1">The following milestones have been added :</t>
-                    <t t-else="">The following milestone has been added :</t>
-                    <ul>
-                        <t t-foreach="milestones['created']" t-as="milestone" t-key="milestone['id']">
-                            <li>
-                                <t t-esc="milestone['name']"/>
-                                <span t-if="milestone['is_deadline_future'] and not milestone['is_reached']">
-                                    <font style="color: rgb(190, 190, 190);">
-                                        <t t-set="color_level" t-value="64"/>
-                                        <t t-call="project.milestone_deadline"/>
-                                    </font>
-                                </span>
-                                <span t-else="">
-                                    <t t-set="color_level" t-value="128"/>
-                                    <t t-call="project.milestone_deadline"/>
-                                </span>
-                            </li>
-                        </t>
-                    </ul>
-                </t>
-            </t>
-        </div>
+<t t-if="milestones['created']">
+<t t-if="len(milestones['created']) > 1">The following milestones have been added :</t>
+<t t-else="">The following milestone has been added :</t>
+<ul>
+<t t-foreach="milestones['created']" t-as="milestone" t-key="milestone['id']">
+<li>
+<t t-esc="milestone['name']"/><span t-if="milestone['is_deadline_future'] and not milestone['is_reached']">
+<font style="color: rgb(190, 190, 190);">
+<t t-set="color_level" t-value="64"/>
+<t t-call="project.milestone_deadline"/>
+</font>
+</span>
+<span t-else="">
+<t t-set="color_level" t-value="128"/>
+<t t-call="project.milestone_deadline"/>
+</span>
+</li>
+</t>
+</ul>
+</t>
+</t>
+</div>
     </template>
 
 </odoo>

--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -1,37 +1,31 @@
 <?xml version="1.0"?>
 <odoo>
     <template id="project_update_default_description" inherit_id="hr_timesheet.project_update_default_description">
+        <!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
         <xpath expr="//div[@name='milestone']" position="after">
-            <hr t-if="profitability"/>
-            <div name="profitability" t-if="profitability">
-                <h1>Profitability</h1>
+<hr t-if="profitability"/>
+<div name="profitability" t-if="profitability">
+<h1>Profitability</h1>
 
-                <t t-if="project.allow_timesheets and user.has_group('hr_timesheet.group_hr_timesheet_user')">
-                    In <t t-esc="profitability['month']"/>,
-                    <b>
-                        <t t-if="profitability['is_timesheet_uom_hour']" t-esc="profitability['timesheet_unit_amount']"/>
-                        <t t-else="" t-esc="profitability['timesheet_unit_amount']"/>
-                        <t t-esc="profitability['timesheet_uom']"/>
-                    </b> have been recorded on the project vs.
-                        <t t-if="profitability['is_timesheet_uom_hour']" t-esc="profitability['previous_timesheet_unit_amount']"/>
-                        <t t-else="" t-esc="profitability['previous_timesheet_unit_amount']"/>
-                        <t t-esc="profitability['timesheet_uom']"/>
-                    in <t t-esc="profitability['previous_month']"/> (<t t-esc="profitability['timesheet_trend']"/> %).
-                </t>
+<t t-if="project.allow_timesheets and user.has_group('hr_timesheet.group_hr_timesheet_user')">
+In <t t-esc="profitability['month']"/>, <b><t t-if="profitability['is_timesheet_uom_hour']" t-esc="profitability['timesheet_unit_amount']"/><t t-else="" t-esc="profitability['timesheet_unit_amount']"/> <t t-esc="profitability['timesheet_uom']"/></b> have been recorded on the project vs.
+<t t-if="profitability['is_timesheet_uom_hour']" t-esc="profitability['previous_timesheet_unit_amount']"/><t t-else="" t-esc="profitability['previous_timesheet_unit_amount']"/>
+<t t-esc="profitability['timesheet_uom']"/> in <t t-esc="profitability['previous_month']"/> (<t t-esc="profitability['timesheet_trend']"/> %).
+</t>
 
-                <t t-if="project.analytic_account_id and project.allow_billable and user.has_group('project.group_project_manager')">
-                    The cost of the project is now at <t t-esc="profitability['costs']"/>, for a revenue of <t t-esc="profitability['revenues']"/>, leading to a
-                    <span>
-                        <font t-if="profitability['margin'] &gt; 0"  style="color: rgb(0, 128, 0)">
-                            <b><t t-esc="profitability['margin_formatted']"/></b>
-                        </font>
-                        <font t-elif="profitability['margin'] &lt; 0" style="color: rgb(128, 0, 0)">
-                            <b><t t-esc="profitability['margin_formatted']"/></b>
-                        </font>
-                        <t t-else="" t-esc="profitability['margin_formatted']"/>
-                    </span> margin (<t t-esc="profitability['margin_percentage']"/> %), and a <b><t t-esc="profitability['billing_rate']"/> % billing rate</b>.
-                </t>
-            </div>
+<t t-if="project.analytic_account_id and project.allow_billable and user.has_group('project.group_project_manager')">
+The cost of the project is now at <t t-esc="profitability['costs']"/>, for a revenue of <t t-esc="profitability['revenues']"/>, leading to a
+<span>
+<font t-if="profitability['margin'] &gt; 0"  style="color: rgb(0, 128, 0)">
+<b><t t-esc="profitability['margin_formatted']"/></b>
+</font>
+<font t-elif="profitability['margin'] &lt; 0" style="color: rgb(128, 0, 0)">
+<b><t t-esc="profitability['margin_formatted']"/></b>
+</font>
+<t t-else="" t-esc="profitability['margin_formatted']"/>
+</span> margin (<t t-esc="profitability['margin_percentage']"/> %), and a <b><t t-esc="profitability['billing_rate']"/> % billing rate</b>.
+</t>
+</div>
         </xpath>
     </template>
 


### PR DESCRIPTION
Prior to this commit, the spaces in the template were transformed into
non-breaking spaces by the html editor while editing the html field
content.
The unordered list with icons as list item also failed to be compatible
with the editor.

With this commit, we remove the indents in the templates to prevent this
behavior.
It now also uses the css class defined by the editor to generate the check
lists.

task-2568809

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
