### PR TITLE
[FIX] web: propelry display reference field in editable form view

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -3580,8 +3580,8 @@ var FieldReference = FieldMany2One.extend({
         if (this.modelName) {
             this.$('.o_input_dropdown').show();
             if (!this.nodeOptions.model_field) {
-                // this class is used to display the two components (select & input) on the same line
-                this.$el.addClass('o_row');
+                // this classes are used to display the two components (select & input) on the same line
+                this.$el.addClass('o_field_reference_editable d-flex w-auto');
             }
         } else {
             // hide the many2one if the selection is empty

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -100,6 +100,20 @@
             padding-top: 0;
             padding-bottom: 0;
         }
+
+        &.o_field_reference_editable {
+            margin-left: -$o-form-spacing-unit/2;
+            margin-right: -$o-form-spacing-unit/2;
+            > .o_field_many2one_selection {
+                > .o_input, > .o_input_dropdown {
+                    flex: 1 1 auto;
+                    width: 0;
+                }
+                > * {
+                    margin: 0 $o-form-spacing-unit/2;
+                }
+            }
+        }
     }
 
     // Many2OneAvatar


### PR DESCRIPTION
Since a recent commit[1], many2one field was improved, and the inner components
are now wrapped within a newly introduced div `o_field_many2one_selection`.

Reference field extends many2one field and due to newly introduced wrapper div,
few editable form view related css rules (mainly for `o_row`) were broken and
the referece field was a mess in editable form view.

This commit fixes the issue by adding reference field specific rules that
restores the UI in the editable form view.

commit[1] - https://github.com/odoo/odoo/commit/288b24cbdf54ac0dbee7e012f074fac9a0c68238

TaskID-2453138

