### PR TITLE
[FIX] account: fix invoices/bills resequence with same name

### DIFF
--- a/addons/account/static/src/xml/account_resequence.xml
+++ b/addons/account/static/src/xml/account_resequence.xml
@@ -8,7 +8,7 @@
                 <th>Before</th>
                 <th>After</th>
             </tr></thead>
-            <tbody t-foreach="data.changeLines" t-as="changeLine" t-key="changeLine.current_name">
+            <tbody t-foreach="data.changeLines" t-as="changeLine" t-key="changeLine.id">
                 <ChangeLine changeLine="changeLine" ordering="data.ordering"/>
             </tbody>
         </table>

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -105,6 +105,7 @@ class ReSequenceWizard(models.TransientModel):
                 # compute the new values period by period
                 for move in period_recs:
                     new_values[move.id] = {
+                        'id': move.id,
                         'current_name': move.name,
                         'state': move.state,
                         'date': format_date(self.env, move.date),


### PR DESCRIPTION
- Create 2 invoices (or 2 bills) but let them in draft
- In invoices list view, select all invoices
- Execute Action > Resequence
Resequence wizard will not show.

It comes from a template in resequence renderer using account move name as t-key
that silently crashes because both draft invoices have the same name ("/").

opw-2590273

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
