### PR TITLE
[FIX] website_rating: display layout of publisher comment

### DIFF
--- a/addons/website_rating/static/src/xml/portal_chatter.xml
+++ b/addons/website_rating/static/src/xml/portal_chatter.xml
@@ -85,7 +85,7 @@
                     </div>
                     <p>Published on <t t-esc="rating.publisher_datetime"/></p>
                 </div>
-                <t t-raw="rating.publisher_comment"/>
+                <t t-esc="rating.publisher_comment"/>
             </div>
         </div>
     </t>


### PR DESCRIPTION
Avoid website_publisher unwittingly breaking portal page layouts where publisher_comment is enabled.
