### PR TITLE
[FIX] payment_authorize: avoid method name ambiguity

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -138,7 +138,7 @@ class AuthorizeAPI:
         return self._format_response(response, 'deleteCustomerProfile')
 
     #=== Transaction management ===#
-    def _prepare_transaction_request(self, transaction_type, tx_data, amount, reference):
+    def _prepare_authorization_transaction_request(self, transaction_type, tx_data, amount, reference):
         return {
             'transactionRequest': {
                 'transactionType': transaction_type,
@@ -166,7 +166,7 @@ class AuthorizeAPI:
         tx_data = self._prepare_tx_data(token=token, opaque_data=opaque_data)
         response = self._make_request(
             'createTransactionRequest',
-            self._prepare_transaction_request('authOnlyTransaction', tx_data, amount, reference)
+            self._prepare_authorization_transaction_request('authOnlyTransaction', tx_data, amount, reference)
         )
         return self._format_response(response, 'auth_only')
 
@@ -187,7 +187,7 @@ class AuthorizeAPI:
         tx_data = self._prepare_tx_data(token=token, opaque_data=opaque_data)
         response = self._make_request(
             'createTransactionRequest',
-            self._prepare_transaction_request('authCaptureTransaction', tx_data, amount, reference)
+            self._prepare_authorization_transaction_request('authCaptureTransaction', tx_data, amount, reference)
         )
 
         result = self._format_response(response, 'auth_capture')


### PR DESCRIPTION
_prepare_transaction_request() introduced in
35a6c1867d8edc9b58c002a6ff6a63c35a0fc708 is only used for
'authOnlyTransaction' and 'authCaptureTransaction' transaction
types. capture(), void() and refund() still build their own request
parameters. Make this clearer by renaming _prepare_transaction_request()
to _prepare_authorization_transaction_request().