### PR TITLE
[FIX] web: read_progress_bar with complex group_by

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -69,14 +69,14 @@ class Base(models.AbstractModel):
 
         # Workaround to match read_group's infrastructure
         # TO DO in master: harmonize this function and readgroup to allow factorization
+        group_by_name = group_by.partition(':')[0]
         group_by_modifier = group_by.partition(':')[2] or 'month'
-        group_by = group_by.partition(':')[0]
 
-        records_values = self.search_read(domain or [], [progress_bar['field'], group_by])
-        field_type = self._fields[group_by].type
+        records_values = self.search_read(domain or [], [progress_bar['field'], group_by_name])
+        field_type = self._fields[group_by_name].type
 
         for record_values in records_values:
-            group_by_value = record_values[group_by]
+            group_by_value = record_values.pop(group_by_name)
 
             # Again, imitating what _read_group_format_result and _read_group_prepare_data do
             if group_by_value and field_type in ['date', 'datetime']:
@@ -93,8 +93,8 @@ class Base(models.AbstractModel):
                     group_by_value = babel.dates.format_date(
                         group_by_value, format=DISPLAY_DATE_FORMATS[group_by_modifier],
                         locale=locale)
-                record_values[group_by] = group_by_value
 
+            record_values[group_by] = group_by_value
             record_values['__count'] = 1
 
         return records_values

--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -56,6 +56,11 @@ class TestReadProgressBar(common.TransactionCase):
                     'relation': 'res.country',
                 }),
                 (0, 0, {
+                    'field_description': 'Date',
+                    'name': 'x_date',
+                    'ttype': 'date',
+                }),
+                (0, 0, {
                     'field_description': 'State',
                     'name': 'x_state',
                     'ttype': 'selection',
@@ -67,21 +72,24 @@ class TestReadProgressBar(common.TransactionCase):
         c1, c2, c3 = self.env['res.country'].search([], limit=3)
 
         self.env['x_progressbar'].create([
-            {'x_country_id': c1.id, 'x_state': 'foo'},
-            {'x_country_id': c1.id, 'x_state': 'foo'},
-            {'x_country_id': c1.id, 'x_state': 'foo'},
-            {'x_country_id': c1.id, 'x_state': 'bar'},
-            {'x_country_id': c1.id, 'x_state': 'baz'},
-            {'x_country_id': c2.id, 'x_state': 'foo'},
-            {'x_country_id': c2.id, 'x_state': 'bar'},
-            {'x_country_id': c2.id, 'x_state': 'bar'},
-            {'x_country_id': c2.id, 'x_state': 'baz'},
-            {'x_country_id': c2.id, 'x_state': 'baz'},
-            {'x_country_id': c3.id, 'x_state': 'foo'},
-            {'x_country_id': c3.id, 'x_state': 'foo'},
-            {'x_country_id': c3.id, 'x_state': 'baz'},
-            {'x_country_id': c3.id, 'x_state': 'baz'},
-            {'x_country_id': c3.id, 'x_state': 'baz'},
+            # week 21
+            {'x_country_id': c1.id, 'x_date': '2021-05-20', 'x_state': 'foo'},
+            {'x_country_id': c1.id, 'x_date': '2021-05-21', 'x_state': 'foo'},
+            {'x_country_id': c1.id, 'x_date': '2021-05-22', 'x_state': 'foo'},
+            {'x_country_id': c1.id, 'x_date': '2021-05-23', 'x_state': 'bar'},
+            # week 22
+            {'x_country_id': c1.id, 'x_date': '2021-05-24', 'x_state': 'baz'},
+            {'x_country_id': c2.id, 'x_date': '2021-05-25', 'x_state': 'foo'},
+            {'x_country_id': c2.id, 'x_date': '2021-05-26', 'x_state': 'bar'},
+            {'x_country_id': c2.id, 'x_date': '2021-05-27', 'x_state': 'bar'},
+            {'x_country_id': c2.id, 'x_date': '2021-05-28', 'x_state': 'baz'},
+            {'x_country_id': c2.id, 'x_date': '2021-05-29', 'x_state': 'baz'},
+            {'x_country_id': c3.id, 'x_date': '2021-05-30', 'x_state': 'foo'},
+            # week 23
+            {'x_country_id': c3.id, 'x_date': '2021-05-31', 'x_state': 'foo'},
+            {'x_country_id': c3.id, 'x_date': '2021-06-01', 'x_state': 'baz'},
+            {'x_country_id': c3.id, 'x_date': '2021-06-02', 'x_state': 'baz'},
+            {'x_country_id': c3.id, 'x_date': '2021-06-03', 'x_state': 'baz'},
         ])
 
         progress_bar = {
@@ -93,6 +101,14 @@ class TestReadProgressBar(common.TransactionCase):
             c1.display_name: {'foo': 3, 'bar': 1, 'baz': 1},
             c2.display_name: {'foo': 1, 'bar': 2, 'baz': 2},
             c3.display_name: {'foo': 2, 'bar': 0, 'baz': 3},
+        })
+
+        # check date aggregation and format
+        result = self.env['x_progressbar'].read_progress_bar([], 'x_date:week', progress_bar)
+        self.assertEqual(result, {
+            'W21 2021': {'foo': 3, 'bar': 1, 'baz': 0},
+            'W22 2021': {'foo': 2, 'bar': 2, 'baz': 3},
+            'W23 2021': {'foo': 1, 'bar': 0, 'baz': 3},
         })
 
         # add a computed field on model
@@ -118,4 +134,11 @@ class TestReadProgressBar(common.TransactionCase):
             c1.display_name: {'foo': 3, 'bar': 1, 'baz': 1},
             c2.display_name: {'foo': 1, 'bar': 2, 'baz': 2},
             c3.display_name: {'foo': 2, 'bar': 0, 'baz': 3},
+        })
+
+        result = self.env['x_progressbar'].read_progress_bar([], 'x_date:week', progress_bar)
+        self.assertEqual(result, {
+            'W21 2021': {'foo': 3, 'bar': 1, 'baz': 0},
+            'W22 2021': {'foo': 2, 'bar': 2, 'baz': 3},
+            'W23 2021': {'foo': 1, 'bar': 0, 'baz': 3},
         })


### PR DESCRIPTION
The naive implementation of read_progress_bar() does not deal properly
with groupings like `date:week`.  The values in the groups are
returned under the wrong key ('date' instead of 'date:week').

This fixes up https://github.com/odoo/odoo/pull/67004.