### PR TITLE
[FIX] point_of_sale : name of user is hide

### DIFF
--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -122,7 +122,7 @@
                                     </div>
                                 </div>
                                 <div style="text-align:right;">
-                                    <field name="current_user_id" widget="many2one_avatar_user"/>
+                                    <field name="current_user_id" widget="many2one_avatar"/>
                                 </div>
                             </div><div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">
                                 <div class="row">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In V12 you can see the full name of user have started a session. In V14 you see only the avatar. If all users have the same avatar image you don't how have open the session.

V12:
![image](https://user-images.githubusercontent.com/16716992/124962917-78c95300-e01f-11eb-9602-88d2e1498371.png)


Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/124962991-90084080-e01f-11eb-9d87-ff8984ccdeda.png)


Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/16716992/124963324-f3926e00-e01f-11eb-991c-14ea79dbf12d.png)

@pimodoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
