### PR TITLE
[FIX] survey: fix survey summary computation

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -626,14 +626,19 @@ class Survey(models.Model):
     @api.model
     def get_input_summary(self, question, current_filters=None):
         """ Returns overall summary of question e.g. answered, skipped, total_inputs on basis of filter """
-        current_filters = current_filters if current_filters else []
-        result = {}
-        search_line_ids = current_filters if current_filters else question.user_input_line_ids.ids
+        domain = [
+            ('user_input_id.test_entry', '=', False),
+            ('user_input_id.state', '!=', 'new'),
+            ('question_id', '=', question.id)
+        ]
+        if current_filters:
+            domain = expression.AND([[('id', 'in', current_filters)], domain])
 
-        result['answered'] = len([line for line in question.user_input_line_ids if line.user_input_id.state != 'new' and not line.user_input_id.test_entry and not line.skipped])
-        result['skipped'] = len([line for line in question.user_input_line_ids if line.user_input_id.state != 'new' and not line.user_input_id.test_entry and line.skipped])
-
-        return result
+        line_ids = self.env["survey.user_input_line"].search(domain)
+        return {
+            'answered': len(set([l.user_input_id for l in line_ids if not l.skipped])),
+            'skipped': len(set([l.user_input_id for l in line_ids if l.skipped])),
+        }
 
     def _get_answers_correctness(self, user_answers):
         if not user_answers.mapped('survey_id') == self:

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -5,10 +5,8 @@ import random
 
 from collections import Counter
 from itertools import product
-from werkzeug import urls
 
 from odoo import _
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.survey.tests import common
 from odoo.tests.common import users
 
@@ -175,3 +173,97 @@ class TestSurveyInternals(common.SurveyCase):
         result = self.env['survey.survey'].prepare_result(question)
         for key in exresult:
             self.assertEqual(result[key], exresult[key])
+
+    def test_get_input_summary_no_answer(self):
+        question = self._add_question(self.page_0, 'Q1', 'numerical_box')
+        result = self.env['survey.survey'].get_input_summary(question)
+        self.assertDictEqual(result, {"answered": 0, "skipped": 0})
+
+    def test_get_input_summary_simple_choice(self):
+        question = self._add_question(
+            self.page_0, 'Q0', 'simple_choice',
+            labels=[{'value': 'Choice0'}, {'value': 'Choice1'}]
+        )
+
+        # 2 answered + 1 skipped
+        answers = [self._add_answer(self.survey, False) for i in range(3)]
+
+        self._add_answer_line(question, answers[0], random.choice(question.labels_ids.ids))
+        self._add_answer_line(question, answers[1], random.choice(question.labels_ids.ids))
+        self._add_answer_line(question, answers[2], None, answer_type=False, skipped=True)
+
+        # no result if not validated
+        result = self.env['survey.survey'].get_input_summary(question)
+        self.assertDictEqual(result, {"answered": 0, "skipped": 0})
+
+        # expected results if validated
+        for answer in answers:
+            answer.state = "done"
+
+        result = self.env['survey.survey'].get_input_summary(question)
+        self.assertDictEqual(result, {"answered": 2, "skipped": 1})
+
+    def test_get_input_summary_multiple_choice(self):
+        question = self._add_question(
+            self.page_0, 'Q0', 'multiple_choice',
+            labels=[{'value': 'Choice0'}, {'value': 'Choice1'}]
+        )
+
+        # 1 answer with one choice + 1 answer with 2 choices + 1 skipped
+        answers = [self._add_answer(self.survey, False) for i in range(3)]
+
+        self._add_answer_line(question, answers[0], random.choice(question.labels_ids.ids))
+        self._add_answer_line(question, answers[1], question.labels_ids[0].id)
+        self._add_answer_line(question, answers[1], question.labels_ids[1].id)
+        self._add_answer_line(question, answers[2], None, answer_type=False, skipped=True)
+
+        # no result if not validated
+        result = self.env['survey.survey'].get_input_summary(question)
+        self.assertDictEqual(result, {"answered": 0, "skipped": 0})
+
+        # expected results if validated
+        for answer in answers:
+            answer.state = "done"
+
+        result = self.env['survey.survey'].get_input_summary(question)
+        self.assertDictEqual(result, {"answered": 2, "skipped": 1})
+
+    def test_get_input_summary_with_filters(self):
+        question = self._add_question(
+            self.page_0, 'Q0', 'multiple_choice',
+            labels=[{'value': 'Choice0'}, {'value': 'Choice1'}]
+        )
+
+        # 1 answer with one choice + 1 answer with 2 choices + 1 skipped
+        answers = [self._add_answer(self.survey, False) for i in range(3)]
+
+        one_choice_line = self._add_answer_line(question, answers[0], random.choice(question.labels_ids.ids))
+        mul_choice_line_1 = self._add_answer_line(question, answers[1], question.labels_ids[0].id)
+        mul_choice_line_2 = self._add_answer_line(question, answers[1], question.labels_ids[1].id)
+        skipped_line = self._add_answer_line(question, answers[2], None, answer_type=False, skipped=True)
+
+        # without validated answers
+        result = self.env['survey.survey'].get_input_summary(
+            question,
+            (one_choice_line | skipped_line | mul_choice_line_1).ids
+        )
+        self.assertDictEqual(result, {"answered": 0, "skipped": 0})
+
+        for answer in answers:
+            answer.state = "done"
+
+        # filter = 1 answer with one choice
+        result = self.env['survey.survey'].get_input_summary(question, one_choice_line.ids)
+        self.assertDictEqual(result, {"answered": 1, "skipped": 0})
+
+        # filter = 1 answer with one choice + 1 skipped
+        result = self.env['survey.survey'].get_input_summary(question, (one_choice_line | skipped_line).ids)
+        self.assertDictEqual(result, {"answered": 1, "skipped": 1})
+
+        # filter = 1 line from multiple choice answer
+        result = self.env['survey.survey'].get_input_summary(question, mul_choice_line_1.ids)
+        self.assertDictEqual(result, {"answered": 1, "skipped": 0})
+
+        # filter = 2 lines from multiple choice answer -> should only count ONE answered question
+        result = self.env['survey.survey'].get_input_summary(question, (mul_choice_line_1 | mul_choice_line_2).ids)
+        self.assertDictEqual(result, {"answered": 1, "skipped": 0})


### PR DESCRIPTION
In Odoo 11, the computation of number of answered questions is based on the number of different `user_input_id` (composed of one to several `user_input_lines`).
In Odoo 13, this computation is based on `user_input_lines` leading to count each choice of a multiple-choices question as an answer, which is not really correct.

Then, in Odoo 13, the computation of number of skipped answers is based on the field `user_input_line_ids` which is defined with a domain `[('skipped', '=', False)]` leading to automatically filtered out skipped answers. So, at the end, the survey report always shows 0 skipped answers.

upg-61474

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
