### PR TITLE
[FIX] mrp: skip service when compute kit quantities

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -380,6 +380,9 @@ class StockMove(models.Model):
         qty_ratios = []
         boms, bom_sub_lines = kit_bom.explode(product_id, kit_qty)
         for bom_line, bom_line_data in bom_sub_lines:
+            # skip service since we never deliver them
+            if bom_line.product_id.type == 'service':
+                continue
             bom_line_moves = self.filtered(lambda m: m.bom_line_id == bom_line)
             if bom_line_moves:
                 if float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):


### PR DESCRIPTION
Since we can't transfer service product, when compute delivered or
received kit quantities, we should skip the service components.

Task-2566373
PR #72306





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
