### PR TITLE
[FIX] l10n_fr : link pcg_7617 to l10n_fr.l10n_fr_pcg_chart_template

### DIFF
--- a/addons/l10n_fr/data/account.account.template.csv
+++ b/addons/l10n_fr/data/account.account.template.csv
@@ -672,7 +672,7 @@
 "pcg_758","Produits divers de gestion courante","758","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_7611","Revenus des titres de participation","7611","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_7616","Revenus sur autres formes de participation","7616","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"
-"pcg_7617","Revenus des créances rattachées à des participations","7617","account.data_account_type_revenue","","False"
+"pcg_7617","Revenus des créances rattachées à des participations","7617","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_7621","Revenus des titres immobilisés","7621","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_7626","Revenus des prêts","7626","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_7627","Revenus des créances immobilisées","7627","account.data_account_type_revenue","l10n_fr.l10n_fr_pcg_chart_template","False"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

the french account 7617 is not associated to the french chart template. 

Note : master branch seems OK.
https://github.com/odoo/odoo/blob/master/addons/l10n_fr/data/account.account.template.csv#L692




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
