### PR TITLE
[REF] Convert JS codes into ES6 format 2nd pass

### DIFF
--- a/addons/calendar/static/src/js/base_calendar.js
+++ b/addons/calendar/static/src/js/base_calendar.js
@@ -1,9 +1,8 @@
-odoo.define('base_calendar.base_calendar', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var BasicModel = require('web.BasicModel');
-var fieldRegistry = require('web.field_registry');
-var relationalFields = require('web.relational_fields');
+import BasicModel from 'web.BasicModel';
+import fieldRegistry from 'web.field_registry';
+import relationalFields from 'web.relational_fields';
 
 const FieldMany2ManyTagsAvatar = relationalFields.FieldMany2ManyTagsAvatar;
 
@@ -52,5 +51,3 @@ const Many2ManyAttendee = FieldMany2ManyTagsAvatar.extend({
 });
 
 fieldRegistry.add('many2manyattendee', Many2ManyAttendee);
-
-});

--- a/addons/calendar/static/src/js/calendar_controller.js
+++ b/addons/calendar/static/src/js/calendar_controller.js
@@ -1,11 +1,8 @@
-odoo.define('calendar.CalendarController', function (require) {
-    "use strict";
+/** @odoo-module **/
 
-    const Controller = require('web.CalendarController');
-    const Dialog = require('web.Dialog');
-    const { qweb, _t } = require('web.core');
-    const core = require('web.core');
-    const QWeb = core.qweb;
+    import Controller from 'web.CalendarController';
+    import Dialog from 'web.Dialog';
+    import { qweb as QWeb, _t } from 'web.core';
 
     const CalendarController = Controller.extend({
 
@@ -27,7 +24,7 @@ odoo.define('calendar.CalendarController', function (require) {
                 new Dialog(this, {
                     title: _t('Edit Recurrent event'),
                     size: 'small',
-                    $content: $(qweb.render('calendar.RecurrentEventUpdate')),
+                    $content: $(QWeb.render('calendar.RecurrentEventUpdate')),
                     buttons: [{
                         text: _t('Confirm'),
                         classes: 'btn-primary',
@@ -89,6 +86,4 @@ odoo.define('calendar.CalendarController', function (require) {
 
     });
 
-    return CalendarController;
-
-});
+    export default CalendarController;

--- a/addons/calendar/static/src/js/calendar_model.js
+++ b/addons/calendar/static/src/js/calendar_model.js
@@ -1,7 +1,6 @@
-odoo.define('calendar.CalendarModel', function (require) {
-    "use strict";
+/** @odoo-module **/
 
-    const Model = require('web.CalendarModel');
+    import Model from 'web.CalendarModel';
 
     const CalendarModel = Model.extend({
 
@@ -78,5 +77,4 @@ odoo.define('calendar.CalendarModel', function (require) {
         },
     });
 
-    return CalendarModel;
-});
+    export default CalendarModel;

--- a/addons/calendar/static/src/js/calendar_renderer.js
+++ b/addons/calendar/static/src/js/calendar_renderer.js
@@ -1,9 +1,8 @@
-odoo.define('calendar.CalendarRenderer', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const CalendarRenderer = require('web.CalendarRenderer');
-const CalendarPopover = require('web.CalendarPopover');
-const session = require('web.session');
+import CalendarRenderer from 'web.CalendarRenderer';
+import CalendarPopover from 'web.CalendarPopover';
+import session from 'web.session';
 
 const AttendeeCalendarPopover = CalendarPopover.extend({
     template: 'Calendar.attendee.status.popover',
@@ -132,9 +131,7 @@ const AttendeeCalendarRenderer = CalendarRenderer.extend({
     },
 });
 
-return {
+export default {
     AttendeeCalendarRenderer: AttendeeCalendarRenderer,
     AttendeeCalendarPopover: AttendeeCalendarPopover,
 };
-
-});

--- a/addons/calendar/static/src/js/calendar_view.js
+++ b/addons/calendar/static/src/js/calendar_view.js
@@ -1,11 +1,12 @@
-odoo.define('calendar.CalendarView', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var CalendarController = require('calendar.CalendarController');
-var CalendarModel = require('calendar.CalendarModel');
-const CalendarRenderer = require('calendar.CalendarRenderer').AttendeeCalendarRenderer;
-var CalendarView = require('web.CalendarView');
-var viewRegistry = require('web.view_registry');
+import CalendarController from '@calendar/js/calendar_controller';
+import CalendarModel from '@calendar/js/calendar_model';
+import AttendeeCalendarRenderer from '@calendar/js/calendar_renderer';
+import CalendarView from 'web.CalendarView';
+import viewRegistry from 'web.view_registry';
+
+const CalendarRenderer = AttendeeCalendarRenderer.AttendeeCalendarRenderer;
 
 var AttendeeCalendarView = CalendarView.extend({
     config: _.extend({}, CalendarView.prototype.config, {
@@ -17,6 +18,4 @@ var AttendeeCalendarView = CalendarView.extend({
 
 viewRegistry.add('attendee_calendar', AttendeeCalendarView);
 
-return AttendeeCalendarView
-
-});
+export default AttendeeCalendarView;

--- a/addons/calendar/static/src/js/systray_activity_menu.js
+++ b/addons/calendar/static/src/js/systray_activity_menu.js
@@ -1,8 +1,7 @@
-odoo.define('calendar.systray.ActivityMenu', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var ActivityMenu = require('@mail/js/systray/systray_activity_menu')[Symbol.for("default")];
-var fieldUtils = require('web.field_utils');
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
+import fieldUtils from 'web.field_utils';
 
 ActivityMenu.include({
 
@@ -51,6 +50,4 @@ ActivityMenu.include({
             this._super.apply(this, arguments);
         }
     },
-});
-
 });

--- a/addons/calendar/static/tests/calendar_tests.js
+++ b/addons/calendar/static/tests/calendar_tests.js
@@ -1,8 +1,7 @@
-odoo.define('calendar.tests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var FormView = require('web.FormView');
-var testUtils = require("web.test_utils");
+import FormView from 'web.FormView';
+import testUtils from "web.test_utils";
 
 var createView = testUtils.createView;
 
@@ -84,5 +83,4 @@ QUnit.module('calendar', {
 
         form.destroy();
     });
-});
 });

--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -1,10 +1,9 @@
-odoo.define('calendar.systray.ActivityMenuTests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const { afterEach, beforeEach, start } = require('@mail/utils/test_utils');
-var ActivityMenu = require('@mail/js/systray/systray_activity_menu')[Symbol.for("default")];
+import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 
-var testUtils = require('web.test_utils');
+import testUtils from 'web.test_utils';
 
 QUnit.module('calendar', {}, function () {
 QUnit.module('ActivityMenu', {
@@ -77,6 +76,4 @@ QUnit.test('activity menu widget:today meetings', async function (assert) {
     assert.doesNotHaveClass(activityMenu.$('.o_meeting_filter').eq(1), 'o_meeting_bold', 'this meeting has been started');
     widget.destroy();
 });
-});
-
 });

--- a/addons/crm/static/src/js/crm_form.js
+++ b/addons/crm/static/src/js/crm_form.js
@@ -1,5 +1,4 @@
-odoo.define("crm.crm_form", function (require) {
-    "use strict";
+/** @odoo-module **/
 
     /**
      * This From Controller makes sure we display a rainbowman message
@@ -9,9 +8,9 @@ odoo.define("crm.crm_form", function (require) {
      * with a rainbowman like when the user click on the button "Mark Won".
      */
 
-    var FormController = require('web.FormController');
-    var FormView = require('web.FormView');
-    var viewRegistry = require('web.view_registry');
+    import FormController from 'web.FormController';
+    import FormView from 'web.FormView';
+    import viewRegistry from 'web.view_registry';
 
     var CrmFormController = FormController.extend({
         /**
@@ -84,8 +83,7 @@ odoo.define("crm.crm_form", function (require) {
 
     viewRegistry.add('crm_form', CrmFormView);
 
-    return {
+    export default {
         CrmFormController: CrmFormController,
         CrmFormView: CrmFormView,
     };
-});

--- a/addons/crm/static/src/js/crm_kanban.js
+++ b/addons/crm/static/src/js/crm_kanban.js
@@ -1,5 +1,4 @@
-odoo.define('crm.crm_kanban', function (require) {
-    "use strict";
+/** @odoo-module **/
 
     /**
      * This Kanban Model make sure we display a rainbowman
@@ -7,9 +6,9 @@ odoo.define('crm.crm_kanban', function (require) {
      * correct column and when it's grouped by stage_id (default).
      */
 
-    var KanbanModel = require('web.KanbanModel');
-    var KanbanView = require('web.KanbanView');
-    var viewRegistry = require('web.view_registry');
+    import KanbanModel from 'web.KanbanModel';
+    import KanbanView from 'web.KanbanView';
+    import viewRegistry from 'web.view_registry';
 
     var CrmKanbanModel = KanbanModel.extend({
         /**
@@ -44,9 +43,7 @@ odoo.define('crm.crm_kanban', function (require) {
 
     viewRegistry.add('crm_kanban', CrmKanbanView);
 
-    return {
+    export default {
         CrmKanbanModel: CrmKanbanModel,
         CrmKanbanView: CrmKanbanView,
     };
-
-});

--- a/addons/crm/static/src/js/systray_activity_menu.js
+++ b/addons/crm/static/src/js/systray_activity_menu.js
@@ -1,7 +1,6 @@
-odoo.define('crm.systray.ActivityMenu', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var ActivityMenu = require('@mail/js/systray/systray_activity_menu')[Symbol.for("default")];
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 
 ActivityMenu.include({
 
@@ -53,5 +52,4 @@ ActivityMenu.include({
             this._super.apply(this, arguments);
         }
     },
-});
 });

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -1,11 +1,8 @@
-odoo.define('crm.tour', function(require) {
-"use strict";
+/** @odoo-module **/
 
-var core = require('web.core');
-const {Markup} = require('web.utils');
-var tour = require('web_tour.tour');
-
-var _t = core._t;
+import { _t } from 'web.core';
+import { Markup } from 'web.utils';
+import tour from 'web_tour.tour';
 
 tour.register('crm_tour', {
     url: "/web",
@@ -91,5 +88,3 @@ tour.register('crm_tour', {
         actions.auto(".breadcrumb-item:not(.active):last");
     }
 }]);
-
-});

--- a/addons/crm/static/tests/crm_rainbowman_tests.js
+++ b/addons/crm/static/tests/crm_rainbowman_tests.js
@@ -1,8 +1,8 @@
 odoo.define('crm.form_rainbowman_tests', function (require) {
     "use strict";
 
-    var CrmFormView = require('crm.crm_form').CrmFormView;
-    var CrmKanbanView = require('crm.crm_kanban').CrmKanbanView;
+    var CrmFormView = require('@crm/js/crm_form')[Symbol.for("default")].CrmFormView;
+    var CrmKanbanView = require('@crm/js/crm_kanban')[Symbol.for("default")].CrmKanbanView;
     var testUtils = require('web.test_utils');
     var createView = testUtils.createView;
 

--- a/addons/crm/static/tests/mock_server.js
+++ b/addons/crm/static/tests/mock_server.js
@@ -1,7 +1,6 @@
-odoo.define('crm.MockServer', function (require) {
-    'use strict';
+/** @odoo-module **/
 
-    var MockServer = require('web.MockServer');
+    import MockServer from 'web.MockServer';
 
     MockServer.include({
         //--------------------------------------------------------------------------
@@ -53,4 +52,3 @@ odoo.define('crm.MockServer', function (require) {
             return this._super(...arguments);
         },
     });
-});

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -1,7 +1,6 @@
-odoo.define('crm.tour_crm_rainbowman', function (require) {
-    "use strict";
+/** @odoo-module **/
 
-    var tour = require('web_tour.tour');
+    import tour from 'web_tour.tour';
 
     tour.register('crm_rainbowman', {
         test: true,
@@ -74,4 +73,3 @@ odoo.define('crm.tour_crm_rainbowman', function (require) {
             content: "last rainbowman appears",
         }
     ]);
-});

--- a/addons/crm_iap_lead/static/src/js/leads_tree_generate_leads.js
+++ b/addons/crm_iap_lead/static/src/js/leads_tree_generate_leads.js
@@ -4,7 +4,7 @@ odoo.define('crm.leads.tree', function (require) {
     var ListView = require('web.ListView');
 
     var KanbanController = require('web.KanbanController');
-    var KanbanView = require('crm.crm_kanban').CrmKanbanView;
+    var KanbanView = require('@crm/js/crm_kanban')[Symbol.for("default")].CrmKanbanView;
 
     var viewRegistry = require('web.view_registry');
 

--- a/addons/crm_iap_lead/static/src/js/tours/crm_iap_lead.js
+++ b/addons/crm_iap_lead/static/src/js/tours/crm_iap_lead.js
@@ -5,7 +5,7 @@ var tour = require('web_tour.tour');
 const {Markup} = require('web.utils');
 var core = require('web.core');
 
-require('crm.tour');
+require('@crm/js/tours/crm');
 var _t = core._t;
 
 var DragOppToWonStepIndex = _.findIndex(tour.tours.crm_tour.steps, function (step) {

--- a/addons/google_calendar/static/src/js/google_calendar.js
+++ b/addons/google_calendar/static/src/js/google_calendar.js
@@ -4,10 +4,10 @@ odoo.define('google_calendar.CalendarView', function (require) {
 var core = require('web.core');
 var Dialog = require('web.Dialog');
 var framework = require('web.framework');
-const CalendarView = require('calendar.CalendarView');
-const CalendarRenderer = require('calendar.CalendarRenderer').AttendeeCalendarRenderer;
-const CalendarController = require('calendar.CalendarController');
-const CalendarModel = require('calendar.CalendarModel');
+const CalendarView = require('@calendar/js/calendar_view')[Symbol.for("default")];
+const CalendarRenderer = require('@calendar/js/calendar_renderer')[Symbol.for("default")].AttendeeCalendarRenderer;
+const CalendarController = require('@calendar/js/calendar_controller')[Symbol.for("default")];
+const CalendarModel = require('@calendar/js/calendar_model')[Symbol.for("default")];
 const viewRegistry = require('web.view_registry');
 const session = require('web.session');
 

--- a/addons/google_calendar/static/src/js/google_calendar_popover.js
+++ b/addons/google_calendar/static/src/js/google_calendar_popover.js
@@ -1,7 +1,7 @@
 odoo.define('google_calendar.GoogleCalendarPopover', function(require) {
     "use strict";
 
-    const CalendarPopover = require('calendar.CalendarRenderer').AttendeeCalendarPopover;
+    const CalendarPopover = require('@calendar/js/calendar_renderer')[Symbol.for("default")].AttendeeCalendarPopover;
 
     const GoogleCalendarPopover = CalendarPopover.include({
         events: _.extend({}, CalendarPopover.prototype.events, {

--- a/addons/google_calendar/static/tests/google_calendar_tests.js
+++ b/addons/google_calendar/static/tests/google_calendar_tests.js
@@ -1,7 +1,7 @@
 odoo.define('google_calendar.calendar_tests', function (require) {
 "use strict";
 
-var GoogleCalendarView = require('calendar.CalendarView');
+var GoogleCalendarView = require('@calendar/js/calendar_view')[Symbol.for("default")];
 var testUtils = require('web.test_utils');
 
 var createCalendarView = testUtils.createCalendarView;

--- a/addons/hr/static/src/js/language.js
+++ b/addons/hr/static/src/js/language.js
@@ -1,9 +1,8 @@
-odoo.define('hr.employee_language', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var FormController = require('web.FormController');
-var FormView = require('web.FormView');
-var viewRegistry = require('web.view_registry');
+import FormController from 'web.FormController';
+import FormView from 'web.FormView';
+import viewRegistry from 'web.view_registry';
 
 var EmployeeFormController = FormController.extend({
     saveRecord: function () {
@@ -23,5 +22,4 @@ var EmployeeProfileFormView = FormView.extend({
 });
 
 viewRegistry.add('hr_employee_profile_form', EmployeeProfileFormView);
-return EmployeeProfileFormView;
-});
+export default EmployeeProfileFormView;

--- a/addons/hr/static/src/js/standalone_m2o_avatar_employee.js
+++ b/addons/hr/static/src/js/standalone_m2o_avatar_employee.js
@@ -1,10 +1,9 @@
-odoo.define('hr.StandaloneM2OAvatarEmployee', function (require) {
-    'use strict';
+/** @odoo-module **/
 
-    const StandaloneFieldManagerMixin = require('web.StandaloneFieldManagerMixin');
-    const Widget = require('web.Widget');
+    import StandaloneFieldManagerMixin from 'web.StandaloneFieldManagerMixin';
+    import Widget from 'web.Widget';
 
-    const { Many2OneAvatarEmployee } = require('hr.Many2OneAvatarEmployee');
+    import { Many2OneAvatarEmployee } from '@hr/js/m2x_avatar_employee';
 
     const StandaloneM2OAvatarEmployee = Widget.extend(StandaloneFieldManagerMixin, {
         className: 'o_standalone_avatar_employee',
@@ -57,5 +56,4 @@ odoo.define('hr.StandaloneM2OAvatarEmployee', function (require) {
         },
     });
 
-    return StandaloneM2OAvatarEmployee;
-});
+    export default StandaloneM2OAvatarEmployee;

--- a/addons/hr/static/src/models/employee/employee.js
+++ b/addons/hr/static/src/models/employee/employee.js
@@ -1,9 +1,8 @@
-odoo.define('hr/static/src/models/employee/employee.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerNewModel } = require('@mail/model/model_core');
-const { attr, one2one } = require('@mail/model/model_field');
-const { insert, unlink } = require('@mail/model/model_field_command');
+import { registerNewModel } from '@mail/model/model_core';
+import { attr, one2one } from '@mail/model/model_field';
+import { insert, unlink } from '@mail/model/model_field_command';
 
 function factory(dependencies) {
 
@@ -203,5 +202,3 @@ function factory(dependencies) {
 }
 
 registerNewModel('hr.employee', factory);
-
-});

--- a/addons/hr/static/src/models/messaging/messaging.js
+++ b/addons/hr/static/src/models/messaging/messaging.js
@@ -1,9 +1,8 @@
-odoo.define('hr/static/src/models/messaging/messaging.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerInstancePatchModel,
-} = require('@mail/model/model_core');
+} from '@mail/model/model_core';
 
 registerInstancePatchModel('mail.messaging', 'hr/static/src/models/messaging/messaging.js', {
     //--------------------------------------------------------------------------
@@ -31,6 +30,4 @@ registerInstancePatchModel('mail.messaging', 'hr/static/src/models/messaging/mes
         }
         return this._super(...arguments);
     },
-});
-
 });

--- a/addons/hr/static/src/models/partner/partner.js
+++ b/addons/hr/static/src/models/partner/partner.js
@@ -1,11 +1,10 @@
-odoo.define('hr/static/src/models/partner/partner.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerInstancePatchModel,
     registerFieldPatchModel,
-} = require('@mail/model/model_core');
-const { attr, one2one } = require('@mail/model/model_field');
+} from '@mail/model/model_core';
+import { attr, one2one } from '@mail/model/model_field';
 
 registerInstancePatchModel('mail.partner', 'hr/static/src/models/partner/partner.js', {
     //--------------------------------------------------------------------------
@@ -58,6 +57,4 @@ registerFieldPatchModel('mail.partner', 'hr/static/src/models/partner/partner.js
     hasCheckedEmployee: attr({
         default: false,
     }),
-});
-
 });

--- a/addons/hr/static/src/models/user/user.js
+++ b/addons/hr/static/src/models/user/user.js
@@ -1,10 +1,9 @@
-odoo.define('hr/static/src/models/user/user.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerFieldPatchModel,
-} = require('@mail/model/model_core');
-const { one2one } = require('@mail/model/model_field');
+} from '@mail/model/model_core';
+import { one2one } from '@mail/model/model_field';
 
 registerFieldPatchModel('mail.user', 'hr/static/src/models/user/user.js', {
     /**
@@ -15,4 +14,3 @@ registerFieldPatchModel('mail.user', 'hr/static/src/models/user/user.js', {
     }),
 });
 
-});

--- a/addons/hr/static/tests/helpers/mock_models.js
+++ b/addons/hr/static/tests/helpers/mock_models.js
@@ -1,8 +1,7 @@
-odoo.define('hr/static/tests/helpers/mock_models.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { MockModels } = require('@mail/../tests/helpers/mock_models');
-const { patch } = require('web.utils');
+import { MockModels } from '@mail/../tests/helpers/mock_models';
+import { patch } from 'web.utils';
 
 patch(MockModels, 'hr/static/tests/helpers/mock_models.js', {
 
@@ -27,7 +26,5 @@ patch(MockModels, 'hr/static/tests/helpers/mock_models.js', {
         });
         return data;
     },
-
-});
 
 });

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -1,18 +1,17 @@
-odoo.define('hr.M2XAvatarEmployeeTests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const {
+import {
     afterEach,
     afterNextRender,
     beforeEach,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
-const FormView = require('web.FormView');
-const KanbanView = require('web.KanbanView');
-const ListView = require('web.ListView');
-const { Many2OneAvatarEmployee } = require('hr.Many2OneAvatarEmployee');
-const { dom, mock } = require('web.test_utils');
+import FormView from 'web.FormView';
+import KanbanView from 'web.KanbanView';
+import ListView from 'web.ListView';
+import { Many2OneAvatarEmployee } from '@hr/js/m2x_avatar_employee';
+import { dom, mock } from 'web.test_utils';
 
 QUnit.module('hr', {}, function () {
     QUnit.module('M2XAvatarEmployee', {
@@ -441,5 +440,4 @@ QUnit.module('hr', {}, function () {
 
         form.destroy();
     });
-});
 });

--- a/addons/hr/static/tests/standalone_m2o_avatar_employee_tests.js
+++ b/addons/hr/static/tests/standalone_m2o_avatar_employee_tests.js
@@ -1,15 +1,14 @@
-odoo.define('hr.StandaloneM2OEmployeeTests', function (require) {
-    "use strict";
+/** @odoo-module **/
 
     const { xml } = owl.tags;
 
-    const AbstractRendererOwl = require('web.AbstractRendererOwl');
-    const BasicView = require("web.BasicView");
-    const BasicRenderer = require("web.BasicRenderer");
-    const RendererWrapper = require('web.RendererWrapper');
-    const { createView } = require('web.test_utils');
+    import AbstractRendererOwl from 'web.AbstractRendererOwl';
+    import BasicView from "web.BasicView";
+    import BasicRenderer from "web.BasicRenderer";
+    import RendererWrapper from 'web.RendererWrapper';
+    import { createView } from 'web.test_utils';
 
-    const StandaloneM2OAvatarEmployee = require('hr.StandaloneM2OAvatarEmployee');
+    import StandaloneM2OAvatarEmployee from '@hr/js/standalone_m2o_avatar_employee';
 
     function getHtmlRenderer(html) {
         return BasicRenderer.extend({
@@ -121,4 +120,3 @@ odoo.define('hr.StandaloneM2OEmployeeTests', function (require) {
             view.destroy();
         });
     });
-});

--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js
@@ -1,12 +1,11 @@
-odoo.define('hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
 QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {
@@ -103,6 +102,4 @@ QUnit.test('on leave & offline', async function (assert) {
 
 });
 });
-});
-
 });

--- a/addons/hr_holidays/static/src/components/thread_icon/thread_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_icon/thread_icon_tests.js
@@ -1,12 +1,11 @@
-odoo.define('hr_holidays/static/src/components/thread_icon/thread_icon_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -134,6 +133,4 @@ QUnit.test('thread icon of a chat when correspondent is on leave & offline', asy
 
 });
 });
-});
-
 });

--- a/addons/hr_holidays/static/src/components/thread_view/thread_view_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_view/thread_view_tests.js
@@ -1,13 +1,12 @@
-odoo.define('hr_holidays/static/src/components/thread_view/thread_view_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { link } = require('@mail/model/model_field_command');
-const {
+import { link } from '@mail/model/model_field_command';
+import {
     afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
 QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {
@@ -83,6 +82,4 @@ QUnit.test('out of office message on direct chat with out of office partner', as
 
 });
 });
-});
-
 });

--- a/addons/microsoft_calendar/static/src/js/microsoft_calendar.js
+++ b/addons/microsoft_calendar/static/src/js/microsoft_calendar.js
@@ -4,10 +4,10 @@ odoo.define('microsoft_calendar.CalendarView', function (require) {
 var core = require('web.core');
 var Dialog = require('web.Dialog');
 var framework = require('web.framework');
-const CalendarView = require('calendar.CalendarView');
-const CalendarRenderer = require('calendar.CalendarRenderer').AttendeeCalendarRenderer;
-const CalendarController = require('calendar.CalendarController');
-const CalendarModel = require('calendar.CalendarModel');
+const CalendarView = require('@calendar/js/calendar_view')[Symbol.for("default")];
+const CalendarRenderer = require('@calendar/js/calendar_renderer')[Symbol.for("default")].AttendeeCalendarRenderer;
+const CalendarController = require('@calendar/js/calendar_controller')[Symbol.for("default")];
+const CalendarModel = require('@calendar/js/calendar_model')[Symbol.for("default")];
 const viewRegistry = require('web.view_registry');
 const session = require('web.session');
 

--- a/addons/microsoft_calendar/static/src/js/microsoft_calendar_popover.js
+++ b/addons/microsoft_calendar/static/src/js/microsoft_calendar_popover.js
@@ -1,7 +1,7 @@
 odoo.define('microsoft_calendar.MicrosoftCalendarPopover', function(require) {
     "use strict";
 
-    const CalendarPopover = require('calendar.CalendarRenderer').AttendeeCalendarPopover;
+    const CalendarPopover = require('@calendar/js/calendar_renderer')[Symbol.for("default")].AttendeeCalendarPopover;
 
     const MicrosoftCalendarPopover = CalendarPopover.include({
         events: _.extend({}, CalendarPopover.prototype.events, {

--- a/addons/mrp/static/src/js/mrp.js
+++ b/addons/mrp/static/src/js/mrp.js
@@ -1,14 +1,11 @@
-odoo.define('mrp.mrp_state', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var AbstractField = require('web.AbstractField');
-var core = require('web.core');
-var fields = require('web.basic_fields');
-var fieldUtils = require('web.field_utils');
-var field_registry = require('web.field_registry');
-var time = require('web.time');
-
-var _t = core._t;
+import AbstractField from 'web.AbstractField';
+import { _t } from 'web.core';
+import fields from 'web.basic_fields';
+import fieldUtils from 'web.field_utils';
+import field_registry from 'web.field_registry';
+import time from 'web.time';
 
 /**
  * This widget is used to display the availability on a workorder.
@@ -264,5 +261,4 @@ field_registry
 
 fieldUtils.format.mrp_time_counter = fieldUtils.format.float_time;
 
-return FieldEmbedURLViewer;
-});
+export default FieldEmbedURLViewer;

--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -1,9 +1,8 @@
-odoo.define('mrp.mrp_bom_report', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var framework = require('web.framework');
-var stock_report_generic = require('stock.stock_report_generic');
+import core from 'web.core';
+import framework from 'web.framework';
+import stock_report_generic from 'stock.stock_report_generic';
 
 var QWeb = core.qweb;
 var _t = core._t;
@@ -225,6 +224,4 @@ var MrpBomReport = stock_report_generic.extend({
 });
 
 core.action_registry.add('mrp_bom_report', MrpBomReport);
-return MrpBomReport;
-
-});
+export default MrpBomReport;

--- a/addons/mrp/static/src/js/mrp_document_kanban_view.js
+++ b/addons/mrp/static/src/js/mrp_document_kanban_view.js
@@ -1,10 +1,9 @@
-odoo.define('mrp.MrpDocumentsKanbanView', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const KanbanView = require('web.KanbanView');
-const MrpDocumentsKanbanController = require('mrp.MrpDocumentsKanbanController');
-const MrpDocumentsKanbanRenderer = require('mrp.MrpDocumentsKanbanRenderer');
-const viewRegistry = require('web.view_registry');
+import KanbanView from 'web.KanbanView';
+import MrpDocumentsKanbanController from '@mrp/js/mrp_documents_kanban_controller';
+import MrpDocumentsKanbanRenderer from '@mrp/js/mrp_documents_kanban_renderer';
+import viewRegistry from 'web.view_registry';
 
 const MrpDocumentsKanbanView = KanbanView.extend({
     config: Object.assign({}, KanbanView.prototype.config, {
@@ -15,6 +14,4 @@ const MrpDocumentsKanbanView = KanbanView.extend({
 
 viewRegistry.add('mrp_documents_kanban', MrpDocumentsKanbanView);
 
-return MrpDocumentsKanbanView;
-
-});
+export default MrpDocumentsKanbanView;

--- a/addons/mrp/static/src/js/mrp_documents_controller_mixin.js
+++ b/addons/mrp/static/src/js/mrp_documents_controller_mixin.js
@@ -1,9 +1,8 @@
-odoo.define('mrp.controllerMixin', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { _t, qweb } = require('web.core');
-const fileUploadMixin = require('web.fileUploadMixin');
-const DocumentViewer = require('mrp.MrpDocumentViewer');
+import { _t, qweb } from 'web.core';
+import fileUploadMixin from 'web.fileUploadMixin';
+import DocumentViewer from '@mrp/js/mrp_documents_document_viewer';
 
 const MrpDocumentsControllerMixin = Object.assign({}, fileUploadMixin, {
     events: {
@@ -123,6 +122,4 @@ const MrpDocumentsControllerMixin = Object.assign({}, fileUploadMixin, {
     },
 });
 
-return MrpDocumentsControllerMixin;
-
-});
+export default MrpDocumentsControllerMixin;

--- a/addons/mrp/static/src/js/mrp_documents_document_viewer.js
+++ b/addons/mrp/static/src/js/mrp_documents_document_viewer.js
@@ -1,7 +1,6 @@
-odoo.define('mrp.MrpDocumentViewer', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const DocumentViewer = require('@mail/js/document_viewer')[Symbol.for("default")];
+import DocumentViewer from '@mail/js/document_viewer';
 
 /**
  * This file defines the DocumentViewer for the MRP Documents Kanban view.
@@ -13,7 +12,4 @@ const MrpDocumentsDocumentViewer = DocumentViewer.extend({
     },
 });
 
-return MrpDocumentsDocumentViewer;
-
-});
-
+export default MrpDocumentsDocumentViewer;

--- a/addons/mrp/static/src/js/mrp_documents_kanban_controller.js
+++ b/addons/mrp/static/src/js/mrp_documents_kanban_controller.js
@@ -1,14 +1,13 @@
-odoo.define('mrp.MrpDocumentsKanbanController', function (require) {
-"use strict";
+/** @odoo-module **/
 
 /**
  * This file defines the Controller for the MRP Documents Kanban view, which is an
  * override of the KanbanController.
  */
 
-const MrpDocumentsControllerMixin = require('mrp.controllerMixin');
+import MrpDocumentsControllerMixin from '@mrp/js/mrp_documents_controller_mixin';
 
-const KanbanController = require('web.KanbanController');
+import KanbanController from 'web.KanbanController';
 
 const MrpDocumentsKanbanController = KanbanController.extend(MrpDocumentsControllerMixin, {
     events: Object.assign({}, KanbanController.prototype.events, MrpDocumentsControllerMixin.events),
@@ -32,6 +31,4 @@ const MrpDocumentsKanbanController = KanbanController.extend(MrpDocumentsControl
     },
 });
 
-return MrpDocumentsKanbanController;
-
-});
+export default MrpDocumentsKanbanController;

--- a/addons/mrp/static/src/js/mrp_documents_kanban_record.js
+++ b/addons/mrp/static/src/js/mrp_documents_kanban_record.js
@@ -1,11 +1,10 @@
-odoo.define('mrp.MrpDocumentsKanbanRecord', function (require) {
-"use strict";
+/** @odoo-module **/
 
 /**
  * This file defines the KanbanRecord for the MRP Documents Kanban view.
  */
 
-const KanbanRecord = require('web.KanbanRecord');
+import KanbanRecord from 'web.KanbanRecord';
 
 const MrpDocumentsKanbanRecord = KanbanRecord.extend({
     events: Object.assign({}, KanbanRecord.prototype.events, {
@@ -45,6 +44,4 @@ const MrpDocumentsKanbanRecord = KanbanRecord.extend({
     },
 });
 
-return MrpDocumentsKanbanRecord;
-
-});
+export default MrpDocumentsKanbanRecord;

--- a/addons/mrp/static/src/js/mrp_documents_kanban_renderer.js
+++ b/addons/mrp/static/src/js/mrp_documents_kanban_renderer.js
@@ -1,13 +1,12 @@
-odoo.define('mrp.MrpDocumentsKanbanRenderer', function (require) {
-"use strict";
+/** @odoo-module **/
 
 /**
  * This file defines the Renderer for the MRP Documents Kanban view, which is an
  * override of the KanbanRenderer.
  */
 
-const KanbanRenderer = require('web.KanbanRenderer');
-const MrpDocumentsKanbanRecord = require('mrp.MrpDocumentsKanbanRecord');
+import KanbanRenderer from 'web.KanbanRenderer';
+import MrpDocumentsKanbanRecord from '@mrp/js/mrp_documents_kanban_record';
 
 const MrpDocumentsKanbanRenderer = KanbanRenderer.extend({
     config: Object.assign({}, KanbanRenderer.prototype.config, {
@@ -22,6 +21,4 @@ const MrpDocumentsKanbanRenderer = KanbanRenderer.extend({
     },
 });
 
-return MrpDocumentsKanbanRenderer;
-
-});
+export default MrpDocumentsKanbanRenderer;

--- a/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
+++ b/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
@@ -1,14 +1,11 @@
-odoo.define('mrp.MrpFieldOne2ManyWithCopy', function (require) {
+/** @odoo-module **/
 
-"use strict";
-
-var FieldOne2Many = require('web.relational_fields').FieldOne2Many;
-var ListRenderer = require('web.ListRenderer');
-var fieldRegistry = require('web.field_registry');
-const {_t} = require('web.core');
+import { FieldOne2Many } from 'web.relational_fields';
+import ListRenderer from 'web.ListRenderer';
+import fieldRegistry from 'web.field_registry';
+import {_t} from 'web.core';
 
 //----------------------------------------------------
-var dialogs = require('web.view_dialogs');
 
 var MrpFieldOne2ManyWithCopyListRenderer = ListRenderer.extend({
 
@@ -80,6 +77,4 @@ var MrpFieldOne2ManyWithCopy = FieldOne2Many.extend({
 
 fieldRegistry.add('mrp_one2many_with_copy', MrpFieldOne2ManyWithCopy);
 
-return MrpFieldOne2ManyWithCopy;
-
-});
+export default MrpFieldOne2ManyWithCopy;

--- a/addons/mrp/static/src/js/mrp_should_consume.js
+++ b/addons/mrp/static/src/js/mrp_should_consume.js
@@ -1,11 +1,8 @@
-odoo.define('mrp.should_consume', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const BasicFields = require('web.basic_fields');
-const FieldFloat = BasicFields.FieldFloat;
-const fieldRegistry = require('web.field_registry');
-const field_utils = require('web.field_utils');
-
+import { FieldFloat } from 'web.basic_fields';
+import fieldRegistry from 'web.field_registry';
+import field_utils from 'web.field_utils';
 /**
  * This widget is used to display alongside the total quantity to consume of a production order,
  * the exact quantity that the worker should consume depending on the BoM. Ex:
@@ -74,8 +71,6 @@ const MrpShouldConsume = FieldFloat.extend({
 
 fieldRegistry.add('mrp_should_consume', MrpShouldConsume);
 
-return {
+export default {
     MrpShouldConsume: MrpShouldConsume,
 };
-
-});

--- a/addons/mrp/static/src/js/mrp_workorder_popover.js
+++ b/addons/mrp/static/src/js/mrp_workorder_popover.js
@@ -1,10 +1,8 @@
-odoo.define('mrp.mrp_workorder_popover', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var PopoverWidget = require('stock.popover_widget');
-var fieldRegistry = require('web.field_registry');
-var core = require('web.core');
-var _t = core._t;
+import PopoverWidget from 'stock.popover_widget';
+import fieldRegistry from 'web.field_registry';
+import { _t } from 'web.core';
 
 
 /**
@@ -47,5 +45,4 @@ var MrpWorkorderPopover = PopoverWidget.extend({
 
 fieldRegistry.add('mrp_workorder_popover', MrpWorkorderPopover);
 
-return MrpWorkorderPopover;
-});
+export default MrpWorkorderPopover;

--- a/addons/mrp/static/tests/mrp_document_kanban_tests.js
+++ b/addons/mrp/static/tests/mrp_document_kanban_tests.js
@@ -1,9 +1,8 @@
-odoo.define('mrp.document_kanban_tests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const MrpDocumentsKanbanView = require('mrp.MrpDocumentsKanbanView');
-const MrpDocumentsKanbanController = require('mrp.MrpDocumentsKanbanController');
-const testUtils = require('web.test_utils');
+import MrpDocumentsKanbanView from '@mrp/js/mrp_document_kanban_view';
+import MrpDocumentsKanbanController from '@mrp/js/mrp_documents_kanban_controller';
+import testUtils from 'web.test_utils';
 
 const createView = testUtils.createView;
 
@@ -165,8 +164,6 @@ QUnit.module('MrpDocumentsKanbanView', {
 
         kanban.destroy();
     });
-});
-
 });
 
 });

--- a/addons/mrp/static/tests/mrp_tests.js
+++ b/addons/mrp/static/tests/mrp_tests.js
@@ -1,8 +1,7 @@
-odoo.define('mrp.tests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var FormView = require('web.FormView');
-var testUtils = require("web.test_utils");
+import FormView from 'web.FormView';
+import testUtils from "web.test_utils";
 
 var createView = testUtils.createView;
 
@@ -129,5 +128,4 @@ QUnit.module('mrp', {
 
         form.destroy();
     });
-});
 });

--- a/addons/note/static/src/js/systray_activity_menu.js
+++ b/addons/note/static/src/js/systray_activity_menu.js
@@ -1,12 +1,9 @@
-odoo.define('note.systray.ActivityMenu', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var ActivityMenu = require('@mail/js/systray/systray_activity_menu')[Symbol.for("default")];
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 
-var core = require('web.core');
-var datepicker = require('web.datepicker');
-
-var _t = core._t;
+import { _t } from 'web.core';
+import datepicker from 'web.datepicker';
 
 ActivityMenu.include({
     events: _.extend({}, ActivityMenu.prototype.events, {
@@ -133,5 +130,4 @@ ActivityMenu.include({
             this._saveNote();
         }
     },
-});
 });

--- a/addons/note/static/tests/systray_activity_menu_tests.js
+++ b/addons/note/static/tests/systray_activity_menu_tests.js
@@ -1,10 +1,9 @@
-odoo.define('note.systray.ActivityMenuTests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var ActivityMenu = require('@mail/js/systray/systray_activity_menu')[Symbol.for("default")];
-const { afterEach, beforeEach, start } = require('@mail/utils/test_utils');
+import ActivityMenu from '@mail/js/systray/systray_activity_menu';
+import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
 
-var testUtils = require('web.test_utils');
+import testUtils from 'web.test_utils';
 
 QUnit.module('note', {}, function () {
 QUnit.module("ActivityMenu", {
@@ -125,6 +124,4 @@ QUnit.test('note activity menu widget: create note from activity menu', async fu
         'ActivityMenu add note input should be hidden');
     widget.destroy();
 });
-});
-
 });

--- a/addons/sms/static/src/components/message/message_tests.js
+++ b/addons/sms/static/src/components/message/message_tests.js
@@ -1,17 +1,16 @@
-odoo.define('sms/static/src/components/message/message_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { create, insert, link } = require('@mail/model/model_field_command');
-const { makeDeferred } = require('@mail/utils/deferred/deferred');
-const {
+import { create, insert, link } from '@mail/model/model_field_command';
+import { makeDeferred } from '@mail/utils/deferred/deferred';
+import {
     afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
-const Bus = require('web.Bus');
+import Bus from 'web.Bus';
 
 QUnit.module('sms', {}, function () {
 QUnit.module('components', {}, function () {
@@ -190,6 +189,4 @@ QUnit.test('Notification Error', async function (assert) {
 
 });
 });
-});
-
 });

--- a/addons/sms/static/src/components/notification_group/notification_group.js
+++ b/addons/sms/static/src/components/notification_group/notification_group.js
@@ -1,13 +1,10 @@
-odoo.define('sms/static/src/components/notification_group/notification_group.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { NotificationGroup } = require('@mail/components/notification_group/notification_group');
+import { NotificationGroup } from '@mail/components/notification_group/notification_group';
 
-const { patch } = require('web.utils');
+import { patch } from 'web.utils';
 
-const components = { NotificationGroup };
-
-patch(components.NotificationGroup.prototype, 'sms/static/src/components/notification_group/notification_group.js', {
+patch(NotificationGroup.prototype, 'sms/static/src/components/notification_group/notification_group.js', {
 
     //--------------------------------------------------------------------------
     // Public
@@ -22,6 +19,4 @@ patch(components.NotificationGroup.prototype, 'sms/static/src/components/notific
         }
         return this._super(...arguments);
     },
-});
-
 });

--- a/addons/sms/static/src/js/fields_sms_widget.js
+++ b/addons/sms/static/src/js/fields_sms_widget.js
@@ -1,11 +1,8 @@
-odoo.define('sms.sms_widget', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var core = require('web.core');
-var fieldRegistry = require('web.field_registry');
-var FieldTextEmojis = require('@mail/js/field_text_emojis')[Symbol.for("default")];
-
-var _t = core._t;
+import { _t } from 'web.core';
+import fieldRegistry from 'web.field_registry';
+import FieldTextEmojis from '@mail/js/field_text_emojis';
 /**
  * SmsWidget is a widget to display a textarea (the body) and a text representing
  * the number of SMS and the number of characters. This text is computed every
@@ -181,5 +178,4 @@ var SmsWidget = FieldTextEmojis.extend({
 
 fieldRegistry.add('sms_widget', SmsWidget);
 
-return SmsWidget;
-});
+export default SmsWidget;

--- a/addons/sms/static/src/models/message/message.js
+++ b/addons/sms/static/src/models/message/message.js
@@ -1,9 +1,8 @@
-odoo.define('sms/static/src/models/message/message.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerInstancePatchModel,
-} = require('@mail/model/model_core');
+} from '@mail/model/model_core';
 
 registerInstancePatchModel('mail.message', 'sms/static/src/models/message/message.js', {
 
@@ -28,6 +27,4 @@ registerInstancePatchModel('mail.message', 'sms/static/src/models/message/messag
             this._super(...arguments);
         }
     },
-});
-
 });

--- a/addons/sms/static/src/models/notification_group/notification_group.js
+++ b/addons/sms/static/src/models/notification_group/notification_group.js
@@ -1,9 +1,8 @@
-odoo.define('sms/static/src/models/notification_group/notification_group.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerInstancePatchModel,
-} = require('@mail/model/model_core');
+} from '@mail/model/model_core';
 
 registerInstancePatchModel('mail.notification_group', 'sms/static/src/models/notification_group/notification_group.js', {
 
@@ -57,6 +56,4 @@ registerInstancePatchModel('mail.notification_group', 'sms/static/src/models/not
             this.messaging.messagingMenu.close();
         }
     },
-});
-
 });

--- a/addons/sms/static/tests/sms_widget_test.js
+++ b/addons/sms/static/tests/sms_widget_test.js
@@ -1,10 +1,8 @@
-odoo.define('sms.sms_widget_tests', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var config = require('web.config');
-var FormView = require('web.FormView');
-var ListView = require('web.ListView');
-var testUtils = require('web.test_utils');
+import FormView from 'web.FormView';
+import ListView from 'web.ListView';
+import testUtils from 'web.test_utils';
 
 var createView = testUtils.createView;
 
@@ -225,5 +223,4 @@ QUnit.module('fields', {
 
         form.destroy();
     });
-});
 });

--- a/addons/snailmail/static/src/components/message/message.js
+++ b/addons/snailmail/static/src/components/message/message.js
@@ -1,9 +1,8 @@
-odoo.define('snailmail/static/src/components/message/message.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { Message } = require("@mail/components/message/message");
+import { Message } from '@mail/components/message/message';
 
-const { patch } = require('web.utils');
+import { patch } from 'web.utils';
 
 const { useState } = owl;
 
@@ -73,6 +72,4 @@ patch(Message.prototype, 'snailmail/static/src/components/message/message.js', {
     _onDialogClosedSnailmailError() {
         this.snailmailState.hasDialog = false;
     },
-});
-
 });

--- a/addons/snailmail/static/src/components/message/message_tests.js
+++ b/addons/snailmail/static/src/components/message/message_tests.js
@@ -1,16 +1,15 @@
-odoo.define('snailmail/static/src/components/message/message_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { create, insert, link } = require('@mail/model/model_field_command');
-const {
+import { create, insert, link } from '@mail/model/model_field_command';
+import {
     afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
-const Bus = require('web.Bus');
+import Bus from 'web.Bus';
 
 QUnit.module('snailmail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -673,6 +672,4 @@ QUnit.test('Missing Required Fields', async function (assert) {
 
 });
 });
-});
-
 });

--- a/addons/snailmail/static/src/components/notification_group/notification_group.js
+++ b/addons/snailmail/static/src/components/notification_group/notification_group.js
@@ -1,13 +1,10 @@
-odoo.define('snailmail/static/src/components/notification_group/notification_group.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { NotificationGroup } = require('@mail/components/notification_group/notification_group');
+import { NotificationGroup } from '@mail/components/notification_group/notification_group';
 
-const { patch } = require('web.utils');
+import { patch } from 'web.utils';
 
-const components = { NotificationGroup };
-
-patch(components.NotificationGroup.prototype, 'snailmail/static/src/components/notification_group/notification_group.js', {
+patch(NotificationGroup.prototype, 'snailmail/static/src/components/notification_group/notification_group.js', {
 
     //--------------------------------------------------------------------------
     // Public
@@ -22,6 +19,4 @@ patch(components.NotificationGroup.prototype, 'snailmail/static/src/components/n
         }
         return this._super(...arguments);
     },
-});
-
 });

--- a/addons/snailmail/static/src/components/notification_list/notification_list_notification_group_tests.js
+++ b/addons/snailmail/static/src/components/notification_list/notification_list_notification_group_tests.js
@@ -1,14 +1,13 @@
-odoo.define('snailmail/static/src/components/notification_list/notification_list_notification_group_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
-const Bus = require('web.Bus');
+import Bus from 'web.Bus';
 
 QUnit.module('snailmail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -295,6 +294,4 @@ QUnit.test('grouped notifications by document model', async function (assert) {
 
 });
 });
-});
-
 });

--- a/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
+++ b/addons/snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js
@@ -1,9 +1,8 @@
-odoo.define('snailmail/static/src/components/snailmail_error_dialog/snailmail_error_dialog.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerMessagingComponent } = require('@mail/utils/messaging_component');
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const Dialog = require('web.OwlDialog');
+import Dialog from 'web.OwlDialog';
 
 const { Component } = owl;
 const { useRef } = owl.hooks;
@@ -94,6 +93,4 @@ Object.assign(SnailmailErrorDialog, {
 
 registerMessagingComponent(SnailmailErrorDialog);
 
-return SnailmailErrorDialog;
-
-});
+export default SnailmailErrorDialog;

--- a/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
+++ b/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js
@@ -1,7 +1,6 @@
-odoo.define('snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerMessagingComponent } = require('@mail/utils/messaging_component');
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 const { Component } = owl;
 
@@ -65,6 +64,4 @@ Object.assign(SnailmailNotificationPopover, {
 
 registerMessagingComponent(SnailmailNotificationPopover);
 
-return SnailmailNotificationPopover;
-
-});
+export default SnailmailNotificationPopover;

--- a/addons/snailmail/static/src/models/message/message.js
+++ b/addons/snailmail/static/src/models/message/message.js
@@ -1,7 +1,6 @@
-odoo.define('snailmail/static/src/models/message.message.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerInstancePatchModel } = require('@mail/model/model_core');
+import { registerInstancePatchModel } from '@mail/model/model_core';
 
 registerInstancePatchModel('mail.message', 'snailmail/static/src/models/message.message.js', {
 
@@ -64,6 +63,4 @@ registerInstancePatchModel('mail.message', 'snailmail/static/src/models/message.
             args: [[this.id]],
         }));
     },
-});
-
 });

--- a/addons/snailmail/static/src/models/messaging/messaging.js
+++ b/addons/snailmail/static/src/models/messaging/messaging.js
@@ -1,11 +1,10 @@
-odoo.define('snailmail/static/src/models/messaging/messaging.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerInstancePatchModel,
     registerFieldPatchModel,
-} = require('@mail/model/model_core');
-const { attr } = require('@mail/model/model_field');
+} from '@mail/model/model_core';
+import { attr } from '@mail/model/model_field';
 
 registerInstancePatchModel('mail.messaging', 'snailmail/static/src/models/messaging/messaging.js', {
     async fetchSnailmailCreditsUrl() {
@@ -33,6 +32,4 @@ registerInstancePatchModel('mail.messaging', 'snailmail/static/src/models/messag
 registerFieldPatchModel('mail.messaging', 'snailmail/static/src/models/messaging/messaging.js', {
     snailmail_credits_url: attr(),
     snailmail_credits_url_trial: attr(),
-});
-
 });

--- a/addons/snailmail/static/src/models/notification_group/notification_group.js
+++ b/addons/snailmail/static/src/models/notification_group/notification_group.js
@@ -1,9 +1,8 @@
-odoo.define('snailmail/static/src/models/notification_group/notification_group.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerInstancePatchModel,
-} = require('@mail/model/model_core');
+} from '@mail/model/model_core';
 
 registerInstancePatchModel('mail.notification_group', 'snailmail/static/src/models/notification_group/notification_group.js', {
 
@@ -57,6 +56,4 @@ registerInstancePatchModel('mail.notification_group', 'snailmail/static/src/mode
             this.messaging.messagingMenu.close();
         }
     },
-});
-
 });

--- a/addons/snailmail/static/tests/helpers/mock_server.js
+++ b/addons/snailmail/static/tests/helpers/mock_server.js
@@ -1,7 +1,6 @@
-odoo.define('snailmail/static/tests/helpers/mock_server.js', function (require) {
-"use strict";
+/** @odoo-module **/
 
-const MockServer = require('web.MockServer');
+import MockServer from 'web.MockServer';
 
 MockServer.include({
     //--------------------------------------------------------------------------
@@ -45,6 +44,4 @@ MockServer.include({
     _mockMailMessageSendLetter(ids) {
         // TODO implement this mock and improve related tests (task-2300496)
     },
-});
-
 });

--- a/addons/website_livechat/static/src/components/discuss/discuss_tests.js
+++ b/addons/website_livechat/static/src/components/discuss/discuss_tests.js
@@ -1,11 +1,10 @@
-odoo.define('website_livechat/static/src/components/discuss/discuss_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     afterEach,
     beforeEach,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
 QUnit.module('website_livechat', {}, function () {
 QUnit.module('components', {}, function () {
@@ -264,6 +263,4 @@ QUnit.test('non-livechat channel should not show visitor banner', async function
 
 });
 });
-});
-
 });

--- a/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.js
+++ b/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.js
@@ -1,7 +1,6 @@
-odoo.define('website_livechat/static/src/components/visitor_banner/visitor_banner.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerMessagingComponent } = require('@mail/utils/messaging_component');
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 const { Component } = owl;
 
@@ -29,6 +28,4 @@ Object.assign(VisitorBanner, {
 
 registerMessagingComponent(VisitorBanner);
 
-return VisitorBanner;
-
-});
+export default VisitorBanner;

--- a/addons/website_livechat/static/src/js/website_livechat.editor.js
+++ b/addons/website_livechat/static/src/js/website_livechat.editor.js
@@ -1,11 +1,8 @@
-odoo.define('website_livechat.editor', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var wUtils = require('website.utils');
-var WebsiteNewMenu = require('website.newMenu');
-
-var _t = core._t;
+import { _t } from 'web.core';
+import wUtils from 'website.utils';
+import WebsiteNewMenu from 'website.newMenu';
 
 WebsiteNewMenu.include({
     actions: _.extend({}, WebsiteNewMenu.prototype.actions || {}, {
@@ -46,6 +43,4 @@ WebsiteNewMenu.include({
             });
         });
     },
-});
-
 });

--- a/addons/website_livechat/static/src/legacy/public_livechat.js
+++ b/addons/website_livechat/static/src/legacy/public_livechat.js
@@ -26,7 +26,7 @@ LivechatButton.include({
     /**
      * @override
      */
-    start() {
+     start() {
         // We trigger a resize to launch the event that checks if this element hides
         // a button when the page is loaded.
         $(window).trigger('resize');

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -1,7 +1,6 @@
-odoo.define('website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerInstancePatchModel } = require('@mail/model/model_core');
+import { registerInstancePatchModel } from '@mail/model/model_core';
 
 registerInstancePatchModel('mail.messaging_notification_handler', 'website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js', {
 
@@ -27,6 +26,4 @@ registerInstancePatchModel('mail.messaging_notification_handler', 'website_livec
         }
         return this._super(data);
     },
-});
-
 });

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler_tests.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler_tests.js
@@ -1,19 +1,14 @@
-odoo.define('website_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler_tests.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     afterEach,
     afterNextRender,
     beforeEach,
     start,
-} = require('@mail/utils/test_utils');
+} from '@mail/utils/test_utils';
 
-const FormView = require('web.FormView');
-const {
-    mock: {
-        intercept,
-    },
-} = require('web.test_utils');
+import FormView from 'web.FormView';
+import { mock } from 'web.test_utils';
 
 QUnit.module('website_livechat', {}, function () {
 QUnit.module('models', {}, function () {
@@ -59,7 +54,7 @@ QUnit.test('should open chat window on send chat request to website visitor', as
         `,
         res_id: 11,
     });
-    intercept(this.widget, 'execute_action', payload => {
+    mock.intercept(this.widget, 'execute_action', payload => {
         this.env.services.rpc({
             route: '/web/dataset/call_button',
             params: {
@@ -93,6 +88,4 @@ QUnit.test('should open chat window on send chat request to website visitor', as
 
 });
 });
-});
-
 });

--- a/addons/website_livechat/static/src/models/thread/thread.js
+++ b/addons/website_livechat/static/src/models/thread/thread.js
@@ -1,12 +1,11 @@
-odoo.define('website_livechat/static/src/models/thread/thread.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const {
+import {
     registerClassPatchModel,
     registerFieldPatchModel,
-} = require('@mail/model/model_core');
-const { many2one } = require('@mail/model/model_field');
-const { insert, unlink } = require('@mail/model/model_field_command');
+} from '@mail/model/model_core';
+import { many2one } from '@mail/model/model_field';
+import { insert, unlink } from '@mail/model/model_field_command';
 
 registerClassPatchModel('mail.thread', 'website_livechat/static/src/models/thread/thread.js', {
 
@@ -38,6 +37,4 @@ registerFieldPatchModel('mail.thread', 'website_livechat/static/src/models/threa
     visitor: many2one('website_livechat.visitor', {
         inverse: 'threads',
     }),
-});
-
 });

--- a/addons/website_livechat/static/src/models/visitor/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor/visitor.js
@@ -1,9 +1,8 @@
-odoo.define('website_livechat/static/src/models/partner/partner.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { registerNewModel } = require('@mail/model/model_core');
-const { attr, many2one, one2many } = require('@mail/model/model_field');
-const { insert, link, unlink } = require('@mail/model/model_field_command');
+import { registerNewModel } from '@mail/model/model_core';
+import { attr, many2one, one2many } from '@mail/model/model_field';
+import { insert, link, unlink } from '@mail/model/model_field_command';
 
 function factory(dependencies) {
 
@@ -147,5 +146,3 @@ function factory(dependencies) {
 }
 
 registerNewModel('website_livechat.visitor', factory);
-
-});

--- a/addons/website_livechat/static/tests/helpers/mock_models.js
+++ b/addons/website_livechat/static/tests/helpers/mock_models.js
@@ -1,8 +1,7 @@
-odoo.define('website_livechat/static/tests/helpers/mock_models.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { MockModels } = require('@mail/../tests/helpers/mock_models');
-const { patch } = require('web.utils');
+import { MockModels } from '@mail/../tests/helpers/mock_models';
+import { patch } from 'web.utils';
 
 patch(MockModels, 'website_livechat/static/tests/helpers/mock_models.js', {
 
@@ -38,7 +37,5 @@ patch(MockModels, 'website_livechat/static/tests/helpers/mock_models.js', {
         });
         return data;
     },
-
-});
 
 });

--- a/addons/website_livechat/static/tests/helpers/mock_server.js
+++ b/addons/website_livechat/static/tests/helpers/mock_server.js
@@ -1,9 +1,8 @@
-odoo.define('website_livechat/static/tests/helpers/mock_server.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-require('@im_livechat/../tests/helpers/mock_server'); // ensure mail overrides are applied first
+import '@im_livechat/../tests/helpers/mock_server'; // ensure mail overrides are applied first
 
-const MockServer = require('web.MockServer');
+import MockServer from 'web.MockServer';
 
 MockServer.include({
     /**
@@ -73,6 +72,4 @@ MockServer.include({
             this._widget.call('bus_service', 'trigger', 'notification', [notification]);
         }
     },
-});
-
 });

--- a/addons/website_sale_slides/static/src/js/slides_course_join.js
+++ b/addons/website_sale_slides/static/src/js/slides_course_join.js
@@ -1,7 +1,7 @@
 odoo.define('website_sale_slides.course.join.widget', function (require) {
 "use strict";
 
-var CourseJoinWidget = require('website_slides.course.join.widget').courseJoinWidget;
+var CourseJoinWidget = require('@website_slides/js/slides_course_join')[Symbol.for("default")].courseJoinWidget;
 const wUtils = require('website.utils');
 
 CourseJoinWidget.include({

--- a/addons/website_sale_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_sale_slides/static/src/js/slides_course_quiz.js
@@ -2,7 +2,7 @@ odoo.define('website_sale_slides.quiz', function (require) {
 "use strict";
 
 var sAnimations = require('website.content.snippets.animation');
-var Quiz = require('website_slides.quiz').Quiz;
+var { Quiz } = require('@website_slides/js/slides_course_quiz');
 
 sAnimations.registry.websiteSlidesQuizNoFullscreen.include({
     _extractChannelData: function (slideData) {

--- a/addons/website_sale_slides/static/src/js/slides_course_unsubscribe.js
+++ b/addons/website_sale_slides/static/src/js/slides_course_unsubscribe.js
@@ -1,7 +1,7 @@
 odoo.define('website_sale_slides.unsubscribe_modal', function (require) {
 "use strict";
 
-var SlidesUnsubscribe = require('website_slides.unsubscribe_modal');
+var SlidesUnsubscribe = require('@website_slides/js/slides_course_unsubscribe')[Symbol.for("default")];
 
 SlidesUnsubscribe.websiteSlidesUnsubscribe.include({
     xmlDependencies: (SlidesUnsubscribe.websiteSlidesUnsubscribe.prototype.xmlDependencies || []).concat(

--- a/addons/website_slides/static/src/components/activity/activity.js
+++ b/addons/website_slides/static/src/components/activity/activity.js
@@ -1,13 +1,10 @@
-odoo.define('website_slides/static/src/components/activity/activity.js', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { Activity } = require('@mail/components/activity/activity');
+import { Activity } from '@mail/components/activity/activity';
 
-const { patch } = require('web.utils');
+import { patch } from 'web.utils';
 
-const components = { Activity };
-
-patch(components.Activity.prototype, 'website_slides/static/src/components/activity/activity.js', {
+patch(Activity.prototype, 'website_slides/static/src/components/activity/activity.js', {
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -37,6 +34,4 @@ patch(components.Activity.prototype, 'website_slides/static/src/components/activ
         });
         this.trigger('reload');
     },
-});
-
 });

--- a/addons/website_slides/static/src/js/portal_chatter.js
+++ b/addons/website_slides/static/src/js/portal_chatter.js
@@ -1,9 +1,7 @@
-odoo.define('website_slides.portal_chatter', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const { _t } = require('web.core');
-const PortalChatter = require('portal.chatter').PortalChatter;
-
+import { _t } from 'web.core';
+import { PortalChatter } from 'portal.chatter';
 
 /**
  * PortalChatter
@@ -23,5 +21,4 @@ PortalChatter.include({
             $('#review-tab').text(_.str.sprintf(_t('Reviews (%d)'), data.rating_count));
         }
     },
-});
 });

--- a/addons/website_slides/static/src/js/rating_field_backend.js
+++ b/addons/website_slides/static/src/js/rating_field_backend.js
@@ -1,12 +1,9 @@
-odoo.define('website_slides.ratingField', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var basicFields = require('web.basic_fields');
-var fieldRegistry = require('web.field_registry');
+import basicFields from 'web.basic_fields';
+import fieldRegistry from 'web.field_registry';
 
-var core = require('web.core');
-
-var QWeb = core.qweb;
+import { qweb as QWeb} from 'web.core';
 
 var FieldFloatRating = basicFields.FieldFloat.extend({
     xmlDependencies: !basicFields.FieldFloat.prototype.xmlDependencies ?
@@ -35,8 +32,6 @@ var FieldFloatRating = basicFields.FieldFloat.extend({
 
 fieldRegistry.add('field_float_rating', FieldFloatRating);
 
-return {
+export default {
     FieldFloatRating: FieldFloatRating,
 };
-
-});

--- a/addons/website_slides/static/src/js/slide_category_one2many.js
+++ b/addons/website_slides/static/src/js/slide_category_one2many.js
@@ -1,11 +1,10 @@
-odoo.define('survey.slide_category_one2many', function (require){
-"use strict";
+/** @odoo-module **/
 
-var Context = require('web.Context');
-var FieldOne2Many = require('web.relational_fields').FieldOne2Many;
-var FieldRegistry = require('web.field_registry');
-var ListRenderer = require('web.ListRenderer');
-var config = require('web.config');
+import Context from 'web.Context';
+import { FieldOne2Many } from 'web.relational_fields';
+import FieldRegistry from 'web.field_registry';
+import ListRenderer from 'web.ListRenderer';
+import config from 'web.config';
 
 var SectionListRenderer = ListRenderer.extend({
     init: function (parent, state, params) {
@@ -179,4 +178,3 @@ var SectionFieldOne2Many = FieldOne2Many.extend({
 });
 
 FieldRegistry.add('slide_category_one2many', SectionFieldOne2Many);
-});

--- a/addons/website_slides/static/src/js/slides.js
+++ b/addons/website_slides/static/src/js/slides.js
@@ -1,8 +1,7 @@
-odoo.define('website_slides.slides', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var publicWidget = require('web.public.widget');
-var time = require('web.time');
+import publicWidget from 'web.public.widget';
+import time from 'web.time';
 
 publicWidget.registry.websiteSlides = publicWidget.Widget.extend({
     selector: '#wrapwrap',
@@ -32,17 +31,9 @@ publicWidget.registry.websiteSlides = publicWidget.Widget.extend({
     },
 });
 
-return publicWidget.registry.websiteSlides;
-
-});
+export default publicWidget.registry.websiteSlides;
 
 //==============================================================================
-
-odoo.define('website_slides.slides_embed', function (require) {
-'use strict';
-
-var publicWidget = require('web.public.widget');
-require('website_slides.slides');
 
 var SlideSocialEmbed = publicWidget.Widget.extend({
     events: {
@@ -119,6 +110,4 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
         var maxPage = $iframe.contents().find('#page_count').val();
         new SlideSocialEmbed(this, maxPage).attachTo($('.oe_slide_js_embed_code_widget'));
     },
-});
-
 });

--- a/addons/website_slides/static/src/js/slides_category_add.js
+++ b/addons/website_slides/static/src/js/slides_category_add.js
@@ -1,10 +1,8 @@
-odoo.define('website_slides.category.add', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var publicWidget = require('web.public.widget');
-var Dialog = require('web.Dialog');
-var core = require('web.core');
-var _t = core._t;
+import publicWidget from 'web.public.widget';
+import Dialog from 'web.Dialog';
+import { _t } from 'web.core';
 
 var CategoryAddDialog = Dialog.extend({
     template: 'slides.category.add',
@@ -76,9 +74,7 @@ publicWidget.registry.websiteSlidesCategoryAdd = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     categoryAddDialog: CategoryAddDialog,
     websiteSlidesCategoryAdd: publicWidget.registry.websiteSlidesCategoryAdd
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_category_delete.js
+++ b/addons/website_slides/static/src/js/slides_category_delete.js
@@ -1,10 +1,8 @@
-odoo.define('website_slides.category.delete', function (require) {
-'use strict';
+/** @odoo-module **/
 
-const publicWidget = require('web.public.widget');
-const Dialog = require('web.Dialog');
-const core = require('web.core');
-const _t = core._t;
+import publicWidget from 'web.public.widget';
+import Dialog from 'web.Dialog';
+import { _t } from 'web.core';
 
 const categoryDeleteDialog = Dialog.extend({
     template: 'slides.category.delete',
@@ -71,9 +69,7 @@ publicWidget.registry.websiteSlidesCategoryDelete = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     categoryDeleteDialog: categoryDeleteDialog,
     websiteSlidesCategoryDelete: publicWidget.registry.websiteSlidesCategoryDelete
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_course_enroll_email.js
+++ b/addons/website_slides/static/src/js/slides_course_enroll_email.js
@@ -1,10 +1,8 @@
-odoo.define('website_slides.course.enroll', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var Dialog = require('web.Dialog');
-var publicWidget = require('web.public.widget');
-var _t = core._t;
+import { _t } from 'web.core';
+import Dialog from 'web.Dialog';
+import publicWidget from 'web.public.widget';
 
 var SlideEnrollDialog = Dialog.extend({
     template: 'slide.course.join.request',
@@ -75,9 +73,7 @@ publicWidget.registry.websiteSlidesEnroll = publicWidget.Widget.extend({
     }
 });
 
-return {
+export default {
     slideEnrollDialog: SlideEnrollDialog,
     websiteSlidesEnroll: publicWidget.registry.websiteSlidesEnroll
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -1,22 +1,15 @@
+/** @odoo-module **/
+
 /* global YT */
-var onYouTubeIframeAPIReady = undefined;
 
-odoo.define('website_slides.fullscreen', function (require) {
-    'use strict';
+    import publicWidget from 'web.public.widget';
+    import  { qweb as QWeb, _t } from 'web.core';
+    import config from 'web.config';
 
-    var publicWidget = require('web.public.widget');
-    var core = require('web.core');
-    var config = require('web.config');
-    var QWeb = core.qweb;
-    var _t = core._t;
-
-    var session = require('web.session');
-
-    var Quiz = require('website_slides.quiz').Quiz;
-
-    var Dialog = require('web.Dialog');
-
-    require('website_slides.course.join.widget');
+    import session from 'web.session';
+    import { Quiz } from '@website_slides/js/slides_course_quiz';
+    import Dialog from 'web.Dialog';
+    import '@website_slides/js/slides_course_join';
 
     /**
      * Helper: Get the slide dict matching the given criteria
@@ -60,7 +53,7 @@ odoo.define('website_slides.fullscreen', function (require) {
 
                     // function called when the Youtube asset is loaded
                     // see https://developers.google.com/youtube/iframe_api_reference#Requirements
-                    onYouTubeIframeAPIReady = function () {
+                    window.onYouTubeIframeAPIReady = function () {
                         resolve();
                     };
                 } else {
@@ -759,5 +752,4 @@ odoo.define('website_slides.fullscreen', function (require) {
         },
     });
 
-    return Fullscreen;
-});
+    export default Fullscreen;

--- a/addons/website_slides/static/src/js/slides_course_join.js
+++ b/addons/website_slides/static/src/js/slides_course_join.js
@@ -1,8 +1,7 @@
-odoo.define('website_slides.course.join.widget', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var publicWidget = require('web.public.widget');
+import core from 'web.core';
+import publicWidget from 'web.public.widget';
 
 var _t = core._t;
 
@@ -153,9 +152,7 @@ publicWidget.registry.websiteSlidesCourseJoin = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     courseJoinWidget: CourseJoinWidget,
     websiteSlidesCourseJoin: publicWidget.registry.websiteSlidesCourseJoin
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -1,20 +1,18 @@
-odoo.define('website_slides.quiz', function (require) {
-    'use strict';
+/** @odoo-module **/
 
-    var publicWidget = require('web.public.widget');
-    var Dialog = require('web.Dialog');
-    var core = require('web.core');
-    var session = require('web.session');
-    const {Markup} = require('web.utils');
+    import publicWidget from 'web.public.widget';
+    import Dialog from 'web.Dialog';
+    import  { qweb as QWeb, _t } from 'web.core';
+    import session from 'web.session';
+    import { Markup } from 'web.utils';
+    import courseJoinWidget from '@website_slides/js/slides_course_join';
+    import QuestionFormWidget from '@website_slides/js/slides_course_quiz_question_form';
+    import SlideQuizFinishModal from '@website_slides/js/slides_course_quiz_finish';
 
-    var CourseJoinWidget = require('website_slides.course.join.widget').courseJoinWidget;
-    var QuestionFormWidget = require('website_slides.quiz.question.form');
-    var SlideQuizFinishModal = require('website_slides.quiz.finish');
+    import slideEnrollDialog from '@website_slides/js/slides_course_enroll_email';
 
-    var SlideEnrollDialog = require('website_slides.course.enroll').slideEnrollDialog;
-
-    var QWeb = core.qweb;
-    var _t = core._t;
+    const { CourseJoinWidget } = courseJoinWidget;
+    const { SlideEnrollDialog } = slideEnrollDialog;
 
     /**
      * This widget is responsible of displaying quiz questions and propositions. Submitting the quiz will fetch the
@@ -343,7 +341,7 @@ odoo.define('website_slides.quiz', function (require) {
          *
          * @private
          */
-        async _submitQuiz() {
+         async _submitQuiz() {
             const data = await this._rpc({
                 route: '/slides/slide/quiz/submit',
                 params: {
@@ -772,9 +770,6 @@ odoo.define('website_slides.quiz', function (require) {
         },
     });
 
-    return {
-        Quiz: Quiz,
-        ConfirmationDialog: ConfirmationDialog,
-        websiteSlidesQuizNoFullscreen: publicWidget.registry.websiteSlidesQuizNoFullscreen
-    };
-});
+    export var Quiz = Quiz;
+    export var ConfirmationDialog = ConfirmationDialog;
+    export const websiteSlidesQuizNoFullscree = publicWidget.registry.websiteSlidesQuizNoFullscreen;

--- a/addons/website_slides/static/src/js/slides_course_quiz_finish.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz_finish.js
@@ -1,9 +1,7 @@
-odoo.define('website_slides.quiz.finish', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var Dialog = require('web.Dialog');
-var core = require('web.core');
-var _t = core._t;
+import Dialog from 'web.Dialog';
+import { _t } from 'web.core';
 
 /**
  * This modal is used when the user finishes the quiz.
@@ -152,6 +150,4 @@ var SlideQuizFinishModal = Dialog.extend({
 
 });
 
-return SlideQuizFinishModal;
-
-});
+export default SlideQuizFinishModal;

--- a/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
@@ -1,8 +1,7 @@
-odoo.define('website_slides.quiz.question.form', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var publicWidget = require('web.public.widget');
-var core = require('web.core');
+import publicWidget from 'web.public.widget';
+import core from 'web.core';
 
 var QWeb = core.qweb;
 var _t = core._t;
@@ -224,5 +223,4 @@ var QuestionFormWidget = publicWidget.Widget.extend({
 
 });
 
-return QuestionFormWidget;
-});
+export default QuestionFormWidget;

--- a/addons/website_slides/static/src/js/slides_course_slides_list.js
+++ b/addons/website_slides/static/src/js/slides_course_slides_list.js
@@ -1,9 +1,7 @@
-odoo.define('website_slides.course.slides.list', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var publicWidget = require('web.public.widget');
-var core = require('web.core');
-var _t = core._t;
+import publicWidget from 'web.public.widget';
+import { _t } from 'web.core';
 
 publicWidget.registry.websiteSlidesCourseSlidesList = publicWidget.Widget.extend({
     selector: '.o_wslides_slides_list',
@@ -109,6 +107,4 @@ publicWidget.registry.websiteSlidesCourseSlidesList = publicWidget.Widget.extend
     }
 });
 
-return publicWidget.registry.websiteSlidesCourseSlidesList;
-
-});
+export default publicWidget.registry.websiteSlidesCourseSlidesList;

--- a/addons/website_slides/static/src/js/slides_course_tag_add.js
+++ b/addons/website_slides/static/src/js/slides_course_tag_add.js
@@ -1,11 +1,8 @@
-odoo.define('website_slides.channel_tag.add', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var Dialog = require('web.Dialog');
-var publicWidget = require('web.public.widget');
-
-var _t = core._t;
+import { _t } from 'web.core';
+import Dialog from 'web.Dialog';
+import publicWidget from 'web.public.widget';
 
 var TagCourseDialog = Dialog.extend({
     template: 'website.slides.tag.add',
@@ -369,9 +366,7 @@ publicWidget.registry.websiteSlidesTag = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     TagCourseDialog: TagCourseDialog,
     websiteSlidesTag: publicWidget.registry.websiteSlidesTag
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_course_unsubscribe.js
+++ b/addons/website_slides/static/src/js/slides_course_unsubscribe.js
@@ -1,10 +1,9 @@
-odoo.define('website_slides.unsubscribe_modal', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var Dialog = require('web.Dialog');
-var publicWidget = require('web.public.widget');
-var utils = require('web.utils');
+import core from 'web.core';
+import Dialog from 'web.Dialog';
+import publicWidget from 'web.public.widget';
+import utils from 'web.utils';
 
 var QWeb = core.qweb;
 var _t = core._t;
@@ -160,9 +159,7 @@ publicWidget.registry.websiteSlidesUnsubscribe = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     SlideUnsubscribeDialog: SlideUnsubscribeDialog,
     websiteSlidesUnsubscribe: publicWidget.registry.websiteSlidesUnsubscribe
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_share.js
+++ b/addons/website_slides/static/src/js/slides_share.js
@@ -1,10 +1,8 @@
-odoo.define('website_slides.slides_share', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var publicWidget = require('web.public.widget');
-require('website_slides.slides');
-var core = require('web.core');
-var _t = core._t;
+import publicWidget from 'web.public.widget';
+import '@website_slides/js/slides';
+import { _t } from 'web.core';
 
 var ShareMail = publicWidget.Widget.extend({
     events: {
@@ -101,5 +99,4 @@ publicWidget.registry.websiteSlidesShare = publicWidget.Widget.extend({
             clipboard.destroy();
         })
     },
-});
 });

--- a/addons/website_slides/static/src/js/slides_slide_archive.js
+++ b/addons/website_slides/static/src/js/slides_slide_archive.js
@@ -1,10 +1,8 @@
-odoo.define('website_slides.slide.archive', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var publicWidget = require('web.public.widget');
-var Dialog = require('web.Dialog');
-var core = require('web.core');
-var _t = core._t;
+import publicWidget from 'web.public.widget';
+import Dialog from 'web.Dialog';
+import { _t } from 'web.core';
 
 var SlideArchiveDialog = Dialog.extend({
     template: 'slides.slide.archive',
@@ -100,9 +98,7 @@ publicWidget.registry.websiteSlidesSlideArchive = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     slideArchiveDialog: SlideArchiveDialog,
     websiteSlidesSlideArchive: publicWidget.registry.websiteSlidesSlideArchive
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_slide_like.js
+++ b/addons/website_slides/static/src/js/slides_slide_like.js
@@ -1,11 +1,8 @@
-odoo.define('website_slides.slides.slide.like', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var publicWidget = require('web.public.widget');
-require('website_slides.slides');
-
-var _t = core._t;
+import { _t } from 'web.core';
+import publicWidget from 'web.public.widget';
+import '@website_slides/js/slides';
 
 var SlideLikeWidget = publicWidget.Widget.extend({
     events: {
@@ -106,9 +103,7 @@ publicWidget.registry.websiteSlidesSlideLike = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     slideLikeWidget: SlideLikeWidget,
     websiteSlidesSlideLike: publicWidget.registry.websiteSlidesSlideLike
 };
-
-});

--- a/addons/website_slides/static/src/js/slides_slide_toggle_is_preview.js
+++ b/addons/website_slides/static/src/js/slides_slide_toggle_is_preview.js
@@ -1,7 +1,6 @@
-odoo.define('website_slides.slide.preview', function (require) {
-    'use strict';
+/** @odoo-module **/
 
-    var publicWidget = require('web.public.widget');
+    import publicWidget from 'web.public.widget';
 
     publicWidget.registry.websiteSlidesSlideToggleIsPreview = publicWidget.Widget.extend({
         selector: '.o_wslides_js_slide_toggle_is_preview',
@@ -33,8 +32,6 @@ odoo.define('website_slides.slide.preview', function (require) {
         },
     });
 
-    return {
+    export default {
         websiteSlidesSlideToggleIsPreview: publicWidget.registry.websiteSlidesSlideToggleIsPreview
     };
-
-});

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -1,13 +1,9 @@
-odoo.define('website_slides.upload_modal', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var core = require('web.core');
-var Dialog = require('web.Dialog');
-var publicWidget = require('web.public.widget');
-var utils = require('web.utils');
-
-var QWeb = core.qweb;
-var _t = core._t;
+import { qweb as QWeb, _t } from 'web.core';
+import Dialog from 'web.Dialog';
+import publicWidget from 'web.public.widget';
+import utils from 'web.utils';
 
 var SlideUploadDialog = Dialog.extend({
     template: 'website.slide.upload.modal',
@@ -670,9 +666,7 @@ publicWidget.registry.websiteSlidesUpload = publicWidget.Widget.extend({
     },
 });
 
-return {
+export default {
     SlideUploadDialog: SlideUploadDialog,
     websiteSlidesUpload: publicWidget.registry.websiteSlidesUpload
 };
-
-});

--- a/addons/website_slides/static/src/js/website_slides.editor.js
+++ b/addons/website_slides/static/src/js/website_slides.editor.js
@@ -1,15 +1,9 @@
-odoo.define('website_slides.editor', function (require) {
-"use strict";
+/** @odoo-module **/
 
-var core = require('web.core');
-var Dialog = require('web.Dialog');
-var QWeb = core.qweb;
-var WebsiteNewMenu = require('website.newMenu');
-var TagCourseDialog = require('website_slides.channel_tag.add').TagCourseDialog;
-var wUtils = require('website.utils');
-
-var _t = core._t;
-
+import { _t } from 'web.core';
+import Dialog from 'web.Dialog';
+import WebsiteNewMenu from 'website.newMenu';
+import { TagCourseDialog }from '@website_slides/js/slides_course_tag_add';
 
 var ChannelCreateDialog = Dialog.extend({
     template: 'website.slide.channel.create',
@@ -184,5 +178,4 @@ WebsiteNewMenu.include({
         });
         return def;
      },
-});
 });

--- a/addons/website_slides/static/src/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/src/tests/tours/slides_course_member.js
@@ -1,7 +1,6 @@
-odoo.define('website_slides.tour.slide.course.member', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 /**
  * Global use case:
@@ -140,5 +139,3 @@ tour.register('course_member', {
     run: function () {}, // check review is correctly added
 }
 ]);
-
-});

--- a/addons/website_slides/static/src/tests/tours/slides_course_member_yt.js
+++ b/addons/website_slides/static/src/tests/tours/slides_course_member_yt.js
@@ -1,8 +1,7 @@
-odoo.define('website_slides.tour.slide.course.member.youtube', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
-var FullScreen = require('website_slides.fullscreen');
+import tour from 'web_tour.tour';
+import FullScreen from '@website_slides/js/slides_course_fullscreen_player';
 
 /**
  * Alter this method for test purposes.
@@ -63,5 +62,3 @@ tour.register('course_member_youtube', {
     trigger: 'a:contains("Back to course")'
 }
 ]);
-
-});

--- a/addons/website_slides/static/src/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/src/tests/tours/slides_course_publisher.js
@@ -1,8 +1,7 @@
-odoo.define('website_slides.tour.slide.course.publisher', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
-var slidesTourTools = require('website_slides.tour.tools');
+import tour from 'web_tour.tour';
+import slidesTourTools from '@website_slides/tests/tours/slides_tour_tools';
 
 /**
  * Global use case:
@@ -92,5 +91,3 @@ tour.register('course_publisher', {
 //     run: 'drag_and_drop div.o_wslides_slides_list_drag a.o_wslides_js_slide_section_add',
 // }]
 ));
-
-});

--- a/addons/website_slides/static/src/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/src/tests/tours/slides_full_screen_web_editor.js
@@ -1,7 +1,6 @@
-odoo.define('website_slides.tour.fullscreen.edition.publisher', function (require) {
-'use strict';
+/** @odoo-module **/
 
-var tour = require('web_tour.tour');
+import tour from 'web_tour.tour';
 
 /**
  * Global use case:
@@ -35,5 +34,3 @@ tour.register('full_screen_web_editor', {
     trigger: 'body.editor_enable',
     run: function () {} // check the editor is automatically opened on the detailed view
 }]);
-
-});

--- a/addons/website_slides/static/src/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/src/tests/tours/slides_tour_tools.js
@@ -1,5 +1,4 @@
-odoo.define('website_slides.tour.tools', function (require) {
-'use strict';
+/** @odoo-module **/
 
 /*
  * PUBLISHER / CONTENT CREATION
@@ -130,12 +129,10 @@ var addNewCourseTag = function (courseTagName) {
 }];
 };
 
-return {
+export default {
 	addSection: addSection,
 	addVideoToSection: addVideoToSection,
 	addWebPageToSection: addWebPageToSection,
 	addExistingCourseTag: addExistingCourseTag,
 	addNewCourseTag: addNewCourseTag,
 };
-
-});

--- a/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
@@ -3,7 +3,7 @@ odoo.define('website_slides_survey.fullscreen', function (require) {
 
 var core = require('web.core');
 var QWeb = core.qweb;
-var Fullscreen = require('website_slides.fullscreen');
+var Fullscreen = require('@website_slides/js/slides_course_fullscreen_player')[Symbol.for("default")];
 
 Fullscreen.include({
     xmlDependencies: (Fullscreen.prototype.xmlDependencies || []).concat(

--- a/addons/website_slides_survey/static/src/js/slides_upload.js
+++ b/addons/website_slides_survey/static/src/js/slides_upload.js
@@ -4,7 +4,7 @@ odoo.define('website_slides_survey.upload_modal', function (require) {
 var core = require('web.core');
 var _t = core._t;
 var sessionStorage = window.sessionStorage;
-var SlidesUpload = require('website_slides.upload_modal');
+var SlidesUpload = require('@website_slides/js/slides_upload')[Symbol.for("default")];
 
 /**
  * Management of the new 'certification' slide_type


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Convert JS codes into ES6 format 2nd pass, the modules involed are (hr, hr_holidays, sms, snailmail, website_livechat, account_invoice_extract, approvals, documents, mail_enterprise, calendar, crm, mrp, note, website_slides, crm_enterprise, sign, social, voip)

No functional change should happen after the refactoring.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
