### PR TITLE
[FIX] pos: Allow scroll on Floor screen on mobile devices

### DIFF
--- a/addons/pos_restaurant/static/src/css/restaurant.css
+++ b/addons/pos_restaurant/static/src/css/restaurant.css
@@ -46,7 +46,7 @@
     box-shadow: 0px 6px 0px -3px rgba(0,0,0,0.07) inset;
     background: #D8D7D7;
     background-repeat: no-repeat;
-    overflow: hidden;
+    overflow: auto;
     background-size: cover;
     transition: all 300ms ease-in-out;
 }
@@ -118,7 +118,7 @@
     z-index: 50;
 }
 .floor-map .edit-button.editing {
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 0;
     font-size: 20px;
@@ -136,7 +136,7 @@
     color: white;
 }
 .floor-map .edit-bar {
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 40px;
     margin: 8px;

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -33,17 +33,20 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
                 selectedTableId: null,
                 isEditMode: false,
                 floorBackground: floor.background_color,
+                floorMapScrollTop: 0,
             });
             this.floorMapRef = useRef('floor-map-ref');
         }
         patched() {
             this.floorMapRef.el.style.background = this.state.floorBackground;
+            this.state.floorMapScrollTop = this.floorMapRef.el.getBoundingClientRect().top;
         }
         mounted() {
             if (this.env.pos.table) {
                 this.env.pos.set_table(null);
             }
             this.floorMapRef.el.style.background = this.state.floorBackground;
+            this.state.floorMapScrollTop = this.floorMapRef.el.getBoundingClientRect().top;
             // call _tableLongpolling once then set interval of 5sec.
             this._tableLongpolling();
             this.tableLongpolling = setInterval(this._tableLongpolling.bind(this), 5000);

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="EditBar" owl="1">
-        <div class="edit-bar">
+        <div class="edit-bar" t-attf-style="top:{{props.floorMapScrollTop}}px;">
             <span class="edit-button" t-on-click.stop="trigger('create-table')">
                 <i class="fa fa-plus" role="img" aria-label="Add" title="Add"></i>
             </span>

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/FloorScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/FloorScreen.xml
@@ -25,10 +25,11 @@
                             <EditableTable t-else="" table="table" />
                         </t>
                     </div>
-                    <span t-if="env.pos.user.role == 'manager'" class="edit-button editing" t-att-class="{ active: state.isEditMode }" t-on-click.stop="toggleEditMode">
+                    <span t-if="env.pos.user.role == 'manager'" class="edit-button editing" t-att-class="{ active: state.isEditMode }" t-on-click.stop="toggleEditMode"
+                          t-attf-style="top:{{state.floorMapScrollTop}}px;">
                         <i class="fa fa-pencil" role="img" aria-label="Edit" title="Edit"></i>
                     </span>
-                    <EditBar t-if="state.isEditMode" selectedTable="selectedTable" />
+                    <EditBar t-if="state.isEditMode" selectedTable="selectedTable" floorMapScrollTop="state.floorMapScrollTop"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Step to reproduce:

1. On mobile devices, open the pos app and lunch a bar/restaurant session;
2. You can't navigate on floor screen => bug

To fix that we allow scroll on mobile devices.

Task ID: 2453679

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
