### PR TITLE
[FIX] web: fixes reports not scrolling

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -24,7 +24,7 @@
                 <t t-call-assets="web.assets_common" t-css="false"/>
                 <t t-call-assets="web.report_assets_common" t-css="false"/>
             </head>
-            <body t-att-class="'container' if not full_width else 'container-fluid'" style="overflow:hidden">
+            <body t-att-class="'container' if not full_width else 'container-fluid'">
                 <div id="wrapwrap">
                     <main>
                         <t t-out="0"/>


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

task-2355704 introduced a bug which prevented scrolling in reports, instead of only in report preview.
This PR fixes this bug.

task-2586245
Current behavior before PR:
Scroll in reports was disabled.

Desired behavior after PR is merged:
Scroll in reports are enabled, but scrolling is disabled in report preview.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
