### PR TITLE
[FIX] web_editor: fixes on colors and unbreakable

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -328,7 +328,7 @@ export class OdooEditor extends EventTarget {
         // Rollback if node.ouid changed. This ensures that nodes never change
         // unbreakable ancestors.
         node.ouid = node.ouid || getOuid(node, true);
-        if (testunbreak) {
+        if (testunbreak && !(node.nodeType === Node.TEXT_NODE && !node.length)) {
             const ouid = getOuid(node);
             if (!this._toRollback && ouid && ouid !== node.ouid) {
                 this._toRollback = UNBREAKABLE_ROLLBACK_CODE;

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -498,7 +498,7 @@ export const editorCommands = {
         // Color the selected <font>s and remove uncolored fonts.
         for (const font of new Set(fonts)) {
             colorElement(font, color, mode);
-            if (!hasColor(font, mode) && !hasColor(font, mode)) {
+            if (!hasColor(font, mode) && !font.hasAttribute('style')) {
                 for (const child of [...font.childNodes]) {
                     font.parentNode.insertBefore(child, font);
                 }

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
-import { UNBREAKABLE_ROLLBACK_CODE, UNREMOVABLE_ROLLBACK_CODE } from '../utils/constants.js';
+import { UNREMOVABLE_ROLLBACK_CODE } from '../utils/constants.js';
 
 import {
     boundariesOut,
@@ -66,9 +66,6 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false) 
         const leftNode = this.childNodes[offset - 1];
         if (isUnremovable(leftNode)) {
             throw UNREMOVABLE_ROLLBACK_CODE;
-        }
-        if (isUnbreakable(leftNode)) {
-            throw UNBREAKABLE_ROLLBACK_CODE;
         }
         if (isMediaElement(leftNode)) {
             leftNode.remove();

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -157,7 +157,6 @@ export class Powerbox {
     open(openOptions) {
         this.options.onActivate && this.options.onActivate();
         this._currentOpenOptions = openOptions;
-        console.log('op', openOptions);
 
         const openOnKeyupTarget =
             this._currentOpenOptions.openOnKeyupTarget || this.options.editable;

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -93,6 +93,35 @@ describe('Editor', () => {
                             '<table><tbody><tr><td>[]<br></td><td>abc</td></tr></tbody></table>',
                     });
                 });
+                it('should remove empty unbreakable', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><div><p>ABC</p></div><div>X[]</div></div>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                        },
+                        contentAfter: '<div><div><p>AB[]</p></div></div>',
+                    });
+                });
+                it('should remove empty unbreakable (formated)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<div>
+                                            <div>
+                                                <p>ABC</p>
+                                            </div>
+                                            <div>X[]</div>
+                                        </div>`,
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                        },
+                        contentAfter: `<div>
+                                            <div>
+                                                <p>AB[]</p></div></div>`,
+                    });
+                });
             });
             describe('white spaces', () => {
                 describe('no intefering spaces', () => {


### PR DESCRIPTION
See odoo task : [2580158](https://www.odoo.com/web#id=2580158&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720)

----------

#### [FIX] web_editor: ensure <font> colors are kept properly

color and background-color styles on `<font>` tags were being wrongly overridden when applying another color or background color to the element.

----------

#### [FIX] web_editor: allow deletion of unbreakable elements when empty

unbreakable elements were being considered as unremovable in some deletebackward cases.
with these changes it is now possible to remove a unbreakble element if it is empty


----------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
