### PR TITLE
[FIX] account_check_printing: wizard use vendor payment method


### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -269,23 +269,6 @@ class AccountPaymentRegister(models.TransientModel):
             else:
                 wizard.partner_bank_id = False
 
-    @api.depends('journal_id')
-    def _compute_payment_method_id(self):
-        for wizard in self:
-            batches = wizard._get_batches()
-            payment_type = batches[0]['key_values']['payment_type']
-
-            if payment_type == 'inbound':
-                available_payment_methods = wizard.journal_id.inbound_payment_method_ids
-            else:
-                available_payment_methods = wizard.journal_id.outbound_payment_method_ids
-
-            # Select the first available one by default.
-            if available_payment_methods:
-                wizard.payment_method_id = available_payment_methods[0]._origin
-            else:
-                wizard.payment_method_id = False
-
     @api.depends('payment_type',
                  'journal_id.inbound_payment_method_ids',
                  'journal_id.outbound_payment_method_ids')

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -8,6 +8,17 @@ from odoo.tools.misc import formatLang, format_date
 INV_LINES_PER_STUB = 9
 
 
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    @api.depends('payment_type', 'journal_id', 'partner_id')
+    def _compute_payment_method_id(self):
+        super()._compute_payment_method_id()
+        for record in self:
+            preferred = record.partner_id.with_company(record.company_id).property_payment_method_id
+            if record.payment_type == 'outbound' and preferred in record.journal_id.outbound_payment_method_ids:
+                record.payment_method_id = preferred
+
 class AccountPayment(models.Model):
     _inherit = "account.payment"
 


### PR DESCRIPTION

The payment method added by account_check_printing is meant as:

> Preferred payment method when paying this vendor. This is used to
> filter vendor bills by preferred payment method to register payments
> in mass. Use cases: create bank files for batch wires, check runs.

But it may also select the default payment method on an account.payment.

With this changeset, we copy what is done in account.payment to
account.payment.register so the behavior is the same for it.

opw-2508263
