### PR TITLE
[FIX] crm_livechat : prevent lead without stage

### DIFF
--- a/addons/crm_livechat/models/mail_channel.py
+++ b/addons/crm_livechat/models/mail_channel.py
@@ -50,8 +50,6 @@ class MailChannel(models.Model):
         return self.env['crm.lead'].create({
             'name': html2plaintext(key[5:]),
             'partner_id': customers[0].id if customers else False,
-            'user_id': False,
-            'team_id': False,
             'description': html2plaintext(description),
             'referred': partner.name,
             'source_id': utm_source and utm_source.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you use /lead in the livechat the created lead have no user, no team and no stage_id.

This PR add user and default team.

@tde-banana-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
