### PR TITLE
[FIX] account: Fix clearing of the accounting date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1093,7 +1093,7 @@ class AccountMove(models.Model):
 
         # Group the moves by journal and month
         for move in self:
-            if not highest_name and move == self[0] and not move.posted_before:
+            if not highest_name and move == self[0] and not move.posted_before and move.date:
                 # In the form view, we need to compute a default sequence so that the user can edit
                 # it. We only check the first move as an approximation (enough for new in form view)
                 pass


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Accounting > Vendors > Bills
- Create a new Bills
- Delete the contents of the 'Accounting Date' field.
- Click off that field.

Problem:
-An AttributeError is triggered because we try to recalculate a new name via the function `"_compute_name"`
and we base ourselves on the date field, but we do not check if it is null or not before accessing it.

This field is only used for purchase receipts, vendor bills, vendor credit notes, payments
and regular journal entries. Other move types are unaffected here.

opw-2511799

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
