### PR TITLE
[FIX] delivery: fix shipping value computation

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMoveLine(models.Model):
         for move_line in self:
             if move_line.move_id.sale_line_id:
                 unit_price = move_line.move_id.sale_line_id.price_reduce_taxinc
-                qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.move_id.sale_line_id.product_uom)
+                qty = move_line.product_uom_id._compute_quantity(move_line.move_id.sale_line_id.product_qty, move_line.move_id.sale_line_id.product_uom)
             else:
                 unit_price = move_line.product_id.list_price
                 qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)


### PR DESCRIPTION
Have a kit product [DEMO] with a single bom line with quantity N
Configure bpost delivery
Create a SO with [DEMO], quantity 1, price P
Confirm, go to delivery, validate

The shipping label generated will have as shipping value P*N instead of
P
This occur because the method does not take into account the bom, so it
uses the quantity of the move line with the price from the sale order.
Moreover the same field is used also in delivery_ups yielding similar
results

opw-2573098

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
