### PR TITLE
[FIX] payment: restore the delay before post-processing a transaction

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -771,7 +771,7 @@ class PaymentTransaction(models.Model):
         txs_to_post_process = self
         if not txs_to_post_process:
             # Let the client post-process transactions so that they remain available in the portal
-            client_handling_limit_date = datetime.now() - relativedelta.relativedelta(minutes=1)
+            client_handling_limit_date = datetime.now() - relativedelta.relativedelta(minutes=10)
             # Don't try forever to post-process a transaction that doesn't go through
             retry_limit_date = datetime.now() - relativedelta.relativedelta(days=2)
             # Retrieve all transactions matching the criteria for post-processing


### PR DESCRIPTION
[FIX] payment: restore the delay before post-processing a transaction
    
Since the payment post-processing cron runs every ten minutes, it is
important that it ignores the transactions that were updated in the same
last ten minutes. This is necessary because customers can only see the
payment confirmation message for transactions that were not already
post-processed.
    
Commit 573ed74 mistakenly changed the post-processing delay from ten
minutes to one minute. This commit changes it back to 10 minutes.
    
task-2494916