### PR TITLE
[IMP] hr: move personal documents to hr

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -118,6 +118,8 @@ class HrEmployeePrivate(models.Model):
     departure_description = fields.Text(string="Additional Information", groups="hr.group_hr_user", copy=False, tracking=True)
     departure_date = fields.Date(string="Departure Date", groups="hr.group_hr_user", copy=False, tracking=True)
     message_main_attachment_id = fields.Many2one(groups="hr.group_hr_user")
+    id_card = fields.Binary(string="ID Card Copy", groups="hr.group_hr_user")
+    driving_license = fields.Binary(string="Driving License", groups="hr.group_hr_user")
 
     _sql_constraints = [
         ('barcode_uniq', 'unique (barcode)', "The Badge ID must be unique, this one is already assigned to another employee."),

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -201,6 +201,12 @@
                                     <group name="application_group"/>
                                 </group>
                             </page>
+                            <page string="Personal Documents" name="personal_documents" groups="hr.group_hr_manager">
+                                <group>
+                                    <field name="id_card"/>
+                                    <field name="driving_license"/>
+                                </group>
+                            </page>
                         </notebook>
 
                     </sheet>


### PR DESCRIPTION
Previously personal documents on employees were added with the belgian
contract salary module. This changes moves part of those fields to the
base hr module

Task ID: 2578139