### PR TITLE
[FIX] purchase_stock: compute_picking perfs improvements

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -33,17 +33,10 @@ class PurchaseOrder(models.Model):
     group_id = fields.Many2one('procurement.group', string="Procurement Group", copy=False)
     is_shipped = fields.Boolean(compute="_compute_is_shipped")
 
-    @api.depends('order_line.move_ids.returned_move_ids',
-                 'order_line.move_ids.state',
-                 'order_line.move_ids.picking_id')
+    @api.depends('order_line.move_ids.picking_id')
     def _compute_picking(self):
         for order in self:
-            pickings = self.env['stock.picking']
-            for line in order.order_line:
-                # We keep a limited scope on purpose. Ideally, we should also use move_orig_ids and
-                # do some recursive search, but that could be prohibitive if not done correctly.
-                moves = line.move_ids | line.move_ids.mapped('returned_move_ids')
-                pickings |= moves.mapped('picking_id')
+            pickings = order.order_line.mapped('move_ids.picking_id')
             order.picking_ids = pickings
             order.picking_count = len(pickings)
 


### PR DESCRIPTION
Avoid calling two mapped in nested for loop and use a defaultdict
instead to improve compute_picking performances.

#### speedup

Client DB, 7550 purchase_order, `order._compute_picking` average time. Preprocessed orders
by calling `_create_picking` until `_action_assign` to create stock.moves beforehand

| # Pickings | Before PR | After PR |
|:----------:|:-----------:|:--------:|
| 10 | 0.854s | 0.229s |
| 50 | 1.406s | 0.498s |
| 200 | 3.664s | 1.5s |
| 1000 | 30.19s | 10.33s |
| 2500 | 58.64s | 22.04s |
| 7550 | 2m15s | 57.45s |

`order._compute_picking` average time by # stock_moves for 1 picking.

| # Stock Moves | Before PR | After PR |
|:---------------:|:----------:|:---------:|
| 10 | 0.053s | 0.027s |
| 25 | 0.075s | 0.031s |
| 50 | 0.115s | 0.039s |
| 100 | 0.192s | 0.055s |
| 246 | 0.418s | 0.099s |


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
