### PR TITLE
[FIX] point_of_sale: Scanning Barcode EAN-13 with price

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2991,14 +2991,14 @@ exports.Order = Backbone.Model.extend({
             line.set_quantity(options.quantity);
         }
 
-        if(options.price !== undefined){
-            line.set_unit_price(options.price);
-            this.fix_tax_included_price(line);
-        }
-
         if (options.price_extra !== undefined){
             line.price_extra = options.price_extra;
             line.set_unit_price(line.product.get_price(this.pricelist, line.get_quantity(), options.price_extra));
+            this.fix_tax_included_price(line);
+        }
+
+        if(options.price !== undefined){
+            line.set_unit_price(options.price);
             this.fix_tax_included_price(line);
         }
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P with sale price = 0€
- P is available in the POS
- Set a barcode to P, 2312345000002 (meaning price = 0€ with check digit = 2)
- Open a session in the POS and scan 2312345003003 (meaning price = 3€ with check digit = 3)

Bug:

A line was added with P but its price was 0€ instead of 3€

PS: Function _getAddProductOptions always sets price_extra to 0€

opw:2566502