### PR TITLE
[IMP] point_of_sale: Limit the loading at the opening

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -3454,7 +3454,7 @@ td {
 .search-bar-portal .search-box .icon {
     position: absolute;
     left: 0;
-    margin-left: 12px;
+    margin-left: 4px;
     z-index: 1;
     color: #4f5b66;
 }
@@ -3462,7 +3462,16 @@ td {
 .search-bar-portal .search-box .clear-icon {
     position: absolute;
     right: 0;
-    margin-right: 12px;
+    margin-right: 24px;
+    z-index: 1;
+    color: #4f5b66;
+    cursor: pointer;
+}
+
+.search-bar-portal .search-box .database-icon {
+    position: absolute;
+    left: 0;
+    margin-left: 22px;
     z-index: 1;
     color: #4f5b66;
     cursor: pointer;

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidget.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidget.js
@@ -17,6 +17,7 @@ odoo.define('point_of_sale.ProductsWidget', function(require) {
             useListener('update-search', this._updateSearch);
             useListener('try-add-product', this._tryAddProduct);
             useListener('clear-search', this._clearSearch);
+            useListener('update-product-list', this._updateProductList);
             this.state = useState({ searchWord: '' });
         }
         mounted() {
@@ -32,14 +33,16 @@ odoo.define('point_of_sale.ProductsWidget', function(require) {
             return this.state.searchWord.trim();
         }
         get productsToDisplay() {
+            let list = [];
             if (this.searchWord !== '') {
-                return this.env.pos.db.search_product_in_category(
+                list = this.env.pos.db.search_product_in_category(
                     this.selectedCategoryId,
                     this.searchWord
                 );
             } else {
-                return this.env.pos.db.get_product_by_category(this.selectedCategoryId);
+                list = this.env.pos.db.get_product_by_category(this.selectedCategoryId);
             }
+            return list.sort(function (a, b) { return a.display_name.localeCompare(b.display_name) });
         }
         get subcategories() {
             return this.env.pos.db
@@ -78,6 +81,10 @@ odoo.define('point_of_sale.ProductsWidget', function(require) {
         }
         _clearSearch() {
             this.state.searchWord = '';
+        }
+        _updateProductList(event) {
+            this.render();
+            this.trigger('switch-category', 0);
         }
     }
     ProductsWidget.template = 'ProductsWidget';

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
@@ -3,6 +3,8 @@ odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
 
     const { useRef } = owl.hooks;
     const { debounce } = owl.utils;
+    const { identifyError } = require('point_of_sale.utils');
+    const { ConnectionLostError, ConnectionAbortedError } = require('@web/core/network/rpc_service');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const { posbus } = require('point_of_sale.utils');
@@ -36,6 +38,38 @@ odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
             this.searchWordInput.el.value = productName;
             this.trigger('switch-category', 0);
             this.trigger('update-search', productName);
+        }
+        async loadProductFromDB() {
+            if(!this.searchWordInput.el.value)
+                return;
+
+            try {
+                let ProductIds = await this.rpc({
+                    model: 'product.product',
+                    method: 'search',
+                    args: [[['name', 'ilike', this.searchWordInput.el.value + "%"]]],
+                    context: this.env.session.user_context,
+                });
+                if(!ProductIds.length) {
+                    this.showPopup('ErrorPopup', {
+                        title: this.env._t(''),
+                        body: this.env._t("No product found"),
+                    });
+                } else {
+                    await this.env.pos._addProducts(ProductIds);
+                }
+                this.trigger('update-product-list');
+            } catch (error) {
+                const identifiedError = identifyError(error)
+                if (identifiedError instanceof ConnectionLostError || identifiedError instanceof ConnectionAbortedError) {
+                    return this.showPopup('OfflineErrorPopup', {
+                        title: this.env._t('Network Error'),
+                        body: this.env._t("Product is not loaded. Tried loading the product from the server but there is a network error."),
+                    });
+                } else {
+                    throw error;
+                }
+            }
         }
     }
     ProductsWidgetControlPanel.template = 'ProductsWidgetControlPanel';

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -363,7 +363,9 @@ var PosDB = core.Class.extend({
         var list = [];
         if (product_ids) {
             for (var i = 0, len = Math.min(product_ids.length, this.limit); i < len; i++) {
-                list.push(this.product_by_id[product_ids[i]]);
+                const product = this.product_by_id[product_ids[i]];
+                if (!(product.active && product.available_in_pos)) continue;
+                list.push(product);
             }
         }
         return list;
@@ -385,7 +387,9 @@ var PosDB = core.Class.extend({
             var r = re.exec(this.category_search_string[category_id]);
             if(r){
                 var id = Number(r[1]);
-                results.push(this.get_product_by_id(id));
+                const product = this.get_product_by_id(id);
+                if (!(product.active && product.available_in_pos)) continue;
+                results.push(product);
             }else{
                 break;
             }

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -137,8 +137,8 @@ exports.PosModel = Backbone.Model.extend({
             searchTerm: '',
         };
     },
-    after_load_server_data: function(){
-        this.load_orders();
+    after_load_server_data: async function(){
+        await this.load_orders();
         this.set_start_order();
         if(this.config.use_proxy){
             if (this.config.iface_customer_facing_display) {
@@ -476,7 +476,7 @@ exports.PosModel = Backbone.Model.extend({
         condition: function (self) { return !self.config.limited_products_loading; },
         fields: ['display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_id', 'taxes_id',
                  'barcode', 'default_code', 'to_weight', 'uom_id', 'description_sale', 'description',
-                 'product_tmpl_id','tracking', 'write_date', 'available_in_pos', 'attribute_line_ids'],
+                 'product_tmpl_id','tracking', 'write_date', 'available_in_pos', 'attribute_line_ids', 'active'],
         order:  _.map(['sequence','default_code','name'], function (name) { return {name: name}; }),
         domain: function(self){
             var domain = ['&', '&', ['sale_ok','=',true],['available_in_pos','=',true],'|',['company_id','=',self.config.company_id[0]],['company_id','=',false]];
@@ -833,8 +833,9 @@ exports.PosModel = Backbone.Model.extend({
      * Second load all orders belonging to the same config but from other sessions,
      * Only if tho order has orderlines.
      */
-    load_orders: function(){
+    load_orders: async function(){
         var jsons = this.db.get_unpaid_orders();
+        await this._loadMissingProducts(jsons);
         var orders = [];
 
         for (var i = 0; i < jsons.length; i++) {

--- a/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientListScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ClientListScreen/ClientListScreen.xml
@@ -44,6 +44,16 @@
                         <input placeholder="Search Customers" size="1" t-on-keyup="updateClientList" />
                         <span class="search-clear-client"></span>
                     </div>
+                    <div class="button back" t-on-click="searchClient()" t-if="!state.detailIsShown">
+                        <span class="database-icon">
+                            <i class="fa fa-database"/>
+                        </span>
+                        <t t-if="!env.isMobile">
+                            <span class="load-customer-search">
+                                Load Customers
+                            </span>
+                        </t>
+                    </div>
                 </div>
                 <section class="full-content">
                     <div class="client-window">

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidgetControlPanel.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidgetControlPanel.xml
@@ -39,10 +39,15 @@
             <Portal target="'.pos .search-bar-portal'">
                 <div class="search-box">
                     <span class="icon"><i class="fa fa-search"></i></span>
+
                     <span t-on-click="clearSearch" class="clear-icon">
                         <i class="fa fa-times" aria-hidden="true"></i>
                     </span>
+                    <span class="database-icon">
+                        <i class="fa fa-database" t-on-click="loadProductFromDB"/>
+                    </span>
                     <input t-ref="search-word-input" type="text" placeholder="Search Products..." t-on-keyup="updateSearch" />
+
                 </div>
             </Portal>
         </div>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -168,6 +168,27 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="limited_partners_loading"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="limited_partners_loading" string="Limited Partners Loading"/>
+                                <div class="text-muted">
+                                    Only load a limited number of customers at the opening of the PoS.
+                                </div>
+                                <div class="content-group mt16" attrs="{'invisible' : [('limited_partners_loading', '=', False)]}">
+                                    <div groups="base.group_no_one">
+                                        <label for="limited_partners_amount" string="Number of Partners Loaded"/>
+                                        <field name="limited_partners_amount" class="oe_inline"/>
+                                    </div>
+                                    <div>
+                                        <field name="partner_load_background" class="oe_inline"/>
+                                        <label for="partner_load_background" string="Load all remaining partners in the background" class="oe_inline"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <h2>Connected Devices</h2>
                     <div class="row mt16 o_settings_container" id="posbox_reference">
@@ -566,6 +587,28 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="limited_products_loading"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="limited_products_loading" string="Limited Products Loading"/>
+                                <div class="text-muted">
+                                    Only load most common products at the opening of the PoS.
+                                </div>
+                                <div class="content-group mt16" attrs="{'invisible' : [('limited_products_loading', '=', False)]}">
+                                    <div groups="base.group_no_one">
+                                        <label for="limited_products_amount" string="Number of Products Loaded"/>
+                                        <field name="limited_products_amount" class="oe_inline"/>
+                                    </div>
+                                    <div>
+                                        <field name="product_load_background" class="oe_inline"/>
+                                        <label for="product_load_background" string="Load all remaining products in the background" class="oe_inline"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
                     <h2>Accounting</h2>
                     <div class="row mt16 o_settings_container" id="accounting_section">


### PR DESCRIPTION
In this PR, in order to make the loading of the POS faster, we limit the loading of the product and partner number.
According to it, we add new fields in the pos config to set a number.
The product are loaded with those rules:
- Starred products
- Services
- Recent stock moves
- Creation date

If the product are not loaded, when we scan them, they're added to the pos db. They're also set as available in the point of sale if they were not.

The partners are loaded by number of pos order done.
For the partners, if they're not loaded, you can search for them with the alphabetical research and load them from the database.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
