### PR TITLE
[IMP] various: added listviews for reporting models

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -5,7 +5,7 @@
          <field name="name">account.invoice.report.pivot</field>
          <field name="model">account.invoice.report</field>
          <field name="arch" type="xml">
-             <pivot string="Invoices Analysis" disable_linking="True" sample="1">
+             <pivot string="Invoices Analysis" sample="1">
                  <field name="product_categ_id" type="col"/>
                  <field name="invoice_date" type="row"/>
                  <field name="price_subtotal" type="measure"/>
@@ -17,12 +17,37 @@
          <field name="name">account.invoice.report.graph</field>
          <field name="model">account.invoice.report</field>
          <field name="arch" type="xml">
-             <graph string="Invoices Analysis" type="line" sample="1" disable_linking="1">
+             <graph string="Invoices Analysis" type="line" sample="1">
                  <field name="product_categ_id"/>
                  <field name="price_subtotal" type="measure"/>
              </graph>
          </field>
     </record>
+
+     <record id="account_invoice_report_view_tree" model="ir.ui.view">
+         <field name="name">account.invoice.report.view.tree</field>
+         <field name="model">account.invoice.report</field>
+         <field name="arch" type="xml">
+             <tree string="Invoices Analysis">
+                <field name="move_id" string="Invoice Number"/>
+                <field name="journal_id" optional="hide"/>
+                <field name="partner_id" optional="show"/>
+                <field name="country_id" optional="hide"/>
+                <field name="invoice_date" optional="show"/>
+                <field name="invoice_date_due" optional="show"/>
+                <field name="invoice_user_id" optional="hide" widget="many2one_avatar_user"/>
+                <field name="product_categ_id" optional="hide"/>
+                <field name="product_id" optional="show"/>
+                <field name="company_id"  groups="base.group_multi_company"/>
+                <field name="price_average" optional="hide" sum="Total"/>
+                <field name="quantity" optional="hide" sum="Total"/>
+                <field name="price_subtotal" optional="show" sum="Total"/>
+                <field name="state" optional="hide"/>
+                <field name="payment_state" optional="hide"/>
+                <field name="move_type" optional="hide"/>
+             </tree>
+         </field>
+     </record>
 
     <!-- Custom reports (aka filters) -->
     <record id="filter_invoice_report_salespersons" model="ir.filters">

--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -5,7 +5,7 @@
             <field name="name">crm.activity.report.graph</field>
             <field name="model">crm.activity.report</field>
             <field name="arch" type="xml">
-                <graph string="Activities Analysis" stacked="True" sample="1" disable_linking="1">
+                <graph string="Activities Analysis" stacked="True" sample="1">
                     <field name="mail_activity_type_id" type="col"/>
                     <field name="date" interval="month" type="row"/>
                 </graph>
@@ -16,7 +16,7 @@
             <field name="name">crm.activity.report.pivot</field>
             <field name="model">crm.activity.report</field>
             <field name="arch" type="xml">
-                <pivot string="Activities Analysis" disable_linking="True" sample="1">
+                <pivot string="Activities Analysis" sample="1">
                     <field name="mail_activity_type_id" type="col"/>
                     <field name="date" interval="month" type="row"/>
                 </pivot>

--- a/addons/fleet/views/fleet_board_view.xml
+++ b/addons/fleet/views/fleet_board_view.xml
@@ -25,7 +25,7 @@
         <field name="name">fleet.vehicle.cost.view.pivot</field>
         <field name="model">fleet.vehicle.cost.report</field>
         <field name="arch" type="xml">
-            <pivot sample="1" disable_linking="True">
+            <pivot sample="1">
                 <field name="date_start" type="col" interval="year" />
                 <field name="cost_type" type="col" />
                 <field name="vehicle_id" type="row" />
@@ -38,7 +38,7 @@
         <field name="name">fleet.vehicle.cost.view.graph</field>
         <field name="model">fleet.vehicle.cost.report</field>
         <field name="arch" type="xml">
