### PR TITLE
[FIX] web: raise error on print "Invoices" if account.move not an invoice

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -2057,10 +2057,13 @@ class ReportController(http.Controller):
 
                 if docids:
                     ids = [int(x) for x in docids.split(",")]
-                    obj = request.env[report.model].browse(ids)
-                    if report.print_report_name and not len(obj) > 1:
-                        report_name = safe_eval(report.print_report_name, {'object': obj, 'time': time})
-                        filename = "%s.%s" % (report_name, extension)
+                    objs = request.env[report.model].browse(ids)
+                    if report.print_report_name:
+                        for obj in objs:
+                            report_name = safe_eval(report.print_report_name, {'object': obj, 'time': time})
+                        if len(objs) == 1:
+                            filename = "%s.%s" % (report_name, extension)
+
                 response.headers.add('Content-Disposition', content_disposition(filename))
                 response.set_cookie('fileToken', token)
                 return response


### PR DESCRIPTION
Step to reproduce:

  - Install "Accounting" and "Payroll" module
  - Create 2 payslips
  - Go to "Journal Entries"
  - Select the 2 payslip entries in list view
  - Click on "Print -> Invoices"

Issue

  A report with payslips is created and downloaded.
  note: Can not print one payslip.

Cause

  Not checking if a report is allowed to be printed.

Solution

  Check if any of selected instances are printable:
  It is done by retrieving the report filename for each instance (move
  in this case) since same code check if move is an invoice and
  therefore will raise an error if not an invoice.

opw-2553496