### PR TITLE
[FIX] web: load_state_tests: avoid undeterministic asserts

### DIFF
--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -972,6 +972,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         class MyAction extends Component {
             mounted() {
+                assert.step("myAction mounted");
                 browser.location.hash = "#action=__test__client__action__&menu_id=1";
             }
         }
@@ -981,8 +982,7 @@ QUnit.module("ActionManager", (hooks) => {
         browser.location.hash = "#action=myAction";
 
         const webClient = await createWebClient({ serverData });
-        assert.containsOnce(webClient, ".not-here");
-        assert.containsNone(webClient, ".test_client_action");
+        assert.verifySteps(["myAction mounted"]);
 
         await nextTick();
         assert.containsNone(webClient, ".not-here");
@@ -1001,6 +1001,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         class MyAction extends Component {
             mounted() {
+                assert.step("myAction mounted");
                 const newURL = baseURL + "#action=__test__client__action__&menu_id=1";
                 // immediate triggering
                 window.dispatchEvent(new HashChangeEvent("hashchange", { newURL }));
@@ -1011,9 +1012,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         browser.location.hash = "#action=myAction";
         const webClient = await createWebClient({ serverData });
-
-        assert.containsOnce(webClient, ".not-here");
-        assert.containsNone(webClient, ".test_client_action");
+        assert.verifySteps(["myAction mounted"]);
 
         await nextTick();
         assert.containsNone(webClient, ".not-here");


### PR DESCRIPTION
Before this commit, two tests had undeterministic outcomes:
they wanted to assert something in DOM was present at the same tiome as an owl rendering

After this commit, the problematic asserts are removed and the tests behave deterministically.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
