### PR TITLE
[FIX] mail: don't bypass model method

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -553,14 +553,21 @@ class ModelManager {
         const records = [];
         for (const data of dataList) {
             /**
-             * 1. Ensure the record can be created: localId must be unique.
+             * 1. Prepare record data.
+             *
+             * '_prepareData' hook can be used to prepare some needed data and
+             * to avoid the override of model methods such as create.
+             */
+            Model._prepareData(data);
+            /**
+             * 2. Ensure the record can be created: localId must be unique.
              */
             const localId = Model._createRecordLocalId(data);
             if (Model.get(localId)) {
                 throw Error(`A record already exists for model "${Model.modelName}" with localId "${localId}".`);
             }
             /**
-             * 2. Prepare record state. Assign various keys and values that are
+             * 3. Prepare record state. Assign various keys and values that are
              * expected to be found on every record.
              */
             const record = new Model({ valid: true });
@@ -583,14 +590,14 @@ class ModelManager {
                 }
             }
             /**
-             * 3. Register record and invoke the life-cycle hook `_willCreate.`
+             * 4. Register record and invoke the life-cycle hook `_willCreate.`
              * After this step the record is in a functioning state and it is
              * considered existing.
              */
             Model.__records[record.localId] = record;
             record._willCreate();
             /**
-             * 4. Write provided data, default data, and register computes.
+             * 5. Write provided data, default data, and register computes.
              */
             const data2 = {};
             for (const field of Model.__fieldList) {
@@ -607,7 +614,7 @@ class ModelManager {
             }
             this._update(record, data2);
             /**
-             * 5. Register post processing operation that are to be delayed at
+             * 6. Register post processing operation that are to be delayed at
              * the end of the update cycle.
              */
             this._createdRecords.add(record);

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -51,20 +51,6 @@ function factory(dependencies) {
         }
 
         /**
-         * @override
-         */
-        static create(data) {
-            const isMulti = typeof data[Symbol.iterator] === 'function';
-            const dataList = isMulti ? data : [data];
-            for (const data of dataList) {
-                if (!data.id) {
-                    data.id = getAttachmentNextTemporaryId();
-                }
-            }
-            return super.create(...arguments);
-        }
-
-        /**
          * View provided attachment(s), with given attachment initially. Prompts
          * the attachment viewer.
          *
@@ -126,6 +112,17 @@ function factory(dependencies) {
          */
         static _createRecordLocalId(data) {
             return `${this.modelName}_${data.id}`;
+        }
+
+        /**
+         * @private
+         * @override
+         * @param {Object|Object[]} data
+         */
+        static _prepareData(data) {
+            if (!data.id) {
+                data.id = getAttachmentNextTemporaryId();
+            }
         }
 
         /**

--- a/addons/mail/static/src/models/model/model.js
+++ b/addons/mail/static/src/models/model/model.js
@@ -233,6 +233,19 @@ function factory() {
         }
 
         /**
+         * This function is called during the create cycle
+         *
+         * The main use case is to prepare the record for the assignation of its
+         * values, for example if a computed field relies on the record to have
+         * some purely technical property correctly set.
+         *
+         * @abstract
+         * @private
+         * @param {Object|Object[]} data
+         */
+        static _prepareData(data) {}
+
+        /**
          * This function is called when this record has been explicitly updated
          * with `.update()` or static method `.create()`, at the end of an
          * record update cycle. This is a backward-compatible behaviour that


### PR DESCRIPTION
PURPOSE:

Some models may specifically override some methods (eg. create in attachment),
which may lead to unexpected behavior.
For example, a create override is currently not called when doing insert because
of how field command is calling _create from model manager directly.

SPECIFICATIONS:

do not override the model method. instead, use the hook.

LINKS:

Task- 2492959

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
