### PR TITLE
[FIX] web: report controller: use context lang

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1980,11 +1980,7 @@ class ReportController(http.Controller):
         if data.get('options'):
             data.update(json.loads(data.pop('options')))
         if data.get('context'):
-            # Ignore 'lang' here, because the context in data is the one from the webclient *but* if
-            # the user explicitely wants to change the lang, this mechanism overwrites it.
             data['context'] = json.loads(data['context'])
-            if data['context'].get('lang'):
-                del data['context']['lang']
             context.update(data['context'])
         if converter == 'html':
             html = report.with_context(context)._render_qweb_html(docids, data=data)[0]


### PR DESCRIPTION
lang from context arg was ignored for 7 years [1], but it's not needed anymore.
At least, this leads to unexpected result in iframe report (e.g. forecasted
report), which would have an ugly fix [2] otherwise

[1] https://github.com/odoo/odoo/commit/fc8592adf2f26bf35007d6cc625fb2005cd65b5d
[2] https://github.com/odoo/odoo/pull/71539
