### PR TITLE
[FIX] web: clickbot: correctly select first level menus

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -158,7 +158,7 @@
      */
     async function getNextMenu() {
         const menus = document.querySelectorAll(
-            ".o_menu_sections .o_dropdown_toggler, .o_menu_sections .o_dropdown_item"
+            ".o_menu_sections > .o_dropdown > .o_dropdown_toggler, .o_menu_sections > .o_dropdown_item"
         );
         if (menuIndex === menus.length) {
             menuIndex = 0;
@@ -374,7 +374,7 @@
     async function _clickEverywhere(xmlId) {
         ensureSetup();
         console.log("Starting ClickEverywhere test");
-        console.log(`Odoo flavor: ${isEnterprise} ? 'Enterprise' : 'Community'`);
+        console.log(`Odoo flavor: ${isEnterprise ? "Enterprise" : "Community"}`);
         const startTime = performance.now();
         testedApps = [];
         testedMenus = [];

--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -22,7 +22,8 @@ class TestMenusAdmin(odoo.tests.HttpCase):
 class TestMenusDemo(odoo.tests.HttpCase):
 
     def test_01_click_everywhere_as_demo(self):
-        menus = self.env['ir.ui.menu'].load_menus(False)
+        user_demo = self.env.ref("base.user_demo")
+        menus = self.env['ir.ui.menu'].with_user(user_demo.id).load_menus(False)
         for app_id in menus['root']['children']:
             with self.subTest(app=menus[app_id]['name']):
                 _logger.runbot('Testing %s', menus[app_id]['name'])


### PR DESCRIPTION
Before this commit, when we wanted to select first level menus
inside an app (i.e. menus available in the navbar), we could by
mistake select sub-menus if the dropdown was opened (e.g. if it
was previously tested). For instance, it happened in the 'Apps'
app. It then led to wrong index computation, and a traceback. As
a consequence, the nightly build failed as the clickEverywhere test
didn't pass.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
