### PR TITLE
[FIX] base_vat: properly checks NL VAT numbers

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -376,7 +376,11 @@ class ResPartner(models.Model):
 
         vat = clean(vat, ' -.').upper().strip()
 
-        if not (len(vat) == 14):
+        # Remove the prefix
+        if vat.startswith("NL"):
+            vat = vat[2:]
+
+        if not len(vat) == 12:
             return False
 
         # Check the format
@@ -388,9 +392,6 @@ class ResPartner(models.Model):
         char_to_int = {k: str(ord(k) - 55) for k in string.ascii_uppercase}
         char_to_int['+'] = '36'
         char_to_int['*'] = '37'
-
-        # Remove the prefix
-        vat = vat[2:]
 
         # 2 possible checks:
         # - For natural persons


### PR DESCRIPTION
In 12.0+ when adding an NL VAT number on a contact without specifying the country as Netherlands, an error shows the VAT number as not valid. This is because the method to check specifically NL VAT numbers requires the complete VAT number with country code, when the country code isn't always provided.

With this commit, we allow the check_vat_nl method to take the NL VAT number as argument, with or without the country code.

opw-2536261