### PR TITLE
[FIX] account: display "Load more" and more correct list expansion

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -1849,6 +1849,9 @@ var ManualModel = StatementModel.extend({
      * @returns {Promise}
      */
     _performMoveLine: function (handle, mode, limit) {
+        if (limit === 0) {
+            return this._formatMoveLine(handle, '', []);
+        }
         limit = limit || this.limitMoveLines;
         var line = this.getLine(handle);
         var excluded_ids = _.map(_.union(line.reconciliation_proposition, line.mv_lines_match), function (prop) {

--- a/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
@@ -382,8 +382,8 @@ var LineRenderer = Widget.extend(FieldManagerMixin, {
         var matching_modes = self.model.modes.filter(x => x.startsWith('match'));
         for (let i = 0; i < matching_modes.length; i++) {
             var stateMvLines = state['mv_lines_'+matching_modes[i]] || [];
-            var recs_count = stateMvLines.length > 0 ? stateMvLines[0].recs_count : 0;
-            var remaining = state['remaining_' + matching_modes[i]];
+            var recs_count = stateMvLines.length > 0 ? stateMvLines.reduce((max, mvLine) => mvLine.recs_count > max ? mvLine.recs_count : max, stateMvLines[0].recs_count) : 0;
+            var remaining = recs_count - ( stateMvLines.length + state.reconciliation_proposition.length );
             var $mv_lines = this.$('div[id*="notebook_page_' + matching_modes[i] + '"] .match table tbody').empty();
             this.$('.o_notebook li a[href*="notebook_page_' + matching_modes[i] + '"]').parent().toggleClass('d-none', stateMvLines.length === 0 && !state['filter_'+matching_modes[i]]);
 


### PR DESCRIPTION
How to reproduce the problem:
- Install the Accounting app
- Create several unpaid (customer) invoices and payments
- Go to Accounting (in the Accounting App) -> Reconciliation
Problem: the button "Load more" is not displayed, and when a line is selected, the list expands.

Cause of the problem : the button fetched an undefined value, and methods incorrectly handle expansion limits

Solution : different value fetched for the button, edge-case about limit handled

opw-2554894