### PR TITLE
[FIX] purchase_stock: allow non admin users to replenish product

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -310,7 +310,7 @@ class StockRule(models.Model):
         )
         if values.get('orderpoint_id'):
             procurement_date = fields.Date.to_date(values['date_planned']) - relativedelta(days=int(values['supplier'].delay) + company_id.po_lead)
-            delta_days = int(self.env['ir.config_parameter'].get_param('purchase_stock.delta_days_merge') or 0)
+            delta_days = int(self.env['ir.config_parameter'].sudo().get_param('purchase_stock.delta_days_merge') or 0)
             domain += (
                 ('date_order', '<=', datetime.combine(procurement_date + relativedelta(days=delta_days), datetime.max.time())),
                 ('date_order', '>=', datetime.combine(procurement_date - relativedelta(days=delta_days), datetime.min.time()))


### PR DESCRIPTION
Before this commit, Non admin user was not allowed to Replenish product
with `Buy` route as access to `ir.config_parameter` is allowed to Admin users only.

With this commit, we are passing `sudo()` to get `purchase_stock.delta_days_merge`
from `ir.config_parameter`.


Fixes #73400

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
