### PR TITLE
[FIX] point_of_sale: Specify max cron for IoT

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo.conf
@@ -5,3 +5,4 @@ logfile = /var/log/odoo/odoo-server.log
 pidfile = /var/run/odoo/odoo.pid
 limit_time_cpu = 600
 limit_time_real = 1200
+max_cron_threads = 0


### PR DESCRIPTION
By default max cron threads is setted to 2.
But this value must be setted to 0 in the IoT
This parameter is added to odoo.conf of the IoT

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
