### PR TITLE
[FIX] calendar, mail: Use user supplied date format in the activity overview

### DIFF
--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -31,7 +31,7 @@
                             <t t-if="meeting.allday">All Day</t>
                             <t t-else=''>
                                 <t t-set="is_next_meeting" t-value="false"/>
-                                <t t-esc="moment(meeting.start).local().format('hh:mm A')"/>
+                                <t t-esc="moment(meeting.start).local().format(Time.strftime_to_moment_format(_t.database.parameters.time_format))"/>
                             </t>
                         </span>
                     </div>

--- a/addons/mail/static/src/js/systray/systray_activity_menu.js
+++ b/addons/mail/static/src/js/systray/systray_activity_menu.js
@@ -5,6 +5,7 @@ var core = require('web.core');
 var session = require('web.session');
 var SystrayMenu = require('web.SystrayMenu');
 var Widget = require('web.Widget');
+var Time = require('web.time');
 var QWeb = core.qweb;
 
 const { Component } = owl;
@@ -80,7 +81,8 @@ var ActivityMenu = Widget.extend({
         var self = this;
         self._getActivityData().then(function (){
             self._$activitiesPreview.html(QWeb.render('mail.systray.ActivityMenu.Previews', {
-                widget: self
+                widget: self,
+                Time: Time
             }));
         });
     },


### PR DESCRIPTION
Ticket: 2578903

In the overview menu, the time of a calendar event was not formatted according to the user preferences. This PR fixes that.