### PR TITLE
[FIX] web_editor: loader split the loading and the creation of wysiwyg

### DIFF
--- a/addons/web_editor/static/src/js/frontend/loader.js
+++ b/addons/web_editor/static/src/js/frontend/loader.js
@@ -7,6 +7,11 @@ let wysiwygPromise;
 
 const exports = {};
 
+function loadWysiwyg(additionnalAssets=[]) {
+    return ajax.loadLibs({assetLibs: ['web_editor.compiled_assets_wysiwyg', ...additionnalAssets]}, undefined, '/web_editor/public_render_template');
+}
+exports.loadWysiwyg = loadWysiwyg;
+
 /**
  * Load the assets and create a wysiwyg.
  *
@@ -16,7 +21,7 @@ const exports = {};
 exports.createWysiwyg = async (parent, options, additionnalAssets = []) => {
     if (!wysiwygPromise) {
         wysiwygPromise = new Promise(async (resolve) => {
-            await ajax.loadLibs({assetLibs: ['web_editor.compiled_assets_wysiwyg', ...additionnalAssets]}, undefined, '/web_editor/public_render_template');
+            await loadWysiwyg(additionnalAssets);
             // Wait the loading of the service and his dependencies (use string to
             // avoid parsing of require function).
             const stringFunction = `return new Promise(resolve => {


### PR DESCRIPTION
Before this commit, the wysiwyg loader had only one method to both load and create it.

After this commit, it has two separate methods to do it. This is practical if one wants to load
in some other context, like studio

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
