### PR TITLE
[FIX] website_form_project: prevent errors on task creation from a form

### DIFF
--- a/addons/website_form_project/static/src/js/website_form_project_editor.js
+++ b/addons/website_form_project/static/src/js/website_form_project_editor.js
@@ -26,7 +26,6 @@ FormEditorRegistry.add('create_task', {
         name: 'project_id',
         type: 'many2one',
         relation: 'project.project',
-        required: true,
         string: _t('Project'),
     }],
 });


### PR DESCRIPTION
In 14.0, when adding a form to a website and
selecting "Create a Task" without an active project,
an error pops up because no projects are found.

In this commit, we prevent an error from popping up
when adding the form without projects,
by allowing the field to be empty (not required).

task-2580436