### PR TITLE
[FIX] web: make activities systray item work

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -9,20 +9,9 @@ import { Dialog } from "../core/dialog/dialog";
 import { useEffect } from "../core/effect_hook";
 import { useService } from "../core/service_hook";
 import { ViewNotFoundError } from "../webclient/actions/action_service";
-import { cleanDomFromBootstrap, mapDoActionOptionAPI } from "./utils";
+import { cleanDomFromBootstrap, wrapSuccessOrFail, mapDoActionOptionAPI } from "./utils";
 
 const { Component, tags } = owl;
-
-function wrapSuccessOrFail(promise, { on_success, on_fail } = {}) {
-    return promise.then(on_success || (() => {})).catch((reason) => {
-        if (on_fail) {
-            on_fail(reason);
-        }
-        if (reason instanceof Error) {
-            throw reason;
-        }
-    });
-}
 
 class ActionAdapter extends ComponentAdapter {
     setup() {
@@ -88,8 +77,8 @@ class ActionAdapter extends ComponentAdapter {
             if (payload.action.context) {
                 payload.action.context = new Context(payload.action.context).eval();
             }
-            this.onReverseBreadcrumb = ev.data.options && ev.data.options.on_reverse_breadcrumb;
-            const legacyOptions = mapDoActionOptionAPI(ev.data.options);
+            this.onReverseBreadcrumb = payload.options && payload.options.on_reverse_breadcrumb;
+            const legacyOptions = mapDoActionOptionAPI(payload.options);
             wrapSuccessOrFail(this.actionService.doAction(payload.action, legacyOptions), payload);
         } else if (ev.name === "breadcrumb_clicked") {
             this.actionService.restore(payload.controllerID);

--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -279,3 +279,14 @@ export function makeLegacyCrashManagerService(legacyEnv) {
         },
     };
 }
+
+export function wrapSuccessOrFail(promise, { on_success, on_fail } = {}) {
+    return promise.then(on_success || (() => {})).catch((reason) => {
+        if (on_fail) {
+            on_fail(reason);
+        }
+        if (reason instanceof Error) {
+            throw reason;
+        }
+    });
+}


### PR DESCRIPTION
The activities systray item didn't work anymore. Nothing happened on
click.

It was because the do action event was never caught. The systray item
logic had a different flow and didn't go through the ViewAdapter code.

We fix this by factoring the do action code and adding a listener
on window (through legacy service provider) to execute this code when
the do_action bubbles up.
Instead of using the legacy service provided, we could have done this
in the SystrayItemAdapter, but we then have the legacy environment and
would need more work for the same result.
