### PR TITLE
[IMP] payment: prevent validation transactions from creating payments

### DIFF
--- a/addons/payment/tests/__init__.py
+++ b/addons/payment/tests/__init__.py
@@ -5,3 +5,4 @@ from . import http_common
 from . import multicompany_common
 from . import test_flows
 from . import test_multicompany_flows
+from . import test_transactions

--- a/addons/payment/tests/test_transactions.py
+++ b/addons/payment/tests/test_transactions.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.payment.tests.common import PaymentCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestTransactions(PaymentCommon):
+
+    def test_no_payment_for_validations(self):
+        tx = self.create_transaction(flow='dummy', operation='validation')  # Overwrite the flow
+        tx._reconcile_after_done()
+        payment_count = self.env['account.payment'].search_count(
+            [('payment_transaction_id', '=', tx.id)]
+        )
+        self.assertEqual(payment_count, 0, "validation transactions should not create payments")


### PR DESCRIPTION
Before commit 139dd9d, only validation transactions made with a validity
check (transfer of a small amount with immediate refund) led to the
creation of an `account.payment` record for the reconciliation. As that
amount was never perceived, there was in fact nothing to reconcile.

With commit 139dd9d, it is possible to make $0-validations (the validity
check is handled by the provider). As this feature now sheds light on
the flawed behavior described above, it has been decided to entirely
stop creating `account.payment` records for validation transactions.

This commit thus prevents the post-processing of validation transactions
from preparing their reconciliation.

task-2494916
