### PR TITLE
[FIX] account: Fix 'amount_by_group' field of invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1407,48 +1407,59 @@ class AccountMove(models.Model):
 
     @api.depends('line_ids.price_subtotal', 'line_ids.tax_base_amount', 'line_ids.tax_line_id', 'partner_id', 'currency_id')
     def _compute_invoice_taxes_by_group(self):
-        ''' Helper to get the taxes grouped according their account.tax.group.
-        This method is only used when printing the invoice.
-        '''
         for move in self:
+
+            # Not working on something else than invoices.
+            if not move.is_invoice(include_receipts=True):
+                move.amount_by_group = []
+                continue
+
             lang_env = move.with_context(lang=move.partner_id.lang).env
-            tax_lines = move.line_ids.filtered(lambda line: line.tax_line_id)
-            tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
-            res = {}
-            # There are as many tax line as there are repartition lines
-            done_taxes = set()
-            for line in tax_lines:
-                res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                tax_key_add_base = tuple(move._get_tax_key_for_group_add_base(line))
-                if tax_key_add_base not in done_taxes:
-                    if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
-                        amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.today())
-                    else:
-                        amount = line.tax_base_amount
-                    res[line.tax_line_id.tax_group_id]['base'] += amount
-                    # The base should be added ONCE
-                    done_taxes.add(tax_key_add_base)
+            balance_multiplicator = -1 if move.is_inbound() else 1
 
-            # At this point we only want to keep the taxes with a zero amount since they do not
-            # generate a tax line.
-            zero_taxes = set()
-            for line in move.line_ids:
-                for tax in line.tax_ids.flatten_taxes_hierarchy():
-                    if tax.tax_group_id not in res or tax.id in zero_taxes:
-                        res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                        res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                        zero_taxes.add(tax.id)
+            tax_lines = move.line_ids.filtered('tax_line_id')
+            base_lines = move.line_ids.filtered('tax_ids')
 
-            res = sorted(res.items(), key=lambda l: l[0].sequence)
-            move.amount_by_group = [(
-                group.name, amounts['amount'],
-                amounts['base'],
-                formatLang(lang_env, amounts['amount'], currency_obj=move.currency_id),
-                formatLang(lang_env, amounts['base'], currency_obj=move.currency_id),
-                len(res),
-                group.id
-            ) for group, amounts in res]
+            tax_group_mapping = defaultdict(lambda: {
+                'base_lines': set(),
+                'base_amount': 0.0,
+                'tax_amount': 0.0,
+            })
+
+            # Compute base amounts.
+            for base_line in base_lines:
+                base_amount = balance_multiplicator * (base_line.amount_currency if base_line.currency_id else base_line.balance)
+
+                for tax in base_line.tax_ids.flatten_taxes_hierarchy():
+
+                    if base_line.tax_line_id.tax_group_id == tax.tax_group_id:
+                        continue
+
+                    tax_group_vals = tax_group_mapping[tax.tax_group_id]
+                    if base_line not in tax_group_vals['base_lines']:
+                        tax_group_vals['base_amount'] += base_amount
+                        tax_group_vals['base_lines'].add(base_line)
+
+            # Compute tax amounts.
+            for tax_line in tax_lines:
+                tax_amount = balance_multiplicator * (tax_line.amount_currency if tax_line.currency_id else tax_line.balance)
+                tax_group_vals = tax_group_mapping[tax_line.tax_line_id.tax_group_id]
+                tax_group_vals['tax_amount'] += tax_amount
+
+            tax_groups = sorted(tax_group_mapping.keys(), key=lambda x: x.sequence)
+            amount_by_group = []
+            for tax_group in tax_groups:
+                tax_group_vals = tax_group_mapping[tax_group]
+                amount_by_group.append((
+                    tax_group.name,
+                    tax_group_vals['tax_amount'],
+                    tax_group_vals['base_amount'],
+                    formatLang(lang_env, tax_group_vals['tax_amount'], currency_obj=move.currency_id),
+                    formatLang(lang_env, tax_group_vals['base_amount'], currency_obj=move.currency_id),
+                    len(tax_group_mapping),
+                    tax_group.id
+                ))
+            move.amount_by_group = amount_by_group
 
     @api.model
     def _get_tax_key_for_group_add_base(self, line):
