### PR TITLE
[IMP] product: Speedup product.name_get method when it is needed

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -424,6 +424,9 @@ class ProductProduct(models.Model):
     def name_get(self):
         # TDE: this could be cleaned a bit I think
 
+        if not self._context.get('display_default_code', True) and not self._context.get('partner_id'):
+            return [(r.id, r.product_tmpl_id.name) for r in self.with_context(prefetch_fields=False)]
+
         def _name_get(d):
             name = d.get('name', '')
             code = self._context.get('display_default_code', True) and d.get('default_code', False) or False


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

The method "product.name_get" is executing heavy process to
show the "default_code" part in the m2o fields to get the following format:
 - "[default_code] name"

But there is a context to avoid adding the "[default_code]" part and only using "name" part

# Current behavior before PR:

if you disable the context called "display_default_code=False" the "default_code" is even computed
but never used

One of the heavy parts is computing the "attribute_line_ids" field:
  - https://github.com/odoo/odoo/blob/2ef8c5c460887dd5109e0c291a50b75e5f2b4144/addons/product/models/product.py#L467

Even if it is prefetched for 12.0:
  - https://github.com/odoo/odoo/blob/2ef8c5c460887dd5109e0c291a50b75e5f2b4144/addons/product/models/product.py#L449

but not for 14.0:
  - https://github.com/odoo/odoo/blob/79afc80e5b4f45c6bc716f55a21f8a2b478e49f6/addons/product/models/product.py#L463

For v14.0 the heavy process is where it is used (so prefetched):
  - https://github.com/odoo/odoo/blob/79afc80e5b4f45c6bc716f55a21f8a2b478e49f6/addons/product/models/product.py#L479

# Desired behavior after PR is merged:
Returning early if the context is used it will be faster and the result will be the same

A good example where you can use this context is here:
 - https://github.com/odoo/enterprise/blob/75d5f206045eb4c95852b3c74b04a030dafed809/stock_barcode/models/product_product.py#L22

Where a lot of records are read but the m2o name is not even used since that the following line only is using the id:
 - https://github.com/odoo/enterprise/blob/75d5f206045eb4c95852b3c74b04a030dafed809/stock_barcode/models/product_product.py#L35

The following modules will be faster too:
https://github.com/odoo/odoo/blob/479cf04bd89f7f8a487a71cf4e52c2442dedcf92/addons/website_sale_comparison/controllers/main.py#L19
https://github.com/odoo/odoo/blob/479cf04bd89f7f8a487a71cf4e52c2442dedcf92/addons/website_sale_comparison/controllers/main.py#L41
https://github.com/odoo/odoo/blob/479cf04bd89f7f8a487a71cf4e52c2442dedcf92/addons/website_sale_wishlist/controllers/main.py#L14
https://github.com/odoo/odoo/blob/479cf04bd89f7f8a487a71cf4e52c2442dedcf92/addons/website_sale_wishlist/controllers/main.py#L40
https://github.com/odoo/odoo/blob/479cf04bd89f7f8a487a71cf4e52c2442dedcf92/addons/pos_cache/models/pos_cache.py#L29
https://github.com/odoo/odoo/blob/479cf04bd89f7f8a487a71cf4e52c2442dedcf92/addons/website_sale/models/sale_order.py#L412

Complement of https://github.com/odoo/enterprise/pull/19057