### PR TITLE
[FIX] point_of_sale: Add possibility to execute odoo in IoT with alias

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/odoo
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DAEMON=/home/pi/odoo/odoo-bin
+CONFIG=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+MODULES=$(ls /home/pi/odoo/addons/ -m -w0 | tr -d ' ')
+
+$DAEMON --load=$MODULES --config $CONFIG --log-level info

--- a/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo.conf
@@ -1,7 +1,6 @@
 [options]
 data_dir = /var/run/odoo
 log_level = error
-logfile = /var/log/odoo/odoo-server.log
 pidfile = /var/run/odoo/odoo.pid
 limit_time_cpu = 600
 limit_time_real = 1200

--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -165,6 +165,9 @@ create_ramdisk_dir () {
     mkdir -v "${1}_ram"
 }
 
+#alias iot_server can take log level in parameter. By default loglevel is error
+echo 'alias iot_server=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo' >> /home/pi/.bashrc
+
 create_ramdisk_dir "/var"
 create_ramdisk_dir "/etc"
 create_ramdisk_dir "/tmp"


### PR DESCRIPTION
Add a alias in the IoT to easily debug with same parameters as the service

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
