### PR TITLE
[FIX] website_blog: Prevent tags loading if no blogs

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -108,8 +108,10 @@ class WebsiteBlog(http.Controller):
             page=page,
             step=self._blog_post_per_page,
         )
-
-        all_tags = blog and blogs.all_tags()[blog.id] or blogs.all_tags(join=True)
+        if not blogs:
+            all_tags = request.env['blog.tag']
+        else:
+            all_tags = blog and blogs.all_tags()[blog.id] or blogs.all_tags(join=True)
         tag_category = sorted(all_tags.mapped('category_id'), key=lambda category: category.name.upper())
         other_tags = sorted(all_tags.filtered(lambda x: not x.category_id), key=lambda tag: tag.name.upper())
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to website app > configuration
- Set the visibility of all the blog to Website A (So that it's not visible on Website B)
- Go to the Blog menu of Website B
- A traceback is triggered

Problem:
The `all_tags` function calls an SQL query to get the tags related to the website blog
with a where condition based on the blog_id. But since there is no blog linked to the site.
The request fails and an error is raised.

Solution:
Do not load the tags, if there is no blog for the website.

Opw-2545315



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
