### PR TITLE
[FIX] web_editor: remove loading effect during snippet drag and drop

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2046,7 +2046,6 @@ var SnippetsMenu = Widget.extend({
                         return;
                     }
 
-                    self._activateSnippet(false);
                     self._activateInsertionZones($selectorSiblings, $selectorChildren);
 
                     self.getEditableArea().find('.oe_drop_zone').droppable({


### PR DESCRIPTION
When starting a drag and drop of a snippet, a loading effect on the
editor panel was performed for the whole duration of the drag. Worse:
even if the drop was done immediately, the loading effect still occurred
for 400ms as it was only marked as finished after the scroll to the
dropped snippet.

The loading effect addition was in fact a side-effect of first disabling
all editor overlays at the start of the drag... but that action was in
fact entirely unnecessary because this is not possible to have any
overlay enabled when the snippet panel is opened (because opening it
already disables all editor overlays and enabling an overlay forces the
editor to switch out of the blocks panel).
