### PR TITLE
[FIX] sale_coupon: avoid reapplying same promotion after change

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -168,7 +168,7 @@ class SaleCouponProgram(models.Model):
             message = {'error': _('A minimum of %s %s should be purchased to get the reward') % (self.rule_minimum_amount, self.currency_id.name)}
         elif self.promo_code and self.promo_code == order.promo_code:
             message = {'error': _('The promo code is already applied on this order')}
-        elif not self.promo_code and self in order.no_code_promo_program_ids:
+        elif self in order.no_code_promo_program_ids:
             message = {'error': _('The promotional offer is already applied on this order')}
         elif not self.active:
             message = {'error': _('Promo code is invalid')}

--- a/addons/sale_coupon/tests/test_program_with_code_operations.py
+++ b/addons/sale_coupon/tests/test_program_with_code_operations.py
@@ -303,6 +303,46 @@ class TestProgramWithCodeOperations(TestSaleCouponCommon):
         order_bis.recompute_coupon_lines()
         self.assertEqual(len(order_bis.order_line), 2, "Free product from a coupon generated from a promotion program on next order should not dissapear")
 
+    def test_edit_and_reapply_promotion_program(self):
+        # The flow:
+        # 1. Create a program auto applied, giving a fixed amount discount
+        # 2. Create a SO and apply the program
+        # 3. Change the program, requiring a mandatory code
+        # 4. Reapply the program on the same SO via code
+
+        # 1.
+        self.p1 = self.env['sale.coupon.program'].create({
+            'name': 'Promo fixed amount',
+            'promo_code_usage': 'no_code_needed',
+            'discount_type': 'fixed_amount',
+            'discount_fixed_amount': 10.0,
+            'program_type': 'promotion_program',
+        })
+        # 2.
+        order = self.empty_order.copy()
+        order.write({'order_line': [
+            (0, False, {
+                'product_id': self.product_A.id,
+                'name': '1 Product A',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+            })
+        ]})
+        order.recompute_coupon_lines()
+        self.assertEqual(len(order.order_line), 2, "You should get a discount line")
+        # 3.
+        self.p1.write({
+            'promo_code_usage': 'code_needed',
+            'promo_code': 'test',
+            })
+        order.recompute_coupon_lines()
+        # 4.
+        with self.assertRaises(UserError):
+            self.env['sale.coupon.apply.code'].with_context(active_id=order.id).create({
+                'coupon_code': 'test'
+            }).process_coupon()
+        self.assertEqual(len(order.order_line), 2, "You should get a discount line")
+
 def test_on_next_order_reward_promo_program(self):
     # TODO: remove me in master, this was never executed due to bad indentation (the method is not indented under the class)
     #       note that this flow did not worked and was not implemented.. now tested with `test_on_next_order_reward_promotion_program()`


### PR DESCRIPTION
- Have a Promotion program [TEST] applied automatically, which apply a
fixed amount discount on order
- Have a Sale Order, apply test via 'promotion' button
- Edit [TEST], add a mandatory code to be used
- Back to SO, add the promotion again via 'coupon' button and insert the
code

Promotion will be applied again in the order

opw-2526950

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
