### PR TITLE
[FIX] mail_group: fix a traceback when a public user subscribe

### DIFF
--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -248,9 +248,9 @@ class PortalMailGroup(http.Controller):
         else:
             # For non-logged user, send an email with a token to confirm the action
             if action == 'subscribe':
-                group_sudo._send_subscribe_confirmation_email(email, action)
+                group_sudo._send_subscribe_confirmation_email(email)
             else:
-                group_sudo._send_unsubscribe_confirmation_email(email, action)
+                group_sudo._send_unsubscribe_confirmation_email(email)
             return 'email_sent'
 
     @http.route('/groups/subscribe', type='http', auth='public', website=True)

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -493,7 +493,7 @@ class MailGroup(models.Model):
         )
         _logger.info('Subscription email sent to %s.', email)
 
-    def _send_unsubscribe_confirmation_email(self, email, action):
+    def _send_unsubscribe_confirmation_email(self, email):
         """Send an email to the given address to subscribe / unsubscribe to the mailing list."""
         self.ensure_one()
         confirm_action_url = self._generate_action_url(email, 'unsubscribe')


### PR DESCRIPTION
Bug
===
When a public user subscribe to a mailing list, a traceback is raised.