### PR TITLE
[IMP] website_event: rename extra register button.

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -40,7 +40,7 @@ class Event(models.Model):
              "of the event on the website.")
     menu_id = fields.Many2one('website.menu', 'Event Menu', copy=False)
     menu_register_cta = fields.Boolean(
-        'Add Register Button', compute='_compute_menu_register_cta',
+        'Extra Register Button', compute='_compute_menu_register_cta',
         readonly=False, store=True)
     community_menu = fields.Boolean(
         "Community Menu", compute="_compute_community_menu",

--- a/addons/website_event/models/event_type.py
+++ b/addons/website_event/models/event_type.py
@@ -14,7 +14,7 @@ class EventType(models.Model):
         readonly=False, store=True,
         help="Display community tab on website")
     menu_register_cta = fields.Boolean(
-        'Add Register Button', compute='_compute_menu_register_cta',
+        'Extra Register Button', compute='_compute_menu_register_cta',
         readonly=False, store=True)
 
     @api.depends('website_menu')

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -23,7 +23,7 @@
                 <div name="event_menu_configuration" groups="base.group_no_one">
                     <label for="website_menu" string="Website Submenu"/>
                     <field name="website_menu"/>
-                    <label for="menu_register_cta" string="Register Button"/>
+                    <label for="menu_register_cta" string="Extra Register Button"/>
                     <field name="menu_register_cta"/>
                     <label for="community_menu" string="Community" invisible="1"/>
                     <field name="community_menu" invisible="1"/>


### PR DESCRIPTION
BEFORE THIS COMMIT

The option adding an extra register button in top right
(at submenu height) of an event website page was presented as a
checkbox 'Register Button' on event form and 'Add Register Button'
on event type form.This was easily mistaken as the option of
allowing / preventing user registrations, which is not the case at all.

AFTER THIS COMMIT

In both event.event and event.type, this option is renamed
'Extra Register Button' to clarify its purpose and prevent such
a confusion.

--- Links ---
Task Id - 2578891
COM PR - odoo/odoo#72686
