### PR TITLE
[FIX] l10n_in: Fix GSTR-1 report multi parent tax fix

### DIFF
--- a/addons/l10n_in_multi_parent_tax_fix/__init__.py
+++ b/addons/l10n_in_multi_parent_tax_fix/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import report

--- a/addons/l10n_in_multi_parent_tax_fix/__manifest__.py
+++ b/addons/l10n_in_multi_parent_tax_fix/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Indian - Accounting Multi Parent tax fix",
+    "version": "1.0",
+    "description": """
+Indian Accounting: Multi Parent tax fix.
+====================================
+
+When There is child tax is use more then one time in group of tax then GSTR1 report line is duplicated.
+Using this module you can fix it.
+
+Note: This give purformence issue if there is too much data.
+  """,
+    "category": "Accounting/Localizations",
+    "depends": [
+        "l10n_in",
+    ],
+    "data": [],
+}

--- a/addons/l10n_in_multi_parent_tax_fix/report/__init__.py
+++ b/addons/l10n_in_multi_parent_tax_fix/report/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_invoice_report

--- a/addons/l10n_in_multi_parent_tax_fix/report/account_invoice_report.py
+++ b/addons/l10n_in_multi_parent_tax_fix/report/account_invoice_report.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class L10nInAccountInvoiceReport(models.Model):
+    _inherit = "l10n_in.account.invoice.report"
+
+    def _where(self):
+        where_str = super()._where()
+        where_str += """
+            AND (
+                parent_at.id is NULL
+                OR
+                parent_at.id in (
+                  SELECT account_tax_id
+                  FROM account_move_line_account_tax_rel aml_taxes
+                  JOIN account_move_line aml2 on aml_taxes.account_move_line_id = aml2.id
+                 WHERE aml2.move_id = aml.move_id
+                   AND aml2.product_id = aml.product_id
+                )
+            )
+        """
+        return where_str


### PR DESCRIPTION
Current behavior before PR:
=====================
If child tax has multi-parents then the line in GSTR-1 is duplicated.
because there is no filter is added

Desired behavior after PR is merged:
===========================
If child tax have multi-parents then we check which one is used in the invoice
so the line is not duplicated.

opw-2577874

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
