### PR TITLE
[FIX] account: taxes: ignore taxes configured as not to be affected by previous taxes when generating tax_ids on tax lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -540,7 +540,7 @@ class AccountTax(models.Model):
             subsequent_taxes = self.env['account.tax']
             subsequent_tags = self.env['account.account.tag']
             if tax.include_base_amount:
-                subsequent_taxes = taxes[i+1:]
+                subsequent_taxes = taxes[i+1:].filtered('is_base_affected')
                 subsequent_tags = subsequent_taxes.get_tax_tags(is_refund, 'base')
 
             # Compute the tax line amounts by multiplying each factor with the tax amount.

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -1060,6 +1060,9 @@ class TestTax(TestTaxCommon):
             (2, 10, False, True),
         ]])
 
+        compute_all_results = taxes.compute_all(100.0)
+
+        # Check the balance of the generated move lines
         self._check_compute_all_results(
             123.2,      # 'total_included'
             100.0,      # 'total_excluded'
@@ -1071,8 +1074,13 @@ class TestTax(TestTaxCommon):
                 (112.0, 11.2),
                 # -------------------------
             ],
-            taxes.compute_all(100.0),
+            compute_all_results,
         )
+
+        # Check the tax_ids on tax lines
+        expected_tax_ids_list = [taxes[2].ids, taxes[2].ids, []]
+        tax_ids_list = [tax_line['tax_ids'] for tax_line in compute_all_results['taxes']]
+        self.assertEqual(tax_ids_list, expected_tax_ids_list, "Only a tax affected by previous taxes should have tax_ids set on its tax line when used after an 'include_base_amount' tax.")
 
     def test_mixing_price_included_excluded_with_affect_base(self):
         tax_10_fix = self.env['account.tax'].create({


### PR DESCRIPTION
Consider the following example:

1) Create tax ONE, 10%, include_base_amount=True
2) Create tax TWO, 20%, is_base_affected=False

Create an invoice with just one line of 100€, with taxes ONE and TWO (in this order).

The journal entry then contains:
- The payable/receivable line => 130
- The base line => 100
- The tax line for ONE => 10
- The tax line for TWO => 20

The bug this commit fixes concerns the tax_ids set on tax lines. In our example, none should be set, since tax TWO is not affected by ONE. But tax line for ONE actually had tax_ids=TWO, hence impacting TWO's base. This was wrong; the base for TWO is 100, not 110.
