### PR TITLE
crm: Anti-spam filter for 'Assign To...' email notifications

### DIFF
--- a/addons/mail/data/mail_templates.xml
+++ b/addons/mail/data/mail_templates.xml
@@ -309,6 +309,10 @@
             View <t t-esc="model_description or 'document'"/>
         </a>
     </p>
+    <div t-if="activity_list_backend" style="margin-top: 8px">
+        To avoid spam as you are receiving a lot of assignation notifications, we won't send you notifications within the next hour.
+        By you can check all <a t-att-href="activity_list_backend" t-att-data-oe-model="'crm.lead'">here</a>.
+    </div>
     <div t-if="activity.note" style="margin-top: 8px;" t-field="activity.note"/>
 </div>
         </template>

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -7,6 +7,7 @@ from . import models
 
 # mixin
 from . import mail_activity_mixin
+from . import mail_activity_log
 from . import mail_alias_mixin
 from . import mail_render_mixin
 from . import mail_composer_mixin

--- a/addons/mail/models/mail_activity_log.py
+++ b/addons/mail/models/mail_activity_log.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+from datetime import timedelta
+
+class MailActivityLog(models.Model):
+    _name = 'mail.activity.log'
+    _description = 'Set of emails sent and linked to an activity'
+    mail_message_id = fields.Many2one('mail.message', store=True)
+
+    @api.autovacuum
+    def _gc_outdated_logs(self):
+        self.env['mail.activity.log'].search([
+            ('create_date', '<', fields.Datetime.now() - timedelta(hours=2))
+        ]).unlink()

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -38,6 +38,7 @@ access_mail_shortcode,mail.shortcode,model_mail_shortcode,base.group_user,1,1,1,
 access_mail_shortcode_portal,mail.shortcode.portal,model_mail_shortcode,base.group_portal,1,0,0,0
 access_mail_activity_all,mail.activity.all,model_mail_activity,,0,0,0,0
 access_mail_activity_user,mail.activity.user,model_mail_activity,base.group_user,1,1,1,1
+access_mail_activity_log_all,mail.activity.all,model_mail_activity_log,,1,0,1,1
 access_mail_activity_type_all,mail.activity.type.all,model_mail_activity_type,,0,0,0,0
 access_mail_activity_type_user,mail.activity.type.user,model_mail_activity_type,base.group_user,1,0,0,0
 access_mail_activity_type_system,mail.activity.type.system,model_mail_activity_type,base.group_system,1,1,1,1


### PR DESCRIPTION
PURPOSE

It turns out that the user can quickly get spammed with "You have been
assigned to" emails. The problem is that the user has no proper way to
avoid sending them. As many tasks can be assigned by day, these emails
can consume a large part of the emails quota that each Odoo instance has.

With these new changes, the system will not send any notification email
related to activity assignments if the user already receives 3 of them
in a timeframe of one hour. Once the system reaches that limit, it will
wait one hour before resending new notifications by email. This
constraint will only applied to the CRM module.

SPECS

- Add a cooldown mechanism to avoid spamming the user with notification
  emails related to activity assignments (on the CRM module).

LINKS

Task ID: 2209392

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
