### PR TITLE
[FIX] base: company.bank_ids is not the company of the company

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -78,7 +78,7 @@ class Company(models.Model):
         'res.country.state', compute='_compute_address', inverse='_inverse_state',
         string="Fed. State", domain="[('country_id', '=?', country_id)]"
     )
-    bank_ids = fields.One2many('res.partner.bank', 'company_id', string='Bank Accounts', help='Bank accounts related to this company')
+    bank_ids = fields.One2many(related='partner_id.bank_ids', readonly=False)
     country_id = fields.Many2one('res.country', compute='_compute_address', inverse='_inverse_country', string="Country")
     email = fields.Char(related='partner_id.email', store=True, readonly=False)
     phone = fields.Char(related='partner_id.phone', store=True, readonly=False)


### PR DESCRIPTION
This field was only used by thinking it was the banks owned by the
company, and not the banks registered for all partners by that
company.[1]
It has always been like that, since 7eab8e26d3d46c53f4be924d6a34e80a66e74960
even though the field didn't exist on `res.company` before that
refactoring.

[1]: checked with the following regex `compan((y(_ids?)?)|ies)\.bank_ids`


Related to https://github.com/odoo/odoo/pull/73226




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
