### PR TITLE
[IMP] hr_skills: remove optional dropdown

### DIFF
--- a/addons/hr_skills/static/src/js/resume_widget.js
+++ b/addons/hr_skills/static/src/js/resume_widget.js
@@ -146,6 +146,18 @@ var AbstractGroupedOne2ManyRenderer = ListRenderer.extend({
         return $body;
     },
 
+    /**
+     * This function enables the top right menu on list views to hide/show fields or, when studio is installed,
+     *  edit the view's content.
+     * For this widget we do not want it at all.
+     *
+     * @override
+     * @private
+     * @returns {boolean}
+     */
+     _shouldRenderOptionalColumnsDropdown: function () {
+         return false;
+     }
 });
 
 var ResumeLineRenderer = AbstractGroupedOne2ManyRenderer.extend({


### PR DESCRIPTION
When studio is installed, the List view renderer will always render a
threedot menu to promote studio, but since resume and skill widget
extend that view it also gets rendered on top of the add button.

This change completely removes the optional dropdown menu from those two
widgets.

Task ID: 2578126
