### PR TITLE
[FIX] web: fix resequencing after moving records with same sequence

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/js/views/basic/basic_renderer.js
@@ -420,9 +420,10 @@ var BasicRenderer = AbstractRenderer.extend({
 
         // determine if we need to reorder all records
         _.each(records, function (record, index) {
-            if ((index < lowerIndex || index >= upperIndex) &&
+            if (((index < lowerIndex || index >= upperIndex) &&
                 ((asc && sequence >= record.data[self.handleField]) ||
-                 (!asc && sequence <= record.data[self.handleField]))) {
+                 (!asc && sequence <= record.data[self.handleField]))) ||
+                (index >= lowerIndex && index < upperIndex && sequence === record.data[self.handleField])) {
                 reorderAll = true;
             }
             sequence = record.data[self.handleField];

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -9314,6 +9314,72 @@ QUnit.module('fields', {}, function () {
             form.destroy();
             delete fieldRegistry.map.my_relational_field;
         });
+
+        QUnit.test('reordering embedded one2many with handle widget starting with same sequence', async function (assert) {
+            assert.expect(3);
+
+            this.data.turtle = {
+                fields: {turtle_int: {string: "int", type: "integer", sortable: true}},
+                records: [
+                    {id: 1, turtle_int: 1},
+                    {id: 2, turtle_int: 1},
+                    {id: 3, turtle_int: 1},
+                    {id: 4, turtle_int: 2},
+                    {id: 5, turtle_int: 3},
+                    {id: 6, turtle_int: 4},
+                ],
+            };
+            this.data.partner.records[0].turtles = [1, 2, 3, 4, 5, 6];
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form string="Partners">
+                        <sheet>
+                            <notebook>
+                                <page string="P page">
+                                    <field name="turtles">
+                                        <tree default_order="turtle_int">
+                                            <field name="turtle_int" widget="handle"/>
+                                            <field name="id"/>
+                                        </tree>
+                                    </field>
+                                </page>
+                            </notebook>
+                        </sheet>
+                    </form>`,
+                res_id: 1,
+            });
+
+            await testUtils.form.clickEdit(form);
+
+            assert.strictEqual(form.$('td.o_data_cell:not(.o_handle_cell)').text(), "123456", "default should be sorted by id");
+
+            // Drag and drop the fourth line in first position
+            await testUtils.dom.dragAndDrop(
+                form.$('.ui-sortable-handle').eq(3),
+                form.$('tbody tr').first(),
+                {position: 'top'}
+            );
+            assert.strictEqual(form.$('td.o_data_cell:not(.o_handle_cell)').text(), "412356", "should still have the 6 rows in the correct order");
+
+            await testUtils.form.clickSave(form);
+
+            assert.deepEqual(_.map(this.data.turtle.records, function (turtle) {
+                return _.pick(turtle, 'id', 'turtle_int');
+            }), [
+                {id: 1, turtle_int: 2},
+                {id: 2, turtle_int: 3},
+                {id: 3, turtle_int: 4},
+                {id: 4, turtle_int: 1},
+                {id: 5, turtle_int: 5},
+                {id: 6, turtle_int: 6},
+            ], "should have saved the updated turtle_int sequence");
+
+            form.destroy();
+        });
     });
 });
 });


### PR DESCRIPTION
- Install Sales > Configuration > Settings and activate Delivery Methods
- Create a SO as followed:
  * Add a section (i.e. Section 1)
  * Add a product (i.e. Product A)
  * Add a product (i.e. Product B)
  * Add a shipping (i.e. Delivery X)
  * Add a section (i.e. Section 2)
  * Add a product (i.e. Product C)
- Move (drag & drop) Delivery X to the first place
SO lines are reordered, but Product B is moved after Section 2.

It comes from the fact that some lines have the same sequence and that
only the lines between the source and the destination position are
re-sequenced.

Before the move, the sequencing is as followed:
 1) Section 1: 10
 2) Product A: 10
 3) Product B: 10
 4) Delivery X: 11
 5) Section 2: 12
 6) Product C: 13

After the move, only lines from 1 to 4 are re-sequenced. Leading to the
following sequencing:
 1) Delivery X: 10
 2) Section 1: 11
 3) Product A: 12
 4) Product B: 13

 5) Section 2: 12
 6) Product C: 13

As Product B has now a greater sequence than Section 2, it will be moved
after it.

If some lines between the source and the destination position have the
same sequence, all lines should be re-sequenced to prevent such a behavior.

opw-2531524

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
