### PR TITLE
[IMP] web_editor, *: add btn to form editor to redirect in the backend

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -883,6 +883,11 @@ body.editor_enable.editor_has_snippets {
             }
         }
 
+        // Buttons with an icon but no text, so no possible overflow
+        we-button.o_we_button_icon {
+            flex: 0 0 auto;
+        }
+
         // Checkboxes
         we-button.o_we_checkbox_wrapper.o_we_user_value_widget {
             min-width: $o-we-sidebar-content-field-toggle-width;

--- a/addons/website_form_project/static/src/js/website_form_project_editor.js
+++ b/addons/website_form_project/static/src/js/website_form_project_editor.js
@@ -28,6 +28,7 @@ FormEditorRegistry.add('create_task', {
         type: 'many2one',
         relation: 'project.project',
         string: _t('Project'),
+        createAction: 'project.open_view_project_all',
     }],
 });
 


### PR DESCRIPTION
*website, website_form_project

In master, there was an error when adding a form to a website and
selecting "Create a Task" with no active projects. This issue was solved
in PR #73269, by allowing tasks without a project associated. This
introduces a new problem: if a user wants to create a project (e.g. if
there is no active project), they will have to save their changes, close
the editor, navigate to Project, and only then will they be able to do
it. This issue could happen for other modules, so the solution has to be
generic.

In this commit, we add the possibility to add a button to the form
editor, next to a we-select item, which will redirect the user to a
specified action after prompting them to save their work. This button
can be added by specifying an action window in the corresponding
registry.

We also add the action window to the website form project editor, so
that the user can be redirected towards the Project app if they want
to create a project to select in their form.

task-2580436