### PR TITLE
[FIX] website_event: properly show social share icons on event sidebar

### DIFF
--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -1,4 +1,4 @@
-.o_wevent_social_link {
+.o_wevent_sidebar_social > .o_wevent_social_link {
     $o_link_size: 3em;
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
PURPOSE

Currently, the social share icons on right sidebar of the event page
are not aligned properly. This is because the rules written from
there are having lower precedence than the generic rules for the
social share snippet.

SPECIFICATION

This PR fixes the issue by providing higher precedence to the
rules specifically written for event's web page.

TaskID-2557077

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
