### PR TITLE
[FIX] point_of_sale: set opening amount with several POS

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -255,8 +255,7 @@ class PosSession(models.Model):
             if session.config_id.cash_control and not session.rescue:
                 last_sessions = self.env['pos.session'].search([('config_id', '=', self.config_id.id)]).ids
                 # last session includes the new one already.
-                if len(last_sessions) > 1:
-                    self.cash_register_id.balance_start = self.env['pos.session'].browse(last_sessions[1]).cash_register_id.balance_end_real
+                self.cash_register_id.balance_start = self.env['pos.session'].browse(last_sessions[1]).cash_register_id.balance_end_real if len(last_sessions) > 1 else 0
                 values['state'] = 'opening_control'
             else:
                 values['state'] = 'opened'

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -624,3 +624,39 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertEqual(cash_register.balance_start, amount_paid)
         self.assertEqual(cash_register.balance_end_real, amount_paid)
         self.assertEqual(self.config.last_session_closing_cash, amount_paid)
+
+    def test_start_balance_with_two_pos(self):
+        """ When having several POS with cash control, this tests ensures that each POS has its correct opening amount """
+
+        def open_and_check(pos_data):
+            self.config = pos_data['config']
+            self.open_new_session()
+            session = self.pos_session
+            self.assertEqual(session.cash_register_id.balance_start, pos_data['amount_paid'])
+            session.set_cashbox_pos(pos_data['amount_paid'], False)
+
+        self.config.cash_control = True
+        pos01_config = self.config
+        pos02_config = pos01_config.copy()
+        pos01_data = {'config': pos01_config, 'p_qty': 1, 'amount_paid': 0}
+        pos02_data = {'config': pos02_config, 'p_qty': 3, 'amount_paid': 0}
+
+        for pos_data in [pos01_data, pos02_data]:
+            open_and_check(pos_data)
+            session = self.pos_session
+
+            order_data = self.create_ui_order_data([(self.product3, pos_data['p_qty'])])
+            pos_data['amount_paid'] += order_data['data']['amount_paid']
+            self.env['pos.order'].create_from_ui([order_data])
+
+            session.action_pos_session_closing_control()
+            self.env['account.bank.statement.cashbox'].create([{
+                'start_bank_stmt_ids': [],
+                'end_bank_stmt_ids': [(4, session.cash_register_id.id,)],
+                'cashbox_lines_ids': [(0, 0, {'number': 1, 'coin_value': pos_data['amount_paid']})],
+                'is_a_template': False
+            }])
+            session.action_pos_session_validate()
+
+        open_and_check(pos01_data)
+        open_and_check(pos02_data)


### PR DESCRIPTION
When having several POS with cash control, if at least one POS already
has a closed session with cash in box, the first session of the other
POS may have an incorrect opening amount

To reproduce the error:
(Let POS01 be the existing point of sale)
1. Edit POS01's settings:
    - Enable "Advanced Cash Control"
2. Duplicate POS01 (-> POS02)
3. Start a session with POS01
4. Sell one product, payment in cash (Let P be the product's price)
5. Close POS01's session (correctly set the closing cash)
6. Start a session with POS02

Error: On opening cash control, the opening amount is P, it should be 0

OPW-2574096