### PR TITLE
[IMP] account: Enhance traceability of payments with chatter log

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -141,6 +141,7 @@ class AccountMove(models.Model):
         readonly=True,
         states={'draft': [('readonly', False)]},
         copy=False,
+        tracking=True,
         default=fields.Date.context_today
     )
     ref = fields.Char(string='Reference', copy=False, tracking=True)
@@ -2072,6 +2073,8 @@ class AccountMove(models.Model):
         self.ensure_one()
 
         if not self.is_invoice(include_receipts=True):
+            if self.payment_id and 'state' in init_values:
+                self.payment_id.message_track(['state'], {self.payment_id.id: init_values})
             return super(AccountMove, self)._track_subtype(init_values)
 
         if 'payment_state' in init_values and self.payment_state == 'paid':

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -34,12 +34,13 @@ class AccountPayment(models.Model):
         compute='_compute_reconciliation_status',
         help="Technical field indicating if the payment has been matched with a statement line.")
     partner_bank_id = fields.Many2one('res.partner.bank', string="Recipient Bank Account",
-        readonly=False, store=True,
+        readonly=False, store=True, tracking=True,
         compute='_compute_partner_bank_id',
         domain="[('partner_id', '=', partner_id)]",
         check_company=True)
     is_internal_transfer = fields.Boolean(string="Internal Transfer",
         readonly=False, store=True,
+        tracking=True,
         compute="_compute_is_internal_transfer")
     qr_code = fields.Char(string="QR Code",
         compute="_compute_qr_code",
@@ -66,6 +67,7 @@ class AccountPayment(models.Model):
     payment_method_id = fields.Many2one(
         related='payment_method_line_id.payment_method_id',
         string="Method",
+        tracking=True,
         store=True
     )
 
@@ -74,12 +76,12 @@ class AccountPayment(models.Model):
     payment_type = fields.Selection([
         ('outbound', 'Send'),
         ('inbound', 'Receive'),
-    ], string='Payment Type', default='inbound', required=True)
+    ], string='Payment Type', default='inbound', required=True, tracking=True)
     partner_type = fields.Selection([
         ('customer', 'Customer'),
         ('supplier', 'Vendor'),
     ], default='customer', tracking=True, required=True)
-    payment_reference = fields.Char(string="Payment Reference", copy=False,
+    payment_reference = fields.Char(string="Payment Reference", copy=False, tracking=True,
         help="Reference of the document used to issue this payment. Eg. check number, file name, etc.")
     currency_id = fields.Many2one('res.currency', string='Currency', store=True, readonly=False,
         compute='_compute_currency_id',
@@ -90,6 +92,7 @@ class AccountPayment(models.Model):
         store=True, readonly=False, ondelete='restrict',
         compute='_compute_partner_id',
         domain="['|', ('parent_id','=', False), ('is_company','=', True)]",
+        tracking=True,
         check_company=True)
     outstanding_account_id = fields.Many2one(
         comodel_name='account.account',
@@ -144,7 +147,7 @@ class AccountPayment(models.Model):
         help="Technical field used to know whether the field `partner_bank_id` needs to be required or not in the payments form views")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
     amount_signed = fields.Monetary(
-        currency_field='currency_id', compute='_compute_amount_signed',
+        currency_field='currency_id', compute='_compute_amount_signed', tracking=True,
         help='Negative value of amount field if payment_type is outbound')
     amount_company_currency_signed = fields.Monetary(
         currency_field='company_currency_id', compute='_compute_amount_company_currency_signed')

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -63,12 +63,14 @@ class SequenceMixin(models.AbstractModel):
                     or format_values['month'] and format_values['month'] != date.month
                 ):
                     raise ValidationError(_(
-                        "The %(date_field)s (%(date)s) doesn't match the %(sequence_field)s (%(sequence)s).\n"
-                        "You might want to clear the field %(sequence_field)s before proceeding with the change of the date.",
+                        "The %(date_field)s (%(date)s) doesn't match the sequence number of the related %(model)s (%(sequence)s)\n"
+                        "You will need to clear the %(model)s's %(sequence_field)s to proceed.\n"
+                        "In doing so, you might want to resequence your entries in order to maintain a continuous date-based sequence.",
                         date=format_date(self.env, date),
                         sequence=sequence,
                         date_field=record._fields[record._sequence_date_field]._description_string(self.env),
                         sequence_field=record._fields[record._sequence_field]._description_string(self.env),
+                        model=self.env['ir.model']._get(record._name).display_name,
                     ))
 
     @api.depends(lambda self: [self._sequence_field])


### PR DESCRIPTION
[IMP] account: improve error message of mismatched date and sequence number

The error message when resetting a payment to draft and changing the date is not adequate. This aims to guide the user to the appropriate journal entry where changes are required.

part 2 of task 2533660

[IMP] account: improve traceability of payments by logging changes in the chatter

Payments that are modified have no real traceability. It would be useful to see a list of modified fields in the chatter, therefore tracking was added to a number of fields.
Date changes on journal entries (account.move) are also tracked in the chatter

part 1 of task 2533660




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
