### PR TITLE
[FIX] digest: avoid exception on user creation

### DIFF
--- a/addons/digest/models/res_users.py
+++ b/addons/digest/models/res_users.py
@@ -13,6 +13,7 @@ class ResUsers(models.Model):
         default_digest_emails = self.env['ir.config_parameter'].sudo().get_param('digest.default_digest_emails')
         default_digest_id = self.env['ir.config_parameter'].sudo().get_param('digest.default_digest_id')
         if user.has_group('base.group_user') and default_digest_emails and default_digest_id:
-            digest = self.env['digest.digest'].sudo().browse(int(default_digest_id))
-            digest.user_ids |= user
+            digest = self.env['digest.digest'].sudo().browse(int(default_digest_id)).exists()
+            if digest:
+                digest.user_ids |= user
         return user


### PR DESCRIPTION
Scenario to reproduce the issue on runbot 12.0 Community:
- Go to Settings > Technical > Email > Digest Emails
- Select the Weekly Digest
- Click on Action > Delete
- Click on OK
- Go to Settings > Users & Companies > Users
- Click on Create
- Fill the Name and the Email Address
- Save
- Odoo Server Error - Missing Record

Some users seem to delete this record to stop receiving the digest for everyone, including for future users.  The problem is that, even if the digest has been deleted, the config parameters are still referencing it.

This commit prevents the exception by having an empty recordset if the digest does not exist.
