### PR TITLE
[IMP] iap_mail: avoid breaking of pill

### DIFF
--- a/addons/iap_mail/data/mail_templates.xml
+++ b/addons/iap_mail/data/mail_templates.xml
@@ -4,8 +4,8 @@
     <template id="enrich_company">
         <p t-esc="flavor_text" />
         <div class="o_partner_autocomplete_enrich_info bg-white p-3 mt-3 mb-3 mr-5">
-            <div class="col-12 row p-0 m-0">
-            <div class="col-10 p-0">
+            <div class="row p-0 m-0">
+            <div class="col-sm-10 p-0">
                 <h4>
                     <span class="mr-3 align-middle" t-esc="name"/>
                     <a t-if="twitter" class="ml-2" target="_blank" t-attf-href="http://www.twitter.com/{{twitter}}">
@@ -23,86 +23,86 @@
                 </h4>
                 <p t-esc="description"/>
             </div>
-            <div class="col-2 p-0 text-right">
+            <div class="col-sm-2 p-0 text-center text-md-right order-first order-md-last">
                 <img t-attf-src="{{logo}}" alt="Company Logo" style="max-width: 80px;"/>
             </div>
             </div>
             <hr/>
 
-            <div class="col-12 row m-0 p-0">
-                <div t-if="company_type" class="my-1 p-0 col-3">
+            <div class="col-sm-12 row m-0 p-0">
+                <div t-if="company_type" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-building text-primary"/>
                     <b>Company type</b>
                 </div>
-                <div t-if="company_type" class="my-1 col-9" t-esc="company_type" />
-                <div t-if="founded_year" class="my-1 p-0 col-3">
+                <div t-if="company_type" class="my-1 col-sm-9" t-esc="company_type" />
+                <div t-if="founded_year" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-calendar text-primary"/>
                     <b>Founded</b>
                 </div>
-                <div t-if="founded_year" class="my-1 col-9" t-esc="founded_year" />
+                <div t-if="founded_year" class="my-1 col-sm-9" t-esc="founded_year" />
                 <t t-set="sectors" t-value="[]" />
                 <t t-if="sector_primary" t-set="sectors" t-value="sectors + [sector_primary]" />
                 <t t-if="industry" t-set="sectors" t-value="sectors + [industry]" />
                 <t t-if="industry_group" t-set="sectors" t-value="sectors + [industry_group]" />
                 <t t-if="sub_industry" t-set="sectors" t-value="sectors + [sub_industry]" />
-                <div t-if="sectors" class="my-1 p-0 col-3">
+                <div t-if="sectors" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-industry text-primary"/>
                     <b>Sectors</b>
                 </div>
-                <div t-if="sectors" class="my-1 col-9">
+                <div t-if="sectors" class="my-1 col-sm-9">
                     <t t-foreach="sectors" t-as="inner_sector">
-                        <label t-esc="inner_sector" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px;"/>
+                        <label t-esc="inner_sector" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
-                <div t-if="employees" class="my-1 p-0 col-3">
+                <div t-if="employees" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-users text-primary"/>
                     <b>Employees</b>
                 </div>
-                <div t-if="employees" class="my-1 col-9" t-esc="'%.0f' % employees" />
-                <div t-if="estimated_annual_revenue" class="my-1 p-0 col-3">
+                <div t-if="employees" class="my-1 col-sm-9" t-esc="'%.0f' % employees" />
+                <div t-if="estimated_annual_revenue" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-money text-primary"/>
                     <b>Estimated revenue</b>
                 </div>
-                <div t-if="estimated_annual_revenue" class="my-1 col-9">
+                <div t-if="estimated_annual_revenue" class="my-1 col-sm-9">
                     <span t-esc="estimated_annual_revenue" /><span> per year</span>
                 </div>
-                <div t-if="phone_numbers" class="my-1 p-0 col-3">
+                <div t-if="phone_numbers" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-phone text-primary"/>
                     <b>Phone</b>
                 </div>
-                <div t-if="phone_numbers" class="col-9">
+                <div t-if="phone_numbers" class="col-sm-9">
                     <t t-foreach="phone_numbers" t-as="phone_number">
-                        <a t-attf-href="tel:{{phone_number}}" t-esc="phone_number" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px;"/>
+                        <a t-attf-href="tel:{{phone_number}}" t-esc="phone_number" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
-                <div t-if="email" class="my-1 p-0 col-3">
+                <div t-if="email" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-envelope text-primary"/>
                     <b>Email</b>
                 </div>
-                <div t-if="email" class="col-9">
+                <div t-if="email" class="col-sm-9">
                     <t t-foreach="email" t-as="email_item">
-                        <a target="_top" t-attf-href="mailto:{{email_item}}" t-esc="email_item" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px;"/>
+                        <a target="_top" t-attf-href="mailto:{{email_item}}" t-esc="email_item" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
-                <div t-if="timezone" class="my-1 p-0 col-3">
+                <div t-if="timezone" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-globe text-primary"/>
                     <b>Timezone</b>
                 </div>
-                <div t-if="timezone" class="my-1 col-9" t-esc="timezone.replace('_', ' ')" />
-                <div t-if="tech" class="my-1 p-0 col-3">
+                <div t-if="timezone" class="my-1 col-sm-9" t-esc="timezone.replace('_', ' ')" />
+                <div t-if="tech" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-cube text-primary"/>
                     <b>Technologies Used</b>
                 </div>
-                <div t-if="tech" class="my-1 col-9">
+                <div t-if="tech" class="my-1 col-sm-9">
                     <t t-foreach="tech" t-as="tech_item">
-                        <label t-esc="tech_item.replace('_', ' ').title()" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px;"/>
+                        <label t-esc="tech_item.replace('_', ' ').title()" style="font-weight:normal; padding: 2px 10px; background-color: #eeeeee; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
-                <div t-if="twitter_bio" class="my-1 p-0 col-3">
+                <div t-if="twitter_bio" class="my-1 p-0 col-sm-3">
                     <i class="fa fa-fw mr-2 fa-twitter text-primary"/>
                     <b>Twitter</b>
                 </div>
-                <div t-if="twitter_bio" class="my-1 col-9">
+                <div t-if="twitter_bio" class="my-1 col-sm-9">
                     <div t-if="twitter_followers"><t t-esc="twitter_followers"/> followers</div>
                     <div t-esc="twitter_bio" />
                 </div>


### PR DESCRIPTION
PURPOSE

- In partner autocomplete Html log note some data in pills
are not displayed in a single line, its breaking.
- If clearbit returns a falsy company logo, a broken
  image icon will be displayed instead of company logo.

SPECIFICATIONS

- Currently, when sending the mail for enrichment with template
`enrich_company`, we display few data with pills, like phones,
emails, industries, sectors etc. When there are too many pills
for these information, pills sometimes break into another line
if there's no enough space and the mail looks ugly.

- If clearbit does not returns a proper company logo, then
  display the default company image as company logo.


LINKS
PR #72507
Task  2577809