### PR TITLE
[IMP] base_import: add import progress bar for batch mode

### DIFF
--- a/addons/base_import/static/src/scss/base_import.scss
+++ b/addons/base_import/static/src/scss/base_import.scss
@@ -68,6 +68,9 @@
             overflow: hidden;
             text-overflow: ellipsis;
         }
+        .o_import_batch_alert {
+            color: #46646d;
+        }
     }
 
     &.oe_import_preview .oe_import_grid {
@@ -231,6 +234,27 @@
         max-height: 192px;
         .text-decoration-underline {
             text-decoration: underline;
+        }
+    }
+}
+
+/* Import Progress Bar */
+.o_import_progress_dialog {
+    .progress {
+        height: 1.5rem;
+        border-radius: 4px;
+        font-size: 1rem;
+
+        .progress-bar {
+            width: 0%;
+            min-width: 3%;
+        }
+    }
+
+    .o_progress_stop_import {
+        cursor: pointer;
+        &:hover {
+            transform: scale(1.2);
         }
     }
 }

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -18,12 +18,6 @@
                 <t t-call="ImportView.data_matching"/>
             </div>
 
-            <div class="o_import_partial_alert alert alert-warning d-none">
-                Click 'Resume' to proceed with the import, resuming at line
-                <span class="o_import_partial_count">0</span>.<br/>
-                You can test or reload your file before resuming the import.
-            </div>
-
             <div class="o_view_nocontent">
                 <div class="o_nocontent_help">
                     <p class="o_view_nocontent_smiling_face">
@@ -225,6 +219,11 @@
                     field corresponding to the column. This makes imports
                     simpler especially when the file has many columns.</p>
             </div>
+            <div class="o_import_partial_alert alert alert-warning d-none mx-2 my-2 font-weight-bold">
+                Click 'Resume' to proceed with the import, resuming at line
+                <span class="o_import_partial_count">0</span>.<br/>
+                You can test or reload your file before resuming the import.
+            </div>
             <div class="oe_import_error_report px-3 py-2"></div>
             <div class="table-responsive">
                 <table class="table-striped oe_import_grid w-100 overflow-hidden" />
@@ -244,7 +243,7 @@
                     <span id="oe_imported_file_extension" class="font-italic"></span>
                 </div>
 
-                <div class="oe_import_has_multiple_sheets js_import_options flex-column mt-2">
+                <div class="oe_import_has_multiple_sheets flex-column mt-2">
                     <label for="oe_import_sheet">Sheet:</label>
                     <input class="oe_import_sheet oe_import_dropdown" id="oe_import_sheet"/>
                 </div>
@@ -270,15 +269,15 @@
 
                 <div class="o_import_batch">
                     <h4 class="mt-3">Batch Import</h4>
-                    <div class="o_import_batch_alert alert alert-info d-none">
-                        The file will be imported by batches.
+                    <div class="o_import_batch_alert font-weight-bold d-none pb-2">
+                        The file will be imported by batches
                     </div>
                     <div class="d-flex">
-                        <div class="js_import_options oe_import_options oe_import_batch_limit w-50 pr-1">
+                        <div class="oe_import_options oe_import_batch_limit w-50 pr-1">
                             <label class="mb-1" for="oe_import_batch_limit">Batch limit</label>
                             <input class="w-100" id="oe_import_batch_limit" value="2000"/>
                         </div>
-                        <div class="js_import_options oe_import_options w-50 pl-1" title="Warning: ignores the labels line, empty lines and
+                        <div class="oe_import_options w-50 pl-1" title="Warning: ignores the labels line, empty lines and
 lines composed only of empty cells">
                             <label class="mb-1" for="oe_import_row_start">Start at line</label>
                             <input class="w-100" id="oe_import_row_start" value="1"/>
@@ -315,4 +314,33 @@ lines composed only of empty cells">
             </div>
         </div>
     </t>
+
+    <div t-name="base_import.progressDialog" class="o_import_progress_dialog text-white">
+        <span class="fa fa-spin fa-circle-o-notch fa-2x mb-2"/>
+        <div t-if="isBatch">
+            <div class="o_import_progress_dialog_batch">
+                <span t-esc="importMode"/> batch <span class="o_import_progress_dialog_batch_count">1</span> out of <span t-esc="totalSteps"/>...
+                <div class="o_import_progress_dialog_time_left d-none">
+                    <span>Estimated time left:</span>
+                    <span class="o_import_progress_dialog_time_left_text"/>
+                    <span>minutes</span>
+                </div>
+            </div>
+            <span class="o_import_progress_dialog_stop d-none">
+                Finalizing current batch before interrupting...
+            </span>
+            <div class="d-flex align-items-center mt-2">
+                <div class="progress flex-grow-1">
+                    <div class="progress-bar progress-bar-striped" role="progressbar"
+                         aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                        <span>0%</span>
+                    </div>
+                </div>
+                <a class="o_progress_stop_import ml-2" role="button"><i class="fa fa-close" aria-label="Stop Import"/></a>
+            </div>
+        </div>
+        <div t-else="">
+            <span t-esc="task"/>...
+        </div>
+    </div>
 </templates>


### PR DESCRIPTION
This commit adds a progress bar that is displayed during the import (or import
test). It is only displayed when importing in batch mode.

The user can decide to stop the import. If it's the case, the current
batch is finalized and the import is interrupted afterwards.

The user can easily resume the import later starting from the line where the
batch was interrupted
e.g: interrupted after 300 / 500 lines, when you resume, it will start from
line 301.
(The above behavior is not applied in test mode, we never alter the starting
line when testing).

Side note: This commit also removes the alert-info box from batch import
disclaimer, for design beauty purpose.

Task-2567591

Co-authored-by: Aurélien Warnon <awa@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
