### PR TITLE
[FIX] base: avoid crash due to generation of key with model

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -499,8 +499,6 @@ actual arch.
                         pass
             if not values.get('key') and values.get('type') == 'qweb':
                 values['key'] = "gen_key.%s" % str(uuid.uuid4())[:6]
-                if values.get('model'):
-                    values['key'] = "%s.gen_key_%s" % (values.get('model'), str(uuid.uuid4())[:6])
             if not values.get('name'):
                 values['name'] = "%s %s" % (values.get('model'), values['type'])
             # Create might be called with either `arch` (xml files), `arch_base` (form view) or `arch_db`.


### PR DESCRIPTION
Until now, when you create a view of type qweb with a model, we use the model
as first part to generate the key. Since this model can contains dot, it is
wrong and we got some key like ir.ui.view.gen_key_xyz

This bug has been seen with commit ee8756b31186f2f21e9b70e124f29c678cebaea7
which make the installation of website & sale_timesheet impossible in dev mode.

  File /home/odoo/addons/base/models/ir_ui_view.py, line 294, in _compute_arch
    arch_fs = get_view_arch_from_file(fullpath, xml_id)
  File /home/odoo/addons/base/models/ir_ui_view.py, line 166, in get_view_arch_from_file
    module, view_id = xmlid.split('.')

  Too many values to unpack

Now we never try to make key beautiful. At first view it doesn't bring any
advantage, but only bug.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
