### PR TITLE
[FIX] account: fix partner mapping with notes on reconcile models

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -9,6 +9,7 @@ from math import copysign
 import itertools
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
+import html2text
 
 class AccountReconcileModelPartnerMapping(models.Model):
     _name = 'account.reconcile.model.partner.mapping'
@@ -756,7 +757,7 @@ class AccountReconcileModel(models.Model):
 
         for partner_mapping in self.partner_mapping_line_ids:
             match_payment_ref = re.match(partner_mapping.payment_ref_regex, st_line.payment_ref) if partner_mapping.payment_ref_regex else True
-            match_narration = re.match(partner_mapping.narration_regex, st_line.narration or '') if partner_mapping.narration_regex else True
+            match_narration = re.match(partner_mapping.narration_regex, html2text.html2text(st_line.narration or '').rstrip()) if partner_mapping.narration_regex else True
 
             if match_payment_ref and match_narration:
                 return partner_mapping.partner_id


### PR DESCRIPTION
On reconcile models, a rule can be set to map a partner to a bstline if
the bstline "Notes" matches a regex. This "Notes" field is actually
the "narration" field inherited from move. In commit 0f3c7f153e8bd20f83b7d1df031634996d36935b
this field is converted from Text to Html. This breaks the regex match.
The fix converts back the field value to text for the regex check.

Task: 2427089