### PR TITLE
[IMP]hr_timesheet,sale_timesheet : better overtime identification

### DIFF
--- a/addons/hr_timesheet/models/hr_employee.py
+++ b/addons/hr_timesheet/models/hr_employee.py
@@ -7,6 +7,6 @@ from odoo import fields, models
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
-    timesheet_cost = fields.Monetary('Timesheet Cost', currency_field='currency_id',
-    	groups="hr.group_hr_user", default=0.0)
+    timesheet_cost = fields.Monetary('Timesheet Cost', groups="hr.group_hr_user")
+    overtime_cost = fields.Monetary('Overtime Cost', groups="hr.group_hr_user")
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -48,6 +48,10 @@ class AccountAnalyticLine(models.Model):
     employee_id = fields.Many2one('hr.employee', "Employee", domain=_domain_employee_id)
     department_id = fields.Many2one('hr.department', "Department", compute='_compute_department_id', store=True, compute_sudo=True)
     encoding_uom_id = fields.Many2one('uom.uom', compute='_compute_encoding_uom_id')
+    is_overtime = fields.Boolean('Is Overtime')
+    overtime_amount = fields.Monetary("Overtime Cost")
+    overtime_duration = fields.Float("Overtime Duration")
+    total_amount = fields.Monetary('Total Amount', compute='_compute_total_amount', store=True)
 
     def name_get(self):
         result = super().name_get()
@@ -70,6 +74,11 @@ class AccountAnalyticLine(models.Model):
     def _compute_encoding_uom_id(self):
         for analytic_line in self:
             analytic_line.encoding_uom_id = analytic_line.company_id.timesheet_encode_uom_id
+
+    @api.depends('overtime_amount', 'amount')
+    def _compute_total_amount(self):
+        for analytic_line in self:
+            analytic_line.total_amount = analytic_line.overtime_amount + analytic_line.amount
 
     @api.depends('task_id', 'task_id.project_id')
     def _compute_project_id(self):
@@ -235,15 +244,25 @@ class AccountAnalyticLine(models.Model):
         result = {id_: {} for id_ in self.ids}
         sudo_self = self.sudo()  # this creates only one env for all operation that required sudo()
         # (re)compute the amount (depending on unit_amount, employee_id for the cost, and account_id for currency)
-        if any(field_name in values for field_name in ['unit_amount', 'employee_id', 'account_id']):
+        if any(field_name in values for field_name in ['unit_amount', 'employee_id', 'account_id', 'is_overtime']):
             for timesheet in sudo_self:
-                cost = timesheet._employee_timesheet_cost()
-                amount = -timesheet.unit_amount * cost
-                amount_converted = timesheet.employee_id.currency_id._convert(
-                    amount, timesheet.account_id.currency_id, self.env.company, timesheet.date)
-                result[timesheet.id].update({
-                    'amount': amount_converted,
-                })
+                if timesheet.is_overtime:
+                    overtime_cost = timesheet.employee_id.overtime_cost
+                    overtime_price = -timesheet.unit_amount * overtime_cost
+                    overtime_converted = timesheet.employee_id.currency_id._convert(
+                        overtime_price, timesheet.account_id.currency_id, self.env.company, timesheet.date)
+                    result[timesheet.id].update({
+                        'overtime_amount': overtime_converted,
+                        'overtime_duration': timesheet.unit_amount,
+                    })
+                else:
+                    cost = timesheet.employee_id.timesheet_cost or 0.0
+                    amount = -timesheet.unit_amount * cost
+                    amount_converted = timesheet.employee_id.currency_id._convert(
+                        amount, timesheet.account_id.currency_id, self.env.company, timesheet.date)
+                    result[timesheet.id].update({
+                        'amount': amount_converted,
+                    })
         return result
 
     def _is_timesheet_encode_uom_day(self):

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -28,6 +28,7 @@
                     <field name="project_id" required="1" options="{'no_create_edit': True}"/>
                     <field name="task_id" optional="show" options="{'no_create_edit': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
                     <field name="name" optional="show" required="0"/>
+                    <field name="is_overtime" optional="hide"/>
                     <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" decoration-danger="unit_amount &gt; 24"/>
                     <field name="company_id" invisible="1"/>
                     <field name="user_id" invisible="1"/>
@@ -169,6 +170,8 @@
                     <field name="task_id"/>
                     <field name="name"/>
                     <filter name="mine" string="My Timesheets" domain="[('user_id', '=', uid)]"/>