-            <graph string="Fleet Costs Analysis" type="bar" sample="1" disable_linking="1">
+            <graph string="Fleet Costs Analysis" type="bar" sample="1">
                 <field name="date_start" type="row" interval="month"/>
                 <field name="cost_type" type="row"/>
                 <field name="cost" type="measure"/>
@@ -46,6 +46,21 @@
         </field>
     </record>
 
+    <record id="fleet_vechicle_costs_report_view_tree" model="ir.ui.view">
+        <field name="name">fleet.vehicle.cost.report.view.tree</field>
+        <field name="model">fleet.vehicle.cost.report</field>
+        <field name="arch" type="xml">
+            <tree string="Fleet Costs Analysis">
+                <field name="name"/>
+                <field name="driver_id" optional="show"/>
+                <field name="fuel_type" optional="hide"/>
+                <field name="date_start" optional="show"/>
+                <field name="cost" optional="show" sum="Sum of Cost"/>
+                <field name="cost_type" optional="show"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+            </tree>
+        </field>
+    </record>
 
  <record id="fleet_costs_reporting_action" model="ir.actions.act_window">
       <field name="name">Costs Analysis</field>

--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -29,8 +29,9 @@
                 </xpath>
              </field>
         </record>
-        <record id="view_project_task_user_search_inherited" model="ir.ui.view">
-            <field name="name">report.project.task.user.search.inherited</field>
+
+        <record id="report_project_task_user_view_search" model="ir.ui.view">
+            <field name="name">report.project.task.user.view.search.inherit.hr.timesheet</field>
             <field name="model">report.project.task.user</field>
             <field name="inherit_id" ref="project.view_task_project_user_search" />
             <field name="arch" type="xml">
@@ -44,6 +45,18 @@
                     <filter string="My Team's Tasks" name="my_team_tasks" domain="[('task_id.user_id.employee_id.parent_id.user_id', '=', uid)]" />
                 </xpath>
              </field>
+         </record>
+
+        <record id="report_project_task_user_view_tree" model="ir.ui.view">
+            <field name="name">report.project.task.user.view.tree.inherit.hr.timesheet</field>
+            <field name="model">report.project.task.user</field>
+            <field name="inherit_id" ref="project.report_project_task_user_view_tree"/>
+            <field name="arch" type="xml">
+                <field name="user_id" position="after">
+                    <field name="hours_effective" optional="hide" widget="float_time"/>
+                    <field name="progress" optional="hide" widget="progressbar"/>
+                </field>
+            </field>
         </record>
     </data>
 </odoo>

--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
@@ -5,7 +5,7 @@
             <field name="name">Search for HR timesheet attendance report</field>
             <field name="model">hr.timesheet.attendance.report</field>
             <field name="arch" type="xml">
-                <search string="timesheet attendance">
+                <search string="Timesheet Attendance">
                     <field name="user_id"/>
                     <filter name="month" string="Date" date="date"/>
                     <filter name="group_by_month" string="Date" date="date" context="{'group_by': 'date'}"/>
@@ -16,12 +16,26 @@
             <field name="name">HR timesheet attendance report: Pivot</field>
             <field name="model">hr.timesheet.attendance.report</field>
             <field name="arch" type="xml">
-                <pivot string="timesheet attendance" disable_linking="True" sample="1">
+                <pivot string="Timesheet Attendance" sample="1">
                     <field name="date" interval="month" type="row"/>
                     <field name="total_attendance" type="measure" widget="timesheet_uom"/>
                     <field name="total_timesheet" type="measure" widget="timesheet_uom"/>
                     <field name="total_difference" type="measure" widget="timesheet_uom"/>
                 </pivot>
