### PR TITLE
[FIX] account: tags form view: make country readonly only when necessary

### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -395,7 +395,7 @@ action = model.setting_init_bank_account_action()
                             <field name="name"/>
                             <field name="applicability"/>
                             <field name="tax_negate" readonly="1" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
-                            <field name="country_id" readonly="1" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
+                            <field name="country_id" attrs="{'invisible': [('applicability', '!=', 'taxes')], 'readonly': [('tax_report_line_ids', '!=', [])]}"/>
                             <field name="tax_report_line_ids" readonly="1" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
                         </group>
                     </sheet>


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/71872 made country_id readonly in every circumstance. This made it impossible to create an account.account.tag targetting taxes from scratch in the UI. We only want to prevent edition of this field when the tag has been generated by a tax.report.line.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
