### PR TITLE
[FIX] uom: avoid unneeded qty conversion and fields fetching

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -143,19 +143,26 @@ class UoM(models.Model):
                 - if true, raise an exception if the conversion is not possible (different UoM category),
                 - otherwise, return the initial quantity
         """
-        if not self:
+        if not self or not qty:
             return qty
         self.ensure_one()
-        if self.category_id.id != to_unit.category_id.id:
+
+        if self != to_unit and self.category_id.id != to_unit.category_id.id:
             if raise_if_failure:
                 raise UserError(_('The unit of measure %s defined on the order line doesn\'t belong to the same category than the unit of measure %s defined on the product. Please correct the unit of measure defined on the order line or on the product, they should belong to the same category.') % (self.name, to_unit.name))
             else:
                 return qty
-        amount = qty / self.factor
-        if to_unit:
-            amount = amount * to_unit.factor
-            if round:
-                amount = tools.float_round(amount, precision_rounding=to_unit.rounding, rounding_method=rounding_method)
+
+        if self == to_unit:
+            amount = qty
+        else:
+            amount = qty / self.factor
+            if to_unit:
+                amount = amount * to_unit.factor
+
+        if to_unit and round:
+            amount = tools.float_round(amount, precision_rounding=to_unit.rounding, rounding_method=rounding_method)
+
         return amount
 
     @api.multi


### PR DESCRIPTION
This could save some time when `_compute_quantity` is used thousands times in
request and there are thousands UOMs in the system

* if qty is zero, then result is zero
* if to_unit is the same, then result is `round((qty / factor) * factor) = round(qty)`

---

opw-2549026

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
