### PR TITLE
[ADD]project : demo data for burndown chart

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -76,6 +76,7 @@
             <field name="name">Meeting Room Furnitures</field>
             <field name="stage_id" ref="project_stage_0"/>
             <field name="color">3</field>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
         <record id="project_task_2" model="project.task">
             <field name="planned_hours" eval="32.0"/>
@@ -83,8 +84,46 @@
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Lunch Room: kitchen</field>
-            <field name="stage_id" ref="project_stage_1"/>
+            <field name="stage_id" ref="project_stage_2"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_2_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_2"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=2)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_2_mail_message_2" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_2"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=1)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_2_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_2_mail_message_1"/>
+        </record>
+        <record id="project_task_2_mail_message_2_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">In Prpgress</field>
+            <field name="new_value_char">Done</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">2</field>
+            <field name="new_value_integer">3</field>
+            <field name="mail_message_id" ref="project_task_2_mail_message_2"/>
+        </record>
+
         <record id="project_task_3" model="project.task">
             <field name="planned_hours" eval="10.0"/>
             <field name="user_id" ref="base.user_admin"/>
@@ -94,7 +133,45 @@
             <field name="date_deadline" eval="time.strftime('%Y-%m-24')"/>
             <field name="stage_id" ref="project_stage_2"/>
             <field name="color">4</field>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_3_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_3"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_3_mail_message_2" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_3"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_3_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_3_mail_message_1"/>
+        </record>
+        <record id="project_task_3_mail_message_2_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">In Progress</field>
+            <field name="new_value_char">Done</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">2</field>
+            <field name="new_value_integer">3</field>
+            <field name="mail_message_id" ref="project_task_3_mail_message_2"/>
+        </record>
+
         <record id="project_task_4" model="project.task">
             <field name="planned_hours" eval="60.0"/>
             <field name="user_id" ref="base.user_demo"/>
@@ -107,7 +184,27 @@
             <field name="stage_id" ref="project_stage_1"/>
             <field name="tag_ids" eval="[(6, 0, [
                     ref('project_tags_01')])]"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_4_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_4"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=1)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_4_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_4_mail_message_1"/>
+        </record>
+
         <record id="project_task_5" model="project.task">
             <field name="planned_hours" eval="76.0"/>
             <field name="user_id" ref="base.user_admin"/>
@@ -120,7 +217,27 @@
             <field name="stage_id" ref="project_stage_1"/>
             <field name="tag_ids" eval="[(6, 0, [
                     ref('project_tags_01')])]"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_5_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_5"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=2)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_5_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_5_mail_message_1"/>
+        </record>
+
         <record id="project_task_6" model="project.task">
             <field name="planned_hours" eval="24.0"/>
             <field name="user_id" ref="base.user_admin"/>
@@ -128,7 +245,27 @@
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Room 2: Decoration</field>
             <field name="stage_id" ref="project_stage_1"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_6_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_6"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=3)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_6_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_6_mail_message_1"/>
+        </record>
+
         <record id="project_task_7" model="project.task">
             <field name="planned_hours" eval="15.0"/>
             <field name="user_id" ref="base.user_admin"/>
@@ -136,7 +273,27 @@
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Energy Certificate</field>
             <field name="stage_id" ref="project_stage_1"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_7_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_7"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_7_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_7_mail_message_1"/>
+        </record>
+
         <record id="project_task_8" model="project.task">
             <field name="planned_hours" eval="22.0"/>
             <field name="user_id" ref="base.user_demo"/>
@@ -147,7 +304,45 @@
             <field name="stage_id" ref="project_stage_2"/>
             <field name="tag_ids" eval="[(6, 0, [
                     ref('project.project_tags_02')])]"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_8_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_8"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(days=3)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_8_mail_message_2" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_8"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(days=1)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_8_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_8_mail_message_1"/>
+        </record>
+        <record id="project_task_8_mail_message_2_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">In Progress</field>
+            <field name="new_value_char">Done</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">2</field>
+            <field name="new_value_integer">3</field>
+            <field name="mail_message_id" ref="project_task_8_mail_message_2"/>
+        </record>
+
         <record id="project_task_9" model="project.task">
             <field name="planned_hours" eval="18.0"/>
             <field name="user_id" ref="base.user_demo"/>
@@ -155,6 +350,7 @@
             <field name="project_id" ref="project.project_project_2"/>
             <field name="name">Document management</field>
             <field name="stage_id" ref="project_stage_0"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
         <record id="project_task_10" model="project.task">
             <field name="planned_hours" eval="38.0"/>
@@ -164,7 +360,27 @@
             <field name="name">Social network integration</field>
             <field name="kanban_state">blocked</field>
             <field name="stage_id" ref="project_stage_1"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_10_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_10"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4, days=5)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_10_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_10_mail_message_1"/>
+        </record>
+
         <record id="project_task_11" model="project.task">
             <field name="planned_hours" eval="16.0"/>
             <field name="user_id" ref="base.user_admin"/>
@@ -175,6 +391,25 @@
                     ref('project.project_tags_01'),
                     ref('project.project_tags_03')])]"/>
             <field name="stage_id" ref="project_stage_1"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+        </record>
