### PR TITLE
Test, don't mind it

### DIFF
--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -29,6 +29,7 @@
         'wizards/account_payment_register_views.xml',
         'wizards/payment_acquirer_onboarding_templates.xml',
         'wizards/payment_link_wizard_views.xml',
+        'wizards/payment_refund_wizard_views.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -99,6 +99,7 @@ class PaymentAcquirer(models.Model):
     # Feature support fields
     support_authorization = fields.Boolean(string="Authorize Mechanism Supported")
     support_fees_computation = fields.Boolean(string="Fees Computation Supported")
+    support_refund = fields.Boolean(string="Refund Supported")
     support_tokenization = fields.Boolean(string="Tokenization supported")
 
     # Kanban view fields

--- a/addons/payment/security/ir.model.access.csv
+++ b/addons/payment/security/ir.model.access.csv
@@ -11,3 +11,4 @@ payment_token_user,payment.token.user,model_payment_token,base.group_user,1,1,1,
 payment_transaction_all,payment.transaction.all,model_payment_transaction,,1,0,0,0
 payment_transaction_system,payment.transaction.system,model_payment_transaction,base.group_system,1,1,1,1
 payment_transaction_user,payment.transaction.user,model_payment_transaction,base.group_user,1,1,1,0
+payment_refund_wizard,payment.refund.wizard,model_payment_refund_wizard,base.group_user,1,1,1,0

--- a/addons/payment/views/account_payment_views.xml
+++ b/addons/payment/views/account_payment_views.xml
@@ -6,6 +6,12 @@
         <field name="model">account.payment</field>
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='action_draft']" position="after">
+                <field name="refund_amount_allowed" invisible="1"/>
+                <button type="object" name="action_refund_wizard"
+                    string="Refund"
+                    attrs="{'invisible': [('refund_amount_allowed', '&lt;=', 0)]}" class="btn-secondary"/>
+            </xpath>
             <xpath expr='//group[2]' position="inside">
                 <field name="payment_transaction_id" groups="base.group_no_one" attrs="{'invisible': [('use_electronic_payment_method', '!=', True)]}"/>
             </xpath>

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -14,6 +14,9 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <button name="action_view_refunds" type="object" class="oe_stat_button" icon="fa-money" attrs="{'invisible': [('refunds_count', '=', 0)]}">
+                            <field name="refunds_count" widget="statinfo" string="Refunds"/>
+                        </button>
                         <button name="action_view_invoices" type="object"
                                 class="oe_stat_button" icon="fa-money"
                                 attrs="{'invisible': [('invoices_count', '=', 0)]}">

--- a/addons/payment/wizards/__init__.py
+++ b/addons/payment/wizards/__init__.py
@@ -3,3 +3,4 @@
 from . import payment_acquirer_onboarding_wizard
 from . import payment_link_wizard
 from . import account_payment_register
+from . import payment_refund_wizard

--- a/addons/payment/wizards/payment_refund_wizard.py
+++ b/addons/payment/wizards/payment_refund_wizard.py
@@ -1,0 +1,55 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.exceptions import ValidationError
+from odoo import _, api, fields, models
+
+
+class PaymentRefundWizard(models.TransientModel):
+    _name = "payment.refund.wizard"
+    _description = "Payment Refund Wizard"
+
+    payment_id = fields.Many2one(
+        string="Payment",
+        comodel_name='account.payment',
+        readonly=True,
+        default=lambda self: self.env.context.get('active_id'))
+    payment_transaction_id = fields.Many2one(
+        string="Payment Transaction",
+        related='payment_id.payment_transaction_id')
+    payment_amount = fields.Monetary(
+        string="Payment Amount",
+        related='payment_transaction_id.amount')
+    refunded_amount = fields.Monetary(
+        string="Refunded Amount",
+        compute='_compute_refunded_amount')
+    refund_amount_allowed = fields.Monetary(
+        string="Maximum Refund Allowed",
+        related="payment_id.refund_amount_allowed")
+    refund_amount = fields.Monetary(
+        string="Refund Amount",
+        compute="_compute_refund_amount",
+        store=True, readonly=False)
+    currency_id = fields.Many2one(
+        string='Currency',
+        related='payment_transaction_id.currency_id')
+
+    @api.constrains("refund_amount")
+    def _check_refund_amount(self):
+        for wiz in self:
+            if wiz.refund_amount <= 0 or wiz.refund_amount > wiz.refund_amount_allowed:
+                raise ValidationError(_("The amount to be refund has to be positive and "
+                                        "can't be superior to %s.", wiz.refund_amount_allowed))
+
+    @api.depends('payment_id', 'refund_amount_allowed')
+    def _compute_refund_amount(self):
+        for wizard in self:
+            wizard.refund_amount = wizard.refund_amount_allowed
+
+    @api.depends('payment_amount', 'payment_id', 'refund_amount_allowed')
+    def _compute_refunded_amount(self):
+        for wiz in self:
+            wiz.refunded_amount = wiz.payment_amount - wiz.refund_amount_allowed
+
+    def action_refund(self):
+        for wiz in self:
+            wiz.payment_transaction_id.action_refund(refund_amount=wiz.refund_amount)

