### PR TITLE
[FIX] point_of_sale: Move parameter in odoo.conf

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo.conf
@@ -3,3 +3,5 @@ data_dir = /var/run/odoo
 log_level = error
 logfile = /var/log/odoo/odoo-server.log
 pidfile = /var/run/odoo/odoo.pid
+limit_time_cpu = 600
+limit_time_real = 1200

--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
@@ -26,7 +26,7 @@ test -x $DAEMON || exit 0
 set -e
 
 function _start() {
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$USER --background --make-pidfile --exec $DAEMON -- --config $CONFIG --logfile $LOGFILE --load=web,hw_proxy,hw_posbox_homepage,hw_escpos,hw_blackbox_be,hw_drivers --limit-time-cpu=600 --limit-time-real=1200
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$USER --background --make-pidfile --exec $DAEMON -- --config $CONFIG --logfile $LOGFILE --load=web,hw_proxy,hw_posbox_homepage,hw_escpos,hw_blackbox_be,hw_drivers
 }
 
 function _stop() {


### PR DESCRIPTION
Move the odoo server parameters into the odoo.conf file
instead of being placed as the service command line argument

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
