### PR TITLE
[FIX] point_of_sale : locked order modify current order

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -79,15 +79,6 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             let currentPOSOrder = this.env.pos.get_order();
             if (currentPOSOrder && (!clickedOrder || clickedOrder.locked)) {
                 this.orderManagementContext.selectedOrder = clickedOrder;
-                if (clickedOrder.attributes.client){
-                    currentPOSOrder.set_client(clickedOrder.attributes.client);
-                }
-                if (clickedOrder.fiscal_position){
-                    currentPOSOrder.fiscal_position = clickedOrder.fiscal_position;
-                }
-                if (clickedOrder.pricelist){
-                    currentPOSOrder.set_pricelist(clickedOrder.pricelist);
-                }
             } else {
                 this._setOrder(clickedOrder);
             }
@@ -102,12 +93,6 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             }
         }
         _close() {
-            let currentOrder = this.env.pos.get_order();
-            if (currentOrder){
-                currentOrder.set_client(false);
-                currentOrder.fiscal_position = false;
-                currentOrder.set_pricelist(this.env.pos.default_pricelist);
-            }
             this.close();
         }
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On PoS
Create a new order with Customer A, Validate
Create a new order, select Customer B
Go to order manager
Select the first order, then click on the second

--> Issue now the customer (and pricelist and fiscal position) is Customer A


https://user-images.githubusercontent.com/16716992/123254351-d7a2ae80-d4ee-11eb-9e8f-aecf595c430c.mov

@pimodoo 
@rhe-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
