### PR TITLE
[IMP] mail: error handling for related field dependencies

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -954,6 +954,9 @@ class ModelManager {
                     let dependencyField = TargetModel.fields[dependencyFieldName];
                     while (!dependencyField) {
                         TargetModel = TargetModel.__proto__;
+                        if (!TargetModel.fields) {
+                            throw Error(`Field ${dependencyFieldName} used in the computation of field ${field.fieldName} is missing from the ${Model.modelName} model`);
+                        }
                         dependencyField = TargetModel.fields[dependencyFieldName];
                     }
                     const dependent = [field.id, field.fieldName].join(DEPENDENT_INNER_SEPARATOR);


### PR DESCRIPTION
PURPOSE

When targeting a field as dependency and that dependency is undefined or doesn't
exist, the javascript ORM crash with a TargetModel.fields is an undefined error.

SPECIFICATIONS

It should show a proper error message with field, dependency, and model.

LINKS

Task- 2431526

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
