### PR TITLE
[IMP] mail: Rename template menu item

### DIFF
--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -124,7 +124,7 @@
         </record>
 
         <record model="ir.actions.act_window" id="action_email_template_tree_all">
-            <field name="name">Templates</field>
+            <field name="name">Email Templates</field>
             <field name="res_model">mail.template</field>
             <field name="view_mode">form,tree</field>
             <field name="view_id" ref="email_template_tree" />


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Rename the menu item 'Template' from the settings to 'Email template' .

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
