### PR TITLE
[FIX] website: set id in xml for carousel rendered by configurator

### DIFF
--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -3,12 +3,13 @@
 
 <template id="s_carousel" name="Carousel">
     <section class="s_carousel_wrapper" data-vxml="001">
-        <div id="myCarousel" class="s_carousel s_carousel_default carousel slide" data-interval="10000">
+        <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
+        <div t-attf-id="myCarousel{{uniq}}" class="s_carousel s_carousel_default carousel slide" data-interval="10000">
             <!-- Indicators -->
             <ol class="carousel-indicators">
-                <li data-target="#myCarousel" data-slide-to="0" class="active"/>
-                <li data-target="#myCarousel" data-slide-to="1"/>
-                <li data-target="#myCarousel" data-slide-to="2"/>
+                <li t-attf-data-target="#myCarousel{{uniq}}" data-slide-to="0" class="active"/>
+                <li t-attf-data-target="#myCarousel{{uniq}}" data-slide-to="1"/>
+                <li t-attf-data-target="#myCarousel{{uniq}}" data-slide-to="2"/>
             </ol>
             <!-- Content -->
             <div class="carousel-inner">
@@ -56,11 +57,11 @@
                 </div>
             </div>
             <!-- Controls -->
-            <a class="carousel-control-prev o_not_editable" contenteditable="false" href="#myCarousel" data-slide="prev" role="img" aria-label="Previous" title="Previous">
+            <a class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-href="#myCarousel{{uniq}}" data-slide="prev" role="img" aria-label="Previous" title="Previous">
                 <span class="carousel-control-prev-icon"/>
                 <span class="sr-only">Previous</span>
             </a>
-            <a class="carousel-control-next o_not_editable" contenteditable="false" href="#myCarousel" data-slide="next" role="img" aria-label="Next" title="Next">
+            <a class="carousel-control-next o_not_editable" contenteditable="false" t-attf-href="#myCarousel{{uniq}}" data-slide="next" role="img" aria-label="Next" title="Next">
                 <span class="carousel-control-next-icon"/>
                 <span class="sr-only">Next</span>
             </a>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -3,12 +3,13 @@
 
 <template id="s_quotes_carousel" name="Quotes">
     <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="001">
-        <div id="myQuoteCarousel" class="s_quotes_carousel s_carousel_default carousel slide bg-200" data-interval="10000">
+        <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
+        <div t-attf-id="myQuoteCarousel{{uniq}}" class="s_quotes_carousel s_carousel_default carousel slide bg-200" data-interval="10000">
             <!-- Indicators -->
             <ol class="carousel-indicators">
-                <li data-target="#myQuoteCarousel" data-slide-to="0" class="active"/>
-                <li data-target="#myQuoteCarousel" data-slide-to="1"/>
-                <li data-target="#myQuoteCarousel" data-slide-to="2"/>
+                <li t-attf-data-target="#myQuoteCarousel{{uniq}}" data-slide-to="0" class="active"/>
+                <li t-attf-data-target="#myQuoteCarousel{{uniq}}" data-slide-to="1"/>
+                <li t-attf-data-target="#myQuoteCarousel{{uniq}}" data-slide-to="2"/>
             </ol>
             <!-- Content -->
             <div class="carousel-inner">
@@ -59,11 +60,11 @@
                 </div>
             </div>
             <!-- Controls -->
-            <div class="carousel-control-prev o_not_editable" data-target="#myQuoteCarousel" data-slide="prev" role="img" aria-label="Previous" title="Previous">
+            <div class="carousel-control-prev o_not_editable" t-attf-data-target="#myQuoteCarousel{{uniq}}" data-slide="prev" role="img" aria-label="Previous" title="Previous">
                 <span class="carousel-control-prev-icon"/>
                 <span class="sr-only">Previous</span>
             </div>
-            <div class="carousel-control-next o_not_editable" data-target="#myQuoteCarousel" data-slide="next" role="img" aria-label="Next" title="Next">
+            <div class="carousel-control-next o_not_editable" t-attf-data-target="#myQuoteCarousel{{uniq}}" data-slide="next" role="img" aria-label="Next" title="Next">
                 <span class="carousel-control-next-icon"/>
                 <span class="sr-only">Next</span>
             </div>


### PR DESCRIPTION
Carousels (carousel and quotes_carousel snippets) in pages created by the
configurator are not added through a drag'n'drop. onBuilt and _assignUniqueId
are thefore not called. We set the unique id directly in the xml to make
the carousel slides also work when these snippets are added by the configurator.

task-2518565

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
