### PR TITLE
[FIX] website: serve_redirect with trailing /

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -305,7 +305,8 @@ class Http(models.AbstractModel):
         req_page = request.httprequest.path
         domain = [
             ('redirect_type', 'in', ('301', '302')),
-            ('url_from', '=', req_page)
+            # trailing / could have been removed by server_page
+            '|', ('url_from', '=', req_page.rstrip('/')), ('url_from', '=', req_page + '/')
         ]
         domain += request.website.website_domain()
         return request.env['website.rewrite'].sudo().search(domain, limit=1)


### PR DESCRIPTION
Before to search if a redirect exists, we try to match a page via serve_page.
But this one redirect without the trailing /. So if none page is found, we
look for redirection, but we need to search with and without this trialing /.

opw-2527063