### PR TITLE
[FIX] point_of_sale: compute ending balance 

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -270,7 +270,7 @@ class PosSession(models.Model):
     def _check_pos_session_balance(self):
         for session in self:
             for statement in session.statement_ids:
-                if (statement != session.cash_register_id) and (statement.balance_end != statement.balance_end_real):
+                if (statement == session.cash_register_id) and (statement.balance_end != statement.balance_end_real):
                     statement.write({'balance_end_real': statement.balance_end})
 
     def action_pos_session_validate(self):


### PR DESCRIPTION
Step to follow

- go to Point Of Sale.
- start a session.
- do not sell anything.
- exit the session.
- close the session.
- close session & post entries.
- open Accounting > Accounting Dashboard > Cash Registers
- the ending balance is at 0. (should be at start value)

Cause of the issue

Wrong assignement of balance_end_real in the compute_ending_balance method.

Solution

statement.balance_end_real = statement.balance_end_real or 0.0 ----> statement.balance_end_real = statement.balance_end or 0.0

opw-2516245

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
