### PR TITLE
[IMP] website: update the artists-1 palette

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -344,11 +344,11 @@ $o-color-palettes: map-merge($o-color-palettes,
             'copyright-custom': 'black-15',
         ),
         'artists-1': (
-            'o-color-1': #ab44ff,
-            'o-color-2': #3a3a3a,
+            'o-color-1': #6930C3,
+            'o-color-2': #333038,
             'o-color-3': #e5e5e5,
             'o-color-4': #ffffff,
-            'o-color-5': #000000,
+            'o-color-5': #110d16,
 
             'o-cc5-text': 'o-color-3',
 


### PR DESCRIPTION
Update the palette "artists-1" to improve the main colors for a better render.
This change is related to an update of the theme Artists on [PR#25](https://github.com/odoo/design-themes/pull/25) in the Design-themes repo.

Task-2580170

