### PR TITLE
Master hotkey add Tab & Delete navkeys

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -17,6 +17,8 @@ const NAV_KEYS = [
     "backspace",
     "enter",
     "escape",
+    "tab",
+    "delete",
 ];
 const MODIFIERS = new Set(["alt", "control", "shift"]);
 const AUTHORIZED_KEYS = new Set([...ALPHANUM_KEYS, ...NAV_KEYS]);

--- a/doc/cla/individual/SplashS.md
+++ b/doc/cla/individual/SplashS.md
@@ -1,0 +1,11 @@
+Russian Federation, 2021-06-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sergey Shebanin sergey@shebanin.ru https://github.com/SplashS


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR adds ability to track Tab & Delete shortcuts via hotkey_service.

Current behavior before PR:
Developers can't use hooks `useHotkey("Tab", ...)` or `useHotkey("Delete", ...)`

Desired behavior after PR is merged:
Developers can use hooks `useHotkey("Tab", ...)` or `useHotkey("Delete", ...)`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