@@ -1457,6 +1468,7 @@ class AccountMove(models.Model):
         must be consistent with _get_tax_grouping_key_from_tax_line
          @return list
         """
+        # DEPRECATED: TO BE REMOVED IN MASTER
         return [line.tax_line_id.id]
 
     @api.depends('date', 'line_ids.debit', 'line_ids.credit', 'line_ids.tax_line_id', 'line_ids.tax_ids', 'line_ids.tag_ids')

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_account_move_out_refund
 from . import test_account_move_in_invoice
 from . import test_account_move_in_refund
 from . import test_account_move_entry
+from . import test_invoice_tax_amount_by_group
 from . import test_account_journal
 from . import test_account_account
 from . import test_account_tax

--- a/addons/account/tests/test_invoice_tax_amount_by_group.py
+++ b/addons/account/tests/test_invoice_tax_amount_by_group.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestInvoiceTaxAmountByGroup(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.tax_group1 = cls.env['account.tax.group'].create({'name': '1'})
+        cls.tax_group2 = cls.env['account.tax.group'].create({'name': '2'})
+
+    def assertAmountByTaxGroup(self, invoice, expected_values):
+        current_values = [(x[6], x[2], x[1]) for x in invoice.amount_by_group]
+        self.assertEqual(current_values, expected_values)
+
+    def test_multiple_tax_lines(self):
+        tax_10 = self.env['account.tax'].create({
+            'name': "tax_10",
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'tax_group_id': self.tax_group1.id,
+        })
+        tax_20 = self.env['account.tax'].create({
+            'name': "tax_20",
+            'amount_type': 'percent',
+            'amount': 20.0,
+            'tax_group_id': self.tax_group2.id,
+        })
+
+        invoice = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, (tax_10 + tax_20).ids)],
+                }),
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, tax_10.ids)],
+                }),
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, tax_20.ids)],
+                }),
+            ]
+        })
+
+        self.assertAmountByTaxGroup(invoice, [
+            (self.tax_group1.id, 2000.0, 200.0),
+            (self.tax_group2.id, 2000.0, 400.0),
+        ])
+
+        # Same but both are sharing the same tax group.
+
+        tax_20.tax_group_id = self.tax_group1
+        invoice.invalidate_cache(['amount_by_group'])
+
+        self.assertAmountByTaxGroup(invoice, [
+            (self.tax_group1.id, 3000.0, 600.0),
+        ])
+
+    def test_zero_tax_lines(self):
+        tax_0 = self.env['account.tax'].create({
+            'name': "tax_0",
+            'amount_type': 'percent',
+            'amount': 0.0,
+        })
+
+        invoice = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, tax_0.ids)],
+                }),
+            ]
+        })
+
+        self.assertAmountByTaxGroup(invoice, [
+            (tax_0.tax_group_id.id, 1000.0, 0.0),
+        ])
+
+    def test_tax_affect_base_1(self):
+        tax_10 = self.env['account.tax'].create({
+            'name': "tax_10",
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'tax_group_id': self.tax_group1.id,
+            'price_include': True,
+            'include_base_amount': True,
+        })
+        tax_20 = self.env['account.tax'].create({
+            'name': "tax_20",
+            'amount_type': 'percent',
+            'amount': 20.0,
+            'tax_group_id': self.tax_group2.id,
+        })
+
+        invoice = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1100.0,
+                    'tax_ids': [(6, 0, (tax_10 + tax_20).ids)],
+                }),
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1100.0,
+                    'tax_ids': [(6, 0, tax_10.ids)],
+                }),
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, tax_20.ids)],
+                }),
+            ]
+        })
+
+        self.assertAmountByTaxGroup(invoice, [
+            (self.tax_group1.id, 2000.0, 200.0),
+            (self.tax_group2.id, 2100.0, 420.0),
+        ])
+
+        # Same but both are sharing the same tax group.
+
+        tax_20.tax_group_id = self.tax_group1
+        invoice.invalidate_cache(['amount_by_group'])
+
+        self.assertAmountByTaxGroup(invoice, [
+            (self.tax_group1.id, 3000.0, 620.0),
+        ])
+
+    def test_tax_affect_base_2(self):
+        tax_10 = self.env['account.tax'].create({
+            'name': "tax_10",
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'tax_group_id': self.tax_group1.id,
+            'include_base_amount': True,
+        })
+        tax_20 = self.env['account.tax'].create({
+            'name': "tax_20",
+            'amount_type': 'percent',
+            'amount': 20.0,
+            'tax_group_id': self.tax_group1.id,
+        })
+        tax_30 = self.env['account.tax'].create({
+            'name': "tax_30",
+            'amount_type': 'percent',
+            'amount': 30.0,
+            'tax_group_id': self.tax_group2.id,
+            'include_base_amount': True,
+        })
+
+        invoice = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, (tax_10 + tax_20).ids)],
+                }),
+                (0, 0, {
+                    'name': 'line',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'price_unit': 1000.0,
+                    'tax_ids': [(6, 0, (tax_30 + tax_10).ids)],
+                }),
+            ]
+        })
+
+        self.assertAmountByTaxGroup(invoice, [
+            (self.tax_group1.id, 2300.0, 450.0),
+            (self.tax_group2.id, 1000.0, 300.0),
+        ])
+
+        # Same but both are sharing the same tax group.
+
+        tax_30.tax_group_id = self.tax_group1
+        invoice.invalidate_cache(['amount_by_group'])
+
+        self.assertAmountByTaxGroup(invoice, [
+            (self.tax_group1.id, 2000.0, 750.0),
+        ])

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -47,6 +47,7 @@ class AccountMove(models.Model):
 
     @api.model
     def _get_tax_key_for_group_add_base(self, line):
+        # DEPRECATED: TO BE REMOVED IN MASTER
         tax_key = super(AccountMove, self)._get_tax_key_for_group_add_base(line)
 
         tax_key += [


### PR DESCRIPTION
When dealing with multiple taxes per line being on the same tax group, the base wasn't well computed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
