### PR TITLE
 [FIX] lunch: Toggle archive products when archiving a vendor 

### DIFF
--- a/addons/lunch/i18n/lunch.pot
+++ b/addons/lunch/i18n/lunch.pot
@@ -1753,6 +1753,14 @@ msgid ""
 msgstr ""
 
 #. module: lunch
+#: code:addons/lunch/models/lunch_product.py:0
+#, python-format
+msgid ""
+"The product supplier is archived. The user have to unarchive the supplier or"
+" change the supplier of the product."
+msgstr ""
+
+#. module: lunch
 #: model:ir.model.fields,help:lunch.field_lunch_supplier__responsible_id
 msgid ""
 "The responsible is the person that will order lunch for everyone. It will be"

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -103,6 +103,14 @@ class LunchSupplier(models.Model):
                 res.append((supplier.id, supplier.name))
         return res
 
+    def toggle_active(self):
+        """ Archiving related lunch product """
+        res = super().toggle_active()
+        Product = self.env['lunch.product'].with_context(active_test=False)
+        all_products = Product.search([('supplier_id', 'in', self.ids)])
+        all_products._sync_active_from_related()
+        return res
+
     @api.model
     def _auto_email_send(self):
         """


### PR DESCRIPTION
When a vendor is (un)archived, we should (un)archive all related products
as well to avoid displaying archived vendors and products in the search
panel of the Order lunch and Products list views.

Description of the issue/feature this PR addresses:
opw-2581253

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
