### PR TITLE
[IMP] mail_plugin: redirect to documentation when mail plugin module …

### DIFF
--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -16,6 +16,13 @@ _logger = logging.getLogger(__name__)
 
 class MailPluginController(http.Controller):
 
+    @http.route('/mail_plugin/test_installation', type="json", auth="public", cors="*")
+    def test_installation(self):
+        """
+            Used by the plugin to determine if the mail_plugin module is installed
+        """
+        return {'status': 'success'}
+
     @http.route('/mail_client_extension/modules/get', type="json", auth="outlook", csrf=False, cors="*")
     def modules_get(self, **kwargs):
         """


### PR DESCRIPTION
…not found

Add a route allowing the plugin to test if the mail plugin module is installed,
if it's not the case, redirect the user to the documentation.

Purpose is to help users understand what went wrong and show them how they can
fix the issue.

PLUGIN-PR: https://github.com/nounoubensebia/mail-client-extensions/pull/5
Task-2577531

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
