### PR TITLE
[IMP] mail: improvement regarding activity type in activity view

### DIFF
--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -51,7 +51,7 @@
         </ul>
     </div>
     <div class="dropdown-divider m-0"/>
-    <div role="menuitem" class="o_schedule_activity dropdown-header p-0 text-center">
+    <div role="menuitem" class="o_schedule_activity dropdown-header p-0 text-center" t-att-data-previous-type-id="typeId">
         <button class="btn btn-secondary btn-block p-3">
             <i class="fa fa-plus fa-fw"></i><strong>Schedule an activity</strong>
         </button>

--- a/addons/mail/static/tests/activity_tests.js
+++ b/addons/mail/static/tests/activity_tests.js
@@ -308,6 +308,7 @@ QUnit.test('activity view: activity widget', async function (assert) {
                     assert.step("do_action_compose");
                 } else if (action.res_model === 'mail.activity') {
                     assert.deepEqual({
+                        "default_activity_type_id": 2,
                         "default_res_id": 30,
                         "default_res_model": "task"
                     }, action.context);


### PR DESCRIPTION
**PURPOSE**

In activity view, if there's already an activity scheduled of some Activity type,
user clicks on the colored cell, and then click "+ Schedule an activity". In
this case the pop up opens but the Activity type is always To do.

**SPECIFICATION**

If user clicks on the colored cell and then click "+ Schedule an activity", pop
up will open with the activity type from the column where the user clicks.

**Task**-2528111