### PR TITLE
[IMP] mail: Allow overwriting field defaults with mail data model.

### DIFF
--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -269,6 +269,7 @@ class ModelManager {
                 Model.fields[fieldName] = field;
             } else {
                 Object.assign(Model.fields[fieldName].dependencies, field.dependencies);
+                if (typeof field.default !== 'undefined') Model.fields[fieldName].default = field.default;
             }
         }
     }


### PR DESCRIPTION
We could not find a way to implement the following modification:
![2021-07-02_12-43](https://user-images.githubusercontent.com/36383311/124255730-2a094e00-db33-11eb-8c59-064accbfba8a.png)

We would like to fix this with code like this:

```javascript
odoo.define('sprintit_chatter_clear_checkbox/static/src/models/chatter/chatter.js', function (require) {
    'use strict';
    const { attr } = require('mail/static/src/model/model_field.js');
    const { registerFieldPatchModel } = require('mail/static/src/model/model_core.js');
    registerFieldPatchModel('mail.suggested_recipient_info', 'sprintit_chatter_clear_checkbox', {
        isSelected: attr({
            default: false,
        }),
    });
});

```


Current behavior before PR:

The code above does not work, the checkbox is still ticked.

Desired behavior after PR is merged:

After this pull request, the code above works and now the checkbox is **_not_** ticked by default.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
