### PR TITLE
[FIX] point_of_sale: receipt printing available for offline mode

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -178,7 +178,8 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                     syncedOrderBackendIds = await this.env.pos.push_single_order(this.currentOrder);
                 }
             } catch (error) {
-                this.error = true;
+                if (error.code == 700)
+                    this.error = true;
                 if (error instanceof Error) {
                     throw error;
                 } else {

--- a/doc/cla/individual/EsamHussein.md
+++ b/doc/cla/individual/EsamHussein.md
@@ -1,0 +1,9 @@
+Egypt, 2021-06-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Esam Hussein esam.n.hussein@gmail.com https://github.com/esamhussein


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
after the last update in 4/6/2021 the receipt printing not working in offline mode
Current behavior before PR:
printing receipt not working in offline mode
Desired behavior after PR is merged:
add exception for "XmlHttpRequestError", to make the receipt printing available for offline mode

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr