### PR TITLE
[FIX] sale_timesheet: fix wrong join condition

### DIFF
--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -181,8 +181,7 @@ class ProfitabilityAnalysis(models.Model):
                                     AND NOT EXISTS (
                                         SELECT SOL.id
                                         FROM sale_order_line SOL
-                                        JOIN sale_order_line_invoice_rel SOINV ON SOINV.order_line_id = SOL.id
-                                        JOIN account_move_line AML ON SOINV.invoice_line_id = AAL.move_id
+                                        JOIN sale_order_line_invoice_rel SOINV ON SOINV.order_line_id = SOL.id AND SOINV.invoice_line_id = AAL.move_id -- AAL.move_id is an account.move.line id
                                         WHERE SOL.qty_delivered_method IN ('timesheet', 'manual')
                                             OR (SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no')
                                     )


### PR DESCRIPTION
Prior to this commit, the account move line was not correctly joined,
and put in relation with SOL. Furthermore, this table isn't use.

In this commit we correctly join the subquery, in this subquery,
we just try to avoid to take into account amounts that are related
to invoiced sale order lines.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
