### PR TITLE
[FIX] sale_stock: Remove incoming picking from Orders Shipping Followup

### DIFF
--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -14,7 +14,7 @@
                     <strong>Delivery Orders</strong>
                 </div>
                 <div>
-                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code != 'internal')" t-as="i">
+                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code not in ['internal', 'incoming'])" t-as="i">
                         <t t-set="delivery_report_url" t-value="'/my/picking/pdf/%s?%s' % (i.id, keep_query())"/>
                         <div class="d-flex flex-wrap align-items-center justify-content-between o_sale_stock_picking">
                             <div>


### PR DESCRIPTION
Remove Delivery Order with "Receipt" type (Vendor->Local) on customer order page as it is usually private information of the company.

task-2547573

----------

Description of the issue/feature this PR addresses:
In the Customer portal : Sale Order, the customer is able to set Delivery orders of type "Receipt". However, receipt delivery order are usually privat information of the company, and never destinated to the client.
See issue: https://www.odoo.com/web?debug=0#action=3531&cids=1&id=2547573&menu_id=4720&model=project.task&view_type=form

Current behavior before PR:
https://drive.google.com/file/d/1HGVP7vGE0m2Jczv1tix5IvfCFmmZH7AR/view
Red rectangle: Delivery order of type Receipt, should not be seen by customer.
Green rectangle: Delivery order of type delivery order, should be seen by customer.

Desired behavior after PR is merged:
https://drive.google.com/file/d/1xAtPj04xr3rMy4JOqnx27fgIN-jMIsDN/view
The Receipt delivery order is not visible on the customer portal anymore


----------

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
