### PR TITLE
[FIX] account: prevent from changing partner's company

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -10800,6 +10800,12 @@ msgid "You can not have an overlap between two fiscal years, please correct the 
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/partner.py:441
+#, python-format
+msgid "You can't change the company of a partner if the latter already has some invoices."
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_invoice.py:1784
 #, python-format
 msgid "You can only delete an invoice line if the invoice is in draft state."

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -434,6 +434,22 @@ class ResPartner(models.Model):
         for partner in self:
             partner.bank_account_count = mapped_data.get(partner.id, 0)
 
+    @api.constrains('company_id')
+    def _check_company_and_invoices(self):
+        partners_with_company = self.filtered(lambda p: p.company_id)
+        if partners_with_company:
+            query = """
+                SELECT partner.id
+                  FROM res_partner partner
+                  JOIN account_invoice invoice ON invoice.partner_id = partner.id
+                                              AND invoice.company_id != partner.company_id
+                 WHERE partner.id IN %s
+                 LIMIT 1
+             """
+            self.env.cr.execute(query, (tuple(partners_with_company.ids),))
+            if self.env.cr.fetchall():
+                raise ValidationError(_("You can't change the company of a partner if the latter already has some invoices."))
+
     def _find_accounting_partner(self, partner):
         ''' Find the partner for which the accounting entries will be created '''
         return partner.commercial_partner_id


### PR DESCRIPTION
When changing the company of a partner, if the latter still has some
unreconciled AML, it will lead to a display error on follow-up report

To reproduce the error:
(Need account_accountant. Let C01 be the current company, its currency
is USD)
1. In Settings, enable:
    - Multi-currencies
    - Multi-companies
2. Create a second company C02
    - Currency: EUR
3. Create a partner P linked to company C01
4. Invoice P with X EUR (!)
5. Open the tree view of the follow-up report:
    - P is present in the list with amount Y USD (X has been converted
to C01's company)
6. Edit P
    - Company: C02
7. Open the tree view of the follow-up report

Error: The amount is Y EUR which is incorrect (it should be either Y USD
or X EUR)

The currency used to display the amount is the partner's currency
https://github.com/odoo/odoo/blob/bc53c49c08d48179a7e2d927f3e2b7ba92e77d6c/addons/account/models/partner.py#L391-L391
https://github.com/odoo/odoo/blob/bc53c49c08d48179a7e2d927f3e2b7ba92e77d6c/addons/account/models/partner.py#L377-L382
This is the reason why the display becomes incorrect

Changing a partner's company does not make sense and should not be
allowed

OPW-2525793