### PR TITLE
[FIX] web: actions in target="new" should not update title

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -40,13 +40,13 @@ class ActionAdapter extends ComponentAdapter {
         let originalUpdateControlPanel;
         useEffect(
             () => {
-                this.title.setParts({ action: this.widget.getTitle() });
                 const query = this.widget.getState();
                 Object.assign(query, this.tempQuery);
                 this.tempQuery = null;
                 this.__widget = this.widget;
                 if (!this.wowlEnv.inDialog) {
                     this.pushState(query);
+                    this.title.setParts({ action: this.widget.getTitle() });
                 }
                 this.wowlEnv.bus.on("ACTION_MANAGER:UPDATE", this, () => {
                     this.env.bus.trigger("close_dialogs");

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -3,6 +3,7 @@
 import testUtils from "web.test_utils";
 import core from "web.core";
 import AbstractAction from "web.AbstractAction";
+import { registry } from "@web/core/registry";
 import { legacyExtraNextTick } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
@@ -296,6 +297,30 @@ QUnit.module("ActionManager", (hooks) => {
             assert.strictEqual($(".modal:last .modal-body").text().trim(), "Another action");
         }
     );
+
+    QUnit.test('actions in target="new" do not update page title', async function (assert) {
+        const mockedTitleService = {
+            start() {
+                return {
+                    setParts({ action }) {
+                        if (action) {
+                            assert.step(action);
+                        }
+                    },
+                };
+            },
+        };
+        registry.category("services").add("title", mockedTitleService);
+        const webClient = await createWebClient({ serverData });
+
+        // sanity check: execute an action in target="current"
+        await doAction(webClient, 1);
+        assert.verifySteps(["Partners Action 1"]);
+
+        // execute an action in target="new"
+        await doAction(webClient, 5);
+        assert.verifySteps([]);
+    });
 
     QUnit.module('Actions in target="inline"');
     QUnit.test(


### PR DESCRIPTION
Before this commit, all actions, even those executed in target
"new" (i.e. in dialogs) updated the document's title. Actions in
dialog should not do that.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
