### PR TITLE
[FIX] no override of Tax ID label

### DIFF
--- a/addons/base_vat/views/res_partner_views.xml
+++ b/addons/base_vat/views/res_partner_views.xml
@@ -5,9 +5,6 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='vat']" position="attributes">
-                    <attribute name="string">VAT</attribute>
-                </xpath>
                 <xpath expr="//span[hasclass('o_vat_label')]" position="replace">
                     <span class="o_vat_label">VAT</span>
                 </xpath>


### PR DESCRIPTION
The default label of the `vat` field is "Tax ID". This code override this for no apparent reason with the label "VAT". It is incorrect to override "Tax ID" for "VAT" because many countries have a Tax ID that they don't call VAT. Keep the default.