### PR TITLE
[MERGE][IMP] mail, mass_mailing: remove mails in batch outside of send loop

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Discuss',
-    'version': '1.8',
+    'version': '1.9',
     'category': 'Productivity/Discuss',
     'sequence': 145,
     'summary': 'Chat, mail gateway and private channels',

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -376,8 +376,6 @@ class MailMail(models.Model):
             try:
                 mail = self.browse(mail_id)
                 if mail.state != 'outgoing':
-                    if mail.state != 'exception' and mail.auto_delete:
-                        mail.sudo().unlink()
                     continue
 
                 # remove attachments if user send the link with the access_token

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -82,6 +82,7 @@ class MailMail(models.Model):
     auto_delete = fields.Boolean(
         'Auto Delete',
         help="This option permanently removes any track of email after it's been sent, including from the Technical menu in the Settings, in order to preserve storage space of your Odoo database.")
+    to_delete = fields.Boolean('To Delete', help='If set, the mail will be deleted during the next Email Queue CRON run.')
     scheduled_date = fields.Char('Scheduled Send Date',
         help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible.")
 
@@ -106,6 +107,19 @@ class MailMail(models.Model):
         for mail_sudo, mail in zip(self.sudo(), self):
             restricted_attaments = mail_sudo.attachment_ids - IrAttachment._filter_attachment_access(mail_sudo.attachment_ids.ids)
             mail_sudo.attachment_ids = restricted_attaments | mail.unrestricted_attachment_ids
+
+    def init(self):
+        """Create a partial index on "to_delete" to make the search on those records fast.
+
+        The benefit on this partial index is to not have a big impact on the
+        update / insert of other records in the database in comparison to a standard
+        index.
+        """
+        self._cr.execute("""
+            CREATE INDEX IF NOT EXISTS mail_mail_to_delete_idx
+                      ON mail_mail(id)
+                   WHERE to_delete = TRUE;
+        """)
 
     @api.model_create_multi
     def create(self, values_list):
@@ -212,6 +226,9 @@ class MailMail(models.Model):
             res = self.browse(ids).send(auto_commit=auto_commit)
         except Exception:
             _logger.exception("Failed processing mail queue")
+
+        # Remove all the <mail.mail> marked as "to delete"
+        self.env['mail.mail'].sudo().search([('to_delete', '=', True)]).unlink()
         return res
 
     def _postprocess_sent_message(self, success_pids, failure_reason=False, failure_type=None):
@@ -249,8 +266,8 @@ class MailMail(models.Model):
                     # TDE TODO: could be great to notify message-based, not notifications-based, to lessen number of notifs
                     messages._notify_message_notification_update()  # notify user that we have a failure
         if not failure_type or failure_type in ['mail_email_invalid', 'mail_email_missing']:  # if we have another error, we want to keep the mail.
-            mail_to_delete_ids = [mail.id for mail in self if mail.auto_delete]
-            self.browse(mail_to_delete_ids).sudo().unlink()
+            self.filtered(lambda mail: mail.auto_delete).to_delete = True
+
         return True
 
     # ------------------------------------------------------

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -61,7 +61,7 @@ class MailTemplate(models.Model):
     mail_server_id = fields.Many2one('ir.mail_server', 'Outgoing Mail Server', readonly=False,
                                      help="Optional preferred server for outgoing mails. If not set, the highest "
                                           "priority one will be used.")
-    scheduled_date = fields.Char('Scheduled Date', help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. You can use dynamic expressions expression.")
+    scheduled_date = fields.Char('Scheduled Date', help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. You can use dynamic expression.")
     auto_delete = fields.Boolean(
         'Auto Delete', default=True,
         help="This option permanently removes any track of email after it's been sent, including from the Technical menu in the Settings, in order to preserve storage space of your Odoo database.")

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -74,6 +74,11 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             self.send_email_mocked = send_email_mocked
             yield
 
+        if mail_unlink_sent:
+            # Remove all the <mail.mail> marked as to_delete to simulate the CRON
+            # Make tests easier and keep backward compatibility before this patch
+            self.env['mail.mail'].sudo().search([('to_delete', '=', True)]).unlink()
+
     def _init_mail_mock(self):
         self._mails = []
         self._mails_args = []

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -29,7 +29,8 @@
                         <group>
                             <field name="email_from"/>
                             <field name="email_to"/>
-                            <field name="recipient_ids" widget="many2many_tags"/>
+                            <field name="recipient_ids" widget="many2many_tags"
+                                domain="[('type', '!=', 'private'), ('active', '=', True)]"/>
                             <field name="email_cc"/>
                             <field name="reply_to"/>
                             <field name="scheduled_date"/>
@@ -77,7 +78,7 @@
             <field name="name">mail.mail.tree</field>
             <field name="model">mail.mail</field>
             <field name="arch" type="xml">
-                <tree string="Emails" decoration-muted="state in ('sent', 'cancel')" decoration-info="state=='outgoing'" decoration-danger="state=='exception'">
+                <tree string="Emails">
                     <header>
                         <button name="action_retry" string="Retry" type="object"/>
                     </header>
@@ -89,8 +90,9 @@
                     <field name="model" invisible="1"/>
                     <field name="res_id" invisible="1"/>
                     <field name="email_from" invisible="1"/>
-                    <field name="state" invisible="1"/>
                     <field name="message_type" invisible="1"/>
+                    <field name="state" widget="badge" decoration-muted="state in ('sent', 'cancel')"
+                        decoration-info="state=='outgoing'" decoration-danger="state=='exception'"/>
                     <button name="send" string="Send Now" type="object" icon="fa-paper-plane" states='outgoing'/>
                     <button name="mark_outgoing" string="Retry" type="object" icon="fa-repeat" states='exception,cancel'/>
                     <button name="cancel" string="Cancel Email" type="object" icon="fa-times-circle" states='outgoing'/>

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -42,7 +42,10 @@
                             <page string="Advanced" name="advanced" groups="base.group_no_one">
                                 <group>
                                     <group string="Status">
-                                        <field name="auto_delete"/>
+                                        <field name="auto_delete"
+                                            attrs="{'invisible': [('state', '!=', 'outgoing'), ('state', '!=', 'exception')]}"/>
+                                        <field name="to_delete"
+                                            attrs="{'invisible': [('state', '=', 'outgoing')]}"/>
                                         <field name="is_notification"/>
                                         <field name="message_type"/>
                                         <field name="mail_server_id"/>
@@ -93,6 +96,7 @@
                     <field name="message_type" invisible="1"/>
                     <field name="state" widget="badge" decoration-muted="state in ('sent', 'cancel')"
                         decoration-info="state=='outgoing'" decoration-danger="state=='exception'"/>
+                    <field name="to_delete"/>
                     <button name="send" string="Send Now" type="object" icon="fa-paper-plane" states='outgoing'/>
                     <button name="mark_outgoing" string="Retry" type="object" icon="fa-repeat" states='exception,cancel'/>
                     <button name="cancel" string="Cancel Email" type="object" icon="fa-times-circle" states='outgoing'/>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -588,6 +588,8 @@ class TestActivityMixin(TestActivityCommon):
             origin_2_activity_4 = origin_2_activity_1.copy()
             origin_2_activity_4.date_deadline = datetime(2020, 1, 2, 0, 0, 0)
 
+            self.env['mail.test.activity'].flush_model()
+
             self.assertEqual(origin_2_activity_1.state, 'planned')
             self.assertEqual(origin_2_activity_2.state, 'today')
             self.assertEqual(origin_2_activity_3.state, 'today')

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -92,3 +92,6 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
+
+        cancelled_mail_count = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])
+        self.assertEqual(len(cancelled_mail_count), 12, 'Should not have auto deleted the blacklisted emails')

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -46,12 +46,19 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        # runbot needs +101 compared to local (1570)
-        with self.assertQueryCount(__system__=1669, marketing=1670):
+        # runbot needs +1 compared to local
+        with self.assertQueryCount(__system__=425, marketing=426):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
+
+        # runbot needs +2 compared to local
+        with self.assertQueryCount(__system__=69, marketing=67):
+            self.env['mail.mail'].sudo().search([('to_delete', '=', True)]).unlink()
+
+        mails = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])
+        self.assertFalse(mails, 'Should have auto-deleted the <mail.mail>')
 
 
 @tagged('mail_performance')
