### PR TITLE
[FIX] sale_timesheet_edit: prevents error on amend timesheet on mobile

### DIFF
--- a/addons/sale_timesheet_edit/static/src/js/so_line_one2many.js
+++ b/addons/sale_timesheet_edit/static/src/js/so_line_one2many.js
@@ -10,6 +10,7 @@ const SoLineOne2Many = FieldOne2Many.extend({
             ev.data.changes &&
             ev.data.changes.hasOwnProperty('timesheet_ids') &&
             ev.data.changes.timesheet_ids.operation === 'UPDATE' &&
+            ev.data.changes.timesheet_ids.data &&
             ev.data.changes.timesheet_ids.data.hasOwnProperty('so_line')) {
             const line = this.value.data.find(line => {
                 return line.id === ev.data.changes.timesheet_ids.id;


### PR DESCRIPTION
In 14.0 when changing the time amount on a timesheet line on a task, if the current layout is mobile, an error will pop up when trying to save the change. This is because we are trying to check a property of an item that does not exist.

With this commit, we first check that the item exists before trying to check its properties. Because of the order of evaluation of the "if" statement, this means we will never try to get the property of the undefined item.

opw-2534800