### PR TITLE
14.0 oss tax duplication oco

### DIFF
--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -32,7 +32,6 @@ class Company(models.Model):
                 ('tax_group_id', 'not in', oss_tax_groups.mapped('res_id'))])
             for country in eu_countries - company.account_tax_fiscal_country_id:
                 mapping = []
-                foreign_taxes = {}
                 fpos = self.env['account.fiscal.position'].search([
                             ('country_id', '=', country.id),
                             ('company_id', '=', company.id),
@@ -45,6 +44,9 @@ class Company(models.Model):
                         'company_id': company.id,
                         'auto_apply': True,
                     })
+
+                foreign_taxes = {tax.amount: tax for tax in fpos.tax_ids.tax_dest_id if tax.amount_type == 'percent'}
+
                 for domestic_tax in taxes:
                     tax_amount = EU_TAX_MAP.get((company.account_tax_fiscal_country_id.code, domestic_tax.amount, country.code), False)
                     if tax_amount and domestic_tax not in fpos.tax_ids.tax_src_id:

--- a/addons/l10n_eu_service/models/res_config_settings.py
+++ b/addons/l10n_eu_service/models/res_config_settings.py
@@ -14,4 +14,6 @@ class ResConfigSettings(models.TransientModel):
 
     @api.depends('company_id')
     def _compute_l10n_eu_services_european_country(self):
-        self.l10n_eu_services_eu_country = self.company_id.country_id in self.env.ref('base.europe').country_ids
+        european_countries = self.env.ref('base.europe').country_ids
+        for record in self:
+            record.l10n_eu_services_eu_country = record.company_id.account_tax_fiscal_country_id in european_countries


### PR DESCRIPTION
[FIX] l10n_eu_service: don't duplicate OSS taxes on refresh of an existing rate

To reproduce:

1) Install an European CoA and make sure the OSS mapping for its taxes has been generated (either installing l10n_eu_service before, or clikcing the "refresh tax mapping" button, in the settings)

2) Create a new tax with the same rate as one of your original taxes

3) Click on "refresh tax mapping"

===> Instead of reusing the OSS tax mapped with the other tax having the same rate, a new tax with the same name has been created.



[FIX] l10n_eu_service: fix computation of l10n_eu_services_eu_country 

This field should be true when the company is subject to VAT in Europe, so the fiscal country should be used instead of the country.