### PR TITLE
[IMP] website: make website configurator build pages through JS tours

### DIFF
--- a/addons/website/static/src/js/tours/configurator_tour.js
+++ b/addons/website/static/src/js/tours/configurator_tour.js
@@ -1,9 +1,9 @@
 odoo.define("website.configurator_tour", function (require) {
 "use strict";
 
-const wTourUtils = require("website.tour_utils");
-const core = require("web.core");
-const _t = core._t;
+const {_t} = require('web.core');
+const tour = require('web_tour.tour');
+const wTourUtils = require('website.tour_utils');
 
 let titleSelector = '#wrap > section:first-child';
 let title = $(titleSelector).find('h1, h2').first();
@@ -43,5 +43,14 @@ const steps = [
 ];
 
 wTourUtils.registerThemeHomepageTour('configurator_tour', steps);
+
+// Now the tour that is used for auto-building pages from the configurator
+const urlParams = new URLSearchParams(window.location.search);
+const snippets = urlParams.get('website_configurator_snippets');
+if (snippets) {
+    tour.register('website_configurator_page_builder_tour', {
+        test: true,
+    }, snippets.split(',').map(key => wTourUtils.dragNDrop({id: key})));
+}
 
 });

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -176,7 +176,7 @@ function clickOnText(snippet, element, position = "bottom") {
  */
 function dragNDrop(snippet, position = "bottom") {
     return {
-        trigger: `#oe_snippets .oe_snippet[name="${snippet.name}"] .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+        trigger: `#oe_snippets .oe_snippet:has(.oe_snippet_body[data-snippet="${snippet.id}"]) .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
         extra_trigger: "body.editor_enable.editor_has_snippets",
         moveTrigger: '.oe_drop_zone',
         content: _.str.sprintf(_t("Drag the <b>%s</b> building block and drop it at the bottom of the page."), snippet.name),


### PR DESCRIPTION
Before this commit, the configurator was building pages by receiving
a list of snippets to use and rendered their XML definition via qweb on
the python side.

This approach has problems:
- the "data-snippet" attribute is not added correctly on snippets and
  was added "by hand", duplicating the logic
- all the JS logic that can be necessary to render the snippet correctly
  on "drop" in the page is not done at all (onBuilt, cleanForSave, ...)
- limits the possibilities to apply options on the snippets (as most
  of those options are coded in JS, so the python does not know how to
  apply one (e.g. shapes on images))

