### PR TITLE
[FIX] payment: Invoice is not linked to tx when using payment link

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -317,6 +317,7 @@ class WebsitePayment(http.Controller):
     def payment_token(self, pm_id, reference, amount, currency_id, partner_id=False, return_url=None, **kwargs):
         token = request.env['payment.token'].browse(int(pm_id))
         order_id = kwargs.get('order_id')
+        invoice_id = kwargs.get('invoice_id')
 
         if not token:
             return request.redirect('/website_payment/pay?error_msg=%s' % _('Cannot setup the payment.'))
@@ -334,6 +335,8 @@ class WebsitePayment(http.Controller):
 
         if order_id:
             values['sale_order_ids'] = [(6, 0, [int(order_id)])]
+        if invoice_id:
+            values['invoice_ids'] = [(6, 0, [int(invoice_id)])]
 
         tx = request.env['payment.transaction'].sudo().with_context(lang=None).create(values)
         PaymentProcessing.add_payment_transaction(tx)


### PR DESCRIPTION
To replicate:
- Enable a payment acquirer that uses a token
- Create an invoice, fill payment reference and confirm it
- Generate a payment link, using the action available at the invoice
- Use the generated link and pay the invoice

Before this commit, even though the transaction is processed, its not
associated to the invoice being paid. This also causes the invoice to
remain as not paid.

After this commit, the transaction is associated to the invoice and
it's paid.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
