### PR TITLE
[FIX] typo on class label

### DIFF
--- a/doc/cla/individual/mashanz.md
+++ b/doc/cla/individual/mashanz.md
@@ -1,0 +1,11 @@
+Indonesia, 2021-06-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Hanjara CA mangatkk@gmail.com https://github.com/mashanz

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -367,7 +367,7 @@
                     <sheet>
                         <field name="type" invisible="1"/>
                         <field name="parent_id" invisible="1"/>
-                        <label for="name" class="oe_editonly"/>
+                        <label for="name" class="oe_edit_only"/>
                         <field name="name" required="0"/>
                         <group>
                             <group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Typo on class label

Current behavior before PR:
class style not rendered because the class is typed wrong

Desired behavior after PR is merged:
class style rendered correctly



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
