### PR TITLE
[IMP] project, hr_timesheet: improve customer rating on project

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -906,9 +906,9 @@ Send it ASAP, its urgent.</field>
             <field name="rating_template_id" ref="rating_project_request_email_template"/>
         </record>
 
-        <function model="project.task" name="rating_apply" eval="([ref('project.project_task_3')], 5)"/>
-        <function model="project.task" name="rating_apply" eval="([ref('project.project_task_24')], 5)"/>
-        <function model="project.task" name="rating_apply" eval="([ref('project.project_task_8')], 1)"/>
+        <function model="project.task" name="rating_apply" eval="([ref('project.project_task_3')], 5, None, 'Good Job')"/>
+        <function model="project.task" name="rating_apply" eval="([ref('project.project_task_24')], 5, None, 'Great work')"/>
+        <function model="project.task" name="rating_apply" eval="([ref('project.project_task_8')], 1, None, 'Not as good as expected')"/>
 
         <record id="project_milestone_1" model="project.milestone">
             <field name="is_reached" eval="True"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -658,10 +658,10 @@
                                                 <div t-if="record.alias_name.value and record.alias_domain.value" class="text-muted">
                                                     <span class="fa fa-envelope-o mr-2" aria-label="Domain Alias" title="Domain Alias"></span><t t-esc="record.alias_id.value"/>
                                                 </div>
-                                                <div t-if="record.rating_active.raw_value" class="text-muted" title="Percentage of happy ratings over the past 30 days." groups="project.group_project_rating">
+                                                <div t-if="record.rating_active.raw_value" class="text-muted" groups="project.group_project_rating">
                                                     <b>
                                                         <t t-if="record.rating_percentage_satisfaction.value != -1">
-                                                            <i class="fa fa-smile-o" role="img" aria-label="Percentage of satisfaction" title="Percentage of satisfaction"/> <t t-esc="record.rating_percentage_satisfaction.value"/>%
+                                                            <i class="fa fa-smile-o" role="img" aria-label="Average satisfaction rate for the last 30 days." title="Average satisfaction rate for the last 30 days."/> <t t-esc="record.rating_percentage_satisfaction.value"/>%
                                                         </t>
                                                     </b>
                                                 </div>
@@ -1436,7 +1436,7 @@
             action="rating_rating_action_project_report"
             parent="menu_project_report"
             groups="project.group_project_rating"
-            sequence="40"/>
+            sequence="51"/>
 
         <record id="project_view_kanban_inherit_project" model="ir.ui.view">
             <field name="name">project.kanban.inherit.project</field>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -300,7 +300,7 @@
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '>=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button oe_read_only text-warning" icon="fa-meh-o" groups="project.group_project_rating">
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button oe_read_only text-warning" icon="fa-meh-o" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
@@ -311,7 +311,7 @@
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), '|', ('rating_percentage_satisfaction', '>=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button oe_read_only text-danger" icon="fa-frown-o" groups="project.group_project_rating">
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), '|', ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button oe_read_only text-danger" icon="fa-frown-o" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
@@ -829,13 +829,13 @@
                                 <span class="o_stat_text text-secondary">Satisfaction</span>
                             </div>
                         </button>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '>=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button text-warning" icon="fa-meh-o" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button text-warning" icon="fa-meh-o" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
                                 <span class="o_stat_text text-secondary">Satisfaction</span>
                             </div>
                         </button>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '>=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button text-danger" icon="fa-frown-o" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button text-danger" icon="fa-frown-o" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
                                 <span class="o_stat_text text-secondary">Satisfaction</span>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -289,35 +289,35 @@
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button oe_read_only text-success" icon="fa-smile-o" groups="project.group_project_rating">
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button oe_read_only" icon="fa-smile-o text-success" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
                                     %
                                 </span>
-                                <span class="o_stat_text text-secondary">
+                                <span class="o_stat_text">
                                     Satisfaction
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button oe_read_only text-warning" icon="fa-meh-o" groups="project.group_project_rating">
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button oe_read_only" icon="fa-meh-o text-warning" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
                                     %
                                 </span>
-                                <span class="o_stat_text text-secondary">
+                                <span class="o_stat_text">
                                     Satisfaction
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), '|', ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button oe_read_only text-danger" icon="fa-frown-o" groups="project.group_project_rating">
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), '|', ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button oe_read_only" icon="fa-frown-o text-danger" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
                                     %
                                 </span>
-                                <span class="o_stat_text text-secondary">
+                                <span class="o_stat_text">
                                     Satisfaction
                                 </span>
                             </div>
@@ -823,22 +823,22 @@
                         <span id="button_worksheet" invisible="1"/>
                         <!-- Dummy tag used to organize buttons, englobing the 3 buttons modifies the width of the button -->
                         <span id="start_rating_buttons" invisible="1"/>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button text-success" icon="fa-smile-o" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button" icon="fa-smile-o text-success" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
