### PR TITLE
[FIX] base: translations of field labels in views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2036,7 +2036,8 @@ class NameManager:
         self.mandatory_names_or_ids = dict()
         self.available_names_or_ids = set()
         self.validate = validate
-        self.Model = Model.with_context(lang=False)
+        # optimization: post-processing requires translations, but validation does not
+        self.Model = Model.with_context(lang=False) if validate else Model
         self.fields_get = self.Model.fields_get()
 
     def has_field(self, name, info=()):

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -570,7 +570,6 @@ class TestTranslationWrite(TransactionCase):
             "Did not fallback to source when reset"
         )
 
-
     def test_field_selection(self):
         """ Test translations of field selections. """
         field = self.env['ir.model']._fields['state']
@@ -587,6 +586,31 @@ class TestTranslationWrite(TransactionCase):
         fg = self.env['ir.model'].with_context(lang='fr_FR').fields_get(['state'])
         self.assertEqual(fg['state']['selection'],
                          [('manual', 'Custo'), ('base', 'Pas touche!')])
+
+    def test_fields_view_get(self):
+        """ Test translations of field descriptions in fields_view_get(). """
+        self.env['res.lang']._activate_lang('fr_FR')
+
+        # add translation for the string of field ir.model.name
+        ir_model_field = self.env['ir.model.fields']._get('ir.model', 'name')
+        LABEL = "Description du Modèle"
+        self.env['ir.translation'].create({
+            'type': 'model',
+            'name': 'ir.model.fields,field_description',
+            'lang': 'fr_FR',
+            'res_id': ir_model_field.id,
+            'src': 'Name',
+            'value': LABEL,
+        })
+
+        # check that fields_get() returns the expected label
+        model = self.env['ir.model'].with_context(lang='fr_FR')
+        info = model.fields_get(['name'])
+        self.assertEqual(info['name']['string'], LABEL)
+
+        # check that fields_view_get() also returns the expected label
+        info = model.fields_view_get()['fields']
+        self.assertEqual(info['name']['string'], LABEL)
 
 
 class TestXMLTranslation(TransactionCase):


### PR DESCRIPTION
The commit e123aa2f305f4b73391d036cc1dd119eba5fd8ae optimizes the call
to fields_get() made in the NameManager to post-process the combined
arch of a view.  The optimization consists in avoiding translations,
with the assumption that the result is only used for validations.  It
turns out that the regular post-processing actually returns the field
descriptions as part of the result of fields_view_get().

We fix this mistake by keeping the optimization only when the flag
'validate' is true, so that the regular post-processing of a view
returns field descriptions with the expected translations.