### PR TITLE
[FIX] mail: dropzone deactivate for text and user's avatar

### DIFF
--- a/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
+++ b/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
@@ -59,7 +59,11 @@ function useDragVisibleDropZone() {
      * @param {DragEvent} ev
      */
     function _onDragenterListener(ev) {
-        if (dragCount === 0) {
+        if (
+            dragCount === 0 &&
+            ev.dataTransfer &&
+            ev.dataTransfer.types.includes('Files')
+        ) {
             isVisible.value = true;
         }
         dragCount++;


### PR DESCRIPTION
**Current behavior before PR:**

Currently, in Discuss, the chat activates the drop zone when try to drag and
drop any user's avatar (or any text). The same thing happens if we do it in
the chat window or chatter.

**Desired behavior after PR is merged:**

The chat will not be activated drop zone if the drag is not actually
a file/a document.

Task-2590510




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
