### PR TITLE
[FIX] l10n_in: HSN report not have right quantity and UOM

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -35,6 +35,8 @@ class AccountMove(models.Model):
         res = super()._get_tax_grouping_key_from_tax_line(tax_line)
         if tax_line.move_id.journal_id.company_id.country_id.code == 'IN':
             res['product_id'] = tax_line.product_id.id
+            res['product_uom_id'] = tax_line.product_uom_id
+            res['quantity'] = tax_line.quantity
         return res
 
     @api.model
@@ -43,6 +45,9 @@ class AccountMove(models.Model):
         res = super()._get_tax_grouping_key_from_base_line(base_line, tax_vals)
         if base_line.move_id.journal_id.company_id.country_id.code == 'IN':
             res['product_id'] = base_line.product_id.id
+            res['product_uom_id'] = base_line.product_uom_id
+            res['quantity'] = base_line.quantity
+            res['id'] = base_line.id
         return res
 
     @api.model
@@ -51,5 +56,8 @@ class AccountMove(models.Model):
 
         tax_key += [
             line.product_id.id,
+            line.product_uom_id,
+            line.quantity,
+            line.id,
         ]
         return tax_key


### PR DESCRIPTION
This is already there before refactoring in saas-12.4
you can check here https://github.com/odoo/odoo/blob/saas-12.3/addons/l10n_in/models/account_invoice.py\#L73

opw-2563120
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
