### PR TITLE
[FIX] sale_timesheet: correctly compute remaining_hours_so

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -250,7 +250,7 @@ class ProjectTask(models.Model):
             if timesheet.so_line == timesheet.task_id.sale_line_id:
                 delta -= timesheet.unit_amount
             if delta:
-                mapped_remaining_hours[timesheet.task_id._origin.id] += timesheet.so_line.product_uom._compute_quantity(delta, uom_hour)
+                mapped_remaining_hours[timesheet.task_id._origin.id] += timesheet.product_uom_id._compute_quantity(delta, uom_hour)
 
         for task in self:
             task.remaining_hours_so = mapped_remaining_hours[task._origin.id]


### PR DESCRIPTION
Steps to reproduce:

    - Install sale_timesheet with demo data

    - Add a UOM 200h with the following characteristics:

        - Category: Working Time
        - Type: Bigger than the reference Unit of Measure
        - Bigger Ratio: 25

    - Create a new product with the following characteristics:

        - Product Type: Service
        - Service Invoicing Policy: Prepaid
        - Unit of Measure: 200h

    - Create a Quotation SO1 with the following characteristics:

        - Customer: Deco Addict
        - a SOL with product 200h and quantity 1

    - Confirm the Quotation SO1

    - Create a new project P1 with the following characteristics:

        - Timesheets: True
        - Billable: True

    - Edit the project and set the customer to Deco Addict

    - Create a new task T1 with the following characteristics:

        - Project: P1
        - Sales Order Item: SOL of SO1 with product 200h

    - Timesheet in the task

Current behavior:

    - When timesheeting, the quantity of Remaining Hours on SO is decreased by 200 * nb of hours in timesheet(s).

Expected behavior:

    - When timesheeting, the quantity of Remaining Hours on SO is decreased by the number of hours in the timesheet(s).


This behavior was introduced in commit b0f165bbd8041b5a01fb09122da76ba14cfa3e94

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
