### PR TITLE
[FIX] website: fix scrollButton option on events

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -965,9 +965,9 @@ registry.ScrollButton = registry.anchorSlide.extend({
      */
     _onAnimateClick: function (ev) {
         ev.preventDefault();
-        const $nextSection = this.$el.closest('section').next('section');
-        if ($nextSection.length) {
-            this._scrollTo($nextSection);
+        const $nextElement = this.$el.closest('section').next();
+        if ($nextElement.length) {
+            this._scrollTo($nextElement);
         }
     },
 });


### PR DESCRIPTION
On events, or in every part of the website that was built without
sections, the scroll button of a dropped snippet was not effective.

This was because we were targeting the next section, which was not there
in the previous case. Yet, we want it to scroll to the next element,
even if it is not a section.

task-2566338


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
