### PR TITLE
[FIX] web: utils/strings: sprintf support lazy translated strings

### DIFF
--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -3,7 +3,7 @@
 import { memoize } from "../utils/functions";
 import { sprintf } from "../utils/strings";
 import { localization } from "./localization";
-import { _lt } from "./translation";
+import { _t } from "./translation";
 
 const { DateTime } = luxon;
 
@@ -276,7 +276,7 @@ export function parseDateTime(value, options = {}) {
     }
 
     if (!result) {
-        throw new Error(sprintf(_lt("'%s' is not a correct date or datetime").toString(), value));
+        throw new Error(sprintf(_t("'%s' is not a correct date or datetime"), value));
     }
 
     result = result.toUTC();

--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -4,7 +4,7 @@ import { browser } from "../browser/browser";
 import { registry } from "../registry";
 import { strftimeToLuxonFormat } from "./dates";
 import { localization } from "./localization";
-import { translatedTerms } from "./translation";
+import { translatedTerms, _t } from "./translation";
 
 export const localizationService = {
     dependencies: ["user"],
@@ -33,9 +33,6 @@ export const localizationService = {
         }
 
         Object.setPrototypeOf(translatedTerms, terms);
-        function _t(str) {
-            return terms[str] || str;
-        }
         env._t = _t;
         env.qweb.translateFn = _t;
         const dateFormat = strftimeToLuxonFormat(userLocalization.date_format);

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -3,6 +3,31 @@
 export const translatedTerms = {};
 
 /**
+ * Translate a term, or return the term if no translation can be found.
+ *
+ * Note that it translates eagerly, which means that if the translations have
+ * not been loaded yet, it will return the untranslated term. If it cannot be
+ * guaranteed that translations are ready, one should use the _lt function
+ * instead (see below)
+ *
+ * @param {string} term
+ * @returns {string}
+ */
+export function _t(term) {
+    return translatedTerms[term] || term;
+}
+
+class LazyTranslatedString extends String {
+    valueOf() {
+        const str = super.valueOf();
+        return _t(str);
+    }
+    toString() {
+        return this.valueOf();
+    }
+}
+
+/**
  * Lazy translation function, only performs the translation when actually
  * printed (e.g. inserted into a template).
  * Useful when defining translatable strings in code evaluated before the
@@ -12,7 +37,7 @@ export const translatedTerms = {};
  * @returns {{toString: () => string}}
  */
 export function _lt(str) {
-    return { toString: () => translatedTerms[str] || str };
+    return new LazyTranslatedString(str);
 }
 
 /*

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -70,7 +70,7 @@ export function intersperse(str, indices, separator = "") {
  * @returns {string}
  */
 export function sprintf(s, ...values) {
-    if (values.length === 1 && typeof values[0] === "object") {
+    if (values.length === 1 && Object.prototype.toString.call(values[0]) === "[object Object]") {
         const valuesDict = values[0];
         s = s.replace(/\%\(?([^\)]+)\)s/g, (match, value) => valuesDict[value]);
     } else if (values.length > 0) {

--- a/addons/web/static/tests/core/l10n/translation_tests.js
+++ b/addons/web/static/tests/core/l10n/translation_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { translatedTerms } from "@web/core/l10n/translation";
+import { translatedTerms, _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { patch, unpatch } from "@web/core/utils/patch";
 import { makeTestEnv } from "../../helpers/mock_env";
@@ -18,6 +18,23 @@ QUnit.module("Translations");
 QUnit.test("can translate a text node", async (assert) => {
     assert.expect(1);
     TestComponent.template = owl.tags.xml`<div>Hello</div>`;
+    serviceRegistry.add("localization", makeFakeLocalizationService());
+    const env = await makeTestEnv();
+    patch(translatedTerms, "add translations", terms);
+    const target = getFixture();
+    await mount(TestComponent, { env, target });
+    assert.strictEqual(target.innerText, "Bonjour");
+    unpatch(translatedTerms, "add translations");
+});
+
+QUnit.test("can lazy translate", async (assert) => {
+    assert.expect(3);
+
+    TestComponent.template = owl.tags.xml`<div><t t-esc="constructor.someLazyText" /></div>`;
+    TestComponent.someLazyText = _lt("Hello");
+    assert.strictEqual(TestComponent.someLazyText.toString(), "Hello");
+    assert.strictEqual(TestComponent.someLazyText.valueOf(), "Hello");
+
     serviceRegistry.add("localization", makeFakeLocalizationService());
     const env = await makeTestEnv();
     patch(translatedTerms, "add translations", terms);

--- a/addons/web/static/tests/core/utils/strings_tests.js
+++ b/addons/web/static/tests/core/utils/strings_tests.js
@@ -1,6 +1,8 @@
 /** @odoo-module **/
 
 import { escapeRegExp, intersperse, sprintf } from "@web/core/utils/strings";
+import { _lt, translatedTerms } from "@web/core/l10n/translation";
+import { patchWithCleanup } from "../../helpers/utils";
 
 QUnit.module("utils", () => {
     QUnit.module("strings");
@@ -61,5 +63,38 @@ QUnit.module("utils", () => {
         assert.deepEqual(sprintf("Hello!"), "Hello!");
         assert.deepEqual(sprintf("Hello %s!"), "Hello %s!");
         assert.deepEqual(sprintf("Hello %(value)s!"), "Hello %(value)s!");
+    });
+
+    QUnit.test("sprintf properly formats numbers", (assert) => {
+        assert.deepEqual(sprintf("Hello %s!", 5), "Hello 5!");
+        assert.deepEqual(sprintf("Hello %s and %s!", 9, 10), "Hello 9 and 10!");
+        assert.deepEqual(sprintf("Hello %(x)s!", { x: 11 }), "Hello 11!");
+        assert.deepEqual(sprintf("Hello %(x)s and %(y)s!", { x: 12, y: 13 }), "Hello 12 and 13!");
+    });
+
+    QUnit.test("sprintf set behavior when value is an Array", (assert) => {
+        assert.deepEqual(sprintf("Hello %s!", ["inarray"]), "Hello inarray!");
+        assert.deepEqual(sprintf("Hello %s and %s!", [9, "10"], [11]), "Hello 9,10 and 11!");
+        assert.deepEqual(sprintf("Hello %(x)s!", { x: [11] }), "Hello 11!");
+        assert.deepEqual(
+            sprintf("Hello %(x)s and %(y)s!", { x: [12], y: ["13"] }),
+            "Hello 12 and 13!"
+        );
+    });
+
+    QUnit.test("sprintf supports lazy translated string", (assert) => {
+        patchWithCleanup(translatedTerms, {
+            one: "en",
+            two: "två",
+        });
+
+        assert.deepEqual(sprintf("Hello %s", _lt("one")), "Hello en");
+        assert.deepEqual(sprintf("Hello %s %s", _lt("one"), _lt("two")), "Hello en två");
+
+        const vals = {
+            one: _lt("one"),
+            two: _lt("two"),
+        };
+        assert.deepEqual(sprintf("Hello %(two)s %(one)s", vals), "Hello två en");
     });
 });


### PR DESCRIPTION
Have something like:
```js

sprintf("my string %s", _lt("lazy translated"));

```
Before this commit, the lazy translated term was not formatted into the string.
This was because _lt returns an object containing a custom toString function, which was not handled by sprintf

After this commit, sprintf is able to handle lazy translated strings

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
