### PR TITLE
support many2many_avatar in kanban and list view

### DIFF
--- a/addons/hr/static/src/js/m2x_avatar_employee.js
+++ b/addons/hr/static/src/js/m2x_avatar_employee.js
@@ -2,8 +2,9 @@
 
 import fieldRegistry from 'web.field_registry';
 
-import { Many2OneAvatarUser, KanbanMany2OneAvatarUser } from '@mail/js/m2x_avatar_user';
+import { Many2OneAvatarUser, KanbanMany2OneAvatarUser, KanbanMany2ManyAvatarUser, ListMany2ManyAvatarUser } from '@mail/js/m2x_avatar_user';
 import { Many2ManyAvatarUser } from '@mail/js/m2x_avatar_user';
+import { KanbanMany2ManyTagsAvatar, ListMany2ManyTagsAvatar } from 'web.relational_fields';
 
 
 // This module defines variants of the Many2OneAvatarUser and Many2ManyAvatarUser
@@ -44,13 +45,25 @@ export const KanbanMany2OneAvatarEmployee = KanbanMany2OneAvatarUser.extend(M2XA
 fieldRegistry.add('many2one_avatar_employee', Many2OneAvatarEmployee);
 fieldRegistry.add('kanban.many2one_avatar_employee', KanbanMany2OneAvatarEmployee);
 
-export const Many2ManyAvatarEmployee = Many2ManyAvatarUser.extend(M2XAvatarEmployeeMixin, {
+const M2MAvatarEmployeeMixin = Object.assign(M2XAvatarEmployeeMixin, {
+    //----------------------------------------------------------------------
+    // Private
+    //----------------------------------------------------------------------
+
     _getEmployeeID(ev) {
         return parseInt(ev.target.getAttribute('data-id'), 10);
     },
 });
 
+export const Many2ManyAvatarEmployee = Many2ManyAvatarUser.extend(M2MAvatarEmployeeMixin, {});
+
+export const KanbanMany2ManyAvatarEmployee = KanbanMany2ManyAvatarUser.extend(M2MAvatarEmployeeMixin, {});
+
+export const ListMany2ManyAvatarEmployee = ListMany2ManyAvatarUser.extend(M2MAvatarEmployeeMixin, {});
+
 fieldRegistry.add('many2many_avatar_employee', Many2ManyAvatarEmployee);
+fieldRegistry.add('kanban.many2many_avatar_employee', KanbanMany2ManyAvatarEmployee);
+fieldRegistry.add('list.many2many_avatar_employee', ListMany2ManyAvatarEmployee);
 
 export default {
     Many2OneAvatarEmployee,

--- a/addons/mail/static/src/js/m2x_avatar_user.js
+++ b/addons/mail/static/src/js/m2x_avatar_user.js
@@ -2,7 +2,7 @@
 
 import fieldRegistry from 'web.field_registry';
 import { Many2OneAvatar } from 'web.relational_fields';
-import { FieldMany2ManyTagsAvatar } from 'web.relational_fields';
+import { FieldMany2ManyTagsAvatar, KanbanMany2ManyTagsAvatar, ListMany2ManyTagsAvatar } from 'web.relational_fields';
 
 const { Component } = owl;
 
@@ -75,7 +75,7 @@ export const KanbanMany2OneAvatarUser = Many2OneAvatarUser.extend({
     _template: 'mail.KanbanMany2OneAvatarUser',
 });
 
-export const Many2ManyAvatarUser = FieldMany2ManyTagsAvatar.extend(M2XAvatarMixin, {
+const M2MAvatarMixin = Object.assign(M2XAvatarMixin, {
     events: Object.assign({}, FieldMany2ManyTagsAvatar.prototype.events, {
         'click .o_m2m_avatar': '_onAvatarClicked',
     }),
@@ -95,7 +95,15 @@ export const Many2ManyAvatarUser = FieldMany2ManyTagsAvatar.extend(M2XAvatarMixi
     },
 });
 
+export const Many2ManyAvatarUser = FieldMany2ManyTagsAvatar.extend(M2MAvatarMixin, {});
+
+export const KanbanMany2ManyAvatarUser = KanbanMany2ManyTagsAvatar.extend(M2MAvatarMixin, {});
+
+export const ListMany2ManyAvatarUser = ListMany2ManyTagsAvatar.extend(M2MAvatarMixin, {});
+
 fieldRegistry.add('many2one_avatar_user', Many2OneAvatarUser);
 fieldRegistry.add('kanban.many2one_avatar_user', KanbanMany2OneAvatarUser);
 fieldRegistry.add('activity.many2one_avatar_user', KanbanMany2OneAvatarUser);
 fieldRegistry.add('many2many_avatar_user', Many2ManyAvatarUser);
+fieldRegistry.add('kanban.many2many_avatar_user', KanbanMany2ManyAvatarUser);
+fieldRegistry.add('list.many2many_avatar_user', ListMany2ManyAvatarUser);

--- a/addons/web/static/src/legacy/js/fields/field_registry.js
+++ b/addons/web/static/src/legacy/js/fields/field_registry.js
@@ -87,6 +87,8 @@ registry
     .add('many2many_binary', relational_fields.FieldMany2ManyBinaryMultiFiles)
     .add('many2many_tags', relational_fields.FieldMany2ManyTags)
     .add('many2many_tags_avatar', relational_fields.FieldMany2ManyTagsAvatar)
+    .add('kanban.many2many_tags_avatar', relational_fields.KanbanMany2ManyTagsAvatar)
+    .add('list.many2many_tags_avatar', relational_fields.ListMany2ManyTagsAvatar)
     .add('form.many2many_tags', relational_fields.FormFieldMany2ManyTags)
     .add('kanban.many2many_tags', relational_fields.KanbanFieldMany2ManyTags)
     .add('many2many_checkboxes', relational_fields.FieldMany2ManyCheckBoxes)

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -2772,6 +2772,72 @@ var FieldMany2ManyTagsAvatar = FieldMany2ManyTags.extend({
     },
 });
 
+
+// Remove event handlers on this widget to ensure that the kanban 'global
+// click' opens the clicked record
+const { click, ...M2MAvatarMixinEvents } = AbstractField.prototype.events;
+const M2MAvatarMixin = {
+    visibleAvatarCount: 3, // number of visible avatar
+    events: M2MAvatarMixinEvents,
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Open tooltip on empty avatar clicked
+     *
+     * @private
+     */
+    _bindPopover(ev) {
+        this.$('.o_m2m_avatar_empty').popover({
+            container: this.$el,
+            trigger: 'hover',
+            html: true,
+            placement: 'auto',
+            content: () => {
+                const elements = this.value ? _.pluck(this.value.data, 'data') : [];
+                return qweb.render('Many2ManyTagAvatarPopover', {
+                    elements: elements.slice(this.visibleAvatarCount - 1),
+                });
+            },
+        });
+    },
+    /**
+     * @override
+     */
+    _getRenderTagsContext() {
+        const result = this._super(...arguments);
+        result['widget'] = this;
+        return result;
+    },
+    /**
+     * @override
+     */
+    _renderReadonly() {
+        this.$el.addClass('o_field_many2manytags_multi');
+        return this._super(...arguments);
+    },
+    /**
+     * Override to bind popover
+     *
+     * @override
+     */
+    _renderTags() {
+        this._super(...arguments);
+        this._bindPopover();
+    },
+}
+
+const KanbanMany2ManyTagsAvatar = FieldMany2ManyTagsAvatar.extend(M2MAvatarMixin, {
+    tag_template: 'KanbanMany2ManyTagAvatar',
+});
+
+const ListMany2ManyTagsAvatar = FieldMany2ManyTagsAvatar.extend(M2MAvatarMixin, {
+    tag_template: 'ListMany2ManyTagAvatar',
+    visibleAvatarCount: 5,
+});
+
 var FormFieldMany2ManyTags = FieldMany2ManyTags.extend({
     events: _.extend({}, FieldMany2ManyTags.prototype.events, {
         'click .dropdown-toggle': '_onOpenColorPicker',
@@ -3697,6 +3763,8 @@ return {
     FieldMany2ManyCheckBoxes: FieldMany2ManyCheckBoxes,
     FieldMany2ManyTags: FieldMany2ManyTags,
     FieldMany2ManyTagsAvatar: FieldMany2ManyTagsAvatar,
+    KanbanMany2ManyTagsAvatar: KanbanMany2ManyTagsAvatar,
+    ListMany2ManyTagsAvatar: ListMany2ManyTagsAvatar,
     FormFieldMany2ManyTags: FormFieldMany2ManyTags,
     KanbanFieldMany2ManyTags: KanbanFieldMany2ManyTags,
 

--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -296,6 +296,27 @@
                 }
             }
         }
+        &.o_field_many2manytags_multi {
+            margin-bottom: 0px;
+            > span {
+                display: inline-block;
+                margin-right: 2px;
+            }
+            .o_m2m_avatar, .o_m2m_avatar_empty {
+                width: 20px;
+                height: 20px;
+                margin-left: 0px;
+            }
+            .o_m2m_avatar_empty {
+                background-color: #dee2e6;
+                vertical-align: bottom;
+            }
+            &.avatar.o_clickable_m2x_avatar {
+                img.o_m2m_avatar {
+                    margin-right: 0px;
+                }
+            }
+        }
     }
 
     // Stars

--- a/addons/web/static/src/legacy/scss/kanban_view.scss
+++ b/addons/web/static/src/legacy/scss/kanban_view.scss
@@ -267,6 +267,14 @@
             line-height: 1.2;
             word-break: break-all;
 
+            &.avatar {
+                margin: 0 6px;
+                .o_m2m_avatar_empty > span {
+                    display: block;
+                    margin-top: 3px;
+                }
+            }
+
             .o_tag {
                 display: inline-block;
                 margin-right: 4px;

--- a/addons/web/static/src/legacy/scss/list_view.scss
+++ b/addons/web/static/src/legacy/scss/list_view.scss
@@ -244,6 +244,13 @@
                     pointer-events: auto;
                 }
             }
+            &.o_many2many_avatar_user_cell {
+                .o_field_many2manytags {
+                    > span {
+                        margin-right: 2px;
+                    }
+                }
+            }
         }
 
         .o_data_row:not(.o_selected_row) {

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1336,6 +1336,48 @@
         <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
     </t>
 </t>
+<t t-name="KanbanMany2ManyTagAvatar">
+    <t t-set="visibleElements" t-value="elements.length === widget.visibleAvatarCount ? elements : elements.slice(0, widget.visibleAvatarCount - 1)"/>
+    <t t-foreach="visibleElements" t-as="el">
+        <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-title="el.display_name" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
+    </t>
+    <t t-if="elements.length > widget.visibleAvatarCount">
+        <span class="o_m2m_avatar_empty rounded-circle text-center font-weight-bold">
+            <span t-if="elements.length - widget.visibleAvatarCount + 1 > 9">9+</span>
+            <span t-else="">+<t t-esc="elements.length - widget.visibleAvatarCount + 1"/></span>
+        </span>
+    </t>
+</t>
+<t t-name="ListMany2ManyTagAvatar">
+    <t t-if="widget.mode !== 'readonly'">
+        <t t-call="FieldMany2ManyTagAvatar"/>
+    </t>
+    <t t-else="">
+        <t t-if="elements.length === 1">
+            <div>
+                <img t-attf-src="/web/image/#{avatarModel}/#{elements[0].id}/#{avatarField}" t-att-data-id="elements[0].id" class="rounded-circle o_m2m_avatar"/>
+                <span t-esc="elements[0].display_name"/>
+            </div>
+        </t>
+        <t t-else="">
+            <t t-set="visibleElements" t-value="elements.length === widget.visibleAvatarCount ? elements : elements.slice(0, widget.visibleAvatarCount - 1)"/>
+            <t t-foreach="visibleElements" t-as="el">
+                <span><img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" t-att-title="el.display_name" t-att-data-id="el.id" class="rounded-circle o_m2m_avatar"/></span>
+            </t>
+            <t t-if="elements.length > widget.visibleAvatarCount">
+                <span class="o_m2m_avatar_empty rounded-circle text-center font-weight-bold">
+                    <span t-if="elements.length - widget.visibleAvatarCount + 1 > 9">9+</span>
+                    <span t-else="">+<t t-esc="elements.length - widget.visibleAvatarCount + 1"/></span>
+                </span>
+            </t>
+        </t>
+    </t>
+</t>
+<t t-name="Many2ManyTagAvatarPopover">
+    <t t-foreach="elements" t-as="el">
+        <div><t t-esc="el.display_name"/></div>
+    </t>
+</t>
 <t t-name="FieldMany2ManyTag.colorpicker">
     <div class="o_colorpicker dropdown-menu tagcolor_dropdown_menu" role="menu">
         <ul>


### PR DESCRIPTION
Purpose
The aim of the current task is to adapt the design of this new widget to the
list and kanban views.

SPECIFICATION

Kanban
when there is only one record set in the m2m field, display it like a
many2one_avatar widget when there are two or three records set in the m2m
field, display the avatars next to each other when there are more than three
records set in the m2m field, display the first two avatars, then a grey circle
with +X in it (where X is the number of records beyond the first two), when
hovering the +X avatar, open a tooltip with the list of the remaining records
the display order of the records is the same as the order in the m2m field
the avatars behave like in the other avatar widgets (i.e. darkens on hover and
clicking on it opens the chat) except the +X avatar that does not darken or has
a cursor:pointer; on hover and is not clickable

List
same specs as for the kanban view, with the difference that the widget displays
up to five records instead of three when the widget is editable display it like
the current formview version of the many2many_avatar_user widget (i.e. tags
with avatars)

task-2563591


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
