### PR TITLE
[IMP] [website_]event: improve menu item layout

### DIFF
--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -39,12 +39,12 @@
             <t t-else="">
                 <nav class="navbar navbar-light border-top shadow-sm navbar-expand-md">
                     <div class="container align-items-baseline">
-                        <a t-att-href="event.website_url" t-field="event.name" class="navbar-brand h4 my-0 mr-0 mr-md-4"/>
+                        <a t-att-href="event.website_url" t-field="event.name" class="navbar-brand h4 my-0 mr-0"/>
                         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#o_wevent_event_submenu" aria-controls="o_wevent_event_submenu" aria-expanded="false" aria-label="Toggle navigation">
                             <span class="navbar-toggler-icon"></span>
                         </button>
                         <div id="o_wevent_event_submenu" class="collapse navbar-collapse">
-                            <ul class="navbar-nav w-100" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
+                            <ul class="navbar-nav w-100 d-flex flex-row flex-wrap" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
                                 <t t-foreach="event.menu_id.child_id" t-as="submenu">
                                     <t t-call="website.submenu">
                                         <t t-set="item_class" t-value="'nav-item'"/>


### PR DESCRIPTION
Remove padding from event name, and center menu items, purpose is to reduce lost
space

Make menu items wrap and move to the bottom to avoid having them overlap with
the register button.

Shorten the name of the "OpenWood Collection Online Reveal" event to
"OpenWood Collection Reveal", because otherwise it would usually take two lines
and would not look good.

Task-2524708

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
