### PR TITLE
[FIX][master] display menu "Moves" in product.product tree view

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -380,6 +380,8 @@
         <record id="act_product_stock_move_open" model="ir.actions.act_window">
             <field name="context">{'search_default_product_id': active_id, 'default_product_id': active_id}</field>
             <field name="name">Moves</field>
+            <field name="binding_model_id" ref="product.model_product_product"/>
+            <field name="src_model">product.product</field>
             <field name="res_model">stock.move</field>
             <field name="view_id" ref="stock.view_move_tree"/>
         </record>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

* go to a product.product tree view (Inventory > Master Data > Product Variants)
* Select some products and click on "Action"

### Current behavior before PR:

* The "moves" button is not displayed

![image](https://user-images.githubusercontent.com/3407482/123116168-f6e30280-d440-11eb-9a37-294a4ce85c25.png)


### Desired behavior after PR is merged:

* The "moves" button is displayed

![image](https://user-images.githubusercontent.com/3407482/123117585-27776c00-d442-11eb-9e2d-e4f9973df083.png)


### Impacted version

8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, master

### Note

- this is due to Odoo refactoring introduced between the version 7.0 ([code](https://github.com/odoo/odoo/blob/7.0/addons/stock/stock_view.xml#L1571)) and the version 8.0 ([code](https://github.com/odoo/odoo/blob/8.0/addons/stock/stock_view.xml#L511)), changing syntax 
from ``<act_window id="act_product_stock_move_futur_open" />`` 
to ``<record id="act_product_stock_move_open" model="ir.actions.act_window">``

- when migrating from an old version (7.0), the bug is silent, but if we install a new database from a "new" version (from 8.0), the menu item is not displayed.

Many others menu items are missing.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
