### PR TITLE
set default activity_type_id from activity view

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -156,6 +156,21 @@ var BasicActivity = AbstractField.extend({
     // Private
     //------------------------------------------------------------
 
+    _getActivityFormAction(id) {
+        return {
+            type: 'ir.actions.act_window',
+            name: _t("Schedule Activity"),
+            res_model: 'mail.activity',
+            view_mode: 'form',
+            views: [[false, 'form']],
+            target: 'new',
+            context: {
+                default_res_id: this.res_id,
+                default_res_model: this.model,
+            },
+            res_id: id || false,
+        };
+    },
     /**
      * Send a feedback and reload page in order to mark activity as done
      *
@@ -216,19 +231,7 @@ var BasicActivity = AbstractField.extend({
      * @return {Promise}
      */
     _openActivityForm: function (id, callback) {
-        var action = {
-            type: 'ir.actions.act_window',
-            name: _t("Schedule Activity"),
-            res_model: 'mail.activity',
-            view_mode: 'form',
-            views: [[false, 'form']],
-            target: 'new',
-            context: {
-                default_res_id: this.res_id,
-                default_res_model: this.model,
-            },
-            res_id: id || false,
-        };
+        var action = this._getActivityFormAction(id);
         return this.do_action(action, { on_close: callback });
     },
     /**

--- a/addons/mail/static/src/js/views/activity/activity_cell.js
+++ b/addons/mail/static/src/js/views/activity/activity_cell.js
@@ -7,6 +7,19 @@ import field_registry from 'web.field_registry';
 const KanbanActivity = field_registry.get('kanban_activity');
 
 const ActivityCell = KanbanActivity.extend({
+    init(parent, name, record, options) {
+        this._super.apply(this, arguments);
+        this.activityType = options && options.activityType;
+    },
+    /**
+     * @private
+     * @override
+     */
+    _getActivityFormAction(id) {
+        const action = this._super.apply(this, arguments);
+        action.context['default_activity_type_id'] = this.activityType;
+        return action;
+    },
     /**
      * @override
      * @private

--- a/addons/mail/static/src/xml/activity_view.xml
+++ b/addons/mail/static/src/xml/activity_view.xml
@@ -62,7 +62,7 @@
     <td t-if="activityGroup.state and !isCellHidden" t-att-data-res-id="resId" t-att-data-activity-type-id="type[0]"
         t-attf-class="o_activity_summary_cell {{activityGroup.state}} {{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state.value : '' }}">
         <ActivityCellAdapter Component="widgetComponents.ActivityCell"
-            widgetArgs="['activity_ids', props.getKanbanActivityData(activityGroup, resId)]"/>
+            widgetArgs="['activity_ids', props.getKanbanActivityData(activityGroup, resId), { activityType: type[0] }]"/>
     </td>
     <td t-else="" t-att-data-res-id="resId" t-att-data-activity-type-id="type[0]"
         class="o_activity_summary_cell o_activity_empty_cell"

--- a/addons/mail/static/tests/activity_tests.js
+++ b/addons/mail/static/tests/activity_tests.js
@@ -311,6 +311,7 @@ QUnit.test('activity view: activity widget', async function (assert) {
                     assert.step("do_action_compose");
                 } else if (action.res_model === 'mail.activity') {
                     assert.deepEqual({
+                        "default_activity_type_id": 2,
                         "default_res_id": 30,
                         "default_res_model": "task"
                     }, action.context);


### PR DESCRIPTION
PURPOSE

When creating scheduled activity from activity cell do not set default activity type, to produce this issue:
CRM -> Activity View -> Click on existing record of activity view which will open popover -> click on Schedule Activity button, this will open scheduled activity form but it will not have default activity type.

SPEC
When clicking on the Schedule Activity button from the activity popover, the default activity type will be passed in context.

TASK 2568793


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
