### PR TITLE
[FIX] mass_mailing: make editor perform cleanForSave on save

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -48,7 +48,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
      *
      * @override
      */
-    commitChanges: function () {
+    commitChanges: async function () {
         var self = this;
         if (this.mode === 'readonly' || !this.isRendered) {
             return this._super();
@@ -60,7 +60,9 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
 
         var $editable = this.wysiwyg.getEditable();
-
+        if (this.wysiwyg.snippetsMenu) {
+            await this.wysiwyg.snippetsMenu.cleanForSave();
+        }
         return this.wysiwyg.saveModifiedImages(this.$content).then(function () {
             self._isDirty = self.wysiwyg.isDirty();
 


### PR DESCRIPTION
Before this commit, when editing a mass_mailing template, on save,
the editor would not tell the snippet menu to perform a cleanForSave
which it should normally do for the option to properly prepare to save.

Bug discovered while working on task-2327045
Ideally, would need to be backported but requires a different fix in the
old editor.
