### PR TITLE
[IMP] base_address_city: allow to search cities based on zip

### DIFF
--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class City(models.Model):
@@ -14,3 +14,18 @@ class City(models.Model):
     country_id = fields.Many2one('res.country', string='Country', required=True)
     state_id = fields.Many2one(
         'res.country.state', 'State', domain="[('country_id', '=', country_id)]")
+
+    def name_get(self):
+        res = []
+        for city in self:
+            name = city.name if not city.zipcode else '%s (%s)' % (city.name, city.zipcode)
+            res.append((city.id, name))
+        return res
+
+    @api.model
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        args = list(args or [])
+        # optimize out the default criterion of ``ilike ''`` that matches everything
+        if not (name == '' and operator == 'ilike'):
+            args += ['|', (self._rec_name, operator, name), ('zipcode', operator, name)]
+        return self._search(args, limit=limit, access_rights_uid=name_get_uid)


### PR DESCRIPTION
When having cities with similar name it may quickly be difficult to find the
right one. Adding zip code to name search helps finding it more easily.

IN order to match this new _name_search we update name_get accordingly and
display the zip code between parenthesis.

Task ID-2525738