### PR TITLE
[FIX] crm: Fix lead multicompany issue

### DIFF
--- a/addons/crm/__init__.py
+++ b/addons/crm/__init__.py
@@ -5,6 +5,3 @@ from . import controllers
 from . import models
 from . import report
 from . import wizard
-
-from odoo import api, SUPERUSER_ID
-

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -298,20 +298,28 @@ class Lead(models.Model):
         for lead in self:
             proposal = lead.company_id
 
-            # invalidate wrong configuration: company not in responsible companies or in team company if set
-            if proposal and lead.user_id and proposal not in lead.user_id.company_ids:
-                proposal = False
-            if proposal and lead.team_id.company_id and proposal != lead.team_id.company_id:
-                proposal = False
+            # invalidate wrong configuration
+            if proposal:
+                # company not in responsible companies
+                if lead.user_id and proposal not in lead.user_id.company_ids:
+                    proposal = False
+                # inconsistent
+                if lead.team_id.company_id and proposal != lead.team_id.company_id:
+                    proposal = False
+                # void company on team and no assignee
+                if lead.team_id and not lead.team_id.company_id and not lead.user_id:
+                    proposal = False
+                # no user and no team -> void company and let assignment do its job
+                if not lead.team_id and not lead.user_id:
+                    proposal = False
 
             # propose a new company based on responsible, limited by team
             if not proposal:
-                if not lead.user_id or lead.user_id == self.env.user:
-                    proposal = self.env.company
-                elif lead.user_id:
-                    proposal = lead.user_id.company_id
-
-                if lead.team_id.company_id and proposal != lead.team_id.company_id:
+                if lead.user_id:
+                    proposal = lead.team_id.company_id or lead.user_id.company_id
+                elif lead.team_id:
+                    proposal = lead.team_id.company_id
+                else:
                     proposal = False
 
             # set a new company

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_crm_activity
 from . import test_crm_lead
 from . import test_crm_lead_assignment
 from . import test_crm_lead_notification
@@ -8,8 +10,8 @@ from . import test_crm_lead_convert_mass
 from . import test_crm_lead_duplicates
 from . import test_crm_lead_lost
 from . import test_crm_lead_merge
+from . import test_crm_lead_multicompany
 from . import test_crm_lead_smart_calendar
-from . import test_crm_activity
 from . import test_crm_ui
 from . import test_crm_pls
 from . import test_performances

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -60,6 +60,21 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         super(TestCrmCommon, cls).setUpClass()
         cls._init_mail_gateway()
 
