### PR TITLE
[IMP] stock: quants import

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -53,7 +53,7 @@ class StockQuant(models.Model):
     product_id = fields.Many2one(
         'product.product', 'Product',
         domain=lambda self: self._domain_product_id(),
-        ondelete='restrict', readonly=True, required=True, index=True, check_company=True)
+        ondelete='restrict', required=True, index=True, check_company=True)
     product_tmpl_id = fields.Many2one(
         'product.template', string='Product Template',
         related='product_id.product_tmpl_id')
@@ -64,18 +64,18 @@ class StockQuant(models.Model):
     location_id = fields.Many2one(
         'stock.location', 'Location',
         domain=lambda self: self._domain_location_id(),
-        auto_join=True, ondelete='restrict', readonly=True, required=True, index=True, check_company=True)
+        auto_join=True, ondelete='restrict', required=True, index=True, check_company=True)
     lot_id = fields.Many2one(
         'stock.production.lot', 'Lot/Serial Number', index=True,
-        ondelete='restrict', readonly=True, check_company=True,
+        ondelete='restrict', check_company=True,
         domain=lambda self: self._domain_lot_id())
     package_id = fields.Many2one(
         'stock.quant.package', 'Package',
         domain="[('location_id', '=', location_id)]",
-        help='The package containing this quant', readonly=True, ondelete='restrict', check_company=True)
+        help='The package containing this quant', ondelete='restrict', check_company=True)
     owner_id = fields.Many2one(
         'res.partner', 'Owner',
-        help='This is the owner of the quant', readonly=True, check_company=True)
+        help='This is the owner of the quant', check_company=True)
     quantity = fields.Float(
         'Quantity',
         help='Quantity of products in this quant, in the default unit of measure of the product',

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -27,8 +27,7 @@ access_product_group_res_partner_stock_manager,res_partner group_stock_manager,b
 access_product_pricelist_item_stock_manager,product.pricelist.item stock_manager,product.model_product_pricelist_item,stock.group_stock_manager,1,1,1,1
 access_stock_warehouse_orderpoint,stock.warehouse.orderpoint,model_stock_warehouse_orderpoint,stock.group_stock_user,1,0,0,0
 access_stock_warehouse_orderpoint_system,stock.warehouse.orderpoint system,model_stock_warehouse_orderpoint,stock.group_stock_manager,1,1,1,1
-access_stock_quant_manager,stock.quant manager,model_stock_quant,stock.group_stock_manager,1,0,0,0
-access_stock_quant_user,stock.quant user,model_stock_quant,stock.group_stock_user,1,0,0,0
+access_stock_quant_manager,stock.quant manager,model_stock_quant,stock.group_stock_manager,1,1,1,0
 access_stock_quant_all,stock.quant all users,model_stock_quant,base.group_user,1,0,0,0
 access_stock_quant_package_all,stock.quant.package all users,model_stock_quant_package,base.group_user,1,0,0,0
 access_stock_quant_package_stock_manager,stock.quant.package stock manager,model_stock_quant_package,stock.group_stock_manager,1,1,1,1

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -90,6 +90,7 @@
                     <group>
                         <group>
                             <field name="product_id"/>
+                            <field name="company_id" invisible="1"/>
                             <field name="location_id" options="{'no_create': True}"/>
                             <field name="lot_id" groups="stock.group_production_lot"/>
                             <field name="package_id" groups="stock.group_tracking_lot"/>
@@ -121,7 +122,7 @@
         <field eval="10" name="priority"/>
         <field name="arch" type="xml">
             <tree editable="bottom"
-                  create="1" edit="1" import="0" js_class="singleton_list"
+                  create="1" edit="1" js_class="singleton_list"
                   sample="1">
                 <field name="id" invisible="1"/>
                 <field name="tracking" invisible="1"/>
@@ -340,7 +341,7 @@
         <field name="model">stock.quant</field>
         <field eval="10" name="priority"/>
         <field name="arch" type="xml">
-            <tree default_order="location_id, inventory_date, product_id, package_id, lot_id, owner_id" editable="bottom" create="1" edit="1" import="0" js_class="singleton_list" sample="1">
+            <tree default_order="location_id, inventory_date, product_id, package_id, lot_id, owner_id" editable="bottom" create="1" edit="1" js_class="singleton_list" sample="1">
                 <field name="id" invisible="1"/>
                 <field name="tracking" invisible="1"/>
                 <field name="location_id" domain="[('usage', 'in', ['internal', 'transit'])]" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)" options="{'no_create': True}"/>


### PR DESCRIPTION
As the Inventory Adjustments have been removed since
bdcb3d192be1e01e1141aa09c60027337009a67b, it was not possible anymore to
import inventories. This commit allows the possibilities to import
quants with pre-counted quantities. It acts the same as creating new
lines in the tree view.

Task : 2555118

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
