### PR TITLE
[FIX] web_editor: fix shape option for non-supported images

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -326,6 +326,14 @@ async function loadImageInfo(img, rpc, attachmentSrc = '') {
     }
 }
 
+/**
+ * @param {String} mimetype
+ * @returns {Boolean}
+ */
+function isImageSupportedForProcessing(mimetype) {
+    return ['image/jpeg', 'image/png'].includes(mimetype);
+}
+
 return {
     applyModifications,
     cropperDataFields,
@@ -333,5 +341,6 @@ return {
     loadImageInfo,
     loadImage,
     removeOnImageChangeAttrs: [...cropperDataFields, ...modifierFields, 'aspectRatio'],
+    isImageSupportedForProcessing,
 };
 });


### PR DESCRIPTION
Issues:

[ 1 ]
- Edit mode > Set a shape on Image
- Replace it by a GIF > GIF is not animated in the shape.
- Remove the shape > the GIF is still not animated (converted and saved
  as base64).

[ 2 ]
- [1] Edit mode > Set a shape on image (mimetype = 'image/jpeg')
- [2] Replace it by an animated GIF.
- [3] Replace the .GIF image again by the old one.
- The shape is not applied on it.

The goal of this PR is to fix all issues related to wrong mimetype
values / incoherent dataset by adding the `_isImageMimetypeSupported()`
method to check if image format is supported and set shape accordingly.

IMPORTANT: after this PR, the right mimetype value for GIF images
is passed and shapes cannot be applied on them > useless shape data will be
removed from non-supported images.

task-2578242