### PR TITLE
[IMP] base_import: add import progress bar

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -94,7 +94,7 @@ var DataImport = AbstractAction.extend({
     ],
     events: {
         'change .oe_import_file': 'loaded_file',
-        'change input.oe_import_has_header, .js_import_options input': 'settings_changed',
+        'change input.oe_import_has_header, .oe_import_sheet': 'settings_changed',
         'change input.oe_import_advanced_mode': function (e) {
             this.do_not_change_match = true;
             this['settings_changed']();

--- a/addons/base_import/static/src/scss/base_import.scss
+++ b/addons/base_import/static/src/scss/base_import.scss
@@ -68,6 +68,9 @@
             overflow: hidden;
             text-overflow: ellipsis;
         }
+        .o_import_batch_alert {
+            color: #46646d;
+        }
     }
 
     &.oe_import_preview .oe_import_grid {
@@ -232,5 +235,16 @@
         .text-decoration-underline {
             text-decoration: underline;
         }
+    }
+}
+
+/* Import Progress Bar */
+.o_progress_dialog {
+    .progress-bar {
+        width: 0%;
+        min-width: 3%;
+    }
+    .o_progress_stop_import {
+        cursor: pointer;
     }
 }

--- a/addons/base_import/static/src/scss/base_import.scss
+++ b/addons/base_import/static/src/scss/base_import.scss
@@ -246,5 +246,8 @@
     }
     .o_progress_stop_import {
         cursor: pointer;
+        &:hover {
+            transform: scale(1.2);
+        }
     }
 }

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -320,17 +320,16 @@ lines composed only of empty cells">
         <div class="oe_blockui_spin" style="height: 50px">
             <img src="/web/static/img/spin.png" style="animation: fa-spin 1s infinite steps(12);" alt="Loading..."/>
         </div>
-        <span t-esc="title"/>
         <div t-if="isBatch">
             <div class="o_progress_dialog_batch">
-                Importing batch <span class="o_progress_dialog_batch_txt">1</span> out of <span t-esc="totalBatch"/>...
+                <span t-esc="task"/> batch <span class="o_progress_dialog_batch_txt">1</span> out of <span t-esc="totalBatch"/>...
             </div>
             <span class="o_progress_dialog_stop d-none">
                 Finalizing current batch before interrupting...
             </span>
-            <div class="w-100 text-right">
-                <span class="o_progress_dialog_txt">0</span>/<span t-esc="totalRows"/> rows
-            </div>
+            <!--<div class="w-100 text-right">-->
+                <!--<span class="o_progress_dialog_txt">0</span>/<span t-esc="totalRows"/> rows-->
+            <!--</div>-->
             <div class="d-flex align-items-center">
                 <div class="progress flex-grow-1">
                     <div class="progress-bar progress-bar-striped" role="progressbar"

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -270,8 +270,8 @@
 
                 <div class="o_import_batch">
                     <h4 class="mt-3">Batch Import</h4>
-                    <div class="o_import_batch_alert alert alert-info d-none">
-                        The file will be imported by batches.
+                    <div class="o_import_batch_alert font-weight-bold d-none pb-2">
+                        The file will be imported by batches
                     </div>
                     <div class="d-flex">
                         <div class="js_import_options oe_import_options oe_import_batch_limit w-50 pr-1">
@@ -315,4 +315,31 @@ lines composed only of empty cells">
             </div>
         </div>
     </t>
+
+    <div t-name="base_import.progressDialog" class="o_progress_dialog text-white">
+        <div class="oe_blockui_spin" style="height: 50px">
+            <img src="/web/static/img/spin.png" style="animation: fa-spin 1s infinite steps(12);" alt="Loading..."/>
+        </div>
+        <span t-esc="title"/>
+        <div t-if="isBatch">
+            <div class="o_progress_dialog_batch">
+                Importing batch <span class="o_progress_dialog_batch_txt">1</span> out of <span t-esc="totalBatch"/>...
+            </div>
+            <span class="o_progress_dialog_stop d-none">
+                Finalizing current batch before interrupting...
+            </span>
+            <div class="w-100 text-right">
+                <span class="o_progress_dialog_txt">0</span>/<span t-esc="totalRows"/> rows
+            </div>
+            <div class="d-flex align-items-center">
+                <div class="progress flex-grow-1">
+                    <div class="progress-bar progress-bar-striped" role="progressbar"
+                         aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                        <span>0%</span>
+                    </div>
+                </div>
+                <a class="o_progress_stop_import ml-2" role="button"><i class="fa fa-close" aria-label="Stop Import"/></a>
+            </div>
+        </div>
+    </div>
 </templates>

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -244,7 +244,7 @@
                     <span id="oe_imported_file_extension" class="font-italic"></span>
                 </div>
 
-                <div class="oe_import_has_multiple_sheets js_import_options flex-column mt-2">
+                <div class="oe_import_has_multiple_sheets flex-column mt-2">
                     <label for="oe_import_sheet">Sheet:</label>
                     <input class="oe_import_sheet oe_import_dropdown" id="oe_import_sheet"/>
                 </div>
@@ -274,11 +274,11 @@
                         The file will be imported by batches
                     </div>
                     <div class="d-flex">
-                        <div class="js_import_options oe_import_options oe_import_batch_limit w-50 pr-1">
+                        <div class="oe_import_options oe_import_batch_limit w-50 pr-1">
                             <label class="mb-1" for="oe_import_batch_limit">Batch limit</label>
                             <input class="w-100" id="oe_import_batch_limit" value="2000"/>
                         </div>
-                        <div class="js_import_options oe_import_options w-50 pl-1" title="Warning: ignores the labels line, empty lines and
+                        <div class="oe_import_options w-50 pl-1" title="Warning: ignores the labels line, empty lines and
 lines composed only of empty cells">
                             <label class="mb-1" for="oe_import_row_start">Start at line</label>
                             <input class="w-100" id="oe_import_row_start" value="1"/>
@@ -339,6 +339,9 @@ lines composed only of empty cells">
                 </div>
                 <a class="o_progress_stop_import ml-2" role="button"><i class="fa fa-close" aria-label="Stop Import"/></a>
             </div>
+        </div>
+        <div t-else="">
+            <span t-esc="task"/>...
         </div>
     </div>
 </templates>


### PR DESCRIPTION
This commit adds a progress bar that is displayed during the import (or import
test). The user can decide to stop the import. If it's the case, the current
batch is finalized and the import is interrupted. The user can continue
the import later starting from the import was interrupted.
The progress bar is only displayed if the import is done by batch.

If the user stops the import, them can resume the import from where them left
it. Indeed, the startign row is increased to the next line to be imported.
In test mode, the starting row remains untouched.

This commit also removes the alert-info box from batch import disclaimer, for
design beauty purpose.

Task ID: 2567591