### PR TITLE
[FIX] stock: picking is merge if transit in other addresse

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -962,18 +962,24 @@ class StockMove(models.Model):
 
     def _key_assign_picking(self):
         self.ensure_one()
-        return self.group_id, self.location_id, self.location_dest_id, self.picking_type_id
+        keys = (self.group_id, self.location_id, self.location_dest_id, self.picking_type_id)
+        if self.partner_id and (self.location_id.usage == 'transit' or self.location_dest_id.usage == 'transit'):
+            keys += (self.partner_id, )
+        return keys
 
     def _search_picking_for_assignation(self):
         self.ensure_one()
-        picking = self.env['stock.picking'].search([
-                ('group_id', '=', self.group_id.id),
-                ('location_id', '=', self.location_id.id),
-                ('location_dest_id', '=', self.location_dest_id.id),
-                ('picking_type_id', '=', self.picking_type_id.id),
-                ('printed', '=', False),
-                ('immediate_transfer', '=', False),
-                ('state', 'in', ['draft', 'confirmed', 'waiting', 'partially_available', 'assigned'])], limit=1)
+        domain = [
+            ('group_id', '=', self.group_id.id),
+            ('location_id', '=', self.location_id.id),
+            ('location_dest_id', '=', self.location_dest_id.id),
+            ('picking_type_id', '=', self.picking_type_id.id),
+            ('printed', '=', False),
+            ('immediate_transfer', '=', False),
+            ('state', 'in', ['draft', 'confirmed', 'waiting', 'partially_available', 'assigned'])]
+        if self.partner_id and (self.location_id.usage == 'transit' or self.location_dest_id.usage == 'transit'):
+            domain += [('partner_id', '=', self.partner_id.id)]
+        picking = self.env['stock.picking'].search(domain, limit=1)
         return picking
 
     def _assign_picking(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- create Tree warehouses, WH1, WH2, WH3, with three different address
- add route 2-1 to resupply WH2 from WH1, complete partner_address_id on rule with partner_id of WH2
- add route 3-1 to resupply WH3 from WH1, complete partner_address_id on rule with partner_id of WH3
- create a product
- add orderpoint, WH2/Stock with route 2-1 and min_quantity to 1
- add orderpoint, WH3/Stock with route 3-1 and min_quantity to 1

Lauch scheduler.
Issue:
You have 1 out picking of WH1, with qty = 2. It doesn't make sens because WH2 and WH3 have not the same address.

With this PR, 2 out picking are created.

@amoyaux




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