--- a/addons/payment/wizards/payment_refund_wizard_views.xml
+++ b/addons/payment/wizards/payment_refund_wizard_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="payment_refund_wizard_view_form" model="ir.ui.view">
+        <field name="name">payment.refund.wizard.form</field>
+        <field name="model">payment.refund.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Refund">
+                <group>
+                    <field name="payment_amount"/>
+                    <field name="refunded_amount"/>
+                    <field name="refund_amount_allowed"/>
+                    <field name="refund_amount"/>
+                    <field name="payment_id" invisible="1"/>
+                    <field name="payment_transaction_id" invisible="1"/>
+                    <field name="currency_id" invisible="1"/>
+                </group>
+                <footer>
+                    <button type="object" name="action_refund" string="Refund" class="btn-primary" />
+                    <button string="Close" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/payment_adyen/const.py
+++ b/addons/payment_adyen/const.py
@@ -3,12 +3,14 @@
 # Endpoints of the API.
 # See https://docs.adyen.com/api-explorer/#/CheckoutService/v53/overview for Checkout API
 # See https://docs.adyen.com/api-explorer/#/Recurring/v49/overview for Recurring API
+# See https://docs.adyen.com/api-explorer/#/Payment/v64/overview for Payment API
 API_ENDPOINT_VERSIONS = {
     '/disable': 49,           # Recurring API
     '/originKeys': 53,        # Checkout API
     '/payments': 53,          # Checkout API
     '/payments/details': 53,  # Checkout API
     '/paymentMethods': 53,    # Checkout API
+    '/refund': 64,            # Payment API
 }
 
 # Adyen-specific mapping of currency codes in ISO 4217 format to the number of decimals.
@@ -28,7 +30,7 @@ RESULT_CODES_MAPPING = {
         'ChallengeShopper', 'IdentifyShopper', 'Pending', 'PresentToShopper', 'Received',
         'RedirectShopper'
     ),
-    'done': ('Authorised',),
+    'done': ('Authorised', 'Refund'),
     'cancel': ('Cancelled',),
     'error': ('Error',),
     'refused': ('Refused',),

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -271,6 +271,8 @@ class AdyenController(http.Controller):
                 notification_data['resultCode'] = 'Authorised'
             elif event_code == 'CANCELLATION':
                 notification_data['resultCode'] = 'Cancelled'
+            elif event_code == 'REFUND':
+                notification_data['resultCode'] = 'Refund'
             else:
                 continue  # Don't handle unsupported event codes
 

--- a/addons/payment_adyen/data/payment_acquirer_data.xml
+++ b/addons/payment_adyen/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">True</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_adyen/models/payment_acquirer.py
+++ b/addons/payment_adyen/models/payment_acquirer.py
@@ -31,6 +31,9 @@ class PaymentAcquirer(models.Model):
     adyen_checkout_api_url = fields.Char(
         string="Checkout API URL", help="The base URL for the Checkout API endpoints",
         required_if_provider='adyen')
+    adyen_payment_api_url = fields.Char(
+        string="Payment API URL", help="The base URL for the Payment API endpoints",
+        required_if_provider='adyen')
     adyen_recurring_api_url = fields.Char(
         string="Recurring API URL", help="The base URL for the Recurring API endpoints",
         required_if_provider='adyen')

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -13,6 +13,7 @@ class AdyenCommon(PaymentCommon):
             'adyen_api_key': 'dummy',
             'adyen_hmac_key': 'dummy',
             'adyen_checkout_api_url': 'https://this.is.an.url',
+            'adyen_payment_api_url': 'https://this.is.an.url',
             'adyen_recurring_api_url': 'https://this.is.an.url',
         })
 

--- a/addons/payment_adyen/views/payment_views.xml
+++ b/addons/payment_adyen/views/payment_views.xml
@@ -12,6 +12,7 @@
                     <field name="adyen_api_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_hmac_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_checkout_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                    <field name="adyen_payment_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_recurring_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                 </group>
             </xpath>

--- a/addons/payment_alipay/data/payment_acquirer_data.xml
+++ b/addons/payment_alipay/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">True</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_authorize/data/payment_acquirer_data.xml
+++ b/addons/payment_authorize/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">True</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_buckaroo/data/payment_acquirer_data.xml
+++ b/addons/payment_buckaroo/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_odoo/data/payment_acquirer_data.xml
+++ b/addons/payment_odoo/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_ogone/data/payment_acquirer_data.xml
+++ b/addons/payment_ogone/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_paypal/data/payment_acquirer_data.xml
+++ b/addons/payment_paypal/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">True</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_payulatam/data/payment_acquirer_data.xml
+++ b/addons/payment_payulatam/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_payumoney/data/payment_acquirer_data.xml
+++ b/addons/payment_payumoney/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_sips/data/payment_acquirer_data.xml
+++ b/addons/payment_sips/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
     </record>
 

--- a/addons/payment_stripe/data/payment_acquirer_data.xml
+++ b/addons/payment_stripe/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
         <field name="support_tokenization">True</field>
+        <field name="support_refund">False</field>
         <field name="allow_tokenization">True</field>
     </record>
 

--- a/addons/payment_test/data/payment_acquirer_data.xml
+++ b/addons/payment_test/data/payment_acquirer_data.xml
@@ -6,6 +6,7 @@
         <field name="inline_form_view_id" ref="inline_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">True</field>
         <field name="allow_tokenization">True</field>
     </record>

--- a/addons/payment_transfer/data/payment_acquirer_data.xml
+++ b/addons/payment_transfer/data/payment_acquirer_data.xml
@@ -7,6 +7,7 @@
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="support_authorization">False</field>
         <field name="support_fees_computation">False</field>
+        <field name="support_refund">False</field>
         <field name="support_tokenization">False</field>
         <!-- Clear the default value to trigger the computation of the message -->
         <field name="pending_msg" eval="False"/>


### PR DESCRIPTION
* : alipay, authorize, buckaroo, odoo, ogone, paypal, payulatam,
payumoney, sips, stripe, test, transfer

The users using Adyen can make a partial or full refund from a payment
without going to the Adyen backend, and have the outbound payment created
once the refund success notification is received from Adyen.

task-2527891

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
