### PR TITLE
[FIX] website: allow non-admin editor to get suggested links

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -282,8 +282,8 @@ class Website(Home):
         suggested_controllers = []
         for name, url, mod in current_website.get_suggested_controllers():
             if needle.lower() in name.lower() or needle.lower() in url.lower():
-                module = mod and request.env.ref('base.module_%s' % mod, False)
-                icon = mod and "<img src='%s' width='24px' class='mr-2 rounded' /> " % (module and module.icon or mod) or ''
+                module_sudo = mod and request.env.ref('base.module_%s' % mod, False).sudo()
+                icon = mod and "<img src='%s' width='24px' class='mr-2 rounded' /> " % (module_sudo and module_sudo.icon or mod) or ''
                 suggested_controllers.append({
                     'value': url,
                     'label': '%s%s (%s)' % (icon, url, name),


### PR DESCRIPTION
New features to show suggested links as an autocomplete when creating a menu
was introduced with 9b9829416ba0b0.

But it was missing a sudo, so non-admin editor could not read module records.

task-2583737
