### PR TITLE
[FIX] web: do not attempt to export group info

### DIFF
--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -350,7 +350,7 @@ var ListController = BasicController.extend({
      */
     _getExportDialogWidget() {
         let state = this.model.get(this.handle);
-        let defaultExportFields = this.renderer.columns.filter(field => field.tag === 'field').map(field => field.attrs.name);
+        let defaultExportFields = this.renderer.columns.filter(field => field.tag === 'field' && state.fields[field.attrs.name].exportable !== false).map(field => field.attrs.name);
         let groupedBy = this.renderer.state.groupedBy;
         return new DataExport(this, state, defaultExportFields, groupedBy,
             this.getActiveDomain(), this.getSelectedIds());

--- a/addons/web/static/tests/widgets/data_export_tests.js
+++ b/addons/web/static/tests/widgets/data_export_tests.js
@@ -15,6 +15,7 @@ QUnit.module('widgets', {
                 fields: {
                     foo: {string: "Foo", type: "char"},
                     bar: {string: "Bar", type: "char"},
+                    unexportable: {string: "Unexportable", type: "boolean", exportable: false},
                 },
                 records: [
                     {
@@ -126,6 +127,53 @@ QUnit.module('widgets', {
             '/web/export/csv',
             'unblock UI',
         ]);
+    });
+
+    QUnit.test('exporting view with non-exportable field', async function (assert) {
+        assert.expect(0);
+
+        var list = await createView({
+            View: ListView,
+            model: 'partner',
+            data: this.data,
+            arch: '<tree><field name="unexportable"/></tree>',
+            viewOptions: {
+                hasSidebar: true,
+            },
+            mockRPC: function (route) {
+                if (route === '/web/export/formats') {
+                    return Promise.resolve([
+                        {tag: 'csv', label: 'CSV'},
+                        {tag: 'xls', label: 'Excel'},
+                    ]);
+                }
+                if (route === '/web/export/get_fields') {
+                    return Promise.resolve([
+                        {
+                            children: false,
+                            field_type: 'boolean',
+                            relation_field: null,
+                            required: false,
+                            string: 'Unexportable',
+                            exportable: false,
+                        }
+                    ]);
+                }
+                return this._super.apply(this, arguments);
+            },
+            session: {
+                get_file: function (params) {
+                    assert.step(params.url);
+                    params.complete();
+                },
+            },
+        });
+
+        await testUtils.dom.click(list.$('thead th.o_list_record_selector input'));
+        await testUtils.dom.click(list.sidebar.$('.o_dropdown_toggler_btn:contains(Action)'));
+        await testUtils.dom.click(list.sidebar.$('a:contains(Export)'));
+
+        list.destroy();
     });
 
     QUnit.test('saving fields list when exporting data', async function (assert) {


### PR DESCRIPTION
Go to User list
With studio add column User type
export

Traceback will occur because the special field sel_groups_*
should not be exported

opw-2565911

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
