### PR TITLE
[FIX] web: py.js: do not crash on empty string

### DIFF
--- a/addons/web/static/src/core/py_js/py.js
+++ b/addons/web/static/src/core/py_js/py.js
@@ -16,8 +16,8 @@ export { formatAST } from "./py_utils";
 
 /**
  * Parses an expression into a valid AST representation
- 
- * @param {string} expr 
+
+ * @param {string} expr
  * @returns { AST }
  */
 export function parseExpr(expr) {

--- a/addons/web/static/src/core/py_js/py_parser.js
+++ b/addons/web/static/src/core/py_js/py_parser.js
@@ -364,5 +364,5 @@ function _parse(tokens, bp = 0) {
  * @returns {AST}
  */
 export function parse(tokens) {
-    return _parse(tokens, 0);
+    return tokens.length ? _parse(tokens, 0) : { type: 0, value: "" };
 }

--- a/addons/web/static/tests/core/py_js/py_utils_tests.js
+++ b/addons/web/static/tests/core/py_js/py_utils_tests.js
@@ -20,6 +20,7 @@ QUnit.module("py", {}, () => {
         assert.ok(checkAST("-12", "negative integer value"));
         assert.ok(checkAST("True", "boolean"));
         assert.ok(checkAST(`"some string"`, "a string"));
+        assert.ok(checkAST("", "the empty string"));
         assert.ok(checkAST("None", "None"));
     });
 


### PR DESCRIPTION
Before this commit, calling "evaluateExpr" with the empty string as
argument crashed. For instance, this happened with at least two
actions in Odoo:
  - Elearning > Courses > Contents
  - Fleet > Vehicules > Odometers
In both cases, the context in the action is the empty string.

Issue spotted thanks to the clickEverywhere test.