### PR TITLE
[FIX] mail_client_extension: not set parent_id if is_company

### DIFF
--- a/addons/mail_client_extension/controllers/main.py
+++ b/addons/mail_client_extension/controllers/main.py
@@ -233,7 +233,7 @@ class MailClientExtensionController(http.Controller):
             # if there is already a company for this partner, just take it without enrichment.
             if partner.parent_id:
                 response['partner']['company'] = self._get_company_dict(partner.parent_id)
-            else:
+            elif not partner.is_company:
                 company = self._find_existing_company(sender_domain)
                 if not company: # create and enrich company
                     company, enrichment_info = self._create_company_from_iap(sender_domain)


### PR DESCRIPTION
When using the Odoo Extension on Outlook, if the mail sender is already
a partner in the database, and if this partner is a company, it will
lead to an error on Outlook side

To reproduce the error:
(Need crm)
1. In Settings, enable "Outlook CRM Extension"
2. Set up an IAP account for service 'reveal'
3. On Outlook, let's have an email from X
4. On Odoo, create a partner P:
    - Partner is a Company
    - Email: X
5. On Outlook, open the Odoo Plugging

Error: An error message appears: "Something bad happened. Please, try
again later." and contact details are empty. There is a warning in Odoo
logs: "You cannot create recursive Partner hierarchies."

On extension loading, the module finds the partner P. Since the partner
hasn't any `parent_id`, the module then searches for a company linked to
the domain of X and finds P. It eventually tries to set the P's company
with P, this is the reason why an error is triggered.

When a partner hasn't any `parent_id`, the module should search for a
company only if the partner is not already a company.

OPW-2485223