### PR TITLE
[FIX] web_editor: reintroduce request_editable event (2)

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1419,7 +1419,6 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
     _renderColorPalette: function () {
         const options = {
             selectedColor: this._value,
-            $editable: this.$target.closest('.o_editable'),
         };
         if (this.options.dataAttributes.excluded) {
             options.excluded = this.options.dataAttributes.excluded.replace(/ /g, '').split(',');

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -52,6 +52,8 @@ const ColorPaletteWidget = Widget.extend({
         this.selectedColor = '';
         this.resetButton = this.options.resetButton;
         this.withCombinations = this.options.withCombinations;
+
+        this.trigger_up('request_editable', {callback: val => this.options.$editable = val});
     },
     /**
      * @override


### PR DESCRIPTION
Forward-port of a commit that was wrongly forward-ported with [1], half
of the diff was lost because it landed in master before the merge of
another commit which removes what was being reintroduced here...

[1]: https://github.com/odoo/odoo/commit/e7f497b027d5931b1cf57febcab5deda573b45bb

X-original-commit: 68d7d42cce012269342e18373a30970e2c582ba3
