### PR TITLE
[FIX] website_sale: Make coupons in the cart deletable again

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -992,7 +992,7 @@
                             </t>
                         </td>
                         <td class="text-center td-qty">
-                            <div class="css_quantity input-group mx-auto">
+                            <div class="css_quantity input-group mx-auto justify-content-center">
                                 <t t-if="not line._is_not_sellable_line()">
                                     <t t-if="show_qty">
                                         <div class="input-group-prepend">
@@ -1013,6 +1013,7 @@
                                 </t>
                                 <t t-else="">
                                     <span class="text-muted w-100" t-esc="int(line.product_uom_qty)"/>
+                                    <input type="hidden" class="js_quantity form-control quantity" t-att-data-line-id="line.id" t-att-data-product-id="line.product_id.id" t-att-value="line.product_uom_qty" />
                                 </t>
                             </div>
                         </td>


### PR DESCRIPTION
The `onClickDeleteProduct` handler in the cart widget triggers a value change in the input field containing the quantity of the sale order line. This only works if there is such an input field, which is only the case for sellable lines, and, as a consequence, not for reward lines. Simply restoring the input field (even if it stays hidden) resolves the problem.