### PR TITLE
[FIX] mail: Don't send e-mail immediately for mass mails

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -284,7 +284,7 @@ class MailComposer(models.TransientModel):
                             ActiveModel.browse(res_id).message_post(**post_params)
 
                 if wizard.composition_mode == 'mass_mail':
-                    batch_mails.send(auto_commit=auto_commit)
+                    batch_mails.mark_outgoing()
 
     def get_mail_values(self, res_ids):
         """Generate the values that will be used by send_mail to create mail_messages


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:** Right now the e-mails are being sent immediately without waiting for the mail queue. This causes a bottleneck when sending several documents at a time. It can also cause more errors as an e-mail can be incorrectly marked as not sent, and then it ends up being sent again.

**Current behavior before PR:** For example, if we try to send ~300 invoices at a time, the `mass_mail` mode will be selected and each mail will be processed after the report generation. The sending of the document can take ~30% of the time for each invoice, so if we try to send and print those 300 invoices, the user will end up waiting ~15 minutes.

**Desired behavior after PR is merged:** The original goal of the patch that added this changes was that "Mails sent from the mail form are sent immediately instead of from the mail queue" (See https://github.com/odoo/odoo/commit/d88c34d11e87857a799ecbb0062fe9309858413d). In `mass_mail` mode there is no form for each individual mail, so it makes more sense to keep that option but only for `comment` messages. This helps reduce the time used in sending those documents.

Note: Another option is to remove this behavior completely and always go through the mail queue. I am not sure what is behind the need for this option, so there might be a better way to fix this.

@Tecnativa
TT30841

ping @Yajo @pedrobaeza @sergio-teruel 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
