### PR TITLE
[WIP] [ADD] web_editor: insert a select element with the command bar

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/select_options_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/select_options_dialog.js
@@ -5,18 +5,14 @@ const core = require('web.core');
 const Dialog = require('wysiwyg.widgets.Dialog');
 
 const _t = core._t;
-const qweb = core.qweb;
 
-let optionId = 1;
 const SelectOptionsDialog = Dialog.extend({
     template: 'wysiwyg.widgets.selectoptions',
     xmlDependencies: Dialog.prototype.xmlDependencies.concat(
         ['/web_editor/static/src/xml/wysiwyg.xml']
     ),
     events: _.extend({}, Dialog.prototype.events, {
-        'click a.js_add_option': '_onAddOptionButtonClick',
-        'click button.js_delete_option': '_onDeleteOptionButtonClick',
-        'click button.js_edit_option': '_onEditOptionButtonClick',
+        'change textarea.o_select_options': '_onChangeOptions',
     }),
 
     /**
@@ -29,14 +25,8 @@ const SelectOptionsDialog = Dialog.extend({
         }, options || {}));
         this.select = select;
         if (this.select) {
-            let id = 0;
             this.selectOptions = [...this.select.querySelectorAll('option')].map(option => {
-                id++;
-                return {
-                    id,
-                    label: $(option).text(),
-                    value: option.getAttribute('value'),
-                };
+                return $(option).text();
             });
         } else {
             this.selectOptions = [];
@@ -45,141 +35,23 @@ const SelectOptionsDialog = Dialog.extend({
     /**
      * @override
      */
-    start: function () {
-        var r = this._super.apply(this, arguments);
-        this.$('.oe_selectoption_editor').sortable({
-            listType: 'ul',
-            handle: 'div',
-            items: 'li',
-            toleranceElement: '> div',
-            forcePlaceholderSize: true,
-            opacity: 0.6,
-            placeholder: 'oe_option_placeholder',
-            tolerance: 'pointer',
-            attribute: 'data-option-id',
-            update: ev => {
-                // Reorder the options.
-                const ids = $(ev.target).find('[data-option-id]').toArray().map(option => +option.dataset.optionId);
-                this.selectOptions = ids.map(id => this.selectOptions.find(option => option.id === id));
-                this._updatePreview();
-            }
-        });
-        return r;
-    },
-    /**
-     * @override
-     */
     save: function () {
-        const $options = this.selectOptions.map(option => $(`<option value=${option.value}>${option.label}</option>`));
+        const $options = this.selectOptions.map(option => $(`<option>${option}</option>`));
         const $select = $('<select contenteditable="false"/>');
         $select.append(...$options);
         this.final_data = $select[0];
         return this._super(...arguments);
     },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * Redraw the preview of the Select element based on `selectOptions`.
-     *
-     * @private
-     */
-    _updatePreview: function () {
-        this.$('#o_selectoptions_dialog_preview').empty().append(
-            $(`<select>${this.selectOptions.map(option => (
-                `<option value=${option.value}>${option.label}</option>`
-            ))}</select>`)
-        );
+    selectOptionsText: function () {
+        return this.selectOptions.join('\n');
     },
 
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
-    /**
-     * Called when the "add option" button is clicked -> Opens the appropriate
-     * dialog to edit this new option.
-     *
-     * @private
-     */
-    _onAddOptionButtonClick: function () {
-        const dialog = new SelectOptionDialog(this);
-        dialog.on('save', this, option => {
-            option.id = optionId;
-            optionId++;
-            this.selectOptions.push(option);
-            this.$('.oe_selectoption_editor').append(
-                qweb.render('wysiwyg.widgets.selectoptions.option', { option })
-            );
-            this._updatePreview();
-        });
-        dialog.open();
-    },
-    /**
-     * Called when the "delete option" button is clicked -> Deletes this option.
-     *
-     * @private
-     */
-    _onDeleteOptionButtonClick: function (ev) {
-        const $option = $(ev.currentTarget).closest('[data-option-id]');
-        const optionID = parseInt($option.data('option-id'));
-        if (optionID) {
-            this.selectOptions.splice(this.selectOptions.findIndex(option => option.id === optionID), 1);
-        }
-        $option.remove();
-        this._updatePreview();
-    },
-    /**
-     * Called when the "edit option" button is clicked -> Opens the appropriate
-     * dialog to edit this option.
-     *
-     * @private
-     */
-    _onEditOptionButtonClick: function (ev) {
-        const $option = $(ev.currentTarget).closest('[data-option-id]');
-        const optionID = parseInt($option.data('option-id'));
-        const option = this.selectOptions.find(option => option.id === optionID);
-        if (option) {
-            const dialog = new SelectOptionDialog(this, {}, option);
-            dialog.on('save', this, updatedOption => {
-                option.label = updatedOption.label;
-                option.value = updatedOption.value;
-                $option.find('.js_option_label').first().text(option.label);
-                this._updatePreview();
-            });
-            dialog.open();
-        } else {
-            Dialog.alert(null, "Could not find option");
-        }
-    },
-});
-
-var SelectOptionDialog = Dialog.extend({
-    template: 'wysiwyg.widgets.selectoption',
-    xmlDependencies: Dialog.prototype.xmlDependencies.concat(
-        ['/web_editor/static/src/xml/wysiwyg.xml']
-    ),
-
-    /**
-     * @constructor
-     */
-    init: function (parent, options, option) {
-        this._super(parent, _.extend({
-            title: _t("Add an option"),
-        }, options || {}));
-        this.option = option;
-    },
-    /**
-     * @override
-     */
-    save: function () {
-        this.final_data = {
-            label: this.$modal.find('input#o_selectoption_dialog_label_input').val(),
-            value: this.$modal.find('input#o_selectoption_dialog_value_input').val(),
-        }
-        return this._super(...arguments);
+    _onChangeOptions: function (ev) {
+        this.selectOptions = $(ev.target).val().split('\n').map(option => option.trim());
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/select_options_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/select_options_dialog.js
@@ -1,0 +1,187 @@
+odoo.define('wysiwyg.widgets.SelectOptionsDialog', function (require) {
+'use strict';
+
+const core = require('web.core');
+const Dialog = require('wysiwyg.widgets.Dialog');
+
+const _t = core._t;
+const qweb = core.qweb;
+
+let optionId = 1;
+const SelectOptionsDialog = Dialog.extend({
+    template: 'wysiwyg.widgets.selectoptions',
+    xmlDependencies: Dialog.prototype.xmlDependencies.concat(
+        ['/web_editor/static/src/xml/wysiwyg.xml']
+    ),
+    events: _.extend({}, Dialog.prototype.events, {
+        'click a.js_add_option': '_onAddOptionButtonClick',
+        'click button.js_delete_option': '_onDeleteOptionButtonClick',
+        'click button.js_edit_option': '_onEditOptionButtonClick',
+    }),
+
+    /**
+     * @constructor
+     */
+    init: function (parent, options, select) {
+        this._super(parent, _.extend({}, {
+            title: _t("Edit your options"),
+            save_text: _t("Add"),
+        }, options || {}));
+        this.select = select;
+        if (this.select) {
+            let id = 0;
+            this.selectOptions = [...this.select.querySelectorAll('option')].map(option => {
+                id++;
+                return {
+                    id,
+                    label: $(option).text(),
+                    value: option.getAttribute('value'),
+                };
+            });
+        } else {
+            this.selectOptions = [];
+        }
+    },
+    /**
+     * @override
+     */
+    start: function () {
+        var r = this._super.apply(this, arguments);
+        this.$('.oe_selectoption_editor').sortable({
+            listType: 'ul',
+            handle: 'div',
+            items: 'li',
+            toleranceElement: '> div',
+            forcePlaceholderSize: true,
+            opacity: 0.6,
+            placeholder: 'oe_option_placeholder',
+            tolerance: 'pointer',
+            attribute: 'data-option-id',
+            update: ev => {
+                // Reorder the options.
+                const ids = $(ev.target).find('[data-option-id]').toArray().map(option => +option.dataset.optionId);
+                this.selectOptions = ids.map(id => this.selectOptions.find(option => option.id === id));
+                this._updatePreview();
+            }
+        });
+        return r;
+    },
+    /**
+     * @override
+     */
+    save: function () {
+        const $options = this.selectOptions.map(option => $(`<option value=${option.value}>${option.label}</option>`));
+        const $select = $('<select contenteditable="false"/>');
+        $select.append(...$options);
+        this.final_data = $select[0];
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Redraw the preview of the Select element based on `selectOptions`.
+     *
+     * @private
+     */
+    _updatePreview: function () {
+        this.$('#o_selectoptions_dialog_preview').empty().append(
+            $(`<select>${this.selectOptions.map(option => (
+                `<option value=${option.value}>${option.label}</option>`
+            ))}</select>`)
+        );
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Called when the "add option" button is clicked -> Opens the appropriate
+     * dialog to edit this new option.
+     *
+     * @private
+     */
+    _onAddOptionButtonClick: function () {
+        const dialog = new SelectOptionDialog(this);
+        dialog.on('save', this, option => {
+            option.id = optionId;
+            optionId++;
+            this.selectOptions.push(option);
+            this.$('.oe_selectoption_editor').append(
+                qweb.render('wysiwyg.widgets.selectoptions.option', { option })
+            );
+            this._updatePreview();
+        });
+        dialog.open();
+    },
+    /**
+     * Called when the "delete option" button is clicked -> Deletes this option.
+     *
+     * @private
+     */
+    _onDeleteOptionButtonClick: function (ev) {
+        const $option = $(ev.currentTarget).closest('[data-option-id]');
+        const optionID = parseInt($option.data('option-id'));
+        if (optionID) {
+            this.selectOptions.splice(this.selectOptions.findIndex(option => option.id === optionID), 1);
+        }
+        $option.remove();
+        this._updatePreview();
+    },
+    /**
+     * Called when the "edit option" button is clicked -> Opens the appropriate
+     * dialog to edit this option.
+     *
+     * @private
+     */
+    _onEditOptionButtonClick: function (ev) {
+        const $option = $(ev.currentTarget).closest('[data-option-id]');
+        const optionID = parseInt($option.data('option-id'));
+        const option = this.selectOptions.find(option => option.id === optionID);
+        if (option) {
+            const dialog = new SelectOptionDialog(this, {}, option);
+            dialog.on('save', this, updatedOption => {
+                option.label = updatedOption.label;
+                option.value = updatedOption.value;
+                $option.find('.js_option_label').first().text(option.label);
+                this._updatePreview();
+            });
+            dialog.open();
+        } else {
+            Dialog.alert(null, "Could not find option");
+        }
+    },
+});
+
+var SelectOptionDialog = Dialog.extend({
+    template: 'wysiwyg.widgets.selectoption',
+    xmlDependencies: Dialog.prototype.xmlDependencies.concat(
+        ['/web_editor/static/src/xml/wysiwyg.xml']
+    ),
+
+    /**
+     * @constructor
+     */
+    init: function (parent, options, option) {
+        this._super(parent, _.extend({
+            title: _t("Add an option"),
+        }, options || {}));
+        this.option = option;
+    },
+    /**
+     * @override
+     */
+    save: function () {
+        this.final_data = {
+            label: this.$modal.find('input#o_selectoption_dialog_label_input').val(),
+            value: this.$modal.find('input#o_selectoption_dialog_value_input').val(),
+        }
+        return this._super(...arguments);
+    },
+});
+
+return SelectOptionsDialog;
+});

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/select_options_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/select_options_popover_widget.js
@@ -1,0 +1,78 @@
+/** @odoo-module **/
+
+import Widget from 'web.Widget';
+
+const SelectOptionsPopoverWidget = Widget.extend({
+    template: 'wysiwyg.widgets.selectoptions.edit.tooltip',
+    xmlDependencies: ['/web_editor/static/src/xml/wysiwyg.xml'],
+    events: {
+        'click .o_we_remove_select': '_onRemoveSelectClick',
+        'click .o_we_edit_select': '_onEditSelectClick',
+    },
+
+    /**
+     * @constructor
+     * @param {Element} target: target Element for which we display a popover
+     * @param {OdooClass} wysiwyg
+     */
+    init(parent, target, wysiwyg) {
+        this._super(...arguments);
+        this.target = target;
+        this.$target = $(target);
+        this.wysiwyg = wysiwyg
+    },
+    /**
+     * @override
+     */
+    start() {
+        this.$target.popover({
+            html: true,
+            delay: 2000,
+            content: this.$el,
+            placement: 'auto',
+            trigger: 'click',
+        })
+        .popover('show')
+        .data('bs.popover').tip.classList.add('o_edit_select_popover');
+
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    destroy() {
+        this.$target.popover('dispose');
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Opens the Select Options Dialog.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onEditSelectClick(ev) {
+        this.wysiwyg.openSelectOptionsDialog(this.target);
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        this.destroy();
+    },
+    /**
+     * Removes the select element.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onRemoveSelectClick(ev) {
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        this.destroy();
+        this.$target.remove();
+    },
+});
+
+export default SelectOptionsPopoverWidget;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/widgets.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/widgets.js
@@ -4,10 +4,12 @@ odoo.define('wysiwyg.widgets', function (require) {
 var Dialog = require('wysiwyg.widgets.Dialog');
 var AltDialog = require('wysiwyg.widgets.AltDialog');
 var MediaDialog = require('wysiwyg.widgets.MediaDialog');
+var SelectOptionsDialog = require('wysiwyg.widgets.SelectOptionsDialog');
 var LinkDialog = require('wysiwyg.widgets.LinkDialog');
 var LinkTools = require('wysiwyg.widgets.LinkTools');
 var ImageCropWidget = require('wysiwyg.widgets.ImageCropWidget');
 const LinkPopoverWidget = require('@web_editor/js/wysiwyg/widgets/link_popover_widget')[Symbol.for("default")];
+const SelectOptionsPopoverWidget = require('@web_editor/js/wysiwyg/widgets/select_options_popover_widget')[Symbol.for("default")];
 const {ColorpickerDialog} = require('web.Colorpicker');
 
 var media = require('wysiwyg.widgets.media');
@@ -16,10 +18,12 @@ return {
     Dialog: Dialog,
     AltDialog: AltDialog,
     MediaDialog: MediaDialog,
+    SelectOptionsDialog: SelectOptionsDialog,
     LinkDialog: LinkDialog,
     LinkTools: LinkTools,
     ImageCropWidget: ImageCropWidget,
     LinkPopoverWidget: LinkPopoverWidget,
+    SelectOptionsPopoverWidget: SelectOptionsPopoverWidget,
     ColorpickerDialog: ColorpickerDialog,
 
     MediaWidget: media.MediaWidget,

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -46,6 +46,7 @@
     }
     select {
         width: fit-content;
+        padding-right: 10px;
     }
     .o_readonly select {
         pointer-events: none;

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -44,6 +44,12 @@
     table.table.table-bordered {
         table-layout: fixed;
     }
+    select {
+        width: fit-content;
+    }
+    .o_readonly select {
+        pointer-events: none;
+    }
 }
 
 .o_field_widgetTextHtml_fullscreen {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -263,10 +263,10 @@ span[data-oe-type="monetary"] {
     white-space: nowrap;
 }
 
-// Menus and selects
+// Menus
 // TODO should not be here but used by web_studio so must stay here for now
-ul.oe_menu_editor, ul.oe_selectoption_editor {
-    .oe_menu_placeholder, .oe_option_placeholder {
+ul.oe_menu_editor {
+    .oe_menu_placeholder {
         outline: 1px dashed #4183C4;
     }
     ul {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -263,10 +263,10 @@ span[data-oe-type="monetary"] {
     white-space: nowrap;
 }
 
-// Menus
+// Menus and selects
 // TODO should not be here but used by web_studio so must stay here for now
-ul.oe_menu_editor {
-    .oe_menu_placeholder {
+ul.oe_menu_editor, ul.oe_selectoption_editor {
+    .oe_menu_placeholder, .oe_option_placeholder {
         outline: 1px dashed #4183C4;
     }
     ul {

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -79,6 +79,76 @@
         </div>
     </form>
 
+    <!-- Select Options Dialog (allows to choose options for a <select>) -->
+    <t t-name="wysiwyg.widgets.selectoptions.option">
+        <li t-att-data-option-id="option.id">
+            <div class="input-group">
+                <div class="input-group-prepend">
+                    <span class="input-group-text fa fa-bars" role="img" aria-label="Move Option" title="Move Option"/>
+                </div>
+                <span class="form-control d-flex align-items-center">
+                    <span class="js_option_label o_text_overflow flex-grow-1">
+                        <t t-esc="option.label"/>
+                    </span>
+                </span>
+                <span class="input-group-append">
+                    <button type="button" class="btn btn-primary js_edit_option fa fa-pencil-square-o" aria-label="Edit Option" title="Edit Option"/>
+                    <button type="button" class="btn btn-danger js_delete_option fa fa-trash-o" aria-label="Delete Option" title="Delete Option"/>
+                </span>
+            </div>
+        </li>
+    </t>
+    <div t-name="wysiwyg.widgets.selectoptions">
+        <div class="row">
+            <div class="col-lg-8">
+                <ul class="oe_selectoption_editor list-unstyled">
+                    <t t-foreach="widget.selectOptions" t-as="option">
+                        <t t-call="wysiwyg.widgets.selectoptions.option"/>
+                    </t>
+                </ul>
+            </div>
+            <div class="col-lg-4 o_selectoptions_dialog_preview">
+                <div class="form-group text-center">
+                    <label>Preview</label>
+                    <div id="o_selectoptions_dialog_preview" style="overflow-x: auto; max-width: 100%; max-height: 200px;"/>
+                </div>
+            </div>
+        </div>
+        <div class="mt32">
+            <a href="#" class="js_add_option">
+                <i class="fa fa-plus-circle"/> Add Option
+            </a><br/>
+        </div>
+    </div>
+    <div t-name="wysiwyg.widgets.selectoption">
+        <div class="row">
+            <form class="col-12">
+                <div class="form-group row">
+                    <label class="col-form-label col-md-3" for="o_selectoption_dialog_label_input">Label</label>
+                    <div class="col-md-9">
+                        <input type="text" name="label" class="form-control" id="o_selectoption_dialog_label_input" required="required" t-att-value="widget.option and widget.option.label"/>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-form-label col-md-3" for="o_selectoption_dialog_value_input">Value</label>
+                    <div class="col-md-9">
+                        <input type="text" name="value" class="form-control" id="o_selectoption_dialog_value_input" required="required" t-att-value="widget.option and widget.option.value"/>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Select Edition : Popover -->
+    <div t-name="wysiwyg.widgets.selectoptions.edit.tooltip" class="d-flex">
+        <a href="#" class="mr-2 o_we_edit_select text-dark flex-grow-1" data-toggle="tooltip" data-placement="top" title="Edit Select">
+            <i class="fa fa-edit"/>
+        </a>
+        <a href="#" class="ml-2 o_we_remove_select text-dark" data-toggle="tooltip" data-placement="top" title="Remove Select">
+            <i class="fa fa-trash"/>
+        </a>
+    </div>
+
     <!-- Media Dialog (allows to choose an img/pictogram/video) -->
     <div t-name="wysiwyg.widgets.media">
         <ul class="nav nav-tabs" role="tablist">

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -80,63 +80,9 @@
     </form>
 
     <!-- Select Options Dialog (allows to choose options for a <select>) -->
-    <t t-name="wysiwyg.widgets.selectoptions.option">
-        <li t-att-data-option-id="option.id">
-            <div class="input-group">
-                <div class="input-group-prepend">
-                    <span class="input-group-text fa fa-bars" role="img" aria-label="Move Option" title="Move Option"/>
-                </div>
-                <span class="form-control d-flex align-items-center">
-                    <span class="js_option_label o_text_overflow flex-grow-1">
-                        <t t-esc="option.label"/>
-                    </span>
-                </span>
-                <span class="input-group-append">
-                    <button type="button" class="btn btn-primary js_edit_option fa fa-pencil-square-o" aria-label="Edit Option" title="Edit Option"/>
-                    <button type="button" class="btn btn-danger js_delete_option fa fa-trash-o" aria-label="Delete Option" title="Delete Option"/>
-                </span>
-            </div>
-        </li>
-    </t>
     <div t-name="wysiwyg.widgets.selectoptions">
-        <div class="row">
-            <div class="col-lg-8">
-                <ul class="oe_selectoption_editor list-unstyled">
-                    <t t-foreach="widget.selectOptions" t-as="option">
-                        <t t-call="wysiwyg.widgets.selectoptions.option"/>
-                    </t>
-                </ul>
-            </div>
-            <div class="col-lg-4 o_selectoptions_dialog_preview">
-                <div class="form-group text-center">
-                    <label>Preview</label>
-                    <div id="o_selectoptions_dialog_preview" style="overflow-x: auto; max-width: 100%; max-height: 200px;"/>
-                </div>
-            </div>
-        </div>
-        <div class="mt32">
-            <a href="#" class="js_add_option">
-                <i class="fa fa-plus-circle"/> Add Option
-            </a><br/>
-        </div>
-    </div>
-    <div t-name="wysiwyg.widgets.selectoption">
-        <div class="row">
-            <form class="col-12">
-                <div class="form-group row">
-                    <label class="col-form-label col-md-3" for="o_selectoption_dialog_label_input">Label</label>
-                    <div class="col-md-9">
-                        <input type="text" name="label" class="form-control" id="o_selectoption_dialog_label_input" required="required" t-att-value="widget.option and widget.option.label"/>
-                    </div>
-                </div>
-                <div class="form-group row">
-                    <label class="col-form-label col-md-3" for="o_selectoption_dialog_value_input">Value</label>
-                    <div class="col-md-9">
-                        <input type="text" name="value" class="form-control" id="o_selectoption_dialog_value_input" required="required" t-att-value="widget.option and widget.option.value"/>
-                    </div>
-                </div>
-            </form>
-        </div>
+        <textarea class="o_select_options" rows="10" cols="30"
+            placeholder="Enter your options separated by a line break."><t t-esc="widget.selectOptionsText()"/></textarea>
     </div>
 
     <!-- Select Edition : Popover -->

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1757,13 +1757,19 @@ class Html(_String):
     column_type = ('text', 'text')
     column_cast_from = ('varchar',)
 
-    sanitize = True                     # whether value must be sanitized
-    sanitize_tags = True                # whether to sanitize tags (only a white list of attributes is accepted)
-    sanitize_attributes = True          # whether to sanitize attributes (only a white list of attributes is accepted)
-    sanitize_style = False              # whether to sanitize style attributes
-    sanitize_form = True                # whether to sanitize forms
-    strip_style = False                 # whether to strip style attributes (removed and therefore not sanitized)
-    strip_classes = False               # whether to strip classes attributes
+    sanitize = True                             # whether value must be sanitized
+    sanitize_tags = True                        # whether to sanitize tags (only a white list of attributes is accepted)
+    sanitize_attributes = True                  # whether to sanitize attributes (only a white list of attributes is accepted)
+    sanitize_style = False                      # whether to sanitize style attributes
+
+    # remove and kill all the tags that are removed and killed by default with
+    # sanitize_form, except for "select"
+    sanitize_form = False                       # whether to sanitize forms
+    remove_tags = ['form']                      # list of tags to remove while keeping their content
+    kill_tags = ['button', 'input', 'textarea'] # list of tags to kill, along with their whole subtree
+
+    strip_style = False                         # whether to strip style attributes (removed and therefore not sanitized)
+    strip_classes = False                       # whether to strip classes attributes
 
     def _get_attrs(self, model_class, name):
         # called by _setup_attrs(), working together with _String._setup_attrs()
@@ -1797,6 +1803,8 @@ class Html(_String):
                 sanitize_attributes=self.sanitize_attributes,
                 sanitize_style=self.sanitize_style,
                 sanitize_form=self.sanitize_form,
+                remove_tags=self.remove_tags,
+                kill_tags=self.kill_tags,
                 strip_style=self.strip_style,
                 strip_classes=self.strip_classes)
         return value
@@ -1811,6 +1819,8 @@ class Html(_String):
                 sanitize_attributes=self.sanitize_attributes,
                 sanitize_style=self.sanitize_style,
                 sanitize_form=self.sanitize_form,
+                remove_tags=self.remove_tags,
+                kill_tags=self.kill_tags,
                 strip_style=self.strip_style,
                 strip_classes=self.strip_classes)
         return value

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -167,7 +167,7 @@ class _Cleaner(clean.Cleaner):
                 del el.attrib['style']
 
 
-def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, sanitize_form=True, strip_style=False, strip_classes=False):
+def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, sanitize_form=True, remove_tags=None, kill_tags=None, strip_style=False, strip_classes=False):
     if not src:
         return src
     src = ustr(src, errors='replace')
@@ -190,16 +190,19 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
         'comments': False,
         'processing_instructions': False
     }
+
     if sanitize_tags:
         kwargs['allow_tags'] = allowed_tags
+        extra_tags_to_kill = [] if kill_tags is None else kill_tags
+        extra_tags_to_remove = [] if remove_tags is None else remove_tags
         if etree.LXML_VERSION >= (2, 3, 1):
             # kill_tags attribute has been added in version 2.3.1
             kwargs.update({
-                'kill_tags': tags_to_kill,
-                'remove_tags': tags_to_remove,
+                'kill_tags': tags_to_kill + extra_tags_to_kill,
+                'remove_tags': tags_to_remove + extra_tags_to_remove,
             })
         else:
-            kwargs['remove_tags'] = tags_to_kill + tags_to_remove
+            kwargs['remove_tags'] = tags_to_kill + tags_to_remove + extra_tags_to_kill + extra_tags_to_remove
 
     if sanitize_attributes and etree.LXML_VERSION >= (3, 1, 0):  # lxml < 3.1.0 does not allow to specify safe_attrs. We keep all attributes in order to keep "style"
         if strip_classes:


### PR DESCRIPTION
### /!\ This requires a new build of Odoo Editor /!\

This allows the use to insert a `<select>` element with the command bar. The `<select>` can then be configured and edited with a dialog.

Given that `<select>` elements are sanitized by default in html fields, we need to bypass that sanitization, which involves creating new options to customize the sanitizer (`remove_tags` and `kill_tags`).

To insert a `<select>` element, type "/" to open the command bar, then pick "Select": a dialog open. Add, edit, remove, reorder options using the dialog, then click "Add" to add it to the DOM.

To edit or remove a `<select>` element, hover over it with the mouse to see a tooltip with an edit button which opens the aforementioned dialog, as well as a remove button.