### PR TITLE
[FIX] point_of_sale: post bank statement of cash

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -322,10 +322,10 @@ class PosSession(models.Model):
                 self.env['pos.order'].search([('session_id', '=', self.id), ('state', '=', 'paid')]).write({'state': 'done'})
             else:
                 self.move_id.unlink()
-        elif not self.cash_register_id.difference:
-            cash_register = self.cash_register_id.sudo() if sudo else self.cash_register_id
-            cash_register.pos_session_id = False
-            cash_register.unlink()
+        else:
+            statement = self.cash_register_id
+            statement.button_post()
+            statement.button_validate()
         self.write({'state': 'closed'})
         return {
             'type': 'ir.actions.client',


### PR DESCRIPTION
The amount of cash present in the POS may be incorrect

To reproduce the error:
1. In POS settings, enable "Advanced Cash Control"
2. Start a POS session
3. Make an order of 70$, payment in cash
4. Close the POS session (correctly set the closing cash)
5. Start a POS session, close it (correctly set the closing cash)

Error: Back to kanban view, the information about the POS are incorrect:
the cash balance is equal to zero, it should be $70

The value of the cash balance is computed in `_compute_last_session`:
https://github.com/odoo/odoo/blob/5ea1d31df9041ca7b25fbea6178e798e62bebca0/addons/point_of_sale/models/pos_config.py#L276-L291
This method gets the last session and extracts the information. However,
in the above case, there were no sales during the last session (step 5).
In such situation, the bank statement of cash is deleted. As a result,
in `_compute_last_session`, `last_session_closing_cashbox` will be
defined to `False`. This is the reason why the cash balance will be
equal to 0

The deletion of `cash_register` has been introduced in case the user
closes a session that does not contain any SO. This fix suggests keeping
such a bank statement and automatically posting it.

Linked to OPW-2507394 and #71932