### PR TITLE
[FIX] website_sale: expand import-compatible ribbon

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -12,6 +12,7 @@ from odoo.osv import expression
 class ProductRibbon(models.Model):
     _name = "product.ribbon"
     _description = 'Product ribbon'
+    _rec_name = 'id'
 
     def name_get(self):
         return [(ribbon.id, '%s (#%d)' % (tools.html2plaintext(ribbon.html), ribbon.id)) for ribbon in self]


### PR DESCRIPTION
- Install the eCommerce app
- Go to the Sales app -> Products -> Products
- (View List ->) select (a) Product(s) -> Action -> Export
- check "I want to update data (import-compatible export)" -> click on the "Ribbon" field to expand

Cause: the export page controller tries to access an undefined field (_rec_name) in the product.ribbon model

Solution: created the _rec_name for the product.ribbon model

opw-2566403