+        # Salesmen organization
+        # ------------------------------------------------------------
+        # Role: M (team member) R (team manager)
+        # SALESMAN---------------sales_team_1
+        # admin------------------M-----------
+        # user_sales_manager-----R-----------
+        # user_sales_leads-------M-----------
+        # user_sales_salesman----/-----------
+
+        # Sales teams organization
+        # ------------------------------------------------------------
+        # SALESTEAM-----------SEQU-----COMPANY
+        # sales_team_1--------5--------False
+        # data----------------9999-----??
+
         cls.sales_team_1.write({
             'alias_name': 'sales.test',
             'use_leads': True,
@@ -224,6 +239,45 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'module': 'crm',
             'model': cls.activity_type_1._name,
             'res_id': cls.activity_type_1.id,
+        })
+
+    @classmethod
+    def _activate_multi_company(cls):
+        cls.company_2 = cls.env['res.company'].create({
+            'country_id': cls.env.ref('base.au').id,
+            'currency_id': cls.env.ref('base.AUD').id,
+            'email': 'company.2@test.example.com',
+            'name': 'New Test Company',
+        })
+
+        cls.user_sales_manager_mc = mail_new_test_user(
+            cls.env,
+            company_id=cls.company_2.id,
+            company_ids=[(4, cls.company_main.id), (4, cls.company_2.id)],
+            email='user.sales.manager.mc@test.example.com',
+            login='user_sales_manager_mc',
+            groups='sales_team.group_sale_manager,base.group_partner_manager',
+            name='Myrddin Sales Manager',
+            notification_type='inbox',
+        )
+        cls.team_company2 = cls.env['crm.team'].create({
+            'company_id': cls.company_2.id,
+            'name': 'C2 Team',
+            'sequence': 10,
+            'user_id': False,
+        })
+        cls.team_company2_m1 = cls.env['crm.team.member'].create({
+            'crm_team_id': cls.team_company2.id,
+            'user_id': cls.user_sales_manager_mc.id,
+            'assignment_max': 30,
+            'assignment_domain': False,
+        })
+
+        cls.team_company1 = cls.env['crm.team'].create({
+            'company_id': cls.company_main.id,
+            'name': 'MainCompany Team',
+            'sequence': 50,
+            'user_id': cls.user_sales_manager.id,
         })
 
     def _create_leads_batch(self, lead_type='lead', count=10, email_dup_count=0,

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.exceptions import AccessError
+from odoo.tests import Form, tagged
+from odoo.tests.common import users
+
+
+@tagged('multi_company')
+class TestCRMLeadMultiCompany(TestCrmCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCRMLeadMultiCompany, cls).setUpClass()
+        cls._activate_multi_company()
+
+    def test_initial_data(self):
+        """ Ensure global data for those tests to avoid unwanted side effects """
+        self.assertFalse(self.sales_team_1.company_id)
+        self.assertEqual(self.user_sales_manager_mc.company_id, self.company_2)
+
+    @users('user_sales_manager_mc')
+    def test_lead_mc_company_computation(self):
+        """ Test lead company computation depending on various parameters. Check
+        the company is set from the team_id or from the env if there is no team.
+        No responsible, no team, should not limit company. """
+        # Lead with falsy values are kept
+        lead_no_team = self.env['crm.lead'].create({
+            'name': 'L1',
+            'team_id': False,
+            'user_id': False,
+        })
+        # self.assertFalse(lead_no_team.company_id)  FIXME: should not limit company
+        self.assertEqual(lead_no_team.company_id, self.user_sales_manager_mc.company_id)
+        self.assertFalse(lead_no_team.team_id)
+        self.assertFalse(lead_no_team.user_id)
+
+        # Lead with team with company sets company
+        lead_team_c2 = self.env['crm.lead'].create({
+            'name': 'L2',
+            'team_id': self.team_company2.id,
+            'user_id': False,
+        })
+        self.assertEqual(lead_team_c2.company_id, self.company_2)
+        self.assertFalse(lead_team_c2.user_id)
+
+        # Update team wo company: reset lead company also
+        lead_team_c2.team_id = self.sales_team_1
+        # self.assertFalse(lead_team_c2.company_id) FIXME: currently kept
+        self.assertEqual(lead_team_c2.company_id, self.company_2)
+
+        # Lead with global team has no company
+        lead_team_no_company = self.env['crm.lead'].create({
+            'name': 'No company',
+            'team_id': self.sales_team_1.id,
+            'user_id': False,
+        })
+        # self.assertFalse(lead_no_team.company_id)  FIXME: should not limit company
+        self.assertEqual(lead_no_team.company_id, self.user_sales_manager_mc.company_id)
+
+        # Update team w company updates company
+        lead_team_no_company.team_id = self.team_company2
+        self.assertEqual(lead_team_no_company.company_id, self.company_2)
+        self.assertEqual(lead_team_no_company.team_id, self.team_company2)
+
+    @users('user_sales_manager_mc')
+    def test_lead_mc_company_form(self):
+        """ Test lead company computation using form view """
+        crm_lead_form = Form(self.env['crm.lead'])
+        crm_lead_form.name = "Test Lead"
+
+        # default values: current user, its team and therefore its company
+        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.user_id, self.user_sales_manager_mc)
+        self.assertEqual(crm_lead_form.team_id, self.team_company2)
+
+        # remove user, team only
+        crm_lead_form.user_id = self.env['res.users']
+        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.user_id, self.env['res.users'])
+        self.assertEqual(crm_lead_form.team_id, self.team_company2)
+
+        # remove team, user only
+        crm_lead_form.user_id = self.user_sales_manager_mc
+        crm_lead_form.team_id = self.env['crm.team']
+        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.user_id, self.user_sales_manager_mc)
+        self.assertEqual(crm_lead_form.team_id, self.env['crm.team'])
+
+        # remove both
+        crm_lead_form.user_id = self.env['res.users']
+        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.user_id, self.env['res.users'])
+        self.assertEqual(crm_lead_form.team_id, self.env['crm.team'])
+
+        lead = crm_lead_form.save()
+
+        # user_sales_manager cannot read it due to MC rules
+        with self.assertRaises(AccessError):
+            lead.with_user(self.user_sales_manager).read(['name'])
+
+    @users('user_sales_manager_mc')
+    def test_lead_mc_company_form_progressives_setup(self):
+        """ Specific bug reported at Task-2520276. Flow
+          0) The sales team have no company set
+          1) Create a lead without a user_id and a team_id
+          2) Assign a team to the lead
+          3) Assign a user_id
+
+        Goal: if no company is set on the sales team the lead at step 2 should
+        not have any company_id set. Previous behavior
+          1) set the company of the env.user
+          2) Keep the company of the lead
+          3) set the user company if the current company is not one of the allowed company of the user
+
+        Wanted behavior
+          1) leave the company empty
+          2) set the company of the team even if it's False (so erase the company if the team has no company set)
+          3) set the user company if the current company is not one of the allowed company of the user
+        """
+        lead = self.env['crm.lead'].create({
+            'name': 'Test Progressive Setup',
+            'user_id': False,
+            'team_id': False,
+        })
+        crm_lead_form = Form(lead)
+        # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  FIXME
+        self.assertEqual(crm_lead_form.company_id, self.company_2)
+
+        crm_lead_form.team_id = self.sales_team_1
+        # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  # FIXME
+        self.assertEqual(crm_lead_form.company_id, self.company_2)
+
+        crm_lead_form.user_id = self.env.user
+        # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  # FIXME
+        self.assertEqual(crm_lead_form.company_id, self.company_2)

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -32,8 +32,7 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
             'team_id': False,
             'user_id': False,
         })
