### PR TITLE
[FIX] base: fix the VAT verification

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -205,6 +205,7 @@ class Company(models.Model):
             'phone': vals.get('phone'),
             'website': vals.get('website'),
             'vat': vals.get('vat'),
+            'country_id' : vals.get('country_id'),
         })
         # compute stored fields, for example address dependent fields
         partner.flush()


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to settings > create a new company :
	- Choose the country : `Mexico`
	- fill in the VAT field : ESA2005273X1
	- save
- Validation error is triggered

Problem:

The Mexican VAT can be on the format: "MXESA2005273X1" or "ESA2005273X1".
But only the "MX .." format is accepted for the moment,
and it fails in the case of "ES.." because the function checks if it is a valid Espganol VAT number.

In the case of failure, we use the `partner.commercial_partner_id.country_id` to get the country code.
The problem is when creating the res.company, we also create a res.partner
with a few fields within `VAT` except `country_id` field
while we use it in the `check_vat` function : https://github.com/odoo/odoo/blob/7a7aacedde81998ec0f1a7f3283337236e56de42/addons/base_vat/models/res_partner.py#L167

Opw-2573557


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
