### PR TITLE
[FIX] account: fix tuple domain

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3661,7 +3661,7 @@ class AccountMoveLine(models.Model):
             return
 
         # get the where clause
-        query = self._where_calc(self.env.context.get('domain_cumulated_balance'))
+        query = self._where_calc(list(self.env.context.get('domain_cumulated_balance') or []))
         order_string = ", ".join(self._generate_order_by_inner(self._table, self.env.context.get('order_cumulated_balance'), query, reverse_direction=True))
         from_clause, where_clause, where_clause_params = query.get_sql()
         sql = """


### PR DESCRIPTION
Domains must be lists on calls to `_where_calc`.
```
 Traceback (most recent call last):
   File "/tmp/tmpjmcn3gby/migrations/base/tests/test_mock_crawl.py", line 162, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpjmcn3gby/migrations/base/tests/test_mock_crawl.py", line 253, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpjmcn3gby/migrations/base/tests/test_mock_crawl.py", line 366, in mock_view_tree
    self.mock_web_read_group(model, view, domain, group_by, fields_list, limit_group=5)
   File "/tmp/tmpjmcn3gby/migrations/base/tests/test_mock_crawl.py", line 442, in mock_web_read_group
    self.mock_web_search_read(model, view, [group["__domain"]], fields_list)
   File "/tmp/tmpjmcn3gby/migrations/base/tests/test_mock_crawl.py", line 402, in mock_web_search_read
    data = model.search_read(domain=domain, fields=fields_list, limit=80)
   File "/home/odoo/src/odoo/14.0/addons/account/models/account_move.py", line 3645, in search_read
    return super(AccountMoveLine, self.with_context(domain_cumulated_balance=to_tuple(domain or []), order_cumulated_balance=order)).search_read(domain, fields, offset, limit, order)
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4839, in search_read
    result = records.read(fields)
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3020, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3040, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5666, in __getitem__
    return self._fields[key].__get__(self, type(self))
   File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1019, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 1175, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4061, in _compute_field_value
    getattr(self, field.compute)()
   File "/home/odoo/src/odoo/14.0/addons/account/models/account_move.py", line 3655, in _compute_cumulated_balance
    query = self._where_calc(self.env.context.get('domain_cumulated_balance'))
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4247, in _where_calc
    domain = [(self._active_name, '=', 1)] + domain
 TypeError: can only concatenate list (not "tuple") to list
```

Observed on upgrade request 11722
Ref 9d28c71a717037a17db061f7290696a307a4761d since saas-13.2

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
