### PR TITLE
13.0 mass mailing fix campaign rights dht

### DIFF
--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -6,13 +6,13 @@
     <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
     <field name="arch" type="xml">
         <xpath expr="//div[@id='utm_statistics']" position="inside">
-            <div class="mr-3" title="Revenues">
+            <div class="mr-3" title="Revenues" groups="sales_team.group_sale_salesman">
                 <field name="currency_id" invisible="True"/>
                 <small class="font-weight-bold">
                     <field name="invoiced_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                 </small>
             </div>
-            <div class="mr-3" title="Quotations">
+            <div class="mr-3" title="Quotations" groups="sales_team.group_sale_salesman">
                 <i class="fa fa-money text-muted"></i>
                 <small class="font-weight-bold">
                     <field name="quotation_count"/>
@@ -29,11 +29,11 @@
     <field name="arch" type="xml">
         <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
             <button name="action_redirect_to_invoiced"
-                type="object" class="oe_stat_button order-1" icon="fa-usd">
+                type="object" class="oe_stat_button order-1" icon="fa-usd" groups="sales_team.group_sale_salesman">
                 <field name="invoiced_amount" widget="statinfo" string="Revenues"/>
             </button>
             <button name="action_redirect_to_quotations"
-                type="object" class="oe_stat_button order-2" icon="fa-money">
+                type="object" class="oe_stat_button order-2" icon="fa-money" groups="sales_team.group_sale_salesman">
                 <field name="quotation_count" widget="statinfo" string="Quotations"/>
             </button>
         </xpath>


### PR DESCRIPTION
PURPOSE
To hide revenue and quotations button if user has no right of it.

SPECIFICATION:
Current:
- In campaign any user can see revenue and quotations smart button and if tries to access it, it gives warning that "You don't have rights of sales and invoice".

To be:
- Revenue and quotations button should be visible to the user who have proper rights of it.

Task id: 241799






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
