### PR TITLE
[FIX] website_event_exhibitor, web_editor: restore exhibitor videos

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -189,7 +189,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             iframeCssAssets: this.nodeOptions.cssEdit,
             snippets: this.nodeOptions.snippets,
             value: this.value,
-            mediaModalParams: {noVideos: true},
+            mediaModalParams: {
+                noVideos: 'noVideos' in this.nodeOptions ? this.nodeOptions.noVideos: true,
+            },
             linkForceNewWindow: true,
 
             tabsize: 0,

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -106,7 +106,7 @@
                         <page string="Description"
                              attrs="{'invisible': [('exhibitor_type', '=', 'sponsor')]}">
                             <group>
-                                <field name="website_description" nolabel="1"/>
+                                <field name="website_description" nolabel="1" options="{'noVideos': False}"/>
                             </group>
                         </page>
                         <page string="Online"


### PR DESCRIPTION
The media modal from the description field of an exhibitor was missing its video tab. This is because it was disabled as a rule for field_html. This adds the possibility to restore it via node option, and sets that option on the exhibitor description field.

Task: 2551345

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
