### PR TITLE
[FIX] l10n_eu_service: remove useless calls to _()

### DIFF
--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -40,7 +40,7 @@ class Company(models.Model):
                             ('vat_required', '=', False)], limit=1)
                 if not fpos:
                     fpos = self.env['account.fiscal.position'].create({
-                        'name': _('OSS B2C %s', country.name),
+                        'name': 'OSS B2C %s' % country.name,
                         'country_id': country.id,
                         'company_id': company.id,
                         'auto_apply': True,
@@ -58,7 +58,7 @@ class Company(models.Model):
                                     'noupdate': True,
                                     })
                             foreign_taxes[tax_amount] = self.env['account.tax'].create({
-                                'name': _('%(rate)s%% %(country)s %(label)s', rate=tax_amount, country=country.code, label=country.vat_label),
+                                'name': '%(rate)s%% %(country)s %(label)s' % {'rate': tax_amount, 'country': country.code, 'label': country.vat_label},
                                 'amount': tax_amount,
                                 'invoice_repartition_line_ids': invoice_repartition_lines,
                                 'refund_repartition_line_ids': refund_repartition_lines,
@@ -94,7 +94,7 @@ class Company(models.Model):
                 return False
             new_code = self.env['account.account']._search_new_account_code(self, len(sales_tax_accounts[0].code), sales_tax_accounts[0].code[:-2])
             oss_account = self.env['account.account'].create({
-                'name': _('%s OSS', sales_tax_accounts[0].name),
+                'name': '%s OSS' % sales_tax_accounts[0].name,
                 'code': new_code,
                 'user_type_id': sales_tax_accounts[0].user_type_id.id,
                 'company_id': self.id,


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/72771 introduced some calls to the translation function without adding the terms in the .pot. We remove those calls to directly use the string, as the terms were basically only concatenated strings with non-translatable acronyms.
