### PR TITLE
[FIX] web: change pivot dropdown submenu

### DIFF
--- a/addons/web/static/src/legacy/js/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/legacy/js/views/pivot/pivot_renderer.js
@@ -57,6 +57,7 @@
         constructor() {
             super(...arguments);
             this.intervalOptions = INTERVAL_OPTIONS;
+            this.openedSubMenus = {};
         }
 
         //---------------------------------------------------------------------
@@ -89,6 +90,11 @@
         */
         _onClickMenuGroupBy(fieldName, interval) {
             this.trigger('groupby-menu-selection', { fieldName, interval });
+        }
+
+        _toggleMenu(groupNumber) {
+            this.openedSubMenus[groupNumber] = !this.openedSubMenus[groupNumber];
+            this.render();
         }
     }
 

--- a/addons/web/static/src/legacy/scss/dropdown.scss
+++ b/addons/web/static/src/legacy/scss/dropdown.scss
@@ -37,3 +37,20 @@
         }
     }
 }
+
+// = Legacy submenus
+// Workaround appling owl 'vertical nested menu' design.
+// Should be removed once we'll support the 'horizontal' design.
+// ----------------------------------------------------------------------------
+.o_inline_dropdown {
+    .dropdown-menu {
+        position: relative;
+        border: 0;
+        padding-top: 0;
+        box-shadow: none;
+
+        > .dropdown-item {
+            padding-left: $dropdown-item-padding-x * 1.5;
+        }
+    }
+}

--- a/addons/web/static/src/legacy/scss/pivot_view.scss
+++ b/addons/web/static/src/legacy/scss/pivot_view.scss
@@ -100,7 +100,12 @@
         @include o-caret-right;
         position: absolute;
         right: 6px;
-        top: 9px;
+        top: 8px;
+    }
+
+    .show > .o_pivot_field_selection::after {
+        @include o-caret-down;
+        top: 10px;
     }
 
     .o_pivot_field_menu .dropdown-item.disabled {

--- a/addons/web/static/src/legacy/xml/pivot.xml
+++ b/addons/web/static/src/legacy/xml/pivot.xml
@@ -95,13 +95,13 @@
                 <t t-if="(item.fieldType === 'date') || (item.fieldType === 'datetime')">
                     <div role="menuitem" aria-haspopup="true" class="o_inline_dropdown">
                         <a href="#"
-                           t-on-click.prevent="_onClickMenuGroupBy(item.fieldName, 'month')"
-                           class="dropdown-item o_pivot_field_selection"
+                           t-on-click.prevent.stop="_toggleMenu(item.groupNumber)"
+                           class="dropdown-item o_pivot_field_selection position-relative"
                            t-att-data-field="item.fieldName"
                         >
                             <t t-esc="item.description"/>
                         </a>
-                        <div class="dropdown-menu" role="menu">
+                        <div class="dropdown-menu o_inline_dropdown" t-att-class="{ show: openedSubMenus[item.groupNumber] }" role="menu">
                             <t t-foreach="Object.values(intervalOptions)" t-as="option" t-key="option.id">
                                 <a role="menuitem"
                                     t-att-data-field="item.fieldName"

--- a/addons/web/static/tests/legacy/views/pivot_tests.js
+++ b/addons/web/static/tests/legacy/views/pivot_tests.js
@@ -625,6 +625,7 @@ QUnit.module('Views', {
             "should not have the non_stored_m2o field as proposition");
 
         await testUtils.dom.click(pivot.$('.o_pivot_field_menu .dropdown-item[data-field="date"]:first'));
+        await testUtils.dom.click(pivot.$('.o_pivot_field_menu .dropdown-item[data-field="date"][role="menuitem"]:contains(Month)'));
 
         assert.containsN(pivot, 'tbody tr', 4,
             "should have 4 rows: one for header, 3 for data");
@@ -1848,6 +1849,7 @@ QUnit.module('Views', {
 
         await testUtils.dom.click(pivot.el.querySelector('thead .o_pivot_header_cell_closed'));
         await testUtils.dom.click(pivot.el.querySelectorAll('.o_pivot_field_menu .dropdown-item[data-field="date"]')[0]);
+        await testUtils.dom.click(pivot.el.querySelector('.o_pivot_field_menu .dropdown-item[data-field="date"][role="menuitem"]:nth-of-type(3)'));
 
         // close and reopen row groupings after changing value
         this.data.partner.records.find(r => r.product_id === 37).date = '2016-10-27';


### PR DESCRIPTION
Since odoo/odoo@1971bf3 the customised dropdown in the pivot view (the one that opens its submenus horizontally) cannot open at all its submenus.

As the correct behaviour cannot be restored without reintroducing the +300 scss lines that has been removed, this commit applies a temporary fix that *changes* the design of this dropdown. Now, its submenus will open vertically, like for the groupby menu near the search bar.

The final dropdowns design is currently ongoing within the taskid: 2578926

Co-authored-by: Stefano Rigano <sri@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
