### PR TITLE
[IMP] stock: quants import

### DIFF
--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -15,6 +15,7 @@
         'views/res_partner_views.xml',
         'views/stock_warehouse_views.xml',
         'views/stock_move_views.xml',
+        'views/stock_quant_views.xml',
         'views/stock_picking_views.xml',
         'views/supplier_info_views.xml',
         'views/product_views.xml',

--- a/addons/mrp_subcontracting/views/stock_quant_views.xml
+++ b/addons/mrp_subcontracting/views/stock_quant_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="quant_subcontracting_search_view" model="ir.ui.view">
+            <field name="name">stock.quant.subcontracting.search</field>
+            <field name="model">stock.quant</field>
+            <field name="inherit_id" ref="stock.quant_search_view" />
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='transit_loc']" position="after">
+                    <filter string="Subcontracting Locations" name="subcontract_loc" domain="[('on_hand', '=', False), ('location_id.usage', '=', 'internal')]" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>
+

--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding='UTF-8'?>
 <odoo>
-        <record id="view_quant_form_expiry" model="ir.ui.view">
-            <field name="name">stock.quant.inherit.form</field>
-            <field name="model">stock.quant</field>
-            <field name="inherit_id" ref="stock.view_stock_quant_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='lot_id']" position="after" >
-                    <field name="removal_date"/>
-                </xpath>
-            </field>
-        </record>
-
     <record id="view_stock_quant_tree_expiry" model="ir.ui.view">
         <field name="name">stock.quant.inherit.form</field>
         <field name="model">stock.quant</field>

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -275,13 +275,10 @@ class StockQuant(models.Model):
             'context': ctx,
             'domain': [('location_id.usage', 'in', ['internal', 'transit'])],
             'help': """
-                <p class="o_view_nocontent_barcode_scanner">
-                    Want to speed up your inventory counts? Try our Barcode app
+                <p class="o_view_nocontent_smiling_face">
+                    Your stock is currently empty
                 </p><p>
-                    Barcode scanner can be activated via inventory settings.
-                    Manual inventory adjustments can also be performed and pre-filled with
-                    suggested counted quantity.
-                </p>
+                    Press the CREATE button to define quantity for each product in your stock or import them from a spreadsheet throughout Favorite > Import</p>
                 """
         }
         return action

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -53,7 +53,7 @@ class StockQuant(models.Model):
     product_id = fields.Many2one(
         'product.product', 'Product',
         domain=lambda self: self._domain_product_id(),
-        ondelete='restrict', readonly=True, required=True, index=True, check_company=True)
+        ondelete='restrict', required=True, index=True, check_company=True)
     product_tmpl_id = fields.Many2one(
         'product.template', string='Product Template',
         related='product_id.product_tmpl_id')
