### PR TITLE
[FIX] mrp: Delivered quantity with kit

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -402,7 +402,7 @@ class StockMove(models.Model):
                 outgoing_moves = bom_line_moves.filtered(filters['outgoing_moves'])
                 qty_processed = sum(incoming_moves.mapped('product_qty')) - sum(outgoing_moves.mapped('product_qty'))
                 # We compute a ratio to know how many kits we can produce with this quantity of that specific component
-                qty_ratios.append(qty_processed / qty_per_kit)
+                qty_ratios.append(float_round(qty_processed / qty_per_kit, precision_rounding=bom_line.product_id.uom_id.rounding))
             else:
                 return 0.0
         if qty_ratios:


### PR DESCRIPTION
Steps to reproduce the bug:
Create 2 product (Finish product , RM product)
Create 1 Kit BOM for Finish product with 1 Component(RM Product) and quantity : 0.0860
Create SO for 10 Finish product and confirm SO
Deliver RM product : Quantity : 0.86 ( as per define ratio in BOM) -> validate

Bug:

Delivery quantity on SO line shows : 9 instead of 10

opw:2540671