### PR TITLE
[FIX] core/expression: fix not in for translated fields

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -703,6 +703,10 @@ class TestExpression(SavepointCaseWithUserDemo):
             countries = self._search(Country, domain)
             self.assertEqual(countries, belgium)
 
+        countries = self._search(Country, [('name', 'not in', ['No country'])])
+        all_countries = self._search(Country, [])
+        self.assertEqual(countries, all_countries)
+
     @mute_logger('odoo.sql_db')
     def test_invalid(self):
         """ verify that invalid expressions are refused, even for magic fields """

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -909,7 +909,7 @@ class expression(object):
                     sql_operator = {'=like': 'like', '=ilike': 'ilike'}.get(operator, operator)
                     if need_wildcard:
                         right = '%%%s%%' % right
-                    if sql_operator == 'in':
+                    if sql_operator in ('in', 'not in'):
                         right = tuple(right)
 
                     unaccent = self._unaccent if sql_operator.endswith('like') else lambda x: x


### PR DESCRIPTION
Domain terms of the form `['field', 'not in', [...]]` generate wrong
queries for translated fields, example (model `res.country`, field `name`):
```
psycopg2.errors.SyntaxError: syntax error at or near "ARRAY"
LINE 1: ...M "res_country" WHERE "res_country"."name" not in ARRAY['No ...
```
The root cause is that the right part of the term is not converted to
tuple.

Observed during the upgrade request 16639
opw-2525553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
