### PR TITLE
[FIX] l10n_in_pos: remove deprecated method and set gst_treatment

### DIFF
--- a/addons/l10n_in_pos/models/pos_order.py
+++ b/addons/l10n_in_pos/models/pos_order.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 
 class PosOrder(models.Model):
     _inherit = 'pos.order'
-
+    #TODO: remove in master
     @api.model
     def _get_account_move_line_group_data_type_key(self, data_type, values, options={}):
         res = super(PosOrder, self)._get_account_move_line_group_data_type_key(data_type, values, options)
@@ -14,7 +14,7 @@ class PosOrder(models.Model):
             if self.env['account.tax'].browse(values['tax_line_id']).company_id.country_id.code == 'IN':
                 return res + (values['product_uom_id'], values['product_id'])
         return res
-
+    #TODO: remove in master
     def _prepare_account_move_line(self, line, partner_id, current_company, currency_id, rounding_method):
         res = super(PosOrder, self)._prepare_account_move_line(line, partner_id, current_company, currency_id, rounding_method)
         for line_values in res:
@@ -24,3 +24,15 @@ class PosOrder(models.Model):
                     'product_uom_id': line.product_id.uom_id.id
                     })
         return res
+
+    def _prepare_invoice_vals(self):
+        vals = super()._prepare_invoice_vals()
+        if self.session_id.company_id.country_id.code == 'IN':
+            partner = self.partner_id
+            l10n_in_gst_treatment = partner.l10n_in_gst_treatment
+            if not l10n_in_gst_treatment and partner.country_id and partner.country_id.code != 'IN':
+                l10n_in_gst_treatment = 'overseas'
+            if not l10n_in_gst_treatment:
+                l10n_in_gst_treatment = partner.vat and 'regular' or 'consumer'
+            vals['l10n_in_gst_treatment'] = l10n_in_gst_treatment
+        return vals


### PR DESCRIPTION
Before this commit:
===================
GST Treatment(l10n_in_gst_treatment) is not when create invoice from POS.

After this commit:
==================
GST Treatment(l10n_in_gst_treatment) is set when create invoice from POS.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