+                    <separator/>
+                    <filter name="overtime" string="Overtime" domain="[('is_overtime', '=', True)]"/>
                     <separator/>
                     <filter name="month" string="Date" date="date"/>
                     <group expand="0" string="Group By">

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -28,7 +28,6 @@
                     <field name="project_id" required="1" options="{'no_create_edit': True}"/>
                     <field name="task_id" optional="show" options="{'no_create_edit': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
                     <field name="name" optional="show" required="0"/>
-                    <field name="is_overtime" optional="hide"/>
                     <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" decoration-danger="unit_amount &gt; 24"/>
                     <field name="company_id" invisible="1"/>
                     <field name="user_id" invisible="1"/>
@@ -59,7 +58,7 @@
                     <field name="employee_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
-                    <field name="amount" string="Timesheet Costs"/>
+                    <field name="amount" string="Timesheet Cost"/>
                 </pivot>
             </field>
         </record>
@@ -71,7 +70,7 @@
                 <pivot string="Timesheet" sample="1">
                     <field name="date" interval="week" type="row"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
-                    <field name="amount" string="Timesheet Costs"/>
+                    <field name="amount" string="Timesheet Cost"/>
                 </pivot>
             </field>
         </record>
@@ -170,8 +169,6 @@
                     <field name="task_id"/>
                     <field name="name"/>
                     <filter name="mine" string="My Timesheets" domain="[('user_id', '=', uid)]"/>
-                    <separator/>
-                    <filter name="overtime" string="Overtime" domain="[('is_overtime', '=', True)]"/>
                     <separator/>
                     <filter name="month" string="Date" date="date"/>
                     <group expand="0" string="Group By">

--- a/addons/hr_timesheet/views/hr_views.xml
+++ b/addons/hr_timesheet/views/hr_views.xml
@@ -41,6 +41,10 @@
                     <field name="timesheet_cost" class="oe_inline"/> per hour
                     <field name="currency_id" invisible="1"/>
                 </div>
+                <label for="overtime_cost"/>
+                <div name="overtime">
+                    <field name="overtime_cost" class="oe_inline"/> per hour
+                </div>
             </group>
             <div name="button_box" position="inside">
                 <button class="oe_stat_button" type="action" name="%(timesheet_action_from_employee)d" icon="fa-calendar" groups="hr_timesheet.group_hr_timesheet_user">

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -114,6 +114,7 @@
                             <field name="user_id" invisible="1"/>
                             <field name="employee_id" required="1" widget="many2one_avatar_employee"/>
                             <field name="name" required="0"/>
+                            <field name="is_overtime" optional="hide"/>
                             <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                             <field name="project_id" invisible="1"/>
                             <field name="task_id" invisible="1"/>

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -114,7 +114,6 @@
                             <field name="user_id" invisible="1"/>
                             <field name="employee_id" required="1" widget="many2one_avatar_employee"/>
                             <field name="name" required="0"/>
-                            <field name="is_overtime" optional="hide"/>
                             <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                             <field name="project_id" invisible="1"/>
                             <field name="task_id" invisible="1"/>

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -21,9 +21,7 @@ class ProfitabilityAnalysis(models.Model):
     line_date = fields.Date("Date", readonly=True)
     # cost
     timesheet_unit_amount = fields.Float("Timesheet Duration", digits=(16, 2), readonly=True, group_operator="sum")
-    overtime_unit_amount = fields.Float("Overtime Duration", digits=(16, 2), readonly=True, group_operator="sum")
     timesheet_cost = fields.Float("Timesheet Cost", digits=(16, 2), readonly=True, group_operator="sum")
-    overtime_cost = fields.Monetary("Overtime Cost", readonly=True, group_operator="sum")
     expense_cost = fields.Float("Other Costs", digits=(16, 2), readonly=True, group_operator="sum")
     # sale revenue
     order_confirmation_date = fields.Datetime('Sales Order Confirmation Date', readonly=True)
@@ -93,9 +91,7 @@ class ProfitabilityAnalysis(models.Model):
                     sub.amount_untaxed_to_invoice as amount_untaxed_to_invoice,
                     sub.amount_untaxed_invoiced as amount_untaxed_invoiced,
                     sub.timesheet_unit_amount as timesheet_unit_amount,
-                    sub.overtime_unit_amount as overtime_unit_amount,
                     sub.timesheet_cost as timesheet_cost,
