### PR TITLE
[REF] product:  taking variants by `ids` to skip `NewId` object

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -135,8 +135,7 @@ class Pricelist(models.Model):
         if is_product_template:
             prod_tmpl_ids = [tmpl.id for tmpl in products]
             # all variants of all products
-            prod_ids = [p.id for p in
-                        list(chain.from_iterable([t.product_variant_ids for t in products]))]
+            prod_ids = list(chain.from_iterable([t.product_variant_ids.ids for t in products]))
         else:
             prod_ids = [product.id for product in products]
             prod_tmpl_ids = [product.product_tmpl_id.id for product in products]


### PR DESCRIPTION
Because ids collected on the changed line are later used in a SQL query, we must skip records with NewId as an id.
This way the these pricelist methods are more flexable to be used in places like onchange and compute methods, where NewId is often possible.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
