### PR TITLE
[FIX] im_livechat: route /support loads correctly

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -94,7 +94,7 @@ Help your customers with this chat, and analyse their feedback.
             # Odoo JS Framework
             'web/static/lib/owl/owl.js',
             'web/static/src/legacy/js/promise_extension.js',
-            'web/static/src/js/boot.js',
+            'web/static/src/boot.js',
             'web/static/src/legacy/js/libs/download.js',
             'web/static/src/legacy/js/libs/content-disposition.js',
             'web/static/src/legacy/js/libs/pdfjs.js',


### PR DESCRIPTION
Before this commit, when arriving on the route /im_livechat/support/1, there was a crash
in the console becauase boot.js was not found.
This was because the file has been moved, and im_livechat has not been adapted

After this commit, the route /support correctly works

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
