### PR TITLE
[FIX] web: restart polling immediately when adding a new polling channel

### DIFF
--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -87,7 +87,7 @@ function jsonrpc(env, rpcId, url, params, settings = {}) {
         if (request.abort) {
             request.abort();
         }
-        rejectFn(new ConnectionAbortedError());
+        rejectFn(new ConnectionAbortedError("XmlHttpRequestError abort"));
     };
     return promise;
 }

--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -145,7 +145,7 @@ export function mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv) {
                     // the legacy guardedCatch code
                     reject({ message: reason, event: $.Event(), legacy: true });
                 } else if (reason instanceof ConnectionAbortedError) {
-                    reject({ message: reason.name, event: $.Event("abort") });
+                    reject({ message: reason.message, event: $.Event("abort") });
                 } else {
                     reject(reason);
                 }


### PR DESCRIPTION
Previously, adding a new channel to the longpolling bus would abort the
current longpolling request, and was supposed to immediately send a new
longpolling request with the new channels, but didn't.

This was caused by the fact that the code that restarts the longpolling
when aborting a previous request relies on the error message of the
aborted request. While rewriting the web client in owl in 0573aca, a new
RPC service was written which did not reject the promise the the same
error message, causing the longpoll to wait for a few seconds before
sending the next request.

This request fixes that by rejecting the promise with the expected error
message.
