### PR TITLE
[FIX] mrp: fix BOM structure & cost

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -96,7 +96,7 @@ class ReportBomStructure(models.AbstractModel):
         bom_quantity = line_qty
         if line_id:
             current_line = self.env['mrp.bom.line'].browse(int(line_id))
-            bom_quantity = current_line.product_uom_id._compute_quantity(line_qty, bom.product_uom_id)
+            bom_quantity = current_line.product_uom_id._compute_quantity(line_qty, bom.product_uom_id) or 0
         # Display bom components for current selected product variant
         if product_id:
             product = self.env['product.product'].browse(int(product_id))


### PR DESCRIPTION
Steps to reproduce the bug:
- Install manufacturing app
- Create a product “A”
- Create a Bill of Materials for product A > add any product > save
- Create another Product “B” > Create a BOM and add the product “A” in quantity “0” > save
- Click on “BOM Structure & Cost” for product “B” > open the sublevel BOM dropdown of the product “A”

Problem:
An error is triggered because the quantity of the product is "None"

opw-2585033




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
