### PR TITLE
[FIX] mail: clean context on attachments creation

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -13,6 +13,7 @@ from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import UserError, AccessError
 from odoo.osv import expression
 from odoo.tools import groupby
+from odoo.tools.misc import clean_context
 
 _logger = logging.getLogger(__name__)
 _image_dataurl = re.compile(r'(data:image/[a-z]+?);base64,([a-z0-9+/\n]{3,}=*)\n*([\'"])(?: data-filename="([^"]*)")?', re.I)
@@ -1031,7 +1032,7 @@ class Message(models.Model):
                 values['attachment_ids'] = []
             # extract base64 images
             if 'body' in values:
-                Attachments = self.env['ir.attachment']
+                Attachments = self.env['ir.attachment'].with_context(clean_context(self._context))
                 data_to_url = {}
                 def base64_to_boundary(match):
                     key = match.group(2)


### PR DESCRIPTION
Steps to reproduce :

  - Install `CRM` and `Sales` modules
  - Go to Settings, activate "External Email Servers" and
    set an alias.
  - Edit 'Sales Team Europe' : add an alias
    (ensure alias end with the "External Email Servers" alias)
  - Send a mail to the europe sale team alias email with a
    base64 image in the html body
    ex: <img alt="" src="data:image/png;base64,ABCDE123....789">

Issue :

  - Traceback is raised.
  ("ValueError: Wrong value for ir.attachment.type: 'opportunity'.")

Cause :

  Both `crm.lead` and `ir.attachment` have a `type` field.

  When creating the thread, in this case of crm.lead model,
  it will add the 'default_type' and 'default_team_id' to the
  context.

  The context will be inhrited and used on the creation of the
  ir.attachment (in this case its the base64 encoded image
  inside the body).

  Since no `type` was provided while creating the ir.attachment,
  it will set the type from `default_type` in context since
  available.

Solution :

- Clean the context (in this case, it will remove `default_X` values)
  when creating the ir.attachment .

opw-2551461