### PR TITLE
[FIX] mail: regarding scheduling activity in list view

### DIFF
--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.KanbanActivity">
     <div class="o_kanban_inline_block dropdown o_mail_activity">
-        <a class="dropdown-toggle o-no-caret o_activity_btn" data-toggle="dropdown" role="button">
+        <a class="dropdown-toggle o-no-caret o_activity_btn" data-boundary="viewport" data-flip="false" data-toggle="dropdown" role="button">
             <!-- span classes are generated dynamically (see _render) -->
             <span t-att-title="widget.selection[widget.activityState]" role="img" t-att-aria-label="widget.selection[widget.activity_state]"/>
        </a>


### PR DESCRIPTION
Open a activity view(record modal), that will show records, clicking on the
'o_activity_btn' of a record will show dropdown and make sure that there are
many scheduled activity there .

**Before this commit:**

The dropdown was bigger than the record modal which had a scroll bar. It was not
scrollable properly and "+ Schedule Activity" button is not accessible.

**After this commit:**

The dropdown follows the scroll, and it will be possible to click the button.

**Task**- 2528111