### PR TITLE
[FIX] website: restore overlay for timeline cards edition

### DIFF
--- a/addons/website/static/src/snippets/s_timeline/options.js
+++ b/addons/website/static/src/snippets/s_timeline/options.js
@@ -4,6 +4,8 @@ odoo.define('website.s_timeline_options', function (require) {
 const options = require('web_editor.snippets.options');
 
 options.registry.Timeline = options.Class.extend({
+    displayOverlayOptions: true,
+
     /**
      * @override
      */


### PR DESCRIPTION
With [1], not all overlays are displayed anymore but we rather show the
parent one in some cases. The timeline cards were considered as one of
those cases while it should not, as it prevents to use the overlay
buttons allowing to switch the cards order.

[1]: https://github.com/odoo/odoo/commit/9bbe5be3fb0d995374a369851df3641979d8e553

Discovered while working on task-2431484
