### PR TITLE
do not display tag as clickable when they aren't

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2428,7 +2428,7 @@ var FormFieldMany2ManyTags = FieldMany2ManyTags.extend({
     init: function () {
         this._super.apply(this, arguments);
 
-        this.hasDropdown = !!this.colorField;
+        this.hasDropdown = !!this.colorField && !this.nodeOptions.no_edit_color;
     },
 
     //--------------------------------------------------------------------------
@@ -2441,10 +2441,6 @@ var FormFieldMany2ManyTags = FieldMany2ManyTags.extend({
      */
     _onOpenColorPicker: function (ev) {
         ev.preventDefault();
-        if (this.nodeOptions.no_edit_color) {
-            ev.stopPropagation();
-            return;
-        }
         var tagID = $(ev.currentTarget).parent().data('id');
         var tagColor = $(ev.currentTarget).parent().data('color');
         var tag = _.findWhere(this.value.data, { res_id: tagID });

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -103,7 +103,6 @@
             flex: 0 0 auto;
             border: 0;
             font-size: 12px;
-            cursor: pointer;
             user-select: none;
             display: flex;
             max-width: 100%;

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -1560,9 +1560,8 @@ QUnit.module('relational_fields', {
             res_id: 1,
         });
 
-        // Click to try to open colorpicker
-        await testUtils.dom.click(form.$('.badge:first() .dropdown-toggle'));
-        assert.containsNone(document.body, '.o_colorpicker');
+        assert.containsNone(form, '.badge:first() .dropdown-toggle',
+            "should not have dropdown-toggle class");
 
         form.destroy();
     });


### PR DESCRIPTION
PURPOSE
When no_edit_color option is passed on many2many_tags then do not show tag clickable.

SPEC
When no_edit_color option is passed on many2many_tags then default cursor will be displayed on hover tag and clicking tag will not open color dropdown.

TASK 2574639

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
