### PR TITLE
[FIX] web: Adjust label#for to match input#id

### DIFF
--- a/addons/web/views/database_manager.html
+++ b/addons/web/views/database_manager.html
@@ -119,7 +119,7 @@
             </div>
         </div>
         <div class="form-group row">
-            <label for="demo" class="col-md-4 col-form-label">Demo data</label>
+            <label for="load_demo_checkbox" class="col-md-4 col-form-label">Demo data</label>
             <div class="col-md-8">
                 <input type="checkbox" id="load_demo_checkbox" class="form-control-sm" name="demo" value="1">
             </div>


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:

The label `for` attribute does not match the `id` of the form element it is supposed to be connected to. 

#### Current behavior before PR:

Clicking on the label does not activate the form element.

#### Desired behavior after PR is merged:

Clicking on the label does activate the form element.

----

This was subitted in #72252 against the `14.0` branch, but this small enhancement should have been targeting the `12.0` branch.

----
- [x] I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
