### PR TITLE
[FIX] website: safely access menu recordset

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -140,7 +140,8 @@ class Website(models.Model):
                 if menu.parent_id and menu.parent_id in menus:
                     menu.parent_id._cache['child_id'] += (menu.id,)
 
-            website.menu_id = menus and menus.filtered(lambda m: not m.parent_id)[0].id or False
+            top_menus = menus.filtered(lambda m: not m.parent_id)
+            website.menu_id = top_menus and top_menus[0].id or False
 
     # self.env.uid for ir.rule groups on menu
     @tools.ormcache('self.env.uid', 'self.id')


### PR DESCRIPTION
Introduced with 7fb016f9966b
[0] access could crash, recordset could be empty after `filtered`.

Step to reproduce:
  - Add admin group to website top level menu (Website > Debug > Menu)
  - Try to access frontend as non admin

opw-2573763
task-2574346
