### PR TITLE
[FIX] payment: accept invoice ids in payment links

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -5,6 +5,7 @@ import werkzeug
 
 from odoo import _, http
 from odoo.exceptions import UserError, ValidationError
+from odoo.fields import Command
 from odoo.http import request
 
 from odoo.addons.payment import utils as payment_utils
@@ -41,7 +42,7 @@ class PaymentPortal(portal.CustomerPortal):
     )
     def payment_pay(
         self, reference=None, amount=None, currency_id=None, partner_id=None, company_id=None,
-        acquirer_id=None, access_token=None, **kwargs
+        acquirer_id=None, access_token=None, invoice_id=None, **kwargs
     ):
         """ Display the payment form with optional filtering of payment options.
 
@@ -62,14 +63,15 @@ class PaymentPortal(portal.CustomerPortal):
         :param str company_id: The related company, as a `res.company` id
         :param str acquirer_id: The desired acquirer, as a `payment.acquirer` id
         :param str access_token: The access token used to authenticate the partner
+        :param str invoice_id: The account move for which a payment id made, as a `account.move` id
         :param dict kwargs: Optional data. This parameter is not used here
         :return: The rendered checkout form
         :rtype: str
         :raise: werkzeug.exceptions.NotFound if the access token is invalid
         """
         # Cast numeric parameters as int or float and void them if their str value is malformed
-        currency_id, acquirer_id, partner_id, company_id = tuple(map(
-            self.cast_as_int, (currency_id, acquirer_id, partner_id, company_id)
+        currency_id, acquirer_id, partner_id, company_id, invoice_id = tuple(map(
+            self.cast_as_int, (currency_id, acquirer_id, partner_id, company_id, invoice_id)
         ))
         amount = self.cast_as_float(amount)
 
@@ -140,6 +142,7 @@ class PaymentPortal(portal.CustomerPortal):
             'transaction_route': '/payment/transaction',
             'landing_route': '/payment/confirmation',
             'partner_is_different': partner_is_different,
+            'invoice_id': invoice_id,
             **self._get_custom_rendering_context_values(**kwargs),
         }
         return request.render('payment.pay', rendering_context)
@@ -222,7 +225,8 @@ class PaymentPortal(portal.CustomerPortal):
 
     def _create_transaction(
         self, payment_option_id, reference_prefix, amount, currency_id, partner_id, flow,
-        tokenization_requested, validation_route, landing_route, custom_create_values=None, **kwargs
+        tokenization_requested, validation_route, landing_route, invoice_id=None,
+        custom_create_values=None, **kwargs
     ):
         """ Create a draft transaction based on the payment context and return it.
 
@@ -239,6 +243,7 @@ class PaymentPortal(portal.CustomerPortal):
         :param str validation_route: The route the user is redirected to in order to refund a
                                      validation transaction
         :param str landing_route: The route the user is redirected to after the transaction
+        :param int|None invoice_id: The account move for which a payment id made, as a `account.move` id
         :param dict custom_create_values: Additional create values overwriting the default ones
         :param dict kwargs: Locally unused data passed to `_is_tokenization_required` and
                             `_compute_reference`
@@ -270,6 +275,12 @@ class PaymentPortal(portal.CustomerPortal):
             raise UserError(
                 _("The payment should either be direct, with redirection, or made by a token.")
             )
+
+        if invoice_id:
+            if custom_create_values is None:
+                custom_create_values = {}
+            custom_create_values['invoice_ids'] = [Command.set([int(invoice_id)])]
+
         reference = request.env['payment.transaction']._compute_reference(
             acquirer_sudo.provider,
             prefix=reference_prefix,

--- a/addons/payment/static/src/js/payment_form_mixin.js
+++ b/addons/payment/static/src/js/payment_form_mixin.js
@@ -297,6 +297,8 @@ odoo.define('payment.payment_form_mixin', require => {
                 'currency_id': this.txContext.currencyId
                     ? parseInt(this.txContext.currencyId) : null,
                 'partner_id': parseInt(this.txContext.partnerId),
+                'invoice_id': this.txContext.invoiceId
+                    ? parseInt(this.txContext.invoiceId) : null,
                 'flow': flow,
                 'tokenization_requested': this.txContext.tokenizationRequested,
                 'validation_route': this.txContext.validationRoute

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -17,6 +17,7 @@
             - 'transaction_route' - The route used to create a transaction when the user clicks Pay
             - 'landing_route' - The route the user is redirected to after the transaction
             - 'footer_template_id' - The template id for the submit button. Optional
+            - 'invoice_id' - The id of the account move being paid. Optional
         -->
         <form name="o_payment_checkout"
               class="o_payment_form mt-3 clearfix"
@@ -27,7 +28,8 @@
               t-att-data-access-token="access_token"
               t-att-data-transaction-route="transaction_route"
               t-att-data-landing-route="landing_route"
-              t-att-data-allow-token-selection="True">
+              t-att-data-allow-token-selection="True"
+              t-att-data-invoice-id="invoice_id">
 
             <t t-set="acquirer_count" t-value="len(acquirers) if acquirers else 0"/>
             <t t-set="token_count" t-value="len(tokens) if tokens else 0"/>
@@ -166,6 +168,7 @@
               t-att-data-reference-prefix="reference_prefix"
               t-att-data-partner-id="partner_id"
               t-att-data-access-token="access_token"
+              t-att-data-invoice-id="invoice_id"
               t-att-data-transaction-route="transaction_route"
               t-att-data-assign-token-route="assign_token_route"
               t-att-data-validation-route="validation_route"

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -75,4 +75,5 @@ class PaymentLinkWizard(models.TransientModel):
                    f'&currency_id={payment_link.currency_id.id}' \
                    f'&partner_id={payment_link.partner_id.id}' \
                    f'&company_id={payment_link.company_id.id}' \
+                   f'&invoice_id={payment_link.res_id}' \
                    f'&access_token={payment_link.access_token}'


### PR DESCRIPTION
This commit brings back the possibility to pass invoice ids in payment
links, a feature that was lost with commit 573ed74c. If such an id is
present in the payment link URL, the transaction that is created must
have a reference starting with the name of the invoice, and must be
linked to it.

task-2494916