### PR TITLE
[FIX] mrp: allow validation when no components

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1528,7 +1528,7 @@ class MrpProduction(models.Model):
         for production in self:
             if float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
                 raise UserError(_('The quantity to produce must be positive!'))
-            if not any(production.move_raw_ids.mapped('quantity_done')):
+            if production.move_raw_ids and not any(production.move_raw_ids.mapped('quantity_done')):
                 raise UserError(_("You must indicate a non-zero amount consumed for at least one of your components"))
 
         consumption_issues = self._get_consumption_issues()


### PR DESCRIPTION
Conflicting fixes for unusual cases of MO validation when no components
assigned and when components assigned all with 0 consumed made it so we
cannot validate an MO with no components despite there being a
confirmation popup that makes it seem like you can. This fix makes it
so we can validate a MO when no components are assigned (ideally we
would allow validating both cases, but fix for 0 consumed is much more
difficult + an extremely unlikely use case).

Task: 2422698

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
