### PR TITLE
[FIX] product: reset `Based on` on change pricelist `Compute Price`

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -494,6 +494,7 @@ class PricelistItem(models.Model):
             self.percent_price = 0.0
         if self.compute_price != 'formula':
             self.update({
+                'base': 'list_price',
                 'price_discount': 0.0,
                 'price_surcharge': 0.0,
                 'price_round': 0.0,


### PR DESCRIPTION
Steps to reproduce:

  - Create a new pricelist;
  - In the Price Computation, select "Formula" then
    change it to "Based on Cost";
  - Change the price computation back to "Percentage (discount);
  - Create a sale and set this new pricelist.

Issue:

  Price discount made on the cost of the product instead to get back
  to sale price as default

Cause:

  When switching `Compute Price` and != 'formula', not setting back
  `Based on` (base) to `Public Price` (list_price).

Solution:

  If compute_price is changed and new value != 'formula'; set
  pricelist `Based on` to `Public Price`.

opw-2587295