### PR TITLE
[FIX] point_of_sale : remove taxe from other company

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -444,6 +444,7 @@ exports.PosModel = Backbone.Model.extend({
                 }
                 product.categ = _.findWhere(self.product_categories, {'id': product.categ_id[0]});
                 product.pos = self;
+                product.taxes_id = _.filter(product.taxes_id, t => t in self.taxes_by_id);
                 return new exports.Product({}, product);
             }));
         },


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- create an other company
- log with user allow in both company and select both company in the company widget
- create a product A with two taxes (one from company A and 1 from company 2)
- lauch the pos (with taxe includ in the price)
- add two product A and pay an order
--> Issue, the ticket is not show

This PR allow only product taxes loaded in POS


@pimodoo @rhe-odoo 

https://user-images.githubusercontent.com/16716992/124459660-a77cca80-dd8e-11eb-94f0-3696120cb6f4.mov

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
