### PR TITLE
[FIX] marketing_automation: update css rules to fix broken test modal

### DIFF
--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -162,7 +162,7 @@ $o-form-label-margin-right: 0px;
                 flex: 1 1 auto;
                 width: 0!important; // 3rd flex argument does not work with input (must be auto and real width 0)
 
-                &.o_field_boolean, &.o_priority {
+                &.o_field_boolean, &.o_field_many2one_selection, &.o_priority {
                     flex: 0 0 auto;
                     width: auto!important;
                 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the marketing automation module, the dropdown of the 'launch test' modal is not fully visible because a css rule forces the field of having a width of 0 (see: `width: 0!important`).

Current behavior before PR:
The dropdown has a width of 0 which makes the field unusable.
Desired behavior after PR is merged:
The dropdown is fully visible.

Task id: 2572330

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
