### PR TITLE
[FIX] purchase_stock: _prepare_stock_moves for Subcontract return moves

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -421,6 +421,11 @@ class PurchaseOrderLine(models.Model):
         move_dests = self.move_dest_ids
         if not move_dests:
             move_dests = self.move_ids.move_dest_ids.filtered(lambda m: m.state != 'cancel' and not m.location_dest_id.usage == 'supplier')
+            # Avoid considering direct self.move_ids as move_dests :
+            # 1) They are already taken into account by _get_outgoing_incoming_moves()
+            # 2) In case of subcontract PO, the stock.move returned to the subcontractor
+            # are in `self.move_ids` but are "location_dest_id.usage == 'internal'"
+            move_dests -= self.move_ids
 
         if not move_dests:
             qty_to_attach = 0


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

The method [_prepare_stock_moves()](https://github.com/odoo/odoo/blob/14.0/addons/purchase_stock/models/purchase.py#L404) in purchase_stock is here to calculate the new stock.moves to create from a change in PO line's quantity based on its new value and the existing stock.moves, including those actually receiving some products (`incoming_moves`), those returning products to the supplier (`outgoing_moves`) and the "descendants moves" (`move_dests`), which will need at least some quantities to be realized.

The main issue with the actual code is that the moves "returning products to the supplier" are identified by `m.location_dest_id.usage == 'supplier'`... which does not work for returning moves in case of a Purchase Order for a subcontracted product (`m.location_dest_id.usage` will be `internal` for these returning moves in order to manage correctly stock valuation for subcontracted product).

With few lines of code it is possible to override [_get_outgoing_incoming_moves()](https://github.com/odoo/odoo/blob/14.0/addons/purchase_stock/models/purchase.py#L536) in order to add the "returning subcontract moves" to the `outgoing_moves` properly. However these "returning subcontract moves" are still present in both `self.move_ids` (because they are directly related to the PO line) and `self.move_ids.move_dest_ids` (because they are themselves "descendant moves" of the "original reception moves").
As they still have `location_dest_id.usage == 'internal'` and not `supplier`, they will be wrongly caught in `move_dests`.

That's why this PR aims to remove these `self.move_ids` from `move_dests`.
Because the moves directly linked to the PO line are already taken into account by [_get_outgoing_incoming_moves()](https://github.com/odoo/odoo/blob/14.0/addons/purchase_stock/models/purchase.py#L536) and they can lead to errors in case of a return Subcontract move.

# Current behavior before PR:

1. Buy 1 subcontracted product to a subcontractor (`quantity = 1`)
2. Receive this product
3. Return this product
4. Change PO product line to `quantity = 2` instead of 1

Current behavior : The new stock.picking will have a stock.move with product_uom_qty = 1 instead of 2

# Desired behavior after PR is merged:

If this PR is mixed with a proper override of [_get_outgoing_incoming_moves()](https://github.com/odoo/odoo/blob/14.0/addons/purchase_stock/models/purchase.py#L536), the new stock.picking created will have the expected product_uom_qty = 2



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
