### PR TITLE
[FIX] payment_ogone: process 3DS feedback data

### DIFF
--- a/addons/payment_ogone/controllers/main.py
+++ b/addons/payment_ogone/controllers/main.py
@@ -48,6 +48,16 @@ class OgoneController(http.Controller):
         # Process the payment through the token
         tree = tx_sudo._ogone_send_order_request(request_3ds_authentication=True)
 
+        feedback_data = {
+            'FEEDBACK_TYPE': 'directlink',
+            'ORDERID': tree.get('orderID'),
+            'tree': tree,
+        }
+        _logger.info(
+            "entering _handle_feedback_data with data:\n%s", pprint.pformat(feedback_data)
+        )
+        request.env['payment.transaction'].sudo()._handle_feedback_data('ogone', feedback_data)
+
         # Handle the response
         redirect_html_element = tree.find('HTML_ANSWER')
         if redirect_html_element:
@@ -64,15 +74,6 @@ class OgoneController(http.Controller):
                 'payment_ogone.directlink_feedback', {'redirect_html': redirect_html}
             )
         else:
-            feedback_data = {
-                'FEEDBACK_TYPE': 'directlink',
-                'ORDERID': tree.get('orderID'),
-                'tree': tree,
-            }
-            _logger.info(
-                "entering _handle_feedback_data with data:\n%s", pprint.pformat(feedback_data)
-            )
-            request.env['payment.transaction'].sudo()._handle_feedback_data('ogone', feedback_data)
             if tx_sudo.state in ('cancel', 'error'):
                 tx_sudo.token_id.active = False  # The initial payment failed, archive the token
             return werkzeug.utils.redirect('/payment/status')


### PR DESCRIPTION
  - When a customer is redirected to a 3DS page, the
    payment transaction was never updated to the pending state.

    We now process the 3DS feeedback data to correctly set the
    transaction to pending mode.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
