### PR TITLE
[FIX] payment_stripe_checkout_webhook: use jsonrequest over kwargs

### DIFF
--- a/addons/payment_stripe_checkout_webhook/controllers/main.py
+++ b/addons/payment_stripe_checkout_webhook/controllers/main.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 import logging
 
 from odoo.http import request
@@ -13,5 +12,5 @@ class StripeController(http.Controller):
 
     @http.route('/payment/stripe/webhook', type='json', auth='public', csrf=False)
     def stripe_webhook(self, **kwargs):
-        request.env['payment.acquirer'].sudo()._handle_stripe_webhook(kwargs)
+        request.env['payment.acquirer'].sudo()._handle_stripe_webhook(request.jsonrequest)
         return 'OK'


### PR DESCRIPTION
Stripe is not sending JSONRPC but plain JSON;
 kwargs is empty, we need to use request.jsonrequest instead.

 Bug was introduced by a1ff4dc25534467e138cdb26f5b52df7dd33b79c

Description of the issue/feature this PR addresses:

Current behavior before PR:
webhook ignores all events

Desired behavior after PR is merged:
webhook handles checkout.session.completed

**Do not merge beyond 13.0 (13.0 excluded)**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
