### PR TITLE
[FIX] fleet: display only current companies' fleet

### DIFF
--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -116,5 +116,29 @@
             <field name="global" eval="True"/>
             <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
         </record>
+        <record id="ir_rule_fleet_log_fuel" model="ir.rule">
+            <field name="name">Fleet log fuel: Multi Company</field>
+            <field name="model_id" ref="model_fleet_vehicle_log_fuel"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
+        <record id="ir_rule_fleet_log_services" model="ir.rule">
+            <field name="name">Fleet log services: Multi Company</field>
+            <field name="model_id" ref="model_fleet_vehicle_log_services"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
+        <record id="ir_rule_fleet_cost" model="ir.rule">
+            <field name="name">Fleet cost: Multi Company</field>
+            <field name="model_id" ref="model_fleet_vehicle_cost"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
+        <record id="ir_rule_fleet_log_contract" model="ir.rule">
+            <field name="name">Fleet log contract: Multi Company</field>
+            <field name="model_id" ref="model_fleet_vehicle_log_contract"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
How to reproduce the problem:
- Install the Fleet app.
- Create a user that has access to 2 or more companies (e.g. Mitchell Admin).
- Log in as this user. Go to fleet -> Vehicles -> Vehicles Costs/Contracts/Fuel Logs/Services Logs
- Uncheck one of your companies.
- The user still has access to the fleet of the other companies, even if they are unchecked.

Cause of the problem : missing record rules

Solution : added multi-companies rules

opw-2518188