### PR TITLE
[FIX] sale: do not discount when reinvoicing at cost

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -119,7 +119,8 @@ class AccountMoveLine(models.Model):
         # create the sale lines in batch
         new_sale_lines = self.env['sale.order.line'].create(sale_line_values_to_create)
         for sol in new_sale_lines:
-            sol._onchange_discount()
+            if sol.product_id.expense_policy != 'cost':
+                sol._onchange_discount()
 
         # build result map by replacing index with newly created record of sale.order.line
         result = {}


### PR DESCRIPTION
- Install Sale, Project, Purchase, Timesheet, Accounting
- Enable pricelists, discount, analytic accounting
- Create a pricelist [PRICELIST]:
  * Discount all product by 50%
  * Discount Policy: Show public price & discount to the customer
- Create a product [SERVICE]:
  * Type: Service
  * Timesheet on task
  * Create a task in sales order project
- Create another product [TEST]:
  * Cost: 40
  * Re-Invoice Expenses: At cost
- Create a SO with pricelist [PRICELIST], product [SERVICE], confirm
- Create a PO with [TEST], specify analytic account from SO
- Receive the product, create the bill & confirm

Back to the SO, the unit price of [TEST] is set to 40, with a further
discount of 50%, added when invoicing, that we should not have when
reinvoicing at cost.

opw-2491693

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
