### PR TITLE
[FIX] sale: add date label to quotation preview at 'sent' stage

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -376,11 +376,11 @@
                 </div>
                 <div class="row" id="so_date">
                     <div class="mb-3 col-6">
-                      <t t-if="sale_order.state == 'draft'">
-                        <strong>Quotation Date:</strong> 
-                      </t>
                       <t t-if="sale_order.state in ['sale', 'done', 'cancel']">
                         <strong>Order Date:</strong> 
+                      </t>
+                      <t t-else="">
+                         <strong>Quotation Date:</strong>
                       </t>
                       <span t-field="sale_order.date_order" t-options='{"widget": "date"}'/>
                     </div>


### PR DESCRIPTION
Steps to reproduce :

  - Install 'Accounting'
  - Create a quotation then send it (without confirming it)
  - Click on Preview

Issue :

  `Date` field is not preceded by a label.

Solution :

  Display "Quotation Date:" label if quotation in 'Sent' stage.

opw-2585000