### PR TITLE
[FIX] core: avoid searching reference for fresh records

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -477,6 +477,17 @@ class Payment(models.Model):
     _inherits = {'test_new_api.move': 'move_id'}
 
     move_id = fields.Many2one('test_new_api.move', required=True, ondelete='cascade')
+    all_lines_visible = fields.Boolean(compute='_compute_all_lines_visible', store=True)
+    ref = fields.Char('Reference')
+
+    @api.depends('move_id.line_ids.visible')
+    def _compute_all_lines_visible(self):
+        for payment in self:
+            payment.all_lines_visible = 0 == sum(not line.visible for line in payment.move_id.line_ids)
+
+    def search(self, *args, **kwargs):
+        # extend to allow patching
+        return super().search(*args, **kwargs)
 
 
 class CompanyDependent(models.Model):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1751,6 +1751,17 @@ class TestFields(TransactionCaseWithUserDemo):
         payment = self.env['test_new_api.payment'].create({'move_id': move.id})
         self.assertEqual(payment.all_lines_visible, True)
 
+    def test_41_search_in_compute2(self):
+        """ Check recomputation of fields on new records. """
+        with patch('odoo.addons.test_new_api.models.test_new_api.Payment.search') as payment_mock:
+            self.env['test_new_api.payment'].search([])
+            payment_mock.search.assert_not_called()
+            payment = self.env['test_new_api.payment'].create({'name': 'Payment 777', 'ref': '123456'})
+            payment.flush()
+            payment_mock.search.assert_not_called()
+        self.assertEqual(payment.name_prefix, 'Payment')
+        self.assertEqual(payment.all_lines_visible, True)
+
     def test_41_new_one2many(self):
         """ Check command on one2many field on new record. """
         move = self.env['test_new_api.move'].create({})

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4009,7 +4009,7 @@ Fields:
 
         # protect fields being written against recomputation
         protected = [(data['protected'], data['record']) for data in data_list]
-        with self.env.protecting(protected):
+        with self.env.protecting(protected), self.env.fresh_records(records):
             # mark computed fields as todo
             records.modified(self._fields, create=True)
 
@@ -5848,7 +5848,7 @@ Fields:
                     new_records = self.filtered(lambda r: not r.id)
                     real_records = self - new_records
                     records = model.browse()
-                    if real_records:
+                    if real_records and self.env.may_have_links(key, real_records):
                         records |= model.search([(key.name, 'in', real_records.ids)], order='id')
                     if new_records:
                         cache_records = self.env.cache.get_records(model, key)


### PR DESCRIPTION
it's extended version of `create` parameter for `_modified_triggers` method.
The method contains following line:

```
                        records |= model.search([(key.name, 'in', real_records.ids)], order='id')
```

this commit extend cases when the search is not needed.

Specific reason for this update is reconciliation process which may create
thousands of new `account.move` lines which would be searched in other models
without this commit. Those searches repeated thousands times would take
significant time and may lead to timeout error.

This commits uses variables in context, because it targets stable branch v14.
Some refactoring must be done in master branch.

STEPS:
* create batch of `account.move` via shell (e.g. 10 records)
* check for the search quieries via --logs-sql or by adding breakpoint:
```
                        records |= model.search([(key.name, 'in', real_records.ids)], order='id')
                        if str(key) == 'account.payment.move_id' and len(real_records.ids) == 10:
                            import wdb; wdb.set_trace()
```
BEFORE: 3 useless queries
AFTER: no of those quieres

---

opw-2497288

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
