### PR TITLE
[IMP] hr,hr_presence: presence report ux improvements

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -28,6 +28,14 @@
         margin-right: -3px;
     }
 
+    .o_hr_employee_kanban_bottom {
+        //Prevent bottom row from preventing to click on buttons
+        pointer-events: none;
+        .oe_kanban_bottom_right {
+            pointer-events: auto;
+        }
+    }
+
 }
 
 .o_kanban_dashboard.o_hr_department_kanban {

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -307,17 +307,17 @@
                                    <li t-if="record.work_email.raw_value" class="o_text_overflow"><field name="work_email" /></li>
                                    <li t-if="record.work_phone.raw_value" class="o_force_ltr"><field name="work_phone" /></li>
                                </ul>
-                                <div class="oe_kanban_content position-absolute fixed-bottom mr-2">
-                                    <div class="o_kanban_record_bottom">
-                                        <div class="oe_kanban_bottom_left"/>
-                                        <div class="oe_kanban_bottom_right">
-                                            <a title="Chat" icon="fa-comments" href="#" class="ml8 o_employee_chat_btn" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
-                                            <div class="hr_activity_container">
-                                                <field name="activity_ids" widget="kanban_activity"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                           </div>
+                           <div class="oe_kanban_content position-absolute fixed-bottom mr-2 o_hr_employee_kanban_bottom">
+                               <div class="o_kanban_record_bottom">
+                                   <div class="oe_kanban_bottom_left"/>
+                                   <div class="oe_kanban_bottom_right float-right">
+                                       <a title="Chat" icon="fa-comments" href="#" class="ml8 o_employee_chat_btn" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
+                                       <div class="hr_activity_container">
+                                           <field name="activity_ids" widget="kanban_activity"/>
+                                       </div>
+                                   </div>
+                               </div>
                            </div>
                        </div>
                        </t>

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -114,10 +114,16 @@ class Employee(models.AbstractModel):
                         'searchpanel_default_hr_presence_state_display': 'to_define'},
         }
 
-    def action_set_present(self):
+    def _action_set_manual_presence(self, state):
         if not self.env.user.has_group('hr.group_hr_manager'):
             raise UserError(_("You don't have the right to do this. Please contact an Administrator."))
-        self.write({'manually_set_present': True})
+        self.write({'manually_set_present': state})
+
+    def action_set_present(self):
+        self._action_set_manual_presence(True)
+
+    def action_set_absent(self):
+        self._action_set_manual_presence(False)
 
     def write(self, vals):
         if vals.get('hr_presence_state_display') == 'present':

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -38,13 +38,16 @@
                 <attribute name="create">0</attribute>
             </xpath>
             <xpath expr="//div[hasclass('oe_kanban_details')]" position="inside">
-                <div class="o_kanban_record_bottom">
-                    <div class="oe_kanban_bottom_left">
+                <div class="oe_kanban_content">
+                    <div class="oe_kanban_row">
                         <field name="hr_presence_state" invisible="1"/>
                         <button name="action_set_present" type="object" class="btn btn-primary btn-sm mt8 fa fa-check" title="Set as present" attrs="{'invisible': [('hr_presence_state', '=', 'present')]}"> </button>
+                        <button name="action_set_absent" type="object" class="btn btn-primary btn-sm mt8 fa fa-times" title="Set as absent" attrs="{'invisible': [('hr_presence_state', '!=', 'present')]}"> </button>
                         <button name="action_open_leave_request" type="object" class="btn btn-primary btn-sm mt8">Time Off</button>
+                    </div>
+                    <div class="oe_kanban_row">
                         <button name="action_send_sms" type="object" class="btn btn-primary btn-sm mt8">SMS</button>
-                        <button name="action_send_mail" type="object" class="btn btn-primary btn-sm mt8">Mail</button>
+                        <button name="action_send_mail" type="object" class="btn btn-primary btn-sm mt8">Log</button>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
Previously all buttons would be displayed in a single row, this commit
changes it to two rows.
Also the bottom half of the button was unclickable due to an invisible
div, fixed with css.
Another button has been added to undo a manual presence state.

Task ID: 2584198
