### PR TITLE
[FIX] web: Adjust label#for to match input#id

### DIFF
--- a/addons/web/views/database_manager.html
+++ b/addons/web/views/database_manager.html
@@ -163,7 +163,7 @@
             </div>
         </div>
         <div class="form-group row">
-            <label for="demo" class="col-md-4 col-form-label">Demo data</label>
+            <label for="load_demo_checkbox" class="col-md-4 col-form-label">Demo data</label>
             <div class="col-md-8">
                 <input type="checkbox" id="load_demo_checkbox" class="form-control-sm" name="demo" value="1">
             </div>


### PR DESCRIPTION
The #for attribute of the LABEL tag should match the #id of the INPUT
tag, not it's #name.

This regression was introduced in a171694644cf5e58f065cf7ed18fd8d259ea744f

Signed-off-by: Romain Tartière <romain@vittoriaconseil.com>

----

- [X] I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
