### PR TITLE
[FIX] point_of_sale : allow edit to amount on done payment after reload

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -80,8 +80,9 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             }
             if (!this.selectedPaymentLine) return; // do nothing if no selected payment line
             // disable changing amount on paymentlines with running or done payments on a payment terminal
+            const payment_terminal = this.selectedPaymentLine.payment_method.payment_terminal;
             if (
-                this.payment_interface &&
+                payment_terminal &&
                 !['pending', 'retry'].includes(this.selectedPaymentLine.get_payment_status())
             ) {
                 return;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you reload the pos (F5) or click on back button, this.payment_terminal is undefined.
And you can update the amount even if the payment is done or delete a validated payment

same issue like https://github.com/odoo/odoo/pull/71326

@pimodoo @rhe-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
