### PR TITLE
[FIX] payment: No error logged if no real error in transaction

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -877,7 +877,7 @@ class PaymentTransaction(models.Model):
             'date': fields.Datetime.now(),
             'state_message': msg,
         })
-        self._log_payment_transaction_received()
+        tx_to_process._log_payment_transaction_received()
 
     def _post_process_after_done(self):
         self._reconcile_after_transaction_done()


### PR DESCRIPTION
Copy behaviour of `_set_transaction_cancel()`.
Only log processed transactions.

OPW-2575711