### PR TITLE
[FIX] base_vat: properly checks XI VAT numbers

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -67,7 +67,12 @@ _ref_vat = {
     'se': 'SE123456789701',
     'si': 'SI12345679',
     'sk': 'SK0012345675',
-    'tr': 'TR1234567890 (VERGINO) veya TR12345678901 (TCKIMLIKNO)'  # Levent Karakas @ Eska Yazilim A.S.
+    'tr': 'TR1234567890 (VERGINO) veya TR12345678901 (TCKIMLIKNO)',  # Levent Karakas @ Eska Yazilim A.S.
+    'xi': 'XI123456782',
+}
+
+_region_specific_vat_codes = {
+    'xi',
 }
 
 
@@ -150,13 +155,15 @@ class ResPartner(models.Model):
             #check with country code as prefix of the TIN
             failed_check = False
             vat_country_code, vat_number = self._split_vat(partner.vat)
-            vat_guessed_country = self.env['res.country'].search([('code', '=', vat_country_code.upper())])
-            if vat_guessed_country:
+            vat_has_legit_country_code = self.env['res.country'].search([('code', '=', vat_country_code.upper())])
+            if not vat_has_legit_country_code:
+                vat_has_legit_country_code = vat_country_code.lower() in _region_specific_vat_codes
+            if vat_has_legit_country_code:
                 failed_check = not check_func(vat_country_code, vat_number)
 
             #if fails, check with country code from country
             partner_country_code = partner.commercial_partner_id.country_id.code
-            if (not vat_guessed_country or failed_check) and partner_country_code:
+            if (not vat_has_legit_country_code or failed_check) and partner_country_code:
                 failed_check = not check_func(partner_country_code.lower(), partner.vat)
 
             # We allow any number if it doesn't start with a country code and the partner has no country.


### PR DESCRIPTION
In 12.0+ when adding an XI (Northern Ireland) VAT number on a vendor and specifying the country as United Kingdom, an error shows the VAT number as not valid. This is because the method to check specifically XI VAT numbers doesn't recognize XI as a country, and thus uses the GB VAT number verification, which doesn't recognize XI VAT numbers as it isn't up to date yet.

A temporary method to check XI VAT number was already added, but is never called because XI is not recognized as a country.
With this commit, we add a list of known legitimate country codes that are not considered as such in Odoo.

opw-2534541
