### PR TITLE
[IMP] website_sale: don't show product from another website to admin

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -207,6 +207,14 @@ class ProductTemplate(models.Model):
 
     product_template_image_ids = fields.One2many('product.image', 'product_tmpl_id', string="Extra Product Media", copy=True)
 
+    def _get_website_accessory_product(self):
+        domain = self.env['website'].sale_product_domain()
+        return self.accessory_product_ids.filtered_domain(domain)
+
+    def _get_website_alternative_product(self):
+        domain = self.env['website'].sale_product_domain()
+        return self.alternative_product_ids.filtered_domain(domain)
+
     def _has_no_variant_attributes(self):
         """Return whether this `product.template` has at least one no_variant
         attribute.

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -302,7 +302,6 @@ class SaleOrder(models.Model):
             for line in order.website_order_line.filtered(lambda l: l.product_id):
                 combination = line.product_id.product_template_attribute_value_ids + line.product_no_variant_attribute_value_ids
                 accessory_products |= line.product_id.product_tmpl_id._get_website_accessory_product().filtered(lambda product:
-                    product.website_published and
                     product not in products and
                     product._is_variant_possible(parent_combination=combination) and
                     (product.company_id == line.company_id or not product.company_id)

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -301,7 +301,7 @@ class SaleOrder(models.Model):
             accessory_products = self.env['product.product']
             for line in order.website_order_line.filtered(lambda l: l.product_id):
                 combination = line.product_id.product_template_attribute_value_ids + line.product_no_variant_attribute_value_ids
-                accessory_products |= line.product_id.accessory_product_ids.filtered(lambda product:
+                accessory_products |= line.product_id.product_tmpl_id._get_website_accessory_product().filtered(lambda product:
                     product.website_published and
                     product not in products and
                     product._is_variant_possible(parent_combination=combination) and

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -146,7 +146,7 @@ class WebsiteSnippetFilter(models.Model):
             if current_template.exists():
                 excluded_products = website.sale_get_order().order_line.product_id.ids
                 excluded_products.extend(current_template.product_variant_ids.ids)
-                included_products = current_template._get_website_accessory_product().filtered('website_published').ids
+                included_products = current_template._get_website_accessory_product().ids
                 products_ids = list(set(included_products) - set(excluded_products))
                 if products_ids:
                     domain = expression.AND([

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -146,7 +146,7 @@ class WebsiteSnippetFilter(models.Model):
             if current_template.exists():
                 excluded_products = website.sale_get_order().order_line.product_id.ids
                 excluded_products.extend(current_template.product_variant_ids.ids)
-                included_products = current_template.product_variant_ids.accessory_product_ids.filtered('website_published').ids
+                included_products = current_template._get_website_accessory_product().filtered('website_published').ids
                 products_ids = list(set(included_products) - set(excluded_products))
                 if products_ids:
                     domain = expression.AND([

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -687,7 +687,7 @@
                 <h3>Alternative Products:</h3>
                 <div class="row mt16" style="">
                     <t t-foreach="alternative_products" t-as="alt_product">
-                        <div class="col-lg-2" style="width: 170px; height:130px; float:left; display:inline; margin-right: 10px; overflow:hidden;">
+                        <div class="col-lg-2" t-att-data-publish="alt_product.website_published and 'on' or 'off'" style="width: 170px; height:130px; float:left; display:inline; margin-right: 10px; overflow:hidden;">
                             <div class="mt16 text-center" style="height: 100%;">
                                 <t t-set="combination_info" t-value="alt_product._get_combination_info()"/>
                                 <t t-set="product_variant" t-value="alt_product.env['product.product'].browse(combination_info['product_id'])"/>
@@ -1147,7 +1147,7 @@
             <h5 class='text-muted js_cart_lines' t-if="suggested_products">Suggested Accessories:</h5>
             <table t-if="suggested_products" id="suggested_products" class="js_cart_lines table table-striped table-sm">
                 <tbody>
-                    <tr t-foreach="suggested_products" t-as="product">
+                    <tr t-foreach="suggested_products" t-as="product" t-att-data-publish="product.website_published and 'on' or 'off'">
                         <t t-set="combination_info" t-value="product._get_combination_info_variant(pricelist=website_sale_order.pricelist_id)"/>
                         <td class='td-img text-center'>
                             <a t-att-href="product.website_url">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -682,10 +682,11 @@
 
     <template id="recommended_products" inherit_id="website_sale.product" customize_show="True" name="Alternative Products">
         <xpath expr="//div[@id='product_full_description']" position="after">
-            <div class="container mt32" t-if="product.alternative_product_ids">
+            <t t-set="alternative_products" t-value="product._get_website_alternative_product()"/>
+            <div class="container mt32" t-if="alternative_products">
                 <h3>Alternative Products:</h3>
                 <div class="row mt16" style="">
-                    <t t-foreach="product.alternative_product_ids" t-as="alt_product">
+                    <t t-foreach="alternative_products" t-as="alt_product">
                         <div class="col-lg-2" style="width: 170px; height:130px; float:left; display:inline; margin-right: 10px; overflow:hidden;">
                             <div class="mt16 text-center" style="height: 100%;">
                                 <t t-set="combination_info" t-value="alt_product._get_combination_info()"/>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -85,7 +85,7 @@
             -->
             <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
             <t t-set="id_list" t-value="[product_variant.id] if product_variant else []"/>
-            <t t-foreach="product.alternative_product_ids" t-as="alt_product">
+            <t t-foreach="product._get_website_alternative_product()" t-as="alt_product">
                 <t t-set="alt_product_variant_id" t-value="alt_product._create_first_product_variant().id"/>
                 <t t-if="alt_product_variant_id" t-set="id_list" t-value="id_list + [alt_product_variant_id]"/>
             </t>


### PR DESCRIPTION
Before this commit, the alternatives products were not multi-website filtered
to the admin.
The suggested product were filtered by website thanks to the
`website_published` filter.
This only concern the admins, as for portal and public user, all of this is
done automatically by the ACLs anyway, where we force_domain to
`website_published` products, which also filter by website (see the mixin).

This will also eases module inheritance as we use `sale_product_domain()`.

Fixes #67501