### PR TITLE
[ecommerce] categories filter attribute value

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -254,6 +254,22 @@
         </div>
     </template>
 
+    <template id="products_breadcrumb" name="Products Breadcrumb">
+        <ol t-if="category" t-attf-class="breadcrumb #{_classes}">
+            <li class="breadcrumb-item">
+                <a href="/shop">Products</a>
+            </li>
+            <t t-foreach="category.parents_and_self" t-as="cat">
+                <li t-if="cat == category" class="breadcrumb-item">
+                    <span class="d-inline-block" t-field="cat.name"/>
+                </li>
+                <li t-else="" class="breadcrumb-item">
+                    <a t-att-href="keep('/shop/category/%s' % slug(cat), category=0)" t-field="cat.name"/>
+                </li>
+            </t>
+        </ol>
+    </template>
+
     <!-- /shop product listing -->
     <template id="products" name="Products">
         <t t-call="website.layout">
@@ -267,6 +283,9 @@
                             <div class="products_attributes_filters"/>
                         </div>
                         <div id="products_grid" t-attf-class="col #{'o_wsale_layout_list' if layout_mode == 'list' else ''}">
+                            <t t-call="website_sale.products_breadcrumb">
+                                <t t-set="_classes" t-valuef="w-100"/>
+                            </t>
                             <div class="products_header form-inline flex-md-nowrap justify-content-end mb-4">
                                 <t t-call="website_sale.search">
                                     <t t-set="_classes" t-valuef="w-100 w-md-auto mr-auto mb-2"/>


### PR DESCRIPTION
PURPOSE;
Make sure that user can see the eCommerce category filter applied if any (even if the e-commerce category is not enabled on the shop page)

SPECIFICATION
If eCommerce Categories aren't enabled on the left, and there is one category selected visible in the URL, then the category should be on the top of the shop page, similar to what we have in the product view. https://drive.google.com/file/d/1GrniKkBwmvPKge7dH677aUdVoOYeqhoY/view  Mockup; https://tinyurl.com/yz98dcz6

Task-2488865
Closes https://github.com/odoo/odoo/pull/72149

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
