### PR TITLE
[FIX] sale: re-invoicing of multiple orders

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -118,7 +118,8 @@ class AccountMoveLine(models.Model):
 
         # create the sale lines in batch
         new_sale_lines = self.env['sale.order.line'].create(sale_line_values_to_create)
-        new_sale_lines._onchange_discount()
+        for sol in new_sale_lines:
+            sol._onchange_discount()
 
         # build result map by replacing index with newly created record of sale.order.line
         result = {}


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to sales app > create two SO with different price lists
- Go to expense app > create a new expense
- Add two expense lines related to the two SO
- Click on the “Submit to Manager” button
- Approve the expense
- Click on “Post journal entries”
- An error is triggered

Problem:
We call the onchange_discount on all SO lines together in the “_sale_create_reinvoice_sale_line function”, while it should be called on each created line separately

Bug introduced by this commit : https://github.com/odoo/odoo/commit/8815f4d9ab8620428d50abbe603c7f6c63076d6c

opw-2571247

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
