### PR TITLE
[IMP] base: prefetch all fields used by get_combined_arch

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -611,7 +611,7 @@ actual arch.
                       AND ({where_clause})
             )
             SELECT
-                v.id, v.inherit_id,
+                v.id, v.inherit_id, v.mode,
                 ARRAY(SELECT r.group_id FROM ir_ui_view_group_rel r WHERE r.view_id=v.id)
             FROM ir_ui_view_inherits v
             ORDER BY v.priority, v.id
@@ -628,14 +628,15 @@ actual arch.
         rows = self.env.cr.fetchall()
 
         # filter out forbidden views
-        if any(row[2] for row in rows):
+        if any(row[3] for row in rows):
             user_groups = set(self.env.user.groups_id.ids)
-            rows = [row for row in rows if not (row[2] and user_groups.isdisjoint(row[2]))]
+            rows = [row for row in rows if not (row[3] and user_groups.isdisjoint(row[3]))]
 
         views = self.browse(row[0] for row in rows)
 
-        # optimization: fill in cache of inherit_id
+        # optimization: fill in cache of inherit_id and mode
         self.env.cache.update(views, type(self).inherit_id, [row[1] for row in rows])
+        self.env.cache.update(views, type(self).mode, [row[2] for row in rows])
 
         # During an upgrade, we can only use the views that have been
         # fully upgraded already.

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -276,6 +276,17 @@ class TestViewInheritance(ViewCase):
         v.arch = '<form></form>'
         self.assertEqual(v.arch, '<form></form>')
 
+    def test_get_combined_arch_query_count(self):
+        # If the query count increases, you probably made the view combination
+        # fetch an extra field on views. You better fetch that extra field with
+        # the query of _get_inheriting_views() and manually feed the cache.
+        self.View.invalidate_cache()
+        with self.assertQueryCount(3):
+            # 1: browse([self.view_ids['A']])
+            # 2: _get_inheriting_views: id, inherit_id, mode, groups
+            # 3: _combine: arch_db
+            self.view_ids['A'].get_combined_arch()
+
 
 class TestApplyInheritanceSpecs(ViewCase):
     """ Applies a sequence of inheritance specification nodes to a base


### PR DESCRIPTION
The `mode` field in used in `_combine` to distinguish `primary` views
from `extension` ones. The field has been retrieved as part of the query
done in `_get_inheriting_views` and manually placed in the cache so the
ORM doesn't perform an extra query just to retrieve the mode.

Using our benchmark (render_all_views test tag, website_sale, mrp,
contacts, crm and timesheet installed), the reported time was 18.46s
with 17890 queries performed without this improvement, it is 17.82 with
17340 queries with.

#72096
