### PR TITLE
[FIX] purchase_mrp: fix received qty of PO with product with archived…

### DIFF
--- a/addons/purchase_mrp/models/purchase_mrp.py
+++ b/addons/purchase_mrp/models/purchase_mrp.py
@@ -17,7 +17,7 @@ class PurchaseOrderLine(models.Model):
     def _compute_qty_received(self):
         kit_lines = self.env['purchase.order.line']
         for line in self:
-            if line.qty_received_method == 'stock_moves' and line.move_ids:
+            if line.qty_received_method == 'stock_moves' and line.move_ids.filtered(lambda m: m.bom_line_id):
                 kit_bom = self.env['mrp.bom']._bom_find(product=line.product_id, company_id=line.company_id.id, bom_type='phantom')
                 if kit_bom:
                     moves = line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)


### PR DESCRIPTION
… kit BoM

- Create a storable product (i.e. Kit A)
- Configure its product category as followed:
  * Costing Method: AVCO
  * Inventory Valuation: Automated
- Create a BoM of Kit type with any component for Kit A
- Archive the created BoM
- Create a PO with Kit A (make sure its unit price is not 0.00)
- Receive product
The received field on the PO line for Kit A is not updated.

It comes from the method computing the received quantity.
It takes into account the kit BoM for its computation even if it is archived.

opw-2492782

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
