### PR TITLE
[FIX] website: parse result of_render as html

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -8,7 +8,7 @@ import hashlib
 import requests
 import re
 
-from lxml import etree
+from lxml import etree, html
 from werkzeug import urls
 from werkzeug.datastructures import OrderedMultiDict
 from werkzeug.exceptions import NotFound
@@ -370,7 +370,7 @@ class Website(models.Model):
                 try:
                     view_id = self.env['website'].with_context(website_id=website.id).viewref(snippet)
                     if view_id:
-                        el = etree.fromstring(view_id._render(values=cta_data))
+                        el = html.fromstring(view_id._render(values=cta_data))
 
                         # Add the data-snippet attribute to identify the snippet
                         # for compatibility code


### PR DESCRIPTION
`_render('<h1> quick &amp; flupke </h1>') `=>` '<h1> quick & flupke </h1>'`
what cannot be parsed in xml after.

Before this commit, if you try to install a page that contains a '&' via
the configurator, you had a traceback:
   xmlParseEntityRef: no name, line 1, column 13

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
