### PR TITLE
[IMP] event: added single line date picker

### DIFF
--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -269,9 +269,13 @@
             <field name="arch" type="xml">
                 <form>
                     <group>
-                        <field name="name"/>
-                        <field name="date_begin"/>
-                        <field name="date_end"/>
+                        <field name="name" placeholder="e.g. Conference for Architects"/>
+                        <label for="date_begin" string="Date"/>
+                        <div class="o_row">
+                            <field name="date_begin" widget="daterange" options="{'related_end_date': 'date_end'}"/>
+                            <i class="fa fa-long-arrow-right mx-2" aria-label="Arrow icon" title="Arrow"/>
+                            <field name="date_end" widget="daterange" options="{'related_start_date': 'date_begin'}"/>
+                        </div>
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
PURPOSE

currenlty, if one tries to create an event through quick create kanban view we have to pick
date range two times aka 'date_begin' and 'date_end'. but we need don't need that anymore.
we should be able to select a date, at a time like wise in form view.

SPECIFICATIONS

- one can select  'date_begin' and 'date_end' from the quick create just like 
  as of form view at a time.
- we have added a placeholder for the event 'name' field.
  
this is the purpose of this commit

LINKS

PR#72906
task-id:2584118

