### PR TITLE
[IMP] calendar: calendar app should open on due date with pop-up opened

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -22,6 +22,8 @@ class MailActivity(models.Model):
             'default_activity_ids': [(6, 0, self.ids)],
             'default_partner_ids': self.user_id.partner_id.ids,
             'default_user_id': self.user_id.id,
+            'initial_date': self.date_deadline,
+            'default_calendar_event_id': self.calendar_event_id.id,
         }
         return action
 

--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_renderer.js
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_renderer.js
@@ -36,6 +36,9 @@ export class AttendeeCalendarCommonRenderer extends CalendarCommonRenderer {
         const record = this.props.model.records[event.id];
 
         if (record) {
+            if (this.env.searchModel?.context?.default_calendar_event_id === parseInt(event.id)) {
+                this.openPopover(info.el, record);
+            }
             if (record.rawRecord.is_highlighted) {
                 el.classList.add("o_event_highlight");
             }


### PR DESCRIPTION
**PURPOSE:**

Calendar app should open with pop-up opened

**SPECIFICATIONS:**

When activity of type meeting is edited(Reschedule), he gets a calendar
app open on due date's week.The calendar app should be opened with the
corresponding meeting highlighted (or the pop-up opened same as if the user
has click on it)

**LINKS:**

Task-2528115

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