-                    sub.overtime_cost as overtime_cost,
                     sub.expense_cost as expense_cost,
                     sub.other_revenues as other_revenues,
                     sub.line_date as line_date,
@@ -122,9 +118,7 @@ class ProfitabilityAnalysis(models.Model):
                         COST_SUMMARY.amount_untaxed_to_invoice AS amount_untaxed_to_invoice,
                         COST_SUMMARY.amount_untaxed_invoiced AS amount_untaxed_invoiced,
                         COST_SUMMARY.timesheet_unit_amount AS timesheet_unit_amount,
-                        COST_SUMMARY.overtime_unit_amount AS overtime_unit_amount,
                         COST_SUMMARY.timesheet_cost AS timesheet_cost,
-                        COST_SUMMARY.overtime_cost AS overtime_cost,
                         COST_SUMMARY.expense_cost AS expense_cost,
                         COST_SUMMARY.other_revenues AS other_revenues,
                         COST_SUMMARY.line_date::date AS line_date
@@ -138,9 +132,7 @@ class ProfitabilityAnalysis(models.Model):
                                 analytic_account_id,
                                 sale_line_id,
                                 SUM(timesheet_unit_amount) AS timesheet_unit_amount,
-                                SUM(overtime_unit_amount) AS overtime_unit_amount,
                                 SUM(timesheet_cost) AS timesheet_cost,
-                                SUM(overtime_cost) AS overtime_cost,
                                 SUM(expense_cost) AS expense_cost,
                                 SUM(other_revenues) AS other_revenues,
                                 SUM(downpayment_invoiced) AS downpayment_invoiced,
@@ -156,9 +148,7 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     TS.so_line AS sale_line_id,
                                     TS.unit_amount AS timesheet_unit_amount,
-                                    TS.overtime_duration AS overtime_unit_amount,
                                     TS.amount AS timesheet_cost,
-                                    TS.overtime_amount AS overtime_cost,
                                     0.0 AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -178,9 +168,7 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     AAL.so_line AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
-                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
-                                    0.0 AS overtime_cost,
                                     AAL.amount AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -211,9 +199,7 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     AAL.so_line AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
-                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
-                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     AAL.amount AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -235,9 +221,7 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     MY_SOLS.id AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
-                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
-                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     0.0 AS expense_cost,
                                     CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced,
@@ -260,9 +244,7 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     OLIS.id AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
-                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
-                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     OLIS.price_reduce AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -288,9 +270,7 @@ class ProfitabilityAnalysis(models.Model):
                                     AMOUNT_UNTAXED.analytic_account_id AS analytic_account_id,
                                     AMOUNT_UNTAXED.sale_line_id AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
-                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
-                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS downpayment_invoiced,

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -21,7 +21,9 @@ class ProfitabilityAnalysis(models.Model):
     line_date = fields.Date("Date", readonly=True)
     # cost
     timesheet_unit_amount = fields.Float("Timesheet Duration", digits=(16, 2), readonly=True, group_operator="sum")
+    overtime_unit_amount = fields.Float("Overtime Duration", digits=(16, 2), readonly=True, group_operator="sum")
     timesheet_cost = fields.Float("Timesheet Cost", digits=(16, 2), readonly=True, group_operator="sum")
+    overtime_cost = fields.Monetary("Overtime Cost", readonly=True, group_operator="sum")
     expense_cost = fields.Float("Other Costs", digits=(16, 2), readonly=True, group_operator="sum")
     # sale revenue
     order_confirmation_date = fields.Datetime('Sales Order Confirmation Date', readonly=True)
@@ -91,7 +93,9 @@ class ProfitabilityAnalysis(models.Model):
                     sub.amount_untaxed_to_invoice as amount_untaxed_to_invoice,
                     sub.amount_untaxed_invoiced as amount_untaxed_invoiced,
                     sub.timesheet_unit_amount as timesheet_unit_amount,
+                    sub.overtime_unit_amount as overtime_unit_amount,
                     sub.timesheet_cost as timesheet_cost,
+                    sub.overtime_cost as overtime_cost,
                     sub.expense_cost as expense_cost,
                     sub.other_revenues as other_revenues,
                     sub.line_date as line_date,
@@ -118,7 +122,9 @@ class ProfitabilityAnalysis(models.Model):
                         COST_SUMMARY.amount_untaxed_to_invoice AS amount_untaxed_to_invoice,
                         COST_SUMMARY.amount_untaxed_invoiced AS amount_untaxed_invoiced,
                         COST_SUMMARY.timesheet_unit_amount AS timesheet_unit_amount,
