### PR TITLE
[FIX] stock: fix inconsistency beteen product variant and product tem…

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -655,14 +655,14 @@ class ProductTemplate(models.Model):
 
     def _compute_quantities_dict(self):
         # TDE FIXME: why not using directly the function fields ?
-        variants_available = self.with_context(active_test=False).mapped('product_variant_ids')._product_available()
+        variants_available = self.mapped('product_variant_ids')._product_available()
         prod_available = {}
         for template in self:
             qty_available = 0
             virtual_available = 0
             incoming_qty = 0
             outgoing_qty = 0
-            for p in template.with_context(active_test=False).product_variant_ids:
+            for p in template.product_variant_ids:
                 qty_available += variants_available[p.id]["qty_available"]
                 virtual_available += variants_available[p.id]["virtual_available"]
                 incoming_qty += variants_available[p.id]["incoming_qty"]
@@ -770,7 +770,7 @@ class ProductTemplate(models.Model):
 
     # Be aware that the exact same function exists in product.product
     def action_open_quants(self):
-        return self.with_context(active_test=False).product_variant_ids.filtered(lambda p: p.active or p.qty_available != 0).action_open_quants()
+        return self.product_variant_ids.filtered(lambda p: p.active or p.qty_available != 0).action_open_quants()
 
     def action_update_quantity_on_hand(self):
         advanced_option_groups = [


### PR DESCRIPTION
…plate

Before commit:
   The issue is that the product is not in the 'available' filter but its
   kanban tile says 'on hand' quantity is available. A different issue is a raise because of this commit:
   https://github.com/odoo/odoo/commit/b08e3d114aa4efe687b4d4cca3de462a3dbe6eea. in this
   commit set the "active_test=False" for product template that's why it fetches all active and inactive
   warehouses and it becomes true for product variant as we don't get
   active_test=False. so condition becomes true and it will fetch only active warehouse and related
   location and result is displayed the different on_hand qty on variant and template.

After commit:
   we prevent the archive location quantity on the product template and its related quants to
   make a consistency between product template and product variant.

This issue was found while on upgrade issue: opw: M1712276115202.