### PR TITLE
[FIX] translate: get class attribute safely

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -152,7 +152,7 @@ TRANSLATED_ATTRS = dict.fromkeys({
     'value_label',
 }, lambda e: True)
 TRANSLATED_ATTRS.update(
-    value=lambda e: (e.tag == 'input' and e.attrib.get('type', 'text') == 'text') and 'datetimepicker-input' not in e.attrib.get('class').split(' '),
+    value=lambda e: (e.tag == 'input' and e.attrib.get('type', 'text') == 'text') and 'datetimepicker-input' not in e.attrib.get('class', '').split(' '),
     text=lambda e: (e.tag == 'field' and e.attrib.get('widget', '') == 'url'),
     **{f't-attf-{attr}': cond for attr, cond in TRANSLATED_ATTRS.items()},
 )


### PR DESCRIPTION
58d3b670221b3 was not correctly forward ported, it misses the `''` fallback part
of the original commit dc20ab9c02c9

Without this, traceback is shown.
Step to reproduce:
 - Open HTML Editor (or edit a backend view)
 - Add an input with no class but a value attribute (no type or type text)