### PR TITLE
[IMP] ir_qweb_fields: Don't return empty addresses

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -718,10 +718,16 @@ class Contact(models.AbstractModel):
 
         value = value.sudo().with_context(show_address=True)
         name_get = value.name_get()[0][1]
-
+        # Avoid having something like:
+        # name_get = 'Foo\n  \n' -> This is a res.partner with a name and no address
+        # That would return markup('<br/>') as address. But there is no address set.
+        if any(elem.strip() for elem in name_get.split("\n")[1:]):
+            address = opsep.join(name_get.split("\n")[1:]).strip()
+        else:
+            address = ''
         val = {
             'name': name_get.split("\n")[0],
-            'address': opsep.join(name_get.split("\n")[1:]).strip(),
+            'address': address,
             'phone': value.phone,
             'mobile': value.mobile,
             'city': value.city,


### PR DESCRIPTION
Purpose
=======

If the contact widget is used on a template, the 'fa-map-marker' icon
will be displayed, even if the address is empty.

This is most probably coming from this commmit: https://github.com/odoo/odoo/commit/62d73253f355fc857cfc6ca11bd5259957a94474#diff-c4cf79d0ff0cb8f7ca865fdfac774ce8fd95c800471a0932d126acb6fd8e7c27R613-R614

If the address is only composed of empty strings separated by \n, return an empty string.

TaskID: 2572149

