### PR TITLE
[13.0][FIX] account: reconciliation analytic domain

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
@@ -542,6 +542,7 @@ var LineRenderer = Widget.extend(FieldManagerMixin, {
             relation: 'account.analytic.account',
             type: 'many2one',
             name: 'analytic_account_id',
+            domain: ["|", ['company_id', '=', state.st_line.company_id], ['company_id', '=', false]]
         }, {
             relation: 'account.analytic.tag',
             type: 'many2many',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes incorrect domain associated to analytic accounts presented during the bank reconciliation.

Current behavior before PR:
When you are doing a bank reconciliation and you want to write-off an amount you are given the option to choose an analytic account, but you can choose analytic accounts that belong to another company, not the one you are doing the bank reconciliation for.

![image](https://user-images.githubusercontent.com/7683926/124891110-f6b63b80-dfd8-11eb-9a35-0d6d7f6857f5.png)


Desired behavior after PR is merged:
The field 'Analytic Account' must only show the analytic accounts that have no company assigned, or the ones where the company matches with that of the bank statement.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
