### PR TITLE
[IMP] sale_(project), hr_timesheet: improve task analysis report

### DIFF
--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -29,5 +29,21 @@
                 </xpath>
              </field>
         </record>
+        <record id="view_project_task_user_search_inherited" model="ir.ui.view">
+            <field name="name">report.project.task.user.search.inherited</field>
+            <field name="model">report.project.task.user</field>
+            <field name="inherit_id" ref="project.view_task_project_user_search" />
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='late']" position="after">
+                    <filter string="Tasks in Overtime" name="overtime" domain="[('task_id.overtime', '&gt;', 0)]"/>
+                </xpath>
+                <xpath expr="//filter[@name='my_tasks']" position="before">
+                    <filter string="My Team's Projects" name="my_team_projects"  domain="[('project_id.user_id.employee_id.parent_id.user_id', '=', uid), ('project_id.user_id', '!=', uid), ('user_id', '!=', uid), ('user_id', '!=', False)]"/>
+                </xpath>
+                <xpath expr="//filter[@name='my_tasks']" position="after">
+                    <filter string="My Team's Tasks" name="my_team_tasks" domain="[('task_id.user_id.employee_id.parent_id.user_id', '=', uid)]" />
+                </xpath>
+             </field>
+        </record>
     </data>
 </odoo>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -764,8 +764,8 @@ class Task(models.Model):
         compute='_compute_email_from', recursive=True, store=True, readonly=False)
     project_privacy_visibility = fields.Selection(related='project_id.privacy_visibility', string="Project Visibility")
     # Computed field about working time elapsed between record creation and assignation/closing.
-    working_hours_open = fields.Float(compute='_compute_elapsed', string='Working Hours to Assign', store=True, group_operator="avg")
-    working_hours_close = fields.Float(compute='_compute_elapsed', string='Working Hours to Close', store=True, group_operator="avg")
+    working_hours_open = fields.Float(compute='_compute_elapsed', string='Working Hours to Assign', digits=(16, 2), store=True, group_operator="avg")
+    working_hours_close = fields.Float(compute='_compute_elapsed', string='Working Hours to Close', digits=(16, 2), store=True, group_operator="avg")
     working_days_open = fields.Float(compute='_compute_elapsed', string='Working Days to Assign', store=True, group_operator="avg")
     working_days_close = fields.Float(compute='_compute_elapsed', string='Working Days to Close', store=True, group_operator="avg")
     # customer portal: include comment and incoming emails in communication history

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -10,21 +10,25 @@ class ReportProjectTaskUser(models.Model):
     _order = 'name desc, project_id'
     _auto = False
 
-    name = fields.Char(string='Task Title', readonly=True)
+    name = fields.Char(string='Task', readonly=True)
     user_id = fields.Many2one('res.users', string='Assigned To', readonly=True)
+    create_date = fields.Datetime("Create Date", readonly=True)
     date_assign = fields.Datetime(string='Assignment Date', readonly=True)
     date_end = fields.Datetime(string='Ending Date', readonly=True)
     date_deadline = fields.Date(string='Deadline', readonly=True)
     date_last_stage_update = fields.Datetime(string='Last Stage Update', readonly=True)
     project_id = fields.Many2one('project.project', string='Project', readonly=True)
