### PR TITLE
[14.0][FIX] use placeholder from parameters in _content_image_get_response

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1534,7 +1534,7 @@ class Binary(http.Controller):
                 placeholder_filename = record._get_placeholder_filename(field=field)
                 placeholder_content = Binary.placeholder(image=placeholder_filename)
             else:
-                placeholder_content = Binary.placeholder()
+                placeholder_content = Binary.placeholder(image=placeholder or 'placeholder.png')
             # Since we set a placeholder for any missing image, the status must be 200. In case one
             # wants to configure a specific 404 page (e.g. though nginx), a 404 status will cause
             # troubles.

--- a/doc/cla/individual/SplashS.md
+++ b/doc/cla/individual/SplashS.md
@@ -1,0 +1,11 @@
+Russian Federation, 2021-06-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sergey Shebanin sergey@shebanin.ru https://github.com/SplashS


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wrong behavior in `/web/partner_image/<int:rec_id>` controller.
It defines specific placeholder ('user_placeholder.jpg'), but it isn't used in descendant method.

Current behavior before PR:
`/web/partner_image/<int:rec_id>` returns 'photo' placeholder if there is no image defined in `res.partner` record.

Desired behavior after PR is merged:
`/web/partner_image/<int:rec_id>` returns 'silhouette' placeholder if there is no image defined in `res.partner` record.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
