### PR TITLE
[FIX] base: fix _process_job modularity

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -102,7 +102,9 @@ class ir_cron(models.Model):
                     if not job:
                         break
                     _logger.debug("job %s acquired", job['id'])
-                    cls._process_job(db, cron_cr, job)
+                    # take into account overridings of _process_job() on that database
+                    registry = odoo.registry(db_name)
+                    registry[cls._name]._process_job(db, cron_cr, job)
                     _logger.debug("job %s updated and released", job['id'])
 
         except BadVersion:


### PR DESCRIPTION
Before this commit
------------------

Since https://github.com/odoo/odoo/commit/4b28f1162a85d03f9dbe0338b06758ad151ea6a8
It's not possible to override _process_job on ir.cron and
have the new method called by _process_jobs because
_process_jobs calls _proccess_job directly from the class
and do not user the registry anymore

After this commit
-----------------

Use the registry and get ir.cron model to call _process_job





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