-        # self.assertFalse(lead_no_team.company_id)  FIXME: should not limit company
-        self.assertEqual(lead_no_team.company_id, self.user_sales_manager_mc.company_id)
+        self.assertFalse(lead_no_team.company_id)
         self.assertFalse(lead_no_team.team_id)
         self.assertFalse(lead_no_team.user_id)
 
@@ -48,8 +47,7 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
 
         # Update team wo company: reset lead company also
         lead_team_c2.team_id = self.sales_team_1
-        # self.assertFalse(lead_team_c2.company_id) FIXME: currently kept
-        self.assertEqual(lead_team_c2.company_id, self.company_2)
+        self.assertFalse(lead_team_c2.company_id)
 
         # Lead with global team has no company
         lead_team_no_company = self.env['crm.lead'].create({
@@ -57,8 +55,7 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
             'team_id': self.sales_team_1.id,
             'user_id': False,
         })
-        # self.assertFalse(lead_no_team.company_id)  FIXME: should not limit company
-        self.assertEqual(lead_no_team.company_id, self.user_sales_manager_mc.company_id)
+        self.assertFalse(lead_no_team.company_id)
 
         # Update team w company updates company
         lead_team_no_company.team_id = self.team_company2
@@ -89,12 +86,14 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         self.assertEqual(crm_lead_form.user_id, self.user_sales_manager_mc)
         self.assertEqual(crm_lead_form.team_id, self.env['crm.team'])
 
-        # remove both
+        # remove both: void company to ease assignment
         crm_lead_form.user_id = self.env['res.users']
-        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.company_id, self.env['res.company'])
         self.assertEqual(crm_lead_form.user_id, self.env['res.users'])
         self.assertEqual(crm_lead_form.team_id, self.env['crm.team'])
 
+        # force company manually
+        crm_lead_form.company_id = self.company_2
         lead = crm_lead_form.save()
 
         # user_sales_manager cannot read it due to MC rules
@@ -126,12 +125,10 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
             'team_id': False,
         })
         crm_lead_form = Form(lead)
-        # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  FIXME
-        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.company_id, self.env['res.company'])
 
         crm_lead_form.team_id = self.sales_team_1
-        # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  # FIXME
-        self.assertEqual(crm_lead_form.company_id, self.company_2)
+        self.assertEqual(crm_lead_form.company_id, self.env['res.company'])
 
         crm_lead_form.user_id = self.env.user
         # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  # FIXME


### PR DESCRIPTION
Context
-------

Lead get assigned a different company than the one defined on the
salesman after being merge with another lead.

This happen because some lead assigned to a user_id have no company set
are merge with lead that receive self.env.company during automated
assignation to the team and than get merged with the lead without
company. So the company of the new lead is written on the old one.

Behavior before this PR
-----------------------

When the crm.team have the field company_id = False
With the following flow

 1) Create a lead without a user_id and a team_id
 2) Assign a team to the lead
 3) Assign a user_id

The status of the company field on the lead is the following

 1) set the company of the env.user
 2) Keep the company of the lead
 3) set the user company if the current company is not one of the allowed company of the user

Behavior after this PR
----------------------

 1) set the company of the env.user
 2) set the company of the team even if it's False
    (so erase the company if the team has no company set)
 3) set the user company if the current company is not one of the allowed company of the user

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
