### PR TITLE
[FIX] base: log Selection.ondelete ORM bypass at runbot level

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1389,7 +1389,7 @@ class IrModelSelection(models.Model):
             except Exception as e:
                 # going through the ORM failed, probably because of an exception
                 # in an override or possibly a constraint.
-                _logger.warning(
+                _logger.runbot(
                     "Could not fulfill ondelete action for field %s.%s, "
                     "attempting ORM bypass...", records._name, fname,
                 )


### PR DESCRIPTION
This commit changes the warning log for Selection fields that states
that the hook could not go through the ORM for the deletion at uninstall
(because of some business error) and that it had to bypass the ORM (aka
pure sql delete) and turns it into a runbot-level log, meaning that it's
technically a warning but the runbot won't fail because of it.

This is done because for the install/uninstall tests it shows up as an
actual failure but it is not as it is non-blocking, and 99.9% of devs
won't ever see this warning on runbot since it triggers on module
uninstall anyway.