### PR TITLE
[FIX] purchase_stock: add sequence to new view

### DIFF
--- a/addons/purchase_stock/wizard/stock_replenishment_info.xml
+++ b/addons/purchase_stock/wizard/stock_replenishment_info.xml
@@ -6,6 +6,7 @@
         <field name="model">product.supplierinfo</field>
         <field name="inherit_id" ref="product.product_supplierinfo_tree_view"/>
         <field name="mode">primary</field>
+        <field name="priority">100</field>
         <field name="arch" type="xml">
             <field name="delay" position="after">
                 <field name="show_set_supplier_button" invisible="1"/>


### PR DESCRIPTION
The commit 6eaa4a2ae3b12b244f4c4277ef9cbc172f492f0a introduced a new
view on model supplier info. The issue is that this new view is meant to
be used on supplier info as One2Many on stock.orderpoint and so contains
some `parent.` relation.

As no sequence has been set. This view replaced the original one in the
Purchase Configuration menu. Leading to some error as `parent.` in not
defined for standalone tree view.

This commit set a sequence on this new view to ensure it is used only on
the orderpoint form view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
