### PR TITLE
[FIX] web: fix clickEverywhere test

### DIFF
--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -11,11 +11,11 @@ class TestMenusAdmin(odoo.tests.HttpCase):
 
     def test_01_click_everywhere_as_admin(self):
         menus = self.env['ir.ui.menu'].load_menus(False)
-        for app in menus['children']:
-                with self.subTest(app=app['name']):
-                    _logger.runbot('Testing %s', app['name'])
-                    self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % app['xmlid'], "odoo.isReady === true", login="admin", timeout=300)
-                    self.terminate_browser()
+        for app_id in menus['root']['children']:
+            with self.subTest(app=menus[app_id]['name']):
+                _logger.runbot('Testing %s', menus[app_id]['name'])
+                self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % menus[app_id]['xmlid'], "odoo.isReady === true", login="admin", timeout=300)
+                self.terminate_browser()
 
 
 @odoo.tests.tagged('click_all', 'post_install', '-at_install', '-standard')
@@ -23,11 +23,11 @@ class TestMenusDemo(odoo.tests.HttpCase):
 
     def test_01_click_everywhere_as_demo(self):
         menus = self.env['ir.ui.menu'].load_menus(False)
-        for app in menus['children']:
-                with self.subTest(app=app['name']):
-                    _logger.runbot('Testing %s', app['name'])
-                    self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % app['xmlid'], "odoo.isReady === true", login="demo", timeout=300)
-                    self.terminate_browser()
+        for app_id in menus['root']['children']:
+            with self.subTest(app=menus[app_id]['name']):
+                _logger.runbot('Testing %s', menus[app_id]['name'])
+                self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere']('%s');" % menus[app_id]['xmlid'], "odoo.isReady === true", login="demo", timeout=300)
+                self.terminate_browser()
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestMenusAdminLight(odoo.tests.HttpCase):
@@ -39,4 +39,4 @@ class TestMenusAdminLight(odoo.tests.HttpCase):
 class TestMenusDemoLight(odoo.tests.HttpCase):
 
     def test_01_click_apps_menus_as_demo(self):
-            self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere'](undefined, true);", "odoo.isReady === true", login="demo", timeout=120)
+        self.browser_js("/web", "odoo.__DEBUG__.services['web.clickEverywhere'](undefined, true);", "odoo.isReady === true", login="demo", timeout=120)


### PR DESCRIPTION
With the rewrite of the webclient in OWL 29731b404fe the load_menus
method now returns all menus instead of the root menu.

This commit adapts the click_everywhere tests to the change.
