### PR TITLE
[FIX] web: add context in pyeval context

### DIFF
--- a/addons/web/static/src/core/py_js/py.js
+++ b/addons/web/static/src/core/py_js/py.js
@@ -29,10 +29,10 @@ export function parseExpr(expr) {
  * Evaluates a python expression
  *
  * @param {string} expr
- * @param {Object} context
+ * @param {Object} [context]
  * @returns {any}
  */
-export function evaluateExpr(expr, context) {
+export function evaluateExpr(expr, context = {}) {
     const ast = parseExpr(expr);
     return evaluate(ast, context);
 }

--- a/addons/web/static/tests/core/py_js/py_interpreter_tests.js
+++ b/addons/web/static/tests/core/py_js/py_interpreter_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { evaluateExpr } from "@web/core/py_js/py";
-import { toPyDict } from "@web/core/py_js/py_utils";
 
 QUnit.module("py", {}, () => {
     QUnit.module("interpreter", () => {
@@ -138,11 +137,13 @@ QUnit.module("py", {}, () => {
             assert.deepEqual(evaluateExpr("foo", { foo: [1, 2, 3] }), [1, 2, 3]);
         });
 
-        QUnit.test("python values in context", (assert) => {
-            const context = toPyDict({ b: 3 });
-            assert.strictEqual(evaluateExpr("context.get('b', 54)", { context }), 3);
-            assert.strictEqual(evaluateExpr("context.get('c', 54)", { context }), 54);
-        });
+        QUnit.test(
+            "special case for context: the eval context can be accessed as 'context'",
+            (assert) => {
+                assert.strictEqual(evaluateExpr("context.get('b', 54)", { b: 3 }), 3);
+                assert.strictEqual(evaluateExpr("context.get('c', 54)", { b: 3 }), 54);
+            }
+        );
 
         QUnit.test("throw error if name is not defined", (assert) => {
             assert.throws(() => evaluateExpr("a"));


### PR DESCRIPTION
When the owl refactoring landed, we rewrote the pyjs evaluation system.
Then, we used the new system in the new code. In particular, the action
service uses it to evaluate the action domain.

But the previous code had a subtle behaviour in the special case of
evaluating domain: it added the context as a pydict object in itself, so
one could evaluate expression such as `context.get('a', 14)` to read the
value of a key in the context with a fallback.

With this commit, we uniformize this behaviour across all python
expression: the `context` key is now reserved, and used to access
anything in the current evaluation context.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
