### PR TITLE
[FIX] event_sale: recompute seats on SO deletion

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -24,6 +24,10 @@ class SaleOrder(models.Model):
                     .for_xml_id('event_sale', 'action_sale_order_event_registration')
         return res
 
+    def unlink(self):
+        self.order_line._unlink_associated_registrations()
+        super(SaleOrder, self).unlink()
+
 
 class SaleOrderLine(models.Model):
 
@@ -82,6 +86,13 @@ class SaleOrderLine(models.Model):
     def _onchange_event_ticket_id(self):
         # we call this to force update the default name
         self.product_id_change()
+
+    def unlink(self):
+        self._unlink_associated_registrations()
+        super(SaleOrderLine, self).unlink()
+
+    def _unlink_associated_registrations(self):
+        self.env['event.registration'].search([('sale_order_line_id', 'in', self.ids)]).unlink()
 
     def get_sale_order_line_multiline_description_sale(self, product):
         """ We override this method because we decided that:

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from odoo.tests import common
+from odoo.tests.common import TransactionCase, users
+from odoo.addons.test_mail.tests.common import mail_new_test_user
 
 
-class EventSaleTest(common.TransactionCase):
+class EventSaleTest(TransactionCase):
 
     def setUp(self):
         super(EventSaleTest, self).setUp()
@@ -18,7 +19,7 @@ class EventSaleTest(common.TransactionCase):
         })
 
         # I create an event from the same type than my product
-        event = self.env['event.event'].create({
+        self.event = self.env['event.event'].create({
             'name': 'test_event',
             'event_type_id': 1,
             'date_end': '2012-01-01 19:05:15',
@@ -28,8 +29,10 @@ class EventSaleTest(common.TransactionCase):
         ticket = self.env['event.event.ticket'].create({
             'name': 'test_ticket',
             'product_id': product.id,
-            'event_id': event.id,
+            'event_id': self.event.id,
         })
+
+        self.user_salesperson = mail_new_test_user(self.env, login='user_salesman', groups='sales_team.group_sale_salesman')
 
         # I create a sales order
         self.sale_order = self.env['sale.order'].create({
@@ -46,7 +49,7 @@ class EventSaleTest(common.TransactionCase):
             'product_uom_qty': 8.0,
             'order_id': self.sale_order.id,
             'name': 'sales order line',
-            'event_id': event.id,
+            'event_id': self.event.id,
             'event_ticket_id': ticket.id,
         })
 
@@ -54,9 +57,10 @@ class EventSaleTest(common.TransactionCase):
         self.register_person = self.env['registration.editor'].create({
             'sale_order_id': self.sale_order.id,
             'event_registration_ids': [(0, 0, {
-                'event_id': event.id,
+                'event_id': self.event.id,
                 'name': 'Administrator',
-                'email': 'abc@example.com'
+                'email': 'abc@example.com',
+                'sale_order_line_id': self.sale_order.order_line.id,
             })],
         })
 
@@ -121,3 +125,23 @@ class EventSaleTest(common.TransactionCase):
         })
         sol.product_id_change()
         self.assertEqual(so.amount_total, 660.0, "Ticket is $1000 but the event product is on a pricelist 10 -> 6. So, $600 + a 10% tax.")
+
+    @users('user_salesman')
+    def test_unlink_so(self):
+        """ This test ensures that when deleting a sale order, if the latter is linked to an event registration,
+        the number of expected seats will be correctly updated """
+        event = self.env['event.event'].browse(self.event.ids)
+        self.register_person.action_make_registration()
+        self.assertEqual(event.seats_expected, 1)
+        self.sale_order.unlink()
+        self.assertEqual(event.seats_expected, 0)
+
+    @users('user_salesman')
+    def test_unlink_soline(self):
+        """ This test ensures that when deleting a sale order line, if the latter is linked to an event registration,
+        the number of expected seats will be correctly updated """
+        event = self.env['event.event'].browse(self.event.ids)
+        self.register_person.action_make_registration()
+        self.assertEqual(event.seats_expected, 1)
+        self.sale_order.order_line.unlink()
+        self.assertEqual(event.seats_expected, 0)

--- a/addons/event_sale/wizard/event_edit_registration.py
+++ b/addons/event_sale/wizard/event_edit_registration.py
@@ -7,7 +7,7 @@ class RegistrationEditor(models.TransientModel):
     _name = "registration.editor"
     _description = 'Edit Attendee Details on Sales Confirmation'
 
-    sale_order_id = fields.Many2one('sale.order', 'Sales Order', required=True)
+    sale_order_id = fields.Many2one('sale.order', 'Sales Order', required=True, ondelete='cascade')
     event_registration_ids = fields.One2many('registration.editor.line', 'editor_id', string='Registrations to Edit')
 
     @api.model


### PR DESCRIPTION
When deleting a SO with an event ticket, the number of attendees becomes
incorrect

To reproduce the error:
1. In Settings, enable "Tickets"
2. On website, register an attendee to event E
3. In module Events, open E

Error: The number of attendees (X) is incorrect. If the user clicks on
it, there are X-1 attendees: the one added on step 2 has been deleted
but the number is not updated

When deleting a SO or a SO line, the associated registration is deleted:
https://github.com/odoo/odoo/blob/3fd3fc5f782f1422f578ad38e3fad444130273a8/addons/event_sale/models/event.py#L197-L198
This is the problem: it won't trigger the `compute` methods.

In the case above, this method won't be called:
https://github.com/odoo/odoo/blob/72ce1b867dc81672e6a73a586542b20216388a05/addons/event/models/event.py#L176
So the number of seats won't be updated

This fix suggests deleting the registrations from the ORM in order to
trigger the `compute` methods.

Note: Writing the tests revealed another problem. When deleting the SO,
if a wizard `registration.editor` exists and is linked to the SO, the
deletion will trigger an SQL constraint. This is the reason why the
`ondelete` has been added to the field `sale_order_id`

OPW-2452760