### PR TITLE
[FIX] web: add missing method to owl renderer wrapper

### DIFF
--- a/addons/web/static/src/js/views/renderer_wrapper.js
+++ b/addons/web/static/src/js/views/renderer_wrapper.js
@@ -7,6 +7,7 @@ odoo.define('web.RendererWrapper', function (require) {
         getLocalState() { }
         setLocalState() { }
         giveFocus() { }
+        resetLocalState() { } 
     }
 
     return RendererWrapper;


### PR DESCRIPTION
The owl abstract renderer must be a mirror of the legacy abstract
renderer.
8776e46f07fcf6f02b40fd3246b39af844d23407 was merged without doing so,
resulting in errors.

See https://github.com/odoo/odoo/pull/67241 for the PR introducing the bug. 
