### PR TITLE
[FIX] web: action_service: alwyas rethrow whatever error

### DIFF
--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -1,5 +1,6 @@
 /** @odoo-modules */
 
+import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { errorService } from "@web/core/errors/error_service";
 import { dialogService } from "@web/core/dialog/dialog_service";
@@ -36,14 +37,14 @@ QUnit.module("base_automation", {}, function () {
             // Both of these are unused but required for the error service to call error handlers
             serviceRegistry.add("notification", notificationService);
             serviceRegistry.add("rpc", makeFakeRPCService());
-            const windowAddEventListener = window.addEventListener;
-            window.addEventListener = (type, cb) => {
+            const windowAddEventListener = browser.addEventListener;
+            browser.addEventListener = (type, cb) => {
                 if (type === "unhandledrejection") {
                     unhandledRejectionCb = cb;
                 }
             };
             registerCleanup(() => {
-                window.addEventListener = windowAddEventListener;
+                browser.addEventListener = windowAddEventListener;
             });
         },
     });

--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -12,7 +12,7 @@
                     <t t-if="!element.hide">
                         <t t-if="element.type == 'item'">
                             <DropdownItem payload="{ callback: element.callback }">
-                                <a t-if="element.href" t-att-href="element.href" t-esc="element.description"/>
+                                <a t-if="element.href" t-att-href="element.href" t-esc="element.description" t-on-click.prevent=""/>
                                 <span t-else="" t-esc="element.description"/>
                             </DropdownItem>
                         </t>

--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -97,7 +97,7 @@ export const errorService = {
             }
         }
 
