### PR TITLE
[FIX] website: improve whatsapp sharing URL for social share snippet

### DIFF
--- a/addons/website/static/src/snippets/s_share/000.js
+++ b/addons/website/static/src/snippets/s_share/000.js
@@ -20,6 +20,14 @@ const ShareWidget = publicWidget.Widget.extend({
                 return href.replace(urlRegex, function (match, a, b, c) {
                     return a + url + c;
                 }).replace(titleRegex, function (match, a, b, c) {
+                    if ($a.hasClass('s_share_whatsapp')) {
+                        // WhatsApp does not support the "url" GET parameter.
+                        // Instead we need to include the url within the passed "text" parameter, merging everything together.
+                        // e.g of output:
+                        // https://wa.me/?text=%20OpenWood%20Collection%20Online%20Reveal%20%7C%20My%20Website%20http%3A%2F%2Flocalhost%3A8888%2Fevent%2Fopenwood-collection-online-reveal-2021-06-21-2021-06-23-8%2Fregister
+                        // see https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat/ for more details
+                        return a + title + url + c;
+                    }
                     return a + title + c;
                 });
             });

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -13,7 +13,7 @@
         <a href="http://www.linkedin.com/sharing/share-offsite/?url={url}" t-attf-class="s_share_linkedin #{_link_classes}" target="_blank">
             <i t-attf-class="fa fa-linkedin #{not _link_classes and 'rounded shadow-sm'}"/>
         </a>
-        <a href="whatsapp://send?text={title}&amp;url={url}" t-attf-class="s_share_whatsapp #{_link_classes}" target="_blank">
+        <a href="https://wa.me/?text={title}" t-attf-class="s_share_whatsapp #{_link_classes}" target="_blank">
             <i t-attf-class="fa fa-whatsapp #{not _link_classes and 'rounded shadow-sm'}"/>
         </a>
         <a href="http://pinterest.com/pin/create/button/?url={url}&amp;description={title}" t-attf-class="s_share_pinterest #{_link_classes}" target="_blank">


### PR DESCRIPTION
PURPOSE

Curretnly, the link responsible for sharing the page on whatsapp
(from social share snippet) is not working correctly. There are
two main problems:
 - it works only for the mobile devices where WhatsApp is alreay
   installed
 - only the page title is being shared, not the page URL

SPECIFICATION

This PR fixes both the issues by changing the sharing URL for
WhatsApp. The URL is now changed to 'https://wa.me/....' instead
of using 'whatsapp://' protocol (see the official link[1] for more
information). With this URL, if the WhatsApp is not installed on the
device, it will provide user with the options to either download it
or use WhatsApp Web, and if WhatsApp is installed, it will open the
app. Also with the URL, we pass both page title and page URL within
'text' URL parameter, and the secure link will be automatically
parsed and converted to hyperlink by the platform.

[1] - https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat/

TaskID-2557077
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
