### PR TITLE
[FIX] point_of_sale: set end balance of cash register

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -270,7 +270,7 @@ class PosSession(models.Model):
     def _check_pos_session_balance(self):
         for session in self:
             for statement in session.statement_ids:
-                if (statement == session.cash_register_id) and (statement.balance_end != statement.balance_end_real):
+                if (statement != session.cash_register_id) and (statement.balance_end != statement.balance_end_real):
                     statement.write({'balance_end_real': statement.balance_end})
 
     def action_pos_session_validate(self):
@@ -324,6 +324,8 @@ class PosSession(models.Model):
                 self.move_id.unlink()
         else:
             statement = self.cash_register_id
+            if not self.config_id.cash_control:
+                statement.write({'balance_end_real': statement.balance_end})
             statement.button_post()
             statement.button_validate()
         self.write({'state': 'closed'})

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -584,3 +584,43 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertEqual(len(other_customer_invoice_receivable_counterpart), 1, msg='there should one aggregated invoice receivable counterpart for self.other_customer')
         self.assertEqual(bool(other_customer_invoice_receivable_counterpart.full_reconcile_id), True, msg='the aggregated receivable for self.other_customer should be reconciled')
         self.assertEqual(other_customer_invoice_receivable_counterpart.balance, -200, msg='aggregated balance should be -200')
+
+    def test_cash_register_if_no_order(self):
+        # Process one order with product3
+        self.open_new_session()
+        session = self.pos_session
+        orders = []
+        order_data = self.create_ui_order_data([(self.product3, 1)])
+        amount_paid = order_data['data']['amount_paid']
+        self.env['pos.order'].create_from_ui([order_data])
+        session.action_pos_session_closing_control()
+
+        cash_register = session.cash_register_id
+        self.assertEqual(cash_register.balance_start, 0)
+        self.assertEqual(cash_register.balance_end_real, amount_paid)
+
+        # Open/Close session without any order
+        self.open_new_session()
+        session = self.pos_session
+        session.action_pos_session_closing_control()
+        cash_register = session.cash_register_id
+        self.assertEqual(cash_register.balance_start, amount_paid)
+        self.assertEqual(cash_register.balance_end_real, amount_paid)
+        self.assertEqual(self.config.last_session_closing_cash, amount_paid)
+
+        # Open/Close session with cash control and without any order
+        self.config.cash_control = True
+        self.open_new_session()
+        session = self.pos_session
+        session.set_cashbox_pos(amount_paid, False)
+        session.action_pos_session_closing_control()
+        self.env['account.bank.statement.cashbox'].create([{
+            'start_bank_stmt_ids': [],
+            'end_bank_stmt_ids': [(4, session.cash_register_id.id,)],
+            'cashbox_lines_ids': [(0, 0, {'number': 1, 'coin_value': amount_paid})],
+            'is_a_template': False
+        }])
+        session.action_pos_session_validate()
+        self.assertEqual(cash_register.balance_start, amount_paid)
+        self.assertEqual(cash_register.balance_end_real, amount_paid)
+        self.assertEqual(self.config.last_session_closing_cash, amount_paid)


### PR DESCRIPTION
This commits is about two problems. The first one is a undesirable
warning message displayed when closing the POS session

To reproduce the error:
1. In POS settings, enable "Advanced Cash Control"
2. Start a POS session
3. Make an order of 70$, payment in cash
4. Close the POS session (correctly set the closing cash)

Error: When clicking on "Close Session & Post Entries", a warning is
displayed: "There is a difference between the expected and actual
closing in cash. Are you sure [...] ?" However the actual cash is equal
to expected cash so the message does not make sense

The error has been introduced with commit 7252350d35c6e8e7f47458c3aedcf05d92e71afa,
so the current commit reverts it.

However, the reverted commit was a solution to a second problem: When
cash control is disabled, if the user opens and closes a POS session
(without any order), the ending balance of the associated cash register
will always be 0. Here are the explanations: if cash control is enabled,
when the user sets the closing cash, it creates a record:
https://github.com/odoo/odoo/blob/80c28189ae6b10ad17c4de2a781233a8ffe663a6/addons/account/models/account_bank_statement.py#L82-L98
and therefore, thanks to `_validate_cashbox`, `balance_end_real` will be
defined with its correct value. However, there isn't anything to define
the ending balance when there isn't any order and when cash control is
disabled.

OPW-2580699