### PR TITLE
[13.0][FIX] account: account move company in analytic entrie

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4205,7 +4205,7 @@ class AccountMoveLine(models.Model):
                 'move_id': move_line.id,
                 'user_id': move_line.move_id.invoice_user_id.id or self._uid,
                 'partner_id': move_line.partner_id.id,
-                'company_id': move_line.analytic_account_id.company_id.id or self.env.company.id,
+                'company_id': move_line.analytic_account_id.company_id.id or move_line.move_id.company_id.id,
             })
         return result
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When an invoice has a  line with a analytic account which has no company, the analytic entrie is saved with the company of the user and not the company of the invoice

Current behavior before PR:

1-Create a new invoice with a journal from a company different of the user actual logged company
2- add a line with a analytic account without company

Check that the analytic entrie is saved with the company logged and not with the invoice company

Desired behavior after PR is merged:

The analytic entries should be saved with the company of the journal (which is the company of the invoice)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
