### PR TITLE
[FIX] account: Fix a traceback in account_payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -752,8 +752,8 @@ class AccountPayment(models.Model):
             for line in writeoff_lines:
                 line_ids_commands.append((2, line.id))
 
-            if writeoff_lines:
-                line_ids_commands.append((0, 0, line_vals_list[2]))
+            for extra_line_vals in line_vals_list[2:]:
+                line_ids_commands.append((0, 0, extra_line_vals))
 
             # Update the existing journal items.
             # If dealing with multiple write-off lines, they are dropped and a new one is generated.


### PR DESCRIPTION
When changing the journal of a payment that has already been saved by
one of another company, a traceback will occur because of writeoff lines.
This ensures that it will not happen.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
