### PR TITLE
14.0 fix boleta report

### DIFF
--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -28,3 +28,10 @@ class L10nLatamDocumentType(models.Model):
             return False
 
         return document_number.zfill(6)
+
+    def _filter_taxes_included(self, taxes):
+        """ In Chile we include taxes depending on document type """
+        self.ensure_one()
+        if self.country_id.code == "CL" and self.code in ['39', '41', '110', '111', '112', '34']:
+            return taxes.filtered(lambda x: x.l10n_cl_sii_code == 14)
+        return super()._filter_taxes_included(taxes)

--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -42,6 +42,11 @@ class ResPartner(models.Model):
         else:
             return values['vat']
 
+    def _format_dotted_vat_cl(self, vat):
+        vat_l = vat.split('-')
+        n_vat, n_dv = vat_l[0], vat_l[1]
+        return '%s-%s' % (format(int(n_vat), ',d').replace(',', '.'), n_dv)
+
     @api.model
     def create(self, values):
         if values.get('vat'):

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -9,7 +9,6 @@
         <t t-set="pre_printed_report" t-value="report_type == 'pdf'"/>
         <t t-set="report_name" t-value="o.l10n_latam_document_type_id.name"/>
         <t t-set="header_address" t-value="o.company_id.partner_id"/>
-        <t t-set="is_tax" t-value="o.l10n_latam_document_type_id.code not in ['39', '41', '110', '111', '112', '34']"/>
         <t t-set="custom_footer">
             <t t-call="l10n_cl.custom_footer"/>
         </t>
@@ -51,7 +50,7 @@
                                         <strong t-att-style="'color: %s;' % o.company_id.primary_color">
                                             <br/>
                                             <span style="line-height: 180%;">RUT:</span>
-                                            <span t-field="o.company_id.partner_id.vat"/>
+                                            <span t-esc="o.company_id.partner_id._format_dotted_vat_cl(o.company_id.partner_id.vat)"/>
                                             <br/>
                                             <span class="text-uppercase" t-esc="report_name"/>
                                             <br/>
@@ -61,13 +60,11 @@
                                     </h6>
                                 </div>
                             </div>
-                            <!-- (6) Titulo de Documento -->
                             <div class="row text-center">
                                 <div class="col-12 text-center" t-att-style="'color: %s;' % o.company_id.primary_color"
                                      name="regional-office"/>
                             </div>
                         </div>
-
                     </div>
                 </div>
 
@@ -145,39 +142,33 @@
             <attribute name="t-field">line.l10n_latam_price_unit</attribute>
         </xpath>
 
+        <xpath expr="//span[@id='line_tax_ids']" position="attributes">
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids))</attribute>
+        </xpath>
+
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
             <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
         </t>
+
+        <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
+            <span groups="account.group_show_line_subtotals_tax_included">Amount</span>
+        </xpath>
 
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
         </span>
 
-
         <span t-field="o.amount_untaxed" position="attributes">
             <attribute name="t-field">o.l10n_latam_amount_untaxed</attribute>
         </span>
 
+        <xpath expr="//th[@name='th_taxes']" position="replace"/>
+        <xpath expr="//span[@id='line_tax_ids']/.." position="replace"/>
 
-        <!-- we remove the taxes column in boletas -->
-        <xpath expr="//th[@name='th_taxes']/span" position="replace">
-            <t t-if="is_tax">
-                <span>Taxes</span>
-            </t>
-        </xpath>
-
-        <xpath expr="//span[@id='line_tax_ids']" position="replace">
-            <t t-if="is_tax">
-                <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
-            </t>
-        </xpath>
-
-        <!-- remove payment term, this is added on information section -->
         <p name="payment_term" position="replace"/>
-
-
         <xpath expr="//span[@t-field='o.payment_reference']/../.." position="replace"/>
 
+        <!-- replace information section and usage chilean style -->
         <div id="informations" position="replace">
             <t t-call="l10n_cl.informations"/>
         </div>
@@ -200,7 +191,6 @@
         </xpath>
 
     </template>
-
 
     <!-- FIXME: Temp fix to allow fetching invoice_documemt in Studio Reports with localisation -->
     <template id="report_invoice" inherit_id="account.report_invoice">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Works together with 18432 in enterprise
Uses the latam fields to choose tax included or not, depending on the type of document

Current behavior before PR:
If you print boletas, the tax is not included
The RUT number is not with thousands dots separator, and this is required for the certification process at SII.

Desired behavior after PR is merged:
The problems specified are solved.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
