### PR TITLE
[IMP] website_{event_meet, jitsi}: set default value for 'Max Capacity'

### DIFF
--- a/addons/website_event_meet/models/event_meeting_room.py
+++ b/addons/website_event_meet/models/event_meeting_room.py
@@ -24,6 +24,7 @@ class EventMeetingRoom(models.Model):
     event_id = fields.Many2one("event.event", string="Event", required=True, ondelete="cascade")
     is_pinned = fields.Boolean("Is Pinned")
     chat_room_id = fields.Many2one("chat.room", required=True, ondelete="restrict")
+    room_max_capacity = fields.Selection(default="8", copy=True)
     summary = fields.Char("Summary", translate=True)
     target_audience = fields.Char("Audience", translate=True)
 

--- a/addons/website_event_meet/tests/test_website_event_meet.py
+++ b/addons/website_event_meet/tests/test_website_event_meet.py
@@ -25,10 +25,11 @@ class TestWebsiteEventMeet(TestEventCommon):
             "event_id": self.event_0.id,
             "target_audience": "dev"
         })
-
         self.assertTrue(meeting_room.chat_room_id)
         self.assertTrue(meeting_room.chat_room_id.name)
         self.assertEqual(meeting_room.chat_room_id.max_capacity, "8")
+        # Ensure default value for room_max_capacity in event.meeting.room
+        self.assertEqual(meeting_room.room_max_capacity, "8")
 
     def test_meeting_room_copy(self):
         """Test the duplication of the meeting room."""
@@ -54,6 +55,10 @@ class TestWebsiteEventMeet(TestEventCommon):
 
         meeting_room_3 = meeting_room_1.copy()
         self.assertEqual(meeting_room_3.room_name, 'odoo-room-test-meeting-room-2')
+        # Ensure room_max_capacity is copied to new meeting room
+        self.assertEqual(meeting_room_3.room_max_capacity, "20")
+        # Ensure max_capacity in linked chat room is same
+        self.assertEqual(meeting_room_3.chat_room_id.max_capacity, "20")
 
     def test_meeting_room_unlink(self):
         """Test the duplication of the meeting room."""

--- a/addons/website_jitsi/models/chat_room_mixin.py
+++ b/addons/website_jitsi/models/chat_room_mixin.py
@@ -38,7 +38,7 @@ class ChatRoomMixin(models.AbstractModel):
             if any(values.get(fmatch[0]) for fmatch in self.ROOM_CONFIG_FIELDS) and not values.get('chat_room_id'):
                 if values.get('room_name'):
                     values['room_name'] = self._jitsi_sanitize_name(values['room_name'])
-                room_values = dict((fmatch[1], values.pop(fmatch[0])) for fmatch in self.ROOM_CONFIG_FIELDS if values.get(fmatch[0]))
+                room_values = dict((fmatch[1], values[fmatch[0]]) for fmatch in self.ROOM_CONFIG_FIELDS if values.get(fmatch[0]))
                 values['chat_room_id'] = self.env['chat.room'].create(room_values).id
         return super(ChatRoomMixin, self).create(values_list)
 


### PR DESCRIPTION
PURPOSE

When one tries to create a room without selecting a max capacity it was throwing
a 'Validation Error' which is not proper warning message.

The purpose of this commit is to provide a default value for that field which
was not getting in the respective situation, and in a way, we can eliminate this
error.

SPECIFICATIONS

Currently, there are two solutions proposed for this task either

to simply raise a proper warning message if the field is empty or
override the room_max_capacity field in 'event.meeting.room' and set some
default value.
In this commit, we chose the second one as the solution because still we could
give that default value.

LINKS

PR #72756
Task 2448435