### PR TITLE
14.0 opw 2516245 cash issue guva

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -270,7 +270,7 @@ class PosSession(models.Model):
     def _check_pos_session_balance(self):
         for session in self:
             for statement in session.statement_ids:
-                if (statement == session.cash_register_id) and (statement.balance_end != statement.balance_end_real):
+                if (statement != session.cash_register_id) and (statement.balance_end != statement.balance_end_real):
                     statement.write({'balance_end_real': statement.balance_end})
 
     def action_pos_session_validate(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Revert the commit 2c86a6bd65675613b88c93a2aad7d38642726c35

Current behavior before PR:

The fix breaks the advance cash control in PoS.

Desired behavior after PR is merged:

Before this fix, we could set the ending balance when closing PoS with the advance cash control option activated.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
