### PR TITLE
[FIX] web_editor: fix snippets custom colors display on color palette

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1418,6 +1418,7 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
     _renderColorPalette: function () {
         const options = {
             selectedColor: this._value,
+            $editable: this.$target.closest('.o_editable'),
         };
         if (this.options.dataAttributes.excluded) {
             options.excluded = this.options.dataAttributes.excluded.replace(/ /g, '').split(',');

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -51,8 +51,6 @@ const ColorPaletteWidget = Widget.extend({
         this.selectedColor = '';
         this.resetButton = this.options.resetButton;
         this.withCombinations = this.options.withCombinations;
-
-        this.trigger_up('request_editable', {callback: val => this.options.$editable = val});
     },
     /**
      * @override


### PR DESCRIPTION
After the new editor was merged, custom event 'request_editable'
triggered by the ColorPaletteWidget to retrieve custom colors from the
editable was not processed.

Now, we pass the editable in the options when we init the
ColorPaletteWidget.

task-2476601

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
