### PR TITLE
[FIX] point_of_sale: reprint in manage order

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ReprintReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ReprintReceiptScreen.js
@@ -7,17 +7,20 @@ odoo.define('point_of_sale.ReprintReceiptScreen', function (require) {
     const ReprintReceiptScreen = (AbstractReceiptScreen) => {
         class ReprintReceiptScreen extends AbstractReceiptScreen {
             mounted() {
-                this.tryReprint();
+                this.printReceipt();
             }
             confirm() {
                 this.showScreen('OrderManagementScreen');
             }
-            async tryReprint() {
+            async printReceipt() {
                 if(this.env.pos.proxy.printer && this.env.pos.config.iface_print_skip_screen) {
                     let result = await this._printReceipt();
                     if(result)
                         this.showScreen('OrderManagementScreen');
                 }
+            }
+            async tryReprint() {
+                await this._printReceipt();
             }
         }
         ReprintReceiptScreen.template = 'ReprintReceiptScreen';


### PR DESCRIPTION
When we clicked on the "print receipt" button in the manage order screen,
it didn't show the pop up that is use when no printer connected.
With this fix, it's now showing the popup correctly.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
