### PR TITLE
[IMP] [website_]crm: clean merge post message

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -28,6 +28,7 @@
         'security/crm_security.xml',
         'security/ir.model.access.csv',
 
+        'data/crm_lead_merge_post_message_template.xml',
         'data/crm_lead_prediction_data.xml',
         'data/crm_lost_reason_data.xml',
         'data/crm_stage_data.xml',

--- a/addons/crm/data/crm_lead_merge_post_message_template.xml
+++ b/addons/crm/data/crm_lead_merge_post_message_template.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="merged_opportunities" name="merged_opportunities">
+        <div class="o_crm_merge_post_message">
+            <t t-foreach="opportunities" t-as="lead">
+                <div>Merged the Lead/Opportunity
+                    <span class="font-weight-bold">
+                        <t t-esc="lead.name"/>
+                    </span>
+                    into this one.
+                </div>
+                <details>
+                    <summary class="h4 mt-1">
+                        <span>
+                            <h6>Info Recap</h6>
+                        </span>
+                    </summary>
+                    <div class="o_crm_merge_content">
+                        <t t-if="lead.expected_revenue">
+                            <div>
+                                Expected Revenues:
+                                <t t-esc="lead.expected_revenue"
+                                   t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                            </div>
+                        </t>
+                        <t t-if="lead.probability">
+                            <div>
+                                Probability:<t t-esc="lead.probability"/>%
+                            </div>
+                        </t>
+                        <div>
+                            Type:
+                            <t t-esc="lead.type"/>
+                        </div>
+                        <t t-if="lead.type != 'lead'">
+                            <div>
+                                Stage:
+                                <t t-esc="lead.stage_id.name"/>
+                            </div>
+                        </t>
+                        <t t-if="lead.priority">
+                            <div>
+                                Priority:
+                                <t t-esc="lead.priority"/>
+                            </div>
+                        </t>
+                        <div>
+                            Created on:
+                            <t t-esc="lead.create_date" t-options='{"widget": "datetime"}'/>
+                        </div>
+                        <t t-if="lead.date_action_last">
+                            <div>
+                                Last Action:
+                                <t t-esc="lead.date_action_last" t-options='{"widget": "datetime"}'/>
+                            </div>
+                        </t>
+                        <t t-if="lead.description and not is_html_empty(lead.description)">
+                            <div>
+                                Notes:
+                                <t t-esc="lead.description"/>
+                            </div>
+                        </t>
+                        <t t-if="lead.user_id">
+                            <div class="mt-3">
+                                Salesperson:
+                                <t t-esc="lead.user_id.name"/>
+                            </div>
+                        </t>
+                        <t t-if="lead.team_id">
+                            <div>
+                                Sales Team:
+                                <t t-esc="lead.team_id.name"/>
+                            </div>
+                        </t>
+                        <div>
+                            Company:
+                            <t t-esc="lead.company_id.name"/>
+                        </div>
+                        <br/>
+                        <t t-if="lead.partner_id">
+                            <div>
+                                Assigned Partner:
+                                <t t-esc="lead.partner_id.display_name"/>
+                            </div>
+                        </t>
+                        <t t-if="lead.date_open">
+                            <div>
+                                Partner Assignment Date:
+                                <t t-esc="lead.date_open"/>
+                            </div>
+                        </t>
+                        <div>
+                            <div class="mt-3"
+                                 t-if="lead.contact_name or lead.partner_name or lead.phone or lead.mobile or lead.email_from or lead.website">
+                                <div class="font-weight-bold">
+                                    Contact Details:
+                                </div>
+                                <t t-if="lead.contact_name">
+                                    <div>
+                                        Contact:
+                                        <t t-esc="lead.contact_name"/>
+                                    </div>
+                                </t>
+                                <t t-if="lead.partner_name">
+                                    <div>
+                                        Company Name:
+                                        <t t-esc="lead.partner_name"/>
+                                    </div>
+                                </t>
+                                <t t-if="lead.phone">
+                                    <div>
+                                        Phone:
+                                        <t t-esc="lead.phone"/>
+                                    </div>
+                                </t>
+                                <t t-if="lead.mobile">
+                                    <div>
+                                        Mobile:
+                                        <t t-esc="lead.mobile"/>
+                                    </div>
+                                </t>
+                                <t t-if="lead.email_from">
+                                    <div>
+                                        Email:
+                                        <t t-esc="lead.email_from"/>
+                                    </div>
+                                </t>
+                                <t t-if="lead.email_cc">
+                                    <div>
+                                        Email cc:
+                                        <t t-esc="lead.email_cc"/>
+                                    </div>
+                                </t>
+                                <t t-if="lead.website">
+                                    <div>
+                                        Website:
+                                        <t t-esc="lead.website"/>
+                                    </div>
+                                </t>
+                            </div>
+                        </div>
+                        <div class="mt-3"
+                             t-if="lead.street or lead.street2 or lead.zip or lead.city or lead.state_id or lead.country_id">
+                            <div class="font-weight-bold">
+                                Address:
+                            </div>
+                            <t t-if="lead.street">
+                                <div>
+                                    <t t-esc="lead.street"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.street2">
+                                <div>
+                                    <t t-esc="lead.street2"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.zip">
+                                <div>
+                                    <t t-esc="lead.zip"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.city">
+                                <div>
+                                    <t t-esc="lead.city"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.state_id">
+                                <div>
+                                    <t t-esc="lead.state_id.display_name"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.country_id">
+                                <div>
+                                    <t t-esc="lead.country_id.display_name"/>
+                                </div>
+                            </t>
+                        </div>
+                        <div class="mt-3 mb-3" name="marketing"
+                             t-if="lead.campaign_id or lead.medium_id or lead.source_id">
+                            <div class="font-weight-bold">
+                                Marketing:
+                            </div>
+                            <t t-if="lead.campaign_id">
+                                <div>
+                                    Campaign:
+                                    <t t-esc="lead.campaign_id.name"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.medium_id">
+                                <div>
+                                    Medium:
+                                    <t t-esc="lead.medium_id.name"/>
+                                </div>
+                            </t>
+                            <t t-if="lead.source_id">
+                                <div>
+                                    Source:
+                                    <t t-esc="lead.source_id.name"/>
+                                </div>
+                            </t>
+                        </div>
+                    </div>
+                </details>
+            </t>
+        </div>
+    </template>
+</odoo>

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -31,3 +31,44 @@
         }
     }
 }
