### PR TITLE
[FIX] hr_holidays: fix being able to select an invalid leave

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -250,7 +250,8 @@ class HolidaysType(models.Model):
 
     @api.model
     def get_days_all_request(self):
-        leave_types = sorted(self.search([]).filtered(lambda x: x.virtual_remaining_leaves or x.max_leaves), key=self._model_sorting_key, reverse=True)
+        leave_types = sorted(self.search([]).filtered(lambda x: ((not x.validity_stop or x.validity_stop >= fields.Date.today())
+                                                            and (x.virtual_remaining_leaves or x.max_leaves))), key=self._model_sorting_key, reverse=True)
         return [lt._get_days_request() for lt in leave_types]
 
     def _get_days_request(self):

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -90,7 +90,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id}"/>
+                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date}"/>
 
                             <field name="allocation_type" invisible="1" widget="radio"/>
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -236,7 +236,7 @@
                         <field name="employee_id" nolabel="1" readonly="1" force_save="1" invisible="1"/>
                     </h1>
                     <h2>
-                        <field name="holiday_status_id" nolabel="1" domain="['&amp;', ('virtual_remaining_leaves', '&gt;', 0), '|', ('allocation_type', 'in', ['fixed_allocation', 'no']),'&amp;',('allocation_type', '=', 'fixed'), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True}" class="w-100"/>
+                        <field name="holiday_status_id" nolabel="1" domain="[('valid', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), '|', ('allocation_type', 'in', ['fixed_allocation', 'no']),'&amp;',('allocation_type', '=', 'fixed'), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True}" class="w-100"/>
                     </h2>
                 </div>
                 <group>


### PR DESCRIPTION
Previously the domain in the view for the leave request didn't check for
the time off type validity, this fix aims to remove that possibility.
Also prevents from selecting expired time off types in allocation
requests.

Task ID: 2578150