### PR TITLE
[FIX] point_of_sale: fix error on reading multiple pos.session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -112,7 +112,7 @@ class PosSession(models.Model):
             cash_payment_method = session.payment_method_ids.filtered('is_cash_count')[:1]
             if cash_payment_method:
                 total_cash_payment = 0.0
-                result = self.env['pos.payment'].read_group([('session_id', '=', self.id), ('payment_method_id', '=', cash_payment_method.id)], ['amount'], ['session_id'])
+                result = self.env['pos.payment'].read_group([('session_id', '=', session.id), ('payment_method_id', '=', cash_payment_method.id)], ['amount'], ['session_id'])
                 if result:
                     total_cash_payment = result[0]['amount']
                 session.cash_register_total_entry_encoding = session.cash_register_id.total_entry_encoding + (


### PR DESCRIPTION
Fixup for https://github.com/odoo/odoo/pull/69933

Standard deployment is not affected, because the computed fields is used in form
only, so `self==session` there, but it may be not the case with customization

Thanks @mahmoudfakhereldin for pointing the problem
