### PR TITLE
[FIX] {mass_mailing}_sms: fix tour bubble for mailing creation

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -21,7 +21,8 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
         content: _t("Let's try the Email Marketing app."),
         edition: 'community',
     }, {
-        trigger: '.o-kanban-button-new',
+        trigger: '.o_list_button_add',
+        extra_trigger: '.o_mass_mailing_mailing_tree',
         content: Markup(_t("Start by creating your first <b>Mailing</b>.")),
         position: 'bottom',
     }, {

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -34,7 +34,7 @@
             <field name="model">mailing.mailing</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <tree string="Mailings" sample="1">
+                <tree string="Mailings" sample="1" class="o_mass_mailing_mailing_tree">
                     <field name="calendar_date" string="Date" widget="datetime"/>
                     <field name="subject" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                     <field name="mailing_model_id" string="Recipients" optional="hide"/>


### PR DESCRIPTION
PURPOSE
Mass Mailing Tour Bubble should not appear any where else.

SPECIFICATION
Current:
Tour bubble of mass mailing is appearing in many kanban view create button.
To be:
It should be only in mass_mailing module.

Task Id: 2583760
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
