### PR TITLE
Master department ux wbr

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -29,3 +29,20 @@
     }
 
 }
+
+.o_kanban_dashboard.o_hr_department_kanban {
+    &.o_kanban_ungrouped {
+        .o_kanban_record {
+            width: 350px;
+        }
+    }
+    .o_kanban_group {
+        &:not(.o_column_folded) {
+            width: 350px + 2*$o-kanban-group-padding;
+
+            @include media-breakpoint-down(sm) {
+                width: 100%;
+            }
+        }
+    }
+}

--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -32,6 +32,7 @@
                     <field name="display_name"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="manager_id"/>
+                    <field name="total_employee" string="Employees"/>
                     <field name="parent_id"/>
                 </tree>
             </field>
@@ -55,7 +56,7 @@
             <field name="name">hr.department.kanban</field>
             <field name="model">hr.department</field>
             <field name="arch" type="xml">
-                <kanban class="oe_background_grey o_kanban_dashboard o_hr_kanban" sample="1">
+                <kanban class="oe_background_grey o_kanban_dashboard o_hr_department_kanban" sample="1">
                     <field name="name"/>
                     <field name="company_id"/>
                     <field name="manager_id"/>
@@ -65,7 +66,7 @@
                             <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
                                 <div t-attf-class="o_kanban_card_header">
                                     <div class="o_kanban_card_header_title">
-                                        <div class="o_primary"><field name="name"/></div>
+                                        <div class="o_primary"><a type="edit"><field name="name"/></a></div>
                                         <div class="o_secondary"><field name="company_id" groups="base.group_multi_company"/></div>
                                     </div>
                                     <div class="o_kanban_manage_button_section" t-if="!selection_mode">

--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -45,3 +45,8 @@
         }
     }
 }
+.o_control_panel .o_list_buttons {
+    .o_button_upload_expense {
+        margin-left: 3px;
+    }
+}

--- a/addons/hr_holidays/models/hr_department.py
+++ b/addons/hr_holidays/models/hr_department.py
@@ -17,8 +17,6 @@ class Department(models.Model):
         compute='_compute_leave_count', string='Time Off to Approve')
     allocation_to_approve_count = fields.Integer(
         compute='_compute_leave_count', string='Allocation to Approve')
-    total_employee = fields.Integer(
-        compute='_compute_total_employee', string='Total Employee')
 
     def _compute_leave_count(self):
         Requests = self.env['hr.leave']
@@ -48,9 +46,3 @@ class Department(models.Model):
             department.leave_to_approve_count = res_leave.get(department.id, 0)
             department.allocation_to_approve_count = res_allocation.get(department.id, 0)
             department.absence_of_today = res_absence.get(department.id, 0)
-
-    def _compute_total_employee(self):
-        emp_data = self.env['hr.employee'].read_group([('department_id', 'in', self.ids)], ['department_id'], ['department_id'])
-        result = dict((data['department_id'][0], data['department_id_count']) for data in emp_data)
-        for department in self:
-            department.total_employee = result.get(department.id, 0)


### PR DESCRIPTION
Moves a field from hr_holidays to hr (`total_employees` of hr.department)
to display it in the department list view.
Widen the department kanban view to display more information and allow
clicking on the department name in the kanban view to edit it.

Force a small margin to the left of the upload button in the expense
list view.
Previously the create and upload button would be stuck to each other.

Task ID: 2582448