### PR TITLE
[FIX] purchase: compute unit price with different uom

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1047,8 +1047,9 @@ class PurchaseOrderLine(models.Model):
 
         # If not seller, use the standard price. It needs a proper currency conversion.
         if not seller:
+            po_line_uom = self.product_uom or self.product_id.uom_po_id
             price_unit = self.env['account.tax']._fix_tax_included_price_company(
-                self.product_id.uom_id._compute_price(self.product_id.standard_price, self.product_id.uom_po_id),
+                self.product_id.uom_id._compute_price(self.product_id.standard_price, po_line_uom),
                 self.product_id.supplier_taxes_id,
                 self.taxes_id,
                 self.company_id,
@@ -1060,9 +1061,6 @@ class PurchaseOrderLine(models.Model):
                     self.order_id.company_id,
                     self.date_order or fields.Date.today(),
                 )
-
-            if self.product_uom:
-                price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom)
 
             self.price_unit = price_unit
             return


### PR DESCRIPTION
On a product form, if the purchase UoM is different from the default
UoM, this will lead to an error when creating a RfQ.

To reproduce the error:
(Need stock)
1. In Settings, enable "Unit of Measures"
2. Create a product P:
    - Cost: 100
    - UoM: Units
    - Purchase UoM: Dozens
3. Create a RfQ:
    - Add P

Error: The quantity is 1 and UoM is Dozens, however the unit price is
$14400. The ratio has been applied twice.

When setting the product, an onchange method computes the unit price.
However, the computation is wrong: it first converts the product's
standard price using the purchase UoM of the product. Then, it converts
the result, this time using the UoM of the PO line.

OPW-2519294