### PR TITLE
datepicker week date offset

### DIFF
--- a/addons/web/static/src/legacy/js/core/session.js
+++ b/addons/web/static/src/legacy/js/core/session.js
@@ -374,9 +374,12 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
      * @private
      */
     _configureLocale: function () {
+        // TODO: try to test when re - writing this file in the new system with luxon
+        const dow = (_t.database.parameters.week_start || 0) % 7;
         moment.updateLocale(moment.locale(), {
             week: {
-                dow: (_t.database.parameters.week_start || 0) % 7,
+                dow: dow,
+                doy: 7 + dow - 4 // Note: ISO 8601 week date: https://momentjscom.readthedocs.io/en/latest/moment/07-customization/16-dow-doy/
             },
         });
     },


### PR DESCRIPTION
PURPOSE

The week dates computed by our datepicker do not meet the ISO 8601 standard:

The ISO 8601 definition for week 01 is the week with the first Thursday of the Gregorian year (i.e. of January) in it.
The following definitions based on properties of this week are mutually equivalent, since the ISO week starts with Monday:

    It is the first week with a majority (4 or more) of its days in January.
    Its first day is the Monday nearest to 1 January.
    It has 4 January in it. Hence the earliest possible first week extends from Monday 29 December (previous Gregorian year) to Sunday 4 January, the latest possible first week extends from Monday 4 January to Sunday 10 January.
    It has the year's first working day in it, if Saturdays, Sundays and 1 January are not working days.

If 1 January is on a Monday, Tuesday, Wednesday or Thursday, it is in W01. If it is on a Friday, it is part of W53 of the previous year. If it is on a Saturday, it is part of the last week of the previous year which is numbered W52 in a common year and W53 in a leap year. If it is on a Sunday, it is part of W52 of the previous year.
https://en.wikipedia.org/wiki/ISO_week_date#First_week

Since Jan 1st 2021 falls on a Friday, according to the ISO 8601 standard above, the first week of 2021 is the one starting on Jan 4th.
Nevertheless, it looks like our datepicker simply assumes that the first week of the year is simply the one including Jan 1st.

SPECIFICATION

Fix the week dates of our datepicker to meet the ISO 8601 standard.

TASK 2458112
