### PR TITLE
[IMP] hr_timesheet: refactor _apply_time_label method

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -134,6 +134,17 @@ class AccountAnalyticLine(models.Model):
             node.set('string', _('Duration (%s)') % (re.sub(r'[\(\)]', '', encoding_uom.name or '')))
         return etree.tostring(doc, encoding='unicode')
 
+    @api.model
+    def _apply_time_label(self, view_arch, related_model):
+        doc = etree.XML(view_arch)
+        Model = self.env[related_model]
+        encoding_uom = self.env.company.timesheet_encode_uom_id
+        for node in doc.xpath("//field[@widget='timesheet_uom'][not(@string)] | //field[@widget='timesheet_uom_no_toggle'][not(@string)]"):
+            name_with_uom = re.sub(_('Hours') + "|Hours", encoding_uom.name or '', Model._fields[node.get('name')]._description_string(self.env), flags=re.IGNORECASE)
+            node.set('string', name_with_uom)
+
+        return etree.tostring(doc, encoding='unicode')
+
     def _timesheet_get_portal_domain(self):
         if self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):
             # Then, he is internal user, and we take the domain for this current user

--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -30,5 +30,5 @@ class ReportProjectTaskUser(models.Model):
     def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
         result = super(ReportProjectTaskUser, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
         if view_type in ['pivot', 'graph'] and self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day'):
-            result['arch'] = self.env['project.task']._apply_time_label(result['arch'], related_model=self._name)
+            result['arch'] = self.env['account.analytic.line']._apply_time_label(result['arch'], related_model=self._name)
         return result


### PR DESCRIPTION
The purpose of the commit is in order to avoid code duplication and ease maintenance,
the _apply_time_label method has been centralized in hr.timesheet
which makes more sense since the relation to the timesheet encoding unit.
It can now be used in other models by providing the right model name.

TaskID: 2451722