-    working_days_close = fields.Float(string='# Working Days to Close',
+    working_days_close = fields.Float(string='Working Days to Close',
         digits=(16,2), readonly=True, group_operator="avg",
         help="Number of Working Days to close the task")
-    working_days_open = fields.Float(string='# Working Days to Assign',
+    working_days_open = fields.Float(string='Working Days to Assign',
         digits=(16,2), readonly=True, group_operator="avg",
         help="Number of Working Days to open the task")
-    delay_endings_days = fields.Float(string='# Days to Deadline', digits=(16,2), readonly=True)
+    delay_endings_days = fields.Float(string='Days to Deadline', digits=(16, 2), group_operator="avg", readonly=True)
     nbr = fields.Integer('# of Tasks', readonly=True)  # TDE FIXME master: rename into nbr_tasks
+    working_hours_open = fields.Float(string='Working Hours to Assign', digits=(16, 2), readonly=True, group_operator="avg", help="Number of Working Hours to open the task")
+    working_hours_close = fields.Float(string='Working Hours to Close', digits=(16, 2), readonly=True, group_operator="avg", help="Number of Working Hours to close the task")
+    rating_last_value = fields.Float('Rating Value (/5)', group_operator="avg", readonly=True, groups="project.group_project_rating")
     priority = fields.Selection([
         ('0', 'Low'),
         ('1', 'Normal'),
@@ -38,12 +42,15 @@ class ReportProjectTaskUser(models.Model):
     company_id = fields.Many2one('res.company', string='Company', readonly=True)
     partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
     stage_id = fields.Many2one('project.task.type', string='Stage', readonly=True)
+    task_id = fields.Many2one('project.task', string='Tasks', readonly=True)
 
     def _select(self):
         select_str = """
              SELECT
                     (select 1 ) AS nbr,
                     t.id as id,
+                    t.id as task_id,
+                    t.create_date as create_date,
                     t.date_assign as date_assign,
                     t.date_end as date_end,
                     t.date_last_stage_update as date_last_stage_update,
@@ -56,8 +63,11 @@ class ReportProjectTaskUser(models.Model):
                     t.partner_id,
                     t.stage_id as stage_id,
                     t.kanban_state as state,
+                    NULLIF(t.rating_last_value, 0) as rating_last_value,
                     t.working_days_close as working_days_close,
                     t.working_days_open  as working_days_open,
+                    t.working_hours_open as working_hours_open,
+                    t.working_hours_close as working_hours_close,
                     (extract('epoch' from (t.date_deadline-(now() at time zone 'UTC'))))/(3600*24)  as delay_endings_days
         """
         return select_str

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -18,7 +18,7 @@
                 <graph string="Tasks Analysis" type="bar" sample="1" disable_linking="1">
                      <field name="project_id" type="row"/>
                      <field name="user_id" type="col"/>
-                     <field name="nbr" type="measure"/>
+                     <field name="nbr" invisible="1"/>
                  </graph>
              </field>
         </record>
@@ -28,16 +28,23 @@
             <field name="model">report.project.task.user</field>
             <field name="arch" type="xml">
                 <search string="Tasks Analysis">
+                    <field name="project_id"/>
                     <field name="name" />
+                    <field name="stage_id"/>
+                    <field name="user_id"/>
+                    <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
+                    <field name="name" string="Tags" filter_domain="[('task_id.tag_ids', 'ilike', self)]"/>
                     <field name="date_assign"/>
                     <field name="date_end"/>
                     <field name="date_deadline"/>
                     <field name="date_last_stage_update"/>
-                    <field name="project_id"/>
-                    <field name="user_id"/>
-                    <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
-                    <field name="stage_id"/>
-                    <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
+                    <filter string="My Projects" name="own_projects" domain="[('project_id.user_id', '=', uid)]"/>
+                    <filter string="My Tasks" name="my_tasks" domain="[('task_id.user_id', '=', uid)]"/>
+                    <separator/>
+                    <filter string="Starred" name="starred" domain="[('task_id.priority', 'in', [0, 1])]"/>
+                    <separator/>
+                    <filter string="Tasks Late" name="late" domain="[('task_id.date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
+                    <filter string="Unassigned Tasks" name="unassigned" domain="[('user_id', '=', False)]"/>
                     <filter string="Open tasks" name="open_tasks" domain="[('stage_id.fold', '=', False), ('stage_id.is_closed', '=', False)]"/>
                     <separator/>
                     <filter name="filter_date_deadline" date="date_deadline"/>
@@ -51,6 +58,8 @@
                         <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
                         <filter string="Stage" name="Stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Assigned to" name="User" context="{'group_by': 'user_id'}"/>
+                        <filter string="Customer" name="Customer" context="{'group_by': 'partner_id'}"/>
+                        <filter string="Deadline" name="deadline" context="{'group_by': 'date_deadline'}"/>
                     </group>
                 </search>
             </field>
@@ -61,7 +70,7 @@
             <field name="res_model">report.project.task.user</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
-            <field name="context">{'group_by_no_leaf':1,'group_by':[]}</field>
+            <field name="context">{'group_by_no_leaf':1, 'group_by':[], 'graph_measure': '__count__'}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     No data yet!

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -26,7 +26,7 @@
                     <filter string="Followed Tasks" name="my_followed_tasks" domain="[('message_is_follower', '=', True)]" />
                     <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
                     <separator/>
-                    <filter string="Starred" name="starred" domain="[('priority', 'in', [1, 2])]"/>
+                    <filter string="Starred" name="starred" domain="[('priority', 'in', [0, 1])]"/>
                     <filter string="Late Tasks" name="late" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter string="Rated tasks" name="rating_task" domain="[('rating_last_value', '!=', 0.0)]" groups="project.group_project_rating"/>
                     <separator/>

--- a/addons/sale_project/__manifest__.py
+++ b/addons/sale_project/__manifest__.py
@@ -13,6 +13,7 @@ This module allows to generate a project/task from sales orders.
     'data': [
         'security/ir.model.access.csv',
         'security/sale_project_security.xml',
+        'report/project_report_views.xml',
         'views/product_views.xml',
         'views/project_task_views.xml',
         'views/sale_order_views.xml',

--- a/addons/sale_project/report/__init__.py
+++ b/addons/sale_project/report/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import controllers
-from . import report
+from . import project_report

--- a/addons/sale_project/report/project_report.py
+++ b/addons/sale_project/report/project_report.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ReportProjectTaskUser(models.Model):
+    _inherit = "report.project.task.user"
+
+    sale_order_id = fields.Many2one('sale.order', string='Sales Order', readonly=True)
+
+    def _select(self):
+        return super()._select() + ", t.sale_order_id"
+
+    def _group_by(self):
+        return super()._group_by() + ", t.sale_order_id"

--- a/addons/sale_project/report/project_report_views.xml
+++ b/addons/sale_project/report/project_report_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_task_project_user_search_inherited" model="ir.ui.view">
+            <field name="name">report.project.task.user.search.inherited</field>
+            <field name="model">report.project.task.user</field>
+            <field name="inherit_id" ref="project.view_task_project_user_search" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='partner_id']" position="after">
+                    <field name="sale_order_id"/>
+                </xpath>
+             </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Purpose of the commit is to improve the task analysis report
of the project app.

So in this commit, done the below changes:
- removed the # of tasks measure
- added the following measures: Rating Value (/5), Working Hours to Assign, Working Hours to Close
- removed the # from the labels of the following measures: Days to Deadline, Working Days to Assign,Working Days to Close
- renamed 'task title' into 'task'
- added a search on tag_ids and sale_order_id
- added the following filters:
   -My Projects + My Team's Projects
   -My Tasks + My Team's Tasks (rename 'Unassigned' into 'Unassigned Tasks')
   -Starred
   -Tasks Late + Tasks in Overtime
- added the following group bys: task, customer, kanban state, assignment date, creation date, deadline, last stage update

TaskID: 2508645

