### PR TITLE
[14.0][FIX] delivery: Allow to customize get_price_from_picking

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -93,10 +93,13 @@ class ProviderGrid(models.Model):
 
         return self._get_price_from_picking(total, weight, volume, quantity)
 
+    def _get_price_from_picking_dict(self, total, weight, volume, quantity):
+        return {'price': total, 'volume': volume, 'weight': weight, 'wv': volume * weight, 'quantity': quantity}
+
     def _get_price_from_picking(self, total, weight, volume, quantity):
         price = 0.0
         criteria_found = False
-        price_dict = {'price': total, 'volume': volume, 'weight': weight, 'wv': volume * weight, 'quantity': quantity}
+        price_dict = self._get_price_from_picking_dict(total, weight, volume, quantity)
         if self.free_over and total >= self.amount:
             return 0
         for line in self.price_rule_ids:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Allow to customize values used to compute price from picking.
Code proposed do exactly the same thing than before: it's just refactoring.

**Current behavior before PR:**

Impossible to customize easily computing of delivery price.

**Desired behavior after PR is merged:**

Possible to customize computing of delivery price.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
