### PR TITLE
[IMP] web: add shortcuts access from the command palette

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -4,16 +4,6 @@ import { isMacOS } from "../browser/feature_detection";
 import { registry } from "../registry";
 import { browser } from "../browser/browser";
 
-export function getHotkeyToPress(hotkey, altIsOptional = false) {
-    let result = hotkey.split("+");
-    if (isMacOS()) {
-        result = result.map((x) => x.replace("control", "command"));
-    }
-    if (!altIsOptional) {
-        result = isMacOS() ? ["control", ...result] : ["alt", ...result];
-    }
-    return result.join("+");
-}
 
 const ALPHANUM_KEYS = "abcdefghijklmnopqrstuvwxyz0123456789".split("");
 const NAV_KEYS = [

--- a/addons/web/static/src/webclient/commands/command_palette.js
+++ b/addons/web/static/src/webclient/commands/command_palette.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { useAutofocus } from "../../core/autofocus_hook";
+import { isMacOS } from "../../core/browser/feature_detection";
 import { useEffect } from "../../core/effect_hook";
 import { useHotkey } from "../../core/hotkey_hook";
 import { scrollTo } from "../../core/utils/scrolling";
@@ -87,6 +88,18 @@ export class CommandPalette extends Component {
             },
             { altIsOptional: true, allowRepeat: true }
         );
+
+        for (const command of this.initialCommands) {
+            if (command.hotkey) {
+                useHotkey(
+                    command.hotkey,
+                    () => {
+                        command.action();
+                        this.props.closeMe();
+                    },
+                );
+            }
+        }
     }
 
     get categories() {
@@ -101,6 +114,19 @@ export class CommandPalette extends Component {
             }
         }
         return categories;
+    }
+
+    getKeysToPress(command) {
+        const { hotkey, hotkeyOptions } = command;
+        const altIsOptional = hotkeyOptions ? hotkeyOptions.altIsOptional : false;
+        let result = hotkey.split("+");
+        if (isMacOS()) {
+            result = result.map((x) => x.replace("control", "command"));
+        }
+        if (altIsOptional) {
+            result = isMacOS() ? ["control", ...result] : ["alt", ...result];
+        }
+        return result.map((key) => key.toUpperCase());
     }
 
     selectCommand(index) {

--- a/addons/web/static/src/webclient/commands/command_palette.xml
+++ b/addons/web/static/src/webclient/commands/command_palette.xml
@@ -21,7 +21,7 @@
               <span t-attf-id="o_command_{{commandIndex}}" class="o_command" t-att-class="{ focused: state.selectedCommand === command }" t-on-click="onCommandClicked(commandIndex)" t-on-mouseenter="onCommandMouseEnter(commandIndex)">
                 <span t-esc="command.name" />
                 <span t-if="command.hotkey">
-                  <t t-foreach="command.hotkey.toUpperCase().split('+')" t-as="key">
+                  <t t-foreach="getKeysToPress(command)" t-as="key">
                     <kbd t-esc="key" />
                     <span t-if="!key_last"> + </span>
                   </t>

--- a/addons/web/static/src/webclient/commands/command_service.js
+++ b/addons/web/static/src/webclient/commands/command_service.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { registry } from "../../core/registry";
-import { getHotkeyToPress } from "../../core/hotkeys/hotkey_service";
 import { CommandPaletteDialog } from "./command_palette_dialog";
 
 /**
@@ -55,7 +54,7 @@ export const commandService = {
 
                 commands.push({
                     name: description,
-                    hotkey: getHotkeyToPress(el.dataset.hotkey),
+                    hotkey: el.dataset.hotkey,
                     action: () => {
                         // AAB: not sure it is enough, we might need to trigger all events that occur when you actually click
                         el.focus();
@@ -95,8 +94,6 @@ export const commandService = {
                     command.action,
                     command.hotkeyOptions
                 );
-                const altIsOptional = command.hotkeyOptions && command.hotkeyOptions.altIsOptional;
-                registration.hotkey = getHotkeyToPress(command.hotkey, altIsOptional);
             }
 
             const token = nextToken++;


### PR DESCRIPTION
This commit adds the possibility to use a shortcut from the command
palette. When a shortcut is called from the command palette, the palette
will be close and the action related to the shortcut will be apply.
