### PR TITLE
[FIX] web_editor: reintroduce request_editable event

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1092,6 +1092,7 @@ var SnippetsMenu = Widget.extend({
         'user_value_widget_opening': '_onUserValueWidgetOpening',
         'user_value_widget_closing': '_onUserValueWidgetClosing',
         'reload_snippet_template': '_onReloadSnippetTemplate',
+        'request_editable': '_onRequestEditable',
     },
     // enum of the SnippetsMenu's tabs.
     tabs: {
@@ -3042,6 +3043,13 @@ var SnippetsMenu = Widget.extend({
      */
     _onRedo: async function() {
         this.options.wysiwyg.redo();
+    },
+    /**
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onRequestEditable: function (ev) {
+        ev.data.callback($(this.options.wysiwyg.odooEditor.editable));
     },
 });
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1418,7 +1418,6 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
     _renderColorPalette: function () {
         const options = {
             selectedColor: this._value,
-            $editable: this.$target.closest('.o_editable'),
         };
         if (this.options.dataAttributes.excluded) {
             options.excluded = this.options.dataAttributes.excluded.replace(/ /g, '').split(',');

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -38,6 +38,7 @@ const ColorPaletteWidget = Widget.extend({
      */
     init: function (parent, options) {
         this._super.apply(this, arguments);
+        this.customColorsArray = [].concat(...customColors);
         this.style = window.getComputedStyle(document.documentElement);
         this.options = _.extend({
             selectedColor: false,
@@ -175,7 +176,7 @@ const ColorPaletteWidget = Widget.extend({
             return;
         }
         this.el.querySelectorAll('.o_custom_color').forEach(el => el.remove());
-        const existingColors = new Set(customColors.concat(
+        const existingColors = new Set(this.customColorsArray.concat(
             Object.keys(this.colorToColorNames)
         ));
         this.trigger_up('get_custom_colors', {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -51,6 +51,8 @@ const ColorPaletteWidget = Widget.extend({
         this.selectedColor = '';
         this.resetButton = this.options.resetButton;
         this.withCombinations = this.options.withCombinations;
+
+        this.trigger_up('request_editable', {callback: val => this.options.$editable = val});
     },
     /**
      * @override


### PR DESCRIPTION
The commit fixes the display of custom colors in the color picker.

It improves previous fix from #72294, which was not returning all
editables from the editor, thus only the custom colors of the target
were displayed.
For that the request_editable event is reintroduced at the SnippetsMenu
level.

task-2476601



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
