### PR TITLE
[FIX] mass_mailing: fix the tour bubble in kanban view create button

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -22,6 +22,7 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
         edition: 'community',
     }, {
         trigger: '.o-kanban-button-new',
+        extra_trigger: '.oe_kanban_mass_mailing',
         content: _t("Start by creating your first <b>Mailing</b>."),
         position: 'bottom',
     }, {


### PR DESCRIPTION
PURPOSE
Mass Mailing Tour Bubble should not be appear any where else.

SPECIFICATION
Current:
Tour bubble of mass mailing is appearing in many kanban view create button.
To be:
It should be only in mass_mailing module.

Task Id: 2583760
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
