### PR TITLE
[FIX] mrp: keep operations at uninstallation

### DIFF
--- a/addons/mrp/models/res_config_settings.py
+++ b/addons/mrp/models/res_config_settings.py
@@ -34,10 +34,7 @@ class ResConfigSettings(models.TransientModel):
         # Work Orders' is deactivated.
         # Long story short: if 'mrp_workorder' is already installed, we don't uninstall it based on
         # group_mrp_routings
-        operations = self.env['mrp.routing.workcenter'].with_context({'active_test': False}).search([('company_id', '=', self.company_id.id)])
         if self.group_mrp_routings:
             self.module_mrp_workorder = True
         else:
-            operations.action_archive()  # When deactivating workorders we want to archive all the operations linked to the company
-            if not self.env['ir.module.module'].search([('name', '=', 'mrp_workorder'), ('state', '=', 'installed')]):
-                self.module_mrp_workorder = False
+            self.module_mrp_workorder = False


### PR DESCRIPTION
The commit 1355c9694ef481df083460464c27af6fef5ca06d
archive all mrp operations at "Work Order" setting unticking. The good
way would be to hide the operations if the setting is deactivate.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
