### PR TITLE
[FIX] payment_sips: prevent clearing the session cookie

### DIFF
--- a/addons/payment_sips/controllers/main.py
+++ b/addons/payment_sips/controllers/main.py
@@ -42,9 +42,15 @@ class SipsController(http.Controller):
         return ''
 
     @http.route([
-        '/payment/sips/dpn'], type='http', auth="none", methods=['POST'], csrf=False)
+        '/payment/sips/dpn'], type='http', auth="none", methods=['POST'], csrf=False, save_session=False)
     def sips_dpn(self, **post):
-        """ Sips DPN """
+        """ Sips DPN
+        The session cookie created by Odoo has not the attribute SameSite. Most of browsers will force this attribute
+        with the value 'Lax'. After the payment, Sips will perform a POST request on this route. For all these reasons,
+        the cookie won't be added to the request. As a result, if we want to save the session, the server will create
+        a new session cookie. Therefore, the previous session and all related information will be lost, so it will lead
+        to undesirable behaviors. This is the reason why `save_session=False` is needed.
+        """
         try:
             _logger.info('Beginning Sips DPN form_feedback with post data %s', pprint.pformat(post))  # debug
             self.sips_validate_data(**post)


### PR DESCRIPTION
When buying a product on website shop, after the payment with SIPS, the
page is redirected to an Error message: "We are not able to find your
payment, but don't worry. You should receive an email confirming your
payment in a few minutes. If the payment hasn't been confirmed you can
contact us."

To reproduce the error:
1. In Payment Acquirers, enable Sips
2. Go on website shop
3. Add a product to the cart, Checkout
4. Pay with Sips
    - Visa card number: 4100000000000000
5. Back to Web-shop, if the payment has been successfully processed,
repeat steps 2 -> 4

Error: The message "Your payment has been successfully processed. Thank
you!" is not displayed. Instead, the message "We are not able [...] you
can contact us." is displayed.

This message is displayed when:
https://github.com/odoo/odoo/blob/5945806c151b13d9d4cc13aa0a6c96a6b1bbad5f/addons/payment/controllers/portal.py#L65-L69
i.e., when the transactions list is empty. Here is how to get the list:
https://github.com/odoo/odoo/blob/5945806c151b13d9d4cc13aa0a6c96a6b1bbad5f/addons/payment/controllers/portal.py#L38-L42
It uses the session of the request. The cookie `session_id` is used to
identify the current session. However, after the payment on SIPS, the
page is redirected to `/payment/sips/dpn` with a POST request. Since the
session cookie has the attribute `SameSite=Lax` and the HTTP request is
a POST, the cookie will be filtered out:
https://drive.google.com/file/d/1xfx3YWkfonO3nK-8Rew45uSoR4lkpjpY/view?usp=sharing
(Browser information: This cookie didn't specify a "SameSite" attribute
when it was stored and was defaulted to "SameSite=Lax," and was blocked
because the request was made from a different site and was not initiated
by a top-level navigation. The cookie had to have been set with
"SameSite=None" to enable cross-site usage)
As a result, the server creates a new one. This is the reason why the
transactions list is empty: the list is based on a new session.

Adding the attribute `save_session = False` to the route will prevent
the server from creating a new session cookie and adding it in the POST
response.

OPW-2518377