### PR TITLE
[IMP] hr_contract: Display first contract date on employee public form

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -69,7 +69,7 @@
                             <page name="public" string="Work Information">
                                 <div id="o_work_employee_container"> <!-- These two div are used to position org_chart -->
                                     <div id="o_work_employee_main">
-                                        <group string="Location">
+                                        <group string="Location" name="location">
                                             <field name="address_id"
                                                 context="{'show_address': 1}"
                                                 options='{"always_reload": True, "highlight_first_line": True}'/>

--- a/addons/hr_contract/__manifest__.py
+++ b/addons/hr_contract/__manifest__.py
@@ -26,6 +26,7 @@ You can assign several contracts per employee.
         'report/hr_contract_history_report_views.xml',
         'views/hr_contract_views.xml',
         'views/hr_employee_views.xml',
+        'views/hr_employee_public_views.xml',
         'views/resource_calendar_views.xml',
         'wizard/hr_departure_wizard_views.xml',
     ],

--- a/addons/hr_contract/models/__init__.py
+++ b/addons/hr_contract/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import hr_employee
+from . import hr_employee_public
 from . import hr_contract
 from . import res_users
 from . import resource

--- a/addons/hr_contract/models/hr_employee_public.py
+++ b/addons/hr_contract/models/hr_employee_public.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = "hr.employee.public"
+
+    first_contract_date = fields.Date(related='employee_id.first_contract_date', groups="base.group_user")

--- a/addons/hr_contract/views/hr_employee_public_views.xml
+++ b/addons/hr_contract/views/hr_employee_public_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
+        <field name="arch" type="xml">
+            <group name="location" position="after">
+                <field name="employee_type" position="replace"/>
+                <field name="user_id" position="replace"/>
+                <group string="Status" name="status">
+                    <field name="employee_type"/>
+                    <field name="first_contract_date"/>
+                    <field name="user_id" string="Related User"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose
=======

The "first contract date" is a usefull information for anybody who onboards
new colleagues. Issue: this information is not on the "public employee" and so,
visible only by hr officer (minimum).

With this task, we would like make this field public and visible by any internal
user in the system. In this way, we don't have to provide too many access rights
to any employees.

TaskID: 2584098

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
