### PR TITLE
[FIX] base: remove branding on t-out nodes

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1655,7 +1655,7 @@ actual arch.
         if not e.get('data-oe-model'):
             return
 
-        if {'t-esc', 't-raw'}.intersection(e.attrib):
+        if {'t-esc', 't-raw', 't-out'}.intersection(e.attrib):
             # nodes which fully generate their content and have no reason to
             # be branded because they can not sensibly be edited
             self._pop_view_branding(e)


### PR DESCRIPTION
Before this commit branding was removed only from nodes using t-esc and
t-raw.
This caused problems such as the ribbon preview rendering being
propagated across all products because the oe-model/id/xpath fields were
referencing the product card view itself.
This appeared because of the conversion from t-esc/t-raw to t-out.
The branding used to be removed from nodes using t-esc and t-raw, but it
was not removed for t-out.

After this commit the branding is also removed from nodes using t-out.
This restores the old way the ribbon preview was rendered, and therefore
also fixes the issue described in the related task.

task-2527056

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
