### PR TITLE
[FIX]stock_account: copy_data safer access to prop

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -34,7 +34,7 @@ class AccountMove(models.Model):
             for copy_vals in res:
                 if 'line_ids' in copy_vals:
                     copy_vals['line_ids'] = [line_vals for line_vals in copy_vals['line_ids']
-                                             if line_vals[0] != 0 or not line_vals[2]['is_anglo_saxon_line']]
+                                             if line_vals[0] != 0 or not line_vals[2].get('is_anglo_saxon_line')]
 
         return res
 


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

In l10n_latam, creating a debit note with stock_account installed ends
up in stock_account checking for a property that may
not exist.

# Current behavior before PR:

ends-up in a traceback with a key-error

# Desired behavior after PR is merged:

debit note gets created properly

But is present from V13 to master


ticket: opw-2580992
bug-fix: opw-2588504


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
