### PR TITLE
[ADD] auth_oauth: added Microsoft Azure auth provider

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -60,7 +60,7 @@ class OAuthLogin(Home):
             return_url = request.httprequest.url_root + 'auth_oauth/signin'
             state = self.get_state(provider)
             params = dict(
-                response_type='token',
+                response_type=provider['response_type'],
                 client_id=provider['client_id'],
                 redirect_uri=return_url,
                 scope=provider['scope'],

--- a/addons/auth_oauth/data/auth_oauth_data.xml
+++ b/addons/auth_oauth/data/auth_oauth_data.xml
@@ -29,6 +29,15 @@
             <field name="css_class">fa fa-fw fa-google</field>
             <field name="body">Log in with Google</field>
         </record>
+        <record id="provider_microsoft" model="auth.oauth.provider">
+             <field name="name">Microsoft OAuth2</field>
+             <field name="auth_endpoint">https://login.microsoftonline.com/common/oauth2/v2.0/authorize</field>
+             <field name="scope">openid profile email</field>
+             <field name="validation_endpoint">https://login.microsoftonline.com/common/oauth2/v2.0/token</field>
+             <field name="css_class">fa fa-fw fa-windows</field>
+             <field name="body">Log in with Microsoft</field>
+             <field name="response_type">code</field>
+         </record>
 
         <!-- Use database uuid as client_id for OpenERP oauth provider -->
         <function model="auth.oauth.provider" name="write">

--- a/addons/auth_oauth/models/auth_oauth.py
+++ b/addons/auth_oauth/models/auth_oauth.py
@@ -13,6 +13,7 @@ class AuthOAuthProvider(models.Model):
 
     name = fields.Char(string='Provider name', required=True)  # Name of the OAuth2 entity, Google, etc
     client_id = fields.Char(string='Client ID')  # Our identifier
+    client_secret = fields.Char(string='Client Secret')
     auth_endpoint = fields.Char(string='Authentication URL', required=True)  # OAuth provider URL to authenticate users
     scope = fields.Char()  # OAUth user data desired to access
     validation_endpoint = fields.Char(string='Validation URL', required=True)  # OAuth provider URL to validate tokens
@@ -20,4 +21,5 @@ class AuthOAuthProvider(models.Model):
     enabled = fields.Boolean(string='Allowed')
     css_class = fields.Char(string='CSS class', default='fa fa-fw fa-sign-in text-primary')
     body = fields.Char(required=True, help='Link text in Login Dialog', translate=True)
+    response_type = fields.Selection([('token', 'Token'), ('code', 'Code')], default='token', required=True)
     sequence = fields.Integer(default=10)

--- a/addons/auth_oauth/models/res_config_settings.py
+++ b/addons/auth_oauth/models/res_config_settings.py
@@ -18,6 +18,9 @@ class ResConfigSettings(models.TransientModel):
     auth_oauth_google_enabled = fields.Boolean(string='Allow users to sign in with Google')
     auth_oauth_google_client_id = fields.Char(string='Client ID')
     server_uri_google = fields.Char(string='Server uri')
+    auth_oauth_microsoft_enabled = fields.Boolean(string='Allow users to sign in with Microsoft')
+    auth_oauth_microsoft_client_id = fields.Char(string='Microsoft Client ID')
+    auth_oauth_microsoft_client_secret = fields.Char(string='Microsoft Client Secret')
 
     @api.model
     def get_values(self):

--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -3,7 +3,10 @@
 
 import json
 
+import logging
 import requests
+
+from odoo.http import request
 
 from odoo import api, fields, models
 from odoo.exceptions import AccessDenied, UserError
@@ -11,6 +14,15 @@ from odoo.addons.auth_signup.models.res_users import SignupError
 
 from odoo.addons import base
 base.models.res_users.USER_PRIVATE_FIELDS.append('oauth_access_token')
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import jwt
+except ImportError:
+    _logger.warning("The PyJWT python library is not installed, login with Microsoft OAuth2 won't be available.")
+    jwt = None
+
 
 class ResUsers(models.Model):
     _inherit = 'res.users'
@@ -37,6 +49,45 @@ class ResUsers(models.Model):
         if oauth_provider.data_endpoint:
             data = self._auth_oauth_rpc(oauth_provider.data_endpoint, access_token)
             validation.update(data)
+        return validation
+
+    @api.model
+    def _auth_oauth_code_validate(self, provider, code):
+        """ requests access_token using provided code and returns
+            the validation data corresponding to the access token
+        """
+        oauth_provider = self.env['auth.oauth.provider'].browse(provider)
+        req_params = dict(
+            client_id=oauth_provider.client_id,
+            client_secret=oauth_provider.client_secret,
+            grant_type='authorization_code',
+            code=code,
+            redirect_uri=request.httprequest.url_root + 'auth_oauth/signin',
+        )
+        headers = {'Accept': 'application/json'}
+
+        token_info = requests.post(oauth_provider.validation_endpoint, headers=headers, data=req_params).json()
+        if token_info.get("error"):
+            raise Exception(token_info['error'])
+
+        access_token = token_info.get('access_token')
+        validation = {
+            'access_token': access_token
+        }
+
+        if token_info.get('id_token'):
+            # Used in case of Microsoft's Azure AD API
+            # We can directly access basic info from 'id_token', without
+            # making another call to any data_endpoint
+            if not jwt:
+                _logger.warning("The PyJWT python library is missing, not able to login with Microsoft Account.")
+                raise AccessDenied()
+            data = jwt.decode(token_info['id_token'], options={"verify_signature": False})
+        else:
+            # For other providers, fetch data using data_endpoint
+            data = self._auth_oauth_rpc(oauth_provider.data_endpoint, access_token)
+
+        validation.update(data)
         return validation
 
     @api.model
@@ -92,13 +143,22 @@ class ResUsers(models.Model):
         #   abort()
         # else:
         #   continue with the process
-        access_token = params.get('access_token')
-        validation = self._auth_oauth_validate(provider, access_token)
+        if params.get('code'):
+            # code grant flow, which will give code to retrieve access_token
+            validation = self._auth_oauth_code_validate(provider, params['code'])
+            access_token = validation.pop('access_token')
+            params['access_token'] = access_token
+        else:
+            # implicit flow, which directly gives access_token
+            access_token = params.get('access_token')
+            validation = self._auth_oauth_validate(provider, access_token)
         # required check
         if not validation.get('user_id'):
-            # Workaround: facebook does not send 'user_id' in Open Graph Api
-            if validation.get('id'):
+            # Workaround for Facebook and Microsoft as they do not send 'user_id'
+            if validation.get('id'):  # for Facebook
                 validation['user_id'] = validation['id']
+            elif validation.get('oid'):  # for Microsoft
+                validation['user_id'] = validation['oid']
             else:
                 raise AccessDenied()
 

--- a/addons/auth_oauth/static/src/scss/auth_oauth.scss
+++ b/addons/auth_oauth/static/src/scss/auth_oauth.scss
@@ -7,6 +7,10 @@
         color: #de564a;
     }
 
