### PR TITLE
add exception for "XmlHttpRequestError", to make the receipt printing…

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -178,6 +178,8 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                     syncedOrderBackendIds = await this.env.pos.push_single_order(this.currentOrder);
                 }
             } catch (error) {
+                //  exception for "XmlHttpRequestError"
+                if (error.code != -32098)
                 this.error = true;
                 if (error instanceof Error) {
                     throw error;


### PR DESCRIPTION
… available for offline mode

Description of the issue/feature this PR addresses:
after the last update in 4/6/2021 the receipt printing not working in offline mode
Current behavior before PR:
printing receipt not working in offline mode
Desired behavior after PR is merged:
add exception for "XmlHttpRequestError", to make the receipt printing available for offline mode


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
