### PR TITLE
[FIX] web: undo search facet on user error

### DIFF
--- a/addons/web/static/src/js/model.js
+++ b/addons/web/static/src/js/model.js
@@ -430,6 +430,9 @@ odoo.define("web/static/src/js/model.js", function (require) {
         async _notifyComponents() {
             const rev = ++this.rev;
             const subscriptions = this.subscriptions.update;
+            if (!subscriptions) {
+                return;
+            }
             const groups = partitionBy(subscriptions, (s) =>
                 s.owner ? s.owner.__owl__.depth : -1
             );

--- a/addons/web/static/src/js/views/action_model.js
+++ b/addons/web/static/src/js/views/action_model.js
@@ -101,9 +101,10 @@ odoo.define("web/static/src/js/views/action_model.js", function (require) {
          */
         __get(excluded, property) {
             const results = super.__get(...arguments);
+            const { domain, context } = this.config;
             switch (property) {
-                case "domain": return [this.config.domain, ...results];
-                case "context": return [this.config.context, ...results];
+                case "domain": return domain ? [domain, ...results] : results;
+                case "context": return context ? [context, ...results] : results;
             }
             return results;
         }


### PR DESCRIPTION
Context: in the search bar of the control panel, search filters
represented by facets are generated synchronously. The problem is that
it lacks validation and if the server throws an error after trying to
perform a search with a falsy domain, there is no way to target the
falsy facet since there is nothing binding it to the error.

The solution that this commit offers is a simple revert mechanism
undoing the last query action input by a user, i.e. involving a value
directly input either in the search bar (autocompletion values) or in
the CustomFilter menu item.

The model then reverts its last user input action if the last search
action triggered by the search model issued a server UserError.

Task [2375667](https://www.odoo.com/web#active_id=2375667&cids=1&id=2375667&model=project.task&menu_id=)
