### PR TITLE
[FIX] purchase_stock: UOM Error when running scheduler

### DIFF
--- a/addons/purchase_requisition_stock/models/stock.py
+++ b/addons/purchase_requisition_stock/models/stock.py
@@ -64,5 +64,6 @@ class Orderpoint(models.Model):
         for op in self:
             for pr in self.env['purchase.requisition'].search([('state','=','draft'),('origin','=',op.name)]):
                 for prline in pr.line_ids.filtered(lambda l: l.product_id.id == op.product_id.id):
-                    res[op.id] += prline.product_uom_id._compute_quantity(prline.product_qty, op.product_uom, round=False)
+                    if prline.product_uom_id.category_id == op.product_uom.category_id:
+                        res[op.id] += prline.product_uom_id._compute_quantity(prline.product_qty, op.product_uom, round=False)
         return res


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two uom category C1, C2
- Let's consider two uom U1 with category C1 and U2 with category C2
- Let's consider two products P1 with uom U1 and P2 with uom U2
- Create a reordering rule R for P1
- Run the scheduler (PO line L will be generated)
- Go to Reordering rule R and change the product to P2.
- Run the scheduler

Bug:

A traceback was raised beacause uom of L is not in the same category of P2

opw:2557562

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