+            </field>
+        </record>
+
+        <record id="hr_timesheet_attendance_report_view_tree" model="ir.ui.view">
+            <field name="name">hr.timesheet.attendance.report.view.tree</field>
+            <field name="model">hr.timesheet.attendance.report</field>
+            <field name="arch" type="xml">
+                <tree string="Timesheet Attendance">
+                    <field name="date"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="total_timesheet" optional="show" sum="Sum of Total Timesheet"/>
+                    <field name="total_attendance" optional="show" sum="Sum of Total Attendance"/>
+                    <field name="total_difference" optional="show" sum="Sum of Total Difference"/>
+                </tree>
             </field>
         </record>
 

--- a/addons/membership/report/report_membership_views.xml
+++ b/addons/membership/report/report_membership_views.xml
@@ -35,7 +35,7 @@
             <field name="name">report.membership.pivot</field>
             <field name="model">report.membership</field>
             <field name="arch" type="xml">
-                <pivot string="Membership" disable_linking="True" sample="1">
+                <pivot string="Membership" sample="1">
                     <field name="membership_id" type="row"/>
                     <field name="start_date" interval="month" type="col"/>
                     <field name="quantity" type="measure"/>
@@ -50,13 +50,33 @@
             <field name="name">report.membership.graph1</field>
             <field name="model">report.membership</field>
             <field name="arch" type="xml">
-                <graph string="Membership" sample="1" disable_linking="1">
+                <graph string="Membership" sample="1">
                     <field name="membership_id" type="row"/>
                     <field name="start_date" interval="month" type="col"/>
                     <field name="quantity" type="measure"/>
                 </graph>
             </field>
         </record>
+
+    <record id="report_membership_view_tree" model="ir.ui.view">
+        <field name="name">report.membership.view.tree</field>
+        <field name="model">report.membership</field>
+        <field name="arch" type="xml">
+            <tree string="Membership">
+                <field name="partner_id"/>
+                <field name="membership_id" optional="hide"/>
+                <field name="start_date" optional="hide"/>
+                <field name="date_to" optional="hide"/>
+                <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                <field name="num_invoiced" optional="show" sum="Sum of # Invoiced"/>
+                <field name="num_paid" optional="show" sum="Sum of # Paid"/>
+                <field name="quantity" optional="show" sum="Sum of Quantity"/>
+                <field name="tot_earned" optional="show" sum="Sum of Earned Amount"/>
+                <field name="membership_state" optional="hide"/>
+            </tree>
+        </field>
+    </record>
 
         <record model="ir.actions.act_window" id="action_report_membership_tree">
             <field name="name">Members Analysis</field>

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -4,7 +4,7 @@
             <field name="name">report.pos.order.pivot</field>
             <field name="model">report.pos.order</field>
             <field name="arch" type="xml">
-                <pivot string="Point of Sale Analysis" disable_linking="True" sample="1">
+                <pivot string="Point of Sale Analysis" sample="1">
                     <field name="product_categ_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="order_id" type="measure"/>
@@ -18,10 +18,27 @@
             <field name="name">report.pos.order.graph</field>
             <field name="model">report.pos.order</field>
             <field name="arch" type="xml">
-                <graph string="Point of Sale Analysis" sample="1" disable_linking="1">
+                <graph string="Point of Sale Analysis" sample="1">
                     <field name="product_categ_id" type="row"/>
                     <field name="price_total" type="measure"/>
                 </graph>
+            </field>
+        </record>
+
+        <record id="report_pos_order_view_tree" model="ir.ui.view">
+            <field name="name">report.pos.order.view.tree</field>
+            <field name="model">report.pos.order</field>
+            <field name="arch" type="xml">
+                <tree string="Point of Sale Analysis">
+                    <field name="date" widget="date"/>
+                    <field name="order_id" optional="hide"/>
+                    <field name="partner_id" optional="hide"/>
+                    <field name="product_id" optional="show"/>
+                    <field name="product_categ_id" optional="show"/>
+                    <field name="config_id" optional="hide"/>
+                    <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                    <field name="state" optional="show"/>
+                </tree>
             </field>
         </record>
 

