### PR TITLE
[FIX] sale_stock_margin: convert purchase_price

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
@@ -14,7 +14,15 @@ class SaleOrderLine(models.Model):
             if not line.move_ids:
                 lines_without_moves |= line
             elif line.product_id.categ_id.property_cost_method != 'standard':
-                line.purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
+                purch_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
                 if line.product_uom and line.product_uom != line.product_id.uom_id:
-                    line.purchase_price = line.product_id.uom_id._compute_price(line.purchase_price, line.product_uom)
+                    purch_price = line.product_id.uom_id._compute_price(purch_price, line.product_uom)
+                to_cur = line.currency_id or line.order_id.currency_id
+                line.purchase_price = line.product_id.cost_currency_id._convert(
+                    from_amount=purch_price,
+                    to_currency=to_cur,
+                    company=line.company_id or self.env.company,
+                    date=line.order_id.date_order or fields.Date.today(),
+                    round=False,
+                ) if to_cur and purch_price else purch_price
         return super(SaleOrderLine, lines_without_moves)._compute_purchase_price()


### PR DESCRIPTION
When confirming a SO, if the costing method of a product's category is
not `Standard' and if the SO's currency is different from the company's
currency, the cost of the product won't be converted to the SO's
currency

To reproduce the error:
1. In Settings, enable:
    - Margins
    - Multi-Currencies
2. Create a product category PC:
    - Costing Method: FIFO
3. Create a product P:
    - Product Type: Storable
    - Product Category: PC
    - Sales Price: 200
    - Cost: 100
4. Update P's quantity to 1
5. Create a pricelist PL:
    - Currency: EUR
6. Create a SO:
    - Pricelist: PL
    - Order Lines:
        - 1 x P
7. Add field "Cost" to the tree view of the order lines
    - The value is correctly converted
8. Confirm the SO

Error: The cost of the order line is now 100€. This is actually the USD
cost, it should be converted

This code applies the same conversion as when the cost method is
standard:
https://github.com/odoo/odoo/blob/8a8ff03f6111f377bcd9c2b0f584c450b82a4182/addons/sale_margin/models/sale_order.py#L42-L48

OPW-2563442