### PR TITLE
[FIX] tests: remove f-string in classCleanUp backport

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -208,7 +208,7 @@ class OdooSuite(unittest.suite.TestSuite):
                                         info=exc)
 
         def _createClassOrModuleLevelException(self, result, exc, method_name, parent, info=None):
-            errorName = f'{method_name} ({parent})'
+            errorName = '%s (%s)' % (method_name, parent)
             self._addClassOrModuleLevelException(result, exc, errorName, info)
 
         def _addClassOrModuleLevelException(self, result, exception, errorName, info=None):


### PR DESCRIPTION
This commit is a fixup to the earlier commits that backport CPython's
3.8 classCleanups, due to the fact that the official supported python
version for Odoo V12 is CPython 3.5, where f-strings are not available.

This one slipped through due to the fact that v12 runbot does not
actually run under Python 3.5 but 3.6+