### PR TITLE
[IMP] crm,{sale}s_team: improve the sales team kanban/list/form UI

### DIFF
--- a/addons/contacts/views/contact_views.xml
+++ b/addons/contacts/views/contact_views.xml
@@ -9,9 +9,9 @@
         <field name="context">{'default_is_company': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
-            Create a contact in your address book
+            Create a Contact in your address book
           </p><p>
-            Odoo helps you to easily track all activities related to a customer.
+            Odoo helps you track all activities related to your contacts.
           </p>
         </field>
     </record>

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -46,7 +46,6 @@
 
         'views/calendar_views.xml',
         'views/crm_recurring_plan_views.xml',
-        'views/crm_menu_views.xml',
         'views/crm_lost_reason_views.xml',
         'views/crm_stage_views.xml',
         'views/crm_lead_views.xml',

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -59,6 +59,8 @@
         'report/crm_activity_report_views.xml',
         'report/crm_opportunity_report_views.xml',
         'views/crm_team_views.xml',
+        'views/crm_menu_views.xml',
+        'views/crm_helper_templates.xml',
     ],
     'demo': [
         'data/crm_team_demo.xml',

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -628,8 +628,14 @@ class Team(models.Model):
         team_with_pipelines.update({'dashboard_button_name': _("Pipeline")})
 
     def action_primary_channel_button(self):
+        self.ensure_one()
         if self.use_opportunities:
-            return self.env["ir.actions.actions"]._for_xml_id("crm.crm_case_form_view_salesteams_opportunity")
+            action = self.env['ir.actions.actions']._for_xml_id('crm.crm_case_form_view_salesteams_opportunity')
+            rcontext = {
+                'team': self,
+            }
+            action['help'] = self.env['ir.ui.view']._render_template('crm.crm_action_helper', values=rcontext)
+            return action
         return super(Team,self).action_primary_channel_button()
 
     def _graph_get_model(self):

--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -79,7 +79,7 @@
         </record>
 
        <record id="crm_activity_report_action" model="ir.actions.act_window">
-           <field name="name">Pipeline Activities</field>
+           <field name="name">Activities</field>
            <field name="res_model">crm.activity.report</field>
            <field name="view_mode">graph,pivot,tree</field>
            <field name="context">{

--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -99,13 +99,6 @@
             </field>
        </record>
 
-       <menuitem
-            id="crm_activity_report_menu"
-            name="Activities"
-            parent="crm_menu_report"
-            action="crm_activity_report_action"
-            sequence="4"/>
-
         <record id="crm_activity_report_action_team" model="ir.actions.act_window">
             <field name="name">Pipeline Activities</field>
             <field name="res_model">crm.activity.report</field>

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -127,10 +127,6 @@
             </field>
         </record>
 
-        <record id="crm_opportunity_report_menu" model="ir.ui.menu">
-            <field name="action" ref="crm.crm_opportunity_report_action"/>
-        </record>
-
         <record id="crm_opportunity_report_action_lead" model="ir.actions.act_window">
             <field name="name">Leads Analysis</field>
             <field name="res_model">crm.lead</field>
@@ -155,10 +151,6 @@
                     This analysis shows you how many leads have been created per month.
                 </p>
             </field>
-        </record>
-
-        <record id="crm_opportunity_report_menu_lead" model="ir.ui.menu">
-            <field name="action" ref="crm.crm_opportunity_report_action_lead"/>
         </record>
 
 </odoo>

--- a/addons/crm/views/crm_helper_templates.xml
+++ b/addons/crm/views/crm_helper_templates.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="crm_action_helper" name="crm action helper">
+        <t t-if="team.alias_name and team.alias_domain">
+            <p class="o_view_nocontent_smiling_face">
+                Create an opportunity to start playing with your pipeline.
+            </p><p>Use the top left <i>Create</i> button, or send an email to
+            <a t-attf-href="mailto:#{team.alias_id.display_name}"><t t-esc="team.alias_id.display_name"/></a>
+            to test the email gateway.</p>
+        </t>
+        <t t-else="">
+            <p class='o_view_nocontent_smiling_face'>Create an opportunity to start playing with your pipeline.</p>
+            <p>Use the top left Create button, or configure an email alias to test the email gateway.</p>
+        </t>
+    </template>
+</odoo>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1259,4 +1259,19 @@
         <record id="crm_lead_menu_my_activities" model="ir.ui.menu">
             <field name="action" ref="crm.crm_lead_action_my_activities"/>
         </record>
+        <!-- create a lead from 'Teams' kanban -->
+        <record id="crm_lead_action_open_lead_form" model="ir.actions.act_window">
+            <field name="name">New Lead</field>
+            <field name="res_model">crm.lead</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="crm_lead_view_form"/>
+            <field name="domain">[('type','=','lead')]</field>
+            <field name="context">{
+                'search_default_team_id': [active_id],
+                'default_team_id': active_id,
+                'default_type': 'lead',
+            }</field>
+            <field name="search_view_id" ref="crm.view_crm_case_leads_filter"/>
+        </record>
 </odoo>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1071,10 +1071,6 @@
             <field name="act_window_id" ref="crm_lead_all_leads"/>
         </record>
 
-        <record id="crm_menu_leads" model="ir.ui.menu">
-            <field name="action" ref="crm.crm_lead_all_leads"/>
-        </record>
-
         <!-- My Activities Menu -->
         <record id="crm_lead_action_my_activities" model="ir.actions.act_window">
             <field name="name">My Activities</field>
@@ -1247,18 +1243,6 @@
             <field name="act_window_id" ref="crm_lead_action_forecast"/>
         </record>
 
-        <record id="menu_crm_opportunities" model="ir.ui.menu">
-            <field name="action" ref="crm.action_your_pipeline"/>
-        </record>
-        <record id="crm_menu_forecast" model="ir.ui.menu">
-            <field name="action" ref="crm.action_opportunity_forecast"/>
-        </record>
-        <record id="crm_menu_root" model="ir.ui.menu">
-            <field name="action" ref="crm.action_your_pipeline"/>
-        </record>
-        <record id="crm_lead_menu_my_activities" model="ir.ui.menu">
-            <field name="action" ref="crm.crm_lead_action_my_activities"/>
-        </record>
         <!-- create a lead from 'Teams' kanban -->
         <record id="crm_lead_action_open_lead_form" model="ir.actions.act_window">
             <field name="name">New Lead</field>

--- a/addons/crm/views/crm_lost_reason_views.xml
+++ b/addons/crm/views/crm_lost_reason_views.xml
@@ -66,8 +66,4 @@
           </p>
         </field>
     </record>
-
-    <record id="menu_crm_lost_reason" model="ir.ui.menu">
-        <field name="action" ref="crm.crm_lost_reason_action"/>
-    </record>
 </odoo>

--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -23,12 +23,14 @@
         id="menu_crm_opportunities"
         name="My Pipeline"
         parent="crm_menu_sales"
+        action="crm.action_your_pipeline"
         sequence="1"/>
     <menuitem
         id="crm_lead_menu_my_activities"
         name="My Activities"
         parent="crm_menu_sales"
         groups="sales_team.group_sale_salesman"
+        action="crm.crm_lead_action_my_activities"
         sequence="2"/>
 
     <menuitem
@@ -50,6 +52,7 @@
         id="crm_menu_leads"
         name="Leads"
         parent="crm_menu_root"
+        action="crm.crm_lead_all_leads"
         groups="crm.group_use_lead"
         sequence="5"/>
 
@@ -64,29 +67,40 @@
         id="crm_menu_forecast"
         name="Forecast"
         parent="crm_menu_report"
+        action="crm.action_opportunity_forecast"
         sequence="1"/>
     <menuitem
         id="crm_opportunity_report_menu_lead"
         name="Leads"
         parent="crm_menu_report"
+        action="crm.crm_opportunity_report_action_lead"
         groups="crm.group_use_lead"
         sequence="2"/>
     <menuitem
         id="crm_opportunity_report_menu" 
         name="Pipeline"
-        parent="crm_menu_report" 
+        parent="crm_menu_report"
+        action="crm.crm_opportunity_report_action"
         sequence="3"/>
+    <menuitem
+        id="crm_activity_report_menu"
+        name="Activities"
+        parent="crm_menu_report"
+        action="crm_activity_report_action"
+        sequence="4"/>
 
     <!-- CONFIGURATION -->
     <menuitem
         id="crm_menu_config"
         name="Configuration"
         parent="crm_menu_root"
+        action="crm.action_your_pipeline"
         sequence="25" groups="sales_team.group_sale_manager"/>
     <menuitem
         id="crm_config_settings_menu"
         name="Settings"
         parent="crm_menu_config"
+        action="crm.crm_config_settings_action"
         groups="base.group_system"
         sequence="0"/>
     <menuitem
@@ -132,6 +146,7 @@
         name="Stages"
         sequence="0"
         parent="menu_crm_config_lead"
+        action="crm.crm_stage_action"
         groups="base.group_no_one"/>
     <menuitem
         id="menu_crm_lead_categ"
@@ -143,6 +158,7 @@
         id="menu_crm_lost_reason"
         name="Lost Reasons"
         parent="menu_crm_config_lead"
+        action="crm.crm_lost_reason_action"
         sequence="6"/>
 
     <menuitem

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -70,8 +70,4 @@
         </field>
     </record>
 
-    <record id="menu_crm_lead_stage_act" model="ir.ui.menu">
-        <field name="action" ref="crm.crm_stage_action"/>
-    </record>
-
 </odoo>

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -119,6 +119,17 @@
             <field name="help">Opportunities Analysis gives you an instant access to your opportunities with information such as the expected revenue, planned cost, missed deadlines or the number of interactions per opportunity. This report is mainly used by the sales manager in order to do the periodic review with the channels of the sales pipeline.</field>
         </record>
 
+        <record id="crm_team_view_tree" model="ir.ui.view">
+            <field name="name">crm.team.tree.inherit.crm</field>
+            <field name="model">crm.team</field>
+            <field name="inherit_id" ref="sales_team.crm_team_view_tree"/>
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field string="Alias" name="alias_id"/>
+                </field>
+            </field>
+        </record>
+
         <record id="sales_team_form_view_in_crm" model="ir.ui.view">
             <field name="name">crm.team.form.inherit</field>
             <field name="model">crm.team</field>
@@ -243,8 +254,8 @@
                     </xpath>
 
                     <xpath expr="//div[hasclass('o_primary')]" position="after">
-                        <div t-if="record.use_leads.raw_value and record.alias_name.value and record.alias_domain.value">
-                            <small t-translation="off"><i class="fa fa-envelope-o" aria-label="Leads" title="Leads" role="img"></i>&amp;nbsp; <field name="alias_id"/></small>
+                        <div t-if="record.alias_name.value and record.alias_domain.value">
+                            <span t-translation="off"><i class="fa fa-envelope-o" aria-label="Leads" title="Leads" role="img"></i>&amp;nbsp; <field name="alias_id"/></span>
                         </div>
                     </xpath>
 
@@ -284,7 +295,7 @@
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
+                    <xpath expr="//div[hasclass('o_kanban_manage_view')]/div[hasclass('o_kanban_card_manage_title')]" position="after">
                         <div t-if="record.use_leads.raw_value" groups="crm.group_use_lead">
                             <a name="%(crm_case_form_view_salesteams_lead)d" type="action">
                                 Leads
@@ -297,7 +308,12 @@
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_new')]" position="inside">
+                    <xpath expr="//div[hasclass('o_kanban_manage_new')]/div[hasclass('o_kanban_card_manage_title')]" position="after">
+                        <div t-if="record.use_leads.raw_value" groups="crm.group_use_lead">
+                            <a name="%(crm_lead_action_open_lead_form)d" type="action">
+                                Leads
+                            </a>
+                        </div>
                         <div t-if="record.use_opportunities.raw_value">
                             <a  name="%(action_opportunity_form)d" type="action">
                                 Opportunity
@@ -305,7 +321,7 @@
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
+                    <xpath expr="//div[hasclass('o_kanban_manage_reports')]/div[hasclass('o_kanban_card_manage_title')]" position="after">
                         <div t-if="record.use_leads.raw_value" groups="crm.group_use_lead">
                             <a name="%(action_report_crm_lead_salesteam)d" type="action">
                                 Leads
@@ -316,10 +332,15 @@
                                 Opportunities
                             </a>
                         </div>
-                        <div t-if="record.use_opportunities.raw_value">
-                            <a name="%(crm.crm_activity_report_action_team)d" type="action">
-                                Activities
-                            </a>
+                    </xpath>
+
+                    <xpath expr="//div[hasclass('o_kanban_manage_reports')]/div[@name='o_team_kanban_report_separator']" position="after">
+                        <div name="activity_report">
+                            <div t-if="record.use_opportunities.raw_value">
+                                <a name="%(crm.crm_activity_report_action_team)d" type="action" style="color: #444B5A;">
+                                    Activities
+                                </a>
+                            </div>
                         </div>
                     </xpath>
                 </data>

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -179,8 +179,4 @@
         <field name="context">{'module' : 'crm', 'bin_size': False}</field>
     </record>
 
-    <record id="crm_config_settings_menu" model="ir.ui.menu">
-        <field name="action" ref="crm.crm_config_settings_action"/>
-    </record>
-
 </odoo>

--- a/addons/sale/static/src/js/sale.js
+++ b/addons/sale/static/src/js/sale.js
@@ -3,6 +3,7 @@ odoo.define('sale.sales_team_dashboard', function (require) {
 
 var core = require('web.core');
 var KanbanRecord = require('web.KanbanRecord');
+var session = require('web.session');
 var _t = core._t;
 
 KanbanRecord.include({
@@ -23,8 +24,20 @@ KanbanRecord.include({
 
         this.$target_input = $('<input>');
         this.$('.o_kanban_primary_bottom:last').html(this.$target_input);
-        this.$('.o_kanban_primary_bottom:last').prepend(_t("Set an invoicing target: "));
         this.$target_input.focus();
+        let preLabel = _t("Set an invoicing target: ");
+        let postLabel = _t(" / Month");
+        const kanbanBottomBlock = this.$el.find('.o_kanban_primary_bottom.bottom_block:last-child');
+        if (this.recordData.currency_id) {
+            const currency = session.get_currency(this.recordData.currency_id.res_id);
+            if (currency.position === "after") {
+                postLabel = ` ${' ' + currency.symbol}${postLabel}`;
+            } else {
+               preLabel = `${preLabel} ${currency.symbol + ' '}`;
+            }
+        }
+        kanbanBottomBlock.prepend($('<span/>').text(preLabel));
+        kanbanBottomBlock.append($('<span/>').text(postLabel));
 
         this.$target_input.on({
             blur: this._onSalesTeamTargetSet.bind(this),

--- a/addons/sale/views/crm_team_views.xml
+++ b/addons/sale/views/crm_team_views.xml
@@ -12,7 +12,11 @@
                     </div>
                 </xpath>
                 <xpath expr="//field[@name='company_id']" position="after">
-                    <field name="invoiced_target" widget="monetary"/>
+                    <label for="invoiced_target"/>
+                    <div class="o_row">
+                        <field name="invoiced_target" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                        <span class="oe_read_only">/ Month</span>
+                    </div>
                 </xpath>
             </field>
         </record>
@@ -81,14 +85,16 @@
                 </div>
             </xpath>
 
-            <xpath expr="//div[hasclass('bottom_block')]" position="inside">
+            <xpath expr="//div[hasclass('o_kanban_primary_bottom')]" position="after">
                 <t groups="sales_team.group_sale_manager">
-                    <t t-if="record.invoiced_target.raw_value" class="col-12 o_kanban_primary_bottom">
-                        <field name="invoiced" widget="progressbar" title="Invoicing" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true, 'on_change': 'update_invoiced_target'}"/>
-                    </t>
-                    <t t-if="!record.invoiced_target.raw_value" class="col-12 o_kanban_primary_bottom text-center">
-                        <a href="#" class="sales_team_target_definition o_inline_link">Click to define an invoicing target</a>
-                    </t>
+                    <div class="col-12 o_kanban_primary_bottom bottom_block">
+                        <t t-if="record.invoiced_target.raw_value" class="col-12 o_kanban_primary_bottom">
+                            <field name="invoiced" widget="progressbar" title="Invoicing" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true, 'on_change': 'update_invoiced_target'}"/>
+                        </t>
+                        <t t-if="!record.invoiced_target.raw_value" class="col-12 o_kanban_primary_bottom text-center">
+                            <a href="#" class="sales_team_target_definition o_inline_link">Click to define an invoicing target</a>
+                        </t>
+                    </div>
                 </t>
             </xpath>
 
@@ -112,7 +118,12 @@
                 </div>
             </xpath>
 
-            <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">
+            <xpath expr="//div[hasclass('o_kanban_manage_reports')]/div[@name='o_team_kanban_report_separator']" position="before">
+                <div t-if="record.use_quotations.raw_value">
+                     <a name="%(action_order_report_quotation_salesteam)d" type="action">
+                         Quotations
+                     </a>
+                </div>
                 <div name="sales_report">
                     <a name="%(action_order_report_so_salesteam)d" type="action">
                         Sales

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1336,6 +1336,13 @@
                 }
             </field>
             <field name="search_view_id" ref="account.view_account_invoice_filter"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Create a customer invoice
+                </p><p>
+                    Create invoices, register payments and keep track of the discussions with your customers.
+                </p>
+            </field>
         </record>
 
         <record id="action_invoice_salesteams_view_tree" model="ir.actions.act_window.view">

--- a/addons/sales_team/views/crm_tag_views.xml
+++ b/addons/sales_team/views/crm_tag_views.xml
@@ -29,7 +29,7 @@
         <field name="name">sales.team.crm.tag.view.tree</field>
         <field name="model">crm.tag</field>
         <field name="arch" type="xml">
-            <tree string="Tags" editable="bottom">
+            <tree string="Tags" editable="bottom" sample="1">
                 <field name="name"/>
                 <field name="color" widget="color_picker" />
             </tree>
@@ -43,9 +43,9 @@
         <field name="view_id" ref="sales_team_crm_tag_view_tree"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-            Create new tags for your opportunities
+            Create CRM Tags
             </p><p>
-            Create tags that fit your business (product structure, sales type, etc.) to better manage and track your opportunities.
+            Use Tags to manage and track your Opportunities (product structure, sales type, ...)
             </p>
         </field>
     </record>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -41,7 +41,7 @@
                             <field name="active" invisible="1"/>
                             <field name="sequence" invisible="1"/>
                             <field name="is_membership_multi" invisible="1"/>
-                            <field name="user_id" domain="[('share', '=', False)]"/>
+                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="member_company_ids" invisible="1"/>
@@ -108,7 +108,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name" readonly="1"/>
                 <field name="active" invisible="1"/>
-                <field name="user_id" domain="[('share', '=', False)]"/>
+                <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -176,8 +176,6 @@
                                     <div class="col-12 o_kanban_primary_bottom">
                                         <t t-call="SalesTeamDashboardGraph"/>
                                     </div>
-                                    <div class="col-12 o_kanban_primary_bottom bottom_block">
-                                    </div>
                                 </div>
                             </div><div class="container o_kanban_card_manage_pane dropdown-menu" role="menu">
                                 <div class="row">
@@ -195,6 +193,7 @@
                                         <div role="menuitem" class="o_kanban_card_manage_title">
                                             <span>Reporting</span>
                                         </div>
+                                        <div name="o_team_kanban_report_separator"></div>
                                     </div>
                                 </div>
 

--- a/addons/website_crm_iap_reveal/views/crm_reveal_views.xml
+++ b/addons/website_crm_iap_reveal/views/crm_reveal_views.xml
@@ -7,13 +7,13 @@
             <form>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button name="action_get_opportunity_tree_view" class="oe_stat_button" type="object" icon="fa-handshake-o" attrs="{'invisible': [('lead_type', '!=', 'opportunity'), ('opportunity_count', '=' , 0)]}">
+                        <button name="action_get_opportunity_tree_view" class="oe_stat_button" type="object" icon="fa-star" attrs="{'invisible': [('lead_type', '!=', 'opportunity'), ('opportunity_count', '=' , 0)]}">
                             <div class="o_stat_info">
                                 <field name="opportunity_count"/>
                                 <span class="o_stat_text"> Opportunities </span>
                             </div>
                         </button>
-                        <button name="action_get_lead_tree_view" class="oe_stat_button" type="object" icon="fa-handshake-o" groups="crm.group_use_lead" attrs="{'invisible': [('lead_type', '!=', 'lead'), ('lead_count', '=' , 0)]}">
+                        <button name="action_get_lead_tree_view" class="oe_stat_button" type="object" icon="fa-star" groups="crm.group_use_lead" attrs="{'invisible': [('lead_type', '!=', 'lead'), ('lead_count', '=' , 0)]}">
                             <div class="o_stat_info">
                                 <field name="lead_count"/>
                                 <span class="o_stat_text"> Leads </span>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -509,9 +509,9 @@
             <field name="search_view_id" ref="view_res_partner_filter"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
-                Create a new customer in your address book
+                Create a Contact in your address book
               </p><p>
-                Odoo helps you easily track all activities related to a customer.
+                Odoo helps you track all activities related to your contacts.
               </p>
             </field>
         </record>


### PR DESCRIPTION
PURPOSE

Walk around in the CRM to improve some UI.

SPECIFICATIONS

- In Visit to Leads changing the icon from fa-handshake
   to fa-star, Handshake is for the app, stars are for the leads

- CRM>Configuration>Tags
   Updating the action helper to:
   Create CRM Tags
   Use Tags to manage and track your Opportunities (product structure,
    sales type, etc.)

- CRM > Sales > Customers
   Updating the action helper to:
   Create a Contact in your address book
   Odoo helps you track all activities related to a contact.

- CRM > Sales > Teams
   - The grey bottom border in the Teams kanban card should appear only 
      when they have a invoice target.

   - Increase the size of the alias in Teams kanban card a bit because it's hard
     to read.

   - The Teams kanban card is very meh if you have no data. So add some dummy
      data.
      
- CRM > Configuration > Sales Teams
   In Sales Teams list view add alias and avatar on the team leader.

- If you go CRM>Team>Pipeline, you get a strange action helper
  Instead, display the normal Pipeline action helper one except the gateway 
  address is always  the alias of the team.

- Sections should be the same for all columns in team kanban view.
   if leads are activated, they should be in View, New & Reporting
   Activities should be at the bottom of the Reporting list since it has no
   counterpart.

- CRM > Sales > Teams (Select invoice from Kanban view)
  added new action helper in Teams/Invoice.

-  CRM > Reporting > Activities
   Rename Action to "Activities" (no "Pipeline" because it's confusing).

LINKS
PR #73530
Task 2582208