@@ -86,12 +93,16 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        # runbot needs +125 compared to local (1836)
-        with self.assertQueryCount(__system__=1959, marketing=1960):
+        # runbot needs +1 compared to local
+        with self.assertQueryCount(__system__=487, marketing=488):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
+
+        # runbot needs +2 compared to local
+        with self.assertQueryCount(__system__=69, marketing=67):
+            self.env['mail.mail'].sudo().search([('to_delete', '=', True)]).unlink()
 
         cancelled_mail_count = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])
         self.assertEqual(len(cancelled_mail_count), 12, 'Should not have auto deleted the blacklisted emails')


### PR DESCRIPTION
Remove `mail.mail` in batch
===========================
Improve the performance of mass mailing by removing the <mail.mail>, in
batch, all at once. The unlink operation is very expensive for the ORM,
in terms of SQL queries.

A new field `to_delete` is required to know which <mail.mail> we need
to delete. The reason is that the `failure_type` is stored on the
<mail.notification>, and it's possible to have <mail.mail> without
<mail.notification>.

Improve some views
==================
Show the state of the <mail.mail> in the tree view and color only the
badge widget instead of the entire row.

Misc improvement
================
Do not remove cancelled email during the sending.
It's not the role of the sending method to remove non outgoing emails.

Do not try to send a lot of emails because of the mass mailing demo data

Task-2587345