### PR TITLE
[FIX] point_of_sale: correctly block ui when sending RPC

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -168,6 +168,9 @@
             ('remove', 'web/static/src/core/errors/error_handlers.js'),
             ('remove', 'web/static/src/legacy/legacy_rpc_error_handler.js'),
         ],
+        'point_of_sale.pos_assets_backend_style': [
+            "web/static/src/core/ui/**/*.scss",
+        ],
         'point_of_sale.tests_assets': [
             'web/static/lib/daterangepicker/daterangepicker.css',
             'web/static/lib/qunit/qunit-2.9.1.css',

--- a/addons/point_of_sale/static/src/js/chrome_adapter.js
+++ b/addons/point_of_sale/static/src/js/chrome_adapter.js
@@ -8,8 +8,7 @@ import { configureGui } from "point_of_sale.Gui";
 import { useBus } from "@web/core/bus_hook";
 import PosComponent from "point_of_sale.PosComponent";
 import PopupControllerMixin from "point_of_sale.PopupControllerMixin";
-import { useErrorHandlers } from "point_of_sale.custom_hooks";
-import { ConnectionLostError } from "@web/core/network/rpc_service";
+import { registry } from "@web/core/registry";
 
 function setupResponsivePlugin(env) {
     const isMobile = () => window.innerWidth <= 768;
@@ -32,7 +31,11 @@ export class ChromeAdapter extends PopupControllerMixin(PosComponent) {
         useBus(this.env.qweb, "update", () => this.render());
         const chrome = owl.hooks.useRef("chrome");
         owl.hooks.onMounted(async () => {
+            // Little trick to avoid displaying the block ui during the POS models loading
+            const BlockUiFromRegistry = registry.category("main_components").get("BlockUI");
+            registry.category("main_components").remove("BlockUI");
             await chrome.comp.start();
+            registry.category("main_components").add("BlockUI", BlockUiFromRegistry);
             configureGui({ component: chrome.comp });
             setupResponsivePlugin(this.env);
         });

--- a/addons/point_of_sale/views/pos_assets_common.xml
+++ b/addons/point_of_sale/views/pos_assets_common.xml
@@ -2,6 +2,7 @@
 <odoo>
 
 <template id="point_of_sale.assets_common" name="POS Assets Common">
+    <t t-call-assets="point_of_sale.pos_assets_backend_style" t-js="false"/>
     <t t-call-assets="point_of_sale.assets" t-js="false" />
     <t t-call-assets="web.assets_common" t-css="false" />
     <t t-call-assets="point_of_sale.pos_assets_backend" t-css="false" />


### PR DESCRIPTION
Before this commit, the block UI component was not visible so the interface
was not blocked when sending RPC (at least).

After this commit, the block UI works correctly

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
