### PR TITLE
[FIX] account: Fix traceback when creating journal item from analytic account

### DIFF
--- a/addons/account/views/account_analytic_view.xml
+++ b/addons/account/views/account_analytic_view.xml
@@ -17,7 +17,7 @@
                     <group name="amount" position="after">
                         <group/> <!-- put Accounting group under Amount group -->
                         <group name="accounting" string="Accounting">
-                            <field name="general_account_id"/>
+                            <field name="general_account_id" options="{'no_create': True}"/>
                             <field name="move_id" options="{'no_create': True}"/>
                         </group>
                     </group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When trying to create a journal item from a new entry in analytic accounts -> cost & revenues, a traceback was issued because there is no account.move linked to it.

Desired behavior after PR is merged:
The user is no longer able to create Journal Items from the form view in Analytic Accounts -> Cost & Revenues.

OPW: 2517311

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