+                        COST_SUMMARY.overtime_unit_amount AS overtime_unit_amount,
                         COST_SUMMARY.timesheet_cost AS timesheet_cost,
+                        COST_SUMMARY.overtime_cost AS overtime_cost,
                         COST_SUMMARY.expense_cost AS expense_cost,
                         COST_SUMMARY.other_revenues AS other_revenues,
                         COST_SUMMARY.line_date::date AS line_date
@@ -132,7 +138,9 @@ class ProfitabilityAnalysis(models.Model):
                                 analytic_account_id,
                                 sale_line_id,
                                 SUM(timesheet_unit_amount) AS timesheet_unit_amount,
+                                SUM(overtime_unit_amount) AS overtime_unit_amount,
                                 SUM(timesheet_cost) AS timesheet_cost,
+                                SUM(overtime_cost) AS overtime_cost,
                                 SUM(expense_cost) AS expense_cost,
                                 SUM(other_revenues) AS other_revenues,
                                 SUM(downpayment_invoiced) AS downpayment_invoiced,
@@ -148,7 +156,9 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     TS.so_line AS sale_line_id,
                                     TS.unit_amount AS timesheet_unit_amount,
+                                    TS.overtime_duration AS overtime_unit_amount,
                                     TS.amount AS timesheet_cost,
+                                    TS.overtime_amount AS overtime_cost,
                                     0.0 AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -168,7 +178,9 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     AAL.so_line AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
+                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
+                                    0.0 AS overtime_cost,
                                     AAL.amount AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -199,7 +211,9 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     AAL.so_line AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
+                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
+                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     AAL.amount AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -221,7 +235,9 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     MY_SOLS.id AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
+                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
+                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     0.0 AS expense_cost,
                                     CASE WHEN MY_SOLS.invoice_status = 'invoiced' THEN MY_SOLS.price_reduce ELSE 0.0 END AS downpayment_invoiced,
@@ -244,7 +260,9 @@ class ProfitabilityAnalysis(models.Model):
                                     P.analytic_account_id AS analytic_account_id,
                                     OLIS.id AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
+                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
+                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     OLIS.price_reduce AS expense_cost,
                                     0.0 AS downpayment_invoiced,
@@ -270,7 +288,9 @@ class ProfitabilityAnalysis(models.Model):
                                     AMOUNT_UNTAXED.analytic_account_id AS analytic_account_id,
                                     AMOUNT_UNTAXED.sale_line_id AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
+                                    0.0 AS overtime_unit_amount,
                                     0.0 AS timesheet_cost,
+                                    0.0 AS overtime_cost,
                                     0.0 AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS downpayment_invoiced,

--- a/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
@@ -10,8 +10,10 @@
                 <field name="amount_untaxed_to_invoice" type="measure"/>
                 <field name="amount_untaxed_invoiced" type="measure"/>
                 <field name="timesheet_cost" type="measure"/>
+                <field name="overtime_cost" type="measure"/>
                 <field name="margin" type="measure"/>
                 <field name="timesheet_unit_amount" widget="timesheet_uom" type="measure"/>
+                <field name="overtime_unit_amount" widget="timesheet_uom" type="measure"/>
             </pivot>
         </field>
     </record>

--- a/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
@@ -10,10 +10,8 @@
                 <field name="amount_untaxed_to_invoice" type="measure"/>
                 <field name="amount_untaxed_invoiced" type="measure"/>
                 <field name="timesheet_cost" type="measure"/>
-                <field name="overtime_cost" type="measure"/>
                 <field name="margin" type="measure"/>
                 <field name="timesheet_unit_amount" widget="timesheet_uom" type="measure"/>
-                <field name="overtime_unit_amount" widget="timesheet_uom" type="measure"/>
             </pivot>
         </field>
     </record>


### PR DESCRIPTION
The purpose of this task is, sometimes it is essential to identify which
employees are doing overtime and how much. Overtime directly
impacts a project's costs and profitability and is sometimes billed at a
higher rate.

In this commit, we add
    - 'is overtime' boolean on timesheets
    - an 'overtime' filter that should return timesheets with 'is overtime' = true
    - an 'overtime cost' field on hr.employee
    - timesheets > reporting: add the following measures: overtime costs,
       overtime duration, total cost(timesheet cost + overtime cost)
    - project > reporting > project costs and revenues: add the following
       measures: overtime duration, overtime costs

Task-Id: 2459664
PR: #73497

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
