### PR TITLE
[IMP] *: always use Odoo Response

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -88,7 +88,7 @@ class OAuthLogin(Home):
         ensure_db()
         if request.httprequest.method == 'GET' and request.session.uid and request.params.get('redirect'):
             # Redirect if already logged in and redirect param is present
-            return http.redirect_with_hash(request.params.get('redirect'))
+            return request.redirect(request.params.get('redirect'))
         providers = self.list_providers()
 
         response = super(OAuthLogin, self).web_login(*args, **kw)
@@ -155,7 +155,7 @@ class OAuthController(http.Controller):
                 # oauth credentials not valid, user could be on a temporary session
                 _logger.info('OAuth2: access denied, redirect to main page in case a valid session exists, without setting cookies')
                 url = "/web/login?oauth_error=3"
-                redirect = werkzeug.utils.redirect(url, 303)
+                redirect = request.redirect(url, 303)
                 redirect.autocorrect_location_header = False
                 return redirect
             except Exception as e:

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -22,7 +22,7 @@ class AuthSignupHome(Home):
         response.qcontext.update(self.get_auth_signup_config())
         if request.httprequest.method == 'GET' and request.session.uid and request.params.get('redirect'):
             # Redirect if already logged in and redirect param is present
-            return http.redirect_with_hash(request.params.get('redirect'))
+            return request.redirect(request.params.get('redirect'))
         return response
 
     @http.route('/web/signup', type='http', auth='public', website=True, sitemap=False)

--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -15,10 +15,10 @@ class Home(odoo.addons.web.controllers.main.Home):
     )
     def web_totp(self, redirect=None, **kwargs):
         if request.session.uid:
-            return http.redirect_with_hash(self._login_redirect(request.session.uid, redirect=redirect))
+            return request.redirect(self._login_redirect(request.session.uid, redirect=redirect))
 
         if not request.session.pre_uid:
-            return http.redirect_with_hash('/web/login')
+            return request.redirect('/web/login')
 
         error = None
         if request.httprequest.method == 'POST':
@@ -32,7 +32,7 @@ class Home(odoo.addons.web.controllers.main.Home):
                 error = _("Invalid authentication code format.")
             else:
                 request.session.finalize()
