### PR TITLE
[FIX] delivery: fix a recent fix and stop deleting invoiced order lines on update

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -1033,6 +1033,16 @@ msgid ""
 msgstr ""
 
 #. module: delivery
+#: code:addons/delivery/models/sale_order.py:0
+#, python-format
+msgid ""
+"You can not update the shipping costs on an order where it was already invoiced!\n"
+"\n"
+"The following delivery lines (product, invoiced quantity and price) have already been processed:\n"
+"\n"
+msgstr ""
+
+#. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.delivery_tracking_url_warning_form
 msgid "You have multiple tracker links, they are available in the chatter."
 msgstr ""

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -37,7 +37,16 @@ class SaleOrder(models.Model):
             self.recompute_delivery_price = True
 
     def _remove_delivery_line(self):
-        self.env['sale.order.line'].search([('order_id', 'in', self.ids), ('is_delivery', '=', True)]).unlink()
+        delivery_lines = self.env['sale.order.line'].search([('order_id', 'in', self.ids), ('is_delivery', '=', True)])
+        if not delivery_lines:
+            return
+        to_delete = delivery_lines.filtered(lambda x: x.qty_invoiced == 0)
+        if not to_delete:
+            raise UserError(
+                _('You can not update the shipping costs on an order where it was already invoiced!\n\nThe following delivery lines (product, invoiced quantity and price) have already been processed:\n\n')
+                + '\n'.join(['- %s: %s x %s' % (line.product_id.with_context(display_default_code=False).display_name, line.qty_invoiced, line.price_unit) for line in delivery_lines])
+            )
+        to_delete.unlink()
 
     def set_delivery_line(self, carrier, amount):
 

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -111,8 +111,10 @@ class SaleOrder(models.Model):
             values['name'] += '\n' + 'Free Shipping'
         if self.order_line:
             values['sequence'] = self.order_line[-1].sequence + 1
-        if self.picking_ids:
-            self.picking_ids.write({'carrier_id': carrier.id})
+
+        to_update = self.picking_ids.filtered(lambda p: p.state not in ['cancel', 'done'] and p.carrier_tracking_ref == False)
+        if to_update:
+            to_update.write({'carrier_id': carrier.id})
         sol = SaleOrderLine.sudo().create(values)
         return sol
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As of https://github.com/odoo/odoo/pull/72859 on every update of the delivery line in a sale order ALL pickings are overwritten with the new carrier, no matter what...

To save you guys from more OPWs and desperate customers, let me help you with two things and I hope it is appreciated.

**Current behavior before PR:**
Updating shipping costs do overwrite carriers of done and processed (tracking reference) pickings and also deleting sale order lines (delivery line) already invoiced.

**Desired behavior after PR is merged:**

- Only pickings are written, where we are kinda sure that it is wanted by the user, on updating the shipping costs on a sale order.
- The user is stopped to update the shipping costs in case it was already invoiced.

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
