### PR TITLE
[FIX] website: allow text editing of blog posts

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -135,7 +135,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         const $target = this._targetForEdition();
         const $skeleton = $target.find('.oe_structure.oe_empty, [data-oe-type="html"]');
         this.$editorMessageElements = $skeleton.not('[data-editor-message]').attr('data-editor-message', _t('DRAG BUILDING BLOCKS HERE'));
-        $skeleton.attr('contentEditable', !$skeleton.is(':empty'));
+        $skeleton.attr('contenteditable', function () { return !$(this).is(':empty'); });
     },
     /**
      * Returns the target for edition.


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/odoo/odoo/pull/67357/commits/f17506676e9d2a605391a3466440a195afa5da63
which prevented editing of text in blog posts

opw-2572176
opw-2572151
opw-2571217

