### PR TITLE
[IMP] website: configurator move skip button in first screen

### DIFF
--- a/addons/website/static/src/components/configurator/configurator.xml
+++ b/addons/website/static/src/components/configurator/configurator.xml
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="website.Configurator.SkipButton" owl="1">
-        <div class="container-fluid py-2 pb-md-3 text-right pr-lg-5">
-            <button class="btn btn-link" t-on-click="skip()">Skip and start from scratch</button>
-        </div>
-    </t>
+<t t-name="website.Configurator.SkipButton" owl="1">
+    <button class="btn btn-link" t-on-click="skip()">Skip and start from scratch</button>
+</t>
 
-    <t t-name="website.Configurator.WelcomeScreen" owl="1">
-        <div class="o_configurator_screen h-100 d-flex flex-column o_welcome_screen">
-            <div class="container-fluid pt-3 pb-2">
-                <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
-            </div>
-            <div class="o_configurator_screen_content d-flex h-100">
-                <div class="container align-self-center o_configurator_show">
-                    <div class="display-4 mb-2">Ready to build the<br class="d-none d-lg-inline"/>
+<t t-name="website.Configurator.WelcomeScreen" owl="1">
+    <div class="o_configurator_screen h-100 d-flex flex-column o_welcome_screen">
+        <div class="container-fluid pt-3 pb-2">
+            <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
+        </div>
+        <div class="o_configurator_screen_content d-flex h-100">
+            <div class="container align-self-center o_configurator_show">
+                <div class="display-4 mb-2">
+                    Ready to build the<br class="d-none d-lg-inline"/>
                     <b>perfect website?</b>
                 </div>
-                <div class="lead font-weight-normal mb-4 text-600">We'll set you up and running in <b>4 steps</b>
+                <div class="lead font-weight-normal mb-4 text-600">
+                    We'll set you up and running in <b>4 steps</b>
                 </div>
-                <button class="o_configurator_show btn btn-primary btn-lg px-4 py-2" t-on-click="goToDescription()">Let's do it</button>
+                <div class="d-flex">
+                    <button class="o_configurator_show btn btn-primary btn-lg px-4 py-2" t-on-click="goToDescription()">Let's do it</button>
+                    <SkipButton/>
+                </div>
             </div>
         </div>
-        <SkipButton/>
     </div>
 </t>
 
@@ -83,7 +85,9 @@
                 </div>
             </div>
         </div>
-        <SkipButton/>
+        <div class="container-fluid py-2 pb-md-3 text-right pr-lg-5">
+            <SkipButton/>
+        </div>
     </div>
 </t>
 
@@ -143,7 +147,9 @@
                 </div>
             </div>
         </div>
-        <SkipButton/>
+        <div class="container-fluid py-2 pb-md-3 text-right pr-lg-5">
+            <SkipButton/>
+        </div>
     </div>
 </t>
 
@@ -179,7 +185,9 @@
                 </div>
             </div>
         </div>
-        <SkipButton/>
+        <div class="container-fluid py-2 pb-md-3 text-right pr-lg-5">
+            <SkipButton/>
+        </div>
     </div>
 </t>
 


### PR DESCRIPTION
The skip button of the configurator's first screen has been moved beside
the 'let's do it' button for more visibility.

task-2518565

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