-                return http.redirect_with_hash(self._login_redirect(request.session.uid, redirect=redirect))
+                return request.redirect(self._login_redirect(request.session.uid, redirect=redirect))
 
         return request.render('auth_totp.auth_totp_form', {
             'error': error,

--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-
 import odoo.http as http
 
 from odoo.http import request
@@ -70,7 +68,7 @@ class CalendarController(http.Controller):
         # If user is internal and logged, redirect to form view of event
         # otherwise, display the simplifyed web page with event informations
         if request.session.uid and request.env['res.users'].browse(request.session.uid).user_has_groups('base.group_user'):
-            return werkzeug.utils.redirect('/web?db=%s#id=%s&view_type=form&model=calendar.event' % (request.env.cr.dbname, id))
+            return request.redirect('/web?db=%s#id=%s&view_type=form&model=calendar.event' % (request.env.cr.dbname, id))
 
         # NOTE : we don't use request.render() since:
         # - we need a template rendering which is not lazy, to render before cursor closing

--- a/addons/crm_mail_plugin/controllers/crm_client.py
+++ b/addons/crm_mail_plugin/controllers/crm_client.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 from odoo.tools import html2plaintext
@@ -36,7 +34,7 @@ class CrmClient(http.Controller):
             for supporting older versions
         """
         server_action = http.request.env.ref("crm_mail_plugin.lead_creation_prefilled_action")
-        return werkzeug.utils.redirect(
+        return request.redirect(
             '/web#action=%s&model=crm.lead&partner_id=%s' % (server_action.id, int(partner_id)))
 
     @http.route('/mail_plugin/lead/create', type='json', auth='outlook', cors="*")
@@ -61,4 +59,4 @@ class CrmClient(http.Controller):
         """
         action = http.request.env.ref("crm.crm_lead_view_form")
         url = '/web#id=%s&action=%s&model=crm.lead&edit=1&model=crm.lead' % (lead_id, action.id)
-        return werkzeug.utils.redirect(url)
+        return request.redirect(url)

--- a/addons/google_account/controllers/main.py
+++ b/addons/google_account/controllers/main.py
@@ -2,9 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-from werkzeug.utils import redirect
 
-from odoo import http, registry
+from odoo import http
 from odoo.http import request
 
 
@@ -18,13 +17,12 @@ class GoogleAuth(http.Controller):
         service = state.get('s')
         url_return = state.get('f')
 
-        with registry(dbname).cursor() as cr:
-            if kw.get('code'):
-                access_token, refresh_token, ttl = request.env['google.service']._get_google_tokens(kw['code'], service)
-                # LUL TODO only defined in google_calendar
-                request.env.user._set_auth_tokens(access_token, refresh_token, ttl)
-                return redirect(url_return)
-            elif kw.get('error'):
-                return redirect("%s%s%s" % (url_return, "?error=", kw['error']))
-            else:
-                return redirect("%s%s" % (url_return, "?error=Unknown_error"))
+        if kw.get('code'):
+            access_token, refresh_token, ttl = request.env['google.service']._get_google_tokens(kw['code'], service)
+            # LUL TODO only defined in google_calendar
+            request.env.user._set_auth_tokens(access_token, refresh_token, ttl)
+            return request.redirect(url_return)
+        elif kw.get('error'):
+            return request.redirect("%s%s%s" % (url_return, "?error=", kw['error']))
+        else:
+            return request.redirect("%s%s" % (url_return, "?error=Unknown_error"))

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -152,9 +152,9 @@ def url_lang(path_or_uri, lang_code=None):
         lang_code = pycompat.to_text(lang_code or request.context['lang'])
         lang_url_code = Lang._lang_code_to_urlcode(lang_code)
         lang_url_code = lang_url_code if lang_url_code in lang_url_codes else lang_code
-
         if (len(lang_url_codes) > 1 or force_lang) and is_multilang_url(location, lang_url_codes):
-            ps = location.split(u'/')
+            loc, sep, qs = location.partition('?')
+            ps = loc.split(u'/')
             default_lg = request.env['ir.http']._get_default_lang()
             if ps[1] in lang_url_codes:
                 # Replace the language only if we explicitly provide a language to url_for
@@ -166,7 +166,7 @@ def url_lang(path_or_uri, lang_code=None):
             # Insert the context language or the provided language
             elif lang_url_code != default_lg.url_code or force_lang:
                 ps.insert(1, lang_url_code)
-            location = u'/'.join(ps)
+            location = u'/'.join(ps) + sep + qs
     return location
 
 

--- a/addons/link_tracker/controller/main.py
+++ b/addons/link_tracker/controller/main.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -18,4 +16,4 @@ class LinkTracker(http.Controller):
             country_code=country_code
         )
         redirect_url = request.env['link.tracker'].get_url_from_code(code)
-        return werkzeug.utils.redirect(redirect_url or '', 301)
+        return request.redirect(redirect_url or '', code=301, local=False)

--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -23,7 +23,7 @@ class MailController(http.Controller):
     @classmethod
     def _redirect_to_messaging(cls):
         url = '/web#%s' % url_encode({'action': 'mail.action_discuss'})
-        return werkzeug.utils.redirect(url)
+        return request.redirect(url)
 
     @classmethod
     def _check_token(cls, token):
@@ -106,7 +106,7 @@ class MailController(http.Controller):
         record_action.pop('target_type', None)
         # the record has an URL redirection: use it directly
         if record_action['type'] == 'ir.actions.act_url':
-            return werkzeug.utils.redirect(record_action['url'])
+            return request.redirect(record_action['url'])
         # other choice: act_window (no support of anything else currently)
         elif not record_action['type'] == 'ir.actions.act_window':
             return cls._redirect_to_messaging()
@@ -124,7 +124,7 @@ class MailController(http.Controller):
         if cids:
             url_params['cids'] = ','.join([str(cid) for cid in cids])
         url = '/web?#%s' % url_encode(url_params)
-        return werkzeug.utils.redirect(url)
+        return request.redirect(url)
 
     @http.route('/mail/read_followers', type='json', auth='user')
     def read_followers(self, res_model, res_id):

--- a/addons/mail_plugin/controllers/authenticate.py
+++ b/addons/mail_plugin/controllers/authenticate.py
@@ -50,7 +50,7 @@ class Authenticate(http.Controller):
         else:
             params.update({'success': 0, 'state': kw.get('state', '')})
         updated_redirect = parsed_redirect.replace(query=werkzeug.urls.url_encode(params))
-        return werkzeug.utils.redirect(updated_redirect.to_url())
+        return request.redirect(updated_redirect.to_url())
 
     # In this case, an exception will be thrown in case of preflight request if only POST is allowed.
     @http.route(['/mail_client_extension/auth/access_token', '/mail_plugin/auth/access_token'], type='json', auth="none", cors="*",

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -146,7 +146,7 @@ class MassMailController(http.Controller):
             country_code=country_code,
             mailing_trace_id=mailing_trace_id
         )
-        return werkzeug.utils.redirect(request.env['link.tracker'].get_url_from_code(code), 301)
+        return request.redirect(request.env['link.tracker'].get_url_from_code(code), code=301, local=False)
 
     @http.route('/mailing/blacklist/check', type='json', auth='public')
     def blacklist_check(self, mailing_id, res_id, email, token):

--- a/addons/mass_mailing_sms/controllers/main.py
+++ b/addons/mass_mailing_sms/controllers/main.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-
 from odoo import http, _
 from odoo.addons.phone_validation.tools import phone_validation
 from odoo.http import request
@@ -30,7 +28,7 @@ class MailingSMSController(http.Controller):
     def blacklist_page(self, mailing_id, trace_code, **post):
         check_res = self._check_trace(mailing_id, trace_code)
         if not check_res.get('trace'):
-            return werkzeug.utils.redirect('/web')
+            return request.redirect('/web')
         return request.render('mass_mailing_sms.blacklist_main', {
             'mailing_id': mailing_id,
             'trace_code': trace_code,
@@ -40,7 +38,7 @@ class MailingSMSController(http.Controller):
     def blacklist_number(self, mailing_id, trace_code, **post):
         check_res = self._check_trace(mailing_id, trace_code)
         if not check_res.get('trace'):
-            return werkzeug.utils.redirect('/web')
+            return request.redirect('/web')
         country_code = request.session.get('geoip', False) and request.session.geoip.get('country_code', False) if request.session.get('geoip') else None
         # parse and validate number
         sms_number = post.get('sms_number', '').strip(' ')
@@ -102,4 +100,4 @@ class MailingSMSController(http.Controller):
             country_code=country_code,
             mailing_trace_id=trace_id
         )
-        return werkzeug.utils.redirect(request.env['link.tracker'].get_url_from_code(code), 301)
+        return request.redirect(request.env['link.tracker'].get_url_from_code(code), code=301, local=False)

--- a/addons/microsoft_account/controllers/main.py
+++ b/addons/microsoft_account/controllers/main.py
@@ -2,9 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-from werkzeug.utils import redirect
 
-from odoo import http, registry
+from odoo import http
 from odoo.http import request
 
 
@@ -18,12 +17,11 @@ class MicrosoftAuth(http.Controller):
         service = state.get('s')
         url_return = state.get('f')
 
-        with registry(dbname).cursor() as cr:
-            if kw.get('code'):
-                access_token, refresh_token, ttl = request.env['microsoft.service']._get_microsoft_tokens(kw['code'], service)
-                request.env.user._set_microsoft_auth_tokens(access_token, refresh_token, ttl)
-                return redirect(url_return)
-            elif kw.get('error'):
-                return redirect("%s%s%s" % (url_return, "?error=", kw['error']))
-            else:
-                return redirect("%s%s" % (url_return, "?error=Unknown_error"))
+        if kw.get('code'):
+            access_token, refresh_token, ttl = request.env['microsoft.service']._get_microsoft_tokens(kw['code'], service)
+            request.env.user._set_microsoft_auth_tokens(access_token, refresh_token, ttl)
+            return request.redirect(url_return)
+        elif kw.get('error'):
+            return request.redirect("%s%s%s" % (url_return, "?error=", kw['error']))
+        else:
+            return request.redirect("%s%s" % (url_return, "?error=Unknown_error"))

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -234,7 +234,7 @@ class AdyenController(http.Controller):
         )
 
         # Redirect the user to the status page
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     @http.route('/payment/adyen/notification', type='json', auth='public')
     def adyen_notification(self):

--- a/addons/payment_alipay/controllers/main.py
+++ b/addons/payment_alipay/controllers/main.py
@@ -4,7 +4,6 @@ import logging
 import pprint
 
 import requests
-import werkzeug
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
@@ -22,7 +21,7 @@ class AlipayController(http.Controller):
         """ Alipay return """
         _logger.info("received Alipay return data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('alipay', data)
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     @http.route(_notify_url, type='http', auth='public', methods=['POST'], csrf=False)
     def alipay_notify(self, **post):

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -3,8 +3,6 @@
 import logging
 import pprint
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -22,4 +20,4 @@ class BuckarooController(http.Controller):
         """
         _logger.info("received notification data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('buckaroo', data)
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')

--- a/addons/payment_ogone/controllers/main.py
+++ b/addons/payment_ogone/controllers/main.py
@@ -95,7 +95,7 @@ class OgoneController(http.Controller):
         else:
             if tx_sudo.state in ('cancel', 'error'):
                 tx_sudo.token_id.active = False  # The initial payment failed, archive the token
-            return werkzeug.utils.redirect('/payment/status')
+            return request.redirect('/payment/status')
 
     @http.route(
         [_directlink_return_url] + _backward_compatibility_urls, type='http', auth='public',
@@ -124,7 +124,7 @@ class OgoneController(http.Controller):
         tx_sudo = request.env['payment.transaction'].sudo()._handle_feedback_data('ogone', data)
         if tx_sudo.state in ('cancel', 'error'):
             tx_sudo.token_id.active = False  # The initial payment failed, archive the token
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     def _homogenize_data(self, data):
         """ Format keys to follow an homogenized convention inspired by Ogone Directlink API.

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -4,7 +4,6 @@ import logging
 import pprint
 
 import requests
-import werkzeug
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
@@ -34,7 +33,7 @@ class PaypalController(http.Controller):
                 request.env['payment.transaction'].sudo()._handle_feedback_data('paypal', data)
             else:
                 pass  # The customer has cancelled the payment, don't do anything
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     @http.route(_notify_url, type='http', auth='public', methods=['GET', 'POST'], csrf=False)
     def paypal_ipn(self, **data):

--- a/addons/payment_payulatam/controllers/main.py
+++ b/addons/payment_payulatam/controllers/main.py
@@ -3,8 +3,6 @@
 import logging
 import pprint
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -18,4 +16,4 @@ class PayuLatamController(http.Controller):
     def payulatam_return(self, **data):
         _logger.info("entering _handle_feedback_data with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('payulatam', data)
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')

--- a/addons/payment_payumoney/controllers/main.py
+++ b/addons/payment_payumoney/controllers/main.py
@@ -3,8 +3,6 @@
 import logging
 import pprint
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -18,4 +16,4 @@ class PayUMoneyController(http.Controller):
     def payumoney_return(self, **data):
         _logger.info("entering handle_feedback_data with data:\n%s", pprint.pformat(data))
         request.env['payment.transaction'].sudo()._handle_feedback_data('payumoney', data)
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')

--- a/addons/payment_sips/controllers/main.py
+++ b/addons/payment_sips/controllers/main.py
@@ -4,8 +4,6 @@
 import logging
 import pprint
 
-import werkzeug
-
 from odoo import http
 from odoo.exceptions import ValidationError
 from odoo.http import request
@@ -32,7 +30,7 @@ class SipsController(http.Controller):
                 request.env['payment.transaction'].sudo()._handle_feedback_data('sips', post)
         except ValidationError:
             pass
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     @http.route(_notify_url, type='http', auth='public', methods=['POST'], csrf=False)
     def sips_ipn(self, **post):

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -45,7 +45,7 @@ class StripeController(http.Controller):
         request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
 
         # Redirect the user to the status page
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     @http.route(_validation_return_url, type='http', auth='public', csrf=False)
     def stripe_return_from_validation(self, **data):
@@ -71,7 +71,7 @@ class StripeController(http.Controller):
         request.env['payment.transaction'].sudo()._handle_feedback_data('stripe', data)
 
         # Redirect the user to the status page
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')
 
     @http.route('/payment/stripe/webhook', type='json', auth='public')
     def stripe_webhook(self):

--- a/addons/payment_transfer/controllers/main.py
+++ b/addons/payment_transfer/controllers/main.py
@@ -3,8 +3,6 @@
 import logging
 import pprint
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -18,4 +16,4 @@ class TransferController(http.Controller):
     def transfer_form_feedback(self, **post):
         _logger.info("beginning _handle_feedback_data with post data %s", pprint.pformat(post))
         request.env['payment.transaction'].sudo()._handle_feedback_data('transfer', post)
-        return werkzeug.utils.redirect('/payment/status')
+        return request.redirect('/payment/status')

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-import werkzeug.utils
 
 from odoo import http
 from odoo.http import request
@@ -49,7 +48,7 @@ class PosController(http.Controller):
             pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
 
         if not pos_session:
-            return werkzeug.utils.redirect('/web#action=point_of_sale.action_client_pos_menu')
+            return request.redirect('/web#action=point_of_sale.action_client_pos_menu')
         # The POS only work in one company, so we enforce the one of the session in the context
         session_info = request.env['ir.http'].session_info()
         session_info['user_context']['allowed_company_ids'] = pos_session.company_id.ids

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
 from werkzeug import urls
 from werkzeug.exceptions import NotFound, Forbidden
 
@@ -241,5 +240,5 @@ class MailController(main.MailController):
                             url_params = url.decode_query()
                             url_params.update([("pid", pid), ("hash", hash)])
                             url = url.replace(query=urls.url_encode(url_params)).to_url()
-                        return werkzeug.utils.redirect(url)
+                        return request.redirect(url)
         return super(MailController, cls)._redirect_to_record(model, res_id, access_token=access_token)

--- a/addons/portal/controllers/web.py
+++ b/addons/portal/controllers/web.py
@@ -11,7 +11,7 @@ class Home(main.Home):
     @http.route()
     def index(self, *args, **kw):
         if request.session.uid and not request.env['res.users'].sudo().browse(request.session.uid).has_group('base.group_user'):
-            return http.local_redirect('/my', query=request.params, keep_hash=True)
+            return request.redirect_query('/my', query=request.params)
         return super(Home, self).index(*args, **kw)
 
     def _login_redirect(self, uid, redirect=None):
@@ -22,5 +22,5 @@ class Home(main.Home):
     @http.route('/web', type='http', auth="none")
     def web_client(self, s_action=None, **kw):
         if request.session.uid and not request.env['res.users'].sudo().browse(request.session.uid).has_group('base.group_user'):
-            return http.local_redirect('/my', query=request.params, keep_hash=True)
+            return request.redirect_query('/my', query=request.params)
         return super(Home, self).web_client(s_action, **kw)

--- a/addons/sale/tests/test_access_rights.py
+++ b/addons/sale/tests/test_access_rights.py
@@ -141,7 +141,7 @@ class TestAccessRightsControllers(HttpCase):
             url='/my/orders/%s?report_type=pdf' % portal_so.id,
             allow_redirects=False,
         )
-        self.assertEqual(req.status_code, 302)
+        self.assertEqual(req.status_code, 303)
 
         # or with a random token
         req = self.url_open(
@@ -151,7 +151,7 @@ class TestAccessRightsControllers(HttpCase):
             ),
             allow_redirects=False,
         )
-        self.assertEqual(req.status_code, 302)
+        self.assertEqual(req.status_code, 303)
 
         # but works fine with the right token
         req = self.url_open(
@@ -177,4 +177,4 @@ class TestAccessRightsControllers(HttpCase):
             url='/my/orders/%s?report_type=pdf' % private_so.id,
             allow_redirects=False,
         )
-        self.assertEqual(req.status_code, 302)
+        self.assertEqual(req.status_code, 303)

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -141,7 +141,7 @@ class Survey(http.Controller):
         elif error_key == 'answer_deadline' and answer_sudo.access_token:
             return request.render("survey.survey_closed_expired", {'survey': survey_sudo})
 
-        return werkzeug.utils.redirect("/")
+        return request.redirect("/")
 
     # ------------------------------------------------------------
     # TEST / RETRY SURVEY ROUTES
@@ -155,7 +155,7 @@ class Survey(http.Controller):
         try:
             answer_sudo = survey_sudo._create_answer(user=request.env.user, test_entry=True)
         except:
-            return werkzeug.utils.redirect('/')
+            return request.redirect('/')
         return request.redirect('/survey/start/%s?%s' % (survey_sudo.access_token, keep_query('*', answer_token=answer_sudo.access_token)))
 
     @http.route('/survey/retry/<string:survey_token>/<string:answer_token>', type='http', auth='public', website=True)
@@ -169,7 +169,7 @@ class Survey(http.Controller):
         survey_sudo, answer_sudo = access_data['survey_sudo'], access_data['answer_sudo']
         if not answer_sudo:
             # attempts to 'retry' without having tried first
-            return werkzeug.utils.redirect("/")
+            return request.redirect("/")
 
         try:
             retry_answer_sudo = survey_sudo._create_answer(
@@ -181,7 +181,7 @@ class Survey(http.Controller):
                 **self._prepare_retry_additional_values(answer_sudo)
             )
         except:
-            return werkzeug.utils.redirect("/")
+            return request.redirect("/")
         return request.redirect('/survey/start/%s?%s' % (survey_sudo.access_token, keep_query('*', answer_token=retry_answer_sudo.access_token)))
 
     def _prepare_retry_additional_values(self, answer):
@@ -227,7 +227,7 @@ class Survey(http.Controller):
                 survey_sudo.with_user(request.env.user).check_access_rights('read')
                 survey_sudo.with_user(request.env.user).check_access_rule('read')
             except:
-                return werkzeug.utils.redirect("/")
+                return request.redirect("/")
             else:
                 return request.render("survey.survey_403_page", {'survey': survey_sudo})
 
@@ -598,7 +598,7 @@ class Survey(http.Controller):
 
         if not survey:
             # no certification found
-            return werkzeug.utils.redirect("/")
+            return request.redirect("/")
 
         succeeded_attempt = request.env['survey.user_input'].sudo().search([
             ('partner_id', '=', request.env.user.partner_id.id),

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -3,7 +3,6 @@
 
 import datetime
 import json
-import werkzeug
 
 from dateutil.relativedelta import relativedelta
 from werkzeug.exceptions import NotFound
@@ -177,9 +176,9 @@ class UserInputSession(http.Controller):
 
         survey = self._fetch_from_session_code(session_code)
         if survey and survey.session_state in ['ready', 'in_progress']:
-            return werkzeug.utils.redirect("/survey/start/%s" % survey.access_token)
+            return request.redirect("/survey/start/%s" % survey.access_token)
 
-        return werkzeug.utils.redirect("/s")
+        return request.redirect("/s")
 
     @http.route('/survey/check_session_code/<string:session_code>', type='json', auth='public', website=True)
     def survey_check_session_code(self, session_code):

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -145,12 +145,12 @@ class Http(models.AbstractModel):
             return False
 
         template = False
-        if hasattr(response, 'qcontext'):  # classic response
+        if hasattr(response, '_cached_page'):
+            website_page, template = response._cached_page, response._cached_template
+        elif hasattr(response, 'qcontext'):  # classic response
             main_object = response.qcontext.get('main_object')
             website_page = getattr(main_object, '_name', False) == 'website.page' and main_object
             template = response.qcontext.get('response_template')
-        elif hasattr(response, '_cached_page'):
-            website_page, template = response._cached_page, response._cached_template
 
         view = template and request.env['website'].get_template(template)
         if view and view.track:
@@ -276,7 +276,7 @@ class Http(models.AbstractModel):
                 path = '/' + request.lang.url_code + path
             if request.httprequest.query_string:
                 path += '?' + request.httprequest.query_string.decode('utf-8')
-            return werkzeug.utils.redirect(path, code=301)
+            return request.redirect(path, code=301)
 
         if page:
             # prefetch all menus (it will prefetch website.page too)
@@ -297,7 +297,7 @@ class Http(models.AbstractModel):
                 try:
                     r = page._get_cache_response(cache_key)
                     if r['time'] + page.cache_time > time.time():
-                        response = werkzeug.Response(r['content'], mimetype=r['contenttype'])
+                        response = odoo.http.Response(r['content'], mimetype=r['contenttype'])
                         response._cached_template = r['template']
                         response._cached_page = page
                         return response

--- a/addons/website/tests/test_crawl.py
+++ b/addons/website/tests/test_crawl.py
@@ -54,7 +54,7 @@ class Crawler(HttpCaseWithUserDemo):
 
         _logger.info("%s %s", msg, url)
         r = self.url_open(url, allow_redirects=False)
-        if r.status_code in (301, 302):
+        if r.status_code in (301, 302, 303):
             # check local redirect to avoid fetch externals pages
             new_url = r.headers.get('Location')
             current_url = r.url

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -97,7 +97,7 @@ def MockRequest(
             referrer='',
         ),
         lang=env['res.lang']._lang_get(lang_code),
-        redirect=werkzeug.utils.redirect,
+        redirect=env['ir.http']._redirect,
         session=DotDict(
             geoip={'country_code': country_code},
             debug=False,

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -161,7 +161,7 @@ class WebsiteBlog(http.Controller):
         blogs = Blog.search(request.website.website_domain(), order="create_date asc, id asc")
 
         if not blog and len(blogs) == 1:
-            return werkzeug.utils.redirect('/blog/%s' % slug(blogs[0]), code=302)
+            return request.redirect('/blog/%s' % slug(blogs[0]), code=302)
 
         date_begin, date_end, state = opt.get('date_begin'), opt.get('date_end'), opt.get('state')
 
@@ -289,7 +289,7 @@ class WebsiteBlog(http.Controller):
             'blog_id': blog_id,
             'is_published': False,
         })
-        return werkzeug.utils.redirect("/blog/%s/%s?enable_editor=1" % (slug(new_blog_post.blog_id), slug(new_blog_post)))
+        return request.redirect("/blog/%s/%s?enable_editor=1" % (slug(new_blog_post.blog_id), slug(new_blog_post)))
 
     @http.route('/blog/post_duplicate', type='http', auth="user", website=True, methods=['POST'])
     def blog_post_copy(self, blog_post_id, **post):
@@ -300,4 +300,4 @@ class WebsiteBlog(http.Controller):
         :return redirect to the new blog created
         """
         new_blog_post = request.env['blog.post'].with_context(mail_create_nosubscribe=True).browse(int(blog_post_id)).copy()
-        return werkzeug.utils.redirect("/blog/%s/%s?enable_editor=1" % (slug(new_blog_post.blog_id), slug(new_blog_post)))
+        return request.redirect("/blog/%s/%s?enable_editor=1" % (slug(new_blog_post.blog_id), slug(new_blog_post)))

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -3,7 +3,6 @@
 
 import logging
 from werkzeug.exceptions import Forbidden, NotFound
-from werkzeug.utils import redirect
 
 from odoo import exceptions, http
 from odoo.http import request
@@ -103,7 +102,7 @@ class WebsiteEventMeetController(EventCommunityController):
         })
         _logger.info("New meeting room (%s) created by %s (uid %s)" % (name, request.httprequest.remote_addr, request.env.uid))
 
-        return redirect(f"/event/{slug(event)}/meeting_room/{slug(meeting_room)}")
+        return request.redirect(f"/event/{slug(event)}/meeting_room/{slug(meeting_room)}")
 
     @http.route(["/event/active_langs"], type="json", auth="public")
     def active_langs(self):

--- a/addons/website_links/controller/main.py
+++ b/addons/website_links/controller/main.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -38,4 +36,4 @@ class WebsiteUrl(http.Controller):
         if code:
             return request.render("website_links.graphs", code.link_id.read()[0])
         else:
-            return werkzeug.utils.redirect('/', 301)
+            return request.redirect('/', code=301)

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -166,9 +166,9 @@ class WebsiteProfile(http.Controller):
         whitelisted_values = {key: values[key] for key in user.SELF_WRITEABLE_FIELDS if key in values}
         user.write(whitelisted_values)
         if kwargs.get('url_param'):
-            return werkzeug.utils.redirect("/profile/user/%d?%s" % (user.id, kwargs['url_param']))
+            return request.redirect("/profile/user/%d?%s" % (user.id, kwargs['url_param']))
         else:
-            return werkzeug.utils.redirect("/profile/user/%d" % user.id)
+            return request.redirect("/profile/user/%d" % user.id)
 
     # Ranks and Badges
     # ---------------------------------------------------

--- a/addons/website_sale_digital/controllers/main.py
+++ b/addons/website_sale_digital/controllers/main.py
@@ -5,7 +5,6 @@ import base64
 import io
 import os
 import mimetypes
-from werkzeug.utils import redirect
 
 from odoo import http
 from odoo.http import request
@@ -66,7 +65,7 @@ class WebsiteSaleDigital(CustomerPortal):
         if attachment:
             attachment = attachment[0]
         else:
-            return redirect(self.orders_page)
+            return request.redirect(self.orders_page)
 
         # Check if the user has bought the associated product
         res_model = attachment['res_model']
@@ -75,21 +74,21 @@ class WebsiteSaleDigital(CustomerPortal):
 
         if res_model == 'product.product':
             if res_id not in purchased_products:
-                return redirect(self.orders_page)
+                return request.redirect(self.orders_page)
 
         # Also check for attachments in the product templates
         elif res_model == 'product.template':
             template_ids = request.env['product.product'].sudo().browse(purchased_products).mapped('product_tmpl_id').ids
             if res_id not in template_ids:
-                return redirect(self.orders_page)
+                return request.redirect(self.orders_page)
 
         else:
-            return redirect(self.orders_page)
+            return request.redirect(self.orders_page)
 
         # The client has bought the product, otherwise it would have been blocked by now
         if attachment["type"] == "url":
             if attachment["url"]:
-                return redirect(attachment["url"])
+                return request.redirect(attachment["url"])
             else:
                 return request.not_found()
         elif attachment["datas"]:

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -600,7 +600,7 @@ class WebsiteSlides(WebsiteProfile):
     @http.route('/slides/channel/add', type='http', auth='user', methods=['POST'], website=True)
     def slide_channel_create(self, *args, **kw):
         channel = request.env['slide.channel'].create(self._slide_channel_prepare_values(**kw))
-        return werkzeug.utils.redirect("/slides/%s" % (slug(channel)))
+        return request.redirect("/slides/%s" % (slug(channel)))
 
     def _slide_channel_prepare_values(self, **kw):
         # `tag_ids` is a string representing a list of int with coma. i.e.: '2,5,7'
@@ -624,7 +624,7 @@ class WebsiteSlides(WebsiteProfile):
         if not request.website.is_public_user():
             channel = request.env['slide.channel'].browse(int(channel_id))
             channel.action_add_member()
-        return werkzeug.utils.redirect("/slides/%s" % (slug(channel)))
+        return request.redirect("/slides/%s" % (slug(channel)))
 
     @http.route(['/slides/channel/join'], type='json', auth='public', website=True)
     def slide_channel_join(self, channel_id):
@@ -795,7 +795,7 @@ class WebsiteSlides(WebsiteProfile):
         next_slide = None
         if next_slide_id:
             next_slide = self._fetch_slide(next_slide_id).get('slide', None)
-        return werkzeug.utils.redirect("/slides/slide/%s" % (slug(next_slide) if next_slide else slug(slide)))
+        return request.redirect("/slides/slide/%s" % (slug(next_slide) if next_slide else slug(slide)))
 
     @http.route('/slides/slide/set_completed', website=True, type="json", auth="public")
     def slide_set_completed(self, slide_id):
@@ -1041,7 +1041,7 @@ class WebsiteSlides(WebsiteProfile):
 
         request.env['slide.slide'].create(self._get_new_slide_category_values(channel, name))
 
-        return werkzeug.utils.redirect("/slides/%s" % (slug(channel)))
+        return request.redirect("/slides/%s" % (slug(channel)))
 
     # --------------------------------------------------
     # SLIDE.UPLOAD

--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -27,7 +27,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
         certification_url = slide._generate_certification_url().get(slide.id)
         if not certification_url:
             raise werkzeug.exceptions.NotFound()
-        return werkzeug.utils.redirect(certification_url)
+        return request.redirect(certification_url)
 
     @http.route(['/slides_survey/certification/search_read'], type='json', auth='user', methods=['POST'], website=True)
     def slides_certification_search_read(self, fields):


### PR DESCRIPTION
This branche replace werkeug.utils.redirect into odoo.http.redirect.

odoo.http.redirect now use an http.Response type, and it become easy
to add an override like 'set_cookies' e.g.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
