### PR TITLE
[IMP] hr_timesheet,sale_timesheet: improve ux for timesheet

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -125,14 +125,14 @@
                     <sheet string="Analytic Entry">
                         <group>
                             <group>
-                                <field name="date"/>
                                 <field name="project_id" required="1" context="{'form_view_ref': 'project.project_project_view_form_simplified',}"/>
                                 <field name="task_id" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
                                 <field name="name"/>
-                                <field name="company_id" groups="base.group_multi_company"/>
+                                <field name="company_id" groups="base.group_multi_company" invisible="1"/>
                             </group>
                             <group>
-                                <field name="amount"/>
+                                <field name="date"/>
+                                <field name="amount" invisible="1"/>
                                 <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                                 <field name="currency_id" invisible="1"/>
                             </group>
@@ -149,8 +149,8 @@
             <field name="mode">primary</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='company_id']" position="before">
-                    <field name="employee_id" required="1" options='{"no_open": True}'/>
+                <xpath expr="//field[@name='date']" position="before">
+                    <field name="employee_id" required="1"/>
                     <field name="user_id" invisible="1"/>
                 </xpath>
             </field>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -6,22 +6,47 @@
             <field name="model">account.analytic.line</field>
             <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_search"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='department_id']" position="after">
-                    <field name="timesheet_invoice_type"/>
+                <xpath expr="//field[@name='task_id']" position="after">
+                    <field name="so_line" groups="sales_team.group_sale_salesman"/>
                 </xpath>
                 <xpath expr="//filter[@name='month']" position="before">
-                    <filter name="billable_timesheet" string="Billable" domain="[('so_line', '!=', False)]"/>
-                    <filter name="non_billable_timesheet" string="Non Billable" domain="[('so_line', '=', False)]"/>
-                    <separator/>
                     <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"/>
                     <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"/>
-                    <filter name="non_billable" string="Non Billable Tasks" domain="[('timesheet_invoice_type', '=', 'non_billable')]"/>
+                    <filter name="non_billable" string="Non Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"/>
                     <separator/>
                 </xpath>
-                <xpath expr="//filter[@name='groupby_department']" position="before">
-                        <filter string="Billable Type" name="groupby_timesheet_invoice_type" domain="[]" context="{'group_by': 'timesheet_invoice_type'}"/>
+                <xpath expr="//filter[@name='groupby_employee']" position="after">
+                    <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]" context="{'group_by': 'so_line'}" groups="sales_team.group_sale_salesman"/>
+                    <filter string="Invoice" name="groupby_invoice" domain="[]" context="{'group_by': 'timesheet_invoice_id'}"/>
+                    <filter string="Billable Type" name="groupby_timesheet_invoice_type" domain="[]" context="{'group_by': 'timesheet_invoice_type'}"/>
                 </xpath>
             </field>
+    </record>
+
+    <record id="hr_timesheet_line_tree_inherit" model="ir.ui.view">
+        <field name="name">account.analytic.line.tree.inherit</field>
+        <field name="model">account.analytic.line</field>
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//tree/field[@name='unit_amount']" position="before">
+                <field name="commercial_partner_id" invisible="1"/>
+                <field name="so_line" optional="hide" options="{'no_create': True}" context="{'create': False, 'edit': False, 'delete': False}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_timesheet_line_form_inherit" model="ir.ui.view">
+        <field name="name">account.analytic.line.form.inherit</field>
+        <field name="model">account.analytic.line</field>
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='task_id']" position="after">
+                <field name="commercial_partner_id" invisible="1"/>
+                <field name="so_line" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False}"/>
+            </xpath>
+        </field>
     </record>
 
     <record id="timesheet_view_pivot_revenue" model="ir.ui.view">


### PR DESCRIPTION
Purpose of the commit is to do the generic improvement for the
timesheets app.

So in this commit, done the following changes:

- add name_get to account_analytic_line model.
- changes in form view of timesheets menu
  - hide company_id and amount field.
  - move date field above unit_amount field.
  - move employee_id field above name field
in all timesheet menu.
  - add so_line field in timesheets menu and
move employee_id before date in all timesheet
menu when so_line is available.
- add so_line field in the list view of timesheets
menu as optional hide.
- add so_line field to kanban view after the name
field and change o_kanban_record_top height
50 to 51 to show it properly.
- add a search for sale order item(so_line) and
remove a search for billable type(timesheet_
invoice_type).
- remove filters Billable and Non-Billable.
- add group_by for so_line and timesheet_
invoice_id fields.

Task Id: 2510313

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
