### PR TITLE
[FIX] base,web: fix display of images of contact's children upon change

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record.js
@@ -172,7 +172,7 @@ var KanbanRecord = Widget.extend({
      * @returns {string} the url of the image
      */
     _getImageURL: function (model, field, id, placeholder) {
-        id = (_.isArray(id) ? id[0] : id) || null;
+        id = (_.isArray(id) ? id[0] : id) || false;
         var isCurrentRecord = this.modelName === model && this.recordData.id === id;
         var url;
         if (isCurrentRecord && this.record[field] && this.record[field].raw_value && !utils.is_bin_size(this.record[field].raw_value)) {

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -328,6 +328,7 @@
                                         </group>
                                         <field name="lang" invisible="True"/>
                                         <field name="user_id" invisible="True"/>
+                                        <field name="image_128" invisible="1"/>
                                     </sheet>
                                 </form>
                             </field>


### PR DESCRIPTION
- Go to Contacts
- Open a contact
- In "Contacts & Addresses" tab, add a child and configure its image
- Once child form is saved, image of the child is not displayed in the
kanban view used for children
It will only appear once the main contact form is saved.
The same issue occurs when editing a child image.
The new image will only be shown once the main contact form is saved.

The issue at the creation is due to the fact the function retrieving
the URL of the image tries to generate the URL from record id, which
is not set.
It should use raw data of image in this case.

For the edition, it is due to the fact that the child form is changing
image_1920 field while the kanban view used for children is displaying
image_128 field.  image_128 is a related field to image_1920, but it
does not appear in the child form.  It is therefore not recomputed (by
onchange) when image_1920 is modified.  Adding it in the child form view
solves the issue.

opw-2516188

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
