### PR TITLE
[IMP] l10n_mx: don't allow Mexican companies to have a currency diffe…

### DIFF
--- a/addons/l10n_mx/models/__init__.py
+++ b/addons/l10n_mx/models/__init__.py
@@ -7,3 +7,4 @@ from . import account_tax
 from . import res_bank
 from . import res_config_settings
 from . import chart_template
+from . import res_company

--- a/addons/l10n_mx/models/res_company.py
+++ b/addons/l10n_mx/models/res_company.py
@@ -1,0 +1,16 @@
+from odoo import models, api, _
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    @api.onchange('country_id', 'currency_id')
+    def _onchange_l10n_mx_currency(self):
+        for company in self:
+            if company.country_id.code == 'MX' and company.currency_id.name != 'MXN':
+                return {
+                    'warning': {
+                        'title': _("Warning"),
+                        'message': _("For Mexico, the currency should be MXN.")
+                    }
+                }


### PR DESCRIPTION
…rent from MXN

Mexican companies should always have their accounting in MXN.
See odoo/enterprise#19245
See odoo/enterprise#19353

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
