### PR TITLE
[FIX] point_of_sale : impossible to reversea paiement after reload

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2465,6 +2465,7 @@ exports.Paymentline = Backbone.Model.extend({
     init_from_JSON: function(json){
         this.amount = json.amount;
         this.payment_method = this.pos.payment_methods_by_id[json.payment_method_id];
+        this.can_be_reversed = json.can_be_reversed;
         this.name = this.payment_method.name;
         this.payment_status = json.payment_status;
         this.ticket = json.ticket;
@@ -2548,6 +2549,7 @@ exports.Paymentline = Backbone.Model.extend({
             payment_method_id: this.payment_method.id,
             amount: this.get_amount(),
             payment_status: this.payment_status,
+            can_be_reversed: this.can_be_resersed,
             ticket: this.ticket,
             card_type: this.card_type,
             cardholder_name: this.cardholder_name,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
1. add an electronic payment, send it
2. you show "reverse paiement"
3. reload the POS
4. go back on the payment 
--> Issue "reverse payment have disappear"


@pimodoo @rhe-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
