### PR TITLE
[FIX] hr_holidays: allow a basic user to attach files on their Time-off

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -729,7 +729,7 @@ class HolidaysRequest(models.Model):
                         pass
 
     def write(self, values):
-        is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user')
+        is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
 
         if not is_officer:
             if any(hol.date_from.date() < fields.Date.today() for hol in self):


### PR DESCRIPTION
Steps to reproduce the bug:
- Log in with a basic user (which is an employee) e.g: “Laurie Poiret”
- Go to TimeOff app > create a new Time Off request with the end date in the past > save
- Go to My time off > Time Off Requests > choose the newly created one
- Try to send a note or message attaching a file

Problem:
An user error is triggered, because we only check if the user is in the group ("group_hr_holidays_user"), we don’t check if is a superuser environment

The `" write "` function is called via a call in the stack which is in sudo mode, so it makes sense to check if we are in a superuser environment:
https://github.com/odoo/odoo/blob/de7c119e666d108564b3889d1c08e5bf2e4da082/addons/mail/models/mail_thread.py#L1802
is_superuser function:
https://github.com/odoo/odoo/blob/cd62d5aca04554ded58d10a75d558486113fb878/odoo/api.py#L503-L505

opw-2525260

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