--- a/addons/pos_hr/views/pos_order_report_view.xml
+++ b/addons/pos_hr/views/pos_order_report_view.xml
@@ -10,5 +10,16 @@
             </xpath>
         </field>
     </record>
+
+   <record id="report_pos_order_view_tree" model="ir.ui.view">
+        <field name="name">report.pos.order.view.tree.inherit.pos.hr</field>
+        <field name="model">report.pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.report_pos_order_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="product_categ_id" position="after">
+                <field name="employee_id" widget="many2one_avatar_employee"/>
+            </field>
+        </field>
+    </record>
 </odoo>
 

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -5,7 +5,7 @@
             <field name="name">report.project.task.user.pivot</field>
             <field name="model">report.project.task.user</field>
             <field name="arch" type="xml">
-                <pivot string="Tasks Analysis" display_quantity="true" disable_linking="True" sample="1">
+                <pivot string="Tasks Analysis" display_quantity="true" sample="1">
                     <field name="project_id" type="row"/>
                 </pivot>
             </field>
@@ -15,12 +15,27 @@
             <field name="name">report.project.task.user.graph</field>
             <field name="model">report.project.task.user</field>
             <field name="arch" type="xml">
-                <graph string="Tasks Analysis" type="bar" sample="1" disable_linking="1">
+                <graph string="Tasks Analysis" type="bar" sample="1">
                      <field name="project_id" type="row"/>
                      <field name="user_id" type="col"/>
                      <field name="nbr" invisible="1"/>
                  </graph>
              </field>
+        </record>
+
+        <record id="report_project_task_user_view_tree" model="ir.ui.view">
+            <field name="name">report.project.task.user.view.tree</field>
+            <field name="model">report.project.task.user</field>
+            <field name="arch" type="xml">
+                <tree string="Tasks Analysis">
+                    <field name="name"/>
+                    <field name="partner_id" optional="hide"/>
+                    <field name="project_id" optional="show"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="stage_id" optional="show"/>
+                    <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                </tree>
+            </field>
         </record>
 
         <record id="view_task_project_user_search" model="ir.ui.view">

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -4,7 +4,7 @@
             <field name="name">product.month.pivot</field>
             <field name="model">purchase.report</field>
             <field name="arch" type="xml">
-                <pivot string="Purchase Analysis" disable_linking="True" display_quantity="true" sample="1">
+                <pivot string="Purchase Analysis" display_quantity="true" sample="1">
                     <field name="category_id" type="row"/>
                     <field name="order_id" type="measure"/>
                     <field name="untaxed_total" type="measure"/>
@@ -16,10 +16,33 @@
             <field name="name">product.month.graph</field>
             <field name="model">purchase.report</field>
             <field name="arch" type="xml">
-                <graph string="Purchase Orders Statistics" type="line" sample="1" disable_linking="1">
+                <graph string="Purchase Analysis" type="line" sample="1">
                     <field name="date_approve" interval="day" type="col"/>
                     <field name="untaxed_total" type="measure"/>
                 </graph>
+            </field>
+        </record>
+
+        <record id="purchase_report_view_tree" model="ir.ui.view">
+            <field name="name">purchase.report.view.tree</field>
+            <field name="model">purchase.report</field>
+            <field name="arch" type="xml">
+                <tree string="Purchase Analysis">
+                    <field name="date_order" widget="date"/>
+                    <field name="order_id" optional="show"/>
+                    <field name="partner_id" optional="show"/>
+                    <field name="product_id" optional="show"/>
+                    <field name="category_id" optional="show"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                    <field name="qty_ordered" optional="hide" sum="Sum of Qty Ordered"/>
+                    <field name="qty_received" optional="hide" sum="Sum of Qty Received"/>
+                    <field name="qty_billed" optional="hide" sum="Sum of Qty Billed"/>
+                    <field name="currency_id" optional="show" invisible="1"/>
+                    <field name="untaxed_total" optional="hide" widget="monetary" sum="Sum of Untaxed Total"/>
+                    <field name="price_total" optional="show" widget="monetary" sum="Sum of Total"/>
+                    <field name="state" optional="show"/>
+                </tree>
             </field>
         </record>
 

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -5,7 +5,7 @@
          <field name="name">sale.report.pivot</field>
          <field name="model">sale.report</field>
          <field name="arch" type="xml">
