### PR TITLE
[FIX] l10n_de: company.bank_ids is not the company's banks

### DIFF
--- a/addons/l10n_de/models/base_document_layout.py
+++ b/addons/l10n_de/models/base_document_layout.py
@@ -10,7 +10,7 @@ class BaseDocumentLayout(models.TransientModel):
     zip = fields.Char(related='company_id.zip', readonly=True)
     city = fields.Char(related='company_id.city', readonly=True)
     company_registry = fields.Char(related='company_id.company_registry', readonly=True)
-    bank_ids = fields.One2many(related='company_id.bank_ids', readonly=True)
+    bank_ids = fields.One2many(related='company_id.partner_id.bank_ids', readonly=True)
     l10n_de_template_data = fields.Binary(compute='_compute_l10n_de_template_data')
     l10n_de_document_title = fields.Char(compute='_compute_l10n_de_document_title')
 

--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -146,8 +146,8 @@
                                     </ul>
                                 </td>
                                 <td>
-                                    <ul class="list-inline" t-if="company.bank_ids">
-                                        <t t-foreach="company.bank_ids[:2]" t-as="bank">
+                                    <ul class="list-inline" t-if="company.partner_id.bank_ids">
+                                        <t t-foreach="company.partner_id.bank_ids[:2]" t-as="bank">
                                             <li><span t-field="bank.bank_id.name"/></li>
                                             <li>IBAN: <span t-field="bank.acc_number"/></li>
                                             <li>BIC: <span t-field="bank.bank_id.bic"/></li>


### PR DESCRIPTION
The definition of the field is
```python
bank_ids = fields.One2many('res.partner.bank', 'company_id', string='Bank Accounts', help='Bank accounts related to this company')
```

So all the banks of all partners registered for one company.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
