### PR TITLE
[FIX] project: remove default group by user

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -535,7 +535,6 @@ class Project(models.Model):
                     'active_id': self.id,
                     'search_default_open_tasks': True,
                     'search_default_Stage': True,
-                    'search_default_User': True
                 }),
             },
             'value': counts['open_tasks_count']

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -17,7 +17,8 @@
             <field name="arch" type="xml">
                 <graph string="Tasks Analysis" type="bar" sample="1" disable_linking="1">
                      <field name="project_id" type="row"/>
-                     <field name="user_id" type="col"/>
+                     <field name="stage_id" type="col"/>
+                     <field name="user_id" invisible="1"/>
                      <field name="nbr" type="measure"/>
                  </graph>
              </field>


### PR DESCRIPTION
This commit removes the default group by User for the Tasks Analysis
report, which was active once one clicked on "Open Tasks" in the Project
Update Kanban view.

Issue :
The graph view of report.project.task.user is not able to render the
project_id>user_id groupby since the number of rows to display is to
high.

After considering improvements client-side (e.g. drop last groupby
when there are too many datasets to render), we concluded that the case
of report.project.task.user is rather isolated. The real issue is that
this 'complex' two-level groupby is forced in the view itself, making
it unusable on larger databases (e.g. next.odoo.com).

On top of that, project_id and user_id are usually dependent dimensions
(users are usually working in the same few projects).

task-2588087

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
