### PR TITLE
[FIX] account: inv. report price_average

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -98,12 +98,12 @@ class AccountInvoiceReport(models.Model):
                 line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                                                                             AS quantity,
                 -line.balance * currency_table.rate                         AS price_subtotal,
-                -COALESCE(line.balance
-                   / NULLIF(line.quantity, 0.0)
-                   / NULLIF(COALESCE(uom_line.factor, 1), 0.0)
-                   / NULLIF(COALESCE(uom_template.factor, 1), 0.0),
-                   0.0) * currency_table.rate
-                                                                            AS price_average,
+                -COALESCE(
+                   -- Average line price
+                   (line.balance / NULLIF(line.quantity, 0.0))
+                   -- convert to template uom
+                   * (NULLIF(COALESCE(uom_line.factor, 1), 0.0) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)),
+                   0.0) * currency_table.rate                               AS price_average,
                 COALESCE(partner.country_id, commercial_partner.country_id) AS country_id
         '''
 

--- a/doc/cla/individual/mhabboush.md
+++ b/doc/cla/individual/mhabboush.md
@@ -1,0 +1,11 @@
+Saudi Arabia, 2021-06-18
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mahmoud Habboush iii.ma7mod.iii@gmail.com https://github.com/mhabboush


### PR DESCRIPTION
When converting a price (average price in this case) the price should be multiplied by the source uom factor (uom_line.factor)
https://github.com/odoo/odoo/blob/72fea2fe11244a55e9a630049fc75f147e26e473/addons/uom/models/uom_uom.py#L172
follow-up fix to 978012b38abb941c88fe85f1befa2ac659545915

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
