### PR TITLE
[12.0][FIX] point_of_sales: create invoice from POS UI, without Billing group

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -822,7 +822,7 @@ class PosOrder(models.Model):
                 pos_order.invoice_id.sudo().with_context(
                     force_company=self.env.user.company_id.id, pos_picking_id=pos_order.picking_id
                 ).action_invoice_open()
-                pos_order.account_move = pos_order.invoice_id.move_id
+                pos_order.account_move = pos_order.invoice_id.sudo().move_id
         return order_ids
 
     def test_paid(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

POS users/managers should be able to _Print invoices on customer request_, from the POS UI, without needing to be part of the Billing group.

**Current behavior before PR:**

- Create a user with group 'Point of Sale / User' only
- Create a POS order, select Customer, select Invoice
- Order creation raises an error:

```
Traceback (most recent call last):
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/odoo/12.0/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/odoo/12.0/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/odoo/12.0/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/odoo/12.0/addons/web/controllers/main.py", line 963, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/odoo/12.0/addons/web/controllers/main.py", line 955, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/12.0/odoo/api.py", line 755, in call_kw
    return _call_kw_model(method, model, args, kwargs)
  File "/opt/odoo/odoo/12.0/odoo/api.py", line 728, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/odoo/12.0/addons/point_of_sale/models/pos_order.py", line 825, in create_from_ui
    pos_order.account_move = pos_order.invoice_id.move_id
  File "/opt/odoo/odoo/12.0/odoo/fields.py", line 1069, in __get__
    self.determine_value(record)
  File "/opt/odoo/odoo/12.0/odoo/fields.py", line 1172, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/odoo/12.0/odoo/models.py", line 2883, in _prefetch_field
    result = self.read([f.name for f in fs], load='_classic_write')
  File "/opt/odoo/odoo/12.0/odoo/models.py", line 2799, in read
    self.check_access_rights('read')
  File "/opt/odoo/odoo/12.0/odoo/models.py", line 3070, in check_access_rights
    return self.env['ir.model.access'].check(self._name, operation, raise_exception)
  File "<decorator-gen-23>", line 2, in check
  File "/opt/odoo/odoo/12.0/odoo/tools/cache.py", line 93, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/12.0/odoo/addons/base/models/ir_model.py", line 1301, in check
    raise AccessError(msg % msg_params)
odoo.exceptions.AccessError: ('Sorry, you are not allowed to access this document. Only users with the following access level are currently allowed to do that:\n- Accounting & Finance/Billing\n\t- Accounting & Finance/Billing\n\t- User types/Portal\n\t- Technical Settings/Show Full Accounting Features\n\n(Document model: account.invoice) - (Operation: read, User: 6)', None)
```

**Desired behavior after PR is merged:**

- Order and invoice are created without error

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
