### PR TITLE
[IMP] product: improvement the pricelist report

### DIFF
--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -53,7 +53,7 @@
                                         </td>
                                     </t>
                                 </tr>
-                                <t t-if="is_product_tmpl">
+                                <t t-if="is_product_tmpl and 'variants' in product">
                                     <tr t-foreach="product['variants']" t-as="variant">
                                         <td>
                                             <a t-if="is_html_type" href="#" class="o_action ml-4" data-model="product.product" t-att-data-res-id="variant['id']">

--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -4,7 +4,7 @@
     <template id="report_pricelist_page">
         <div class="container bg-white p-4 my-4">
             <div class="row my-3">
-                <div class="col-12">
+                <div class="col-12" t-if="is_visible_title">
                     <h2 t-if="is_html_type">
                         Pricelist:
                         <a href="#" class="o_action" data-model="product.pricelist" t-att-data-res-id="pricelist.id">
@@ -17,13 +17,19 @@
                 </div>
             </div>
             <div class="row">
+                <div t-att-class="'text-center' + (' offset-8' if is_html_type else ' offset-7')">
+                    <strong>Sales Order Line Quantities (price per unit)</strong>
+                </div>
+            </div>
+            <div class="row">
                 <div class="col-12">
                     <table class="table table-sm">
                         <thead>
                             <tr>
                                 <th>Products</th>
+                                <th groups="uom.group_uom">UoM</th>
                                 <t t-foreach="quantities" t-as="qty">
-                                    <th class="text-right"><t t-esc="qty"/> Units</th>
+                                    <th class="text-right"><t t-esc="qty"/></th>
                                 </t>
                             </tr>
                         </thead>
@@ -38,6 +44,9 @@
                                             <t t-esc="product['name']"/>
                                         </t>
                                     </td>
+                                    <td groups="uom.group_uom">
+                                        <t t-esc="product['uom']"/>
+                                    </td>
                                     <t t-foreach="quantities" t-as="qty">
                                         <td class="text-right">
                                             <t t-esc="product['price'][qty]" t-options='{"widget": "monetary", "display_currency": pricelist.currency_id}'/>
@@ -51,6 +60,9 @@
                                                 <t t-esc="variant['name']"/>
                                             </a>
                                             <span t-else="" class="ml-4" t-esc="variant['name']"/>
+                                        </td>
+                                        <td groups="uom.group_uom">
+                                            <t t-esc="product['uom']"/>
                                         </td>
                                         <t t-foreach="quantities" t-as="qty">
                                             <td class="text-right">

