### PR TITLE
[FIX] web_tour: send correct tour names to consume

### DIFF
--- a/addons/web_tour/static/src/debug/debug_manager.js
+++ b/addons/web_tour/static/src/debug/debug_manager.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 import ToursDialog from "@web_tour/debug/tour_dialog_component";
 import utils from "web_tour.utils";
 
-function disableTours({ env }) {
+export function disableTours({ env }) {
     if (!env.services.user.isSystem) {
         return null;
     }
@@ -17,8 +17,9 @@ function disableTours({ env }) {
         type: "item",
         description: env._t("Disable Tours"),
         callback: async () => {
-            await env.services.orm.call("web_tour.tour", "consume", [activeTours]);
-            for (const tourName of activeTours) {
+            const tourNames = activeTours.map(tour => tour.name);
+            await env.services.orm.call("web_tour.tour", "consume", [tourNames]);
+            for (const tourName of tourNames) {
                 browser.localStorage.removeItem(utils.get_debugging_key(tourName));
             }
             browser.location.reload();
@@ -27,7 +28,7 @@ function disableTours({ env }) {
     };
 }
 
-function startTour({ env }) {
+export function startTour({ env }) {
     if (!env.services.user.isSystem) {
         return null;
     }

--- a/addons/web_tour/static/tests/debug_manager_tests.js
+++ b/addons/web_tour/static/tests/debug_manager_tests.js
@@ -1,0 +1,72 @@
+/** @odoo-module **/
+
+import { disableTours } from "@web_tour/debug/debug_manager";
+
+import { DebugMenu } from "@web/core/debug/debug_menu";
+import { debugService } from "@web/core/debug/debug_service";
+import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
+import { ormService } from "@web/core/orm_service";
+import { registry } from "@web/core/registry";
+import { uiService } from "@web/core/ui/ui_service";
+
+import { click, getFixture } from "@web/../tests/helpers/utils";
+import { registerCleanup } from "@web/../tests/helpers/cleanup";
+import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
+
+const { mount } = owl;
+
+const debugRegistry = registry.category("debug");
+let target;
+
+QUnit.module("Tours", (hooks) => {
+
+    QUnit.module("DebugManager");
+
+    hooks.beforeEach(async () => {
+        target = getFixture();
+        registry
+            .category("services")
+            .add("hotkey", hotkeyService)
+            .add("ui", uiService)
+            .add("orm", ormService)
+            .add("debug", debugService)
+            .add("localization", makeFakeLocalizationService());
+    });
+
+    QUnit.test("can disable tours", async (assert) => {
+        debugRegistry.add("disableTours", disableTours);
+
+        const fakeTourService = {
+            start(env) {
+                return {
+                    getActiveTours() {
+                        return [{ name: 'a' }, { name: 'b' }];
+                    }
+                }
+            },
+        };
+        registry.category("services").add("tour", fakeTourService);
+
+        const mockRPC = async (route, args) => {
+            if (args.method === "check_access_rights") {
+                return Promise.resolve(true);
+            }
+            if (args.method === "consume") {
+                assert.step("consume");
+                assert.deepEqual(args.args[0], ['a', 'b']);
+                return Promise.resolve(true);
+            }
+        };
+        const env = await makeTestEnv({ mockRPC });
+
+        const debugManager = await mount(DebugMenu, { env, target });
+        registerCleanup(() => debugManager.destroy());
+
+        await click(debugManager.el.querySelector("button.o_dropdown_toggler"));
+
+        assert.containsOnce(debugManager.el, ".o_dropdown_item");
+        await click(debugManager.el.querySelector(".o_dropdown_item"));
+        assert.verifySteps(["consume"]);
+    });
+});


### PR DESCRIPTION
In the debug menu, when there is at least a tour "alive", click on
"Disable tours". Before this commit, it crashed because we sent the
whole tour description as argument to the consume method.

Issue reported on the wowl-bugs pad.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
