### PR TITLE
[FIX] web: legacy: customFilterMenu is focusable

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -329,7 +329,7 @@
 
 <t t-name="web.CustomFilterItem" owl="1">
     <div class="o_generator_menu">
-        <span class="o_add_custom_filter dropdown-item"
+        <button class="btn o_add_custom_filter dropdown-item"
             aria-expanded="false"
             t-ref="fallback-focus"
             t-on-click="state.open = !state.open"
@@ -337,7 +337,7 @@
             t-att-class="{ 'active': state.open, 'o_dropdown_item_active_noarrow' : state.open}"
             >
             <t>Add Custom Filter</t>
-        </span>
+        </button>
         <t t-if="state.open">
             <t t-set="showRemoveIcons" t-value="state.conditions.length gt 1"/>
 

--- a/addons/web/static/tests/legacy/control_panel/custom_filter_item_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/custom_filter_item_tests.js
@@ -228,7 +228,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
 
             // The only thing visible should be the button 'Add Custome Filter';
             assert.strictEqual(cfi.el.children.length, 1);
-            assert.containsOnce(cfi, 'span.o_add_custom_filter');
+            assert.containsOnce(cfi, 'button.o_add_custom_filter');
 
             cfi.destroy();
         });

--- a/addons/web/static/tests/legacy/helpers/test_utils_control_panel.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_control_panel.js
@@ -93,7 +93,7 @@ odoo.define('web.test_utils_control_panel', function (require) {
      * @returns {Promise}
      */
     async function toggleAddCustomFilter(el) {
-        await click(getNode(el).querySelector(`span.o_add_custom_filter`));
+        await click(getNode(el).querySelector(`button.o_add_custom_filter`));
     }
 
     /**


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
