### PR TITLE
[FIX] sale_mrp: filter cancelled moves when computing dropship delivered qty

### DIFF
--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -41,7 +41,8 @@ class SaleOrderLine(models.Model):
                     # the products for this PO will set the qty_delivered. We might need to check the
                     # state of all PO as well... but sale_mrp doesn't depend on purchase.
                     if dropship:
-                        if order_line.move_ids and all([m.state == 'done' for m in order_line.move_ids]):
+                        moves = order_line.move_ids.filtered(lambda m: m.state != 'cancel')
+                        if moves and all([m.state == 'done' for m in moves]):
                             order_line.qty_delivered = order_line.product_uom_qty
                         else:
                             order_line.qty_delivered = 0.0


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Currently, the quantity delivered of a sales order line for a dropship product with a kit BoM will never be updated if there is any related move that has been cancelled, for example there are several pickings and one of them has been cancelled.

Current behavior before PR: The quantity delivered is not updated in the scenario described above.

Desired behavior after PR is merged: The quantity delivered is computed considering the stock moves that are not cancelled.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
