### PR TITLE
[FIX] stock: outdated+difference_qty not searchable outside adjustment


### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -6463,6 +6463,13 @@ msgid "Unreserve"
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_inventory.py:0
+#: code:addons/stock/models/stock_inventory.py:0
+#, python-format
+msgid "Unsupported search on %s outside of an Inventory Adjustment"
+msgstr ""
+
+#. module: stock
 #: model:ir.ui.menu,name:stock.menu_stock_uom_form_action
 #: model_terms:ir.ui.view,arch_db:stock.stock_inventory_line_tree2
 msgid "UoM"

--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -521,6 +521,8 @@ class InventoryLine(models.Model):
             result = False
         else:
             raise NotImplementedError()
+        if not self.env.context.get('default_inventory_id'):
+            raise NotImplementedError(_('Unsupported search on %s outside of an Inventory Adjustment') % 'difference_qty')
         lines = self.search([('inventory_id', '=', self.env.context.get('default_inventory_id'))])
         line_ids = lines.filtered(lambda line: float_is_zero(line.difference_qty, line.product_id.uom_id.rounding) == result).ids
         return [('id', 'in', line_ids)]
@@ -531,6 +533,8 @@ class InventoryLine(models.Model):
                 value = not value
             else:
                 raise NotImplementedError()
+        if not self.env.context.get('default_inventory_id'):
+            raise NotImplementedError(_('Unsupported search on %s outside of an Inventory Adjustment') % 'outdated')
         lines = self.search([('inventory_id', '=', self.env.context.get('default_inventory_id'))])
         line_ids = lines.filtered(lambda line: line.outdated == value).ids
         return [('id', 'in', line_ids)]


### PR DESCRIPTION

Scenario:

- go to inventory lines without going to a inventory adjustement to get
to them (eg. add a view in studio or use "Open View" of debug tools)

- filter by outdated or difference_qty

There is always no resultat found.

Both of these fields are non-stored and so to search them, we only
support a single inventory adjustment to avoid needing to compute them
for all the database inventory lines.

opw-2578208
