### PR TITLE
[FIX] web: correct res_id in FieldBinaryFileUploader

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1543,7 +1543,7 @@
             <t t-set="fileupload_action" t-translation="off">/web/binary/upload_attachment</t>
             <t t-set="multi_upload" t-value="true"/>
             <input type="hidden" name="model" t-att-value="widget.model"/>
-            <input type="hidden" name="id" value="0"/>
+            <input type="hidden" name="id" t-att-value="widget.res_id or 0"/>
         </t>
     </div>
 </div>


### PR DESCRIPTION
Having value 0 in ir.attachment field makes it invisible in Attachments menu for
any non-superuser, though normally it should be visible if user has access to
corresponding record where the file is attached.

STEPS:

* create a `mail.template` record, upload a file, save
* nagivate to Settings >> Database Structure >> Attachments

---

opw-2455134

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
