### PR TITLE
[FIX] sale: make sure that bulk invoice creation is not blocked and those orders are skipped instead

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -696,7 +696,7 @@ Reason(s) of this behavior could be:
             invoiceable_lines = order._get_invoiceable_lines(final)
 
             if not any(not line.display_type for line in invoiceable_lines):
-                raise self._nothing_to_invoice_error()
+                continue
 
             invoice_line_vals = []
             down_payment_section_added = False


### PR DESCRIPTION
In case you have installed `sale_timesheet` and try to do a bulk invoice creation you will be blocked if one order does not have invoiceable lines instead of skipping this specific order.

**Description of the issue/feature this PR addresses:**
As soon as you try to invoice a single order which does not fit the date range given, the whole process is blocked.
So, we should just move on and skip those and only block and inform the user if nothing was possible to be invoiced.

**Current behavior before PR:**
One order is blocking all and without being explicit which order was blocking

**Desired behavior after PR is merged:**
Skip those orders and invoice the legit orders via bulk invoice creation.

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
