### PR TITLE
[FIX] purchase : narration is overide when add invoice

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -46,6 +46,7 @@ class AccountMove(models.Model):
         # Copy data from PO
         invoice_vals = self.purchase_id.with_company(self.purchase_id.company_id)._prepare_invoice()
         del invoice_vals['ref']
+        invoice_vals['narration'] = '\n'.join([n for n in [self.narration, invoice_vals.get('narration')] if n])
         self.update(invoice_vals)
 
         # Copy purchase lines.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- create invoice
- write an 'narration 1' in invoice (or it already imported if you use OCR)
- add purchase A (with notes = 'narration 2')
- add purchase B (with notes = 'narration 3')
--> Issue : narration is 'narration 3'
After this PR it is:
'''narration 1
narration 2
narration 3'''

@oco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
