### PR TITLE
[FIX] l10n_latam_invoice_document: unit price rounding

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -28,17 +28,20 @@ class AccountMoveLine(models.Model):
             included_taxes = \
                 invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
                     line.tax_ids)
+            # For the unit price, we need the number rounded based on the product price precision.
+            # The method compute_all uses the accuracy of the currency so, we multiply and divide for 10^(decimal accuracy of product price) to get the price correctly rounded.
+            price_digits = 10**self.env['decimal.precision'].precision_get('Product Price')
             if not included_taxes:
                 price_unit = line.tax_ids.with_context(round=False, force_sign=invoice._get_tax_force_sign()).compute_all(
-                    line.price_unit, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)
-                l10n_latam_price_unit = price_unit['total_excluded']
+                    line.price_unit * price_digits, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)
+                l10n_latam_price_unit = price_unit['total_excluded'] / price_digits
                 l10n_latam_price_subtotal = line.price_subtotal
                 not_included_taxes = line.tax_ids
                 l10n_latam_price_net = l10n_latam_price_unit * (1 - (line.discount or 0.0) / 100.0)
             else:
                 not_included_taxes = line.tax_ids - included_taxes
                 l10n_latam_price_unit = included_taxes.with_context(force_sign=invoice._get_tax_force_sign()).compute_all(
-                    line.price_unit, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)['total_included']
+                    line.price_unit * price_digits, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)['total_included'] / price_digits
                 l10n_latam_price_net = l10n_latam_price_unit * (1 - (line.discount or 0.0) / 100.0)
                 price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
                 l10n_latam_price_subtotal = included_taxes.with_context(force_sign=invoice._get_tax_force_sign()).compute_all(


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

For the unit price (field l10n_latam_price_unit), we need the number
rounded based on the product price precision.

To compute it we use the method compute_all that rounds using the
currency accuracy, so to fix this we multiply and divide for
10^(decimal accuracy of product price) to get the price correctly rounded.

**Current behavior before PR:**
Steps to replicate the error:
    1) In a base with l10n_ar localization installed change the decimal
       accuracy of "Product Price" to 5 digits (keeping the currency
       precision in two digits).
    2) Create an invoice with a product with a price of $10.12345
    3) Print the invoice and check the column price unit.
       Before this commit, the price unit would be $10.12000.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
