### PR TITLE
[FIX] web: blacklist odoo payments menu from click_all test

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -13,6 +13,7 @@
         "account.menu_action_account_bank_journal_form",
         "pos_adyen.menu_pos_adyen_account",
         "payment_odoo.menu_adyen_account",
+        "payment_odoo.root_adyen_menu",
     ];
 
     const { isEnterprise } = odoo.info;


### PR DESCRIPTION
Avoid to click on Odoo Payments menu during click_all test as this menu leads to nowhere.