### PR TITLE
[FIX] account: cash basis taxes: fix the case where an invoice has the same taxes on a negative line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4430,9 +4430,13 @@ class AccountMoveLine(models.Model):
                         # Tax line.
                         grouping_key = self.env['account.partial.reconcile']._get_cash_basis_tax_line_grouping_key_from_record(line)
                         if grouping_key in account_vals_to_fix:
+                            debit = account_vals_to_fix[grouping_key]['debit'] + vals['debit']
+                            credit = account_vals_to_fix[grouping_key]['credit'] + vals['credit']
+                            balance = debit - credit
+
                             account_vals_to_fix[grouping_key].update({
-                                'debit': account_vals_to_fix[grouping_key]['debit'] + vals['debit'],
-                                'credit': account_vals_to_fix[grouping_key]['credit'] + vals['credit'],
+                                'debit': balance if balance > 0 else 0,
+                                'credit': -balance if balance < 0 else 0,
                                 'tax_base_amount': account_vals_to_fix[grouping_key]['tax_base_amount'] + line.tax_base_amount,
                             })
                         else:

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -533,11 +533,16 @@ class AccountPartialReconcile(models.Model):
                     if grouping_key in partial_lines_to_create:
                         aggregated_vals = partial_lines_to_create[grouping_key]['vals']
 
+                        debit = aggregated_vals['debit'] + cb_line_vals['debit']
+                        credit = aggregated_vals['credit'] + cb_line_vals['credit']
+                        balance = debit - credit
+
                         aggregated_vals.update({
-                            'debit': aggregated_vals['debit'] + cb_line_vals['debit'],
-                            'credit': aggregated_vals['credit'] + cb_line_vals['credit'],
+                            'debit': balance if balance > 0 else 0,
+                            'credit': -balance if balance < 0 else 0,
                             'amount_currency': aggregated_vals['amount_currency'] + cb_line_vals['amount_currency'],
                         })
+
                         if line.tax_repartition_line_id:
                             aggregated_vals.update({
                                 'tax_base_amount': aggregated_vals['tax_base_amount'] + cb_line_vals['tax_base_amount'],

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -2354,6 +2354,32 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.assertEqual(len(caba_move.line_ids), 4, "All lines should be there")
         self.assertEqual(caba_move.line_ids.filtered(lambda x: x.tax_line_id).balance, 66.66, "Tax amount should take into account both lines")
 
+    def test_caba_double_tax_negative_line(self):
+        """ Tests making a cash basis invoice with 2 lines using the same tax: a positive and a negative one.
+        """
+        invoice = self.init_invoice('in_invoice', amounts=[300, -60], post=True, taxes=self.cash_basis_tax_a_third_amount)
+
+        pmt_wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'amount': 320,
+            'payment_date': invoice.date,
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+        })
+
+        pmt_wizard._create_payments()
+
+        partial_rec = invoice.mapped('line_ids.matched_debit_ids')
+        caba_move = self.env['account.move'].search([('tax_cash_basis_rec_id', '=', partial_rec.id)])
+
+        self.assertRecordValues(caba_move.line_ids.sorted(lambda line: (-abs(line.balance), -line.debit, line.account_id)), [
+            # Base amount:
+            {'debit': 240.0,    'credit': 0.0,      'tax_tag_ids': self.tax_tags[0].ids,    'account_id': self.cash_basis_base_account.id},
+            {'debit': 0.0,      'credit': 240.0,    'tax_tag_ids': [],                      'account_id': self.cash_basis_base_account.id},
+            # tax:
+            {'debit': 80.0,     'credit': 0.0,      'tax_tag_ids': self.tax_tags[1].ids,    'account_id': self.tax_account_1.id},
+            {'debit': 0.0,      'credit': 80.0,     'tax_tag_ids': [],                      'account_id': self.cash_basis_transfer_account.id},
+        ])
+
     def test_caba_dest_acc_reconciliation_partial_pmt(self):
         """ Test the reconciliation of tax lines (when using a reconcilable tax account)
         for partially paid invoices with cash basis taxes.


### PR DESCRIPTION
To reproduce:

- Create a cash basis tax
- Make an invoice with two lines, a positive and a negative one (the positive having a higher value), both using this tax
- Post the invoice and register a payment for it

===> It crashes when registering the payment. The SQL constraint ensuring debit/credit consistency fails when creating the cash basis entry.

This is because we were not grouping debit and credit values together on the lines sharing the same taxes; we were summing them separately. The cash basis entry then received line values with both credit and debit set, which is forbidden by the SQL constraint. We now compute the balance first, and set either debit or credit depending on its sign.
