### PR TITLE
[FIX] account: provide wizard.composer_id in onchange response

### DIFF
--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -13,6 +13,7 @@
                     <field name="invoice_ids" invisible="1"/>
                     <field name="email_from" invisible="1" />
                     <field name="mail_server_id" invisible="1"/>
+                    <field name="composer_id" invisible="1"/>
                     <div name="option_print">
                         <field name="is_print" />
                         <b><label for="is_print"/></b>


### PR DESCRIPTION
When Send&Print several invoices, if the user unchecks and then checks
option 'Send', it will lead to an undesirable behavior: customers may
receive other customers' invoices

To reproduce the error:
1. Invoicing > Invoices, select 2 invoices
    - Customers must be different!
2. Action > Send & print
3. Uncheck all options
4. Check Email
5. Send

Error: One of the customers received both invoices

When clicking on 'Send & print', a wizard is created. Since there are
several invoices, its composition mode is 'mass_mail'. The field
`composition_mode` is inherited from its field `composer_id`:
https://github.com/odoo/odoo/blob/685fbbb621ee3d93c66d92398916a6366c47b824/addons/account/wizard/account_invoice_send.py#L20
and the values are the same: `wizard.composition_mode ==
wizard.composer_id.composition_mode == 'mass_mail'`

When selecting again the option 'Email', an onchange call is made. In
`onchange` method, a new record is created for the wizard
`account.invoice.send`:
https://github.com/odoo/odoo/blob/e7a5ba95d8b7df5bbf545ef8afe0a1f5d0f70272/odoo/models.py#L6217
`initial_values` contains `composition_mode: 'mass_mail'`. However,
there is not any information about the field `composer_id` and this is
the issue. Indeed, the record creation is done in two steps:
https://github.com/odoo/odoo/blob/e7a5ba95d8b7df5bbf545ef8afe0a1f5d0f70272/odoo/models.py#L5568-L5569
First it creates the record. Since there isn't any information about
`composer_id`, some default values are used:
https://github.com/odoo/odoo/blob/e87f599d4eb22250b628d650b9f59b54db8d043c/addons/mail/wizard/mail_compose_message.py#L145
So, we have `record.composition_mode ==
record.composer_id.composition_mode == 'comment'`
On next step, the record is updated with `values` (this variable
corresponds to `initial_values`). As a result, the `composition_mode` of
the record is updated, but not the `composition_mode` of the
`composer_id`. We then have `record.composition_mode == 'mass_mail'` and
`record.composer_id.composition_mode == 'mass_mail'`, this will lead to
unintended behaviors.

OPW-2524336