### PR TITLE
[FIX] stock: allow lot change in tablet view (intermediate step)

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -307,7 +307,13 @@ class StockMoveLine(models.Model):
 
                 # Unreserve the old charateristics of the move line.
                 if not ml._should_bypass_reservation(ml.location_id):
-                    Quant._update_reserved_quantity(ml.product_id, ml.location_id, -ml.product_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
+                    try:
+                        Quant._update_reserved_quantity(ml.product_id, ml.location_id, -ml.product_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
+                    except UserError:
+                        pass
+                    if new_product_uom_qty == 0:
+                        moves_to_recompute_state |= ml.move_id
+                        ml.with_context(bypass_reservation_update=True).product_uom_qty = 0
 
                 # Reserve the maximum available of the new charateristics of the move line.
                 if not ml._should_bypass_reservation(updates.get('location_id', ml.location_id)):


### PR DESCRIPTION
- Have a [DEMO] product:
  - Tracket by SN
  - Manufactured
- The BOM for [DEMO] has:
  - product [COMPONENT] tracked by lot
  - At least an operation
- Add at least 1 lot with 2 units to [COMPONENT]
- Create a manufacturing order for [DEMO], specifying 2 units to produce
- Confirm, check availability
- In operations tab start the production and go to tablet mode
- Assign the serial to [DEMO], change the lot of [COMPONENT] to a new
lot, then mark as done

Error will raise

opw-2577094

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
