### PR TITLE
[FIX] hr_recruitment: fix calendar_events

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -312,6 +312,7 @@ class Applicant(models.Model):
         category = self.env.ref('hr_recruitment.categ_meet_interview')
         res = self.env['ir.actions.act_window'].for_xml_id('calendar', 'action_calendar_event')
         res['context'] = {
+            'default_applicant_id': self.id,
             'default_partner_ids': partners.ids,
             'default_user_id': self.env.uid,
             'default_name': self.name,


### PR DESCRIPTION
When using the Add button on the calendar view introduced with
odoo/odoo#64948 the event would not be linked with the applicant.

After further investigation the method used to get the applicant id in
default_get was not flexible enough, the one from crm calendar has been
'copied'

Task ID: 2578165