### PR TITLE
[FIX] web: remove leftover token param in export

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1849,7 +1849,7 @@ class ExportFormat(object):
     def from_group_data(self, fields, groups):
         raise NotImplementedError()
 
-    def base(self, data, token):
+    def base(self, data):
         params = json.loads(data)
         model, fields, ids, domain, import_compat = \
             operator.itemgetter('model', 'fields', 'ids', 'domain', 'import_compat')(params)
@@ -1896,8 +1896,8 @@ class CSVExport(ExportFormat, http.Controller):
 
     @http.route('/web/export/csv', type='http', auth="user")
     @serialize_exception
-    def index(self, data, token):
-        return self.base(data, token)
+    def index(self, data):
+        return self.base(data)
 
     @property
     def content_type(self):
@@ -1932,8 +1932,8 @@ class ExcelExport(ExportFormat, http.Controller):
 
     @http.route('/web/export/xlsx', type='http', auth="user")
     @serialize_exception
-    def index(self, data, token):
-        return self.base(data, token)
+    def index(self, data):
+        return self.base(data)
 
     @property
     def content_type(self):


### PR DESCRIPTION
In commit adf34b9001eb34e, we remove unused token param.
These token's parameters are still a leftover of the previous cleaning.

This commit fixes the export in Xls in view form that crash with:
TypeError: index() missing 1 required positional argument: 'token'

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
