### PR TITLE
[FIX] base_import: ensure errors are always reported

### DIFF
--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -190,7 +190,7 @@
         </span>
     </t>
     <t t-name="ImportView.error.multi.body">
-        <span class="oe_import_report_message">
+        <span class="oe_import_report_message" t-if="error.rows">
             <t t-esc="at_multi(error.rows)"/>
         </span>
     </t>


### PR DESCRIPTION
Import errors don't necessarily have the `rows` metadata (they may not
have been enriched with this information if they're high level
recovery).

The back2basics error handling changes did not properly handle this
situation, so it was possible to end up in situations where the
display of error information would silently fail due to the template
failing to render. As a result the import (or test) would look like
it'd succeeded despite that not being the case.

Add the condition to the error multi template, similar to the error
single one.
