### PR TITLE
[FIX] l10n_fr_pos_cert: hash and DUPLICATA doesn't appear in ticket during reprint

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -49,9 +49,15 @@ models.Order = models.Order.extend({
         this.l10n_fr_hash = this.l10n_fr_hash || false;
         this.save_to_db();
     },
+    init_from_JSON: function (json) {
+        _super_order.init_from_JSON.apply(this, arguments);
+        this.set_l10n_fr_hash(json.l10n_fr_hash || false);
+    },
     export_for_printing: function() {
       var result = _super_order.export_for_printing.apply(this,arguments);
       result.l10n_fr_hash = this.get_l10n_fr_hash();
+      // If a paid order is load from database it is considered already printed
+      result.l10n_fr_is_printed = this.locked || this._printed;
       return result;
     },
     set_l10n_fr_hash: function (l10n_fr_hash){

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -4,6 +4,7 @@
         <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
             <t t-if="receipt.l10n_fr_hash !== false">
                 <br/>
+                <div t-if="receipt.l10n_fr_is_printed">DUPLICATA</div>
                 <div style="word-wrap:break-word;"><t t-esc="receipt.l10n_fr_hash"/></div>
             </t>
         </xpath>


### PR DESCRIPTION
- Create a pos order, pay and valide (in french company)
- Close Pos
- reopen pos
- search this order
- click print ticket

--> Issue the hash and DUPLICATA doesn't appear on the ticket according to the french law.

Fine tuning of https://github.com/odoo/odoo/commit/f5f64536171d1bc2e4d89e1b5c5356763ffb8a87

@oco-odoo @pimodoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