-             <pivot string="Sales Analysis" disable_linking="True" sample="1">
+             <pivot string="Sales Analysis" sample="1">
                  <field name="team_id" type="col"/>
                  <field name="date" interval="month" type="row"/>
                  <field name="price_subtotal" type="measure"/>
@@ -17,11 +17,29 @@
          <field name="name">sale.report.graph</field>
          <field name="model">sale.report</field>
          <field name="arch" type="xml">
-             <graph string="Sales Analysis" type="line" sample="1" disable_linking="1">
+             <graph string="Sales Analysis" type="line" sample="1">
                  <field name="date" type="row" interval="day"/>
                  <field name="price_subtotal" type="measure"/>
              </graph>
          </field>
+    </record>
+
+    <record id="sale_report_view_tree" model="ir.ui.view">
+        <field name="name">sale.report.view.tree</field>
+        <field name="model">sale.report</field>
+        <field name="arch" type="xml">
+            <tree string="Sales Analysis">
+                <field name="date" widget="date"/>
+                <field name="order_id" optional="show"/>
+                <field name="partner_id" optional="hide"/>
+                <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                <field name="team_id" optional="show"/>
+                <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                <field name="price_subtotal" optional="hide" sum="Sum of Untaxed Total"/>
+                <field name="price_total" optional="show" sum="Sum of Total"/>
+                <field name="state" optional="hide"/>
+            </tree>
+        </field>
     </record>
 
     <record id="view_order_product_search" model="ir.ui.view">

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1246,6 +1246,18 @@
             </field>
         </record>
 
+        <!-- Update account invoice report  -->
+        <record id="account_invoice_report_view_tree" model="ir.ui.view">
+            <field name="name">account.invoice.report.view.tree.inherit.sale</field>
+            <field name="model">account.invoice.report</field>
+            <field name="inherit_id" ref="account.account_invoice_report_view_tree"/>
+            <field name="arch" type="xml">
+                <field name="invoice_user_id" position="after">
+                    <field name="team_id" optional="hide"/>
+                </field>
+            </field>
+        </record>
+
         <!-- search by Salesteams -->
         <record id="action_orders_salesteams" model="ir.actions.act_window">
             <field name="name">Sales Orders</field>

--- a/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
@@ -5,7 +5,7 @@
         <field name="name">project.profitability.report.pivot</field>
         <field name="model">project.profitability.report</field>
         <field name="arch" type="xml">
-            <pivot string="Profitability Analysis" display_quantity="true" disable_linking="True" sample="1">
+            <pivot string="Profitability Analysis" display_quantity="true" sample="1">
                 <field name="project_id" type="row"/>
                 <field name="amount_untaxed_to_invoice" type="measure"/>
                 <field name="amount_untaxed_invoiced" type="measure"/>
@@ -20,7 +20,7 @@
         <field name="name">project.profitability.report.graph</field>
         <field name="model">project.profitability.report</field>
         <field name="arch" type="xml">
-            <graph string="Profitability Analysis" type="bar" sample="1" disable_linking="1" js_class="hr_timesheet_graphview">
+            <graph string="Profitability Analysis" type="bar" sample="1" js_class="hr_timesheet_graphview">
                 <field name="project_id" type="row"/>
                 <field name="product_id" type="col"/>
                 <field name="amount_untaxed_to_invoice" type="measure"/>
@@ -31,6 +31,29 @@
                 <field name="timesheet_unit_amount" widget="timesheet_uom" type="measure"/>
              </graph>
          </field>
