### PR TITLE
[FIX] sale_timesheet : improve profitability report perf

### DIFF
--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -72,330 +72,550 @@ class ProfitabilityAnalysis(models.Model):
         tools.drop_view_if_exists(self._cr, self._table)
         query = """
             CREATE VIEW %s AS (
-                SELECT
-                    sub.id as id,
-                    sub.project_id as project_id,
-                    sub.task_id as task_id,
-                    sub.user_id as user_id,
-                    sub.sale_line_id as sale_line_id,
-                    sub.analytic_account_id as analytic_account_id,
-                    sub.partner_id as partner_id,
-                    sub.company_id as company_id,
-                    sub.currency_id as currency_id,
-                    sub.sale_order_id as sale_order_id,
-                    sub.order_confirmation_date as order_confirmation_date,
-                    sub.product_id as product_id,
-                    sub.sale_qty_delivered_method as sale_qty_delivered_method,
-                    sub.expense_amount_untaxed_to_invoice as expense_amount_untaxed_to_invoice,
-                    sub.expense_amount_untaxed_invoiced as expense_amount_untaxed_invoiced,
-                    sub.amount_untaxed_to_invoice as amount_untaxed_to_invoice,
-                    sub.amount_untaxed_invoiced as amount_untaxed_invoiced,
-                    sub.timesheet_unit_amount as timesheet_unit_amount,
-                    sub.timesheet_cost as timesheet_cost,
-                    sub.expense_cost as expense_cost,
-                    sub.other_revenues as other_revenues,
-                    sub.line_date as line_date,
-                    (sub.expense_amount_untaxed_to_invoice + sub.expense_amount_untaxed_invoiced + sub.amount_untaxed_to_invoice +
-                        sub.amount_untaxed_invoiced + sub.other_revenues + sub.timesheet_cost + sub.expense_cost)
-                        as margin
-                FROM (
+                     -- Get empty project
+                     SELECT
+                           -1 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           NULL AS sale_line_id,
+                           NULL AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           NULL AS sale_order_id,
+                           NULL AS order_confirmation_date,
+                           NULL AS product_id,
+                           NULL AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           0.0 AS expense_amount_untaxed_to_invoice,
+                           0.0 AS expense_amount_untaxed_invoiced,
+                           0.0 AS amount_untaxed_to_invoice,
+                           0.0 AS amount_untaxed_invoiced,
+                           NULL AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                UNION ALL
+                     -- Get the timesheet costs and amount
+                     SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOL.id)) * 10 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOL.id AS sale_line_id,
+                           SOL.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOL.product_id AS product_id,
+                           SOL.qty_delivered_method AS sale_qty_delivered_method,
+                           TS.unit_amount AS timesheet_unit_amount,
+                           TS.amount AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           0.0 AS expense_amount_untaxed_to_invoice,
+                           0.0 AS expense_amount_untaxed_invoiced,
+                           0.0 AS amount_untaxed_to_invoice,
+                           0.0 AS amount_untaxed_invoiced,
+                           TS.date AS line_date,
+                           -TS.amount AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                INNER JOIN account_analytic_line TS
+                        ON P.id = TS.project_id
+                 LEFT JOIN sale_order_line SOL
+                        ON TS.so_line = SOL.id
+                 LEFT JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                     WHERE P.active = 't' AND P.allow_timesheets = 't'
+                UNION ALL
+                    -- Get the timesheet costs and amount, for every timesheet's SOL :
+                    --      take the untaxed_amount_to_invoice of SOL expenses as to re-invoice amount,
+                    --      take the price_reduce of SOL expenses as re-invoiced amount
+                    --      sum the untaxed_amount_to_invoice of SOL (timesheet ou manual) as amount
+                    --      sum the untaxed_amount_invoiced of SOL (timesheet ou manual)
                     SELECT
-                        ROW_NUMBER() OVER (ORDER BY P.id, SOL.id) AS id,
-                        P.id AS project_id,
-                        P.user_id AS user_id,
-                        SOL.id AS sale_line_id,
-                        SOL.task_id AS task_id,
-                        P.analytic_account_id AS analytic_account_id,
-                        P.partner_id AS partner_id,
-                        C.id AS company_id,
-                        C.currency_id AS currency_id,
-                        S.id AS sale_order_id,
-                        S.date_order AS order_confirmation_date,
-                        SOL.product_id AS product_id,
-                        SOL.qty_delivered_method AS sale_qty_delivered_method,
-                        COST_SUMMARY.expense_amount_untaxed_to_invoice AS expense_amount_untaxed_to_invoice,
-                        COST_SUMMARY.expense_amount_untaxed_invoiced AS expense_amount_untaxed_invoiced,
-                        COST_SUMMARY.amount_untaxed_to_invoice AS amount_untaxed_to_invoice,
-                        COST_SUMMARY.amount_untaxed_invoiced AS amount_untaxed_invoiced,
-                        COST_SUMMARY.timesheet_unit_amount AS timesheet_unit_amount,
-                        COST_SUMMARY.timesheet_cost AS timesheet_cost,
-                        COST_SUMMARY.expense_cost AS expense_cost,
-                        COST_SUMMARY.other_revenues AS other_revenues,
-                        COST_SUMMARY.line_date::date AS line_date
-                    FROM project_project P
-                        JOIN res_company C ON C.id = P.company_id
-                        LEFT JOIN (
-                            -- Each costs and revenues will be retrieved individually by sub-requests
-                            -- This is required to able to get the date
-                            SELECT
-                                project_id,
-                                analytic_account_id,
-                                sale_line_id,
-                                SUM(timesheet_unit_amount) AS timesheet_unit_amount,
-                                SUM(timesheet_cost) AS timesheet_cost,
-                                SUM(expense_cost) AS expense_cost,
-                                SUM(other_revenues) AS other_revenues,
-                                SUM(downpayment_invoiced) AS downpayment_invoiced,
-                                SUM(expense_amount_untaxed_to_invoice) AS expense_amount_untaxed_to_invoice,
-                                SUM(expense_amount_untaxed_invoiced) AS expense_amount_untaxed_invoiced,
-                                SUM(amount_untaxed_to_invoice) AS amount_untaxed_to_invoice,
-                                SUM(amount_untaxed_invoiced) AS amount_untaxed_invoiced,
-                                line_date AS line_date
-                            FROM (
-                                -- Get the timesheet costs
-                                SELECT
-                                    P.id AS project_id,
-                                    P.analytic_account_id AS analytic_account_id,
-                                    TS.so_line AS sale_line_id,
-                                    TS.unit_amount AS timesheet_unit_amount,
-                                    TS.amount AS timesheet_cost,
-                                    0.0 AS other_revenues,
-                                    0.0 AS expense_cost,
-                                    0.0 AS downpayment_invoiced,
-                                    0.0 AS expense_amount_untaxed_to_invoice,
-                                    0.0 AS expense_amount_untaxed_invoiced,
-                                    0.0 AS amount_untaxed_to_invoice,
-                                    0.0 AS amount_untaxed_invoiced,
-                                    TS.date AS line_date
-                                FROM account_analytic_line TS, project_project P
-                                WHERE TS.project_id IS NOT NULL AND P.id = TS.project_id AND P.active = 't' AND P.allow_timesheets = 't'
-
-                                UNION ALL
-
-                                -- Get the other revenues
-                                SELECT
-                                    P.id AS project_id,
-                                    P.analytic_account_id AS analytic_account_id,
-                                    AAL.so_line AS sale_line_id,
-                                    0.0 AS timesheet_unit_amount,
-                                    0.0 AS timesheet_cost,
-                                    AAL.amount AS other_revenues,
-                                    0.0 AS expense_cost,
-                                    0.0 AS downpayment_invoiced,
-                                    0.0 AS expense_amount_untaxed_to_invoice,
-                                    0.0 AS expense_amount_untaxed_invoiced,
-                                    0.0 AS amount_untaxed_to_invoice,
-                                    0.0 AS amount_untaxed_invoiced,
-                                    AAL.date AS line_date
-                                FROM project_project P
-                                    LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
-                                    LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
-                                WHERE AAL.amount > 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-                                    AND NOT EXISTS (
-                                        SELECT SOL.id
-                                        FROM sale_order_line SOL
-                                        JOIN sale_order_line_invoice_rel SOINV ON SOINV.order_line_id = SOL.id
-                                        JOIN account_move_line AML ON SOINV.invoice_line_id = AAL.move_id
-                                        WHERE SOL.qty_delivered_method IN ('timesheet', 'manual')
-                                            OR (SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no')
-                                    )
-
-                                UNION ALL
-
-                                -- Get the expense costs from account analytic line
-                                SELECT
-                                    P.id AS project_id,
-                                    P.analytic_account_id AS analytic_account_id,
-                                    AAL.so_line AS sale_line_id,
-                                    0.0 AS timesheet_unit_amount,
-                                    0.0 AS timesheet_cost,
-                                    0.0 AS other_revenues,
-                                    AAL.amount AS expense_cost,
-                                    0.0 AS downpayment_invoiced,
-                                    0.0 AS expense_amount_untaxed_to_invoice,
-                                    0.0 AS expense_amount_untaxed_invoiced,
-                                    0.0 AS amount_untaxed_to_invoice,
-                                    0.0 AS amount_untaxed_invoiced,
-                                    AAL.date AS line_date
-                                FROM project_project P
-                                    LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
-                                    LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
-                                WHERE AAL.amount < 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-
-                                UNION ALL
-
-                                -- Get the invoiced downpayments
-                                SELECT
-                                    P.id AS project_id,
-                                    P.analytic_account_id AS analytic_account_id,
-                                    MY_SOLS.id AS sale_line_id,
-                                    0.0 AS timesheet_unit_amount,
-                                    0.0 AS timesheet_cost,
-                                    0.0 AS other_revenues,
-                                    0.0 AS expense_cost,
-                                    CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced,
-                                    0.0 AS expense_amount_untaxed_to_invoice,
-                                    0.0 AS expense_amount_untaxed_invoiced,
-                                    0.0 AS amount_untaxed_to_invoice,
-                                    0.0 AS amount_untaxed_invoiced,
-                                    MY_S.date_order AS line_date
-                                FROM project_project P
-                                    LEFT JOIN sale_order_line MY_SOL ON P.sale_line_id = MY_SOL.id
-                                    LEFT JOIN sale_order MY_S ON MY_SOL.order_id = MY_S.id
-                                    LEFT JOIN sale_order_line MY_SOLS ON MY_SOLS.order_id = MY_S.id
-                                WHERE MY_SOLS.is_downpayment = 't'
-
-                                UNION ALL
-
-                                -- Get the expense costs from sale order line
-                                SELECT
-                                    P.id AS project_id,
-                                    P.analytic_account_id AS analytic_account_id,
-                                    OLIS.id AS sale_line_id,
-                                    0.0 AS timesheet_unit_amount,
-                                    0.0 AS timesheet_cost,
-                                    0.0 AS other_revenues,
-                                    OLIS.price_reduce AS expense_cost,
-                                    0.0 AS downpayment_invoiced,
-                                    0.0 AS expense_amount_untaxed_to_invoice,
-                                    0.0 AS expense_amount_untaxed_invoiced,
-                                    0.0 AS amount_untaxed_to_invoice,
-                                    0.0 AS amount_untaxed_invoiced,
-                                    ANLI.date AS line_date
-                                FROM project_project P
-                                    LEFT JOIN account_analytic_account ANAC ON P.analytic_account_id = ANAC.id
-                                    LEFT JOIN account_analytic_line ANLI ON ANAC.id = ANLI.account_id
-                                    LEFT JOIN sale_order_line OLI ON P.sale_line_id = OLI.id
-                                    LEFT JOIN sale_order ORD ON OLI.order_id = ORD.id
-                                    LEFT JOIN sale_order_line OLIS ON ORD.id = OLIS.order_id
-                                WHERE OLIS.product_id = ANLI.product_id AND OLIS.is_downpayment = 't' AND ANLI.amount < 0.0 AND ANLI.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-
-                                UNION ALL
-
-                                -- Get the following values: expense amount untaxed to invoice/invoiced, amount untaxed to invoice/invoiced
-                                -- These values have to be computed from all the records retrieved just above but grouped by project and sale order line
-                                SELECT
-                                    AMOUNT_UNTAXED.project_id AS project_id,
-                                    AMOUNT_UNTAXED.analytic_account_id AS analytic_account_id,
-                                    AMOUNT_UNTAXED.sale_line_id AS sale_line_id,
-                                    0.0 AS timesheet_unit_amount,
-                                    0.0 AS timesheet_cost,
-                                    0.0 AS other_revenues,
-                                    0.0 AS expense_cost,
-                                    0.0 AS downpayment_invoiced,
-                                    CASE
-                                        WHEN SOL.qty_delivered_method = 'analytic' THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
-                                        ELSE 0.0
-                                    END AS expense_amount_untaxed_to_invoice,
-                                    CASE
-                                        WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
-                                        THEN
-                                            CASE
-                                                WHEN T.expense_policy = 'sales_price'
-                                                THEN (SOL.price_reduce / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END) * SOL.qty_invoiced
-                                                ELSE -AMOUNT_UNTAXED.expense_cost
-                                            END
-                                        ELSE 0.0
-                                    END AS expense_amount_untaxed_invoiced,
-                                    CASE
-                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
-                                        ELSE 0.0
-                                    END AS amount_untaxed_to_invoice,
-                                    CASE
-                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (COALESCE(SOL.untaxed_amount_invoiced, AMOUNT_UNTAXED.downpayment_invoiced) / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
-                                        ELSE 0.0
-                                    END AS amount_untaxed_invoiced,
-                                    S.date_order AS line_date
-                                FROM project_project P
-                                    JOIN res_company C ON C.id = P.company_id
-                                    LEFT JOIN (
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            AAL.so_line AS sale_line_id,
-                                            0.0 AS expense_cost,
-                                            0.0 AS downpayment_invoiced
-                                        FROM account_analytic_line AAL, project_project P
-                                        WHERE AAL.project_id IS NOT NULL AND P.id = AAL.project_id AND P.active = 't'
-                                        GROUP BY P.id, AAL.so_line
-
-                                        UNION
-
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            AAL.so_line AS sale_line_id,
-                                            0.0 AS expense_cost,
-                                            0.0 AS downpayment_invoiced
-                                        FROM project_project P
-                                            LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
-                                            LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
-                                        WHERE AAL.amount > 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-                                        GROUP BY P.id, AA.id, AAL.so_line
-                                        UNION
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            AAL.so_line AS sale_line_id,
-                                            SUM(AAL.amount) AS expense_cost,
-                                            0.0 AS downpayment_invoiced
-                                        FROM project_project P
-                                            LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
-                                            LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
-                                        WHERE AAL.amount < 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-                                        GROUP BY P.id, AA.id, AAL.so_line
-                                        UNION
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            MY_SOLS.id AS sale_line_id,
-                                            0.0 AS expense_cost,
-                                            CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced
-                                        FROM project_project P
-                                            LEFT JOIN sale_order_line MY_SOL ON P.sale_line_id = MY_SOL.id
-                                            LEFT JOIN sale_order MY_S ON MY_SOL.order_id = MY_S.id
-                                            LEFT JOIN sale_order_line MY_SOLS ON MY_SOLS.order_id = MY_S.id
-                                        WHERE MY_SOLS.is_downpayment = 't'
-                                        GROUP BY P.id, MY_SOLS.id
-                                        UNION
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            OLIS.id AS sale_line_id,
-                                            OLIS.price_reduce AS expense_cost,
-                                            0.0 AS downpayment_invoiced
-                                        FROM project_project P
-                                            LEFT JOIN account_analytic_account ANAC ON P.analytic_account_id = ANAC.id
-                                            LEFT JOIN account_analytic_line ANLI ON ANAC.id = ANLI.account_id
-                                            LEFT JOIN sale_order_line OLI ON P.sale_line_id = OLI.id
-                                            LEFT JOIN sale_order ORD ON OLI.order_id = ORD.id
-                                            LEFT JOIN sale_order_line OLIS ON ORD.id = OLIS.order_id
-                                        WHERE OLIS.product_id = ANLI.product_id AND OLIS.is_downpayment = 't' AND ANLI.amount < 0.0 AND ANLI.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
-                                        GROUP BY P.id, OLIS.id
-                                        UNION
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            SOL.id AS sale_line_id,
-                                            0.0 AS expense_cost,
-                                            0.0 AS downpayment_invoiced
-                                        FROM sale_order_line SOL
-                                            INNER JOIN project_project P ON SOL.project_id = P.id
-                                        WHERE P.active = 't' AND P.allow_timesheets = 't'
-                                        UNION
-                                        SELECT
-                                            P.id AS project_id,
-                                            P.analytic_account_id AS analytic_account_id,
-                                            SOL.id AS sale_line_id,
-                                            0.0 AS expense_cost,
-                                            0.0 AS downpayment_invoiced
-                                        FROM sale_order_line SOL
-                                            INNER JOIN project_task T ON SOL.task_id = T.id
-                                            INNER JOIN project_project P ON P.id = T.project_id
-                                        WHERE P.active = 't' AND P.allow_timesheets = 't'
-                                    ) AMOUNT_UNTAXED ON AMOUNT_UNTAXED.project_id = P.id
-                                    LEFT JOIN sale_order_line SOL ON AMOUNT_UNTAXED.sale_line_id = SOL.id
-                                    LEFT JOIN sale_order S ON SOL.order_id = S.id
-                                    LEFT JOIN product_product PP on (SOL.product_id = PP.id)
-                                    LEFT JOIN product_template T on (PP.product_tmpl_id = T.id)
-                                    WHERE P.active = 't' AND P.analytic_account_id IS NOT NULL
-                            ) SUB_COST_SUMMARY
-                            GROUP BY project_id, analytic_account_id, sale_line_id, line_date
-                        ) COST_SUMMARY ON COST_SUMMARY.project_id = P.id
-                        LEFT JOIN sale_order_line SOL ON COST_SUMMARY.sale_line_id = SOL.id
-                        LEFT JOIN sale_order S ON SOL.order_id = S.id
-                        WHERE P.active = 't' AND P.analytic_account_id IS NOT NULL
-                    ) AS sub
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOL.id)) * 10 + 1 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOL.id AS sale_line_id,
+                           SOL.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOL.product_id AS product_id,
+                           SOL.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount, -- TODO
+                           0.0 AS timesheet_cost, -- TODO
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic'
+                               THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
+                               THEN
+                                   CASE
+                                       WHEN TPL.expense_policy = 'sales_price'
+                                       THEN (SOL.price_reduce / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0)) * SOL.qty_invoiced
+                                       ELSE 0.0
+                                   END
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_invoiced / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_invoiced,
+                           SO.date_order AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                INNER JOIN res_company C
+                        ON C.id = P.company_id
+                INNER JOIN account_analytic_line TS
+                        ON P.id = TS.project_id
+                INNER JOIN sale_order_line SOL
+                        ON TS.so_line = SOL.id
+                INNER JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                      JOIN product_product PRO
+                        ON PRO.id = SOL.product_id
+                      JOIN product_template TPL
+                        ON TPL.id = PRO.product_tmpl_id
+                     WHERE P.active = 't' AND P.allow_timesheets = 't'
+                  GROUP BY P.id, P.user_id, SOL.id, SOL.task_id, P.analytic_account_id, P.partner_id, C.id, C.currency_id, SO.id, SO.date_order, SOL.product_id, SOL.qty_delivered_method,
+                           SOL.untaxed_amount_invoiced, SOL.untaxed_amount_to_invoice, SO.currency_rate, TPL.expense_policy, SOL.qty_invoiced
+                UNION ALL
+                    -- Get the timesheet costs and amount, for every SOL linked to a project :
+                    --      take the untaxed_amount_to_invoice of SOL expenses as to re-invoice amount,
+                    --      take the price_reduce of SOL expenses as re-invoiced amount
+                    --      sum the untaxed_amount_to_invoice of SOL (timesheet ou manual) as amount
+                    --      sum the untaxed_amount_invoiced of SOL (timesheet ou manual)
+                    SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOL.id)) * 10 + 2 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOL.id AS sale_line_id,
+                           SOL.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOL.product_id AS product_id,
+                           SOL.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic'
+                               THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
+                               THEN
+                                   CASE
+                                       WHEN TPL.expense_policy = 'sales_price'
+                                       THEN (SOL.price_reduce / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0)) * SOL.qty_invoiced
+                                       ELSE 0.0
+                                   END
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_invoiced / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_invoiced,
+                           SO.date_order AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                      JOIN sale_order_line SOL
+                        ON SOL.project_id = P.id
+                      JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                      JOIN product_product PRO
+                        ON PRO.id = SOL.product_id
+                      JOIN product_template TPL
+                        ON TPL.id = PRO.product_tmpl_id
+                     WHERE P.active = 't' AND P.allow_timesheets = 't'
+                        AND SOL.task_id IS NULL
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM account_analytic_line TS
+                            WHERE TS.so_line = SOL.id and TS.project_id = P.id
+                        )
+                  GROUP BY P.id, P.user_id, SOL.id, SOL.task_id, P.analytic_account_id, P.partner_id, C.id, C.currency_id, SO.id, SO.date_order, SOL.product_id, SOL.qty_delivered_method,
+                           SOL.untaxed_amount_invoiced, SOL.untaxed_amount_to_invoice, SO.currency_rate, TPL.expense_policy, SOL.qty_invoiced
+                UNION ALL
+                    -- Get the timesheet costs and amount, for every SOL linked to the task :
+                    --      take the untaxed_amount_to_invoice of SOL expenses as to re-invoice amount,
+                    --      take the price_reduce of SOL expenses as re-invoiced amount
+                    --      sum the untaxed_amount_to_invoice of SOL (timesheet ou manual) as amount
+                    --      sum the untaxed_amount_invoiced of SOL (timesheet ou manual)
+                    SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOL.id)) * 10 + 3 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOL.id AS sale_line_id,
+                           SOL.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOL.product_id AS product_id,
+                           SOL.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic'
+                               THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
+                               THEN
+                                   CASE
+                                       WHEN TPL.expense_policy = 'sales_price'
+                                       THEN (SOL.price_reduce / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0)) * SOL.qty_invoiced
+                                       ELSE 0.0
+                                   END
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_invoiced / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_invoiced,
+                           SO.date_order AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                INNER JOIN project_task TA
+                        ON P.id = TA.project_id
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                 LEFT JOIN sale_order_line SOL
+                        ON SOL.task_id = TA.id
+                      JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                      JOIN product_product PRO
+                        ON PRO.id = SOL.product_id
+                      JOIN product_template TPL
+                        ON TPL.id = PRO.product_tmpl_id
+                     WHERE P.active = 't' AND P.allow_timesheets = 't'
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM account_analytic_line TS
+                           WHERE TS.so_line = SOL.id and TS.project_id = P.id
+                       )
+                  GROUP BY P.id, P.user_id, SOL.id, SOL.task_id, P.analytic_account_id, P.partner_id, C.id, C.currency_id, SO.id, SO.date_order, SOL.product_id, SOL.qty_delivered_method,
+                           SOL.untaxed_amount_invoiced, SOL.untaxed_amount_to_invoice, SO.currency_rate, TPL.expense_policy, SOL.qty_invoiced
+                UNION ALL
+                    -- Get the other revenues
+                     SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOL.id)) * 10 + 4 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOL.id AS sale_line_id,
+                           SOL.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOL.product_id AS product_id,
+                           SOL.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           CASE
+                               WHEN AAL.amount > 0.0
+                               THEN AAL.amount
+                               ELSE 0.0
+                           END AS other_revenues,
+                           CASE
+                               WHEN AAL.amount < 0.0
+                               THEN AAL.amount
+                               ELSE 0.0
+                           END AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           0.0 AS expense_amount_untaxed_to_invoice,
+                           0.0 AS expense_amount_untaxed_invoiced,
+                           0.0 AS amount_untaxed_to_invoice,
+                           0.0 AS amount_untaxed_invoiced,
+                           AAL.date AS line_date,
+                           AAL.amount AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                INNER JOIN account_analytic_account AA
+                        ON P.analytic_account_id = AA.id
+                      JOIN account_analytic_line AAL
+                        ON AAL.account_id = AA.id
+                 LEFT JOIN sale_order_line SOL
+                        ON AAL.so_line = SOL.id
+                 LEFT JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                 LEFT JOIN sale_order_line_invoice_rel SOINV -- opw-2444237
+                        ON SOINV.order_line_id = SOL.id AND SOINV.invoice_line_id = AAL.move_id
+                     WHERE AAL.project_id IS NULL
+                       AND P.active = 't' AND P.allow_timesheets = 't'
+                       AND ( -- opw-2444237
+                           SOINV.invoice_line_id IS NULL
+                           OR NOT (SOL.qty_delivered_method IN ('timesheet', 'manual')
+                                OR (SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no')) -- TODO : OK ?
+                       )
+                UNION ALL
+                    -- Get the other revenues, for every SOL linked to Project AA :
+                    --      take the untaxed_amount_to_invoice of SOL expenses as to re-invoice amount,
+                    --      take the price_reduce of SOL expenses as re-invoiced amount
+                    --      take the untaxed_amount_to_invoice of SOL (timesheet ou manual) as amount
+                    --      take the untaxed_amount_invoiced of SOL (timesheet ou manual)
+                     SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOL.id)) * 10 + 5 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOL.id AS sale_line_id,
+                           SOL.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOL.product_id AS product_id,
+                           SOL.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic'
+                               THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no'
+                               THEN
+                                   CASE
+                                       WHEN TPL.expense_policy = 'sales_price'
+                                       THEN (SOL.price_reduce / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0)) * SOL.qty_invoiced
+                                       ELSE SUM(CASE WHEN AAL.amount < 0.0 THEN AAL.amount ELSE 0.0 END) -- TODO SUM negative AAL amount : OK ?
+                                   END
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_invoiced,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_invoiced / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_invoiced,
+                           SO.date_order AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                INNER JOIN account_analytic_account AA
+                        ON P.analytic_account_id = AA.id
+                      JOIN account_analytic_line AAL
+                        ON AAL.account_id = AA.id
+                 LEFT JOIN sale_order_line SOL
+                        ON AAL.so_line = SOL.id
+                      JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                      JOIN product_product PRO
+                        ON PRO.id = SOL.product_id
+                      JOIN product_template TPL
+                        ON TPL.id = PRO.product_tmpl_id
+                     WHERE AAL.project_id IS NULL
+                       AND P.active = 't' AND P.allow_timesheets = 't'
+                  GROUP BY P.id, P.user_id, SOL.id, SOL.task_id, P.analytic_account_id, P.partner_id, C.id, C.currency_id, SO.id, SO.date_order, SOL.product_id, SOL.qty_delivered_method,
+                           SOL.untaxed_amount_invoiced, SOL.untaxed_amount_to_invoice, SO.currency_rate, TPL.expense_policy, SOL.qty_invoiced
+                UNION ALL
+                    -- Get the invoiced downpayments, for every downpayments :
+                    --      take the untaxed_amount_to_invoice of SOL expenses as to re-invoice amount,
+                    --      take the price_reduce of SOL expenses as re-invoiced amount
+                    --      take the untaxed_amount_to_invoice of SOL (timesheet ou manual) as amount
+                    --      take the untaxed_amount_invoiced of SOL (timesheet ou manual)
+                     SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOLS.id)) * 10 + 8 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOLS.id AS sale_line_id,
+                           SOLS.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOLS.product_id AS product_id,
+                           SOLS.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           0.0 AS expense_cost,
+                           CASE WHEN SOLS.invoice_status = 'invoiced' THEN SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced,
+                           CASE
+                               WHEN SOLS.qty_delivered_method = 'analytic'
+                               THEN (SOLS.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOLS.qty_delivered_method = 'analytic' AND SOLS.invoice_status != 'no'
+                               THEN
+                                   CASE
+                                       WHEN TPL.expense_policy = 'sales_price'
+                                       THEN (SOLS.price_reduce / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0)) * SOLS.qty_invoiced
+                                       ELSE 0.0
+                                   END
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_invoiced,
+                           CASE
+                               WHEN SOLS.qty_delivered_method IN ('timesheet', 'manual') THEN (SOLS.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOLS.qty_delivered_method IN ('timesheet', 'manual')
+                               THEN (
+                                   COALESCE(
+                                               SOLS.untaxed_amount_invoiced,
+                                               CASE WHEN SOLS.invoice_status = 'invoiced' THEN SOLS.price_reduce ELSE 0.0 END
+                                       )
+                                   /
+                                   COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_invoiced,
+                           SO.date_order AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                INNER JOIN sale_order_line SOL
+                        ON P.sale_line_id = SOL.id
+                      JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                      JOIN sale_order_line SOLS
+                        ON SOLS.order_id = SO.id
+                      JOIN product_product PRO
+                        ON PRO.id = SOLS.product_id
+                      JOIN product_template TPL
+                        ON TPL.id = PRO.product_tmpl_id
+                     WHERE SOLS.is_downpayment = 't'
+                  GROUP BY P.id, P.user_id, SOLS.id, SOLS.task_id, P.analytic_account_id, P.partner_id, C.id, C.currency_id, SO.id, SO.date_order, SOLS.product_id, SOLS.qty_delivered_method,
+                           SOLS.untaxed_amount_invoiced, SOLS.untaxed_amount_to_invoice, SO.currency_rate, TPL.expense_policy, SOLS.qty_invoiced
+                UNION ALL
+                    -- Get the expense costs from sale order line :
+                    --      price reduce of SOL as expense cost
+                    --      take the untaxed_amount_to_invoice of SOL expenses as to re-invoice amount,
+                    --      take the price_reduce of SOL expenses as re-invoiced amount
+                    --      take the untaxed_amount_to_invoice of SOL (timesheet ou manual) as amount
+                    --      take the untaxed_amount_invoiced of SOL (timesheet ou manual)
+                    SELECT
+                           (ROW_NUMBER() OVER (ORDER BY P.id, SOLS.id)) * 10 + 9 AS id,
+                           P.id AS project_id,
+                           P.user_id AS user_id,
+                           SOLS.id AS sale_line_id,
+                           SOLS.task_id AS task_id,
+                           P.analytic_account_id AS analytic_account_id,
+                           P.partner_id AS partner_id,
+                           C.id AS company_id,
+                           C.currency_id AS currency_id,
+                           SO.id AS sale_order_id,
+                           SO.date_order AS order_confirmation_date,
+                           SOLS.product_id AS product_id,
+                           SOLS.qty_delivered_method AS sale_qty_delivered_method,
+                           0.0 AS timesheet_unit_amount,
+                           0.0 AS timesheet_cost,
+                           0.0 AS other_revenues,
+                           SOLS.price_reduce AS expense_cost,
+                           0.0 AS downpayment_invoiced,
+                           CASE
+                               WHEN SOLS.qty_delivered_method = 'analytic'
+                               THEN (SOLS.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOLS.qty_delivered_method = 'analytic' AND SOLS.invoice_status != 'no'
+                               THEN
+                                   CASE
+                                       WHEN TPL.expense_policy = 'sales_price'
+                                       THEN (SOLS.price_reduce / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0)) * SOLS.qty_invoiced
+                                       ELSE -SOLS.price_reduce
+                                   END
+                               ELSE 0.0
+                           END AS expense_amount_untaxed_invoiced,
+                           CASE
+                               WHEN SOLS.qty_delivered_method IN ('timesheet', 'manual') THEN (SOLS.untaxed_amount_to_invoice / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_to_invoice,
+                           CASE
+                               WHEN SOLS.qty_delivered_method IN ('timesheet', 'manual') THEN (SOLS.untaxed_amount_invoiced / COALESCE(NULLIF(SO.currency_rate, 0.0), 1.0))
+                               ELSE 0.0
+                           END AS amount_untaxed_invoiced,
+                           SO.date_order AS line_date,
+                           0.0 AS margin
+                      FROM project_project P
+                      JOIN res_company C
+                        ON C.id = P.company_id
+                INNER JOIN account_analytic_account AA
+                        ON P.analytic_account_id = AA.id
+                      JOIN account_analytic_line AAL
+                        ON AA.id = AAL.account_id
+                INNER JOIN sale_order_line SOL
+                        ON P.sale_line_id = SOL.id
+                      JOIN sale_order SO
+                        ON SOL.order_id = SO.id
+                      JOIN sale_order_line SOLS
+                        ON SO.id = SOLS.order_id
+                      JOIN product_product PRO
+                        ON PRO.id = SOLS.product_id
+                      JOIN product_template TPL
+                        ON TPL.id = PRO.product_tmpl_id
+                     WHERE SOLS.product_id = AAL.product_id
+                       AND SOLS.is_downpayment = 't'
+                       AND AAL.amount < 0.0 AND AAL.project_id IS NULL
+                       AND P.active = 't' AND P.allow_timesheets = 't'
+                  GROUP BY P.id, P.user_id, SOLS.id, SOLS.task_id, P.analytic_account_id, P.partner_id, C.id, C.currency_id, SO.id, SO.date_order, SOLS.product_id, SOLS.qty_delivered_method,
+                           SOLS.untaxed_amount_invoiced, SOLS.untaxed_amount_to_invoice, SO.currency_rate, TPL.expense_policy, SOLS.qty_invoiced
             )
         """ % self._table
         self._cr.execute(query)


### PR DESCRIPTION
With this PR we aim to improve the profitability report query.

The first step is exploding the preceding query and understand what it
does.
In this commit we just re-write the query.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
