### PR TITLE
[FIX] mrp: fix backorder name generation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1380,8 +1380,9 @@ class MrpProduction(models.Model):
         if not sequence:
             return name
         seq_back = "-" + "0" * (SIZE_BACK_ORDER_NUMERING - 1 - int(math.log10(sequence))) + str(sequence)
-        if re.search("-\\d{%d}$" % SIZE_BACK_ORDER_NUMERING, name):
-            return name[:-SIZE_BACK_ORDER_NUMERING-1] + seq_back
+        regex = re.compile(r"-\d+$")
+        if regex.search(name):
+            return regex.sub(seq_back, name)
         return name + seq_back
 
     def _get_backorder_mo_vals(self):


### PR DESCRIPTION
backorder name is generated in `_get_name_backorder`, which tries to change last
numbers first or adds new number to the end. The problem comes when we need to
generate more than 1000 backorders (e.g. on using mrp_subcontracting with
products tracked by serial): in that case the name would be

> WH/XXX/00001-1000-1001-1002-1003-1004-1005-1006-1007-1008-1009-...

Which is not user friendly and may lead to postgres constrain errors:

> psycopg2.errors.ProgramLimitExceeded: index row size 2712 exceeds btree version 4 maximum 2704 for index "mrp_production_name_uniq"

To fix that we increase SIZE_BACK_ORDER_NUMERING, so the name will be good up to
1_000_000 backorders

STEPS:
Create a few test products (4 or 5) with route Buy + Resupplier subcontractor
from order.
Then make product which:
- has BoM and BoM type = subcontracting with components test 2, test 3, test 4, ...
- has costing method = FIFO , inventory valuation = automated, Tracking = unique SN
Now Create a receipt transfer of 4000 units. Click "Validate" and use "Create backorder" option.

---

opw-2579461

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
