### PR TITLE
[IMP] account: Reversal on same journal type as original AccountMove

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1141,6 +1141,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2019-02-01'),
             'reason': 'no reason',
             'refund_method': 'refund',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1192,6 +1193,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2019-02-01'),
             'reason': 'no reason again',
             'refund_method': 'cancel',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1255,6 +1257,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2017-01-01'),
             'reason': 'no reason',
             'refund_method': 'refund',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1312,6 +1315,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2017-01-01'),
             'reason': 'no reason again',
             'refund_method': 'cancel',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1746,6 +1746,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2019-02-01'),
             'reason': 'no reason',
             'refund_method': 'refund',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1798,6 +1799,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2019-02-01'),
             'reason': 'no reason',
             'refund_method': 'cancel',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1861,6 +1863,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2017-01-01'),
             'reason': 'no reason',
             'refund_method': 'refund',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1918,6 +1921,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2017-01-01'),
             'reason': 'no reason',
             'refund_method': 'cancel',
+            'journal_id': self.invoice.journal_id.id,
         })
         reversal = move_reversal.reverse_moves()
         reverse_move = self.env['account.move'].browse(reversal['res_id'])
@@ -1978,6 +1982,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'date': fields.Date.today() + timedelta(days=7),
             'reason': 'no reason',
             'refund_method': 'modify',
+            'journal_id': self.invoice.journal_id.id,
         })
         move_reversal.reverse_moves()
         refund = self.env['account.move'].search([('move_type', '=', 'out_refund'), ('company_id', '=', self.invoice.company_id.id)])

--- a/addons/account/wizard/account_move_reversal_view.xml
+++ b/addons/account/wizard/account_move_reversal_view.xml
@@ -10,6 +10,7 @@
                     <field name="company_id" invisible="1"/>
                     <field name="move_ids" invisible="1"/>
                     <field name="move_type" invisible="1"/>
+                    <field name="available_journal_ids" invisible="1"/>
                     <group>
                          <group attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'in_invoice'))]}">
                             <field name="refund_method" widget="radio" attrs="{'readonly': [('residual', '=', 0)]}"/>
@@ -28,15 +29,15 @@
                          </group>
                     </group>
                     <group>
-                         <group>
-                             <field name="reason" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>
-                             <field name="date_mode" string="Reversal Date" widget="radio"/>
-                         </group>
-                         <group>
-                            <field name="journal_id"/>
-                            <field name="date" string="Refund Date" attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'in_invoice')), ('date_mode', '!=', 'custom')], 'required':[('date_mode', '=', 'custom')]}"/>
-                            <field name="date" attrs="{'invisible': ['|', ('move_type', 'in', ('out_invoice', 'in_invoice')), ('date_mode', '!=', 'custom')], 'required':[('date_mode', '=', 'custom')]}"/>
-                         </group>
+                        <group>
+                            <field name="reason" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>
+                            <field name="date_mode" string="Reversal Date" widget="radio"/>
+                        </group>
+                        <group>
+                        <field name="journal_id" domain="[('id', 'in', available_journal_ids)]"/>
+                        <field name="date" string="Refund Date" attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'in_invoice')), ('date_mode', '!=', 'custom')], 'required':[('date_mode', '=', 'custom')]}"/>
+                        <field name="date" attrs="{'invisible': ['|', ('move_type', 'in', ('out_invoice', 'in_invoice')), ('date_mode', '!=', 'custom')], 'required':[('date_mode', '=', 'custom')]}"/>
+                        </group>
                     </group>
                     <footer>
                         <button string='Reverse' name="reverse_moves" type="object" class="btn-primary"/>

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -109,6 +109,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             'reason': 'test_invoice_shipment_refund',
             'refund_method': 'cancel',
             'date': '2018-03-15',
+            'journal_id': invoice.journal_id.id,
         })
         refund_invoice = self.env['account.move'].browse(refund_invoice_wiz.reverse_moves()['res_id'])
 

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -100,6 +100,7 @@ class TestSaleToInvoice(TestSaleCommon):
         credit_note_wizard = self.env['account.move.reversal'].with_context({'active_ids': [self.invoice.id], 'active_id': self.invoice.id, 'active_model': 'account.move'}).create({
             'refund_method': 'refund',  # this is the only mode for which the SO line is linked to the refund (https://github.com/odoo/odoo/commit/e680f29560ac20133c7af0c6364c6ef494662eac)
             'reason': 'reason test create',
+            'journal_id': self.invoice.journal_id.id,
         })
         credit_note_wizard.reverse_moves()
         invoice_refund = self.sale_order.invoice_ids.sorted(key=lambda inv: inv.id, reverse=False)[-1]  # the first invoice, its refund, and the new invoice
@@ -191,6 +192,7 @@ class TestSaleToInvoice(TestSaleCommon):
         credit_note_wizard = self.env['account.move.reversal'].with_context({'active_ids': self.invoice.ids, 'active_id': self.invoice.id, 'active_model': 'account.move'}).create({
             'refund_method': 'cancel',
             'reason': 'reason test cancel',
+            'journal_id': self.invoice.journal_id.id,
         })
         invoice_refund = self.env['account.move'].browse(credit_note_wizard.reverse_moves()['res_id'])
 
@@ -253,6 +255,7 @@ class TestSaleToInvoice(TestSaleCommon):
         credit_note_wizard = self.env['account.move.reversal'].with_context({'active_ids': [self.invoice.id], 'active_id': self.invoice.id, 'active_model': 'account.move'}).create({
             'refund_method': 'modify',  # this is the only mode for which the SO line is linked to the refund (https://github.com/odoo/odoo/commit/e680f29560ac20133c7af0c6364c6ef494662eac)
             'reason': 'reason test modify',
+            'journal_id': self.invoice.journal_id.id,
         })
         invoice_refund = self.env['account.move'].browse(credit_note_wizard.reverse_moves()['res_id'])
 

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -115,6 +115,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
         refund_invoice_wiz = self.env['account.move.reversal'].with_context(active_model='account.move', active_ids=[invoice.id]).create({
             'reason': 'test_invoice_shipment_refund',
             'refund_method': 'cancel',
+            'journal_id': invoice.journal_id.id,
         })
         refund_invoice = self.env['account.move'].browse(refund_invoice_wiz.reverse_moves()['res_id'])
         self.assertEqual(invoice.payment_state, 'reversed', "Invoice should be in 'reversed' state.")


### PR DESCRIPTION
For data quality purposes and bug prevention, when I reverse an entry,
the reversal should always be postable on a journal having the same type
as the initial Journal Entry's journal.

Task: 2497529
Enterprise PR: https://github.com/odoo/enterprise/pull/19543