### PR TITLE
[FIX] *: search_view_id expects an id/name pair

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -345,7 +345,7 @@ class ResCompany(models.Model):
             'res_model': 'account.account',
             'view_mode': 'tree',
             'limit': 99999999,
-            'search_view_id': self.env.ref('account.view_account_search').id,
+            'search_view_id': [self.env.ref('account.view_account_search').id],
             'views': [[view_id, 'list']],
             'domain': domain,
         }

--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -96,7 +96,7 @@ class LeaveReport(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'hr.leave.report',
             'view_mode': 'tree,pivot,form',
-            'search_view_id': self.env.ref('hr_holidays.view_hr_holidays_filter_report').id,
+            'search_view_id': [self.env.ref('hr_holidays.view_hr_holidays_filter_report').id],
             'domain': domain,
             'context': {
                 'search_default_group_type': True,

--- a/addons/membership/wizard/membership_invoice.py
+++ b/addons/membership/wizard/membership_invoice.py
@@ -31,5 +31,5 @@ class MembershipInvoice(models.TransientModel):
             'res_model': 'account.move',
             'type': 'ir.actions.act_window',
             'views': [(tree_view_ref.id, 'tree'), (form_view_ref.id, 'form')],
-            'search_view_id': search_view_ref and search_view_ref.id,
+            'search_view_id': search_view_ref and [search_view_ref.id],
         }

--- a/addons/point_of_sale/wizard/pos_open_statement.py
+++ b/addons/point_of_sale/wizard/pos_open_statement.py
@@ -34,5 +34,5 @@ class PosOpenStatement(models.TransientModel):
             'res_model': 'account.bank.statement',
             'domain': str([('id', 'in', BankStatement.ids)]),
             'views': [(tree_id, 'tree'), (form_id, 'form')],
-            'search_view_id': search_id,
+            'search_view_id': [search_id],
         }

--- a/addons/product_margin/wizard/product_margin.py
+++ b/addons/product_margin/wizard/product_margin.py
@@ -52,5 +52,5 @@ class ProductMargin(models.TransientModel):
             'type': 'ir.actions.act_window',
             'views': views,
             'view_id': False,
-            'search_view_id': search_view_id,
+            'search_view_id': [search_view_id],
         }

--- a/addons/website_sale/models/crm_team.py
+++ b/addons/website_sale/models/crm_team.py
@@ -45,7 +45,7 @@ class CrmTeam(models.Model):
             'type': 'ir.actions.act_window',
             'view_mode': 'tree,form',
             'domain': [('is_abandoned_cart', '=', True)],
-            'search_view_id': self.env.ref('sale.sale_order_view_search_inherit_sale').id,
+            'search_view_id': [self.env.ref('sale.sale_order_view_search_inherit_sale').id],
             'context': {
                 'search_default_team_id': self.id,
                 'default_team_id': self.id,


### PR DESCRIPTION
Passing an id directly to `search_view_id` is not working. It is silently
ignored.
The framework js code expects an id/name pair, as described in the ORM doc.

Most of the time, this will be unoticed as the specified search view being
ignored, the default one will be used instead, which is often the same one as
there is only one search view.

Only 3 occurences are real misbehavior.

Note that the `name` of the pair is useless, you can just pass the ID in an
array.

Working:
'search_view_id': [123, 'search'],
'search_view_id': [123],

Not working:
'search_view_id': 123,

**Technical explanation:**
It will silently just ignore the value set to `search_view_id` in Javascript [here](https://github.com/odoo/odoo/blame/master/addons/web/static/src/js/chrome/action_manager_act_window.js#L424) since
```javascript
const a = 123;
const b = a && a[0]; // this is undefined
```

Noticed on https://github.com/odoo/odoo/pull/71826#discussion_r652720721