### PR TITLE
[REF] mail: remove plus addressing on bounce alias

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -314,15 +314,9 @@ class MailMail(models.Model):
                 headers = {}
                 ICP = self.env['ir.config_parameter'].sudo()
                 bounce_alias = ICP.get_param("mail.bounce.alias")
-                bounce_alias_static = tools.str2bool(ICP.get_param("mail.bounce.alias.static", "False"))
                 catchall_domain = ICP.get_param("mail.catchall.domain")
                 if bounce_alias and catchall_domain:
-                    if bounce_alias_static:
-                        headers['Return-Path'] = '%s@%s' % (bounce_alias, catchall_domain)
-                    elif mail.mail_message_id.is_thread_message():
-                        headers['Return-Path'] = '%s+%d-%s-%d@%s' % (bounce_alias, mail.id, mail.model, mail.res_id, catchall_domain)
-                    else:
-                        headers['Return-Path'] = '%s+%d@%s' % (bounce_alias, mail.id, catchall_domain)
+                    headers['Return-Path'] = '%s@%s' % (bounce_alias, catchall_domain)
                 if mail.headers:
                     try:
                         headers.update(ast.literal_eval(mail.headers))

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -764,57 +764,11 @@ class TestMailgateway(TestMailCommon):
         with self.mock_mail_gateway():
             new_recs = self.format_and_process(
                 MAIL_TEMPLATE, self.partner_1.email_formatted,
-                '%s+%s-%s-%s@%s' % (
-                    self.alias_bounce, self.fake_email.id,
-                    self.fake_email.model, self.fake_email.res_id,
-                    self.alias_domain
-                ),
+                '%s@%s' % (self.alias_bounce, self.alias_domain),
                 subject='Should bounce',
             )
         self.assertFalse(new_recs)
         self.assertNotSentEmail()
