### PR TITLE
[FIX] purchase_requisition: Wrong translation

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -48,7 +48,7 @@ class PurchaseOrder(models.Model):
         for line in requisition.line_ids:
             # Compute name
             product_lang = line.product_id.with_context(
-                lang=partner.lang,
+                lang=partner.lang or self.env.user.lang,
                 partner_id=partner.id
             )
             name = product_lang.display_name


### PR DESCRIPTION
Steps to reproduce the bug:

1. Activate the 2 language “’English’ , ‘Spanish (AR) / Español (AR)’ ”
2. User -> select the language ‘Spanish (AR) / Español (AR)’
3. Create a new product (Test Product).
4. Create a another product using “Duplicate” function.
5. Rename new product name(Test Product -1)
6. Translate the name ( “Spanish (AR) / Español (AR) : 111 Spanish product “ , “English: English Product” )
7. create a purchase agreement -> select product “111 Spanish product ” -> Save -> confirm -> new quotation.
8. Purchase Quotation -> Order line

Bug:

Description shows “Test Item (copia)”

opw:2582778