### PR TITLE
[FIX] core: have HttpCase automatically set `web.base.url`

### DIFF
--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -11,7 +11,7 @@ from odoo.tests import HttpCase
 from odoo.addons.payment.tests.utils import PaymentTestUtils
 
 
-class PaymentHttpCommon(HttpCase, PaymentTestUtils):
+class PaymentHttpCommon(PaymentTestUtils, HttpCase):
     """ HttpCase common to build and simulate requests going through payment controllers.
 
     Only use if you effectively want to test controllers.


### PR DESCRIPTION
While HttpCase did set `web.base.url` before starting a browser, in
the non-browser test cases (or cases which would mix browser and
non-browser) it would not do so.

This is an issue when installing the database with one http-port and
running tests with an other e.g. after duplicating the database (or
even not duplicating it) in order to run multiple test instances
concurrently, which requires using different http ports.

Tests would then see the base url generated during installation,
embedding the port used at installation, and would break weirdly (at
best exploding due to not finding any server to bind to, and at worst
making request on the wrong instance entirely). Simply updating the
base url during setup seems to fix most of the tests.

`payment` needed a fix because the vagaries of the MRO led to the
extra parameter internally used by the thing to be passed to
`HttpCase`'s `setUpClass`, which would not expect it.

Issue 2580388