### PR TITLE
[FIX] purchase_stock: purchase product route can't be triggered

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -470,7 +470,6 @@ class PurchaseOrderLine(models.Model):
             'origin': self.order_id.name,
             'description_picking': description_picking,
             'propagate_cancel': self.propagate_cancel,
-            'route_ids': self.order_id.picking_type_id.warehouse_id and [(6, 0, [x.id for x in self.order_id.picking_type_id.warehouse_id.route_ids])] or [],
             'warehouse_id': self.order_id.picking_type_id.warehouse_id.id,
             'product_uom_qty': product_uom_qty,
             'product_uom': product_uom.id,


### PR DESCRIPTION
To reproduce:
1. set WH receipt in 3 steps
2. create a "receipt in 2 steps" route for product
3. create a PO with product "receipt in 2 steps"
In inventory, we will see this product still follow the "receipt in 3
steps" route.

This is caused when we create move for PO, we prepare the route_ids
according to warehouse's route_ids. After the move has it's own
route_ids, it will not search for route set on product or product
category (which should has higher priority over warehouse route).
To fix it, we remove the route_ids when create the move for PO. A route
will be found when the move being comfirmed.

Task 2448439
PR #65509

Signed-off-by: William Henrotin <Whenrow@users.noreply.github.com>

backport of af9b926766083cdc0920e461f949f304ee3780b0


