### PR TITLE
[FIX] web : isue with german translation

### DIFF
--- a/addons/web/i18n/de.po
+++ b/addons/web/i18n/de.po
@@ -2175,7 +2175,7 @@ msgstr "Bild"
 #: code:addons/web/static/src/js/fields/basic_fields.js:0
 #, python-format
 msgid "In %s days"
-msgstr "Vor %s Tagen"
+msgstr "In %s Tagen"
 
 #. module: web
 #. openerp-web


### PR DESCRIPTION
In a german database, when creating an invoice with a due date
in the future, the result on the due date field in the list view is :
"Vor %s Tags" ("%s days ago") instead of "In %s Tags" ("In %s days").

opw-2573126

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
