### PR TITLE
[IMP] website: don't show parent menu if only non-visible children

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2,8 +2,8 @@
 <odoo>
 
 <template id="submenu" name="Submenu">
-    <t t-set="has_visible_submenu" t-value="(submenu.is_mega_menu and submenu.is_visible) or submenu.child_id.filtered(lambda menu: menu.is_visible)"/>
-    <li t-if="submenu.is_visible and not has_visible_submenu" t-attf-class="#{item_class or ''}">
+    <t t-set="show_dropdown" t-value="(submenu.is_mega_menu and submenu.is_visible) or submenu.child_id.filtered(lambda menu: menu.is_visible)"/>
+    <li t-if="submenu.is_visible and not (submenu.child_id or submenu.is_mega_menu)" t-attf-class="#{item_class or ''}">
         <a t-att-href="submenu.clean_url()"
             t-attf-class="#{link_class or ''} #{'active' if submenu.clean_url() and unslug_url(request.httprequest.path) == unslug_url(submenu.clean_url()) else ''}"
             role="menuitem"
@@ -12,7 +12,7 @@
             <span t-field="submenu.name"/>
         </a>
     </li>
-    <li t-if="has_visible_submenu" t-attf-class="#{item_class or ''} dropdown #{
+    <li t-elif="show_dropdown" t-attf-class="#{item_class or ''} dropdown #{
         (submenu.clean_url() and submenu.clean_url() != '/' and any(request.httprequest.path == child.url for child in submenu.child_id if child.url) or
          (submenu.clean_url() and request.httprequest.path == submenu.clean_url())) and 'active'
         } #{submenu.is_mega_menu and 'position-static'}">


### PR DESCRIPTION
Before this commit, if a parent menu had child menus and all of those were not
visible (eg linked to an unpublished page), that parent menu would still be
shown.

While it is more a choice than an error, it might makes more sense to not show
it as most of the time, that parent menu has no sense itself, it just served as
a way to group submenus. Its URL can't be clicked (as it opens a dropdown)
despite the fact it is required, and is actually most of the time a random URL
typed by the user as it has no real purpose.

The parent menu is just used as a dropdown entry and shouldn't be displayed if
there is nothing in the dropdown, instead of converting it to a regular menu.

Historically, it was decided to do it that way to fulfill this usecase:
```
- /dogs
   - /german-sheperds
   - /beagles
```
If you were to unpublished your beagles and german sheperds pages, the menu
would auto convert to a regular menu pointing to your dogs page.

This use case now seems less prefered than the behavior to hide that menu.

task-2583737

| |  visible  | has child |  visible child  |  is mega menu | |
| --- | ------------- |-------------| -----|------------- | --- |
megamenu visible |     +     |           |           |     +     | `<Dropdown/>` |
megamenu invisible |           |           |           |     +     |  / |
menu visible - no children |     +     |           |           |           |  `<a/>` |
menu invisible - no children |           |           |           |           |  / |
menu visible - only invisible children |     +     |     +     |           |           | / (**fixed with this PR**) |
menu visible - visible children |     +     |     +     |     +     |           |  `<Dropdown/>` |
menu invisible - only invisible children |           |     +     |           |           | / |
menu invisible - visible children |           |     +     |     +     |           |   `<Dropdown/>` |
