### PR TITLE
[FIX] product: traceback if unlink pricelist used in pricelist

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2807,6 +2807,12 @@ msgid ""
 msgstr ""
 
 #. module: product
+#: code:addons/product/models/product_pricelist.py:0
+#, python-format
+msgid "You cannot delete this pricelist (%s), it is used in other pricelist(s) : \n%s"
+msgstr ""
+
+#. module: product
 #: code:addons/product/models/product.py:0
 #, python-format
 msgid ""

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -345,6 +345,15 @@ class Pricelist(models.Model):
             'label': _('Import Template for Pricelists'),
             'template': '/product/static/xls/product_pricelist.xls'
         }]
+    
+    def unlink(self):
+        for pricelist in self:
+            linked_items = self.env['product.pricelist.item'].sudo().with_context(active_test=False).search(
+                [('base', '=', 'pricelist'), ('base_pricelist_id', '=', pricelist.id), ('pricelist_id', 'not in', self.ids)])
+            if linked_items:
+                raise UserError(_('You cannot delete this pricelist (%s), it is used in other pricelist(s) : \n%s',
+                    pricelist.display_name, '\n'.join(linked_items.pricelist_id.mapped('display_name'))))
+        return super().unlink()
 
 
 class ResCountryGroup(models.Model):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Goto runbot : https://8565349-14-0-all.runbot50.odoo.com/web?#id=&action=1113&model=sale.order&view_type=form&cids=1&menu_id=791

- Create a pricelist A
- Create a pricelist B, add item with base='pricelist' and pricelist_is = Pricelist A
- Unlink Pricelist A
- Create a sale order with pricelist B
- Add product
--> Traceback KeyError: 'pricelist'

@tde-banana-odoo 

To according the stable guideline I have no use `ondelete='restrict'`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
