### PR TITLE
[FIX] web_editor: save zone with proper res_model

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -339,7 +339,8 @@ const Wysiwyg = Widget.extend({
             await this.snippetsMenu.cleanForSave();
         }
 
-        await this.saveModifiedImages();
+        const editables = this.options.getContentEditableAreas();
+        await this.saveModifiedImages(editables.length ? $(editables) : this.$editable);
         await this._saveViewBlocks();
 
         this.trigger_up('edition_was_stopped');


### PR DESCRIPTION
Without this commit, the method `saveModifiedImages` did not use
editables zone but rather the whole `$editable`.
Because of that, oeModel and oeId were undefined and saving images
was done without the proper metadata.

That made impossible the retrieval of the images from the method
`ir.qweb.field.image` `from_html` defined by the module `web_unsplash`.

task-2581567
