### PR TITLE
[FIX] mrp: Wrong quantity in unbuild order

### DIFF
--- a/addons/mrp/wizard/mrp_product_produce.py
+++ b/addons/mrp/wizard/mrp_product_produce.py
@@ -148,6 +148,8 @@ class MrpProductProduce(models.TransientModel):
             quantity = wizard.qty_producing
             if float_compare(quantity, 0, precision_rounding=self.product_uom_id.rounding) <= 0:
                 raise UserError(_("The production order for '%s' has no quantity specified.") % self.product_id.display_name)
+            if float_compare(quantity, wizard.production_id.product_qty, precision_rounding=self.product_uom_id.rounding) > 0:
+                wizard.production_id.write({'product_qty': quantity})
         self._update_finished_move()
         self._update_moves()
         self.production_id.filtered(lambda mo: mo.state == 'confirmed').write({


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P with a BOM B
- B has one component C tracked by lot
- Create a MO for one P
- After clicking in "Produce" a popup opens.
In there, change the quantity to 2. Once you change the quantity, a new component C is added.
Provide the same lot_id for both components. (Field Quantity on the MO was not changed)
- Create a UB (unbuild order) providing the previously created MO in the field mo_id.
- The default quantity is 1 instead of 2 (produced quantity)

Bug:

Go Traceability of P and you'll find 2 UB with the same name.
As we only unbuild 1 P from MO, we expect 1 UB

opw:2450041