### PR TITLE
[imp] Detailed operations are ordered by: source and dest location

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -14,7 +14,7 @@ class StockMoveLine(models.Model):
     _name = "stock.move.line"
     _description = "Product Moves (Stock Move Line)"
     _rec_name = "product_id"
-    _order = "result_package_id desc, id"
+    _order = "result_package_id desc, location_id asc, location_dest_id asc, id"
 
     picking_id = fields.Many2one(
         'stock.picking', 'Transfer', auto_join=True,

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -86,7 +86,7 @@
                                 <tbody>
                                     <t t-foreach="o.move_ids_without_package" t-as="move">
                                         <!-- In case you come across duplicated lines, ask NIM or LAP -->
-                                        <t t-foreach="move.move_line_ids.sorted(key=lambda ml: ml.location_id.id)" t-as="ml">
+                                        <t t-foreach="move.move_line_ids" t-as="ml">
                                             <tr>
                                                 <td>
                                                     <span t-field="ml.product_id.display_name"/><br/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
The transfer line order has no sense for a picker (it's in the order of the creation of the line)

Desired behavior after PR is merged:
We want to have the line of the detailed operation in the same order as the picker will be picking the products

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
