### PR TITLE
[REF] l10n_de: move `l10n_de_stnr` and `l10n_de_widnr` from `l10n_de_…

### DIFF
--- a/addons/l10n_de/models/res_company.py
+++ b/addons/l10n_de/models/res_company.py
@@ -7,4 +7,5 @@ from odoo import models, fields
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    l10n_de_nat_tax_nb = fields.Char(string="National Tax ID")  # This is not the vat
+    l10n_de_stnr = fields.Char(string="St.-Nr.", help="Steuernummer. Scheme: ??FF0BBBUUUUP, e.g.: 2893081508152 https://de.wikipedia.org/wiki/Steuernummer")
+    l10n_de_widnr = fields.Char(string="W-IdNr.", help="Wirtschafts-Identifikationsnummer.")

--- a/addons/l10n_de/views/res_company_views.xml
+++ b/addons/l10n_de/views/res_company_views.xml
@@ -5,11 +5,10 @@
             <field name="model">res.company</field>
             <field name="inherit_id" ref="base.view_company_form"/>
             <field name="arch" type="xml">
-            <data>
-                 <xpath expr="//field[@name='vat']" position="after">
-                    <field name="l10n_de_nat_tax_nb" attrs="{'invisible':[('country_code', '!=', 'DE')]}"/>
-                 </xpath>
-            </data>
+                <field name="vat" position="after">
+                    <field name="l10n_de_stnr" attrs="{'invisible':[('country_code', '!=', 'DE')]}"/>
+                    <field name="l10n_de_widnr" attrs="{'invisible':[('country_code', '!=', 'DE')]}"/>
+                </field>
             </field>
         </record>
 </odoo>


### PR DESCRIPTION
…pos_cert` module

These fields are more relevant in the German localization rather than the German POS localization

Related enterprise PR:  https://github.com/odoo/enterprise/pull/19183