### PR TITLE
[IMP] l10n_eu_service: set country on new taxes

### DIFF
--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -67,6 +67,7 @@ class Company(models.Model):
                                 'type_tax_use': 'sale',
                                 'description': "%s%%" % tax_amount,
                                 'tax_group_id': self.env.ref('l10n_eu_service.%s' % tax_group_fid).id,
+                                'country_id': country.id,
                                 'sequence': 1000,
                                 'company_id': company.id,
                             })


### PR DESCRIPTION
Since 14.3, Taxes have a country field. Till now, New taxes created by l10n_eu_service don't update this field. This improves identification of new foreign taxes.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
