### PR TITLE
[FIX] web: DebugManager: editView: correctly load view

### DIFF
--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -6,7 +6,6 @@ import { formatDateTime, parseDateTime } from "../core/l10n/dates";
 import { _lt } from "../core/l10n/translation";
 import { registry } from "../core/registry";
 import { formatMany2one } from "../fields/format";
-import { json_node_to_xml } from "../views/view_utils";
 
 const { hooks, tags } = owl;
 const { useState } = hooks;
@@ -403,7 +402,8 @@ export function editView({ accessRights, action, component, env }) {
     if (!accessRights.canEditView) {
         return null;
     }
-    const { viewId, viewType } = component.widget;
+    let { view_id: viewId, type: viewType } = component.props.viewInfo;
+    viewType = viewType === "tree" ? "list" : viewType;
     const displayName = action.views.find((v) => v.type === viewType).name.toString();
     const description = env._t("Edit View: ") + displayName;
     return {

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -126,11 +126,11 @@ export class MockServer {
         if (!arch) {
             const genericViewKey = Object.keys(this.archs).find((fullKey) => {
                 const [_model, _viewID, _viewType] = fullKey.split(",");
-                viewId = parseInt(_viewID, 10);
                 return _model === modelName && _viewType === viewType;
             });
             if (genericViewKey) {
                 arch = this.archs[genericViewKey];
+                viewId = parseInt(genericViewKey.split(",")[1], 10) || false;
             }
         }
         if (!arch) {


### PR DESCRIPTION
Before this commit, the "Edit View" debug item only worked for
kanban, list and form views. For the other views, it opened a
blank form view. The reason is that for the other views, it didn't
correctly get the id of the view to edit.

Bug reported in the wowl-bugs pad

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
