### PR TITLE
[FIX] mrp_account: fix reference to a deleted bom line

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -52,9 +52,13 @@ class ProductProduct(models.Model):
         value = 0
         for move in stock_moves:
             bom_line = move.bom_line_id
-            bom_line_data = bom_lines[bom_line]
-            bom_line_qty = bom_line_data['qty']
-            value += bom_line_qty * move.product_id._compute_average_price(qty_invoiced * bom_line_qty, qty_to_invoice * bom_line_qty, move)
+            if bom_line:
+                bom_line_data = bom_lines[bom_line]
+                line_qty = bom_line_data['qty']
+            else:
+                # bom was altered (i.e. bom line removed) after being used
+                line_qty = move.product_qty
+            value += line_qty * move.product_id._compute_average_price(qty_invoiced * line_qty, qty_to_invoice * line_qty, move)
         return value
 
     def _compute_bom_price(self, bom, boms_to_recompute=False):


### PR DESCRIPTION
- Enable Margin analysis
- Have a product [TEST] in a category with
  - FIFO and Automated Valuation.
  - Kit BOM with 3 items (A,B,C)
- Create a SO with [TEST] and confirm.
- Modify the BOM and remove C from the kit.
- Back to the SO, cancel it.

Traceback will show, because there no more a bom_line associated with
the move

opw-2541674

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