-                                <span class="o_stat_text text-secondary">Satisfaction</span>
+                                <span class="o_stat_text">Satisfaction</span>
                             </div>
                         </button>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button text-warning" icon="fa-meh-o" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button" icon="fa-meh-o text-warning" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
-                                <span class="o_stat_text text-secondary">Satisfaction</span>
+                                <span class="o_stat_text">Satisfaction</span>
                             </div>
                         </button>
-                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button text-danger" icon="fa-frown-o" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&gt;=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button" icon="fa-frown-o text-danger" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
-                                <span class="o_stat_text text-secondary">Satisfaction</span>
+                                <span class="o_stat_text">Satisfaction</span>
                             </div>
                         </button>
                         <!-- Dummy tag used to organize buttons -->

--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -24,6 +24,13 @@
         <field name="inherit_id" ref="rating.rating_rating_view_form"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <xpath expr="//form" position="attributes">
+                <attribute name="edit">0</attribute>
+            </xpath>
+            <field name="resource_ref" position="before">
+                <field name="rated_partner_id" position="move"/>
+                <field name="parent_ref" position="move"/>
+            </field>
             <field name="res_name" position="attributes">
                 <attribute name="string">Task</attribute>
             </field>
@@ -46,8 +53,11 @@
                 <attribute name="readonly">1</attribute>
             </field>
             <div name="rating_image_container" position="replace">
-                <field name="rating_text" string="Rating"/>
+                <field name="rating_text" string="Rating" decoration-danger="rating_text == 'ko'" decoration-warning="rating_text == 'ok'" decoration-success="rating_text == 'top'" widget='badge'/>
             </div>
+            <field name="create_date" position="after">
+                <field name="partner_id" position="move"/>
+            </field>
             <xpath expr="//field[@name='is_internal']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
@@ -62,6 +72,9 @@
         <field name="arch" type="xml">
             <xpath expr="//pivot" position="attributes">
                 <attribute name="js_class">project_rating_pivot</attribute>
+            </xpath>
+            <xpath expr="//field[@name='create_date']" position="attributes">
+                <attribute name="invisible">1</attribute>
             </xpath>
         </field>
     </record>
@@ -84,8 +97,24 @@
         <field name="inherit_id" ref="rating.rating_rating_view_search"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='resource']" position="after">
+            <xpath expr="//field[@name='rated_partner_id']" position="after">
+                <field name="parent_res_name" position="move"/>
+                <field name="res_name" position="move"/>
+            </xpath>
+            <xpath expr="//field[@name='parent_res_name']" position="attributes">
+                <attribute name="string">Project</attribute>
+            </xpath>
+            <xpath expr="//field[@name='res_name']" position="attributes">
+                <attribute name="string">Task</attribute>
+            </xpath>
+            <xpath expr="//filter[@name='responsible']" position="after">
+                <filter name="rating_text" position="move"/>
                 <filter string="Project" name="groupby_project" context="{'group_by': 'parent_res_name'}"/>
+                <filter name="resource" position="move"/>
+                <filter name="customer" position="move"/>
+            </xpath>
+            <xpath expr="//filter[@name='resource']" position="attributes">
+                <attribute name="string">Task</attribute>
             </xpath>
             <xpath expr="//filter[@name='responsible']" position="replace"></xpath>
             <xpath expr="/search" position="inside">
@@ -208,7 +237,10 @@
                 Let's wait for your customers to manifest themselves.
             </p>
         </field>
-        <field name="context">{'search_default_rating_last_30_days': 1, 'search_default_responsible': 1}</field>
+        <field name="context">{
+            'search_default_rating_last_30_days': 1,
+            'graph_groupbys': ['rated_partner_id'],
+        }</field>
     </record>
 
     <record id="rating_rating_action_project_report_kanban" model="ir.actions.act_window.view">


### PR DESCRIPTION
The purpose of the commit is to improve the customer rating report
of the project app.

So in this commit, done the below changes:

- remove the project and task measures
- switch the rating value and the count from a place in pivot view
- remove the default group by the rated operator, keep it for graph view
- reorder some fields on form and list view
- use the badge widget for the rating field and the color code is applied to the form view
- add an optional list view
  - the following fields should be optional: rated_partner_id, parent_ref, resource_ref, partner_id, feedback
  - all of these fields are displayed by default, except the feedback one that is hidden by default
  - add some demo data for the feedback field
- center the information vertically in kanban view
- move the 'customer ratings' menu item below the 'project costs and revenues' one
- add the following filters: My Projects, My Team
  - reorder the group bys and rename 'Resource' into 'Task'
  - reorder the search fields
- project kanban card:[Done]
  - the rating % represents the average satisfaction rate of the ratings submitted in the last 30 days (including today)
  - change the tooltip to the Average satisfaction rate for the last 30 days
- the 'customer satisfaction' stat button display the last 30 days' rating on the project.project
and this stat button should open the kanban view by default instead of the list view

TaskId: 2531428

