### PR TITLE
[FIX] web, *: fix options for table of content

### DIFF
--- a/addons/web/static/src/js/libs/bootstrap.js
+++ b/addons/web/static/src/js/libs/bootstrap.js
@@ -96,6 +96,17 @@ $.fn.scrollspy.Constructor.prototype.refresh = function () {
     }
 };
 
+/**
+ * In some cases, we need to keep the first element of navbars selected.
+ */
+const bootstrapSpyProcessFunction = $.fn.scrollspy.Constructor.prototype._process;
+$.fn.scrollspy.Constructor.prototype._process = function () {
+    bootstrapSpyProcessFunction.apply(this, arguments);
+    if (this._activeTarget === null && this._config.alwaysKeepFirstActive) {
+        this._activate(this._targets[0]);
+    }
+};
+
 /* Bootstrap modal scrollbar compensation on non-body */
 const bsSetScrollbarFunction = $.fn.modal.Constructor.prototype._setScrollbar;
 $.fn.modal.Constructor.prototype._setScrollbar = function () {

--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -42,7 +42,7 @@ const TableOfContent = publicWidget.Widget.extend({
         const $mainNavBar = $('#oe_main_menu_navbar');
         position += $mainNavBar.length ? $mainNavBar.outerHeight() : 0;
         position += isHorizontalNavbar ? this.$target.outerHeight() : 0;
-        $().getScrollingElement().scrollspy({target: '.s_table_of_content_navbar', method: 'offset', offset: position + 100});
+        $().getScrollingElement().scrollspy({target: '.s_table_of_content_navbar', method: 'offset', offset: position + 100, alwaysKeepFirstActive: true});
     },
 });
 


### PR DESCRIPTION
*: web_editor, website

In this PR, the following changes have been made:

- Disable link edition (Popover) in snippet navigation.
- The first element is selected once the snippet is visible
at the bottom of screen.

task-2431484