### PR TITLE
[FIX] account: allow to change currency when posted before

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -716,7 +716,7 @@
                                         groups="base.group_multi_currency"> in </span>
                                     <field name="currency_id"
                                         groups="base.group_multi_currency"
-                                        attrs="{'readonly': [('posted_before', '=', True)]}"/>
+                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
There is no reason to forbid changing the currency when a move has been
posted before.
Was introduced in [1] without reason.

[1] https://github.com/odoo/odoo/commit/d1bbf11af27e4ce12b025ef22e397302ee6336c2


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