@@ -64,18 +64,18 @@ class StockQuant(models.Model):
     location_id = fields.Many2one(
         'stock.location', 'Location',
         domain=lambda self: self._domain_location_id(),
-        auto_join=True, ondelete='restrict', readonly=True, required=True, index=True, check_company=True)
+        auto_join=True, ondelete='restrict', required=True, index=True, check_company=True)
     lot_id = fields.Many2one(
         'stock.production.lot', 'Lot/Serial Number', index=True,
-        ondelete='restrict', readonly=True, check_company=True,
+        ondelete='restrict', check_company=True,
         domain=lambda self: self._domain_lot_id())
     package_id = fields.Many2one(
         'stock.quant.package', 'Package',
         domain="[('location_id', '=', location_id)]",
-        help='The package containing this quant', readonly=True, ondelete='restrict', check_company=True)
+        help='The package containing this quant', ondelete='restrict', check_company=True)
     owner_id = fields.Many2one(
         'res.partner', 'Owner',
-        help='This is the owner of the quant', readonly=True, check_company=True)
+        help='This is the owner of the quant', check_company=True)
     quantity = fields.Float(
         'Quantity',
         help='Quantity of products in this quant, in the default unit of measure of the product',

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -866,7 +866,7 @@ class StockQuant(models.Model):
             action['id'] = target_action.id
 
         if self.env.context.get('inventory_mode') and self.user_has_groups('stock.group_stock_manager'):
-            action['view_id'] = self.env.ref('stock.view_stock_quant_tree_editable').id
+            action['view_id'] = self.env.ref('stock.view_stock_quant_tree_inventory_editable').id
             form_view = self.env.ref('stock.view_stock_quant_form_editable').id
         else:
             action['view_id'] = self.env.ref('stock.view_stock_quant_tree').id

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -27,8 +27,7 @@ access_product_group_res_partner_stock_manager,res_partner group_stock_manager,b
 access_product_pricelist_item_stock_manager,product.pricelist.item stock_manager,product.model_product_pricelist_item,stock.group_stock_manager,1,1,1,1
 access_stock_warehouse_orderpoint,stock.warehouse.orderpoint,model_stock_warehouse_orderpoint,stock.group_stock_user,1,0,0,0
 access_stock_warehouse_orderpoint_system,stock.warehouse.orderpoint system,model_stock_warehouse_orderpoint,stock.group_stock_manager,1,1,1,1
-access_stock_quant_manager,stock.quant manager,model_stock_quant,stock.group_stock_manager,1,0,0,0
-access_stock_quant_user,stock.quant user,model_stock_quant,stock.group_stock_user,1,0,0,0
+access_stock_quant_manager,stock.quant manager,model_stock_quant,stock.group_stock_manager,1,1,1,0
 access_stock_quant_all,stock.quant all users,model_stock_quant,base.group_user,1,0,0,0
 access_stock_quant_package_all,stock.quant.package all users,model_stock_quant_package,base.group_user,1,0,0,0
 access_stock_quant_package_stock_manager,stock.quant.package stock manager,model_stock_quant_package,stock.group_stock_manager,1,1,1,1

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -18,7 +18,6 @@
                     <filter name='internal_loc' string="Internal Locations" domain="[('location_id.usage','=', 'internal')]"/>
                     <filter name='transit_loc' string="Transit Locations" domain="[('location_id.usage' ,'=', 'transit')]"/>
                     <separator/>
-                    <filter name="on_hand" string="On Hand" domain="[('on_hand', '=', True)]"/>
                     <filter name="to_count" string="To Count" domain="[('inventory_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter name="to_apply" string="To Apply" domain="[('inventory_quantity_set', '=', True)]"/>
                     <separator/>
@@ -71,43 +70,6 @@
                                 <field name="reserved_quantity"/>
                                 <field name="product_uom_id" groups="uom.group_uom"/>
                             </div>
-                        </group>
-                    </group>
-                </sheet>
-            </form>
-        </field>
-    </record>
-
-    <record model="ir.ui.view" id="view_stock_quant_form">
-        <field name="name">stock.quant.form</field>
-        <field name="model">stock.quant</field>
-        <field eval="10" name="priority"/>
-        <field name="arch" type="xml">
-            <form string="Inventory Valuation" create="false" edit="false" delete="false">
-                <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" icon="fa-exchange" type="object" name="action_view_stock_moves" string="Product Moves"/>
-                    </div>
-                    <group>
-                        <group>
-                            <field name="product_id"/>
-                            <field name="location_id" options="{'no_create': True}"/>
-                            <field name="lot_id" groups="stock.group_production_lot"/>
-                            <field name="package_id" groups="stock.group_tracking_lot"/>
-                            <field name="owner_id" groups="stock.group_tracking_owner"/>
-                        </group>
-                        <group>
-                            <label for="quantity" string="Quantity On Hand"/>
-                            <div class="o_row">
-                                <field name="quantity"/>
-                                <field name="product_uom_id" groups="uom.group_uom"/>
-                            </div>
-                            <label for="reserved_quantity" string="Quantity Reserved"/>
-                            <div class="o_row">
-                                <field name="reserved_quantity"/>
-                                <field name="product_uom_id" groups="uom.group_uom"/>
-                            </div>
-                            <field name="in_date" attrs="{'invisible': [('lot_id', '=', False)]}" groups="stock.group_production_lot"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -360,7 +360,7 @@
                 <field name="quantity" optional="show" string="On Hand Quantity"/>
                 <field name="product_uom_id" groups="uom.group_uom" string="UoM"/>
                 <field name="inventory_quantity" widget="counted_quantity_widget"/>
-                <field name="inventory_diff_quantity" string="Difference"  attrs="{'invisible': [('inventory_quantity_set', '=', False)]}" decoration-muted="inventory_quantity == 0" decoration-danger="inventory_diff_quantity &lt; 0" decoration-success="inventory_diff_quantity &gt; 0" decoration-bf="inventory_diff_quantity != 0"/>
+                <field name="inventory_diff_quantity" string="Difference"  attrs="{'invisible': [('inventory_quantity_set', '=', False)]}" decoration-muted="inventory_diff_quantity == 0" decoration-danger="inventory_diff_quantity &lt; 0" decoration-success="inventory_diff_quantity &gt; 0" decoration-bf="inventory_diff_quantity != 0"/>
                 <field name="inventory_date" optional="show"/>
                 <field name="user_id" string="User" optional="show"/>
                 <field name='company_id' groups="base.group_multi_company" optional="hide"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -341,7 +341,6 @@
             <tree default_order="location_id, inventory_date, product_id, package_id, lot_id, owner_id" decoration-warning='is_outdated' editable="bottom" create="1" edit="1" import="0" js_class="singleton_list" sample="1">
                 <header>
                     <button name="stock.action_stock_inventory_adjustement_name" groups="stock.group_stock_manager" type="action" string="Apply"/>
-                    <button name="action_set_inventory_quantity" type="object" string="Set"/>
                     <button name="action_reset" type="object" string="Clear"/>
                     <button name="stock.action_stock_request_count" groups="stock.group_stock_manager" type="action" string="Request a Count"/>
                 </header>
@@ -370,6 +369,18 @@
                 <button name="action_set_inventory_quantity" type="object" string="Set" class="btn btn-link" icon="fa-bullseye" attrs="{'invisible': [('inventory_quantity_set', '=', True)]}"/>
                 <button name="action_set_inventory_quantity_to_zero" type="object" string="Clear" class="btn text-warning" icon="fa-times" attrs="{'invisible': [('inventory_quantity_set', '=', False)]}"/>
             </tree>
+        </field>
+    </record>
+
+    <record model="ir.actions.server" id="action_view_set_quants_tree">
+        <field name="name">Set</field>
+        <field name="model_id" ref="model_stock_quant"/>
+        <field name="binding_model_id" ref="stock.model_stock_quant"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
+        <field name="code">
+            action = records.action_set_inventory_quantity()
         </field>
     </record>
 

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -17,7 +17,9 @@
                 <group expand='0' string='Filters'>
                     <filter name='internal_loc' string="Internal Locations" domain="[('location_id.usage','=', 'internal')]"/>
                     <filter name='transit_loc' string="Transit Locations" domain="[('location_id.usage' ,'=', 'transit')]"/>
+                    <separator/>
                     <filter name="on_hand" string="On Hand" domain="[('on_hand', '=', True)]"/>
+                    <filter name="to_count" string="To Count" domain="[('inventory_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter name="to_apply" string="To Apply" domain="[('inventory_quantity_set', '=', True)]"/>
                     <separator/>
                     <filter name="negative" string="Negative Stock" domain="[('quantity', '&lt;', 0.0)]"/>
@@ -26,7 +28,6 @@
                     <filter name="filter_in_date" date="in_date"/>
                     <separator/>
                     <filter name="my_count" string="My Counts" domain="[('user_id', '=', uid)]"/>
-                    <filter name="to_count" string="To Count" domain="[('inventory_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"/>
                 </group>
                 <group expand='0' string='Group by...'>
                     <filter string='Product' name="productgroup" context="{'group_by': 'product_id'}"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -121,7 +121,7 @@
         <field eval="10" name="priority"/>
         <field name="arch" type="xml">
             <tree editable="bottom"
-                  create="1" edit="1" import="0" js_class="singleton_list"
+                  create="1" edit="1" js_class="singleton_list"
                   sample="1">
                 <field name="id" invisible="1"/>
                 <field name="tracking" invisible="1"/>

--- a/addons/stock/wizard/stock_inventory_adjustment_name.py
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models, _
 
 class StockInventoryAdjustmentName(models.TransientModel):
     _name = 'stock.inventory.adjustment.name'
-    _description = 'Inventory Adjustment Name'
+    _description = 'Inventory Adjustment Reference / Reason'
 
     def default_get(self, fields_list):
         res = super().default_get(fields_list=fields_list)

--- a/addons/stock/wizard/stock_inventory_adjustment_name.py
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.py
@@ -1,18 +1,26 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 
 
 class StockInventoryAdjustmentName(models.TransientModel):
     _name = 'stock.inventory.adjustment.name'
     _description = 'Inventory Adjustment Name'
 
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list=fields_list)
+        if self.env.context.get('default_quant_ids'):
+            quants = self.env['stock.quant'].browse(self.env.context['default_quant_ids'])
+            res['show_info'] = any(not quant.inventory_quantity_set for quant in quants)
+        return res
+
     def _default_inventory_adjustment_name(self):
         return _("Inventory Adjustment") + " - " + fields.Date.to_string(fields.Date.today())
 
     quant_ids = fields.Many2many('stock.quant')
     inventory_adjustment_name = fields.Char(default=_default_inventory_adjustment_name)
