### PR TITLE
[13.0][auth_oauth] use sudo() to access ir.config_parameter

### DIFF
--- a/addons/auth_oauth/models/res_config_settings.py
+++ b/addons/auth_oauth/models/res_config_settings.py
@@ -13,7 +13,8 @@ class ResConfigSettings(models.TransientModel):
 
     @api.model
     def get_uri(self):
-        return "%s/auth_oauth/signin" % (self.env['ir.config_parameter'].get_param('web.base.url'))
+        return "%s/auth_oauth/signin" % (
+            self.env['ir.config_parameter'].sudo().get_param('web.base.url'))
 
     auth_oauth_google_enabled = fields.Boolean(string='Allow users to sign in with Google')
     auth_oauth_google_client_id = fields.Char(string='Client ID')

--- a/addons/purchase_stock/models/res_config_settings.py
+++ b/addons/purchase_stock/models/res_config_settings.py
@@ -14,6 +14,7 @@ class ResConfigSettings(models.TransientModel):
     def get_values(self):
         res = super(ResConfigSettings, self).get_values()
         res.update(
-            is_installed_sale=self.env['ir.module.module'].search([('name', '=', 'sale'), ('state', '=', 'installed')]).id,
+            is_installed_sale=self.env['ir.module.module'].sudo().search(
+                [('name', '=', 'sale'), ('state', '=', 'installed')]).id,
         )
         return res


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Accessess to ir.config_parameter should be done using sudo() because you cannot guarantee that the user accessing will have the permissions.

![image](https://user-images.githubusercontent.com/7683926/124237661-0d135180-db18-11eb-9847-edb27dbd332c.png)


Current behavior before PR:
With module auth_oauth installed, any time a user tries to access to get a value from ir.config_parameter via any module will end up with a failure in permissions if the user does not have read access to ir.config_parameter.

Desired behavior after PR is merged:
The access to 'web.base.url' is always done using sudo(). Examples:
https://github.com/odoo/odoo/blob/13.0/addons/google_calendar/models/res_config_settings.py#L17
https://github.com/odoo/odoo/blob/13.0/addons/mail/models/update.py#L48



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
