### PR TITLE
[FIX] google_calendar: make commit after user sync

### DIFF
--- a/addons/google_calendar/models/google_calendar.py
+++ b/addons/google_calendar/models/google_calendar.py
@@ -595,6 +595,8 @@ class GoogleCalendar(models.AbstractModel):
                     _logger.info("[%s] Calendar Synchro - Done with status : %s  !", user_to_sync, resp.get("status"))
             except Exception as e:
                 _logger.info("[%s] Calendar Synchro - Exception : %s !", user_to_sync, exception_to_unicode(e))
+            # make commit after processing a user to avoid starting over in case of timeout error
+            self.env.cr.commit()
         _logger.info("Calendar Synchro - Ended by cron")
 
     def synchronize_events(self, lastSync=True):


### PR DESCRIPTION
syncing calendar for a single user may take few minutes, which could easily lead
to cron timeout. To avoid starting the syncronization over and over again, we
should commit jobs that is already done.

The module already has many commit() calls, but those are not always used and
hence we need to add a new one.

---

opw-2577018

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
