### PR TITLE
[IMP] l10n_eu_service: raise Error message when trying to open old MOSS wizard

### DIFF
--- a/addons/l10n_eu_service/wizard/wizard.py
+++ b/addons/l10n_eu_service/wizard/wizard.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import Warning
+from odoo.exceptions import UserError, Warning
 
 
 class l10n_eu_service(models.TransientModel):
@@ -69,6 +69,12 @@ class l10n_eu_service(models.TransientModel):
     todo_country_ids = fields.Many2many(
         'res.country', 'l10n_eu_service_country_rel_todo', default=_default_todo_country_ids,
         string='EU Customers From', required=True)
+
+    @api.model
+    def load_views(self, views, options=None):
+        # This wizard is outdated; it shouldn't be used anymore. Users might still be able to open it using the
+        # link in the settings if they didn't update the module. If they try, we tell them.
+        raise UserError(_("Starting July 1st 2021, OSS regulation has replaced MOSS. Please first upgrade 'l10n_eu_service' module in the Apps menu, then go back to this setting and click on 'Refresh tax mapping'."))
 
     def _get_repartition_line_copy_values(self, original_rep_lines):
         return [(0, 0, {


### PR DESCRIPTION
l10n_eu_service has been modified in order to follow the new OSS regulation. We now auto-generate the mapping instead of relying on a wizard. Databases that were already using the module will still see the button to open this wizard, unless they upgrade the module. Wit this, we add an error message in case they try to do so, asking them to update the module, so that they can use the new OSS mapping.
