### PR TITLE
[IMP] Make hotkey_service overlay modifier configurable

### DIFF
--- a/doc/cla/individual/SplashS.md
+++ b/doc/cla/individual/SplashS.md
@@ -1,0 +1,11 @@
+Russian Federation, 2021-06-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sergey Shebanin sergey@shebanin.ru https://github.com/SplashS


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
To support certain hotkey overlay replacement in the `web_responsive` module with current implementation of hotkey_service we will have to override hotkey_service altogether. This doesn't seem like the correct way to extend odoo.
This PR makes hotkey_service patchable.
Also this PR introduce method `isAlted` what accumulates logic for determining hotkey overlay modifier. This logic was in 2 different methods of this service. It is the best case for patching this service in the future to replace overlay modifier from `Alt` to `Alt+Shift` in `web_responsive` v15.0.

Current behavior before PR:
There is no way to patch hotkey_service.
Prooflink why there is no way: https://stackoverflow.com/questions/59647878/how-to-monkey-patch-a-function-declared-inside-another-function

Desired behavior after PR is merged:
hotkey_service is patchable via "web.utils" patch method.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
