### PR TITLE
[REM] account: remove unexisted attribute "reason"

### DIFF
--- a/addons/account/wizard/account_move_reversal_view.xml
+++ b/addons/account/wizard/account_move_reversal_view.xml
@@ -29,7 +29,7 @@
                     </group>
                     <group>
                          <group>
-                             <field name="reason" attrs="{'invisible': [('move_type', '==', 'entry')], 'reason': [('move_type', '==', 'entry')]}"/>
+                             <field name="reason" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>
                              <field name="date_mode" string="Reversal Date" widget="radio"/>
                          </group>
                          <group>


### PR DESCRIPTION
There is no reason to have attribute reason