### PR TITLE
display issue with fixed table layout list in group

### DIFF
--- a/addons/web/static/src/legacy/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_editable_renderer.js
@@ -725,6 +725,9 @@ ListRenderer.include({
             }
         });
 
+        // set max-width before setting table-layout fixed
+        this.$el.css({ 'max-width': this.$el.width() });
+
         // Set the table layout to fixed
         table.style.tableLayout = 'fixed';
     },


### PR DESCRIPTION
PURPOSE
When o2m inside the inner group and it has record then sometime group is not displayed side by side instead the second group comes below the first group.

SPEC
If o2m inside the inner group and it has a record, it will always be displayed beside the first group, the issue is occurring due to list table layout which is fixed and due to which group width increased and the second group comes below the first group,
Set max-width to listview so that it never increases width than max-width.

TASK 2571376



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