+    </record>
+
+    <record id="project_profitability_report_view_tree" model="ir.ui.view">
+        <field name="name">project.profitability.report.view.tree</field>
+        <field name="model">project.profitability.report</field>
+        <field name="arch" type="xml">
+            <tree string="Profitability Analysis">
+                <field name="project_id"/>
+                <field name="user_id" optional="hide"/>
+                <field name="task_id" optional="hide"/>
+                <field name="partner_id" optional="hide"/>
+                <field name="analytic_account_id" optional="hide"/>
+                <field name="line_date" optional="show"/>
+                <field name="currency_id" optional="show" invisible="1"/>
+                <field name="amount_untaxed_to_invoice" optional="show" sum="Sum of Amount to Invoice"
+                       widget="monetary"/>
+                <field name="amount_untaxed_invoiced" optional="hide" sum="Sum of Amount Invoiced" widget="monetary"/>
+                <field name="other_revenues" optional="hide" widget="monetary"/>
+                <field name="timesheet_cost" optional="show" sum="Sum of Timesheet Cost" widget="monetary"/>
+                <field name="expense_cost" optional="hide" widget="monetary"/>
+                <field name="margin" optional="show" sum="Sum of Margin" widget="monetary"/>
+            </tree>
+        </field>
     </record>
 
     <record id="project_profitability_report_view_search" model="ir.ui.view">

--- a/addons/website_sale/views/sale_report_views.xml
+++ b/addons/website_sale/views/sale_report_views.xml
@@ -36,7 +36,7 @@
         <field name="name">sale.report.view.pivot.website</field>
         <field name="model">sale.report</field>
         <field name="arch" type="xml">
-            <pivot string="Sales Report" disable_linking="True" sample="1">
+            <pivot string="Sales Analysis" sample="1">
                 <field name="date" type="row"/>
                 <field name="state" type="col"/>
                 <field name="price_subtotal" type="measure"/>
@@ -48,10 +48,21 @@
         <field name="name">sale.report.view.graph.website</field>
         <field name="model">sale.report</field>
         <field name="arch" type="xml">
-            <graph string="Sale Report" type="bar" sample="1" disable_linking="1">
+            <graph string="Sale Analysis" type="bar" sample="1">
                 <field name="date"/>
                 <field name="price_subtotal" type='measure'/>
             </graph>
+        </field>
+    </record>
+
+    <record id="sale_report_view_tree" model="ir.ui.view">
+        <field name="name">sale.report.view.tree.inherit.website.sale</field>
+        <field name="model">sale.report</field>
+        <field name="inherit_id" ref="sale.sale_report_view_tree"/>
+        <field name="arch" type="xml">
+             <field name="order_id" position="after">
+                <field name="website_id" optional="hide"/>
+            </field>
         </field>
     </record>
 

--- a/addons/website_sale_slides/report/sale_report_views.xml
+++ b/addons/website_sale_slides/report/sale_report_views.xml
@@ -4,7 +4,7 @@
          <field name="name">sale.report.view.graph.slides</field>
          <field name="model">sale.report</field>
          <field name="arch" type="xml">
-             <graph string="eLearning Sales Analysis" type="line" sample="1" disable_linking="1">
+             <graph string="eLearning Sales Analysis" type="line" sample="1">
                  <field name="date" type="row" interval="day"/>
                  <field name="price_subtotal" type="measure"/>
              </graph>


### PR DESCRIPTION
PURPOSE

currently, there are pivot views on reporting models those do not have a
dedicated listview and therefore disabled it. The purpose of this commit is
to add those listviews that will allow the user to drill down from the pivot
views themselves.

SPECIFICATION

1. we have removed 'disabled_linking' attribute from pivot views as listed
   in pad
2. also, now we have dedicated list views for the following models in
   reporting

  - account.invoice.report
  - fleet.vehicle.cost.report
  - hr.timesheet.attendance.report
  - report.pos.order
  - purchase.report
  - project.profitability.report
  - report.project.task.user
  - sale.report

LINKS

PR #72394
task-id:2547881

