### PR TITLE
[FIX] product,purchase_stock: get correct supplier for lead days

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -150,7 +150,7 @@ class StockRule(models.Model):
         delay, delay_description = super()._get_lead_days(product)
         bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')
-        seller = product._prepare_sellers()
+        seller = product.with_company(buy_rule.company_id)._select_seller()
         if not buy_rule or not seller:
             return delay, delay_description
         buy_rule.ensure_one()


### PR DESCRIPTION
Resupplying a product with a purchase order ask to choose the suitable
supplier to put on the purchase order. Another search is perform on top
of that to compute de date to order in order to respect the lead days
promise by the supplier. The issue is that the first search is done with
the orderpoint company into account but not the second one.

This commit passes the company to _prepare_seller when computing the total
lead days required for an order.

opw :

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
