### PR TITLE
[IMP] point_of_sale: store related company_id field in pos.payment

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -24,7 +24,7 @@ class PosPayment(models.Model):
     currency_rate = fields.Float(string='Conversion Rate', related='pos_order_id.currency_rate', help='Conversion rate from company currency to order currency.')
     partner_id = fields.Many2one('res.partner', string='Customer', related='pos_order_id.partner_id')
     session_id = fields.Many2one('pos.session', string='Session', related='pos_order_id.session_id', store=True, index=True)
-    company_id = fields.Many2one('res.company', string='Company', related='pos_order_id.company_id')  # TODO: add store=True in master
+    company_id = fields.Many2one('res.company', string='Company', related='pos_order_id.company_id', store=True)
     card_type = fields.Char('Type of card used')
     cardholder_name = fields.Char('Cardholder Name')
     transaction_id = fields.Char('Payment Transaction ID')


### PR DESCRIPTION
it speeds up checking multi-company rule, partically, computed field
`total_payments_amount` works faster in large databases: 2,8 sec -> 0,01
sec (see fe3e84085fc9446fb2b745d99df341de980a92c0 )

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
