### PR TITLE
[FIX] delivery: update carrier also on delivery

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -111,6 +111,8 @@ class SaleOrder(models.Model):
             values['name'] += '\n' + 'Free Shipping'
         if self.order_line:
             values['sequence'] = self.order_line[-1].sequence + 1
+        if self.picking_ids:
+            self.picking_ids.write({'carrier_id': carrier.id})
         sol = SaleOrderLine.sudo().create(values)
         return sol
 


### PR DESCRIPTION
Create a sale order, add a product and shipping line
Confirm
Update shipping cost changing carrier
Save

Carrier on picking is not updated with the change

opw-2496008

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
