### PR TITLE
[IMP] website: update the odoo-experts-1 palette

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -1390,9 +1390,9 @@ $o-color-palettes: map-merge($o-color-palettes,
 
             'o-cc5-link': #65e4d7,
 
-            'menu': 3,
-            'footer': 3,
-            'copyright': 3,
+            'menu': 1,
+            'footer': 5,
+            'copyright': 5,
         ),
         'odoo-experts-2': (
             'o-color-1': #414f8a,


### PR DESCRIPTION
Update the presets of the header and the footer, in the palette "odoo-experts-1", to improve the contrast.
This change is related to an update of the theme Odoo Experts on [PR#27](https://github.com/odoo/design-themes/pull/27) in the Design-themes repo.

Task-2585389