### PR TITLE
[FIX] core: install new dependencies of module in 'to upgrade' state

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -421,7 +421,7 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
 
             module_names = [k for k, v in tools.config['update'].items() if v]
             if module_names:
-                modules = Module.search([('state', '=', 'installed'), ('name', 'in', module_names)])
+                modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', module_names)])
                 if modules:
                     modules.button_upgrade()
 


### PR DESCRIPTION
When a custom module is in 'to upgrade' state, and the new version has a new dependency that is not yet installed, Odoo refuses to upgrade it, and says the new dependency is unmet.

This commit fixes this by calling button_upgrade() in this situation too, so as to recursively mark all dependencies for upgrade/installation.

This situation arises in a version migration scenarios. Custom modules are in 'to upgrade' state when the database comes back from the Odoo migration service. If one of these custom modules has a new dependency after migration, it refuses to upgrade.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
