### PR TITLE
[IMP] codeowners: reactivate accounting for frozen version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,11 +30,11 @@
 
 # Generic fallback rules
 
-# /addons/account*/ @odoo/rd-accounting
+/addons/account*/ @odoo/rd-accounting
 /addons/auth_*/ @odoo/rd-security
 /addons/crm*/ @odoo/rd-sm
 /addons/event*/ @odoo/rd-sm
-# /addons/l10n_*/ @odoo/rd-accounting
+/addons/l10n_*/ @odoo/rd-accounting
 /addons/*/data/mail_template_data.xml @odoo/rd-sm
 /addons/*/models/ir_http.py @odoo/rd-website @odoo/rd-security
 /addons/*/models/ir_qweb.py @odoo/rd-website @odoo/rd-security


### PR DESCRIPTION
The rule is disabled in master but activated for frozen versions.

See https://github.com/odoo/odoo/pull/66150



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
