### PR TITLE
[FIX] web,stock: use context lang in forecasted report

### DIFF
--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -52,7 +52,7 @@ const ReplenishReport = clientAction.extend({
                 this.active_warehouse = this.warehouses[0];
                 this.context.warehouse = this.active_warehouse.id;
             }
-            this.report_url += `?context=${JSON.stringify(this.context)}`;
+            this.report_url += `?context=${JSON.stringify(this.context)}&force_context_lang=1`;
         });
         return Promise.all([
             this._super.apply(this, arguments),

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -2010,7 +2010,7 @@ class ReportController(http.Controller):
             # Ignore 'lang' here, because the context in data is the one from the webclient *but* if
             # the user explicitely wants to change the lang, this mechanism overwrites it.
             data['context'] = json.loads(data['context'])
-            if data['context'].get('lang'):
+            if data['context'].get('lang') and not data.get('force_context_lang'):
                 del data['context']['lang']
             context.update(data['context'])
         if converter == 'html':


### PR DESCRIPTION
Forecasted report is an iframe report to /report/html controller.
That controller makes priority for lang value in `request.env.context` which
makes priority for cookie lang, i.e. OS lang.

It makes senses for website, but in fronted it's unexpected to get part of UI in
another language.

So, fix it by making priority to `data['context']['lang']`.

STEPS:
* Go to profile
* Set language as anything other than English
* Go to Inventory > Products
* Select any product
* Click Forecasted Report

---

opw-2535025

X-original-commit: 12634f9261cd48fd7e54024adb925600ab1c8175

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