--- a/addons/product/static/src/js/product_pricelist_report.js
+++ b/addons/product/static/src/js/product_pricelist_report.js
@@ -109,19 +109,19 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
      * @override
      */
     willStart: function () {
-        let getPricelit;
+        let getPricelist;
         // started without a selected pricelist in context? just get the first one
         if (this.context.default_pricelist) {
-            getPricelit = Promise.resolve([this.context.default_pricelist]);
+            getPricelist = Promise.resolve([this.context.default_pricelist]);
         } else {
-            getPricelit = this._rpc({
+            getPricelist = this._rpc({
                 model: 'product.pricelist',
                 method: 'search',
                 args: [[]],
                 kwargs: {limit: 1}
-            })
+            });
         }
-        const fieldSetup = getPricelit.then(pricelistIds => {
+        const fieldSetup = getPricelist.then(pricelistIds => {
             return this.model.makeRecord('report.product.report_pricelist', [{
                 name: 'pricelist_id',
                 type: 'many2one',
@@ -158,12 +158,12 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
      * the proper context.
      * @override
      */
-    getState: function() {
+    getState: function () {
         return {
             active_model: this.context.active_model,
         };
     },
-    getTitle: function() {
+    getTitle: function () {
         return _t('Pricelist Report');
     },
 
@@ -171,6 +171,21 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * Returns the expected data for the report rendering call (html or pdf)
+     *
+     * @private
+     * @returns {Object}
+     */
+    _prepareActionReportParams: function () {
+        return {
+            active_model: this.context.active_model,
+            active_ids: this.context.active_ids,
+            is_visible_title: this.context.is_visible_title || '',
+            pricelist_id: this.context.pricelist_id || '',
+            quantities: this.context.quantities || [1],
+        };
+    },
     /**
      * Get template to display report.
      *
@@ -181,7 +196,9 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
         return this._rpc({
             model: 'report.product.report_pricelist',
             method: 'get_html',
-            kwargs: {context: this.context},
+            kwargs: {
+                data: this._prepareActionReportParams(),
+            },
         }).then(result => {
             this.reportHtml = result;
         });
@@ -253,18 +270,12 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
      * @private
      */
     _onClickPrint: function () {
-        const reportName = _.str.sprintf('product.report_pricelist?active_model=%s&active_ids=%s&is_visible_title=%s&pricelist_id=%s&quantities=%s',
-            this.context.active_model,
-            this.context.active_ids,
-            this.context.is_visible_title || '',
-            this.context.pricelist_id || '',
-            this.context.quantities.toString() || '1',
-        );
         return this.do_action({
             type: 'ir.actions.report',
             report_type: 'qweb-pdf',
-            report_name: reportName,
+            report_name: 'product.report_pricelist',
             report_file: 'product.report_pricelist',
+            data: this._prepareActionReportParams(),
         });
     },
     /**

--- a/addons/product/static/src/js/product_pricelist_report.js
+++ b/addons/product/static/src/js/product_pricelist_report.js
@@ -147,6 +147,8 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
      */
     start: function () {
         this.controlPanelProps.cp_content = this._renderComponent();
+        const $content = this.controlPanelProps.cp_content;
+        $content["$searchview"][0].querySelector('.o_is_visible_title').addEventListener('click', this._onClickVisibleTitle.bind(this));
         return this._super.apply(this, arguments).then(() => {
             this.$('.o_content').html(this.reportHtml);
         });
@@ -219,6 +221,17 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
     //--------------------------------------------------------------------------
 
     /**
+     * Checkbox is checked, the report title will show.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onClickVisibleTitle(ev) {
+        this.context.is_visible_title = ev.currentTarget.checked;
+        this._reload();
+    },
+
+    /**
      * Open form view of particular record when link clicked.
      *
      * @private
@@ -240,9 +253,10 @@ var GeneratePriceList = AbstractAction.extend(StandaloneFieldManagerMixin, {
      * @private
      */
     _onClickPrint: function () {
-        const reportName = _.str.sprintf('product.report_pricelist?active_model=%s&active_ids=%s&pricelist_id=%s&quantities=%s',
+        const reportName = _.str.sprintf('product.report_pricelist?active_model=%s&active_ids=%s&is_visible_title=%s&pricelist_id=%s&quantities=%s',
             this.context.active_model,
             this.context.active_ids,
+            this.context.is_visible_title || '',
             this.context.pricelist_id || '',
             this.context.quantities.toString() || '1',
         );

--- a/addons/product/static/src/xml/pricelist_report.xml
+++ b/addons/product/static/src/xml/pricelist_report.xml
@@ -29,11 +29,17 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="font-weight-bold" for="qty_to_add">Quantities:</label>
+                <label class="font-weight-bold mb-4" for="qty_to_add">Quantities:</label>
                 <div class="row">
                     <div class="col">
                         <span class="o_product_qty"/>
                     </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="form-check">
+                    <input class="form-check-input o_is_visible_title ml-2" type="checkbox"/>
+                    <label class="form-check-label">Display Pricelist</label>
                 </div>
             </div>
         </form>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -150,7 +150,7 @@
     </record>
 
     <record id="action_product_template_price_list_report" model="ir.actions.server">
-        <field name="name">Generate Pricelist</field>
+        <field name="name">Generate Pricelist Report</field>
         <field name="groups_id" eval="[(4, ref('product.group_product_pricelist'))]"/>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="binding_model_id" ref="product.model_product_template"/>


### PR DESCRIPTION
PURPOSE
------
In the new pricelist report, showing the resulting price of a product in the
the situation of a pricelist or another, for certain quantities, the specified
quantities are shown as "X Units".

This can be misleading when using multiple Unit of Measure, because
the quantities are expressed in the product's unit of measures, thus
not always in "Units".

We should probably either group the products by UoM, to display
adequates column titles, or we should update the display to make sure the user
understands clearly that the prices are /unit in the product uom.

users should be able to 'hide' pricelist name on the PDF.

TaskID-2360597
