### PR TITLE
[FIX] stock: impossible to set procurement group on order point

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -51,6 +51,7 @@
                 <field name="json_lead_days_popover" optional="show" nolabel="1" string="Forecast Description" width="10px" widget="popover_widget" attrs="{'invisible': [('id', '=', False)]}"/>
                 <field name="route_id" options="{'no_create': True, 'no_open': True}"/>
                 <field name="trigger" optional="hide"/>
+                <field name="group_id" optional="hide" groups="stock.group_adv_location"/>
                 <field name="product_min_qty" optional="show"/>
                 <field name="product_max_qty" optional="show"/>
                 <field name="qty_multiple" optional="hide"/>
@@ -80,6 +81,7 @@
                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                 <field name="route_id" optional="hide"/>
                 <field name="trigger" optional="hide"/>
+                <field name="group_id" optional="hide" groups="stock.group_adv_location"/>
                 <field name="product_min_qty" optional="show"/>
                 <field name="product_max_qty" optional="show"/>
                 <field name="qty_multiple" optional="show"/>
@@ -99,6 +101,7 @@
                 <field name="product_id"/>
                 <field name="trigger"/>
                 <field name="product_category_id"/>
+                <field name="group_id" groups="stock.group_adv_location"/>
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
                 <filter string="To Reorder" name="filter_to_reorder" domain="[('qty_to_order', '&gt;', 0.0)]"/>
@@ -123,6 +126,7 @@
                 <field name="name" string="Reordering Rule"/>
                 <field name="product_id"/>
                 <field name="trigger"/>
+                <field name="group_id" groups="stock.group_adv_location"/>
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The field `group_id` is not present in the view.

@simongoffin 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
