### PR TITLE
[FIX] mrp_product_expiry: fix expired lot used for another product

### DIFF
--- a/addons/mrp_product_expiry/wizard/confirm_expiry.py
+++ b/addons/mrp_product_expiry/wizard/confirm_expiry.py
@@ -33,8 +33,12 @@ class ConfirmExpiry(models.TransientModel):
             super(ConfirmExpiry, self)._compute_descriptive_fields()
 
     def confirm_produce(self):
-        return self.production_ids.with_context(skip_expired=True).button_mark_done()
+        ctx = dict(self._context, skip_expired=True)
+        ctx.pop('default_lot_ids')
+        return self.production_ids.with_context(ctx).button_mark_done()
 
     def confirm_workorder(self):
-        return self.workorder_id.with_context(skip_expired=True).record_production()
+        ctx = dict(self._context, skip_expired=True)
+        ctx.pop('default_lot_ids')
+        return self.workorder_id.with_context(ctx).record_production()
 


### PR DESCRIPTION
- Go to Inventory > Configuration > Settings and activate "Expiration Dates"
- Create a storable product tracked by lot with expiration date (i.e. Component A)
- Update quantity of Component A in a lot with an expired expiration date (i.e. Lot A)
- Create a consumable product (i.e. Component B)
- Create a storable product (i.e. Product X) with a BoM having Component A & B as components
- Create a MO for Product X with a quantity to produce set to 1
- Confirm MO
- Edit MO to set quantity produced to 2
- Set consumed quantity for Component A to Lot A
- Mark MO as done
- Confirm confirmation wizard about using expired Lot A for Component A
The following Validation Error is triggered:
"This lot Lot A is incompatible with this product Component B"

In order to display lot in the confirmation wizard, the ids of the expired
lots are added in the context under key "default_lot_ids".
As we have set a produced quantity higher than the original quantity, some
additional stock moves will be created for final product and it components.
As "default_lot_ids" is still in the context at that point, it will set it
for stock move lines of both components, which will generate the Validation
Error for Component B.

"default_lot_ids" should be removed from context after confirming confirmation
wizard for expired lots.

opw-2543863

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
