### PR TITLE
[FIX] translation: Change save french translation

### DIFF
--- a/addons/base_setup/i18n/fr.po
+++ b/addons/base_setup/i18n/fr.po
@@ -131,7 +131,7 @@ msgid ""
 "<strong>Save</strong> this page and come back here to choose your Geo "
 "Provider."
 msgstr ""
-"<strong>Sauver</strong> cette page et revenez ici pour choisir votre "
+"<strong>Sauvegarder</strong> cette page et revenez ici pour choisir votre "
 "Fournisseur Geo."
 
 #. module: base_setup

--- a/addons/mass_mailing/i18n/fr.po
+++ b/addons/mass_mailing/i18n/fr.po
@@ -2257,7 +2257,7 @@ msgstr "Assistant d'emails d'exemple"
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.snippet_options
 msgid "Save the block to use it elsewhere"
-msgstr "Sauver l'élément pour l'utiliser ailleurs"
+msgstr "Sauvegarder l'élément pour l'utiliser ailleurs"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mailing_mailing_schedule_date_view_form

--- a/addons/mrp/i18n/fr.po
+++ b/addons/mrp/i18n/fr.po
@@ -4267,7 +4267,7 @@ msgid ""
 msgstr ""
 "La date de fin planifiée de l'ordre de travail ne peut pas être antérieure à"
 " la date de début planifiée. Veuillez s'il vous plait corriger les dates "
-"afin de pouvoir sauver l'ordre de travail."
+"afin de pouvoir sauvegarder l'ordre de travail."
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_production.py:0

--- a/addons/web/i18n/fr.po
+++ b/addons/web/i18n/fr.po
@@ -4735,7 +4735,7 @@ msgid ""
 "You need to save this new record before editing the translation. Do you want"
 " to proceed?"
 msgstr ""
-"Vous devez sauver ce nouvel enregistrement avant de modifier la traduction. "
+"Vous devez sauvegarder ce nouvel enregistrement avant de modifier la traduction. "
 "Voulez-vous poursuivre?"
 
 #. module: web

--- a/addons/web_editor/i18n/fr.po
+++ b/addons/web_editor/i18n/fr.po
@@ -1785,28 +1785,28 @@ msgstr "Saturation"
 #: model_terms:ir.ui.view,arch_db:web_editor.snippets
 #, python-format
 msgid "Save"
-msgstr "Sauver"
+msgstr "Sauvegarder"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/snippets.options.js:0
 #, python-format
 msgid "Save Your Block"
-msgstr "Sauver votre élément"
+msgstr "Sauvegarder votre élément"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/snippets.editor.js:0
 #, python-format
 msgid "Save and Install"
-msgstr "Sauver et Installer"
+msgstr "Sauvegarder et Installer"
 
 #. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/snippets.options.js:0
 #, python-format
 msgid "Save and Reload"
-msgstr "Sauver et recharger"
+msgstr "Sauvegarder et recharger"
 
 #. module: web_editor
 #. openerp-web
@@ -2072,7 +2072,7 @@ msgid ""
 "This change needs to reload the page, this will save all your changes and "
 "reload the page, are you sure you want to proceed?"
 msgstr ""
-"Ce changement implique de recharger la page, cela va sauver tous vos "
+"Ce changement implique de recharger la page, cela va sauvegarder tous vos "
 "changements et recharger la page, êtes-vous sûr de vouloir faire cela?"
 
 #. module: web_editor
@@ -2148,7 +2148,7 @@ msgid ""
 "To save a snippet, we need to save all your previous modifications and "
 "reload the page."
 msgstr ""
-"Pour sauver votre élément, nous devons sauver tous vos changements "
+"Pour sauvegarder votre élément, nous devons sauvegarder tous vos changements "
 "précédents et recharger la page."
 
 #. module: web_editor

--- a/addons/website/i18n/fr.po
+++ b/addons/website/i18n/fr.po
@@ -2040,7 +2040,7 @@ msgid ""
 "changes, are you sure you want to proceed? Be careful that changing the "
 "theme will reset all your color customizations."
 msgstr ""
