### PR TITLE
fix traceback on dialog close

### DIFF
--- a/addons/web/static/src/js/core/owl_dialog.js
+++ b/addons/web/static/src/js/core/owl_dialog.js
@@ -232,7 +232,9 @@ odoo.define('web.OwlDialog', function (require) {
             // Activate last dialog and update body class
             const lastDialog = this.displayed[this.displayed.length - 1];
             if (lastDialog) {
-                lastDialog.el.focus();
+                if (lastDialog.el) { // sometime dialog xml is not loaded so el is false
+                    lastDialog.el.focus();
+                }
                 const modalEl = lastDialog instanceof this ?
                     // Owl dialog
                     lastDialog.modalRef.el :


### PR DESCRIPTION
Scenario: Go to Sales -> Add Order Line -> write something that doesn't exist
in product field, click outside, it will show M2ODialog for quick create
(it will show blank dialog when dialog xml is not loaded on slow network)
close the dialog -> again add something in product field that doesn't exist and
click outside again M2ODialog for quick create is open, again close it, it will
throw traceback.

Issue is generated on slow network because first time dialog xml is tries to
load from server so meanwhile empty dialog is displayed and  of of dialog is
not set, so when dialog is opened second time so owlDialog will try to set
focus on last dialog  but as first time dialog was empty and  is not set so it
will throw error.

TASK 2570905


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
