### PR TITLE
[FIX] pos_restaurant: fix kitchen ticket display with arabic

### DIFF
--- a/addons/pos_restaurant/static/src/css/restaurant.css
+++ b/addons/pos_restaurant/static/src/css/restaurant.css
@@ -576,3 +576,8 @@
     outline: none;
     border-bottom: solid 1px #555555;
 }
+
+.multiprint-flex {
+    display: flex;
+    justify-content: space-between;
+}

--- a/addons/pos_restaurant/static/src/xml/multiprint.xml
+++ b/addons/pos_restaurant/static/src/xml/multiprint.xml
@@ -29,9 +29,9 @@
                     <br />
                     <br />
                     <t t-foreach="changes.cancelled" t-as="change">
-                        <div>
+                        <div class="multiprint-flex">
                             <t t-esc="change.qty"/>
-                            <span t-esc="change.name_wrapped[0]" class="pos-receipt-right-align"/>
+                            <span t-esc="change.name_wrapped[0]"/>
                         </div>
                         <t t-call="NameWrapped"/>
                         <t t-if="change.note">
@@ -55,9 +55,9 @@
                 <br />
                 <br />
                 <t t-foreach="changes.new" t-as="change">
-                    <div>
+                    <div class="multiprint-flex">
                         <t t-esc="change.qty"/>
-                        <span t-esc="change.name_wrapped[0]" class="pos-receipt-right-align"/>
+                        <span t-esc="change.name_wrapped[0]"/>
                     </div>
                     <t t-call="NameWrapped"/>
                     <t t-if="change.note">


### PR DESCRIPTION
Printing a kitchen ticket with arabic product name lead to bad css layout.
The layout has been switched to make it no matter language is used.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
