### PR TITLE
[FIX] web: make js tooling safe with paths with spaces

### DIFF
--- a/addons/web/tooling/disable.sh
+++ b/addons/web/tooling/disable.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 script="$0"
-basename="$(dirname $script)"
+basename="$(dirname "$script")"
 
 read -p "Do you want to delete the tooling installed in enterprise too ? [y, n]" willingToDeleteToolingInEnterprise
 if [[ $willingToDeleteToolingInEnterprise != "n" ]]
@@ -10,25 +10,25 @@ then
     pathToEnterprise=${pathToEnterprise:-../enterprise}
 fi
 
-rm -rf $basename/../../../.husky
-rm -rf $basename/../../../.eslintignore
-rm -rf $basename/../../../.prettierignore
-rm -rf $basename/../../../.eslintrc.json
-rm -rf $basename/../../../.prettierrc.json
-rm -rf $basename/../../../package.json
-rm -rf $basename/../../../package-lock.json
-rm -rf $basename/../../../node_modules
+rm -rf "$basename/../../../.husky"
+rm -rf "$basename/../../../.eslintignore"
+rm -rf "$basename/../../../.prettierignore"
+rm -rf "$basename/../../../.eslintrc.json"
+rm -rf "$basename/../../../.prettierrc.json"
+rm -rf "$basename/../../../package.json"
+rm -rf "$basename/../../../package-lock.json"
+rm -rf "$basename/../../../node_modules"
 
 if [[ $willingToDeleteToolingInEnterprise != "n" ]]
 then
-    rm -rf $basename/../../../$pathToEnterprise/.husky
-    rm -rf $basename/../../../$pathToEnterprise/.eslintignore
-    rm -rf $basename/../../../$pathToEnterprise/.prettierignore
-    rm -rf $basename/../../../$pathToEnterprise/.eslintrc.json
-    rm -rf $basename/../../../$pathToEnterprise/.prettierrc.json
-    rm -rf $basename/../../../$pathToEnterprise/package.json
-    rm -rf $basename/../../../$pathToEnterprise/package-lock.json
-    rm -rf $basename/../../../$pathToEnterprise/node_modules
+    rm -rf "$basename/../../../$pathToEnterprise/.husky"
+    rm -rf "$basename/../../../$pathToEnterprise/.eslintignore"
+    rm -rf "$basename/../../../$pathToEnterprise/.prettierignore"
+    rm -rf "$basename/../../../$pathToEnterprise/.eslintrc.json"
+    rm -rf "$basename/../../../$pathToEnterprise/.prettierrc.json"
+    rm -rf "$basename/../../../$pathToEnterprise/package.json"
+    rm -rf "$basename/../../../$pathToEnterprise/package-lock.json"
+    rm -rf "$basename/../../../$pathToEnterprise/node_modules"
 fi
 
 

--- a/addons/web/tooling/enable.sh
+++ b/addons/web/tooling/enable.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 script="$0"
-basename="$(dirname $script)"
+basename="$(dirname "$script")"
 
 read -p "Do you want the tooling installed in enterprise too ? [y, n]" willingToInstallToolingInEnterprise
 if [[ $willingToInstallToolingInEnterprise != "n" ]]
@@ -10,30 +10,30 @@ then
     pathToEnterprise=${pathToEnterprise:-../enterprise}
 fi
 
-cp -r $basename/_husky  $basename/../../../.husky
-cp  $basename/_eslintignore  $basename/../../../.eslintignore
-cp  $basename/_prettierignore  $basename/../../../.prettierignore
-cp  $basename/_eslintrc.json  $basename/../../../.eslintrc.json
-cp  $basename/_prettierrc.json  $basename/../../../.prettierrc.json
-cp  $basename/_package.json  $basename/../../../package.json
+cp -r "$basename/_husky"  "$basename/../../../.husky"
+cp  "$basename/_eslintignore"  "$basename/../../../.eslintignore"
+cp  "$basename/_prettierignore"  "$basename/../../../.prettierignore"
+cp  "$basename/_eslintrc.json"  "$basename/../../../.eslintrc.json"
+cp  "$basename/_prettierrc.json"  "$basename/../../../.prettierrc.json"
+cp  "$basename/_package.json"  "$basename/../../../package.json"
 
 if [[ $willingToInstallToolingInEnterprise != "n" ]]
 then
-    cp -r $basename/_husky  $basename/../../../$pathToEnterprise/.husky
-    cp  $basename/_eslintignore  $basename/../../../$pathToEnterprise/.eslintignore
-    cp  $basename/_prettierignore  $basename/../../../$pathToEnterprise/.prettierignore
-    cp  $basename/_eslintrc.json  $basename/../../../$pathToEnterprise/.eslintrc.json
-    cp  $basename/_prettierrc.json  $basename/../../../$pathToEnterprise/.prettierrc.json
-    cp  $basename/_package.json  $basename/../../../$pathToEnterprise/package.json
+    cp -r "$basename/_husky"  "$basename/../../../$pathToEnterprise/.husky"
+    cp  "$basename/_eslintignore"  "$basename/../../../$pathToEnterprise/.eslintignore"
+    cp  "$basename/_prettierignore"  "$basename/../../../$pathToEnterprise/.prettierignore"
+    cp  "$basename/_eslintrc.json"  "$basename/../../../$pathToEnterprise/.eslintrc.json"
+    cp  "$basename/_prettierrc.json"  "$basename/../../../$pathToEnterprise/.prettierrc.json"
+    cp  "$basename/_package.json" "$basename/../../../$pathToEnterprise/package.json"
 fi
 
-cd $basename
+cd "$basename"
 npm install
 cd -
 
 if [[ $willingToInstallToolingInEnterprise != "n" ]]
 then
-    cd $basename/../../../$pathToEnterprise
+    cd "$basename/../../../$pathToEnterprise"
     npm install
     cd -
 fi

--- a/addons/web/tooling/reload.sh
+++ b/addons/web/tooling/reload.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 script="$0"
-basename="$(dirname $script)"
+basename="$(dirname "$script")"
 
-$basename/disable.sh
-$basename/enable.sh
+"$basename/disable.sh"
+"$basename/enable.sh"


### PR DESCRIPTION
If $basepath in the tooling contained spaces, it could have dramatic
consequences on the rm -rf command.
We simply escape everything to avoid the problem.