+    show_info = fields.Boolean('Show warning')
 
     def action_apply(self):
         return self.quant_ids.with_context(

--- a/addons/stock/wizard/stock_inventory_adjustment_name.xml
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.xml
@@ -7,8 +7,12 @@
         <field name="arch" type="xml">
             <form>
                 <div>
+                    <div attrs="{'invisible': [('show_info', '=', False)]}">
+                        Some selected lines don't have any quantities set, they will be ignored.
+                    </div>
                     <group>
                         <field name="inventory_adjustment_name" string="Inventory Reference"/>
+                        <field name="show_info" invisible="1"/>
                     </group>
                 </div>
                 <footer>

--- a/addons/stock/wizard/stock_inventory_adjustment_name.xml
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.xml
@@ -11,7 +11,7 @@
                         Some selected lines don't have any quantities set, they will be ignored.
                     </div>
                     <group>
-                        <field name="inventory_adjustment_name" string="Inventory Reference"/>
+                        <field name="inventory_adjustment_name" string="Inventory Reference / Reason"/>
                         <field name="show_info" invisible="1"/>
                     </group>
                 </div>
@@ -23,7 +23,7 @@
         </field>
     </record>
     <record id="action_stock_inventory_adjustement_name" model="ir.actions.act_window">
-        <field name="name">Name Inventory Adjustement</field>
+        <field name="name">Inventory Adjustement Reference / Reason</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">stock.inventory.adjustment.name</field>
         <field name="view_mode">form</field>

--- a/addons/stock/wizard/stock_inventory_warning.py
+++ b/addons/stock/wizard/stock_inventory_warning.py
@@ -10,9 +10,6 @@ class StockInventoryWarning(models.TransientModel):
 
     quant_ids = fields.Many2many('stock.quant')
 
-    def action_apply(self):
-        return self.quant_ids.filtered(lambda q: q.inventory_quantity_set).action_apply_inventory()
-
     def action_reset(self):
         return self.quant_ids.action_set_inventory_quantity_to_zero()
 

--- a/addons/stock/wizard/stock_inventory_warning.xml
+++ b/addons/stock/wizard/stock_inventory_warning.xml
@@ -33,21 +33,4 @@
             </form>
         </field>
     </record>
-
-    <record id="inventory_warning_apply_view" model="ir.ui.view">
-        <field name="name">inventory.apply.warning.view</field>
-        <field name="model">stock.inventory.warning</field>
-        <field name="mode">primary</field>
-        <field name="arch" type="xml">
-            <form>
-                <div>
-                    Some selected lines don't have any quantities set, they will be ignored.
-                </div>
-                <footer>
-                    <button name="action_apply" string="Continue" type="object" class="btn-primary"/>
-                    <button name="cancel_button" string="Discard" class="btn-secondary" special="cancel"/>
-                </footer>
-            </form>
-        </field>
-    </record>
 </odoo>

--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -14,11 +14,14 @@ class StockRequestCount(models.TransientModel):
         default=fields.Datetime.now)
     user_id = fields.Many2one('res.users', string="User")
     quant_ids = fields.Many2many('stock.quant')
+    set_count = fields.Selection([('empty', 'Leave Empty'), ('set', 'Set Current Value')], string='Count')
 
     def action_request_count(self):
         for count_request in self:
             count_request.quant_ids.with_context(inventory_mode=True).write(
                 count_request._get_values_to_write())
+            if count_request.set_count == 'set':
+                count_request.quant_ids.filtered(lambda q: not q.inventory_quantity_set).action_set_inventory_quantity()
 
     def _get_values_to_write(self):
         values = {

--- a/addons/stock/wizard/stock_request_count.xml
+++ b/addons/stock/wizard/stock_request_count.xml
@@ -10,6 +10,7 @@
                     <field name="quant_ids" invisible="1"/>
                     <field name="inventory_date"/>
                     <field name="user_id"/>
+                    <field name="set_count" widget='radio'/>
                 </group>
                 <footer>
                     <button name="action_request_count" string="Confirm" type="object" class="btn-primary"/>


### PR DESCRIPTION
As the Inventory Adjustments have been removed since
bdcb3d192be1e01e1141aa09c60027337009a67b, it was not possible anymore to
import inventories. This commit allows the possibilities to import
quants with pre-counted quantities. It acts the same as creating new
lines in the tree view.

Task : 2555118

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
