### PR TITLE
[FIX] mrp,stock: do not block MO unlink when merging

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -215,7 +215,7 @@ class StockMove(models.Model):
     def unlink(self):
         # Avoid deleting move related to active MO
         for move in self:
-            if move.production_id and move.production_id.state not in ('draft', 'cancel'):
+            if move.production_id and move.production_id.state not in ('draft', 'cancel') and not self._context.get('force_delete'):
                 raise UserError(_('Please cancel the Manufacture Order first.'))
         return super(StockMove, self).unlink()
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -832,7 +832,7 @@ class StockMove(models.Model):
             # We are using propagate to False in order to not cancel destination moves merged in moves[0]
             moves_to_unlink._clean_merged()
             moves_to_unlink._action_cancel()
-            moves_to_unlink.sudo().unlink()
+            moves_to_unlink.sudo().with_context(force_delete=True).unlink()
         return (self | self.env['stock.move'].concat(*moves_to_merge)) - moves_to_unlink
 
     def _get_relevant_state_among_moves(self):


### PR DESCRIPTION
Confirming a manufacturing order the system may merge moves,
deleting unnecessary moves with active production, blocking the action

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
