### PR TITLE
[FIX] payment_payumoney: prevent clearing the session cookie

### DIFF
--- a/addons/payment_payumoney/controllers/main.py
+++ b/addons/payment_payumoney/controllers/main.py
@@ -12,9 +12,15 @@ _logger = logging.getLogger(__name__)
 
 
 class PayuMoneyController(http.Controller):
-    @http.route(['/payment/payumoney/return', '/payment/payumoney/cancel', '/payment/payumoney/error'], type='http', auth='public', csrf=False)
+    @http.route(['/payment/payumoney/return', '/payment/payumoney/cancel', '/payment/payumoney/error'], type='http', auth='public', csrf=False, save_session=False)
     def payu_return(self, **post):
-        """ PayUmoney."""
+        """ PayUmoney.
+        The session cookie created by Odoo has not the attribute SameSite. Most of browsers will force this attribute
+        with the value 'Lax'. After the payment, PayUMoney will perform a POST request on this route. For all these reasons,
+        the cookie won't be added to the request. As a result, if we want to save the session, the server will create
+        a new session cookie. Therefore, the previous session and all related information will be lost, so it will lead
+        to undesirable behaviors. This is the reason why `save_session=False` is needed.
+        """
         _logger.info(
             'PayUmoney: entering form_feedback with post data %s', pprint.pformat(post))
         if post:


### PR DESCRIPTION
See commit https://github.com/odoo/odoo/commit/f7800a059a1e8ed52cf7ddfa81ab5df6867b78da
for details about this fix

OPW-2368473