### PR TITLE
[FIX] web: legacy client action push state

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1194,7 +1194,9 @@ function makeActionManager(env) {
         }
         if (action.context) {
             const activeId = action.context.active_id;
-            newState.active_id = activeId ? `${activeId}` : undefined;
+            if (activeId) {
+                newState.active_id = `${activeId}`;
+            }
             const activeIds = action.context.active_ids;
             // we don't push active_ids if it's a single element array containing
             // the active_id to make the url shorter in most cases


### PR DESCRIPTION
Before this commit, the push state from client actions to the URL did
not work properly:
1. the action.params key was ignored
2. some "reserved" keys (active_id) were not handled properly
3. within a legacy client action, the call to parent.do_push_state did not work

After this commit, all of those work properly letting discuss in particular have the right URL

It is worth noting that in the full wowl stack, that the right way to push something
in the URL from a component is always to call the router service's pushState when the component is mounted