+
+
+.o_crm_merge_post_message {
+
+    .o_crm_merge_content {
+        border-left: solid 0.5px black;
+        padding-left: 1em;
+    }
+
+    summary {
+        font-size: 1em;
+    }
+
+    details > summary {
+        list-style: none;
+    }
+
+    details {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+    }
+
+    // remove old caret
+    summary::-webkit-details-marker {
+        display: none
+    }
+
+    // put a new caret after the label
+    summary {
+        h6::after {
+            content: ' ►';
+        }
+    }
+
+    details[open] summary {
+        h6:after {
+            content: " ▼";
+        }
+    }
+
+}

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -286,5 +286,4 @@ class TestLeadMerge(TestLeadMergeCommon):
         self.assertEqual(calendar_event.res_id, master_lead.id)
         self.assertTrue(all(att.res_id == master_lead.id for att in attachments))
         # 2many accessors updated
-        self.assertEqual(master_lead.activity_ids, activity)
         self.assertEqual(master_lead.calendar_event_ids, calendar_event)

--- a/addons/website_crm/__manifest__.py
+++ b/addons/website_crm/__manifest__.py
@@ -15,6 +15,7 @@ This module includes contact phone and mobile numbers validation.""",
     'data': [
         'security/ir.model.access.csv',
         'data/website_crm_data.xml',
+        'data/website_crm_lead_merge_post_message_template.xml',
         'views/website_crm_lead_views.xml',
         'views/website_crm_templates.xml',
         'views/res_config_settings_views.xml',

--- a/addons/website_crm/data/website_crm_lead_merge_post_message_template.xml
+++ b/addons/website_crm/data/website_crm_lead_merge_post_message_template.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="merged_opportunities" inherit_id="crm.merged_opportunities">
+
+        <xpath expr="//div[@name='marketing']" position="attributes">
+            <attribute name="t-if">lead.campaign_id or lead.medium_id or lead.source_id or lead.visitor_ids</attribute>
+        </xpath>
+
+        <xpath expr="//div[@name='marketing']" position="inside">
+            <t t-if="lead.visitor_ids">
+                <div>
+                    Web Visitors:
+                    <t t-esc="', '.join(lead.visitor_ids.mapped('name'))"/>
+                </div>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Use a template for merge post messages and clean how fields are displayed,
notably by fixing the display format, and the field order.

Purpose is to improve the clarity of merge post messages so that users can more
easily get the most important information about a merged lead.

Task-2451164
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
