### PR TITLE
[FIX] web_editor: ensure changes are saved for cover options

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -496,7 +496,11 @@ const UserValueWidget = Widget.extend({
         if (!previewMode && !isPreviewed) {
             this.notifyValueChange(true);
         }
-
+        // Ensure oe-field are saved when they are inside the target snippet.
+        if(!previewMode) {
+            this.$target.find('[data-oe-field]').addClass('o_dirty');
+        }
+        
         const data = {
             previewMode: previewMode || false,
             isSimulatedEvent: !!isSimulatedEvent,


### PR DESCRIPTION
On blog post / event pages the changes on "Size" and "Background Color" options were not saved properly.

We force the class "o_dirty" on the odoo field inside the snippet affected by the changes to ensure the changes are correctly saved.

task-2547729


---------


Related Odoo task : https://www.odoo.com/web#action=333&active_id=1695&cids=1&id=2547729&menu_id=4720&model=project.task&view_type=form

Also see : #70126


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
