### PR TITLE
[FIX] hr_timesheet: never update timesheet rounding params

### DIFF
--- a/addons/hr_timesheet/data/hr_timesheet_data.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_data.xml
@@ -15,13 +15,15 @@
         name="_init_data_analytic_account"
         eval="[]"/>
 
-    <record id="ir_config_parameter_timesheet_rounding" model="ir.config_parameter">
-        <field name="key">hr_timesheet.timesheet_rounding</field>
-        <field name="value">15</field>
-    </record>
-    <record id="ir_config_parameter_timesheet_min_duration" model="ir.config_parameter">
-        <field name="key">hr_timesheet.timesheet_min_duration</field>
-        <field name="value">15</field>
-    </record>
+    <data noupdate="1">
+        <record id="ir_config_parameter_timesheet_rounding" model="ir.config_parameter">
+            <field name="key">hr_timesheet.timesheet_rounding</field>
+            <field name="value">15</field>
+        </record>
+        <record id="ir_config_parameter_timesheet_min_duration" model="ir.config_parameter">
+            <field name="key">hr_timesheet.timesheet_min_duration</field>
+            <field name="value">15</field>
+        </record>
+    </data>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Prevent update from user configured settings

Current behavior before PR: Before this fix if a user updated the module hr_timesheet the ir.config_parameters would be reset.

Desired behavior after PR is merged: By wrapping them in a no-update they're no longer updated with a module update and thus kept as set by the user.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
