### PR TITLE
[FIX] pos_hr : cashier don't appear in reprint in some case

### DIFF
--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -7,21 +7,14 @@ models.load_models([{
     model:  'hr.employee',
     fields: ['name', 'id', 'user_id'],
     domain: function(self){
-        return self.config.employee_ids.length > 0
-            ? [
-                  '&',
-                  ['company_id', '=', self.config.company_id[0]],
-                  '|',
-                  ['user_id', '=', self.user.id],
-                  ['id', 'in', self.config.employee_ids],
-              ]
-            : [['company_id', '=', self.config.company_id[0]]];
+        return [['company_id', '=', self.config.company_id[0]]];
     },
     loaded: function(self, employees) {
         if (self.config.module_pos_hr) {
-            self.employees = employees;
             self.employee_by_id = {};
-            self.employees.forEach(function(employee) {
+            var employee_ids = self.config.employee_ids;
+            var config_employees = [];
+            employees.forEach(function(employee) {
                 self.employee_by_id[employee.id] = employee;
                 var hasUser = self.users.some(function(user) {
                     if (user.id === employee.user_id[0]) {
@@ -33,7 +26,11 @@ models.load_models([{
                 if (!hasUser) {
                     employee.role = 'cashier';
                 }
+                if (hasUser || employee_ids.includes(employee.id)){
+                    config_employees.push(employee);
+                }
             });
+            self.employees = config_employees;
         }
     }
 }]);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
1. create a pos order with Cashier A, validate him
2. remove Cashier A in pose.config.employee_ids
3. reprint ticket --> Issue the name of cashier is not present

@pimodoo @rhe-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
