### PR TITLE
[FIX] web_editor: fix logo poor quality

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -230,6 +230,11 @@ async function applyModifications(img) {
     result.width = resizeWidth || croppedImg.width;
     result.height = croppedImg.height * result.width / croppedImg.width;
     const ctx = result.getContext('2d');
+    ctx.imageSmoothingQuality = "high";
+    ctx.mozImageSmoothingEnabled = true;
+    ctx.webkitImageSmoothingEnabled = true;
+    ctx.msImageSmoothingEnabled = true;
+    ctx.imageSmoothingEnabled = true;
     ctx.drawImage(croppedImg, 0, 0, croppedImg.width, croppedImg.height, 0, 0, result.width, result.height);
 
     // GL filter

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -62,6 +62,9 @@
             @include print-variable('o-cc#{$index}-btn-secondary-border', $-btn-secondary or theme-color('secondary'));
         }
     }
+
+    @include print-variable('o-grid-gutter-width', $grid-gutter-width);
+    @include print-variable('o-md-container-max-width', map-get($container-max-widths, md));
 }
 
 html, body {


### PR DESCRIPTION
This commit fixes and improves the suggested width that we compute for
images optimizations.
Before, images displayed outside .container elements were resized to
their container size. As a result logos were resized to 2.5rem (40px).

Now, it handles these scenarios :
- The image is in the navbar, it is a logo
- The image is in a container/container-small
- The image is in a container-fluid
- The image is outside a container

Values are read from the css instead of being hardcoded.

Note : another issue remains with our resizing method. Drawing on a
canvas is not performant enough when there are large differences between
the width and the resize width. A solution could be to use
createImageBitmap for the resize, but it is not supported by enough
browsers.
In the meantime, imageSmoothing was enabled on the context.

task-2506205

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
