### PR TITLE
[IMP] web: improve the calendar year mode popover

### DIFF
--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -137,7 +137,7 @@
                         t-attf-class="o_cw_popover_link o_calendar_color_#{typeof color === 'number' ? _.str.sprintf('%s', color) : '1'} o_attendee_status_#{record.is_alone ? 'alone' : record.attendee_status} btn-link d-block"
                         t-att-data-id="record.id"
                         t-att-data-title="record.display_name">
-                        <t t-esc="record.display_name"/> <t t-esc="record.start_hour"/>
+                        <t t-esc="record.start_hour"/> <t t-esc="record.display_name"/>
                     </a>
                 </t>
             </t>

--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -3869,7 +3869,7 @@ QUnit.module('Views', {
         assert.containsOnce(calendar, '.o_cw_popover');
         popoverText = calendar.el.querySelector('.o_cw_popover')
             .textContent.replace(/\s{2,}/g, ' ').trim();
-        assert.strictEqual(popoverText, 'December 12, 2016 event 2 10:55 event 3 15:55');
+        assert.strictEqual(popoverText, 'December 12, 2016 10:55 event 2 15:55 event 3');
         await testUtils.dom.click(calendar.el.querySelector('.o_cw_popover_close'));
         assert.containsNone(calendar, '.o_cw_popover');
 


### PR DESCRIPTION
In calendar year mode, the duration will appear before the event name because
if the event name is too long, the duration does not appear.
Like:
crop the shift name if it becomes too long to display on one line. then the
duration is cropped.

TaskID:- 2502245
