### PR TITLE
[FIX] mail: fix the width field in preview

### DIFF
--- a/addons/mail/wizard/mail_template_preview_views.xml
+++ b/addons/mail/wizard/mail_template_preview_views.xml
@@ -16,7 +16,7 @@
                             <span class="col-md-5 col-lg-4 col-sm-12 pl-0">Choose an example <field name="model_id" readonly="1"/> record:</span>
                             <div class="col-md-7 col-lg-6 col-sm-12 pl-0">
                                 <field name="resource_ref" readonly="False"
-                                    options="{'hide_model': True, 'no_create': True, 'no_edit': True, 'no_open': True}"
+                                    options="{'hide_model': True, 'no_create': True, 'no_edit': True, 'no_open': True, 'model_field': 'model_id'}"
                                     attrs="{'invisible': [('no_record', '=', True)]}"/>
                                 <b attrs="{'invisible': [('no_record', '=', False)]}" class="text-warning">No record for this model</b>
                             </div>


### PR DESCRIPTION
The field resource_ref in the template preview was of
`width: 0!important` because of a the class `o_row`
added when the options `model_field` was not provided.

This fix provides the name of the field (`model_id`) to the
option.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
