### PR TITLE
[FIX] web: webclient: remove bootstrap tooltips more accurately

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -11,7 +11,7 @@ import { useService } from "../core/service_hook";
 import { ViewNotFoundError } from "../webclient/actions/action_service";
 import { cleanDomFromBootstrap, wrapSuccessOrFail, mapDoActionOptionAPI } from "./utils";
 
-const { Component, tags } = owl;
+const { Component, tags, hooks } = owl;
 
 const warningDialogBodyTemplate = tags.xml`<t t-esc="props.message"/>`;
 
@@ -58,6 +58,9 @@ class ActionAdapter extends ComponentAdapter {
             },
             () => []
         );
+        hooks.useExternalListener(window, "click", () => {
+            cleanDomFromBootstrap();
+        });
     }
 
     get actionId() {

--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -40,9 +40,6 @@ ActionDialog.props = {
  * The "ActionDialog" class should get exported from this file when the cleaning will occur.
  */
 class LegacyAdaptedActionDialog extends ActionDialog {
-    constructor(...args) {
-        super(...args);
-    }
     setup() {
         super.setup();
         const actionProps = this.props && this.props.actionProps;

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -561,6 +561,7 @@ function makeActionManager(env) {
                         }
                         dialog = {};
                     }
+                    cleanDomFromBootstrap();
                 },
             });
             nextDialog = {
@@ -920,7 +921,6 @@ function makeActionManager(env) {
     }
 
     async function _executeCloseAction(params = {}) {
-        cleanDomFromBootstrap();
         let onClose;
         const removeDialog = dialog.remove;
         if (removeDialog) {
@@ -1101,12 +1101,7 @@ function makeActionManager(env) {
         }
         // END LEGACY CODE COMPATIBILITY
 
-        newController.props = _getViewProps(
-            view,
-            controller.action,
-            controller.views,
-            props
-        );
+        newController.props = _getViewProps(view, controller.action, controller.views, props);
         controller.action.controllers[viewType] = newController;
         let index;
         if (view.multiRecord) {


### PR DESCRIPTION
Before this commit, when hovering a button with a bootstrap tooltip set on it
(form view with header button in debug mode) and then clicking while staying hover
the tooltip was not destroyed and there was no easy means to destroy it.

After this commit, any click within a legacy context remove any bootstrap tooltip from the DOM,
since popper and tooltip are not meant to be used in the future in a wowl setting.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
