### PR TITLE
[FIX] website: parse url before redirect when langue updated

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -108,6 +108,7 @@ class Website(Home):
 
     @http.route('/website/lang/<lang>', type='http', auth="public", website=True, multilang=False)
     def change_lang(self, lang, r='/', **kwargs):
+        r = request.website._get_relative_url(r)
         if lang == 'default':
             lang = request.website.default_lang_code
             r = '/%s%s' % (lang, r or '/')

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -834,6 +834,9 @@ class Website(models.Model):
         res = urls.url_parse(self.domain)
         return 'http://' + self.domain if not res.scheme else self.domain
 
+    def _get_relative_url(self, url):
+        return urls.url_parse(url).replace(scheme='', netloc='').to_url()
+
 
 class SeoMetadata(models.AbstractModel):
 
@@ -918,7 +921,6 @@ class SeoMetadata(models.AbstractModel):
             'opengraph_meta': opengraph_meta,
             'twitter_meta': twitter_meta
         }
-
 
 class WebsiteMultiMixin(models.AbstractModel):
 


### PR DESCRIPTION
Before this commit, you can provide arbitrary url for redirect.
Now, we always return a relative url, since this method should be only called
from a page on your current website, their are no reason to let redirect to
another domain.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
