### PR TITLE
[FIX] l10n_generic_coa: Fix demo data for reconciliation tests

### DIFF
--- a/addons/l10n_generic_coa/demo/account_invoice_demo.xml
+++ b/addons/l10n_generic_coa/demo/account_invoice_demo.xml
@@ -42,7 +42,7 @@
             <field name="partner_id" ref="base.res_partner_2"/>
             <field name="invoice_user_id" ref="base.user_demo"/>
             <field name="invoice_payment_term_id" ref="account.account_payment_term_immediate"/>
-            <field name="invoice_date" eval="(datetime.today() + timedelta(days=-15)).strftime('%Y-%m-%d')"/>
+            <field name="invoice_date" eval="(datetime.today() + relativedelta(months=-1)).strftime('%Y-%m-%d')"/>
             <field name="invoice_line_ids" eval="[
                 (0, 0, {'product_id': ref('product.consu_delivery_02'), 'price_unit': 642.0, 'quantity': 5}),
                 (0, 0, {'product_id': ref('product.consu_delivery_03'), 'price_unit': 280.0, 'quantity': 5}),


### PR DESCRIPTION
One of the invoices created in the demo data has a variable date. This cause
the enumeration of these invoices to vary depending on the date.
This variation then cause an issue when testing the reconciliation tour,
causing it to fail on certain dates.

This change will make sure that the enumeration of the demo invoices stays
the same, and avoid such kinds of issues.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