-"Changer de thème nécessite de quitter l'éditeur. Cela sauvera tous vos "
+"Changer de thème nécessite de quitter l'éditeur. Cela sauvegardera tous vos "
 "changements, êtes vous sûr de vouloir continuer? Notez que changer de thème "
 "remettra à zero vos customisations de couleurs."
 
@@ -2170,7 +2170,7 @@ msgstr "Cliquez sur l'icône pour l'adapter <br/>à vos besoins"
 #: code:addons/website/static/src/js/tours/homepage.js:0
 #, python-format
 msgid "Click the <b>Save</b> button."
-msgstr "Cliquez sur <b>Sauver</b> ."
+msgstr "Cliquez sur <b>Suavegarder</b> ."
 
 #. module: website
 #. openerp-web
@@ -2845,7 +2845,7 @@ msgid ""
 "Deleting a font requires a reload of the page. This will save all your "
 "changes and reload the page, are you sure you want to proceed?"
 msgstr ""
-"Supprimer une police nécessite de recharger la page. Ceci sauvera tous vos "
+"Supprimer une police nécessite de recharger la page. Ceci sauvegardera tous vos "
 "changements et rechargera la page, êtes vous sûr de vouloir continuer?"
 
 #. module: website
@@ -3866,7 +3866,7 @@ msgstr ""
 #: code:addons/website/static/src/js/tours/tour_utils.js:0
 #, python-format
 msgid "Good job! It's time to <b>Save</b> your work."
-msgstr "Bon travail! Il est temps de <b>Sauver</b>votre travail."
+msgstr "Bon travail! Il est temps de <b>Sauvegarder</b>votre travail."
 
 #. module: website
 #: model:ir.model.fields,field_description:website.field_res_config_settings__has_google_analytics
@@ -6486,26 +6486,26 @@ msgstr "Satellite"
 #: model_terms:ir.ui.view,arch_db:website.view_edit_robots
 #, python-format
 msgid "Save"
-msgstr "Sauver"
+msgstr "Sauvegarder"
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/editor/snippets.options.js:0
 #, python-format
 msgid "Save & Reload"
-msgstr "Sauver et recharger"
+msgstr "Sauvegarder et recharger"
 
 #. module: website
 #. openerp-web
 #: code:addons/website/static/src/js/editor/snippets.options.js:0
 #, python-format
 msgid "Save & copy"
-msgstr "Sauver et copier"
+msgstr "Sauvegarder et copier"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.snippet_options
 msgid "Save the block to use it elsewhere"
-msgstr "Sauver l'élément pour l'utiliser ailleurs"
+msgstr "Sauvegarder l'élément pour l'utiliser ailleurs"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_rating_options

--- a/addons/website_event/i18n/fr.po
+++ b/addons/website_event/i18n/fr.po
@@ -781,7 +781,7 @@ msgstr ""
 #: code:addons/website_event/static/src/js/tours/website_event.js:0
 #, python-format
 msgid "Once you click on save, your event is updated."
-msgstr "Lorsque vous cliquez sur \"Sauver\", votre événement est mis à jour."
+msgstr "Lorsque vous cliquez sur \"Sauvegarder\", votre événement est mis à jour."
 
 #. module: website_event
 #: model_terms:ir.ui.view,arch_db:website_event.event_description_full

--- a/doc/cla/individual/rpradal.md
+++ b/doc/cla/individual/rpradal.md
@@ -1,0 +1,11 @@
+France, 2021-06-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rémi Pradal remi.pradal@gmail.com https://github.com/rpradal

--- a/doc/cla/individual/rpradal.md
+++ b/doc/cla/individual/rpradal.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Rémi Pradal remi.pradal@gmail.com https://github.com/rpradal
+Rémi Pradal remi.p@foodles.co https://github.com/rpradal


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Translating "save" to "sauver" in french language is a semantic misunderstanding. In this particular context, we should use "sauvegarder"

**Current behavior before PR:**

"Save" is translated to "sauver" in french

**Desired behavior after PR is merged:**

"Save" is translated to "sauvegarder" in french


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
