### PR TITLE
[FIX] web_editor: close font color palette when opening the bg one

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1050,7 +1050,7 @@ var SnippetsMenu = Widget.extend({
 
         // Active snippet editor on click in the page
         var lastElement;
-        this.$document.on('click.snippets_menu', '*', ev => {
+        const onClick = ev => {
             var srcElement = ev.target || (ev.originalEvent && (ev.originalEvent.target || ev.originalEvent.originalTarget)) || ev.srcElement;
             if (!srcElement || lastElement === srcElement) {
                 return;
@@ -1078,7 +1078,11 @@ var SnippetsMenu = Widget.extend({
                 return;
             }
             this._activateSnippet($target);
-        });
+        };
+
+        this.$document.on('click.snippets_menu', '*', onClick);
+        // Needed as bootstrap stop the propagation of click events for dropdowns
+        this.$document.on('mouseup.snippets_menu', '.dropdown-toggle', onClick);
 
         core.bus.on('deactivate_snippet', this, this._onDeactivateSnippet);
 
@@ -1123,7 +1127,7 @@ var SnippetsMenu = Widget.extend({
                     editor.cover();
                 }
             }, 250);
-        }, 50)
+        }, 50);
         // We use addEventListener instead of jQuery because we need 'capture'.
         // Setting capture to true allows to take advantage of event bubbling
         // for events that otherwise don’t support it. (e.g. useful when

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1447,10 +1447,11 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
      */
     _onClick: function (ev) {
         // Do not close the colorpalette on colorpicker click
-        if (!ev.originalEvent.__isColorpickerClick) {
-            this._super(...arguments);
+        if (ev.originalEvent.__isColorpickerClick) {
+            ev.stopPropagation();
+            return;
         }
-        ev.stopPropagation();
+        return this._super(...arguments);
     },
 });
 


### PR DESCRIPTION
When the color palette for the text was open, opening the background
color options was not closing it.
The click event was stopped at the snippet level, where it should only
be the case if the click was done inside the colorpicker.

task-2476601

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
