### PR TITLE
[FW][Master] Allow overwrite bank name search domain

### DIFF
--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -40,12 +40,15 @@ class Bank(models.Model):
             result.append((bank.id, name))
         return result
 
+    def _name_search_domain(self, domain, name, operator):
+        domain += ['|', ('bic', '=ilike', name + '%'), ('name', operator, name)]
+
     @api.model
     def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
         args = args or []
         domain = []
         if name:
-            domain = ['|', ('bic', '=ilike', name + '%'), ('name', operator, name)]
+            self._name_search_domain(domain, name, operator)
             if operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = ['&'] + domain
         return self._search(domain + args, limit=limit, access_rights_uid=name_get_uid)


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/72202

Today is hard to improve bank name search domain, to do that we can´t call super.

For example: 

```

    @api.model
    def _name_search(
        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
    ):
        args = args or []
        domain = []
        if name:
            domain = [
                "|",
                ("code_bc", "=ilike", name + "%"),
                "|",
                ("bic", "=ilike", name + "%"),
                ("name", operator, name),
            ]
            if operator in expression.NEGATIVE_TERM_OPERATORS:
                domain = ["&"] + domain
        bank_ids = self._search(
            domain + args, limit=limit, access_rights_uid=name_get_uid
        )
        return self.browse(bank_ids).name_get()

```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
