### PR TITLE
[FIX] web: expand import-compatible fields

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1700,7 +1700,7 @@ class Export(http.Controller):
         fields = self.fields_get(model)
         if import_compat:
             if parent_field_type in ['many2one', 'many2many']:
-                rec_name = request.env[model]._rec_name
+                rec_name = request.env[model]._rec_name_fallback()
                 fields = {'id': fields['id'], rec_name: fields[rec_name]}
         else:
             fields['.id'] = {**fields['id']}


### PR DESCRIPTION
- Install the eCommerce (for the ribbon, in 14.0) and the Sales app
- Go to the Sales app -> Products -> Products
- (View List ->) select (a) Product(s) -> Action -> Export
- check "I want to update data (import-compatible export)" -> click on the "Ribbon" field (in 14.0, or another many2x field for wich the model has no _rec_name defined) to expand

Cause: the export page controller tries to access an undefined field (_rec_name)

Solution: the controller now uses a fallback method to retrieve the wanted field

opw-2566403