### PR TITLE
[FIX] mail: translate mail template based on recipient language

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -135,7 +135,7 @@ SELECT DISTINCT ON(pid, cid) * FROM (
     )
     SELECT partner.id as pid, NULL::int AS cid,
             partner.active as active, partner.partner_share as pshare, NULL as ctype,
-            users.notification_type AS notif, array_agg(groups.id) AS groups
+            users.notification_type AS notif, array_agg(groups.id) AS groups, partner.lang as lang
         FROM res_partner partner
         LEFT JOIN res_users users ON users.partner_id = partner.id AND users.active
         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
@@ -150,7 +150,7 @@ SELECT DISTINCT ON(pid, cid) * FROM (
     UNION
     SELECT NULL::int AS pid, channel.id AS cid,
             TRUE as active, NULL AS pshare, channel.channel_type AS ctype,
-            CASE WHEN channel.email_send = TRUE THEN 'email' ELSE 'inbox' END AS notif, NULL AS groups
+            CASE WHEN channel.email_send = TRUE THEN 'email' ELSE 'inbox' END AS notif, NULL AS groups, NULL as lang
         FROM mail_channel channel
         WHERE EXISTS (
             SELECT channel_id FROM sub_followers WHERE partner_id IS NULL AND sub_followers.channel_id = channel.id
@@ -171,7 +171,7 @@ ORDER BY pid, cid, notif
                 query_pid = """
 SELECT DISTINCT ON (partner.id) partner.id as pid, NULL::int AS cid,
     partner.active as active, partner.partner_share as pshare, NULL as ctype,
-    users.notification_type AS notif, NULL AS groups
+    users.notification_type AS notif, NULL AS groups, partner.lang as lang
 FROM res_partner partner
 LEFT JOIN res_users users ON users.partner_id = partner.id AND users.active
 WHERE partner.id IN %s
@@ -181,7 +181,7 @@ ORDER BY partner.id, users.notification_type"""
                 query_cid = """
 SELECT NULL::int AS pid, channel.id AS cid,
     TRUE as active, NULL AS pshare, channel.channel_type AS ctype,
-    CASE when channel.email_send = TRUE then 'email' else 'inbox' end AS notif, NULL AS groups
+    CASE when channel.email_send = TRUE then 'email' else 'inbox' end AS notif, NULL AS groups, NULL as lang
 FROM mail_channel channel WHERE channel.id IN %s """
                 params.append(tuple(cids))
             query = ' UNION'.join(x for x in [query_pid, query_cid] if x)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2234,24 +2234,7 @@ class MailThread(models.AbstractModel):
         if not partners_data:
             return True
 
-        model = msg_vals.get('model') if msg_vals else message.model
-        model_name = model_description or (self.with_lang().env['ir.model']._get(model).display_name if model else False) # one query for display name
-        recipients_groups_data = self._notify_classify_recipients(partners_data, model_name, msg_vals=msg_vals)
-
-        if not recipients_groups_data:
-            return True
         force_send = self.env.context.get('mail_notify_force_send', force_send)
-
-        template_values = self._notify_prepare_template_context(message, msg_vals, model_description=model_description) # 10 queries
-
-        email_layout_xmlid = msg_vals.get('email_layout_xmlid') if msg_vals else message.email_layout_xmlid
-        template_xmlid = email_layout_xmlid if email_layout_xmlid else 'mail.message_notification_email'
-        try:
-            base_template = self.env.ref(template_xmlid, raise_if_not_found=True).with_context(lang=template_values['lang']) # 1 query
-        except ValueError:
-            _logger.warning('QWeb template %s not found when sending notification emails. Sending without layouting.' % (template_xmlid))
-            base_template = False
-
         mail_subject = message.subject or (message.record_name and 'Re: %s' % message.record_name) # in cache, no queries
         # prepare notification mail values
         base_mail_values = {
@@ -2277,7 +2260,10 @@ class MailThread(models.AbstractModel):
         # loop on groups (customer, portal, user,  ... + model specific like group_sale_salesman)
         notif_create_values = []
         recipients_max = 50
-        for recipients_group_data in recipients_groups_data:
+        for result in self.get_template_generator(partners_data, msg_vals, message, model_description):            
+            if not result:
+                return False
+            (base_template, template_values, recipients_group_data) = result
             # generate notification email content
             recipients_ids = recipients_group_data.pop('recipients')
             render_values = {**template_values, **recipients_group_data}
@@ -2357,6 +2343,32 @@ class MailThread(models.AbstractModel):
 
         return True
 
+    def get_template_generator(self, partners_data, msg_vals, message, model_description):
+        model = msg_vals.get('model') if msg_vals else message.model
+        emails = self.env['mail.mail'].sudo()
+        email_layout_xmlid = msg_vals.get('email_layout_xmlid') if msg_vals else message.email_layout_xmlid
+        template_xmlid = email_layout_xmlid if email_layout_xmlid else 'mail.message_notification_email'
+        for (lang, partners_data_batch) in self.group_partners_data_by_lang(partners_data):
+            self = self.with_context(lang=lang)
+            model_name = model_description or (self.env['ir.model']._get(model).display_name if model else False) # one query for display name
+            recipients_groups_data = self._notify_classify_recipients(partners_data_batch, model_name, msg_vals=msg_vals)
+            if not recipients_groups_data:
+                return False
+            template_values = self._notify_prepare_template_context(message, msg_vals, model_description=model_description) # 10 queries
+            try:
+                base_template = self.env.ref(template_xmlid, raise_if_not_found=True).with_context(lang=lang) # 1 query
+            except ValueError:
+                _logger.warning('QWeb template %s not found when sending notification emails. Sending without layouting.' % (template_xmlid))
+                base_template = False
+            for group in recipients_groups_data:
+                yield (base_template, template_values, group)
+
+    def group_partners_data_by_lang(self, partners_data):
+        batches = {}
+        for data in partners_data:
+            batches.setdefault(data.get('lang') or self.env.lang, []).append(data)
+        return batches.items()
+
     @api.model
     def _notify_prepare_template_context(self, message, msg_vals, model_description=False, mail_auto_delete=True):
         # compute send user and its related signature
@@ -2366,7 +2378,6 @@ class MailThread(models.AbstractModel):
         model = msg_vals.get('model') if msg_vals else message.model
         add_sign = msg_vals.get('add_sign') if msg_vals else message.add_sign
         subtype_id = msg_vals.get('subtype_id') if msg_vals else message.subtype_id.id
-        message_id = message.id
         record_name = msg_vals.get('record_name') if msg_vals else message.record_name
         author_user = user if user.partner_id == author else author.user_ids[0] if author and author.user_ids else False
         # trying to use user (self.env.user) instead of browing user_ids if he is the author will give a sudo user,
@@ -2385,14 +2396,7 @@ class MailThread(models.AbstractModel):
         else:
             website_url = False
 
-        # Retrieve the language in which the template was rendered, in order to render the custom
-        # layout in the same language.
         lang = self.env.context.get('lang')
-        if {'default_template_id', 'default_model', 'default_res_id'} <= self.env.context.keys():
-            template = self.env['mail.template'].browse(self.env.context['default_template_id'])
-            if template and template.lang:
-                lang = template._render_template(template.lang, self.env.context['default_model'], self.env.context['default_res_id'])
-
         if not model_description and model:
             model_description = self.env['ir.model'].with_context(lang=lang)._get(model).display_name
 
@@ -2418,7 +2422,6 @@ class MailThread(models.AbstractModel):
             'tracking_values': tracking,
             'is_discussion': is_discussion,
             'subtype': message.subtype_id,
-            'lang': lang,
         }
 
     def _notify_by_email_add_values(self, base_mail_values):
@@ -2453,13 +2456,13 @@ class MailThread(models.AbstractModel):
             return recipient_data
 
         author_id = msg_vals.get('author_id') or message.author_id.id
-        for pid, cid, active, pshare, ctype, notif, groups in res:
+        for pid, cid, active, pshare, ctype, notif, groups, lang in res:
             if pid and pid == author_id and not self.env.context.get('mail_notify_author'):  # do not notify the author of its own messages
                 continue
             if pid:
                 if active is False:
                     continue
-                pdata = {'id': pid, 'active': active, 'share': pshare, 'groups': groups}
+                pdata = {'id': pid, 'active': active, 'share': pshare, 'groups': groups, 'lang': lang}
                 if notif == 'inbox':
                     recipient_data['partners'].append(dict(pdata, notif=notif, type='user'))
                 elif not pshare and notif:  # has an user and is not shared, is therefore user

--- a/addons/mail/wizard/invite.py
+++ b/addons/mail/wizard/invite.py
@@ -73,8 +73,8 @@ class Invite(models.TransientModel):
                 })
                 partners_data = []
                 recipient_data = self.env['mail.followers']._get_recipient_data(document, 'comment', False, pids=new_partners.ids)
