### PR TITLE
Separate attributes from variants

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -108,6 +108,8 @@ class ProductProduct(models.Model):
         'Barcode', copy=False,
         help="International Article Number used for product identification.")
     product_template_attribute_value_ids = fields.Many2many('product.template.attribute.value', relation='product_variant_combination', string="Attribute Values", ondelete='restrict')
+    product_template_variant_value_ids = fields.Many2many('product.template.attribute.value', relation='product_variant_combination',
+                                                          domain=[('attribute_line_id.value_count', '>', 1)], string="Variant Values", ondelete='restrict')
     combination_indices = fields.Char(compute='_compute_combination_indices', store=True, index=True)
     is_product_variant = fields.Boolean(compute='_compute_is_product_variant')
 

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -54,9 +54,10 @@
             </div>
 
             <xpath expr="//page[@name='general_information']" position="after">
-                <page name="variants" string="Variants" groups="product.group_product_variant">
+                <page name="variants" string="Attributes &amp; Variants" groups="product.group_product_variant">
                     <field name="attribute_line_ids" widget="one2many" context="{'show_attribute': False}">
-                        <tree string="Variants" editable="bottom">
+                        <tree string="Variants" editable="bottom" decoration-info="value_count &lt;= 1">
+                            <field name="value_count" invisible="1"/>
                             <field name="attribute_id" attrs="{'readonly': [('id', '!=', False)]}"/>
                             <field name="value_ids" widget="many2many_tags" options="{'no_create_edit': True, 'color_field': 'color'}" context="{'default_attribute_id': attribute_id, 'show_attribute': False}"/>
                         </tree>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -46,9 +46,9 @@
                         <page string="General Information" name="general_information">
                             <group>
                                 <group name="group_general">
+                                    <field name="categ_id" string="Product Category"/>
                                     <field name="active" invisible="1"/>
                                     <field name="type"/>
-                                    <field name="categ_id" string="Product Category"/>
                                 </group>
                                 <group name="group_standard_price">
                                     <label for="list_price" class="mt-1"/>
@@ -316,7 +316,7 @@
                     <field name="default_code" optional="show" readonly="1"/>
                     <field name="barcode" optional="hide" readonly="1"/>
                     <field name="name" readonly="1"/>
-                    <field name="product_template_attribute_value_ids" widget="many2many_tags" groups="product.group_product_variant" readonly="1"/>
+                    <field name="product_template_variant_value_ids" widget="many2many_tags" groups="product.group_product_variant" readonly="1"/>
                     <field name="company_id" groups="base.group_multi_company" optional="hide" readonly="1"/>
                     <field name="lst_price" optional="show" string="Sales Price"/>
                     <field name="standard_price" optional="show"/>
@@ -361,9 +361,8 @@
                 <field name="name" position="after">
                     <field name="product_tmpl_id" class="oe_inline" readonly="1" invisible="1" attrs="{'required': [('id', '!=', False)]}"/>
                 </field>
-                <xpath expr="//div[hasclass('oe_title')]" position="inside">
-                    <field name="product_template_attribute_value_ids" widget="many2many_tags" readonly="1"
-                        groups="product.group_product_variant"/>
+                <xpath expr="//div[hasclass('oe_title')]//div[@name='options']" position="before">
+                    <field name="product_template_variant_value_ids" widget="many2many_tags" readonly="1" groups="product.group_product_variant"/>
                 </xpath>
             </field>
         </record>
@@ -391,7 +390,7 @@
                                         <small t-if="record.default_code.value">[<field name="default_code"/>]</small>
                                     </strong>
                                     <div class="o_kanban_tags_section">
-                                        <field name="product_template_attribute_value_ids" groups="product.group_product_variant" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                        <field name="product_template_variant_value_ids" groups="product.group_product_variant" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                     </div>
                                     <ul>
                                         <li><strong>Price: <field name="lst_price"></field></strong></li>

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -14,8 +14,8 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
                 trigger: '#customize-menu > a',
             },
             {
-                content: "click on 'Product Attribute's Filters'",
-                trigger: "#customize-menu a:contains(Product Attribute's Filters)",
+                content: "click on 'Attributes & Variants filters'",
+                trigger: "#customize-menu a:contains(Attributes & Variants filters)",
             },
             {
                 content: "select product attribute Steel",
@@ -132,8 +132,8 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
                 trigger: '#customize-menu > a',
             },
             {
-                content: "remove 'Product Attribute's Filters'",
-                trigger: "#customize-menu a:contains(Product Attribute's Filters):has(input:checked)",
+                content: "remove 'Attributes & Variants filters'",
+                trigger: "#customize-menu a:contains(Attributes & Variants filters):has(input:checked)",
             },
             {
                 content: "finish",

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -486,7 +486,7 @@
         </xpath>
     </template>
 
-    <template id="products_attributes" inherit_id="website_sale.products" active="False" customize_show="True" name="Product Attribute's Filters">
+    <template id="products_attributes" inherit_id="website_sale.products" active="False" customize_show="True" name="Attributes &amp; Variants filters">
         <xpath expr="//div[@id='products_grid_before']" position="before">
             <t t-set="enable_left_column" t-value="True"/>
         </xpath>

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3648,7 +3648,8 @@ class Many2many(_RelationalMulti):
             )
         if self.store:
             if not (self.relation and self.column1 and self.column2):
-                self._explicit = False
+                if not self.relation:
+                    self._explicit = False
                 # table name is based on the stable alphabetical order of tables
                 comodel = model.env[self.comodel_name]
                 if not self.relation:


### PR DESCRIPTION
Several changes distinguish product attributes better from variant attributes. The variant creation mode is added on the template form for attribute lines with more than one value. Specification attributes are no longer listed as variant attributes in the product variant form and tree views.
    
Additionally, a visibility option is added to hide attributes from the ecommerce filter section.

task-2466988