### PR TITLE
[FIX] purchase_stock: improve partner._compute_on_time_rate perfs

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta, datetime, time
+from collections import defaultdict
 
 from odoo import api, fields, models
 
@@ -20,12 +21,19 @@ class ResPartner(models.Model):
             ('partner_id', 'in', self.ids),
             ('date_order', '>', fields.Date.today() - timedelta(365)),
             ('qty_received', '!=', 0),
-        ]).filtered(lambda l: l.product_id.sudo().product_tmpl_id.type != 'service' and l.order_id.state in ['done', 'purchase'])
+            ('order_id.state', 'in', ['done', 'purchase'])
+        ]).filtered(lambda l: l.product_id.sudo().product_tmpl_id.type != 'service')
+        lines_qty_done = defaultdict(lambda: 0)
+        moves = self.env['stock.move'].search([
+            ('purchase_line_id', 'in', order_lines.ids),
+            ('state', '=', 'done')]).filtered(lambda m: m.date.date() <= m.purchase_line_id.date_planned.date())
+        for move, qty_done in zip(moves, moves.mapped('quantity_done')):
+            lines_qty_done[move.purchase_line_id.id] += qty_done
         partner_dict = {}
         for line in order_lines:
             on_time, ordered = partner_dict.get(line.partner_id, (0, 0))
             ordered += line.product_uom_qty
-            on_time += sum(line.mapped('move_ids').filtered(lambda m: m.state == 'done' and m.date.date() <= m.purchase_line_id.date_planned.date()).mapped('quantity_done'))
+            on_time += lines_qty_done[line.id]
             partner_dict[line.partner_id] = (on_time, ordered)
         seen_partner = self.env['res.partner']
         for partner, numbers in partner_dict.items():

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -327,12 +327,12 @@ class StockMove(models.Model):
                 move.quantity_done = quantity_done
         else:
             # compute
-            move_lines = self.env['stock.move.line']
+            move_lines_ids = set()
             for move in self:
-                move_lines |= move._get_move_lines()
+                move_lines_ids |= set(move._get_move_lines().ids)
 
             data = self.env['stock.move.line'].read_group(
-                [('id', 'in', move_lines.ids)],
+                [('id', 'in', list(move_lines_ids))],
                 ['move_id', 'product_uom_id', 'qty_done'], ['move_id', 'product_uom_id'],
                 lazy=False
             )


### PR DESCRIPTION
Improve `res.partner._compute_on_time_rate` performances by calling
`mapped('quantity_done')` once on all the `order_lines.move_ids`.

Moving it out of the for loop allows to befinit from the performance
gains of the read_group call in `stock.move._quantity_done_compute`.

##### speedup

Client DB with 10k purchase.order.line and 111k stock_moves.
`res_partner._compute_on_time_rate` time by purchase.order.line.

| purchase.order.line | before PR | after PR |
|:-------------------:|:-----------:|:--------:|
| 20 | 0.091s | 0.055s |
| 80 | 0.041s | 0.040s |
| 175 | 0.125s | 0.057s |
| 904 | 0.322s | 0.086s |
| 7982 | 7.794s | 0.777s |


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