-                for pid, cid, active, pshare, ctype, notif, groups in recipient_data:
-                    pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or []}
+                for pid, cid, active, pshare, ctype, notif, groups, lang in recipient_data:
+                    pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or [], 'lang': lang }
                     if not pshare and notif:  # has an user and is not shared, is therefore user
                         partners_data.append(dict(pdata, type='user'))
                     elif pshare and notif:  # has an user and is shared, is therefore portal

--- a/addons/mail/wizard/mail_resend_message.py
+++ b/addons/mail/wizard/mail_resend_message.py
@@ -63,9 +63,9 @@ class MailResendMessage(models.TransientModel):
                 record = self.env[message.model].browse(message.res_id) if message.is_thread_message() else self.env['mail.thread']
 
                 email_partners_data = []
-                for pid, cid, active, pshare, ctype, notif, groups in self.env['mail.followers']._get_recipient_data(None, 'comment', False, pids=to_send.ids):
+                for pid, cid, active, pshare, ctype, notif, groups, lang in self.env['mail.followers']._get_recipient_data(None, 'comment', False, pids=to_send.ids):
                     if pid and notif == 'email' or not notif:
-                        pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or []}
+                        pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or [], 'lang': lang}
                         if not pshare and notif:  # has an user and is not shared, is therefore user
                             email_partners_data.append(dict(pdata, type='user'))
                         elif pshare and notif:  # has an user and is shared, is therefore portal