+    .fa-windows {
+        color: #327ed0;
+    }
+
     .o_custom_icon {
         margin: 0 0.15em;
         @include size(1em);

--- a/addons/auth_oauth/views/auth_oauth_views.xml
+++ b/addons/auth_oauth/views/auth_oauth_views.xml
@@ -17,6 +17,8 @@
                             <field name="auth_endpoint" />
                             <field name="scope" />
                             <field name="validation_endpoint" />
+                            <field name="response_type" />
+                            <field name="client_secret" password="True" attrs="{'invisible': [('response_type', '!=', 'code')], 'required': [('response_type', '=', 'code')]}"/>
                             <field name="data_endpoint" />
                         </group>
                     </sheet>

--- a/addons/auth_oauth/views/res_config_settings_views.xml
+++ b/addons/auth_oauth/views/res_config_settings_views.xml
@@ -1,40 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <record id="res_config_settings_view_form" model="ir.ui.view">
-            <field name="name">res.config.settings.view.form.inherit.auth.oauth</field>
-            <field name="model">res.config.settings</field>
-            <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
-            <field name="arch" type="xml">
-                <div id="msg_module_auth_oauth" position="replace">
-                    <div class="content-group" attrs="{'invisible': [('module_auth_oauth','=',False)]}">
-                        <div class="mt8">
-                            <button type="action" name="%(auth_oauth.action_oauth_provider)d" string="OAuth Providers" icon="fa-arrow-right" class="btn-link"/>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.auth.oauth</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <div id="msg_module_auth_oauth" position="replace">
+                <div class="content-group" attrs="{'invisible': [('module_auth_oauth','=',False)]}">
+                    <div class="mt8">
+                        <button type="action" name="%(auth_oauth.action_oauth_provider)d" string="OAuth Providers" icon="fa-arrow-right" class="btn-link"/>
+                    </div>
+                </div>
+            </div>
+            <div id="module_auth_oauth" position="after">
+                <div class="col-12 col-lg-6 o_setting_box"
+                     id="signin_google_setting"
+                     attrs="{'invisible': [('module_auth_oauth','=',False)]}">
+                    <div class="o_setting_left_pane">
+                        <field name="auth_oauth_google_enabled"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label string="Google Authentication" for="auth_oauth_google_enabled"/>
+                        <a href="https://www.odoo.com/documentation/14.0/applications/general/auth/google.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                        <div class="text-muted">
+                            Allow users to sign in with their Google account
+                        </div>
+                        <div class="content-group" attrs="{'invisible': [('auth_oauth_google_enabled','=',False)]}">
+                            <div class="row mt16">
+                                <label for="auth_oauth_google_client_id" string="Client ID:" class="col-lg-3 o_light_label"/>
+                                <field name="auth_oauth_google_client_id" placeholder="e.g. 1234-xyz.apps.googleusercontent.com"/>
+                            </div>
+                            <a href="https://www.odoo.com/documentation/14.0/applications/general/auth/google.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
                         </div>
                     </div>
                 </div>
-                <div id="module_auth_oauth" position="after">
-                    <div class="col-12 col-lg-6 o_setting_box"
-                        id="signin_google_setting"
-                        attrs="{'invisible': [('module_auth_oauth','=',False)]}">
-                        <div class="o_setting_left_pane">
-                            <field name="auth_oauth_google_enabled"/>
+                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_auth_oauth','=',False)]}">
+                    <div class="o_setting_left_pane">
+                        <field name="auth_oauth_microsoft_enabled"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label string="Microsoft Authentication" for="auth_oauth_microsoft_enabled"/>
+                        <div class="text-muted">
+                            Allow users to sign in with their Microsoft account
                         </div>
-                        <div class="o_setting_right_pane">
-                            <label string="Google Authentication" for="auth_oauth_google_enabled"/>
-                            <a href="https://www.odoo.com/documentation/14.0/applications/general/auth/google.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                            <div class="text-muted">
-                                Allow users to sign in with their Google account
+                        <div class="content-group" attrs="{'invisible': [('auth_oauth_microsoft_enabled','=',False)]}">
+                            <div class="row mt16">
+                                <label for="auth_oauth_microsoft_client_id" string="Client ID:" class="col-md-3 o_light_label"/>
+                                <field name="auth_oauth_microsoft_client_id"/>
+                                <label for="auth_oauth_microsoft_client_secret" string="Client Secret:" class="col-md-3 o_light_label"/>
+                                <field name="auth_oauth_microsoft_client_secret" password="True"/>
                             </div>
-                            <div class="content-group" attrs="{'invisible': [('auth_oauth_google_enabled','=',False)]}">
-                                <div class="row mt16">
-                                    <label for="auth_oauth_google_client_id" string="Client ID:" class="col-lg-3 o_light_label"/>
-                                    <field name="auth_oauth_google_client_id" placeholder="e.g. 1234-xyz.apps.googleusercontent.com"/>
-                                </div>
-                                <a href="https://www.odoo.com/documentation/14.0/applications/general/auth/google.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
-                            </div>
+                            <a href="https://www.odoo.com/documentation/user/online/general/auth/microsoft.html" target="_blank"><i class="fa fa-fw fa-arrow-right"/>Tutorial</a>
                         </div>
                     </div>
                 </div>
-            </field>
-        </record>
+            </div>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This commit enables user to login with their Microsoft Account.

We have used implicit type authentication for all other providers,
which directly gives access_token for fetching user details.

However, to implement implicit type auth in case of Microsoft, an
extra parameter 'nonce' needs to be passed in the request to fetch
the access_token and id_token (id_token is used for fetching basic
user details). Here 'nonce', should be a randomized value which can
be verified in response to mitigate token replay attacks, and thus
have to be stored somewhere if we want to verify it.

Also, instead of using implicit type auth, it is recommended for
web-apps to use Authorization Code Grant flow for authentication,
which is more secure than the former one.

For both above reasons, this commit makes it possible to use the
Authorization Code Grant flow for all providers, and uses it
by default for Microsoft Azure.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


PS : I used this PR https://github.com/odoo/odoo/pull/29180

thanks @dep-odoo 

@odony @antonylesuisse Any customers ask to have this feature in Odoo.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
