### PR TITLE
focusable element issue with optional product msh

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1868,7 +1868,7 @@ var FieldOne2Many = FieldX2Many.extend({
                         index = self.value.data.length - 1;
                     }
                     var newID = self.value.data[index].id;
-                    self.renderer.editRecord(newID);
+                    return self.renderer.editRecord(newID);
                 }
             }
         });

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -315,7 +315,7 @@ ListRenderer.include({
     editRecord: function (recordID) {
         var $row = this._getRow(recordID);
         var rowIndex = $row.prop('rowIndex') - 1;
-        this._selectCell(rowIndex, 0);
+        return this._selectCell(rowIndex, 0);
     },
     /**
      * Gives focus to a specific cell, given its row and its related column.


### PR DESCRIPTION
PURPOSE
Boolean field on Sale Order Line throws error when optional field wizard is closed, it should not throw error.

SPEC
Closing optional field wizard on Sale Order Line should close without error if there is boolean field on sale.order.line

TASK 2570901



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
