### PR TITLE
[IMP] account: yearly sequence for sales journals

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1200,7 +1200,10 @@ class AccountMove(models.Model):
 
     def _get_starting_sequence(self):
         self.ensure_one()
-        starting_sequence = "%s/%04d/%02d/0000" % (self.journal_id.code, self.date.year, self.date.month)
+        if self.journal_id.type == 'sale':
+            starting_sequence = "%s/%04d/00000" % (self.journal_id.code, self.date.year)
+        else:
+            starting_sequence = "%s/%04d/%02d/0000" % (self.journal_id.code, self.date.year, self.date.month)
         if self.journal_id.refund_sequence and self.move_type in ('out_refund', 'in_refund'):
             starting_sequence = "R" + starting_sequence
         return starting_sequence

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1787,7 +1787,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         ], {
             **self.move_vals,
             'invoice_payment_term_id': None,
-            'name': 'RINV/2019/02/0001',
+            'name': 'RINV/2019/00001',
             'date': move_reversal.date,
             'state': 'draft',
             'ref': 'Reversal of: %s, %s' % (self.invoice.name, move_reversal.reason),
@@ -2610,7 +2610,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.term_line_vals_1,
                 'currency_id': self.currency_data['currency'].id,
-                'name': 'INV/2017/01/0001',
+                'name': 'INV/2017/00001',
                 'amount_currency': 1410.0,
                 'debit': 705.0,
                 'credit': 0.0,
@@ -2620,7 +2620,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'currency_id': self.currency_data['currency'].id,
             'date': fields.Date.from_string('2017-01-01'),
-            'payment_reference': 'INV/2017/01/0001',
+            'payment_reference': 'INV/2017/00001',
         })
 
         accrual_lines = self.env['account.move'].browse(wizard_res['domain'][0][2]).line_ids.sorted('date')

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -10,7 +10,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
-        
+
         cls.currency_data_3 = cls.setup_multi_currency_data({
             'name': "Umbrella",
             'symbol': '☂',
@@ -91,7 +91,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
+            'ref': 'INV/2017/00001 INV/2017/00002',
             'payment_method_id': self.inbound_payment_method.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -125,7 +125,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
+            'ref': 'INV/2017/00001 INV/2017/00002',
             'payment_method_id': self.inbound_payment_method.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -160,7 +160,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
+            'ref': 'INV/2017/00001 INV/2017/00002',
             'payment_method_id': self.inbound_payment_method.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -203,7 +203,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
+            'ref': 'INV/2017/00001 INV/2017/00002',
             'payment_method_id': self.inbound_payment_method.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -328,11 +328,11 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertRecordValues(payments, [
             {
-                'ref': 'INV/2017/01/0001',
+                'ref': 'INV/2017/00001',
                 'payment_method_id': self.inbound_payment_method.id,
             },
             {
-                'ref': 'INV/2017/01/0002',
+                'ref': 'INV/2017/00002',
                 'payment_method_id': self.inbound_payment_method.id,
             },
         ])

--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -97,7 +97,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 'line_ids': [
                     (0, 0, {
                         'date': '2020-01-01',
-                        'payment_ref': 'invoice %s-%s-%s' % tuple(invoice_number.split('/')[1:]),
+                        'payment_ref': 'invoice %s-%s' % tuple(invoice_number.split('/')[1:]),
                         'partner_id': cls.partner_1.id,
                         'amount': 100,
                         'sequence': 1,

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -169,10 +169,10 @@ class TestSequenceMixin(AccountTestInvoicingCommon):
         all_moves.action_post()
         self.assertEqual(entry.name, 'MISC/2016/01/0002')
         self.assertEqual(entry2.name, 'MISC/2016/01/0003')
-        self.assertEqual(invoice.name, 'INV/2016/01/0001')
-        self.assertEqual(invoice2.name, 'INV/2016/01/0002')
-        self.assertEqual(refund.name, 'RINV/2016/01/0001')
-        self.assertEqual(refund2.name, 'RINV/2016/01/0002')
+        self.assertEqual(invoice.name, 'INV/2016/00001')
+        self.assertEqual(invoice2.name, 'INV/2016/00002')
+        self.assertEqual(refund.name, 'RINV/2016/00001')
+        self.assertEqual(refund2.name, 'RINV/2016/00002')
 
     def test_journal_sequence_groupby_compute(self):
         """The grouping optimization is correctly done."""

--- a/addons/account_edi_facturx/tests/test_facturx.py
+++ b/addons/account_edi_facturx/tests/test_facturx.py
@@ -66,7 +66,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
                     </GuidelineSpecifiedDocumentContextParameter>
                 </ExchangedDocumentContext>
                 <ExchangedDocument>
-                    <ID>INV/2017/01/0001</ID>
+                    <ID>INV/2017/00001</ID>
                     <TypeCode>380</TypeCode>
                     <IssueDateTime>
                         <DateTimeString format="102">20170101</DateTimeString>
@@ -119,7 +119,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
                             <PostalTradeAddress/>
                         </BuyerTradeParty>
                         <BuyerOrderReferencedDocument>
-                            <IssuerAssignedID>INV/2017/01/0001: INV/2017/01/0001</IssuerAssignedID>
+                            <IssuerAssignedID>INV/2017/00001: INV/2017/00001</IssuerAssignedID>
                         </BuyerOrderReferencedDocument>
                     </ApplicableHeaderTradeAgreement>
                     <ApplicableHeaderTradeDelivery/>

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -73,7 +73,7 @@ class TestL10nBeEdi(AccountEdiTestCommon):
         cls.expected_invoice_efff_values = '''
             <Invoice>
                 <UBLVersionID>2.0</UBLVersionID>
-                <ID>INV/2017/01/0001</ID>
+                <ID>INV/2017/00001</ID>
                 <IssueDate>2017-01-01</IssueDate>
                 <InvoiceTypeCode>380</InvoiceTypeCode>
                 <DocumentCurrencyCode>Gol</DocumentCurrencyCode>
@@ -107,7 +107,7 @@ class TestL10nBeEdi(AccountEdiTestCommon):
                 </AccountingCustomerParty>
                 <PaymentMeans>
                     <PaymentMeansCode listID="UN/ECE 4461">31</PaymentMeansCode>
-                    <InstructionID>INV/2017/01/0001</InstructionID>
+                    <InstructionID>INV/2017/00001</InstructionID>
                     <PaymentDueDate>2017-01-01</PaymentDueDate>
                 </PaymentMeans>
                 <TaxTotal>


### PR DESCRIPTION
PURPOSE
Align default sequence numbering on customer's expectation per journal.
Because of some feedbacks received, we acknowledge that most users will
want an annual sequence on sales documents and a monthly sequence for
the rest.

SPECIFICATION
By default, on customer invoices/credit notes (the default sequence
should be annual.)
We don't want an option and therefore, we make a decision ; user can
change it by resequencing if he doesn't like it.

[task-2591145](https://www.odoo.com/web#cids=1&id=2591145&model=project.task)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
