### PR TITLE
base: load_menus optimization

### DIFF
--- a/addons/web/models/ir_ui_menu.py
+++ b/addons/web/models/ir_ui_menu.py
@@ -20,7 +20,7 @@ class IrUiMenu(models.Model):
 
         web_menus = {}
         for menu in menus.values():
-            if not menu['id']:
+            if menu['id'] == 'root':
                 # special root menu case
                 web_menus['root'] = {
                     "id": 'root',

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -213,7 +213,6 @@ class IrUiMenu(models.Model):
             'name': 'root',
             'parent_id': [-1, ''],
             'children': menu_roots_data,
-            'all_menu_ids': menu_roots.ids,
         }
 
         xmlids = menu_roots._get_menuitems_xmlids()


### PR DESCRIPTION
1.
[REM] base: delete all_menu_ids from load_menus
it's not used since Odoo 11
https://github.com/odoo/odoo/commit/13f84b9aca163a8d295678f234ddc0f5b9407111

2.
[IMP] base: load_menus: exclude child_of query
less queries -> more speed

Performance measurements (odoo and browser are running on the same machine):

```
|                                | Number of queries | Query time, sec | Remaining time, sec |
|--------------------------------+-------------------+-----------------+---------------------|
| Before (single query via cURL) |                18 |           0.042 |               0.113 |
| Before (page loading)          |                18 |           0.129 |               0.408 |
| After (single query via cURL)  |                14 |           0.025 |               0.095 |
| After (page loading)           |                14 |           0.132 |               0.255 |
```


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
