### PR TITLE
[FIX] web_editor: prevent edition of links in non editable areas

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.js
+++ b/addons/web_editor/static/src/js/editor/rte.js
@@ -675,7 +675,7 @@ var RTEWidget = Widget.extend({
             $editable.find('[_moz_abspos]').removeAttr('_moz_abspos');
         });
 
-        if (isLink) {
+        if (isLink && !$target.closest('.o_not_editable').length) {
             /**
              * Remove content editable everywhere and add it on the link only so that characters can be added
              * and removed at the start and at the end of it.


### PR DESCRIPTION
There is a system which marks all editable areas as non editable when
a link is clicked so that the only editable element in the page becomes
this link (to allow start and last character edition in that link).

That system bypassed the fact that the link could simply be in a non
editable area when it is clicked.

Related to task-2431484
