### PR TITLE
[FIX] point_of_sale: characters overlap in the receipt with html2canvas

### DIFF
--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -56,7 +56,8 @@ var PrinterMixin = {
                 onrendered: function (canvas) {
                     $('.pos-receipt-print').empty();
                     resolve(self.process_canvas(canvas));
-                } 
+                },
+                letterRendering: true,
             })
         });
         return promise;


### PR DESCRIPTION
Some characters were overlapped in the printed receipt or receipt sent by email because the library html2canvas doesn't handle well the css wrapping (e.g. in the German localization) by default.

