### PR TITLE
[FIX] {point_of_sale,account}: forbid posting cash bank statement whe…

### DIFF
--- a/addons/point_of_sale/models/account_bank_statement.py
+++ b/addons/point_of_sale/models/account_bank_statement.py
@@ -24,6 +24,12 @@ class AccountBankStatement(models.Model):
                 raise UserError(_("You cannot delete a bank statement linked to Point of Sale session."))
         return super( AccountBankStatement, self).unlink()
 
+    def button_post(self):
+        for statement in self:
+            if statement.journal_id.type == 'cash' and statement.pos_session_id and statement.pos_session_id.state != 'closed':
+                raise UserError(_("You cannot manually post a cash bank statement from an ongoing POS session"))
+        return super().button_post()
+
 class AccountBankStatementLine(models.Model):
     _inherit = 'account.bank.statement.line'
 

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -707,7 +707,7 @@ class PosSession(models.Model):
         for statement in self.statement_ids:
             if not self.config_id.cash_control:
                 statement.write({'balance_end_real': statement.balance_end})
-            statement.button_post()
+            statement._post_statement()
             all_lines = (
                   split_cash_statement_lines[statement].mapped('move_id.line_ids').filtered(lambda aml: aml.account_id.internal_type == 'receivable')
                 | combine_cash_statement_lines[statement].mapped('move_id.line_ids').filtered(lambda aml: aml.account_id.internal_type == 'receivable')


### PR DESCRIPTION
…n `pos.session` is ongoing

The user was able to post a cash bank statement regarding a `pos.session`. The latter could then not be closed. This commit prevents such situation from happening.

task-2492631