### PR TITLE
[FIX] web_tour: use .concat to avoid max call stack error

### DIFF
--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -133,7 +133,7 @@ return session.is_bound.then(function () {
         let mutationTimer;
         const observer = new MutationObserver(mutations => {
             clearTimeout(mutationTimer);
-            currentMutations.push(...mutations);
+            currentMutations = currentMutations.concat(mutations);
             mutationTimer = setTimeout(() => _processMutations(), 750);
         });
 


### PR DESCRIPTION
Variable `mutations` may have thousands of records. Using `.push(...mutations)`
would lead to error

STEPS:
* install website_sale
* create many categories:

```
for x in range(0, 4000):
    env['product.public.category'].create({'name': str(x), 'parent_id': 9})
```
* open /shop
* click [Edit]

BEFORE:

```
Uncaught RangeError: Maximum call stack size exceeded
http://devel.14.localhost:14069/web_tour/static/src/js/tour_service.js:136
```

https://github.com/odoo/odoo/blob/87a75c41a5721115c562aadca1512d1bfaa47939/addons/web_tour/static/src/js/tour_service.js#L136

AFTER: no errors

---

opw-2515707

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
