### PR TITLE
[FIX] mass_mailing: cleanup 'assets_mail_themes_edition' sub-bundle

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -65,7 +65,6 @@
             ('include', 'web._assets_helpers'),
             'web/static/lib/bootstrap/scss/_variables.scss',
             'mass_mailing/static/src/scss/mass_mailing.ui.scss',
-            'web/static/src/legacy/scss/webclient.scss',
         ],
         'web.assets_common': [
             'mass_mailing/static/src/js/tours/**/*',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Solve SCSS compilation issues due to 'webclient.scss' that was initially added in https://github.com/odoo/odoo/commit/b3e7fd040b934ee1a60ddaf8c866af3e787e484c.
The file is now unnecessary and it's actually causing the editor to behave incorrectly.

**Current behavior before PR:**
The editor opens with a blank page 

**Desired behavior after PR is merged:**
The editor opens with the themes selection view



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
