### PR TITLE
[IMP] mail, *: use explicit export instead of default

### DIFF
--- a/addons/hr/static/tests/helpers/mock_models.js
+++ b/addons/hr/static/tests/helpers/mock_models.js
@@ -1,7 +1,7 @@
 odoo.define('hr/static/tests/helpers/mock_models.js', function (require) {
 'use strict';
 
-const MockModels = require('@mail/../tests/helpers/mock_models')[Symbol.for("default")];
+const { MockModels } = require('@mail/../tests/helpers/mock_models');
 const { patch } = require('web.utils');
 
 patch(MockModels, 'hr/static/tests/helpers/mock_models.js', {

--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
@@ -1,15 +1,15 @@
 odoo.define('hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js', function (require) {
 'use strict';
 
-const components = {
-    PartnerImStatusIcon: require('@mail/components/partner_im_status_icon/partner_im_status_icon')[Symbol.for("default")],
-};
+const { PartnerImStatusIcon } = require('@mail/components/partner_im_status_icon/partner_im_status_icon');
 const {
     afterEach,
     beforeEach,
     createRootComponent,
     start,
 } = require('@mail/utils/test_utils');
+
+const components = { PartnerImStatusIcon };
 
 QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/hr_holidays/static/src/components/thread_icon/thread_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_icon/thread_icon_tests.js
@@ -1,15 +1,15 @@
 odoo.define('hr_holidays/static/src/components/thread_icon/thread_icon_tests.js', function (require) {
 'use strict';
 
-const components = {
-    ThreadIcon: require('@mail/components/thread_icon/thread_icon')[Symbol.for("default")],
-};
+const { ThreadIcon } = require('@mail/components/thread_icon/thread_icon');
 const {
     afterEach,
     beforeEach,
     createRootComponent,
     start,
 } = require('@mail/utils/test_utils');
+
+const components = { ThreadIcon };
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/hr_holidays/static/src/components/thread_view/thread_view.js
+++ b/addons/hr_holidays/static/src/components/thread_view/thread_view.js
@@ -1,11 +1,11 @@
 odoo.define('hr_holidays/static/src/components/thread_view/thread_view.js', function (require) {
 'use strict';
 
-const components = {
-    ThreadView: require('@mail/components/thread_view/thread_view')[Symbol.for("default")],
-};
+const { ThreadView } = require('@mail/components/thread_view/thread_view');
 
 const { patch } = require('web.utils');
+
+const components = { ThreadView };
 
 patch(components.ThreadView.prototype, 'hr_holidays/static/src/components/thread_view/thread_view.js', {
     //--------------------------------------------------------------------------

--- a/addons/hr_holidays/static/src/components/thread_view/thread_view_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_view/thread_view_tests.js
@@ -1,9 +1,7 @@
 odoo.define('hr_holidays/static/src/components/thread_view/thread_view_tests.js', function (require) {
 'use strict';
 
-const components = {
-    ThreadView: require('@mail/components/thread_view/thread_view')[Symbol.for("default")],
-};
+const { ThreadView } = require('@mail/components/thread_view/thread_view');
 const { link } = require('@mail/model/model_field_command');
 const {
     afterEach,
@@ -11,6 +9,8 @@ const {
     createRootComponent,
     start,
 } = require('@mail/utils/test_utils');
+
+const components = { ThreadView };
 
 QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/hr_holidays/static/tests/helpers/mock_models.js
+++ b/addons/hr_holidays/static/tests/helpers/mock_models.js
@@ -1,8 +1,7 @@
-odoo.define('hr_holidays/static/tests/helpers/mock_models.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const MockModels = require('@mail/../tests/helpers/mock_models')[Symbol.for("default")];
-const { patch } = require('web.utils');
+import { MockModels } from '@mail/../tests/helpers/mock_models';
+import { patch } from 'web.utils';
 
 patch(MockModels, 'hr_holidays/static/tests/helpers/mock_models.js', {
 
@@ -21,7 +20,5 @@ patch(MockModels, 'hr_holidays/static/tests/helpers/mock_models.js', {
         });
         return data;
     },
-
-});
 
 });

--- a/addons/im_livechat/static/src/components/composer/composer_tests.js
+++ b/addons/im_livechat/static/src/components/composer/composer_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Composer from '@mail/components/composer/composer';
+import { Composer } from '@mail/components/composer/composer';
 import {
     afterEach,
     afterNextRender,

--- a/addons/im_livechat/static/src/components/discuss/discuss.js
+++ b/addons/im_livechat/static/src/components/discuss/discuss.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Discuss from '@mail/components/discuss/discuss';
+import { Discuss } from '@mail/components/discuss/discuss';
 
 import { patch } from 'web.utils';
 

--- a/addons/im_livechat/static/src/components/discuss_sidebar/discuss_sidebar.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar/discuss_sidebar.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import DiscussSidebar from '@mail/components/discuss_sidebar/discuss_sidebar';
+import { DiscussSidebar } from '@mail/components/discuss_sidebar/discuss_sidebar';
 
 import { patch } from 'web.utils';
 

--- a/addons/im_livechat/static/src/components/discuss_sidebar_item/discuss_sidebar_item.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_item/discuss_sidebar_item.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import DiscussSidebarItem from '@mail/components/discuss_sidebar_item/discuss_sidebar_item';
+import { DiscussSidebarItem } from '@mail/components/discuss_sidebar_item/discuss_sidebar_item';
 
 import { patch } from 'web.utils';
 

--- a/addons/im_livechat/static/src/components/notification_list/notification_list.js
+++ b/addons/im_livechat/static/src/components/notification_list/notification_list.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import NotificationList from '@mail/components/notification_list/notification_list';
+import { NotificationList } from '@mail/components/notification_list/notification_list';
 import { patch } from 'web.utils';
 
 const components = { NotificationList };

--- a/addons/im_livechat/static/src/components/thread_icon/thread_icon_tests.js
+++ b/addons/im_livechat/static/src/components/thread_icon/thread_icon_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadIcon from '@mail/components/thread_icon/thread_icon';
+import { ThreadIcon } from '@mail/components/thread_icon/thread_icon';
 import {
     afterEach,
     afterNextRender,

--- a/addons/im_livechat/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/im_livechat/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadNeedactionPreview from '@mail/components/thread_needaction_preview/thread_needaction_preview';
+import { ThreadNeedactionPreview } from '@mail/components/thread_needaction_preview/thread_needaction_preview';
 
 import { patch } from 'web.utils';
 
@@ -23,4 +23,3 @@ patch(components.ThreadNeedactionPreview.prototype, 'thread_needaction_preview',
     }
 
 });
-

--- a/addons/im_livechat/static/src/components/thread_preview/thread_preview.js
+++ b/addons/im_livechat/static/src/components/thread_preview/thread_preview.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadPreview from '@mail/components/thread_preview/thread_preview';
+import { ThreadPreview } from '@mail/components/thread_preview/thread_preview';
 
 import { patch } from 'web.utils';
 

--- a/addons/im_livechat/static/src/components/thread_textual_typing_status/thread_textual_typing_status_tests.js
+++ b/addons/im_livechat/static/src/components/thread_textual_typing_status/thread_textual_typing_status_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadTextualTypingStatus from '@mail/components/thread_textual_typing_status/thread_textual_typing_status';
+import { ThreadTextualTypingStatus } from '@mail/components/thread_textual_typing_status/thread_textual_typing_status';
 import {
     afterEach,
     afterNextRender,

--- a/addons/im_livechat/static/src/widgets/discuss/discuss.js
+++ b/addons/im_livechat/static/src/widgets/discuss/discuss.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
-import Discuss from '@mail/widgets/discuss/discuss';
+import DiscussWidget from '@mail/widgets/discuss/discuss';
 
-Discuss.include({
+DiscussWidget.include({
     //----------------------------------------------------------------------
     // Private
     //----------------------------------------------------------------------

--- a/addons/im_livechat/static/tests/helpers/mock_models.js
+++ b/addons/im_livechat/static/tests/helpers/mock_models.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import MockModels from '@mail/../tests/helpers/mock_models';
+import { MockModels } from '@mail/../tests/helpers/mock_models';
 import { patch } from 'web.utils';
 
 patch(MockModels, 'im_livechat/static/tests/helpers/mock_models.js', {

--- a/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
+++ b/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
@@ -9,7 +9,7 @@ const { useState, onMounted, onWillUnmount } = owl.hooks;
  *
  * @returns {Object}
  */
-function useDragVisibleDropZone() {
+export function useDragVisibleDropZone() {
     /**
      * Determine whether the drop zone should be visible or not.
      * Note that this is an observed value, and primitive types such as
@@ -86,5 +86,3 @@ function useDragVisibleDropZone() {
 
     return isVisible;
 }
-
-export default useDragVisibleDropZone;

--- a/addons/mail/static/src/component_hooks/use_refs/use_refs.js
+++ b/addons/mail/static/src/component_hooks/use_refs/use_refs.js
@@ -8,11 +8,9 @@ const { Component } = owl;
  * @returns {function} returns object whose keys are t-ref values of active refs.
  *   and values are refs.
  */
-function useRefs() {
+export function useRefs() {
     const component = Component.current;
     return function () {
         return component.__owl__.refs || {};
     };
 }
-
-export default  useRefs;

--- a/addons/mail/static/src/component_hooks/use_rendered_values/use_rendered_values.js
+++ b/addons/mail/static/src/component_hooks/use_rendered_values/use_rendered_values.js
@@ -12,7 +12,7 @@ const { onMounted, onPatched } = owl.hooks;
  *  render and of which the result will be stored for future reference.
  * @returns {function} function to call to retrieve the last rendered values.
  */
-function useRenderedValues(selector) {
+export function useRenderedValues(selector) {
     const component = Component.current;
     let renderedValues;
     let patchedValues;
@@ -29,5 +29,3 @@ function useRenderedValues(selector) {
     }
     return () => patchedValues;
 }
-
-export default useRenderedValues;

--- a/addons/mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js
+++ b/addons/mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js
@@ -53,7 +53,7 @@ function isEqual(a, b, compareDepth) {
  * @param {Object} [param0.compareDepth={}] allows to specify the comparison
  *  depth to use for each prop. Default is shallow compare (depth = 0).
  */
-function useShouldUpdateBasedOnProps({ compareDepth = {} } = {}) {
+export function useShouldUpdateBasedOnProps({ compareDepth = {} } = {}) {
     const component = Component.current;
     component.shouldUpdate = nextProps => {
         const allNewProps = Object.assign({}, nextProps);
@@ -66,5 +66,3 @@ function useShouldUpdateBasedOnProps({ compareDepth = {} } = {}) {
         return !isEqual(component.props, allNewProps, compareDepth);
     };
 }
-
-export default useShouldUpdateBasedOnProps;

--- a/addons/mail/static/src/component_hooks/use_store/use_store.js
+++ b/addons/mail/static/src/component_hooks/use_store/use_store.js
@@ -14,7 +14,7 @@
  *  as number (applies to all keys) or as an object (depth for specific keys)
  * @returns {Proxy} @see owl.hooks.useStore
  */
-function useStore(selector, options = {}) {
+export function useStore(selector, options = {}) {
     const store = options.store || owl.Component.current.env.store;
     const hashFn = store.observer.revNumber.bind(store.observer);
     const isEqual = options.isEqual || ((a, b) => a === b);
@@ -119,5 +119,3 @@ function useStore(selector, options = {}) {
         isEqual: proxyComparatorDeep(options.compareDepth),
     }));
 }
-
-export default useStore;

--- a/addons/mail/static/src/component_hooks/use_store/use_store_tests.js
+++ b/addons/mail/static/src/component_hooks/use_store/use_store_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 import {
     afterNextRender,
     nextAnimationFrame,

--- a/addons/mail/static/src/component_hooks/use_update/use_update.js
+++ b/addons/mail/static/src/component_hooks/use_update/use_update.js
@@ -8,9 +8,7 @@ const { onMounted, onPatched } = owl.hooks;
  * @param {Object} param0
  * @param {function} param0.func the function to execute after the update.
  */
-function useUpdate({ func }) {
+export function useUpdate({ func }) {
     onMounted(func);
     onPatched(func);
 }
-
-export default useUpdate;

--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import ActivityMarkDonePopover from '@mail/components/activity_mark_done_popover/activity_mark_done_popover';
-import FileUploader from '@mail/components/file_uploader/file_uploader';
-import MailTemplate from '@mail/components/mail_template/mail_template';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { ActivityMarkDonePopover } from '@mail/components/activity_mark_done_popover/activity_mark_done_popover';
+import { FileUploader } from '@mail/components/file_uploader/file_uploader';
+import { MailTemplate } from '@mail/components/mail_template/mail_template';
 
 import {
     auto_str_to_date,
@@ -21,7 +21,7 @@ const components = {
     MailTemplate,
 };
 
-class Activity extends Component {
+export class Activity extends Component {
 
     /**
      * @override
@@ -196,5 +196,3 @@ Object.assign(Activity, {
     },
     template: 'mail.Activity',
 });
-
-export default Activity;

--- a/addons/mail/static/src/components/activity/activity_tests.js
+++ b/addons/mail/static/src/components/activity/activity_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import useStore from '@mail/component_hooks/use_store/use_store';
-import Activity from '@mail/components/activity/activity';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { Activity } from '@mail/components/activity/activity';
 import { insert } from '@mail/model/model_field_command';
 import {
     afterEach,
@@ -15,6 +15,7 @@ import Bus from 'web.Bus';
 import { date_to_str } from 'web.time';
 
 const { Component, tags: { xml } } = owl;
+
 const components = { Activity };
 
 QUnit.module('mail', {}, function () {

--- a/addons/mail/static/src/components/activity_box/activity_box.js
+++ b/addons/mail/static/src/components/activity_box/activity_box.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import Activity from '@mail/components/activity/activity';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { Activity } from '@mail/components/activity/activity';
 
 const { Component } = owl;
 
 const components = { Activity };
 
-class ActivityBox extends Component {
+export class ActivityBox extends Component {
 
     /**
      * @override
@@ -57,5 +57,3 @@ Object.assign(ActivityBox, {
     },
     template: 'mail.ActivityBox',
 });
-
-export default ActivityBox;

--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
-class ActivityMarkDonePopover extends Component {
+export class ActivityMarkDonePopover extends Component {
 
     /**
      * @override
@@ -115,5 +115,3 @@ Object.assign(ActivityMarkDonePopover, {
     },
     template: 'mail.ActivityMarkDonePopover',
 });
-
-export default ActivityMarkDonePopover;

--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
-import ActivityMarkDonePopover from '@mail/components/activity_mark_done_popover/activity_mark_done_popover';
-
+import { ActivityMarkDonePopover } from '@mail/components/activity_mark_done_popover/activity_mark_done_popover';
 import { insert } from '@mail/model/model_field_command';
 import {
     afterEach,

--- a/addons/mail/static/src/components/attachment/attachment.js
+++ b/addons/mail/static/src/components/attachment/attachment.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import AttachmentDeleteConfirmDialog from '@mail/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { AttachmentDeleteConfirmDialog } from '@mail/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog';
 
 const { Component, useState } = owl;
 
 const components = { AttachmentDeleteConfirmDialog };
 
-class Attachment extends Component {
+export class Attachment extends Component {
 
     /**
      * @override
@@ -195,5 +195,3 @@ Object.assign(Attachment, {
     },
     template: 'mail.Attachment',
 });
-
-export default Attachment;

--- a/addons/mail/static/src/components/attachment/attachment_tests.js
+++ b/addons/mail/static/src/components/attachment/attachment_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Attachment from '@mail/components/attachment/attachment';
+import { Attachment } from '@mail/components/attachment/attachment';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/attachment_box/attachment_box.js
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.js
@@ -1,19 +1,19 @@
 /** @odoo-module **/
 
-import useDragVisibleDropZone from '@mail/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import AttachmentList from '@mail/components/attachment_list/attachment_list';
-import DropZone from '@mail/components/drop_zone/drop_zone';
-import FileUploader from '@mail/components/file_uploader/file_uploader';
+import { useDragVisibleDropZone } from '@mail/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { AttachmentList } from '@mail/components/attachment_list/attachment_list';
+import { DropZone } from '@mail/components/drop_zone/drop_zone';
+import { FileUploader } from '@mail/components/file_uploader/file_uploader';
 import { link } from '@mail/model/model_field_command';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
-const components = {AttachmentList, DropZone, FileUploader};
+const components = { AttachmentList, DropZone, FileUploader };
 
-class AttachmentBox extends Component {
+export class AttachmentBox extends Component {
 
     /**
      * @override
@@ -118,6 +118,3 @@ Object.assign(AttachmentBox, {
     },
     template: 'mail.AttachmentBox',
 });
-
-export default AttachmentBox;
-

--- a/addons/mail/static/src/components/attachment_box/attachment_box_tests.js
+++ b/addons/mail/static/src/components/attachment_box/attachment_box_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import AttachmentBox from '@mail/components/attachment_box/attachment_box';
+import { AttachmentBox } from '@mail/components/attachment_box/attachment_box';
 import { insert } from '@mail/model/model_field_command';
 import {
     afterEach,

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
@@ -1,16 +1,16 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
-import Dialog from 'web.OwlDialog'
+import Dialog from 'web.OwlDialog';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { Dialog };
 
-class AttachmentDeleteConfirmDialog extends Component {
+export class AttachmentDeleteConfirmDialog extends Component {
 
     /**
      * @override
@@ -85,5 +85,3 @@ Object.assign(AttachmentDeleteConfirmDialog, {
     },
     template: 'mail.AttachmentDeleteConfirmDialog',
 });
-
-export default AttachmentDeleteConfirmDialog;

--- a/addons/mail/static/src/components/attachment_list/attachment_list.js
+++ b/addons/mail/static/src/components/attachment_list/attachment_list.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import Attachment from '@mail/components/attachment/attachment';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { Attachment } from '@mail/components/attachment/attachment';
 
 const { Component } = owl;
 
 const components = { Attachment };
 
-class AttachmentList extends Component {
+export class AttachmentList extends Component {
 
     /**
      * @override
@@ -111,5 +111,3 @@ Object.assign(AttachmentList, {
     },
     template: 'mail.AttachmentList',
 });
-
-export default AttachmentList;

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
-import useRefs from '@mail/component_hooks/use_refs/use_refs';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useRefs } from '@mail/component_hooks/use_refs/use_refs';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 import { link } from '@mail/model/model_field_command';
 
 import { hidePDFJSButtons } from '@web/legacy/js/libs/pdfjs';
@@ -14,7 +14,7 @@ const MIN_SCALE = 0.5;
 const SCROLL_ZOOM_STEP = 0.1;
 const ZOOM_STEP = 0.5;
 
-class AttachmentViewer extends Component {
+export class AttachmentViewer extends Component {
 
     /**
      * @override
@@ -614,5 +614,3 @@ Object.assign(AttachmentViewer, {
 });
 
 QWeb.registerComponent('AttachmentViewer', AttachmentViewer);
-
-export default AttachmentViewer;

--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/;
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
 
 const { Component } = owl;
 
-class AutocompleteInput extends Component {
+export class AutocompleteInput extends Component {
 
     constructor(...args) {
         super(...args);
@@ -167,5 +167,3 @@ Object.assign(AutocompleteInput, {
     },
     template: 'mail.AutocompleteInput',
 });
-
-export default AutocompleteInput;

--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import AutocompleteInput from '@mail/components/autocomplete_input/autocomplete_input';
-import ChatWindowHeader from '@mail/components/chat_window_header/chat_window_header';
-import ThreadView from '@mail/components/thread_view/thread_view';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { AutocompleteInput } from '@mail/components/autocomplete_input/autocomplete_input';
+import { ChatWindowHeader } from '@mail/components/chat_window_header/chat_window_header';
+import { ThreadView } from '@mail/components/thread_view/thread_view';
 import { isEventHandled } from '@mail/utils/utils';
 
 const { Component } = owl;
@@ -13,7 +13,7 @@ const { useRef } = owl.hooks;
 
 const components = { AutocompleteInput, ChatWindowHeader, ThreadView };
 
-class ChatWindow extends Component {
+export class ChatWindow extends Component {
 
     /**
      * @override
@@ -354,5 +354,3 @@ Object.assign(ChatWindow, {
     },
     template: 'mail.ChatWindow',
 });
-
-export default ChatWindow;

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -1,18 +1,18 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 import {
     isEventHandled,
     markEventHandled,
 } from '@mail/utils/utils';
-import ThreadIcon from '@mail/components/thread_icon/thread_icon';
+import { ThreadIcon } from '@mail/components/thread_icon/thread_icon';
 
 const { Component } = owl;
 
 const components = { ThreadIcon };
 
-class ChatWindowHeader extends Component {
+export class ChatWindowHeader extends Component {
 
     /**
      * @override
@@ -141,5 +141,3 @@ Object.assign(ChatWindowHeader, {
     },
     template: 'mail.ChatWindowHeader',
 });
-
-export default ChatWindowHeader;

--- a/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.js
+++ b/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useStore from '@mail/component_hooks/use_store/use_store';
-import ChatWindowHeader from '@mail/components/chat_window_header/chat_window_header';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { ChatWindowHeader } from '@mail/components/chat_window_header/chat_window_header';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { ChatWindowHeader };
 
-class ChatWindowHiddenMenu extends Component {
+export class ChatWindowHiddenMenu extends Component {
 
     /**
      * @override
@@ -133,5 +133,3 @@ Object.assign(ChatWindowHiddenMenu, {
     props: {},
     template: 'mail.ChatWindowHiddenMenu',
 });
-
-export default ChatWindowHiddenMenu;

--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager.js
@@ -1,15 +1,15 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import ChatWindow from '@mail/components/chat_window/chat_window';
-import ChatWindowHiddenMenu from '@mail/components/chat_window_hidden_menu/chat_window_hidden_menu';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { ChatWindow } from '@mail/components/chat_window/chat_window';
+import { ChatWindowHiddenMenu } from '@mail/components/chat_window_hidden_menu/chat_window_hidden_menu';
 
 const { Component } = owl;
 
 const components = { ChatWindow, ChatWindowHiddenMenu };
 
-class ChatWindowManager extends Component {
+export class ChatWindowManager extends Component {
 
     /**
      * @override
@@ -44,5 +44,3 @@ Object.assign(ChatWindowManager, {
     props: {},
     template: 'mail.ChatWindowManager',
 });
-
-export default ChatWindowManager;

--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import ActivityBox from '@mail/components/activity_box/activity_box';
-import AttachmentBox from '@mail/components/attachment_box/attachment_box';
-import ChatterTopbar from '@mail/components/chatter_topbar/chatter_topbar';
-import Composer from '@mail/components/composer/composer';
-import ThreadView from '@mail/components/thread_view/thread_view';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { ActivityBox } from '@mail/components/activity_box/activity_box';
+import { AttachmentBox } from '@mail/components/attachment_box/attachment_box';
+import { ChatterTopbar } from '@mail/components/chatter_topbar/chatter_topbar';
+import { Composer } from '@mail/components/composer/composer';
+import { ThreadView } from '@mail/components/thread_view/thread_view';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
@@ -20,7 +20,7 @@ const components = {
     ThreadView,
 };
 
-class Chatter extends Component {
+export class Chatter extends Component {
 
     /**
      * @override
@@ -149,5 +149,3 @@ Object.assign(Chatter, {
     },
     template: 'mail.Chatter',
 });
-
-export default Chatter;

--- a/addons/mail/static/src/components/chatter/chatter_suggested_recipient_tests.js
+++ b/addons/mail/static/src/components/chatter/chatter_suggested_recipient_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import Chatter from '@mail/components/chatter/chatter';
-import Composer from '@mail/components/composer/composer';
+import { Chatter } from '@mail/components/chatter/chatter';
+import { Composer } from '@mail/components/composer/composer';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/chatter/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/chatter_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import Chatter from '@mail/components/chatter/chatter';
-import Composer from '@mail/components/composer/composer';
+import { Chatter } from '@mail/components/chatter/chatter';
+import { Composer } from '@mail/components/composer/composer';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -1,9 +1,9 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import Chatter from '@mail/components/chatter/chatter';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { Chatter } from '@mail/components/chatter/chatter';
 import { clear } from '@mail/model/model_field_command';
 
 const { Component } = owl;
@@ -18,7 +18,7 @@ const components = { Chatter };
  * may attempt to create a chatter before messaging has been initialized, so
  * this component delays the mounting of chatter until it becomes initialized.
  */
-class ChatterContainer extends Component {
+export class ChatterContainer extends Component {
 
     /**
      * @override
@@ -131,6 +131,3 @@ Object.assign(ChatterContainer, {
     },
     template: 'mail.ChatterContainer',
 });
-
-
-export default ChatterContainer;

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
@@ -1,15 +1,15 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import FollowButton from '@mail/components/follow_button/follow_button';
-import FollowerListMenu from '@mail/components/follower_list_menu/follower_list_menu';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { FollowButton } from '@mail/components/follow_button/follow_button';
+import { FollowerListMenu } from '@mail/components/follower_list_menu/follower_list_menu';
 
 const { Component } = owl;
 
 const components = { FollowButton, FollowerListMenu };
 
-class ChatterTopbar extends Component {
+export class ChatterTopbar extends Component {
 
     /**
      * @override
@@ -130,5 +130,3 @@ Object.assign(ChatterTopbar, {
     },
     template: 'mail.ChatterTopbar',
 });
-
-export default ChatterTopbar;

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ChatterTopBar from '@mail/components/chatter_topbar/chatter_topbar';
+import { ChatterTopbar } from '@mail/components/chatter_topbar/chatter_topbar';
 import {
     afterEach,
     afterNextRender,
@@ -11,7 +11,7 @@ import {
 
 import { makeTestPromise } from 'web.test_utils';
 
-const components = { ChatterTopBar };
+const components = { ChatterTopbar };
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -22,7 +22,7 @@ QUnit.module('chatter_topbar_tests.js', {
 
         this.createChatterTopbarComponent = async (chatter, otherProps) => {
             const props = Object.assign({ chatterLocalId: chatter.localId }, otherProps);
-            await createRootComponent(this, components.ChatterTopBar, {
+            await createRootComponent(this, components.ChatterTopbar, {
                 props,
                 target: this.widget.el,
             });

--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -1,16 +1,16 @@
 /** @odoo-module **/
 
-import useDragVisibleDropZone from '@mail/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import AttachmentList from '@mail/components/attachment_list/attachment_list';
-import ComposerSuggestedRecipientList from '@mail/components/composer_suggested_recipient_list/composer_suggested_recipient_list';
-import DropZone from '@mail/components/drop_zone/drop_zone';
-import EmojisPopover from '@mail/components/emojis_popover/emojis_popover';
-import FileUploader from '@mail/components/file_uploader/file_uploader';
-import TextInput from '@mail/components/composer_text_input/composer_text_input';
-import ThreadTextualTypingStatus from '@mail/components/thread_textual_typing_status/thread_textual_typing_status';
+import { useDragVisibleDropZone } from '@mail/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { AttachmentList } from '@mail/components/attachment_list/attachment_list';
+import { ComposerSuggestedRecipientList } from '@mail/components/composer_suggested_recipient_list/composer_suggested_recipient_list';
+import { ComposerTextInput } from '@mail/components/composer_text_input/composer_text_input';
+import { DropZone } from '@mail/components/drop_zone/drop_zone';
+import { EmojisPopover } from '@mail/components/emojis_popover/emojis_popover';
+import { FileUploader } from '@mail/components/file_uploader/file_uploader';
+import { ThreadTextualTypingStatus } from '@mail/components/thread_textual_typing_status/thread_textual_typing_status';
 import { replace } from '@mail/model/model_field_command';
 import {
     isEventHandled,
@@ -23,14 +23,14 @@ const { useRef } = owl.hooks;
 const components = {
     AttachmentList,
     ComposerSuggestedRecipientList,
+    ComposerTextInput,
     DropZone,
     EmojisPopover,
     FileUploader,
-    TextInput,
     ThreadTextualTypingStatus,
 };
 
-class Composer extends Component {
+export class Composer extends Component {
 
     /**
      * @override
@@ -446,5 +446,3 @@ Object.assign(Composer, {
     },
     template: 'mail.Composer',
 });
-
-export default Composer;

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -69,7 +69,7 @@
                         'o-composer-is-extended': composer.thread and composer.thread.mass_mailing,
                     }"
                 >
-                    <TextInput
+                    <ComposerTextInput
                         class="o_Composer_textInput"
                         t-att-class="{
                             'o-composer-is-compact': props.isCompact,

--- a/addons/mail/static/src/components/composer/composer_tests.js
+++ b/addons/mail/static/src/components/composer/composer_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Composer from '@mail/components/composer/composer';
+import { Composer } from '@mail/components/composer/composer';
 import { create } from '@mail/model/model_field_command';
 import {
     afterEach,

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 
 import { FormViewDialog } from 'web.view_dialogs';
 import { ComponentAdapter } from 'web.OwlCompatibility';
@@ -21,11 +21,9 @@ class FormViewDialogComponentAdapter extends ComponentAdapter {
 
 }
 
-const components = {
-    FormViewDialogComponentAdapter,
-};
+const components = { FormViewDialogComponentAdapter };
 
-class ComposerSuggestedRecipient extends Component {
+export class ComposerSuggestedRecipient extends Component {
 
     constructor(...args) {
         super(...args);
@@ -151,5 +149,3 @@ Object.assign(ComposerSuggestedRecipient, {
     },
     template: 'mail.ComposerSuggestedRecipient',
 });
-
-export default ComposerSuggestedRecipient;

--- a/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.js
@@ -1,15 +1,15 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import ComposerSuggestedRecipient from '@mail/components/composer_suggested_recipient/composer_suggested_recipient';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { ComposerSuggestedRecipient } from '@mail/components/composer_suggested_recipient/composer_suggested_recipient';
 
 const { Component } = owl;
 const { useState } = owl.hooks;
 
 const components = { ComposerSuggestedRecipient };
 
-class ComposerSuggestedRecipientList extends Component {
+export class ComposerSuggestedRecipientList extends Component {
 
     /**
      * @override
@@ -70,5 +70,3 @@ Object.assign(ComposerSuggestedRecipientList, {
     },
     template: 'mail.ComposerSuggestedRecipientList',
 });
-
-export default ComposerSuggestedRecipientList;

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -1,16 +1,16 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import PartnerImStatusIcon from '@mail/components/partner_im_status_icon/partner_im_status_icon';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { PartnerImStatusIcon } from '@mail/components/partner_im_status_icon/partner_im_status_icon';
 import { link } from '@mail/model/model_field_command';
 
 const { Component } = owl;
 
 const components = { PartnerImStatusIcon };
 
-class ComposerSuggestion extends Component {
+export class ComposerSuggestion extends Component {
 
     /**
      * @override
@@ -136,5 +136,3 @@ Object.assign(ComposerSuggestion, {
     },
     template: 'mail.ComposerSuggestion',
 });
-
-export default ComposerSuggestion;

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion_canned_response_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ComposerSuggestion from '@mail/components/composer_suggestion/composer_suggestion';
+import { ComposerSuggestion } from '@mail/components/composer_suggestion/composer_suggestion';
 import {
     afterEach,
     beforeEach,

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion_channel_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion_channel_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ComposerSuggestion from '@mail/components/composer_suggestion/composer_suggestion';
+import { ComposerSuggestion } from '@mail/components/composer_suggestion/composer_suggestion';
 import {
     afterEach,
     beforeEach,

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion_command_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion_command_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/;
 
-import ComposerSuggestion  from '@mail/components/composer_suggestion/composer_suggestion';
+import { ComposerSuggestion }  from '@mail/components/composer_suggestion/composer_suggestion';
 import {
     afterEach,
     beforeEach,

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion_partner_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion_partner_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ComposerSuggestion from '@mail/components/composer_suggestion/composer_suggestion';
+import { ComposerSuggestion } from '@mail/components/composer_suggestion/composer_suggestion';
 import {
     afterEach,
     beforeEach,

--- a/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.js
+++ b/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import ComposerSuggestion from '@mail/components/composer_suggestion/composer_suggestion';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { ComposerSuggestion } from '@mail/components/composer_suggestion/composer_suggestion';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
 const components = { ComposerSuggestion };
 
-class ComposerSuggestionList extends Component {
+export class ComposerSuggestionList extends Component {
 
     /**
      * @override
@@ -66,5 +66,3 @@ Object.assign(ComposerSuggestionList, {
     },
     template: 'mail.ComposerSuggestionList',
 });
-
-export default ComposerSuggestionList;

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -1,9 +1,9 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import ComposerSuggestionList from '@mail/components/composer_suggestion_list/composer_suggestion_list';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { ComposerSuggestionList } from '@mail/components/composer_suggestion_list/composer_suggestion_list';
 import { markEventHandled } from '@mail/utils/utils';
 
 const { Component } = owl;
@@ -11,7 +11,7 @@ const { useRef } = owl.hooks;
 
 const components = { ComposerSuggestionList };
 
-class ComposerTextInput extends Component {
+export class ComposerTextInput extends Component {
 
     /**
      * @override
@@ -422,5 +422,3 @@ Object.assign(ComposerTextInput, {
     },
     template: 'mail.ComposerTextInput',
 });
-
-export default ComposerTextInput;

--- a/addons/mail/static/src/components/dialog/dialog.js
+++ b/addons/mail/static/src/components/dialog/dialog.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
-class Dialog extends Component {
+export class Dialog extends Component {
 
     /**
      * @param {...any} args
@@ -110,5 +110,3 @@ Object.assign(Dialog, {
     },
     template: 'mail.Dialog',
 });
-
-export default Dialog;

--- a/addons/mail/static/src/components/dialog_manager/dialog_manager.js
+++ b/addons/mail/static/src/components/dialog_manager/dialog_manager.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import Dialog from '@mail/components/dialog/dialog';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { Dialog } from '@mail/components/dialog/dialog';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
 const components = { Dialog };
 
-class DialogManager extends Component {
+export class DialogManager extends Component {
 
     /**
      * @override
@@ -62,5 +62,3 @@ Object.assign(DialogManager, {
     props: {},
     template: 'mail.DialogManager',
 });
-
-export default DialogManager;

--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -1,16 +1,16 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import AutocompleteInput from '@mail/components/autocomplete_input/autocomplete_input';
-import Composer from '@mail/components/composer/composer';
-import DiscussMobileMailboxSelection from '@mail/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection';
-import DiscussSidebar from '@mail/components/discuss_sidebar/discuss_sidebar';
-import MobileMessagingNavbar from '@mail/components/mobile_messaging_navbar/mobile_messaging_navbar';
-import ModerationDiscardDialog from '@mail/components/moderation_discard_dialog/moderation_discard_dialog';
-import ModerationRejectDialog from '@mail/components/moderation_reject_dialog/moderation_reject_dialog';
-import NotificationList from '@mail/components/notification_list/notification_list';
-import ThreadView from '@mail/components/thread_view/thread_view';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { AutocompleteInput } from '@mail/components/autocomplete_input/autocomplete_input';
+import { Composer } from '@mail/components/composer/composer';
+import { DiscussMobileMailboxSelection } from '@mail/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection';
+import { DiscussSidebar } from '@mail/components/discuss_sidebar/discuss_sidebar';
+import { MobileMessagingNavbar } from '@mail/components/mobile_messaging_navbar/mobile_messaging_navbar';
+import { ModerationDiscardDialog } from '@mail/components/moderation_discard_dialog/moderation_discard_dialog';
+import { ModerationRejectDialog } from '@mail/components/moderation_reject_dialog/moderation_reject_dialog';
+import { NotificationList } from '@mail/components/notification_list/notification_list';
+import { ThreadView } from '@mail/components/thread_view/thread_view';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
@@ -27,7 +27,7 @@ const components = {
     ThreadView,
 };
 
-class Discuss extends Component {
+export class Discuss extends Component {
     /**
      * @override
      */
@@ -313,5 +313,3 @@ Object.assign(Discuss, {
     props: {},
     template: 'mail.Discuss',
 });
-
-export default Discuss;

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.js
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class DiscussMobileMailboxSelection extends Component {
+export class DiscussMobileMailboxSelection extends Component {
 
     /**
      * @override
@@ -88,5 +88,3 @@ Object.assign(DiscussMobileMailboxSelection, {
     props: {},
     template: 'mail.DiscussMobileMailboxSelection',
 });
-
-export default DiscussMobileMailboxSelection;

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
@@ -1,17 +1,17 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import AutocompleteInput from '@mail/components/autocomplete_input/autocomplete_input';
-import DiscussSidebarItem from '@mail/components/discuss_sidebar_item/discuss_sidebar_item';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { AutocompleteInput } from '@mail/components/autocomplete_input/autocomplete_input';
+import { DiscussSidebarItem } from '@mail/components/discuss_sidebar_item/discuss_sidebar_item';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { AutocompleteInput, DiscussSidebarItem };
 
-class DiscussSidebar extends Component {
+export class DiscussSidebar extends Component {
 
     /**
      * @override
@@ -301,5 +301,3 @@ Object.assign(DiscussSidebar, {
     props: {},
     template: 'mail.DiscussSidebar',
 });
-
-export default DiscussSidebar;

--- a/addons/mail/static/src/components/discuss_sidebar_item/discuss_sidebar_item.js
+++ b/addons/mail/static/src/components/discuss_sidebar_item/discuss_sidebar_item.js
@@ -1,18 +1,18 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import EditableText from '@mail/components/editable_text/editable_text';
-import ThreadIcon from '@mail/components/thread_icon/thread_icon';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { EditableText } from '@mail/components/editable_text/editable_text';
+import { ThreadIcon } from '@mail/components/thread_icon/thread_icon';
 import { isEventHandled } from '@mail/utils/utils';
 
 import Dialog from 'web.Dialog';
 
 const { Component } = owl;
 
-const components = { EditableText, ThreadIcon }
+const components = { EditableText, ThreadIcon };
 
-class DiscussSidebarItem extends Component {
+export class DiscussSidebarItem extends Component {
 
     /**
      * @override
@@ -213,5 +213,3 @@ Object.assign(DiscussSidebarItem, {
     },
     template: 'mail.DiscussSidebarItem',
 });
-
-export default DiscussSidebarItem;

--- a/addons/mail/static/src/components/drop_zone/drop_zone.js
+++ b/addons/mail/static/src/components/drop_zone/drop_zone.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
 
 const { Component, useState } = owl;
 
-class DropZone extends Component {
+export class DropZone extends Component {
 
     /**
      * @override
@@ -132,5 +132,3 @@ Object.assign(DropZone, {
     props: {},
     template: 'mail.DropZone',
 });
-
-export default DropZone;

--- a/addons/mail/static/src/components/editable_text/editable_text.js
+++ b/addons/mail/static/src/components/editable_text/editable_text.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
 import { markEventHandled } from '@mail/utils/utils';
 
 const { Component } = owl;
 
-class EditableText extends Component {
+export class EditableText extends Component {
 
     constructor(...args) {
         super(...args);
@@ -84,5 +84,3 @@ Object.assign(EditableText, {
     },
     template: 'mail.EditableText',
 });
-
-export default EditableText;

--- a/addons/mail/static/src/components/emojis_popover/emojis_popover.js
+++ b/addons/mail/static/src/components/emojis_popover/emojis_popover.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
 import emojis from '@mail/js/emojis';
 
 const { Component } = owl;
 
-class EmojisPopover extends Component {
+export class EmojisPopover extends Component {
 
     /**
      * @param {...any} args
@@ -71,5 +71,3 @@ Object.assign(EmojisPopover, {
     props: {},
     template: 'mail.EmojisPopover',
 });
-
-export default EmojisPopover;

--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
 
 import core from 'web.core';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
-class FileUploader extends Component {
+export class FileUploader extends Component {
 
     /**
      * @override
@@ -234,5 +234,3 @@ Object.assign(FileUploader, {
     },
     template: 'mail.FileUploader',
 });
-
-export default FileUploader;

--- a/addons/mail/static/src/components/file_uploader/file_uploader_tests.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import FileUploader from '@mail/components/file_uploader/file_uploader';
+import { FileUploader } from '@mail/components/file_uploader/file_uploader';
 import {
     afterEach,
     beforeEach,

--- a/addons/mail/static/src/components/follow_button/follow_button.js
+++ b/addons/mail/static/src/components/follow_button/follow_button.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 const { useState } = owl.hooks;
 
-class FollowButton extends Component {
+export class FollowButton extends Component {
     /**
      * @override
      */
@@ -86,5 +86,3 @@ Object.assign(FollowButton, {
     },
     template: 'mail.FollowButton',
 });
-
-export default FollowButton;

--- a/addons/mail/static/src/components/follow_button/follow_button_tests.js
+++ b/addons/mail/static/src/components/follow_button/follow_button_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import FollowButton from '@mail/components/follow_button/follow_button';
+import { FollowButton } from '@mail/components/follow_button/follow_button';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/follower/follower.js
+++ b/addons/mail/static/src/components/follower/follower.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import FollowerSubtypeList from '@mail/components/follower_subtype_list/follower_subtype_list';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { FollowerSubtypeList } from '@mail/components/follower_subtype_list/follower_subtype_list';
 
 const { Component } = owl;
 
 const components = { FollowerSubtypeList };
 
-class Follower extends Component {
+export class Follower extends Component {
 
     /**
      * @override
@@ -73,5 +73,3 @@ Object.assign(Follower, {
     },
     template: 'mail.Follower',
 });
-
-export default Follower;

--- a/addons/mail/static/src/components/follower/follower_tests.js
+++ b/addons/mail/static/src/components/follower/follower_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Follower from '@mail/components/follower/follower';
+import { Follower } from '@mail/components/follower/follower';
 import { insert, link } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
@@ -1,15 +1,15 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import Follower from '@mail/components/follower/follower';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { Follower } from '@mail/components/follower/follower';
 
 const { Component } = owl;
 const { useRef, useState } = owl.hooks;
 
 const components = { Follower };
 
-class FollowerListMenu extends Component {
+export class FollowerListMenu extends Component {
     /**
      * @override
      */
@@ -137,5 +137,3 @@ Object.assign(FollowerListMenu, {
     },
     template: 'mail.FollowerListMenu',
 });
-
-export default FollowerListMenu;

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu_tests.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import FollowerListMenu from '@mail/components/follower_list_menu/follower_list_menu';
+import { FollowerListMenu } from '@mail/components/follower_list_menu/follower_list_menu';
 import { insert, link } from '@mail/model/model_field_command';
 import {
     afterEach,

--- a/addons/mail/static/src/components/follower_subtype/follower_subtype.js
+++ b/addons/mail/static/src/components/follower_subtype/follower_subtype.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class FollowerSubtype extends Component {
+export class FollowerSubtype extends Component {
 
     /**
      * @override
@@ -64,5 +64,3 @@ Object.assign(FollowerSubtype, {
     },
     template: 'mail.FollowerSubtype',
 });
-
-export default FollowerSubtype;

--- a/addons/mail/static/src/components/follower_subtype/follower_subtype_tests.js
+++ b/addons/mail/static/src/components/follower_subtype/follower_subtype_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import FollowerSubtype from '@mail/components/follower_subtype/follower_subtype';
+import { FollowerSubtype } from '@mail/components/follower_subtype/follower_subtype';
 import { insert, link } from '@mail/model/model_field_command';
 import {
     afterEach,

--- a/addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.js
+++ b/addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import FollowerSubtype from '@mail/components/follower_subtype/follower_subtype';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { FollowerSubtype } from '@mail/components/follower_subtype/follower_subtype';
 
 const { Component, QWeb } = owl;
 
 const components = { FollowerSubtype };
 
-class FollowerSubtypeList extends Component {
+export class FollowerSubtypeList extends Component {
 
     /**
      * @override
@@ -82,5 +82,3 @@ Object.assign(FollowerSubtypeList, {
 });
 
 QWeb.registerComponent('FollowerSubtypeList', FollowerSubtypeList);
-
-export default FollowerSubtypeList;

--- a/addons/mail/static/src/components/mail_template/mail_template.js
+++ b/addons/mail/static/src/components/mail_template/mail_template.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class MailTemplate extends Component {
+export class MailTemplate extends Component {
 
     /**
      * @override
@@ -74,5 +74,3 @@ Object.assign(MailTemplate, {
     },
     template: 'mail.MailTemplate',
 });
-
-export default MailTemplate;

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -1,15 +1,15 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import AttachmentList from '@mail/components/attachment_list/attachment_list';
-import MessageSeenIndicator from '@mail/components/message_seen_indicator/message_seen_indicator';
-import ModerationBanDialog from '@mail/components/moderation_ban_dialog/moderation_ban_dialog';
-import ModerationDiscardDialog from '@mail/components/moderation_discard_dialog/moderation_discard_dialog';
-import ModerationRejectDialog from '@mail/components/moderation_reject_dialog/moderation_reject_dialog';
-import NotificationPopover from '@mail/components/notification_popover/notification_popover';
-import PartnerImStatusIcon from '@mail/components/partner_im_status_icon/partner_im_status_icon';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { AttachmentList } from '@mail/components/attachment_list/attachment_list';
+import { MessageSeenIndicator } from '@mail/components/message_seen_indicator/message_seen_indicator';
+import { ModerationBanDialog } from '@mail/components/moderation_ban_dialog/moderation_ban_dialog';
+import { ModerationDiscardDialog } from '@mail/components/moderation_discard_dialog/moderation_discard_dialog';
+import { ModerationRejectDialog } from '@mail/components/moderation_reject_dialog/moderation_reject_dialog';
+import { NotificationPopover } from '@mail/components/notification_popover/notification_popover';
+import { PartnerImStatusIcon } from '@mail/components/partner_im_status_icon/partner_im_status_icon';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 import { _lt } from 'web.core';
@@ -31,7 +31,7 @@ const components = {
     PartnerImStatusIcon,
 };
 
-class Message extends Component {
+export class Message extends Component {
 
     /**
      * @override
@@ -698,5 +698,3 @@ Object.assign(Message, {
     },
     template: 'mail.Message',
 });
-
-export default Message;

--- a/addons/mail/static/src/components/message/message_tests.js
+++ b/addons/mail/static/src/components/message/message_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Message from '@mail/components/message/message';
+import { Message } from '@mail/components/message/message';
 import {
     create,
     insert,

--- a/addons/mail/static/src/components/message_author_prefix/message_author_prefix.js
+++ b/addons/mail/static/src/components/message_author_prefix/message_author_prefix.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class MessageAuthorPrefix extends Component {
+export class MessageAuthorPrefix extends Component {
 
     /**
      * @override
@@ -60,5 +60,3 @@ Object.assign(MessageAuthorPrefix, {
     },
     template: 'mail.MessageAuthorPrefix',
 });
-
-export default MessageAuthorPrefix;

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -1,18 +1,18 @@
 /** @odoo-module **/
 
-import useRefs from '@mail/component_hooks/use_refs/use_refs';
-import useRenderedValues from '@mail/component_hooks/use_rendered_values/use_rendered_values';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import Message from '@mail/components/message/message';
+import { useRefs } from '@mail/component_hooks/use_refs/use_refs';
+import { useRenderedValues } from '@mail/component_hooks/use_rendered_values/use_rendered_values';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { Message } from '@mail/components/message/message';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { Message };
 
-class MessageList extends Component {
+export class MessageList extends Component {
 
     /**
      * @override
@@ -612,5 +612,3 @@ Object.assign(MessageList, {
     },
     template: 'mail.MessageList',
 });
-
-export default MessageList;

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class MessageSeenIndicator extends Component {
+export class MessageSeenIndicator extends Component {
 
     /**
      * @override
@@ -129,5 +129,3 @@ Object.assign(MessageSeenIndicator, {
     },
     template: 'mail.MessageSeenIndicator',
 });
-
-export default MessageSeenIndicator;

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator_tests.js
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import MessageSendIndicator from '@mail/components/message_seen_indicator/message_seen_indicator';
+import { MessageSeenIndicator } from '@mail/components/message_seen_indicator/message_seen_indicator';
 import { create, insert, link } from '@mail/model/model_field_command';
 import {
     afterEach,
@@ -9,7 +9,7 @@ import {
     start,
 } from '@mail/utils/test_utils';
 
-const components = { MessageSendIndicator };
+const components = { MessageSeenIndicator };
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -23,7 +23,7 @@ QUnit.module('message_seen_indicator_tests.js', {
                 { messageLocalId: message.localId, threadLocalId: thread.localId },
                 otherProps
             );
-            await createRootComponent(this, components.MessageSendIndicator, {
+            await createRootComponent(this, components.MessageSeenIndicator, {
                 props,
                 target: this.widget.el,
             });

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import AutocompleteInput from '@mail/components/autocomplete_input/autocomplete_input';
-import MobileMessagingNavbar from '@mail/components/mobile_messaging_navbar/mobile_messaging_navbar';
-import NotificationList from '@mail/components/notification_list/notification_list';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { AutocompleteInput } from '@mail/components/autocomplete_input/autocomplete_input';
+import { MobileMessagingNavbar } from '@mail/components/mobile_messaging_navbar/mobile_messaging_navbar';
+import { NotificationList } from '@mail/components/notification_list/notification_list';
 
 const { Component } = owl;
 
@@ -14,7 +14,7 @@ const components = {
     NotificationList,
 };
 
-class MessagingMenu extends Component {
+export class MessagingMenu extends Component {
 
     /**
      * @override
@@ -229,5 +229,3 @@ Object.assign(MessagingMenu, {
     props: {},
     template: 'mail.MessagingMenu',
 });
-
-export default MessagingMenu;

--- a/addons/mail/static/src/components/mobile_messaging_navbar/mobile_messaging_navbar.js
+++ b/addons/mail/static/src/components/mobile_messaging_navbar/mobile_messaging_navbar.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
 
 const { Component } = owl;
 
-class MobileMessagingNavbar extends Component {
+export class MobileMessagingNavbar extends Component {
 
     constructor(...args) {
         super(...args);
@@ -54,5 +54,3 @@ Object.assign(MobileMessagingNavbar, {
     },
     template: 'mail.MobileMessagingNavbar',
 });
-
-export default MobileMessagingNavbar;

--- a/addons/mail/static/src/components/moderation_ban_dialog/moderation_ban_dialog.js
+++ b/addons/mail/static/src/components/moderation_ban_dialog/moderation_ban_dialog.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 import Dialog from 'web.OwlDialog';
 
@@ -10,7 +10,7 @@ const { useRef } = owl.hooks;
 
 const components = { Dialog };
 
-class ModerationBanDialog extends Component {
+export class ModerationBanDialog extends Component {
 
     /**
      * @override
@@ -87,5 +87,3 @@ Object.assign(ModerationBanDialog, {
     },
     template: 'mail.ModerationBanDialog',
 });
-
-export default ModerationBanDialog;

--- a/addons/mail/static/src/components/moderation_discard_dialog/moderation_discard_dialog.js
+++ b/addons/mail/static/src/components/moderation_discard_dialog/moderation_discard_dialog.js
@@ -1,7 +1,8 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+
 import Dialog from 'web.OwlDialog';
 
 const { Component } = owl;
@@ -9,7 +10,7 @@ const { useRef } = owl.hooks;
 
 const components = { Dialog };
 
-class ModerationDiscardDialog extends Component {
+export class ModerationDiscardDialog extends Component {
 
     /**
      * @override
@@ -101,5 +102,3 @@ Object.assign(ModerationDiscardDialog, {
     },
     template: 'mail.ModerationDiscardDialog',
 });
-
-export default ModerationDiscardDialog;

--- a/addons/mail/static/src/components/moderation_reject_dialog/moderation_reject_dialog.js
+++ b/addons/mail/static/src/components/moderation_reject_dialog/moderation_reject_dialog.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 import Dialog from 'web.OwlDialog';
 
@@ -10,7 +10,7 @@ const { useRef } = owl.hooks;
 
 const components = { Dialog };
 
-class ModerationRejectDialog extends Component {
+export class ModerationRejectDialog extends Component {
 
     /**
      * @override
@@ -97,5 +97,3 @@ Object.assign(ModerationRejectDialog, {
     },
     template: 'mail.ModerationRejectDialog',
 });
-
-export default ModerationRejectDialog;

--- a/addons/mail/static/src/components/notification_alert/notification_alert.js
+++ b/addons/mail/static/src/components/notification_alert/notification_alert.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class NotificationAlert extends Component {
+export class NotificationAlert extends Component {
 
     /**
      * @override
@@ -47,5 +47,3 @@ Object.assign(NotificationAlert, {
     props: {},
     template: 'mail.NotificationAlert',
 });
-
-export default NotificationAlert;

--- a/addons/mail/static/src/components/notification_group/notification_group.js
+++ b/addons/mail/static/src/components/notification_group/notification_group.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
-class NotificationGroup extends Component {
+export class NotificationGroup extends Component {
 
     /**
      * @override
@@ -86,5 +86,3 @@ Object.assign(NotificationGroup, {
     },
     template: 'mail.NotificationGroup',
 });
-
-export default NotificationGroup;

--- a/addons/mail/static/src/components/notification_list/notification_list.js
+++ b/addons/mail/static/src/components/notification_list/notification_list.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import NotificationGroup from '@mail/components/notification_group/notification_group';
-import NotificationRequest from '@mail/components/notification_request/notification_request';
-import ThreadNeedactionPreview from '@mail/components/thread_needaction_preview/thread_needaction_preview';
-import ThreadPreview from '@mail/components/thread_preview/thread_preview';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { NotificationGroup } from '@mail/components/notification_group/notification_group';
+import { NotificationRequest } from '@mail/components/notification_request/notification_request';
+import { ThreadNeedactionPreview } from '@mail/components/thread_needaction_preview/thread_needaction_preview';
+import { ThreadPreview } from '@mail/components/thread_preview/thread_preview';
 
 const { Component } = owl;
 
@@ -16,7 +16,7 @@ const components = {
     ThreadPreview,
 };
 
-class NotificationList extends Component {
+export class NotificationList extends Component {
 
     /**
      * @override
@@ -223,5 +223,3 @@ Object.assign(NotificationList, {
     },
     template: 'mail.NotificationList',
 });
-
-export default NotificationList;

--- a/addons/mail/static/src/components/notification_list/notification_list_notification_group_tests.js
+++ b/addons/mail/static/src/components/notification_list/notification_list_notification_group_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import NotificationList from '@mail/components/notification_list/notification_list';
+import { NotificationList } from '@mail/components/notification_list/notification_list';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/notification_list/notification_list_tests.js
+++ b/addons/mail/static/src/components/notification_list/notification_list_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import NotificationList from '@mail/components/notification_list/notification_list';
+import { NotificationList } from '@mail/components/notification_list/notification_list';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/notification_popover/notification_popover.js
+++ b/addons/mail/static/src/components/notification_popover/notification_popover.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class NotificationPopover extends Component {
+export class NotificationPopover extends Component {
 
     /**
      * @override
@@ -89,5 +89,3 @@ Object.assign(NotificationPopover, {
     },
     template: 'mail.NotificationPopover',
 });
-
-export default NotificationPopover;

--- a/addons/mail/static/src/components/notification_request/notification_request.js
+++ b/addons/mail/static/src/components/notification_request/notification_request.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import PartnerImStatusIcon from '@mail/components/partner_im_status_icon/partner_im_status_icon';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { PartnerImStatusIcon } from '@mail/components/partner_im_status_icon/partner_im_status_icon';
 
 const { Component } = owl;
 
 const components = { PartnerImStatusIcon };
 
-class NotificationRequest extends Component {
+export class NotificationRequest extends Component {
 
     /**
      * @override
@@ -86,5 +86,3 @@ Object.assign(NotificationRequest, {
     props: {},
     template: 'mail.NotificationRequest',
 });
-
-export default NotificationRequest;

--- a/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.js
+++ b/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
 
 const { Component } = owl;
 
-class PartnerImStatusIcon extends Component {
+export class PartnerImStatusIcon extends Component {
 
     /**
      * @override
@@ -67,5 +67,3 @@ Object.assign(PartnerImStatusIcon, {
     },
     template: 'mail.PartnerImStatusIcon',
 });
-
-export default PartnerImStatusIcon;

--- a/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
+++ b/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import PartnerImStatusIcon from '@mail/components/partner_im_status_icon/partner_im_status_icon';
+import { PartnerImStatusIcon } from '@mail/components/partner_im_status_icon/partner_im_status_icon';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/thread_icon/thread_icon.js
+++ b/addons/mail/static/src/components/thread_icon/thread_icon.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import ThreadTypingIcon from '@mail/components/thread_typing_icon/thread_typing_icon';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { ThreadTypingIcon } from '@mail/components/thread_typing_icon/thread_typing_icon';
 
 const { Component } = owl;
 
 const components = { ThreadTypingIcon };
 
-class ThreadIcon extends Component {
+export class ThreadIcon extends Component {
 
     /**
      * @override
@@ -57,5 +57,3 @@ Object.assign(ThreadIcon, {
     },
     template: 'mail.ThreadIcon',
 });
-
-export default ThreadIcon;

--- a/addons/mail/static/src/components/thread_icon/thread_icon_tests.js
+++ b/addons/mail/static/src/components/thread_icon/thread_icon_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadIcon from '@mail/components/thread_icon/thread_icon';
+import { ThreadIcon } from '@mail/components/thread_icon/thread_icon';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -1,17 +1,18 @@
 /** @odoo-module **/
 
 import * as mailUtils from '@mail/js/utils';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import MessageAuthorPrefix from '@mail/components/message_author_prefix/message_author_prefix';
-import PartnerImStatusIcon from '@mail/components/partner_im_status_icon/partner_im_status_icon';
+
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { MessageAuthorPrefix } from '@mail/components/message_author_prefix/message_author_prefix';
+import { PartnerImStatusIcon } from '@mail/components/partner_im_status_icon/partner_im_status_icon';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { MessageAuthorPrefix, PartnerImStatusIcon };
 
-class ThreadNeedactionPreview extends Component {
+export class ThreadNeedactionPreview extends Component {
 
     /**
      * @override
@@ -132,5 +133,3 @@ Object.assign(ThreadNeedactionPreview, {
     },
     template: 'mail.ThreadNeedactionPreview',
 });
-
-export default ThreadNeedactionPreview;

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview_tests.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadNeedactionPreview from '@mail/components/thread_needaction_preview/thread_needaction_preview';
+import { ThreadNeedactionPreview } from '@mail/components/thread_needaction_preview/thread_needaction_preview';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/thread_preview/thread_preview.js
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.js
@@ -1,17 +1,18 @@
 /** @odoo-module **/
 
 import * as mailUtils from '@mail/js/utils';
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import MessageAuthorPrefix from '@mail/components/message_author_prefix/message_author_prefix';
-import PartnerImStatusIcon from '@mail/components/partner_im_status_icon/partner_im_status_icon';
+
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { MessageAuthorPrefix } from '@mail/components/message_author_prefix/message_author_prefix';
+import { PartnerImStatusIcon } from '@mail/components/partner_im_status_icon/partner_im_status_icon';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { MessageAuthorPrefix, PartnerImStatusIcon };
 
-class ThreadPreview extends Component {
+export class ThreadPreview extends Component {
 
     /**
      * @override
@@ -123,5 +124,3 @@ Object.assign(ThreadPreview, {
     },
     template: 'mail.ThreadPreview',
 });
-
-export default ThreadPreview;

--- a/addons/mail/static/src/components/thread_preview/thread_preview_tests.js
+++ b/addons/mail/static/src/components/thread_preview/thread_preview_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadPreview from '@mail/components/thread_preview/thread_preview';
+import { ThreadPreview } from '@mail/components/thread_preview/thread_preview';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status.js
+++ b/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status.js
@@ -1,14 +1,14 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import ThreadTypingIcon from '@mail/components/thread_typing_icon/thread_typing_icon';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { ThreadTypingIcon } from '@mail/components/thread_typing_icon/thread_typing_icon';
 
 const { Component } = owl;
 
 const components = { ThreadTypingIcon };
 
-class ThreadTextualTypingStatus extends Component {
+export class ThreadTextualTypingStatus extends Component {
 
     /**
      * @override
@@ -45,5 +45,3 @@ Object.assign(ThreadTextualTypingStatus, {
     },
     template: 'mail.ThreadTextualTypingStatus',
 });
-
-export default ThreadTextualTypingStatus;

--- a/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadTextualTypingStatus from '@mail/components/thread_textual_typing_status/thread_textual_typing_status';
+import { ThreadTextualTypingStatus } from '@mail/components/thread_textual_typing_status/thread_textual_typing_status';
 import {
     afterEach,
     afterNextRender,

--- a/addons/mail/static/src/components/thread_typing_icon/thread_typing_icon.js
+++ b/addons/mail/static/src/components/thread_typing_icon/thread_typing_icon.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
 
 const { Component } = owl;
 
-class ThreadTypingIcon extends Component {
+export class ThreadTypingIcon extends Component {
 
     constructor(...args) {
         super(...args);
@@ -34,5 +34,3 @@ Object.assign(ThreadTypingIcon, {
     },
     template: 'mail.ThreadTypingIcon',
 });
-
-export default ThreadTypingIcon;

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -1,17 +1,17 @@
 /** @odoo-module **/
 
-import useShouldUpdateBasedOnProps from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
-import useStore from '@mail/component_hooks/use_store/use_store';
-import useUpdate from '@mail/component_hooks/use_update/use_update';
-import Composer from '@mail/components/composer/composer';
-import MessageList from '@mail/components/message_list/message_list';
+import { useShouldUpdateBasedOnProps } from '@mail/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props';
+import { useStore } from '@mail/component_hooks/use_store/use_store';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { Composer } from '@mail/components/composer/composer';
+import { MessageList } from '@mail/components/message_list/message_list';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
 const components = { Composer, MessageList };
 
-class ThreadView extends Component {
+export class ThreadView extends Component {
 
     /**
      * @param {...any} args
@@ -229,5 +229,3 @@ Object.assign(ThreadView, {
     },
     template: 'mail.ThreadView',
 });
-
-export default ThreadView;

--- a/addons/mail/static/src/components/thread_view/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/thread_view_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ThreadView from '@mail/components/thread_view/thread_view';
+import { ThreadView } from '@mail/components/thread_view/thread_view';
 import { insert, link } from '@mail/model/model_field_command';
 import {
     afterEach,

--- a/addons/mail/static/src/js/main.js
+++ b/addons/mail/static/src/js/main.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ModelManager from '@mail/model/model_manager';
+import { ModelManager } from '@mail/model/model_manager';
 import MessagingService from '@mail/services/messaging/messaging';
 
 import env from 'web.commonEnv';

--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -7,7 +7,7 @@ import { FieldCommand, link, replace, unlink, unlinkAll } from '@mail/model/mode
  * These field definitions are generated from declared fields in static prop
  * `fields` on the model.
  */
-class ModelField {
+export class ModelField {
 
     //--------------------------------------------------------------------------
     // Public
@@ -931,7 +931,6 @@ class ModelField {
 
 }
 
-export default ModelField;
 export const attr = ModelField.attr;
 export const many2many = ModelField.many2many;
 export const many2one = ModelField.many2one;

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from '@mail/model/model_core';
-import ModelField from '@mail/model/model_field';
+import { ModelField } from '@mail/model/model_field';
 import { patchClassMethods, patchInstanceMethods } from '@mail/utils/utils';
 import { unlinkAll } from '@mail/model/model_field_command';
 
@@ -18,7 +18,7 @@ const DEPENDENT_INNER_SEPARATOR = "--//--//--";
  * `create()` or record method `update()`), this object processes them with
  * direct field & and computed field updates.
  */
-class ModelManager {
+export class ModelManager {
 
     //--------------------------------------------------------------------------
     // Public
@@ -1166,5 +1166,3 @@ class ModelManager {
     }
 
 }
-
-export default ModelManager;

--- a/addons/mail/static/src/services/chat_window_service/chat_window_service.js
+++ b/addons/mail/static/src/services/chat_window_service/chat_window_service.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ChatWindowManager from '@mail/components/chat_window_manager/chat_window_manager';
+import { ChatWindowManager } from '@mail/components/chat_window_manager/chat_window_manager';
 
 import AbstractService from 'web.AbstractService';
 import { bus, serviceRegistry } from 'web.core';

--- a/addons/mail/static/src/services/dialog_service/dialog_service.js
+++ b/addons/mail/static/src/services/dialog_service/dialog_service.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import DialogManager from '@mail/components/dialog_manager/dialog_manager';
+import { DialogManager } from '@mail/components/dialog_manager/dialog_manager';
 
 import AbstractService from 'web.AbstractService';
 import { bus, serviceRegistry } from 'web.core';

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -6,13 +6,13 @@ import {
     addMessagingToEnv,
     addTimeControlToEnv,
 } from '@mail/env/test_env';
-import ModelManager from '@mail/model/model_manager';
+import { ModelManager } from '@mail/model/model_manager';
 import ChatWindowService from '@mail/services/chat_window_service/chat_window_service';
 import DialogService from '@mail/services/dialog_service/dialog_service';
 import { nextTick } from '@mail/utils/utils';
 import DiscussWidget from '@mail/widgets/discuss/discuss';
 import MessagingMenuWidget from '@mail/widgets/messaging_menu/messaging_menu';
-import MockModels from '@mail/../tests/helpers/mock_models';
+import { MockModels } from '@mail/../tests/helpers/mock_models';
 
 import AbstractStorageService from 'web.AbstractStorageService';
 import NotificationService from 'web.NotificationService';

--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import Discuss from '@mail/components/discuss/discuss';
+import { Discuss } from '@mail/components/discuss/discuss';
 import InvitePartnerDialog from '@mail/widgets/discuss_invite_partner_dialog/discuss_invite_partner_dialog';
 
 import AbstractAction from 'web.AbstractAction';

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import ChatterContainer from '@mail/components/chatter_container/chatter_container';
+import { ChatterContainer } from '@mail/components/chatter_container/chatter_container';
 
 import FormRenderer from 'web.FormRenderer';
 import { ComponentWrapper } from 'web.OwlCompatibility';

--- a/addons/mail/static/src/widgets/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/widgets/messaging_menu/messaging_menu.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import MessagingMenuComponent from '@mail/components/messaging_menu/messaging_menu';
+import { MessagingMenu } from '@mail/components/messaging_menu/messaging_menu';
 
 import SystrayMenu from 'web.SystrayMenu';
 import Widget from 'web.Widget';
@@ -8,7 +8,7 @@ import Widget from 'web.Widget';
 /**
  * Odoo Widget, necessary to instantiate component.
  */
-const MessagingMenu = Widget.extend({
+const MessagingMenuWidget = Widget.extend({
     template: 'mail.widgets.MessagingMenu',
     /**
      * @override
@@ -27,7 +27,7 @@ const MessagingMenu = Widget.extend({
         this._super(...arguments);
     },
     async on_attach_callback() {
-        this.component = new MessagingMenuComponent(null);
+        this.component = new MessagingMenu(null);
         await this.component.mount(this.el);
         // unwrap
         this.el.parentNode.insertBefore(this.component.el, this.el);
@@ -42,9 +42,9 @@ const MessagingMenu = Widget.extend({
 const activityMenuIndex = SystrayMenu.Items.findIndex(SystrayMenuItem =>
     SystrayMenuItem.prototype.name === 'activity_menu');
 if (activityMenuIndex > 0) {
-    SystrayMenu.Items.splice(activityMenuIndex, 0, MessagingMenu);
+    SystrayMenu.Items.splice(activityMenuIndex, 0, MessagingMenuWidget);
 } else {
-    SystrayMenu.Items.push(MessagingMenu);
+    SystrayMenu.Items.push(MessagingMenuWidget);
 }
 
-export default MessagingMenu;
+export default MessagingMenuWidget;

--- a/addons/mail/static/src/widgets/notification_alert/notification_alert.js
+++ b/addons/mail/static/src/widgets/notification_alert/notification_alert.js
@@ -1,19 +1,19 @@
 /** @odoo-module **/
 
-import NotificationAlertComponent from '@mail/components/notification_alert/notification_alert';
+import { NotificationAlert } from '@mail/components/notification_alert/notification_alert';
 
 import { ComponentWrapper, WidgetAdapterMixin } from 'web.OwlCompatibility';
 import Widget from 'web.Widget';
 import widgetRegistry from 'web.widget_registry';
 
-const components = { NotificationAlertComponent };
+const components = { NotificationAlert };
 
 class NotificationAlertWrapper extends ComponentWrapper {}
 
 // -----------------------------------------------------------------------------
 // Display Notification alert on user preferences form view
 // -----------------------------------------------------------------------------
-const NotificationAlert = Widget.extend(WidgetAdapterMixin, {
+const NotificationAlertWidget = Widget.extend(WidgetAdapterMixin, {
     /**
      * @override
      */
@@ -29,13 +29,13 @@ const NotificationAlert = Widget.extend(WidgetAdapterMixin, {
 
         this.component = new NotificationAlertWrapper(
             this,
-            components.NotificationAlertComponent,
+            components.NotificationAlert,
             {}
         );
         await this.component.mount(this.el);
     },
 });
 
-widgetRegistry.add('notification_alert', NotificationAlert);
+widgetRegistry.add('notification_alert', NotificationAlertWidget);
 
-export default NotificationAlert;
+export default NotificationAlertWidget;

--- a/addons/mail/static/tests/helpers/mock_models.js
+++ b/addons/mail/static/tests/helpers/mock_models.js
@@ -6,7 +6,7 @@
  * data object is generated every time to ensure any test can modify it without
  * impacting other tests.
  */
-class MockModels {
+export class MockModels {
 
     //--------------------------------------------------------------------------
     // Public
@@ -249,5 +249,3 @@ class MockModels {
     }
 
 }
-
-export default MockModels;

--- a/addons/sms/static/src/components/message/message_tests.js
+++ b/addons/sms/static/src/components/message/message_tests.js
@@ -1,9 +1,7 @@
 odoo.define('sms/static/src/components/message/message_tests.js', function (require) {
 'use strict';
 
-const components = {
-    Message: require('@mail/components/message/message')[Symbol.for("default")],
-};
+const { Message } = require('@mail/components/message/message');
 const { create, insert, link } = require('@mail/model/model_field_command');
 const { makeDeferred } = require('@mail/utils/deferred/deferred');
 const {
@@ -15,6 +13,8 @@ const {
 } = require('@mail/utils/test_utils');
 
 const Bus = require('web.Bus');
+
+const components = { Message };
 
 QUnit.module('sms', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/sms/static/src/components/notification_group/notification_group.js
+++ b/addons/sms/static/src/components/notification_group/notification_group.js
@@ -1,11 +1,11 @@
 odoo.define('sms/static/src/components/notification_group/notification_group.js', function (require) {
 'use strict';
 
-const components = {
-    NotificationGroup: require('@mail/components/notification_group/notification_group')[Symbol.for("default")],
-};
+const { NotificationGroup } = require('@mail/components/notification_group/notification_group');
 
 const { patch } = require('web.utils');
+
+const components = { NotificationGroup };
 
 patch(components.NotificationGroup.prototype, 'sms/static/src/components/notification_group/notification_group.js', {
 

--- a/addons/sms/static/src/components/notification_list/notification_list_notification_group_tests.js
+++ b/addons/sms/static/src/components/notification_list/notification_list_notification_group_tests.js
@@ -1,10 +1,7 @@
 odoo.define('sms/static/src/components/notification_list/notification_list_notification_group_tests.js', function (require) {
 'use strict';
 
-const components = {
-    NotificationList: require('@mail/components/notification_list/notification_list')[Symbol.for("default")],
-};
-
+const { NotificationList } = require('@mail/components/notification_list/notification_list');
 const {
     afterEach,
     beforeEach,
@@ -13,6 +10,8 @@ const {
 } = require('@mail/utils/test_utils');
 
 const Bus = require('web.Bus');
+
+const components = { NotificationList };
 
 QUnit.module('sms', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/snailmail/static/src/components/message/message.js
+++ b/addons/snailmail/static/src/components/message/message.js
@@ -1,8 +1,10 @@
 odoo.define('snailmail/static/src/components/message/message.js', function (require) {
 'use strict';
 
+const { Message } = require('@mail/components/message/message');
+
 const components = {
-    Message:  require('@mail/components/message/message')[Symbol.for("default")],
+    Message,
     SnailmailErrorDialog: require('snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js'),
     SnailmailNotificationPopover: require('snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js'),
 };

--- a/addons/snailmail/static/src/components/message/message_tests.js
+++ b/addons/snailmail/static/src/components/message/message_tests.js
@@ -1,9 +1,7 @@
 odoo.define('snailmail/static/src/components/message/message_tests.js', function (require) {
 'use strict';
 
-const components = {
-    Message: require('@mail/components/message/message')[Symbol.for("default")],
-};
+const { Message } = require('@mail/components/message/message');
 const { create, insert, link } = require('@mail/model/model_field_command');
 const {
     afterEach,
@@ -14,6 +12,8 @@ const {
 } = require('@mail/utils/test_utils');
 
 const Bus = require('web.Bus');
+
+const components = { Message };
 
 QUnit.module('snailmail', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/snailmail/static/src/components/notification_group/notification_group.js
+++ b/addons/snailmail/static/src/components/notification_group/notification_group.js
@@ -1,11 +1,11 @@
 odoo.define('snailmail/static/src/components/notification_group/notification_group.js', function (require) {
 'use strict';
 
-const components = {
-    NotificationGroup: require('@mail/components/notification_group/notification_group')[Symbol.for("default")],
-};
+const { NotificationGroup } = require('@mail/components/notification_group/notification_group');
 
 const { patch } = require('web.utils');
+
+const components = { NotificationGroup };
 
 patch(components.NotificationGroup.prototype, 'snailmail/static/src/components/notification_group/notification_group.js', {
 

--- a/addons/snailmail/static/src/components/notification_list/notification_list_notification_group_tests.js
+++ b/addons/snailmail/static/src/components/notification_list/notification_list_notification_group_tests.js
@@ -1,10 +1,7 @@
 odoo.define('snailmail/static/src/components/notification_list/notification_list_notification_group_tests.js', function (require) {
 'use strict';
 
-const components = {
-    NotificationList: require('@mail/components/notification_list/notification_list')[Symbol.for("default")],
-};
-
+const { NotificationList } = require('@mail/components/notification_list/notification_list');
 const {
     afterEach,
     beforeEach,
@@ -13,6 +10,8 @@ const {
 } = require('@mail/utils/test_utils');
 
 const Bus = require('web.Bus');
+
+const components = { NotificationList };
 
 QUnit.module('snailmail', {}, function () {
 QUnit.module('components', {}, function () {

--- a/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
+++ b/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
@@ -1,7 +1,7 @@
 odoo.define('snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js', function (require) {
 'use strict';
 
-const useStore = require('@mail/component_hooks/use_store/use_store')[Symbol.for("default")];
+const { useStore } = require('@mail/component_hooks/use_store/use_store');
 
 const Dialog = require('web.OwlDialog');
 

--- a/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
+++ b/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
@@ -2,7 +2,7 @@ odoo.define('snailmail/static/src/components/snailmail_notification_popover/snai
 'use strict';
 
 const { Component } = owl;
-const useStore = require('@mail/component_hooks/use_store/use_store')[Symbol.for("default")];
+const { useStore } = require('@mail/component_hooks/use_store/use_store');
 
 class SnailmailNotificationPopover extends Component {
 

--- a/addons/snailmail/static/tests/helpers/mock_models.js
+++ b/addons/snailmail/static/tests/helpers/mock_models.js
@@ -1,8 +1,7 @@
-odoo.define('snailmail/static/tests/helpers/mock_models.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const MockModels = require('@mail/../tests/helpers/mock_models')[Symbol.for("default")];
-const { patch } = require('web.utils');
+import { MockModels } from '@mail/../tests/helpers/mock_models';
+import { patch } from 'web.utils';
 
 patch(MockModels, 'snailmail/static/tests/helpers/mock_models.js', {
 
@@ -25,7 +24,5 @@ patch(MockModels, 'snailmail/static/tests/helpers/mock_models.js', {
         });
         return data;
     },
-
-});
 
 });

--- a/addons/website_livechat/static/src/components/discuss/discuss.js
+++ b/addons/website_livechat/static/src/components/discuss/discuss.js
@@ -1,8 +1,10 @@
 odoo.define('website_livechat/static/src/components/discuss/discuss.js', function (require) {
 'use strict';
 
+const { Discuss } = require('@mail/components/discuss/discuss');
+
 const components = {
-    Discuss: require('@mail/components/discuss/discuss')[Symbol.for("default")],
+    Discuss,
     VisitorBanner: require('website_livechat/static/src/components/visitor_banner/visitor_banner.js'),
 };
 const { patch } = require('web.utils');

--- a/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.js
+++ b/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.js
@@ -1,7 +1,7 @@
 odoo.define('website_livechat/static/src/components/visitor_banner/visitor_banner.js', function (require) {
 'use strict';
 
-const useStore = require('@mail/component_hooks/use_store/use_store')[Symbol.for("default")];
+const { useStore } = require('@mail/component_hooks/use_store/use_store');
 
 const { Component } = owl;
 

--- a/addons/website_livechat/static/tests/helpers/mock_models.js
+++ b/addons/website_livechat/static/tests/helpers/mock_models.js
@@ -1,7 +1,7 @@
 odoo.define('website_livechat/static/tests/helpers/mock_models.js', function (require) {
 'use strict';
 
-const MockModels = require('@mail/../tests/helpers/mock_models')[Symbol.for("default")];
+const { MockModels } = require('@mail/../tests/helpers/mock_models');
 const { patch } = require('web.utils');
 
 patch(MockModels, 'website_livechat/static/tests/helpers/mock_models.js', {

--- a/addons/website_slides/static/src/components/activity/activity.js
+++ b/addons/website_slides/static/src/components/activity/activity.js
@@ -1,10 +1,11 @@
 odoo.define('website_slides/static/src/components/activity/activity.js', function (require) {
 'use strict';
 
-const components = {
-    Activity: require('@mail/components/activity/activity')[Symbol.for("default")],
-};
+const { Activity } = require('@mail/components/activity/activity');
+
 const { patch } = require('web.utils');
+
+const components = { Activity };
 
 patch(components.Activity.prototype, 'website_slides/static/src/components/activity/activity.js', {
 

--- a/addons/website_slides/static/src/components/activity/activity_tests.js
+++ b/addons/website_slides/static/src/components/activity/activity_tests.js
@@ -1,9 +1,7 @@
 odoo.define('website_slides/static/src/tests/activity_tests.js', function (require) {
 'use strict';
 
-const components = {
-    Activity: require('@mail/components/activity/activity')[Symbol.for("default")],
-};
+const { Activity } = require('@mail/components/activity/activity');
 const { insert } = require('@mail/model/model_field_command');
 const {
     afterEach,
@@ -11,6 +9,8 @@ const {
     createRootComponent,
     start,
 } = require('@mail/utils/test_utils');
+
+const components = { Activity };
 
 QUnit.module('website_slides', {}, function () {
 QUnit.module('components', {}, function () {


### PR DESCRIPTION
* = hr, hr_holidays, im_livechat, sms, snailmail, website_livechat,
    website_slides

Exporting directly on the line of the class or variable definition is less lines
of code and less repetition (and risk or mistake).

Exporting with a name instead of default allows to catch typos more easily when
importing and ensures the same name is used for consistency (and ease of grep).