+        <record id="project_task_11_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_11"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_11_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_11_mail_message_1"/>
         </record>
 
         <record id="project_task_12" model="project.task">
@@ -185,6 +420,7 @@
             <field name="name">Planning and budget</field>
             <field name="stage_id" ref="project_stage_0"/>
             <field name="color">6</field>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
 
         <record id="project_task_19" model="project.task">
@@ -195,6 +431,43 @@
             <field name="name">Basic outline</field>
             <field name="tag_ids" eval="[(6, 0, [
                     ref('project_tags_02')])]"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+        </record>
+        <record id="project_task_19_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_19"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_19_mail_message_2" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_19"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4, days=10)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_19_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_19_mail_message_1"/>
+        </record>
+        <record id="project_task_19_mail_message_2_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">In Progress</field>
+            <field name="new_value_char">Cancelled</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">2</field>
+            <field name="new_value_integer">4</field>
+            <field name="mail_message_id" ref="project_task_19_mail_message_2"/>
         </record>
 
         <record id="project_task_20" model="project.task">
@@ -203,6 +476,7 @@
             <field name="stage_id" ref="project_stage_0"/>
             <field name="project_id" ref="project.project_project_2"/>
             <field name="name">Create new components</field>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
 
         <record id="project_task_21" model="project.task">
@@ -213,6 +487,25 @@
             <field name="name">Useablity review</field>
             <field name="tag_ids" eval="[(6, 0, [
                     ref('project_tags_03')])]"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+        </record>
+        <record id="project_task_21_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_21"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=1)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_21_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_21_mail_message_1"/>
         </record>
 
         <record id="project_task_22" model="project.task">
@@ -223,7 +516,27 @@
             <field name="project_id" ref="project.project_project_2"/>
             <field name="name">Customer analysis + Architecture</field>
             <field name="color">7</field>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
+        <record id="project_task_22_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_22"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=2)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_22_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_22_mail_message_1"/>
+        </record>
+
         <record id="project_task_24" model="project.task">
             <field name="sequence">17</field>
             <field name="planned_hours">8.0</field>
@@ -234,6 +547,43 @@
             <field name="name">Modifications asked by the customer</field>
             <field name="tag_ids" eval="[(6, 0, [
                     ref('project_tags_00')])]"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+        </record>
+        <record id="project_task_24_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_24"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_24_mail_message_2" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_24"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=3)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_24_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_24_mail_message_1"/>
+        </record>
+        <record id="project_task_24_mail_message_2_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">In Progress</field>
+            <field name="new_value_char">Done</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">2</field>
+            <field name="new_value_integer">3</field>
+            <field name="mail_message_id" ref="project_task_24_mail_message_2"/>
         </record>
 
         <record id="project_task_25" model="project.task">
@@ -243,6 +593,7 @@
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Office planning</field>
             <field name="stage_id" ref="project_stage_0"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
 
         <record id="project_task_26" model="project.task">
@@ -251,7 +602,44 @@
             <field name="user_id" eval="False"/>
             <field name="project_id" ref="project.project_project_2"/>
             <field name="name">Unit Testing</field>
-            <field name="stage_id" ref="project_stage_0"/>
+            <field name="stage_id" ref="project_stage_2"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+        </record>
+        <record id="project_task_26_mail_message_1" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_26"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=4)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_26_mail_message_2" model="mail.message">
+            <field name="model">project.task</field>
+            <field name="res_id" ref="project.project_task_26"/>
+            <field name="message_type">notification</field>
+            <field name="subtype_id" ref="mt_task_stage"/>
+            <field name="date" eval="DateTime.now() - relativedelta(months=3)"/>
+            <field name="author_id" ref="base.partner_admin"/>
+        </record>
+        <record id="project_task_26_mail_message_1_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">New</field>
+            <field name="new_value_char">In Progress</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">1</field>
+            <field name="new_value_integer">2</field>
+            <field name="mail_message_id" ref="project_task_26_mail_message_1"/>
+        </record>
+        <record id="project_task_26_mail_message_2_track_1" model="mail.tracking.value">
+            <field name="field" model="ir.model.fields" eval="obj().search([('model', '=', 'project.task'), ('name', '=', 'stage_id')])"/>
+            <field name="field_desc">Stage</field>
+            <field name="old_value_char">In Progress</field>
+            <field name="new_value_char">Done</field>
+            <field name="field_type">many2one</field>
+            <field name="old_value_integer">2</field>
+            <field name="new_value_integer">3</field>
+            <field name="mail_message_id" ref="project_task_26_mail_message_2"/>
         </record>
 
         <record id="message_task_1" model="mail.message">

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -31,6 +31,7 @@
             <field name="name">Internal training</field>
             <field name="user_id" ref="base.user_admin"/>
             <field name="project_id" ref="project.project_project_1"/>
+            <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
 
         <!-- Products -->


### PR DESCRIPTION
Before this commit-
Burndown chart for a year was nearly blank due to lack of data of task.
After this commit-
In this commit, Demo data for the burndown chart is added in different spans of
time duration for a year.  So burndown chart is filled with the kindred project
app task's data.

Task - 2504119

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
