### PR TITLE
[ADD] http: allow env variable to disable session_gc

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -54,6 +54,7 @@ from .sql_db import flush_env
 from .tools.func import lazy_property
 from .tools import ustr, consteq, frozendict, pycompat, unique, date_utils
 from .tools.mimetypes import guess_mimetype
+from .tools.misc import str2bool
 from .tools._vendor import sessions
 from .modules.module import module_manifest
 
@@ -1172,6 +1173,14 @@ def session_gc(session_store):
             except OSError:
                 pass
 
+ODOO_DISABLE_SESSION_GC = str2bool(os.environ.get('ODOO_DISABLE_SESSION_GC', '0'))
+
+if ODOO_DISABLE_SESSION_GC:
+    # empty function, in case another module would be
+    # calling it out of setup_session()
+    session_gc = lambda s: None
+
+
 #----------------------------------------------------------
 # WSGI Layer
 #----------------------------------------------------------
@@ -1273,6 +1282,8 @@ class Root(object):
         # Setup http sessions
         path = odoo.tools.config.session_dir
         _logger.debug('HTTP sessions stored in: %s', path)
+        if ODOO_DISABLE_SESSION_GC:
+            _logger.info('Default session GC disabled, manual GC required.')
         return sessions.FilesystemSessionStore(
             path, session_class=OpenERPSession, renew_missing=True)
 


### PR DESCRIPTION
Introduce the env variable ODOO_DISABLE_SESSION_GC to disable session_gc
on high-volume systems and avoid random slow calls as discussed in
https://github.com/odoo/odoo/pull/70063

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
