### PR TITLE
[FIX] models.py: path ok on delete parent and grandparent


### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3807,12 +3807,14 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             SET parent_path = concat(%s, substr(child.parent_path,
                     length(node.parent_path) - length(node.id || '/') + 1))
             FROM {0} node
-            WHERE node.id IN %s
+            WHERE node.id = %s
             AND child.parent_path LIKE concat(node.parent_path, '%%')
             RETURNING child.id
         """
-        cr.execute(query.format(self._table), [prefix, tuple(self.ids)])
-        modified_ids = {row[0] for row in cr.fetchall()}
+        modified_ids = set([])
+        for record in self:
+            cr.execute(query.format(self._table), [prefix, record.id])
+            modified_ids.update(row[0] for row in cr.fetchall())
         self.browse(modified_ids).modified(['parent_path'])
 
     def _load_records_write(self, values):


### PR DESCRIPTION

Scenario:

- have records with [id, parent_path] as follows:

 [8, "10/8/"]
 [10, "10/"]
 [11, "10/8/11]

- delete both records 8 and 10

=> record 11 has wrong path "8/11/" because the code updating
parent_path remove only one out of either 10/ or 10/8/ and in this case
remove the wrong one (10/).

With this changeset, we do a query by record removed.

TODO: see if it's possible to optimize this

opw-2512996
