### PR TITLE
[13.0] Add UserError on update of task

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -71,9 +71,9 @@ class AccountAnalyticLine(models.Model):
         values = super(AccountAnalyticLine, self)._timesheet_preprocess(values)
         # task implies so line (at create)
         if 'task_id' in values and not values.get('so_line') and (values.get('employee_id') or self.mapped('employee_id')):
-            if not values.get('employee_id') and len(self.mapped('employee_id')) > 1:
-                raise UserError(_('You can not modify timesheets from different employees'))
             task = self.env['project.task'].sudo().browse(values['task_id'])
+            if task.billable_type == 'employee_rate' and not values.get('employee_id') and len(self.mapped('employee_id')) > 1:
+                raise UserError(_('You can not change task on timesheets from different employees if the task Billing Type is at Employee Rate'))
             employee = self.env['hr.employee'].sudo().browse(values['employee_id']) if values.get('employee_id') else self.mapped('employee_id')
             values['so_line'] = self._timesheet_determine_sale_line(task, employee).id
         return values


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is OCA module https://github.com/OCA/server-ux/tree/13.0/mass_editing, which allows update or remove the values of more than one records on the fly at the same time. It is highly used on different customer's projects to update tasks on timesheets from different employees.  At the moment in version 13 it is deprecated to modify timesheets from different employees for all types of tasks, although in version 14 there is no such constrain. 

Current behavior before PR:
Timesheets from different employees can't be modified at the same time for all types of tasks.

Desired behavior after PR is merged:
Timesheets from different employees can be modified if the task Billing Type is at Employee Rate.

This PR will also solve another one:
- [ ] https://github.com/odoo/odoo/pull/70296

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
