### PR TITLE
[IMP]project,web: bug fix on calendar and project generic improvement

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -4,15 +4,13 @@
 # Copyright (c) 2005-2006 Axelor SARL. (http://www.axelor.com)
 
 import logging
-import math
 
 from collections import namedtuple
 
-from datetime import datetime, date, timedelta, time
-from dateutil.rrule import rrule, DAILY
+from datetime import datetime, timedelta, time
 from pytz import timezone, UTC
 
-from odoo import api, fields, models, SUPERUSER_ID, tools
+from odoo import api, fields, models, tools
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.addons.resource.models.resource import float_to_time, HOURS_PER_DAY
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -1272,13 +1270,4 @@ class HolidaysRequest(models.Model):
 
     @api.model
     def get_unusual_days(self, date_from, date_to=None):
-        # Checking the calendar directly allows to not grey out the leaves taken
-        # by the employee
-        calendar = self.env.user.employee_id.resource_calendar_id
-        if not calendar:
-            return {}
-        dfrom = datetime.combine(fields.Date.from_string(date_from), time.min).replace(tzinfo=UTC)
-        dto = datetime.combine(fields.Date.from_string(date_to), time.max).replace(tzinfo=UTC)
-
-        works = {d[0].date() for d in calendar._work_intervals_batch(dfrom, dto)[False]}
-        return {fields.Date.to_string(day.date()): (day.date() not in works) for day in rrule(DAILY, dfrom, until=dto)}
+        return self.env.user.employee_id._get_unusual_days(date_from, date_to)

--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -68,6 +68,4 @@ class LeaveReportCalendar(models.Model):
 
     @api.model
     def get_unusual_days(self, date_from, date_to=None):
-        # Checking the calendar directly allows to not grey out the leaves taken
-        # by the employee
-        return self.env['hr.leave'].get_unusual_days(date_from, date_to=date_to)
+        return self.env.user.employee_id._get_unusual_days(date_from, date_to)

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -690,7 +690,7 @@
                             attrs="{'invisible' : [('user_id', '!=', False)]}"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                     </header>
-                    <div class="alert alert-info oe_edit_only" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}">
+                    <div class="alert alert-info oe_edit_only mb-0" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}">
                         <p>Edit recurring task</p>
                         <field name="recurrence_update" widget="radio"/>
                     </div>
@@ -929,7 +929,7 @@
                                             <s t-if="!record.active.raw_value"><field name="name" widget="name_with_subtask_count"/></s>
                                             <t t-else=""><field name="name" widget="name_with_subtask_count"/></t>
                                         </strong>
-                                        <span  invisible="context.get('default_project_id', False) or context.get('fsm_mode', False)"><br/><field name="project_id" required="1"/></span>
+                                        <span invisible="context.get('default_project_id', False)"><br/><field name="project_id" required="1"/></span>
                                         <br />
                                         <t t-if="record.partner_id.value">
                                             <span t-if="!record.partner_is_company.raw_value">
@@ -960,7 +960,7 @@
                                     </div>
                                 </div>
                                 <div class="o_kanban_record_body">
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="context.get('fsm_mode', False)"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                     <div t-if="record.date_deadline.raw_value" name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}">
                                         <field name="date_deadline" widget="remaining_days"/>
                                     </div>
@@ -1055,10 +1055,12 @@
             <field name="name">project.task.pivot</field>
             <field name="model">project.task</field>
             <field name="arch" type="xml">
-                <pivot string="Project Tasks" sample="1" js_class="project_pivot">
+                <pivot string="Tasks" sample="1" js_class="project_pivot">
                     <field name="project_id" type="row"/>
                     <field name="stage_id" type="col"/>
                     <field name="color" invisible="1"/>
+                    <field name="sequence" invisible="1"/>
+                    <field name="rating_last_value" type="measure" string="Rating (/5)"/>
                 </pivot>
             </field>
         </record>
@@ -1067,9 +1069,12 @@
             <field name="name">project.task.graph</field>
             <field name="model">project.task</field>
             <field name="arch" type="xml">
-                <graph string="Project Tasks" sample="1" js_class="project_graph">
+                <graph string="Tasks" sample="1" js_class="project_graph">
                     <field name="project_id"/>
                     <field name="stage_id"/>
+                    <field name="color" invisible="1"/>
+                    <field name="sequence" invisible="1"/>
+                    <field name="rating_last_value" type="measure" string="Rating (/5)"/>
                 </graph>
             </field>
         </record>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -41,13 +41,13 @@
         <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
         <field name="inherit_id" ref="project.view_task_form2"/>
         <field name="arch" type="xml">
-            <div name="button_box" position="inside">
+            <xpath expr="//button[@name='action_recurring_tasks']" position="before">
                 <button class="d-none d-md-inline oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': [('sale_order_id', '=', False)]}"
                         string="Sales Order"
                         groups="sales_team.group_sale_salesman_all_leads"/>
-            </div>
+            </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="options">{'always_reload': True}</attribute>
                 <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_renderer.js
@@ -905,7 +905,7 @@ return AbstractRenderer.extend({
             const start = moment(event.extendedProps.r_start);
             const end = moment(event.extendedProps.r_end);
             const duration = moment.duration(end.diff(start)).asDays();
-            event.extendedProps.record.start_hour = event.extendedProps.record.allday === false && duration < 1 ? start.format("HH:mm") : "";
+            event.extendedProps.record.start_hour = !event.extendedProps.record.allday && duration < 1 ? start.format("HH:mm") : "";
             const key = this._getFormattedDate(start, end, false, event.extendedProps.record.allday);
             if (!(key in groupedEvents)) {
                 groupedEvents[key] = [];

--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -137,7 +137,7 @@
                         t-attf-class="o_cw_popover_link o_calendar_color_#{typeof color === 'number' ? _.str.sprintf('%s', color) : '1'} o_attendee_status_#{record.is_alone ? 'alone' : record.attendee_status} btn-link d-block"
                         t-att-data-id="record.id"
                         t-att-data-title="record.display_name">
-                        <t t-esc="record.display_name"/> <t t-esc="record.start_hour"/>
+                        <t t-esc="record.start_hour"/> <t t-esc="record.display_name"/>
                     </a>
                 </t>
             </t>

--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -3877,7 +3877,7 @@ QUnit.module('Views', {
         assert.containsOnce(calendar, '.o_cw_popover');
         popoverText = calendar.el.querySelector('.o_cw_popover')
             .textContent.replace(/\s{2,}/g, ' ').trim();
-        assert.strictEqual(popoverText, 'December 12, 2016 event 2 10:55 event 3 15:55');
+        assert.strictEqual(popoverText, 'December 12, 2016 10:55 event 2 15:55 event 3');
         await testUtils.dom.click(calendar.el.querySelector('.o_cw_popover_close'));
         assert.containsNone(calendar, '.o_cw_popover');
 


### PR DESCRIPTION
project:
project_id and tag_ids should be always visible in fsm mode too. also re-sequence the task form view buttons and added class for the proper xpath.
web: 
Currently, the time in popover of the year view does not appear with the title due to record.allday is undefined instead of false

So in this commit, check if record.allday is not exist then display the time in front of the title instead of after the title.

TaskID: 2502339