-        window.addEventListener("error", async (ev) => {
+        browser.addEventListener("error", async (ev) => {
             const { colno, error: originalError, filename, lineno, message } = ev;
             let uncaughtError;
             if (!filename && !lineno && !colno) {
@@ -119,7 +119,7 @@ export const errorService = {
             handleError(uncaughtError, originalError);
         });
 
-        window.addEventListener("unhandledrejection", async (ev) => {
+        browser.addEventListener("unhandledrejection", async (ev) => {
             const originalError = ev.reason;
             const uncaughtError = new UncaughtPromiseError();
             uncaughtError.unhandledRejectionEvent = ev;

--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -13,6 +13,8 @@ import { cleanDomFromBootstrap, wrapSuccessOrFail, mapDoActionOptionAPI } from "
 
 const { Component, tags } = owl;
 
+const warningDialogBodyTemplate = tags.xml`<t t-esc="props.message"/>`;
+
 class ActionAdapter extends ComponentAdapter {
     setup() {
         super.setup();
@@ -95,7 +97,7 @@ class ActionAdapter extends ComponentAdapter {
                         this.title = this.props.title;
                     }
                 }
-                WarningDialog.bodyTemplate = tags.xml`<t t-esc="props.message"/>`;
+                WarningDialog.bodyTemplate = warningDialogBodyTemplate;
                 this.dialogs.add(WarningDialog, {
                     title: payload.title,
                     message: payload.message,

--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -16,6 +16,8 @@ odoo.define('web.OwlCompatibility', function () {
     const widgetSymbol = odoo.widgetSymbol;
     const children = new WeakMap(); // associates legacy widgets with their Owl children
 
+    const templateForLegacy = tags.xml`<div/>`;
+    const templateForOwl = tags.xml`<t t-component="props.Component" t-props="childProps" />`;
     /**
      * Case 1) An Owl component has to instantiate legacy widgets
      * ----------------------------------------------------------
@@ -85,15 +87,9 @@ odoo.define('web.OwlCompatibility', function () {
             }
             let template;
             if (!(props.Component.prototype instanceof Component)) {
-                template = tags.xml`<div/>`;
+                template = templateForLegacy;
             } else {
-                let propsStr = '';
-                for (let p in props) {
-                    if (p !== 'Component') {
-                        propsStr += ` ${p}="props.${p}"`;
-                    }
-                }
-                template = tags.xml`<t t-component="props.Component"${propsStr}/>`;
+                template = templateForOwl;
             }
             ComponentAdapter.template = template;
             super(...arguments);
@@ -101,6 +97,14 @@ odoo.define('web.OwlCompatibility', function () {
             ComponentAdapter.template = null;
 
             this.widget = null; // widget instance, if Component is a legacy widget
+        }
+
+        get childProps() {
+            if (!this._childProps) {
+                this._childProps = Object.assign({}, this.props);
+                delete this._childProps.Component;
+            }
+            return this._childProps;
         }
 
         /**

--- a/addons/web/static/src/legacy/legacy_client_actions.js
+++ b/addons/web/static/src/legacy/legacy_client_actions.js
@@ -11,6 +11,11 @@ import { breadcrumbsToLegacy } from "./utils";
 const { Component, hooks, tags } = owl;
 const actionRegistry = registry.category("actions");
 
+const legacyClientActionTemplate = tags.xml`
+    <ClientActionAdapter Component="Widget" widgetArgs="widgetArgs" widget="widget"
+                         onReverseBreadcrumb="onReverseBreadcrumb" t-ref="controller"
+                         t-on-scrollTo.stop="onScrollTo"/>`;
+
 // registers an action from the legacy action registry to the wowl one, ensuring
 // that widget actions are actually Components
 function registerClientAction(name, action) {
@@ -44,11 +49,7 @@ function registerClientAction(name, action) {
                 };
             }
         }
-        Action.template = tags.xml`
-      <ClientActionAdapter Component="Widget" widgetArgs="widgetArgs" widget="widget"
-                           onReverseBreadcrumb="onReverseBreadcrumb" t-ref="controller"
-                           t-on-scrollTo.stop="onScrollTo"/>
-    `;
+        Action.template = legacyClientActionTemplate;
         Action.components = { ClientActionAdapter };
         Action.isLegacy = true;
         Action.target = action.prototype.target;

--- a/addons/web/static/src/legacy/legacy_views.js
+++ b/addons/web/static/src/legacy/legacy_views.js
@@ -18,6 +18,11 @@ function getJsClassWidget(fieldsInfo) {
     return legacyViewRegistry.get(key);
 }
 
+const legacyViewTemplate = tags.xml`
+    <ViewAdapter Component="Widget" View="View" viewInfo="viewInfo" viewParams="viewParams"
+                 widget="widget" onReverseBreadcrumb="onReverseBreadcrumb" t-ref="controller"
+                 t-on-scrollTo.stop="onScrollTo"/>`;
+
 // registers a view from the legacy view registry to the wowl one, but wrapped
 // into an Owl Component
 function registerView(name, LegacyView) {
@@ -106,7 +111,7 @@ function registerView(name, LegacyView) {
                 .map(([vid, vtype]) => {
                     const view = this.props.viewSwitcherEntries.find((v) => v.type === vtype);
                     if (view) {
-                        return Object.assign({}, view, {viewID: vid});
+                        return Object.assign({}, view, { viewID: vid });
                     } else {
                         return {
                             viewID: vid,
@@ -122,12 +127,8 @@ function registerView(name, LegacyView) {
             });
         }
     }
+    Controller.template = legacyViewTemplate;
 
-    Controller.template = tags.xml`
-    <ViewAdapter Component="Widget" View="View" viewInfo="viewInfo" viewParams="viewParams"
-                 widget="widget" onReverseBreadcrumb="onReverseBreadcrumb" t-ref="controller"
-                 t-on-scrollTo.stop="onScrollTo"/>
-  `;
     Controller.components = { ViewAdapter };
     Controller.display_name = LegacyView.prototype.display_name;
     Controller.icon = LegacyView.prototype.icon;

--- a/addons/web/static/src/legacy/systray_menu_item.js
+++ b/addons/web/static/src/legacy/systray_menu_item.js
@@ -20,6 +20,8 @@ const legacySystrayMenuItems = legacySystrayMenu.Items;
 const convertedItems = [];
 let id = 1;
 
+const legacySystrayItemTemplate = tags.xml`<SystrayItemAdapter Component="Widget" />`;
+
 function addSystrayItem(Widget) {
     const name = `_legacy_systray_item_${id++}`;
 
@@ -29,7 +31,7 @@ function addSystrayItem(Widget) {
             this.Widget = Widget;
         }
     }
-    SystrayItem.template = tags.xml`<SystrayItemAdapter Component="Widget" />`;
+    SystrayItem.template = legacySystrayItemTemplate;
     SystrayItem.components = { SystrayItemAdapter };
 
     systrayRegistry.add(name, { Component: SystrayItem }, { sequence: Widget.prototype.sequence });

--- a/addons/web/static/src/webclient/actions/action_container.js
+++ b/addons/web/static/src/webclient/actions/action_container.js
@@ -20,21 +20,6 @@ export class ActionContainer extends Component {
         this.env.bus.off("ACTION_MANAGER:UPDATE", this);
         super.destroy();
     }
-
-    catchError() {
-        this.info = {};
-        this.render();
-        // we trigger here the 'MENUS-APP-CHANGED' event to make sure the navbar
-        // is properly displayed/updated.
-        this.env.bus.trigger("MENUS:APP-CHANGED");
-
-        // we do not rethrow the error here, because the controller component
-        // already caught the error, and rejected the doAction promise. That
-        // doAction promise will then trigger an unhandledRejection error, which
-        // will be displayed by the error service (unless the promise is handled
-        // by some caller code, but then in that case, it is its own responsibility
-        // to handle the error properly.
-    }
 }
 ActionContainer.components = { ActionDialog };
 ActionContainer.template = tags.xml`

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -69,6 +69,13 @@ export class InvalidButtonParamsError extends Error {}
 // regex that matches context keys not to forward from an action to another
 const CTX_KEY_REGEX = /^(?:(?:default_|search_default_|show_).+|.+_view_ref|group_by|group_by_no_leaf|active_id|active_ids|orderedBy)$/;
 
+// only register this template once for all dynamic classes ControllerComponent
+const ControllerComponentTemplate = tags.xml`<t t-component="Component" t-props="props"
+    registerCallback="registerCallback"
+    t-ref="component"
+    t-on-history-back="onHistoryBack"
+    t-on-controller-title-updated.stop="onTitleUpdated"/>`;
+
 function makeActionManager(env) {
     const keepLast = new KeepLast();
     let id = 0;
@@ -525,13 +532,7 @@ function makeActionManager(env) {
                 controller.title = ev.detail;
             }
         }
-
-        ControllerComponent.template = tags.xml`<t t-component="Component" t-props="props"
-          registerCallback="registerCallback"
-          t-ref="component"
-          t-on-history-back="onHistoryBack"
-          t-on-controller-title-updated.stop="onTitleUpdated"/>`;
-
+        ControllerComponent.template = ControllerComponentTemplate;
         ControllerComponent.Component = controller.Component;
 
         let nextDialog = {};

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -472,6 +472,7 @@ function makeActionManager(env) {
                     }).then(() => {
                         dialogCloseProm = undefined;
                     });
+                    dialog = nextDialog;
                 } else {
                     // LEGACY CODE COMPATIBILITY: remove when controllers will be written in owl
                     // we determine here which actions no longer occur in the nextStack,
@@ -529,6 +530,7 @@ function makeActionManager(env) {
 
         ControllerComponent.Component = controller.Component;
 
+        let nextDialog = {};
         if (action.target === "new") {
             cleanDomFromBootstrap();
             const actionDialogProps = {
@@ -556,7 +558,7 @@ function makeActionManager(env) {
                     }
                 },
             });
-            dialog = {
+            nextDialog = {
                 remove: removeDialog,
                 onClose: onClose || options.onClose,
             };

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -20,7 +20,7 @@
           t-esc="currentApp.name"
           class="o_menu_brand"
           t-ref="menuBrand"
-          t-on-click="menuService.selectMenu(currentApp)"
+          t-on-click.prevent="menuService.selectMenu(currentApp)"
         />
 
         <!-- Current App Sections -->
@@ -54,7 +54,7 @@
           t-att-class="{ o_dropdown_active: menuService.getCurrentApp() === app }"
           payload="app"
         >
-          <a t-att-href="getMenuItemHref(app)" t-esc="app.name" />
+          <a t-att-href="getMenuItemHref(app)" t-esc="app.name" t-on-click.prevent="" />
         </MenuItem>
       </t>
     </Dropdown>
@@ -80,6 +80,7 @@
           <MenuItem title="section.name" class="o_nav_entry" payload="section" hotkey="hotkey">
             <a
               t-att-href="getMenuItemHref(section)"
+              t-on-click.prevent=""
               t-att-data-section="section.id"
               t-esc="section.name"
             />
@@ -115,7 +116,7 @@
   <t t-name="web.NavBar.SectionsMenu.Dropdown.MenuSlot" owl="1">
     <t t-foreach="items" t-as="item" t-key="item.id">
       <MenuItem t-if="!item.childrenTree.length" payload="item">
-        <a t-att-href="getMenuItemHref(item)" t-esc="item.name" />
+        <a t-att-href="getMenuItemHref(item)" t-esc="item.name" t-on-click.prevent="" />
       </MenuItem>
 
       <t t-else="">
@@ -126,7 +127,7 @@
           t-key="subItem.id"
           class="o_dropdown_menu_group_entry"
           payload="subItem">
-          <a t-att-href="getMenuItemHref(subItem)" t-esc="subItem.name" />
+          <a t-att-href="getMenuItemHref(subItem)" t-esc="subItem.name" t-on-click.prevent="" />
         </MenuItem>
       </t>
     </t>
@@ -140,7 +141,7 @@
 
           <t t-if="!section.childrenTree.length">
             <MenuItem class="o_more_dropdown_section" payload="section">
-              <a t-att-href="getMenuItemHref(section)" t-esc="section.name" />
+              <a t-att-href="getMenuItemHref(section)" t-esc="section.name" t-on-click.prevent="" />
             </MenuItem>
           </t>
           <t t-else="">

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -9,7 +9,7 @@
                     <t t-if="!element.hide">
                         <t t-if="element.type == 'item'">
                             <UserMenuItem payload="{ callback: element.callback, id: element.id }">
-                                <a t-if="element.href" t-att-href="element.href" t-esc="element.description"/>
+                                <a t-if="element.href" t-att-href="element.href" t-esc="element.description" t-on-click.prevent="" />
                                 <span t-else="" t-esc="element.description"/>
                             </UserMenuItem>
                         </t>

--- a/addons/web/static/tests/core/errors/error_service_tests.js
+++ b/addons/web/static/tests/core/errors/error_service_tests.js
@@ -36,8 +36,8 @@ QUnit.module("Error Service", {
         serviceRegistry.add("notification", notificationService);
         serviceRegistry.add("rpc", makeFakeRPCService());
         serviceRegistry.add("localization", makeFakeLocalizationService());
-        const windowAddEventListener = window.addEventListener;
-        window.addEventListener = (type, cb) => {
+        const windowAddEventListener = browser.addEventListener;
+        browser.addEventListener = (type, cb) => {
             if (type === "unhandledrejection") {
                 unhandledRejectionCb = cb;
             }
@@ -46,7 +46,7 @@ QUnit.module("Error Service", {
             }
         };
         registerCleanup(() => {
-            window.addEventListener = windowAddEventListener;
+            browser.addEventListener = windowAddEventListener;
         });
     },
 });

--- a/addons/web/static/tests/webclient/actions/error_handling_tests.js
+++ b/addons/web/static/tests/webclient/actions/error_handling_tests.js
@@ -24,12 +24,13 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         assert.strictEqual(webClient.el.querySelector(".o_action_manager").innerHTML, "");
         await doAction(webClient, "1");
-        assert.ok(webClient.el.querySelector(".o_action_manager").innerHTML !== "");
+        const contents = webClient.el.querySelector(".o_action_manager").innerHTML;
+        assert.ok(contents !== "");
         try {
             await doAction(webClient, "Boom");
         } catch (e) {
             assert.ok(e instanceof TypeError);
         }
-        assert.strictEqual(webClient.el.querySelector(".o_action_manager").innerHTML, "");
+        assert.strictEqual(webClient.el.querySelector(".o_action_manager").innerHTML, contents);
     });
 });


### PR DESCRIPTION
on a legacy form view, do an action in target new
The view in target new should, during its onchange, trigger a ValidationError

Before this commit, the dialog_container was stuck in an error loop.
This was because the received error was never an instance of Error, rather it was
a legacy error event. So it was never transmitted upstream were the ErrorHandler could remove
the dialog in error from is dialog array.

After this commit, the ValidationError mesage is displayed.

Before this commi

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
