### PR TITLE
fleet : small fixes/improvements

### DIFF
--- a/addons/fleet/i18n/fleet.pot
+++ b/addons/fleet/i18n/fleet.pot
@@ -2313,6 +2313,12 @@ msgid "You can define several models (e.g. A3, A4) for each make (Audi)."
 msgstr ""
 
 #. module: fleet
+#: code:addons/fleet/models/fleet_vehicle_cost.py:76
+#, python-format
+msgid "You cannot delete an activation cost linked to a contract. You should delete the contract instead."
+msgstr ""
+
+#. module: fleet
 #: model_terms:ir.ui.view,arch_db:fleet.fleet_vehicle_log_contract_view_form
 msgid "amount"
 msgstr ""

--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -174,6 +174,12 @@ class FleetVehicleLogContract(models.Model):
         if self.vehicle_id:
             self.odometer_unit = self.vehicle_id.odometer_unit
 
+    @api.model_create_multi
+    def create(self, vals):
+        res = super(FleetVehicleLogContract, self).create(vals)
+        res.cost_id.write({'contract_id': res.id})
+        return res
+
     @api.multi
     def write(self, vals):
         res = super(FleetVehicleLogContract, self).write(vals)

--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -253,7 +253,7 @@ class FleetVehicleLogContract(models.Model):
             while (startdate <= today) & (startdate <= contract.expiration_date):
                 data = {
                     'amount': contract.cost_generated,
-                    'date': fields.Date.context_today(self),
+                    'date': startdate,
                     'vehicle_id': contract.vehicle_id.id,
                     'cost_subtype_id': contract.cost_subtype_id.id,
                     'contract_id': contract.id,

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -10,6 +10,7 @@
                     <field name="description"/>
                     <field name="cost_subtype_id"/>
                     <field name="date"/>
+                    <field name="contract_id"/>
                 </tree>
             </field>
         </record>
@@ -126,6 +127,7 @@
                             </group>
                             <group>
                                 <field name="date"/>
+                                <field name="contract_id"/>
                                 <field name="parent_id" groups="base.group_no_one"/>
                             </group>
                         </group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

 [FIX] fleet: correct cost date on recurring costs creation

When creating the recurring costs through the cron task, we should set the date
accordingly with the specified recurrence instead of setting it to today.

--------------------------------------------------------------------------------------------------------

 [FIX] fleet: set correct contract on activation cost line creation

When creating a vehicle contract, we are creating automatically a cost line
corresponding to the activation costs. The contract was not correctly set
on that line before this commit.

--------------------------------------------------------------------------------------------------------

 [FIX] fleet: prevent deletion of vehicle contract

When we create a contract information on a vehicle, there is an activation cost
automatically created. Before this fix, if we delete the activation cost line, it
deletes automatically the associated contract. We should prevent this and add a
warning message instead.

To make it easier for the user, we should also show the contract information on
the list and form views of the vehicule cost.

When deleting the vehicle contract, we should also automatically delete the
activation cost line associated.

--------------------------------------------------------------------------------------------------------

opw-2534547

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
