### PR TITLE
[FIX] point_of_sale : ticket is not save in DB

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -63,6 +63,7 @@ class PosOrder(models.Model):
             'cardholder_name': ui_paymentline.get('cardholder_name'),
             'transaction_id': ui_paymentline.get('transaction_id'),
             'payment_status': ui_paymentline.get('payment_status'),
+            'ticket': ui_paymentline.get('ticket'),
             'pos_order_id': order.id,
         }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If you use electronic terminal, electronic ticket is not save in database.
I you want reprint the ticket, electronic ticket is not present in the reprint ticket.


@pimodoo @rhe-odoo @guva-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