-
-    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
-    def test_message_route_bounce_if_static_but_still_has_plus_addressing(self):
-        """Incoming email: bounce using bounce alias without plus addressing: keep old behavior."""
-        self.env['ir.config_parameter'].set_param('mail.bounce.alias.static', True)
-        with self.mock_mail_gateway():
-            new_recs = self.format_and_process(
-                MAIL_TEMPLATE, self.partner_1.email_formatted,
-                '%s+%s-%s-%s@%s' % (
-                    self.alias_bounce, self.fake_email.id,
-                    self.fake_email.model, self.fake_email.res_id,
-                    self.alias_domain
-                ),
-                subject='Should bounce',
-            )
-        self.assertFalse(new_recs)
-        self.assertEqual(len(self._mails), 0, 'message_process: incoming bounce produces no mails')
-
-    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
-    def test_message_route_bounce_if_static_without_plus_addressing(self):
-        """Incoming email: bounce using bounce alias without plus addressing: bounce it."""
-        self.env['ir.config_parameter'].set_param('mail.bounce.alias.static', True)
-        with self.mock_mail_gateway():
-            new_recs = self.format_and_process(
-                MAIL_TEMPLATE, self.partner_1.email_formatted,
-                '%s@%s' % (self.alias_bounce, self.alias_domain),
-                subject='Should bounce',
-            )
-        self.assertFalse(new_recs)
-        self.assertEqual(len(self._mails), 0, 'message_process: incoming bounce produces no mails')
-
-    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
-    def test_message_route_no_bounce_if_not_static_without_plus_addressing(self):
-        """Incoming email: bounce using bounce alias without plus addressing: raise as
-        considering as a direct write to bounce alias -> invalid """
-        self.env['ir.config_parameter'].set_param('mail.bounce.alias.static', False)
-        with self.assertRaises(ValueError):
-            self.format_and_process(
-                MAIL_TEMPLATE, self.partner_1.email_formatted,
-                '%s@%s' % (self.alias_bounce, self.alias_domain),
-                subject="Should fail because it is not a bounce and there's no alias",
-            )
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_route_bounce_other_recipients(self):
@@ -822,11 +776,9 @@ class TestMailgateway(TestMailCommon):
         with self.mock_mail_gateway():
             new_recs = self.format_and_process(
                 MAIL_TEMPLATE, self.partner_1.email_formatted,
-                '%s@%s, %s+%s-%s-%s@%s' % (
+                '%s@%s, %s@%s' % (
                     self.alias.alias_name, self.alias_domain,
-                    self.alias_bounce, self.fake_email.id,
-                    self.fake_email.model, self.fake_email.res_id,
-                    self.alias_domain
+                    self.alias_bounce, self.alias_domain
                 ),
                 subject='Should bounce',
             )
@@ -882,7 +834,7 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(self.test_record.message_bounce, 0)
 
         bounced_mail_id = 4442
-        bounce_email_to = '%s+%s-%s-%s@%s' % ('bounce.test', bounced_mail_id, self.test_record._name, self.test_record.id, 'test.com')
+        bounce_email_to = '%s@%s' % ('bounce.test', 'test.com')
         record = self.format_and_process(MAIL_TEMPLATE, self.partner_1.email_formatted, bounce_email_to, subject='Undelivered Mail Returned to Sender')
         self.assertFalse(record)
         # No information found in bounce email -> not possible to do anything except avoiding email
@@ -908,7 +860,7 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(self.test_record.message_bounce, 0)
 
         bounced_mail_id = 4442
-        bounce_email_to = '%s+%s-%s-%s@%s' % ('bounce.test', bounced_mail_id, self.test_record._name, self.test_record.id, 'test.com')
+        bounce_email_to = '%s@%s' % ('bounce.test', 'test.com')
         record = self.format_and_process(test_mail_data.MAIL_BOUNCE, self.partner_1.email_formatted, bounce_email_to, subject='Undelivered Mail Returned to Sender')
         self.assertFalse(record)
         # Missing in reply to message_id -> cannot find original record
@@ -922,7 +874,7 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(self.test_record.message_bounce, 0)
 
         bounced_mail_id = 4442
-        bounce_email_to = '%s+%s-%s-%s@%s' % ('bounce.test', bounced_mail_id, self.test_record._name, self.test_record.id, 'test.com')
+        bounce_email_to = '%s@%s' % ('bounce.test', 'test.com')
         extra = self.fake_email.message_id
         record = self.format_and_process(test_mail_data.MAIL_BOUNCE, self.partner_1.email_formatted, bounce_email_to, subject='Undelivered Mail Returned to Sender', extra=extra)
         self.assertFalse(record)
@@ -936,7 +888,7 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(self.test_record.message_bounce, 0)
 
         bounced_mail_id = 4442
-        bounce_email_to = '%s+%s-%s-%s@%s' % ('bounce.test', bounced_mail_id, self.test_record._name, self.test_record.id, 'test.com')
+        bounce_email_to = '%s@%s' % ('bounce.test', 'test.com')
         extra = self.fake_email.message_id
         record = self.format_and_process(test_mail_data.MAIL_BOUNCE, 'Whatever <what@ever.com>', bounce_email_to, subject='Undelivered Mail Returned to Sender', extra=extra)
         self.assertFalse(record)

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -45,24 +45,6 @@ class TestMailMail(TestMailCommon):
         mail = self.env['mail.mail'].create(base_values)
         with self.mock_mail_gateway():
             mail.send()
-        self.assertEqual(self._mails[0]['headers']['Return-Path'], '%s+%d@%s' % (self.alias_bounce, mail.id, self.alias_domain))
-
-        # mail on thread-enabled record
-        mail = self.env['mail.mail'].create(dict(base_values, **{
-            'model': self.test_record._name,
-            'res_id': self.test_record.id,
-        }))
-        with self.mock_mail_gateway():
-            mail.send()
-        self.assertEqual(self._mails[0]['headers']['Return-Path'], '%s+%d-%s-%s@%s' % (self.alias_bounce, mail.id, self.test_record._name, self.test_record.id, self.alias_domain))
-
-        # force static addressing on bounce alias
-        self.env['ir.config_parameter'].set_param('mail.bounce.alias.static', True)
-
-        # mail without thread-enabled record
-        mail = self.env['mail.mail'].create(base_values)
-        with self.mock_mail_gateway():
-            mail.send()
         self.assertEqual(self._mails[0]['headers']['Return-Path'], '%s@%s' % (self.alias_bounce, self.alias_domain))
 
         # mail on thread-enabled record


### PR DESCRIPTION
Starting from this commit bounce addresses set in emails will not use any
plus addressing. They will always be ``bounce_alias#@alias_domain`` and
not ``bounce_alias+<mail_id>-<mail_model>-<mail_res_id>@alias_domain``.

Reasons are

  * this plus addressing adds information we do not use anymore since a long
    time as bounced messages are found using their message ID and not any
    information coming from this bounce address;
  * this generates unnecessary noise;
  * not all email providers really support plus addressing as a mean to
    generate "fake" additional email addresses;

This is the followup of odoo/odoo#71244 where a solution to avoid plus
addressing was done in table. We can now safely remove this feature in
master as a cleaning step.

Task ID-2577328
