### PR TITLE
[FIX] web: debug: allow to edit SearchView

### DIFF
--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -416,16 +416,16 @@ export function editView({ accessRights, action, component, env }) {
     };
 }
 
-function editControlPanelView({ accessRights, component, env }) {
+export function editSearchView({ accessRights, component, env }) {
     if (!accessRights.canEditView) {
         return null;
     }
-    const description = env._t("Edit ControlPanelView");
+    const description = env._t("Edit SearchView");
     return {
         type: "item",
         description,
         callback: () => {
-            editModelDebug(env, description, "ir.ui.view", component.props.viewInfo.view_id);
+            editModelDebug(env, description, "ir.ui.view", component.props.viewParams.controlPanelFieldsView.view_id);
         },
         sequence: 360,
     };
@@ -516,7 +516,7 @@ debugRegistry
     .add("viewSeparator", viewSeparator)
     .add("fieldsViewGet", fieldsViewGet)
     .add("editView", editView)
-    .add("editControlPanelView", editControlPanelView);
+    .add("editSearchView", editSearchView);
 
 debugRegistry
     .category("form")


### PR DESCRIPTION
Before this commit, clicking on "Edit ControlPanelView" in the
debug manager actually edited the "main" view (e.g. kanban), because
we used the wrong view id.

This commit also renames "Edit ControlPanelView" into "Edit
SearchView", which is more accurate w.r.t. to the view type.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
