### PR TITLE
[FIX] im_livechat: add session.js to manifest

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -111,6 +111,7 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/src/legacy/js/core/rpc.js',
             'web/static/src/legacy/js/core/widget.js',
             'web/static/src/legacy/js/core/registry.js',
+            'web/static/src/session.js',
             'web/static/src/legacy/js/core/session.js',
             'web/static/src/legacy/js/core/concurrency.js',
             'web/static/src/legacy/js/core/utils.js',


### PR DESCRIPTION
Since 54e9527ec2fdf0467de08b372c7e891fedaa68ae, a new session module is
used to access the session info. The legacy session uses also this
module to access the session info. This means that if a module uses the
legacy session, the new session.js needs to be added to the manifest.
