### PR TITLE
[FIX] sale: impossible to generate link if there are an cancel invoice

### DIFF
--- a/addons/sale/wizard/sale_payment_link.py
+++ b/addons/sale/wizard/sale_payment_link.py
@@ -17,7 +17,7 @@ class SalePaymentLink(models.TransientModel):
             record = self.env[res['res_model']].browse(res['res_id'])
             res.update({
                 'description': record.name,
-                'amount': record.amount_total - sum(record.invoice_ids.mapped('amount_total')),
+                'amount': record.amount_total - sum(record.invoice_ids.filtered(lambda x: x.state != 'cancel').mapped('amount_total')),
                 'currency_id': record.currency_id.id,
                 'partner_id': record.partner_id.id,
                 'amount_max': record.amount_total


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
To compute the amout don't use canceled invoice.

Go to runbot
- create sale order, confirm
- create full invoice
- cancel invoice
- in SO action/ generate payment link
--> Error The value of the payment amount must be positive.

@tde-banana-odoo
@oco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
