### PR TITLE
[FIX] payment_{ogone,payulatam}: use the document name in the reference

### DIFF
--- a/addons/payment_ogone/tests/common.py
+++ b/addons/payment_ogone/tests/common.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.addons.payment.tests.common import PaymentCommon
 
 

--- a/addons/payment_ogone/tests/test_ogone.py
+++ b/addons/payment_ogone/tests/test_ogone.py
@@ -2,6 +2,7 @@
 
 from freezegun import freeze_time
 
+from odoo.fields import Command
 from odoo.tests import tagged
 from odoo.tools import mute_logger
 
@@ -15,32 +16,45 @@ from ..controllers.main import OgoneController
 class OgoneTest(OgoneCommon):
 
     def test_validation_amount(self):
+        """ Test the value of the validation amount. """
         self.assertEqual(self.ogone._get_validation_amount(), 1.0)
 
-    # freeze time for consistent singularize_prefix behavior during the test
-    @freeze_time("2011-11-02 12:00:21")
-    def test_reference(self):
-        tx = self.create_transaction(flow="redirect", reference="")
-        self.assertEqual(tx.reference, "tx-20111102120021",
-            "Ogone: transaction reference wasn't correctly singularized.")
-
-        # Test prefixes of length > 40 chars
-        reference = self.env['payment.transaction']._compute_reference(
-            provider=self.ogone.provider,
-            prefix="This is a reference of more than 40 characters to annoy ogone",
+    @freeze_time('2011-11-02 12:00:21')  # Freeze time for consistent singularization behavior
+    def test_reference_is_singularized(self):
+        """ Test singularization of reference prefixes. """
+        reference = self.env['payment.transaction']._compute_reference(self.ogone.provider)
+        self.assertEqual(
+            reference, 'tx-20111102120021', "transaction reference was not correctly singularized"
         )
-        self.assertEqual(reference, "This is a reference of mo-20111102120021")
+
+    @freeze_time('2011-11-02 12:00:21')  # Freeze time for consistent singularization behavior
+    def test_reference_is_stripped_at_max_length(self):
+        """ Test stripping of reference prefixes of length > 40 chars. """
+        reference = self.env['payment.transaction']._compute_reference(
+            self.ogone.provider,
+            prefix='this is a reference of more than 40 characters to annoy ogone',
+        )
+        self.assertEqual(reference, 'this is a reference of mo-20111102120021')
         self.assertEqual(len(reference), 40)
 
-    # freeze time for consistent singularize_prefix behavior during the test
-    @freeze_time("2011-11-02 12:00:21")
+    @freeze_time('2011-11-02 12:00:21')  # Freeze time for consistent singularization behavior
+    def test_reference_is_computed_based_on_document_name(self):
+        """ Test computation of reference prefixes based on the provided invoice. """
+        invoice = self.env['account.move'].create({})
+        reference = self.env['payment.transaction']._compute_reference(
+            self.ogone.provider, invoice_ids=[Command.set([invoice.id])]
+        )
+        self.assertEqual(reference, 'MISC/2011/11/0001-20111102120021')
+
+    @freeze_time('2011-11-02 12:00:21')  # Freeze time for consistent singularization behavior
     def test_redirect_form_values(self):
+        """ Test the values of the redirect form inputs. """
         return_url = self._build_url(OgoneController._flexcheckout_return_url)
         expected_values = {
             'ACCOUNT_PSPID': self.ogone.ogone_pspid,
             'ALIAS_ALIASID': payment_utils.singularize_reference_prefix(prefix='ODOO-ALIAS'),
             'ALIAS_ORDERID': self.reference,
-            'ALIAS_STOREPERMANENTLY': 'N', # 'Y' if self.tokenize
+            'ALIAS_STOREPERMANENTLY': 'N',  # 'Y' if self.tokenize
             'CARD_PAYMENTMETHOD': 'CreditCard',
             'LAYOUT_LANGUAGE': self.partner.lang,
             'PARAMETERS_ACCEPTURL': return_url,
@@ -50,7 +64,7 @@ class OgoneTest(OgoneCommon):
             expected_values, incoming=False, format_keys=True
         ).upper()
 
-        tx = self.create_transaction(flow="redirect")
+        tx = self.create_transaction(flow='redirect')
         with mute_logger('odoo.addons.payment.models.payment_transaction'):
             processing_values = tx._get_processing_values()
 
@@ -64,7 +78,5 @@ class OgoneTest(OgoneCommon):
             self.assertEqual(
                 inputs[form_key],
                 value,
-                "Ogone: received value %s for input %s (expected %s)" % (
-                    inputs[form_key], form_key, value,
-                )
+                f"received value {inputs[form_key]} for input {form_key} (expected {value})"
             )

--- a/addons/payment_payulatam/models/payment_transaction.py
+++ b/addons/payment_payulatam/models/payment_transaction.py
@@ -34,6 +34,15 @@ class PaymentTransaction(models.Model):
         :rtype: str
         """
         if provider == 'payulatam':
+            if not prefix:
+                # If no prefix is provided, it could mean that a module has passed a kwarg intended
+                # for the `_compute_reference_prefix` method, as it is only called if the prefix is
+                # empty. We call it manually here because singularizing the prefix would generate a
+                # default value if it was empty, hence preventing the method from ever being called
+                # and the transaction from received a reference named after the related document.
+                prefix = self.sudo()._compute_reference_prefix(
+                    provider, separator, **kwargs
+                ) or None
             prefix = payment_utils.singularize_reference_prefix(prefix=prefix, separator=separator)
         return super()._compute_reference(provider, prefix=prefix, separator=separator, **kwargs)
 

--- a/addons/payment_payulatam/tests/common.py
+++ b/addons/payment_payulatam/tests/common.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.addons.payment.tests.common import PaymentCommon
 
 
-class PayulatamCommon(PaymentCommon):
+class PayULatamCommon(PaymentCommon):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Before this commit, the implementation of Ogone and PayU Latam's
requirements regarding the transaction reference was preventing the
computation of the reference prefix from being based on the related
document (invoice, SO).

This commit attempts to compute the reference based on the document if
no reference prefix is provided, before applying the said requirements.

task-2494916
