### PR TITLE
[FIX] mrp_account: correctly retrieve rounding factor of currency

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -63,7 +63,7 @@ class MrpProduction(models.Model):
         AccountAnalyticLine = self.env['account.analytic.line'].sudo()
         for wc_line in self.workorder_ids.filtered('workcenter_id.costs_hour_account_id'):
             vals = self._prepare_wc_analytic_line(wc_line)
-            precision_rounding = wc_line.workcenter_id.costs_hour_account_id.currency_id.rounding
+            precision_rounding = (wc_line.workcenter_id.costs_hour_account_id.currency_id or self.company_id.currency_id).rounding
             if not float_is_zero(vals.get('amount', 0.0), precision_rounding=precision_rounding):
                 # we use SUPERUSER_ID as we do not guarantee an mrp user
                 # has access to account analytic lines but still should be


### PR DESCRIPTION
The company is not mandatory on the analytic account, and the currency on it
is a related field to the currency of that company, if set. In case it is not
set, we should add a default fallback on the currency of the company of the
manufacturing order.

Description of the issue/feature this PR addresses:
opw-2574461

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
