### PR TITLE
[FIX] sale_report: duplicated ids

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -23,7 +23,7 @@ class SaleReport(models.Model):
         res = super(SaleReport, self)._query(with_clause, fields, groupby, from_clause)
 
         select_ = '''
-            MIN(l.id) AS id,
+            MIN(-l.id) AS id,
             l.product_id AS product_id,
             t.uom_id AS product_uom,
             sum(l.qty) AS product_uom_qty,


### PR DESCRIPTION
When `pos_sale` is installed, we get two sets of ids. One coming from
`sale.order.line` and another from `pos.order.line`.

There are some situations in which we could get another record from the
one we're looking for.

For example:

```
pos.order.line(555,) from date 2019-05-05 name POS/55
sale.order.line(555,) from date 2021-06-01 name SO/55
```

With this search:

```
env["sale.report"].search([("date", ">=", "2021-06-01")])
```

We'd get:

`sale.report(555,)` which corresponds to **POS/55** and not to **SO/55** as we'd
expect!

This commit proposes a to flag `pos.order.line` ids as negative so we can
always have a unique id no matter what the series is.

cc @Tecnativa TT30546


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
