### PR TITLE
[FIX] translate: get class attribute safely

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -151,7 +151,7 @@ TRANSLATED_ATTRS = dict.fromkeys({
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
     'value_label',
 }, lambda e: True)
-TRANSLATED_ATTRS['value'] = lambda e: (e.tag == 'input' and e.attrib.get('type', 'text') == 'text') and 'datetimepicker-input' not in e.attrib['class'].split(' ')
+TRANSLATED_ATTRS['value'] = lambda e: (e.tag == 'input' and e.attrib.get('type', 'text') == 'text') and 'datetimepicker-input' not in e.attrib.get('class', '').split(' ')
 
 TRANSLATED_ATTRS.update({f't-attf-{attr}': cond for attr, cond in TRANSLATED_ATTRS.items()})
 


### PR DESCRIPTION
The 'class' attribute was not safely accessed using get. Since this attribute is not always
present the condition evaluation failed in some cases.

task-2276724

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
