### PR TITLE
[FIX] account: correcty sort invoices to confirm

### DIFF
--- a/addons/account/wizard/account_invoice_state.py
+++ b/addons/account/wizard/account_invoice_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import models, api, _
+from odoo import models, api, fields, _
 from odoo.exceptions import UserError
 
 
@@ -16,7 +16,7 @@ class AccountInvoiceConfirm(models.TransientModel):
         context = dict(self._context or {})
         active_ids = context.get('active_ids', []) or []
 
-        invoice_list = self.env['account.invoice'].browse(active_ids).sorted(lambda i: (i.date_invoice, i.reference or '', i.id))
+        invoice_list = self.env['account.invoice'].browse(active_ids).sorted(lambda i: (i.date_invoice or fields.Date.context_today(self), i.reference or '', i.id))
         for record in invoice_list:
             if record.state != 'draft':
                 raise UserError(_("Selected invoice(s) cannot be confirmed as they are not in 'Draft' state."))


### PR DESCRIPTION
Steps to reproduce the bug:
1: Invoice List -> Select few Invoices (With and Without Invoice Date filled in)
2: Action Confirm Draft Invoices

Bug: 
`TypeError: '<' not supported between instances of 'datetime.date' and 'bool'`

With this commit, we are using `fields.Date.context_today(self)` as default date if
`date_invoice` is not filled in.

Followup on  https://github.com/odoo/odoo/commit/6f319988ac15a366bcb370af870ec08cde75fb30
Fixes #73188

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
