### PR TITLE
append sms icon inside sms widget element

### DIFF
--- a/addons/sms/static/src/js/fields_phone_widget.js
+++ b/addons/sms/static/src/js/fields_phone_widget.js
@@ -33,7 +33,7 @@ Phone.include({
      */
     getFocusableElement() {
         if (this.enableSMS && this.mode === 'readonly') {
-            return this.$el.filter('.' + this.className).find('a');
+            return this.$el.find('a:first');
         }
         return this._super.apply(this, arguments);
     },
@@ -88,7 +88,7 @@ Phone.include({
             });
             $composerButton.prepend($('<i>', {class: 'fa fa-mobile'}));
             $composerButton.on('click', this._onClickSMS.bind(this));
-            this.$el = this.$el.add($composerButton);
+            this.$el = this.$el.append($composerButton);
         }
         return def;
     },

--- a/addons/sms/static/tests/sms_widget_test.js
+++ b/addons/sms/static/tests/sms_widget_test.js
@@ -150,7 +150,7 @@ QUnit.module('fields', {
         assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text(), 'yopSMS',
             "value should be displayed properly with a link to send SMS");
 
-        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a', 2,
+        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a:not(.o_field_phone_sms)', 2,
             "should have the correct classnames");
 
         // Edit a line and check the result
@@ -167,7 +167,7 @@ QUnit.module('fields', {
         assert.doesNotHaveClass($cell.parent(), 'o_selected_row', 'should not be in edit mode anymore');
         assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text(), 'newSMS',
             "value should be properly updated");
-        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a', 2,
+        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a:not(.o_field_phone_sms)', 2,
             "should still have links with correct classes");
 
         await testUtils.dom.click(list.$('tbody td:not(.o_list_record_selector) .o_field_phone_sms').first());
@@ -209,7 +209,7 @@ QUnit.module('fields', {
             },
         });
         // check initial rendering
