### PR TITLE
[FIX] core: fix `_get_default_calendar_view`

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1488,15 +1488,9 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         view = E.calendar(string=self._description)
         view.append(E.field(name=self._rec_name_fallback()))
 
-        if self._date_name not in self._fields:
-            date_found = False
-            for dt in ['date', 'date_start', 'x_date', 'x_date_start']:
-                if dt in self._fields:
-                    self._date_name = dt
-                    break
-            else:
-                raise UserError(_("Insufficient fields for Calendar View!"))
-        view.set('date_start', self._date_name)
+        if not set_first_of([self._date_name, 'date', 'date_start', 'x_date', 'x_date_start'],
+                            self._fields, 'date_start'):
+            raise UserError(_("Insufficient fields for Calendar View!"))
 
         set_first_of(["user_id", "partner_id", "x_user_id", "x_partner_id"],
                      self._fields, 'color')


### PR DESCRIPTION
Due to odoo/odoo#51075 it's an error to assign the `_date_name` field on
an empty recordset.

```
 Traceback (most recent call last):
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 1582, in _fields_view_get
    arch_etree = getattr(self, '_get_default_%s_view' % view_type)()
   File "/home/odoo/src/odoo/14.0/odoo/models.py", line 1495, in _get_default_calendar_view
    self._date_name = dt
 AttributeError: 'project.phase' object attribute '_date_name' is read-only
```

Issue observed on upgrade requests 2615 and 3121.

Co-authored-by: Christophe Simonis <chs@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
