### PR TITLE
[FIX] mrp: issue with products with variants

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -638,9 +638,7 @@ class MrpProduction(models.Model):
     @api.onchange('bom_id', 'product_id', 'product_qty', 'product_uom_id')
     def _onchange_move_finished(self):
         if self.product_id and self.product_qty > 0:
-            # keep manual entries
-            list_move_finished = [(4, move.id) for move in self.move_finished_ids.filtered(
-                lambda m: not m.byproduct_id and m.product_id != self.product_id)]
+            list_move_finished = []
             moves_finished_values = self._get_moves_finished_values()
             moves_byproduct_dict = {move.byproduct_id.id: move for move in self.move_finished_ids.filtered(lambda m: m.byproduct_id)}
             move_finished = self.move_finished_ids.filtered(lambda m: m.product_id == self.product_id)
@@ -653,6 +651,7 @@ class MrpProduction(models.Model):
                 else:
                     # add new entries
                     list_move_finished += [(0, 0, move_finished_values)]
+            self.move_finished_ids = [(5, 0, 0)]
             self.move_finished_ids = list_move_finished
         else:
             self.move_finished_ids = [(2, move.id) for move in self.move_finished_ids.filtered(lambda m: m.bom_line_id)]


### PR DESCRIPTION
Step to follow

- Create a product with 2 variants and set route to Manufacture
- Create a BOM for the product
- Create an MO for one of the variants
- Save (in Draft State)
- Edit
- Change to the other variant
- Confirm
- Finish the MO Order
- Look at product moves on MO

Cause of the issue

In MrpProduction._onchange_move_finished method, move_finished variable contain two values when changing the product variant, because of the filter on the product_id. product_id represents the id of a specific product variant.

Solution

As product_id represents the id of a specific product variant, product_tmpl_id represents the id of the product itself.
When filter on the product_tmpl_id, we're sure the move_finished variable contains only one value, even if we change the MO for the same product, but another variant.

opw-2572644

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
