### PR TITLE
[FIX] l10n_ar: show CBU in electronic debit notes

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -233,7 +233,8 @@
                     <br/><strong>Currency: </strong><span t-esc="'%s - %s' % (o.currency_id.name, o.currency_id.currency_unit_label)"/>
                     <br/><strong>Exchange rate: </strong> <span t-field="o.l10n_ar_currency_rate"/>
                 </t>
-                <t t-if="o.l10n_latam_document_type_id.code in ['201', '206', '211']">
+                <!-- Show CBU for FACTURA DE CREDITO ELECTRONICA MiPyMEs and NOTA DE DEBITO ELECTRONICA MiPyMEs -->
+                <t t-if="o.l10n_latam_document_type_id.code in ['201', '206', '211', '202', '207', '212'] and o.invoice_partner_bank_id">
                     <br/><strong>CBU for payment: </strong><span t-esc="o.invoice_partner_bank_id.acc_number or '' if o.invoice_partner_bank_id.acc_type == 'cbu' else ''"/>
                 </t>
 
@@ -411,7 +412,8 @@
                     <br/><strong>Currency: </strong><span t-esc="'%s - %s' % (o.currency_id.name, o.currency_id.currency_unit_label)"/>
                     <br/><strong>Exchange rate: </strong> <span t-field="o.l10n_ar_currency_rate"/>
                 </t>
-                <t t-if="o.l10n_latam_document_type_id.code in ['201', '206', '211']">
+                <!-- Show CBU for FACTURA DE CREDITO ELECTRONICA MiPyMEs and NOTA DE DEBITO ELECTRONICA MiPyMEs -->
+                <t t-if="o.l10n_latam_document_type_id.code in ['201', '206', '211', '202', '207', '212'] and o.invoice_partner_bank_id">
                     <br/><strong>CBU for payment: </strong><span t-esc="o.invoice_partner_bank_id.acc_number or '' if o.invoice_partner_bank_id.acc_type == 'cbu' else ''"/>
                 </t>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

According to Argentinean law 27440, Art. 5º it is mandatory to show the
CBU on the report for electronic invoices and electronic debit notes.
Before this commit, we were showing only in FCE (MiPyMEs), and here we
add it for NDE (MiPyMEs) on invoices reports with/without payment.
Example:
- [Report before](https://github.com/odoo/odoo/files/6709464/before.pdf)
- [Report after](https://github.com/odoo/odoo/files/6709465/after.pdf)

Do no FW-port. PR for 14.0:  https://github.com/odoo/odoo/pull/72716

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
