### PR TITLE
[FIX] account: muting CABA entry lines generation at non-caba move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4591,6 +4591,12 @@ class AccountMoveLine(models.Model):
             :param lines:                   The account.move.lines to which fix the residual amounts.
             :param exchange_diff_move_vals: The current vals of the exchange difference journal entry.
             '''
+            skip_fx_on_caba_base_lines = self.env['ir.config_parameter'].sudo().get_param('account.skip_fx_on_caba_base_lines', '')
+            skip_fx_on_caba_base_lines = [int(x) for x in  skip_fx_on_caba_base_lines.split(',') if x.isnumeric()]
+            if skip_fx_on_caba_base_lines and lines.move_id.company_id.id in skip_fx_on_caba_base_lines:
+                # /!\ Note: Some l10n_** might no need these extra lines as it causes to unbalance the taxes.
+                # Taxes are already balanced in the method `_create_tax_cash_basis_moves` in account_reconcile_partial
+                return
             for move in lines.move_id:
                 account_vals_to_fix = {}
 


### PR DESCRIPTION
Main
=

Odoo is creating extra lines to compensate the difference in Base lines. And in doing so is creating new lines for the taxes.
- The base is reported at the rate of the payment. Therefore, the extra lines are not needed.
- Hence the extra lines for the taxes neither are needed. because they were reconciled and any difference has already be written off in the FX JE.

When Payment is in Past Dates
-

[FIX] account: muting CABA entry lines generation at non-caba move

### Without this Muting

![Screen Shot 2021-06-22 at 23 04 29](https://user-images.githubusercontent.com/7598010/123034797-d454d900-d3af-11eb-9892-dd03d3e97a3e.png)

### With this Muting


![Screen Shot 2021-06-22 at 22 34 08](https://user-images.githubusercontent.com/7598010/123034813-df0f6e00-d3af-11eb-9471-8ad226a1b666.png)


When Payment is in Future Dates.
=

### Without this Muting
![Screen Shot 2021-06-24 at 13 42 23](https://user-images.githubusercontent.com/7598010/123316777-dbd0cb00-d4f2-11eb-956a-4ab6a577115c.png)


### With this Muting

![Screen Shot 2021-06-24 at 13 36 19](https://user-images.githubusercontent.com/7598010/123316798-e1c6ac00-d4f2-11eb-8a7d-e410a22010dc.png)

Solution / Mitigation
=

![Screen Shot 2021-06-24 at 14 28 33](https://user-images.githubusercontent.com/7598010/123321389-8ac3d580-d4f8-11eb-8a5f-50024d30b3c0.png)


Opw
=

- 2627191


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr