### PR TITLE
[FIX] website_slides: can edit frontend enroll message


### DIFF
--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -314,7 +314,9 @@
                             </small>
                         </div>
                         <div t-else="" class="o_wslides_enroll_msg">
-                            <small t-field="channel.enroll_msg"/>
+                            <small>
+                                <div t-field="channel.enroll_msg"/>
+                            </small>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The frontend enroll message was display as a `<small/>` tag, but it
seems that lxml HTMLParser parse it wrongly, for example:

  `html.tostring(html.fromstring('<small data-oe-model="test"><p></p></small>'))`

returns:

  `'<div><small data-oe-model="test"></small><p></p></div>'`

So branding attributes like data-oe-model that are on small tag are not
found on root node that has become a `div` tag after parsing => this causes
a traceback error when saving a change in this part.

Fix: use small as wrapper for span tag that is treated correctly by
HTMLParser.

opw-2573955
