### PR TITLE
[FIX] sale_project,sale_timesheet: display Sale Order button w/o need for Billable

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -29,6 +29,18 @@ class Project(models.Model):
         defaults['sale_line_id'] = False
         return defaults
 
+    def action_view_so(self):
+        self.ensure_one()
+        action_window = {
+            "type": "ir.actions.act_window",
+            "res_model": "sale.order",
+            "name": "Sales Order",
+            "views": [[False, "form"]],
+            "context": {"create": False, "show_sale": True},
+            "res_id": self.sale_order_id.id
+        }
+        return action_window
+
 
 class ProjectTask(models.Model):
     _inherit = "project.task"

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -18,6 +18,15 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
+            <div class="oe_button_box" position="inside">
+                <button class="d-none d-md-inline oe_stat_button" 
+                    type="object" name="action_view_so" icon="fa-dollar" 
+                    attrs="{'invisible': [('sale_order_id', '=', False)]}" 
+                    groups="sales_team.group_sale_salesman"
+                    string="Sales Order">
+                    <field name="sale_order_id" attrs="{'invisible': True}"/> 
+                </button>
+            </div>
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="options">{'always_reload': True}</attribute>
                 <attribute name="context">{'res_partner_search_mode': 'customer'}</attribute>

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -185,18 +185,6 @@ class Project(models.Model):
             },
         }
 
-    def action_view_so(self):
-        self.ensure_one()
-        action_window = {
-            "type": "ir.actions.act_window",
-            "res_model": "sale.order",
-            "name": "Sales Order",
-            "views": [[False, "form"]],
-            "context": {"create": False, "show_sale": True},
-            "res_id": self.sale_order_id.id
-        }
-        return action_window
-
 
 class ProjectTask(models.Model):
     _inherit = "project.task"

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -8,11 +8,6 @@
         <field name="arch" type="xml">
             <div class="oe_button_box" position="inside">
                 <button string="Project Overview" class="oe_stat_button" type="object" name="action_view_timesheet" icon="fa-puzzle-piece" attrs="{'invisible': [('allow_billable', '=', False)]}"/>
-                <button class="d-none d-md-inline oe_stat_button"
-                        type="object" name="action_view_so" icon="fa-dollar"
-                        attrs="{'invisible': ['|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('bill_type', '!=', 'customer_project')]}"
-                        string="Sales Order"
-                        groups="sales_team.group_sale_salesman"/>
             </div>
             <xpath expr="//header" position="inside">
                 <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>


### PR DESCRIPTION
Previously, the button Sale Order in a Project form could only be seen when the sale_timesheet module (installed automatically with the Timesheet, Sales and Project apps) is installed.
Now, only the Sales and Project apps are needed to be able to display the Sale Order button.

opw-2530161