-        assert.strictEqual(form.$('.o_field_phone').text(), "+32494444444",
+        assert.strictEqual(form.$('.o_field_phone > a:first').text(), "+32494444444",
             'Initial Phone text should be set');
         assert.strictEqual(form.$('.o_field_phone_sms').text(), 'SMS',
             'SMS button label should be rendered');
@@ -218,7 +218,7 @@ QUnit.module('fields', {
         await testUtils.fields.editInput($('input[name="foo"]'), 'someOtherFoo');
 
         // check rendering after changes
-        assert.strictEqual(form.$('.o_field_phone').text(), NEW_PHONE,
+        assert.strictEqual(form.$('.o_field_phone > a:first').text(), NEW_PHONE,
             'Phone text should be updated');
         assert.strictEqual(form.$('.o_field_phone_sms').text(), 'SMS',
             'SMS button label should not be changed');

--- a/addons/web/static/tests/legacy/fields/basic_fields_mobile_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_mobile_tests.js
@@ -54,7 +54,7 @@ QUnit.module('basic_fields', {
     QUnit.module('PhoneWidget');
 
     QUnit.test('phone field in form view on extra small screens', async function (assert) {
-        assert.expect(7);
+        assert.expect(8);
 
         var form = await createView({
             View: FormView,
@@ -70,8 +70,10 @@ QUnit.module('basic_fields', {
             res_id: 1,
         });
 
-        var $phoneLink = form.$('div.o_form_uri.o_field_widget.o_field_phone > a');
+        let $phoneLink = form.$('div.o_form_uri.o_field_widget.o_field_phone > a:not(".o_field_phone_sms")');
         assert.strictEqual($phoneLink.length, 1,
+            "should have a anchor with correct classes");
+        assert.containsOnce(form, 'div.o_form_uri.o_field_widget.o_field_phone > a.o_field_phone_sms',
             "should have a anchor with correct classes");
         assert.strictEqual($phoneLink.text(), 'yop',
             "value should be displayed properly");
@@ -90,7 +92,7 @@ QUnit.module('basic_fields', {
 
         // save
         await testUtils.form.clickSave(form);
-        $phoneLink = form.$('div.o_form_uri.o_field_widget.o_field_phone > a');
+        $phoneLink = form.$('div.o_form_uri.o_field_widget.o_field_phone > a:not(".o_field_phone_sms")');
         assert.strictEqual($phoneLink.text(), 'new',
             "new value should be displayed properly");
         assert.hasAttrValue($phoneLink, 'href', 'tel:new',
@@ -114,7 +116,7 @@ QUnit.module('basic_fields', {
         assert.strictEqual(list.$('tbody td:not(.o_list_record_selector) a').first().text(), 'yop',
             "value should be displayed properly");
 
-        var $phoneLink = list.$('div.o_form_uri.o_field_widget.o_field_phone > a');
+        var $phoneLink = list.$('div.o_form_uri.o_field_widget.o_field_phone > a:not(".o_field_phone_sms")');
         assert.strictEqual($phoneLink.length, 3,
             "should have anchors with correct classes");
         assert.hasAttrValue($phoneLink.first(), 'href', 'tel:yop',
@@ -134,7 +136,7 @@ QUnit.module('basic_fields', {
         assert.doesNotHaveClass($cell.parent(), 'o_selected_row', 'should not be in edit mode anymore');
         assert.strictEqual(list.$('tbody td:not(.o_list_record_selector) a').first().text(), 'new',
             "value should be properly updated");
-        $phoneLink = list.$('div.o_form_uri.o_field_widget.o_field_phone > a');
+        $phoneLink = list.$('div.o_form_uri.o_field_widget.o_field_phone > a:not(".o_field_phone_sms")');
         assert.strictEqual($phoneLink.length, 3,
             "should still have anchors with correct classes");
         assert.hasAttrValue($phoneLink.first(), 'href', 'tel:new',
@@ -168,7 +170,7 @@ QUnit.module('basic_fields', {
 
         // save
         await testUtils.form.clickSave(form);
-        assert.strictEqual(form.$('.o_field_widget').text(), val,
+        assert.strictEqual(form.$('.o_field_widget > a:first').text(), val,
             "value should have been correctly escaped");
 
         form.destroy();

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -5985,7 +5985,7 @@ QUnit.module('basic_fields', {
             },
         });
 
-        var $phone = form.$('div.o_field_widget.o_form_uri.o_field_phone > a');
+        var $phone = form.$('div.o_field_widget.o_form_uri.o_field_phone > a:not(.o_field_phone_sms)');
         assert.strictEqual($phone.length, 1,
             "should have rendered the phone number as a link with correct classes");
         assert.strictEqual($phone.text(), 'yop',
@@ -6003,7 +6003,7 @@ QUnit.module('basic_fields', {
 
         // save
         await testUtils.form.clickSave(form);
-        assert.strictEqual(form.$('div.o_field_widget.o_form_uri.o_field_phone > a').text(), 'new',
+        assert.strictEqual(form.$('div.o_field_widget.o_form_uri.o_field_phone > a:not(.o_field_phone_sms)').text(), 'new',
             "new value should be displayed properly");
 
         form.destroy();
@@ -6029,7 +6029,7 @@ QUnit.module('basic_fields', {
         assert.strictEqual(list.$('tbody td:not(.o_list_record_selector) a').first().text(), 'yop',
             "value should be displayed properly with a link to send SMS");
 
-        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a', 5,
+        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a:not(.o_field_phone_sms)', 5,
             "should have the correct classnames");
 
         // Edit a line and check the result
@@ -6046,7 +6046,7 @@ QUnit.module('basic_fields', {
         assert.doesNotHaveClass($cell.parent(), 'o_selected_row', 'should not be in edit mode anymore');
         assert.strictEqual(list.$('tbody td:not(.o_list_record_selector) a').first().text(), 'new',
             "value should be properly updated");
-        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a', 5,
+        assert.containsN(list, 'div.o_field_widget.o_form_uri.o_field_phone > a:not(.o_field_phone_sms)', 5,
             "should still have links with correct classes");
 
         list.destroy();


### PR DESCRIPTION
PURPOSE

sms icon was sibling of sms widget element due to which creating instance of phone widget and appending it do not appends both elements.

For example, Calendar popover, appending phone widget inside calendar popover
do not adds sms icon inside caledar popover.

SPEC
Append phone widget inside calendar popover should add phone number as well as sms icon.

TASK 2577276



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
