### PR TITLE
[FIX] web_editor: properly handle media "text tools" options

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -31,6 +31,8 @@ const CSS_UNITS_CONVERSION = {
     'ms-s': () => 0.001,
     'rem-px': () => _computePxByRem(),
     'px-rem': () => _computePxByRem(true),
+    '%-px': () => -1, // Not implemented but should simply be ignored for now
+    'px-%': () => -1, // Not implemented but should simply be ignored for now
 };
 /**
  * Colors of the default palette, used for substitution in shapes/illustrations.

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3336,17 +3336,25 @@ const SnippetOptionWidget = Widget.extend({
             case 'selectClass': {
                 let maxNbClasses = 0;
                 let activeClassNames = '';
-                params.possibleValues.forEach(classNames => {
+                for (const classNames of params.possibleValues) {
                     if (!classNames) {
-                        return;
+                        continue;
                     }
                     const classes = classNames.split(/\s+/g);
+                    if (params.stateToFirstClass) {
+                        if (this.$target[0].classList.contains(classes[0])) {
+                            return classNames;
+                        } else {
+                            continue;
+                        }
+                    }
+
                     if (classes.length >= maxNbClasses
                             && classes.every(className => this.$target[0].classList.contains(className))) {
                         maxNbClasses = classes.length;
                         activeClassNames = classNames;
                     }
-                });
+                }
                 return activeClassNames;
             }
             case 'selectAttribute':
@@ -4137,157 +4145,9 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
 });
 
 /**
- * General options that are common to a font awesome icon and an image.
- */
-registry.StaticMediaTools = SnippetOptionWidget.extend({
-    currentShapes: {},
-    alignments: {
-        left: ['float-left'],
-        center: ['d-block', 'mx-auto'],
-        right: ['float-right'],
-    },
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
-    toggleShapeRounded(previewMode) {
-        this._toggleShape(previewMode, 'rounded');
-    },
-    toggleShapeCircle(previewMode) {
-        this._toggleShape(previewMode, 'rounded-circle');
-    },
-    toggleShapeShadow(previewMode) {
-        this._toggleShape(previewMode, 'shadow');
-    },
-    toggleShapeThumbnail(previewMode) {
-        this._toggleShape(previewMode, 'img-thumbnail');
-    },
-    setPadding(previewMode, padding, params) {
-        if (previewMode === true) {
-            this.currentPadding = params.possibleValues.find(c => this.$target.hasClass(c)) || '';
-        }
-        for (const value of params.possibleValues) {
-            if (previewMode === 'reset') {
-                this.$target.toggleClass(value, value === this.currentPadding);
-            } else {
-                this.$target.toggleClass(value, value === padding)
-            }
-        }
-        if (previewMode === false) {
-            this.currentPadding = padding;
-        }
-    },
-    align(previewMode, alignment, params) {
-        if (previewMode === true) {
-            this.currentAlignment = this._getAlignment();
-        }
-        const targetAlignment = previewMode === 'reset' ? this.currentAlignment : alignment;
-        for (const value of params.possibleValues) {
-            this.$target.toggleClass(this.alignments[value] || '', value === targetAlignment);
-        }
-        if (previewMode === false) {
-            this.currentAlignment = alignment;
-        }
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    _computeWidgetState(methodName, params) {
-        if (['toggleShapeRounded', 'toggleShapeCircle', 'toggleShapeShadow', 'toggleShapeThumbnail'].includes(methodName)) {
-            return params.possibleValues.find(c => this.$target.hasClass(c)) || '';
-        } else if (methodName === 'setPadding') {
-            return params.possibleValues.find(c => this.$target.hasClass(c)) || '';
-        } else if (methodName === 'align') {
-            return this._getAlignment();
-        }
-        return this._super(...arguments);
-    },
-    _getAlignment() {
-        for (const [alignment, [alignClass]] of Object.entries(this.alignments)) {
-            if (this.$target.hasClass(alignClass)) {
-                return alignment;
-            }
-        }
-        return '';
-    },
-    _toggleShape(previewMode, shape) {
-        if (previewMode === true) {
-            this.currentShapes[shape] = this.$target.hasClass(shape);
-            this.$target.toggleClass(shape, true);
-        } else if (previewMode === 'reset') {
-            this.$target.toggleClass(shape, this.currentShapes[shape]);
-        } else if (previewMode === false) {
-            this.$target.toggleClass(shape, !this.currentShapes[shape]);
-            this.currentShapes[shape] = this.$target.hasClass(shape);
-        }
-    },
-});
-
-/**
- * General options of a font awesome icon.
- */
-registry.FontawesomeTools = SnippetOptionWidget.extend({
-    setSize(previewMode, size, params) {
-        if (previewMode === true) {
-            this.currentSize = params.possibleValues.find(c => this.$target.hasClass(c)) || '';
-        }
-        for (const value of params.possibleValues) {
-            if (previewMode === 'reset') {
-                this.$target.toggleClass(value, value === this.currentSize);
-            } else {
-                this.$target.toggleClass(value, value === size)
-            }
-        }
-        if (previewMode === false) {
-            this.currentSize = size;
-        }
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    _computeWidgetState(methodName, params) {
-        if (methodName === 'setSize') {
-            return params.possibleValues.find(c => this.$target.hasClass(c)) || '';
-        } else if (methodName === 'align') {
-            return this._getAlignment();
-        }
-        return this._super(...arguments);
-    },
-});
-
-/**
  * General options of an image.
  */
 registry.ImageTools = SnippetOptionWidget.extend({
-    setWidth(previewMode, width, params) {
-        if (previewMode === true) {
-            this.currentWidth = this.$target.css('width');
-        }
-        if (previewMode === 'reset') {
-            this.$target.css('width', this.currentWidth);
-        } else {
-            this.$target.css('width', width);
-        }
-        if (previewMode === false) {
-            this.currentWidth = width;
-        }
-    },
-    setAlt(previewMode, alt) {
-        this.$target.attr('alt', alt);
-    },
-    setTitle(previewMode, title) {
-        this.$target.attr('title', title);
-    },
     crop() {
         new weWidgets.ImageCropWidget(this, this.$target[0]).appendTo(this.options.wysiwyg.$editable);
     },
@@ -4296,8 +4156,8 @@ registry.ImageTools = SnippetOptionWidget.extend({
             this.$target.removeData('transfo-destroy');
             return;
         }
-        const document = this.$target[0].ownerDocument
-        this.$target.transfo({ document });
+        const document = this.$target[0].ownerDocument;
+        this.$target.transfo({document});
         const mousedown = mousedownEvent => {
             if (!$(mousedownEvent.target).closest('.transfo-container').length) {
                 this.$target.transfo('destroy');
@@ -4321,13 +4181,17 @@ registry.ImageTools = SnippetOptionWidget.extend({
     /**
      * @override
      */
-    _computeWidgetState(methodName, params) {
-        if (methodName === 'setWidth') {
-            return this.$target[0].style.width || '';
-        } else if (methodName === 'setAlt') {
-            return this.$target.attr('alt');
-        } else if (methodName === 'setTitle') {
-            return this.$target.attr('title');
+    async _computeWidgetState(methodName, params) {
+        if (methodName === 'selectStyle' && params.cssProperty === 'width') {
+            // TODO check how to handle this the right way (here using inline
+            // style instead of computed because of the messy %-px convertion
+            // and the messy auto keyword).
+            const width = this.$target[0].style.width.trim();
+            if (width[width.length - 1] === '%') {
+                return `${parseInt(width)}%`;
+            } else {
+                return '';
+            }
         }
         return this._super(...arguments);
     },

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -381,18 +381,30 @@
                 data-color-prefix="bg-"/>
 
         <we-button-group string="Size">
-            <we-button data-set-size="fa-1x" title="Size 1x">1x</we-button>
-            <we-button data-set-size="fa-2x" title="Size 2x">2x</we-button>
-            <we-button data-set-size="fa-3x" title="Size 3x">3x</we-button>
-            <we-button data-set-size="fa-4x" title="Size 4x">4x</we-button>
-            <we-button data-set-size="fa-5x" title="Size 5x">5x</we-button>
+            <we-button data-select-class="" title="Size 1x">1x</we-button>
+            <we-button data-select-class="fa-2x" title="Size 2x">2x</we-button>
+            <we-button data-select-class="fa-3x" title="Size 3x">3x</we-button>
+            <we-button data-select-class="fa-4x" title="Size 4x">4x</we-button>
+            <we-button data-select-class="fa-5x" title="Size 5x">5x</we-button>
+
+            <!-- Hidden buttons which allows to automatically remove other fa
+                 sizing class we do not suggest.
+                 TODO: implement a param to add those extra classes to remove
+                 via selectClass (also fixes the fact that nothing is selected
+                 if fa-1x is actually used on the icon in this case) -->
+            <we-button data-select-class="fa-1x" data-dependencies="fake"/>
+            <we-button data-select-class="fa-lg" data-dependencies="fake"/>
         </we-button-group>
     </div>
 
     <div data-js="ImageTools" data-selector="img">
-        <we-input class="o_we_large_input" string="Description" data-set-alt="" placeholder="Alt tag"
+        <we-input string="Description" class="o_we_large_input"
+            data-select-attribute="" data-attribute-name="alt"
+            placeholder="Alt tag"
             title="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...)."/>
-        <we-input class="o_we_large_input" string="Tooltip" data-set-title="" placeholder="Title tag"
+        <we-input string="Tooltip" class="o_we_large_input"
+            data-select-attribute="" data-attribute-name="title"
+            placeholder="Title tag"
             title="'Title tag' is shown as a tooltip when you hover the picture."/>
 
         <we-row string="Transform">
@@ -402,35 +414,35 @@
             </we-button>
         </we-row>
 
-        <we-button-group string="Width">
-            <we-button data-set-width="" title="Resize Auto">Auto</we-button>
-            <we-button data-set-width="25%" title="Resize Quarter">25%</we-button>
-            <we-button data-set-width="50%" title="Resize Half">50%</we-button>
-            <we-button data-set-width="100%" title="Resize Full">100%</we-button>
+        <we-button-group string="Width" data-css-property="width">
+            <we-button data-select-style="" title="Resize Auto">Auto</we-button>
+            <we-button data-select-style="25%" title="Resize Quarter">25%</we-button>
+            <we-button data-select-style="50%" title="Resize Half">50%</we-button>
+            <we-button data-select-style="100%" title="Resize Full">100%</we-button>
         </we-button-group>
     </div>
 
-    <div data-js="StaticMediaTools" data-selector="span.fa, i.fa, img">
-        <we-select string="Alignment">
-            <we-button data-align="" title="Unalign">None</we-button>
-            <we-button data-align="left" title="Align Left">Left</we-button>
-            <we-button data-align="center" title="Align Center">Center</we-button>
-            <we-button data-align="right" title="Align Right">Right</we-button>
+    <div data-selector="span.fa, i.fa, img">
+        <we-select string="Alignment" data-state-to-first-class="true">
+            <we-button data-select-class="" title="Unalign">None</we-button>
+            <we-button data-select-class="float-left" title="Align Left">Left</we-button>
+            <we-button data-select-class="mx-auto d-block" title="Align Center">Center</we-button>
+            <we-button data-select-class="float-right" title="Align Right">Right</we-button>
         </we-select>
 
         <we-row string="Shape">
-            <we-button data-toggle-shape-rounded="rounded" title="Shape: Rounded"><i class="fa fa-square fa-fw"></i></we-button>
-            <we-button data-toggle-shape-circle="rounded-circle" title="Shape: Circle"><i class="fa fa-circle-o fa-fw"></i></we-button>
-            <we-button data-toggle-shape-shadow="shadow" title="Shadow"><i class="fa fa-sun-o fa-fw"></i></we-button>
-            <we-button data-toggle-shape-thumbnail="img-thumbnail" title="Shape: Thumbnail"><i class="fa fa-picture-o fa-fw"></i></we-button>
+            <we-button data-select-class="rounded" title="Shape: Rounded"><i class="fa fa-square fa-fw"/></we-button>
+            <we-button data-select-class="rounded-circle" title="Shape: Circle"><i class="fa fa-circle-o fa-fw"/></we-button>
+            <we-button data-select-class="shadow" title="Shadow"><i class="fa fa-sun-o fa-fw"/></we-button>
+            <we-button data-select-class="img-thumbnail" title="Shape: Thumbnail"><i class="fa fa-picture-o fa-fw"/></we-button>
         </we-row>
 
         <we-select string="Padding">
-            <we-button data-set-padding="" title="Padding: None">None</we-button>
-            <we-button data-set-padding="padding-small" title="Padding: Small">Small</we-button>
-            <we-button data-set-padding="padding-medium" title="Padding: Medium">Medium</we-button>
-            <we-button data-set-padding="padding-large" title="Padding: Large">Large</we-button>
-            <we-button data-set-padding="padding-xl" title="Padding: XL">Extra Large</we-button>
+            <we-button data-select-class="" title="Padding: None">None</we-button>
+            <we-button data-select-class="padding-small" title="Padding: Small">Small</we-button>
+            <we-button data-select-class="padding-medium" title="Padding: Medium">Medium</we-button>
+            <we-button data-select-class="padding-large" title="Padding: Large">Large</we-button>
+            <we-button data-select-class="padding-xl" title="Padding: XL">Extra Large</we-button>
         </we-select>
     </div>
 


### PR DESCRIPTION
    
    Since their convertion to "snippet" options with [1], the media options
    were not handling previews correctly anymore, but also were recoding
    their entire logic for each of the options instead of using generic
    methods like selectClass or selectStyle.
    
    One example of a bug was that previewing the 25% width option on an
    image, not enabling it and saving the editor forced the image to a fixed
    px width (its original one). Changing that image to another would keep
    that wrong fixed width.
    
    Note: this reveals that selectClass and selectStyle need more parameters
    to handle all of this correctly. Most was added as a specific override
    for these features but it could be handled even more generically.
    
    [1]: https://github.com/odoo/odoo/commit/d934b81aaae8d68b5579d1489b1fbe8ea347b4ed
    
    Related to task-2578242
    task-2577848