--- a/addons/sms/models/mail_followers.py
+++ b/addons/sms/models/mail_followers.py
@@ -15,10 +15,10 @@ class Followers(models.Model):
                 sms_pids = pids
             res = super(Followers, self)._get_recipient_data(records, message_type, subtype_id, pids=pids, cids=cids)
             new_res = []
-            for pid, cid, pactive, pshare, ctype, notif, groups in res:
+            for pid, cid, pactive, pshare, ctype, notif, groups, lang in res:
                 if pid and pid in sms_pids:
                     notif = 'sms'
-                new_res.append((pid, cid, pactive, pshare, ctype, notif, groups))
+                new_res.append((pid, cid, pactive, pshare, ctype, notif, groups, lang))
             return new_res
         else:
             return super(Followers, self)._get_recipient_data(records, message_type, subtype_id, pids=pids, cids=cids)

--- a/addons/sms/wizard/sms_resend.py
+++ b/addons/sms/wizard/sms_resend.py
@@ -84,9 +84,9 @@ class SMSResend(models.TransientModel):
             numbers = [r.sms_number for r in self.recipient_ids if r.resend and not r.partner_id]
 
             rdata = []
-            for pid, cid, active, pshare, ctype, notif, groups in self.env['mail.followers']._get_recipient_data(record, 'sms', False, pids=pids):
+            for pid, cid, active, pshare, ctype, notif, groups, lang in self.env['mail.followers']._get_recipient_data(record, 'sms', False, pids=pids):
                 if pid and notif == 'sms':
-                    rdata.append({'id': pid, 'share': pshare, 'active': active, 'notif': notif, 'groups': groups or [], 'type': 'customer' if pshare else 'user'})
+                    rdata.append({'id': pid, 'share': pshare, 'active': active, 'notif': notif, 'groups': groups or [], 'type': 'customer' if pshare else 'user', 'lang': lang})
             if rdata or numbers:
                 record._notify_record_by_sms(
                     self.mail_message_id, {'partners': rdata}, check_existing=True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The buttons, the access links and the signature of the email are not properly translated in the language of the recipients.

Current behavior before PR:
These components are translated in the language of the user who wrote the email (i.e: in the language of the context). 

Desired behavior after PR is merged:
These components will be translated in the language of each recipient.

Task id: 2555155

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
