### PR TITLE
[IMP] hr,website_hr_recruitment: improve job views

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -9,8 +9,10 @@ class Job(models.Model):
     _name = "hr.job"
     _description = "Job Position"
     _inherit = ['mail.thread']
+    _order = 'sequence'
 
     name = fields.Char(string='Job Position', required=True, index=True, translate=True)
+    sequence = fields.Integer(default=10)
     expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees', store=True,
         help='Expected number of employees for this job position after new recruitment.')
     no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees", store=True,
@@ -31,6 +33,7 @@ class Job(models.Model):
 
     _sql_constraints = [
         ('name_company_uniq', 'unique(name, company_id, department_id)', 'The name of the job position must be unique per department in company!'),
+        ('no_of_recruitment_positive', 'CHECK(no_of_recruitment >= 0)', 'The expected number of new employees must be positive.')
     ]
 
     @api.depends('no_of_recruitment', 'employee_ids.job_id', 'employee_ids.active')

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -50,6 +50,7 @@
             <field name="model">hr.job</field>
             <field name="arch" type="xml">
                 <tree string="Job" sample="1">
+                    <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="department_id"/>
                     <field name="no_of_employee"/>

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models, _
 class Job(models.Model):
     _name = "hr.job"
     _inherit = ["mail.alias.mixin", "hr.job"]
-    _order = "state desc, name asc"
+    _order = "sequence, state desc, name asc"
 
     @api.model
     def _default_address_id(self):

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -30,7 +30,7 @@ class WebsiteHrRecruitment(http.Controller):
 
         # List jobs available to current UID
         domain = request.website.website_domain()
-        job_ids = Jobs.search(domain, order="is_published desc, no_of_recruitment desc").ids
+        job_ids = Jobs.search(domain, order="is_published desc, sequence, no_of_recruitment desc").ids
         # Browse jobs as superuser, because address is restricted
         jobs = Jobs.sudo().browse(job_ids)
 

--- a/addons/website_hr_recruitment/models/hr_recruitment.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment.py
@@ -51,6 +51,7 @@ class Job(models.Model):
         default_description = self.env["ir.model.data"].xmlid_to_object("website_hr_recruitment.default_website_description")
         return (default_description._render() if default_description else "")
 
+    website_published = fields.Boolean(help='Set if the application is published on the website of the company.')
     website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, default=_get_default_website_description, prefetch=False, sanitize_form=False)
 
     def _compute_website_url(self):

--- a/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
+++ b/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
@@ -20,4 +20,20 @@
             }
         }
     }
+    .o_website_hr_recruitment_job_description {
+        //The ellipsis may not be supported on all platforms, the text will just break for them
+        max-height: 60px; //Limit to 3 lines
+        line-height: 20px;
+        -webkit-line-clamp: 3;
+        -moz-line-clamp: 3;
+        -ms-line-clamp: 3;
+        line-clamp: 3;
+        word-break: break-word;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -moz-box-orient: vertical;
+        -ms-box-orient: vertical;
+        box-orient: vertical;
+        overflow: hidden;
+    }
 }

--- a/addons/website_hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/website_hr_recruitment/views/hr_recruitment_views.xml
@@ -35,6 +35,9 @@
             <div name="button_box" position="inside">
                 <field name="is_published" widget="website_redirect_button"/>
             </div>
+            <xpath expr="//field[@name='no_of_recruitment']" position="after">
+                <field name="website_published" string="Is Published"/>
+            </xpath>
         </field>
     </record>
 
@@ -57,6 +60,9 @@
             <field name="department_id" position="after">
                 <field name="website_id" groups="website.group_multi_website"/>
             </field>
+            <xpath expr="//field[@name='state']" position="after">
+                <field name="website_published" string="Published"/>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -49,14 +49,14 @@
                                     <h3 class="text-secondary mt0 mb4">
                                         <span t-field="job.name"/>
                                     </h3>
-                                    <h5 t-if="job.no_of_recruitment &gt; 1">
+                                    <h5 t-if="job.no_of_recruitment &gt;= 1">
                                         <t t-esc="job.no_of_recruitment"/> open positions
                                     </h5>
                                     <div t-if="editable"
                                        t-field="job.description"
                                        class="mt16 mb0 css_non_editable_mode_hidden"/>
-                                    <div t-esc="len((job.description or '').split(' ')) > 35 and '%s ...' % ' '.join(job.description.split(' ')[:35]) or job.description"
-                                        class="mt16 mb0 css_editable_mode_hidden"
+                                    <div t-esc="job.description or ''"
+                                        class="mt16 mb0 css_editable_mode_hidden o_website_hr_recruitment_job_description"
                                     />
                                     <div class="o_job_infos mt16">
                                         <span t-field="job.address_id" t-options='{


### PR DESCRIPTION
Multiple improvement with job views:
 - Add a sequence field for jobs
 - Display 'Open Positions' on the website event if there is only 1 open
   position
 - Display whether the website is published on both the list and the
   form views of hr.job
 - Fix an issue introduced with 446d906f508880eb787debbec3c23cfd081bb045
   where html field would be cut and html tags would be displayed
Minor change:
 - Add an sql constraint on the estimated number of recruitment to be
   positive

Task ID: 2581595
