### PR TITLE
[IMP] website: rename website_type_preselection field

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -295,7 +295,7 @@
         <field name="name">News</field>
         <field name="description">Blogging and posting relevant content</field>
         <field name="sequence">6</field>
-        <field name="website_types_preselection">blog</field>
+        <field name="website_config_preselection">blog</field>
         <field name="module_id" ref="base.module_website_blog"/>
         <field name="icon">fa-rss</field>
     </record>
@@ -317,7 +317,7 @@
         <field name="name">Shop</field>
         <field name="description">Sell more with an eCommerce</field>
         <field name="sequence">9</field>
-        <field name="website_types_preselection">online_store</field>
+        <field name="website_config_preselection">online_store</field>
         <field name="module_id" ref="base.module_website_sale"/>
         <field name="icon">fa-shopping-cart</field>
     </record>
@@ -325,7 +325,7 @@
         <field name="name">Events</field>
         <field name="description">Publish on-site and online events</field>
         <field name="sequence">10</field>
-        <field name="website_types_preselection">event</field>
+        <field name="website_config_preselection">event</field>
         <field name="module_id" ref="base.module_website_event_sale"/>
         <field name="icon">fa-ticket</field>
     </record>
@@ -347,7 +347,7 @@
         <field name="name">eLearning</field>
         <field name="description">Share knowledge publicly or for a fee</field>
         <field name="sequence">13</field>
-        <field name="website_types_preselection">elearning</field>
+        <field name="website_config_preselection">elearning</field>
         <field name="module_id" ref="base.module_website_slides"/>
         <field name="icon">fa-graduation-cap</field>
     </record>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -301,7 +301,7 @@ class Website(models.Model):
             'description': feature.description,
             'type': feature.type,
             'icon': feature.icon,
-            'website_types_preselection': feature.website_types_preselection,
+            'website_config_preselection': feature.website_config_preselection,
             'module_state': feature.module_id.state,
         } for feature in configurator_features]
         r['logo'] = False

--- a/addons/website/models/website_configurator_feature.py
+++ b/addons/website/models/website_configurator_feature.py
@@ -16,7 +16,7 @@ class WebsiteConfiguratorFeature(models.Model):
     description = fields.Char(translate=True)
     icon = fields.Char()
     iap_page_code = fields.Char(help='Page code used to tell IAP website_service for which page a snippet list should be generated')
-    website_types_preselection = fields.Char(help='Comma-separated list of website type/purpose for which this feature should be pre-selected')
+    website_config_preselection = fields.Char(help='Comma-separated list of website type/purpose for which this feature should be pre-selected')
     type = fields.Selection([('page', "Page"), ('app', "App")], compute='_compute_type')
     page_view_id = fields.Many2one('ir.ui.view', ondelete='cascade')
     module_id = fields.Many2one('ir.module.module', ondelete='cascade')

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -357,14 +357,14 @@ const getters = {
 const actions = {
     selectWebsiteType({state}, id) {
         Object.values(state.features).filter((feature) => feature.module_state !== 'installed').forEach((feature) => {
-            feature.selected = feature.website_types_preselection.includes(WEBSITE_TYPES[id].name);
+            feature.selected = feature.website_config_preselection.includes(WEBSITE_TYPES[id].name);
         });
         state.selectedType = id;
     },
     selectWebsitePurpose({state}, id) {
         Object.values(state.features).filter((feature) => feature.module_state !== 'installed').forEach((feature) => {
             // need to check id, since we set to undefined in mount() to avoid the auto next screen on back button
-            feature.selected |= id && feature.website_types_preselection.includes(WEBSITE_PURPOSES[id].name);
+            feature.selected |= id && feature.website_config_preselection.includes(WEBSITE_PURPOSES[id].name);
         });
         state.selectedPurpose = id;
     },
@@ -458,8 +458,8 @@ async function getInitialState() {
     const features = {};
     results.features.forEach(feature => {
         features[feature.id] = Object.assign({}, feature, {selected: feature.module_state === 'installed'});
-        const wtp = features[feature.id].website_types_preselection;
-        features[feature.id].website_types_preselection = wtp ? wtp.split(',') : [];
+        const wtp = features[feature.id].website_config_preselection;
+        features[feature.id].website_config_preselection = wtp ? wtp.split(',') : [];
     });
 
     return Object.assign(r, {


### PR DESCRIPTION
Rename field website_type_preselection to website_config_preselection since feature
preselection is not only based on website type anymore but also on website purpose.

task-2518565

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
