### PR TITLE
[FIX] web: fix error when getting image URL with default id

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record.js
@@ -172,8 +172,8 @@ var KanbanRecord = Widget.extend({
      * @returns {string} the url of the image
      */
     _getImageURL: function (model, field, id, placeholder) {
-        id = (_.isArray(id) ? id[0] : id) || false;
-        var isCurrentRecord = this.modelName === model && this.recordData.id === id;
+        id = (_.isArray(id) ? id[0] : id) || null;
+        var isCurrentRecord = this.modelName === model && (this.recordData.id === id || (!this.recordData.id && !id));
         var url;
         if (isCurrentRecord && this.record[field] && this.record[field].raw_value && !utils.is_bin_size(this.record[field].raw_value)) {
             // Use magic-word technique for detecting image type

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -6392,6 +6392,41 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test("test displaying image from m2o field (m2o field not set)", async function (assert) {
+        assert.expect(2);
+        this.data.foo_partner = {
+            fields: {
+                name: {string: "Foo Name", type: "char"},
+                partner_id: {string: "Partner", type: "many2one", relation: "partner"},
+            },
+            records: [
+                {id: 1, name: 'foo_with_partner_image', partner_id: 1},
+                {id: 2, name: 'foo_no_partner'},
+            ]
+        };
+
+        const kanban = await createView({
+            View: KanbanView,
+            model: "foo_partner",
+            data: this.data,
+            arch: `
+                <kanban>
+                    <templates>
+                        <div t-name="kanban-box">
+                            <field name="name"/>
+                            <field name="partner_id"/>
+                            <img t-att-src="kanban_image('partner', 'image', record.partner_id.raw_value)"/>
+                        </div>
+                    </templates>
+                </kanban>`,
+        });
+
+        assert.containsOnce(kanban, 'img[data-src*="/web/image"][data-src$="&id=1"]', "image url should contain id of set partner_id");
+        assert.containsOnce(kanban, 'img[data-src*="/web/image"][data-src$="&id="]', "image url should contain an empty id if partner_id is not set");
+
+        kanban.destroy();
+    });
+
     QUnit.test('check if the view destroys all widgets and instances', async function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
Linked to commit: https://github.com/odoo/odoo/commit/7eac23573c77415c84cb9c234c8063d4c68be425

Using false as default value instead of null will lead to the following
error if we try to get image URL of a record that is not the current one
and if no placeholder is available:
ValueError: invalid literal for int() with base 10: 'false'

opw-2516188

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
