### PR TITLE
[FIX] l10n_fr: fix accounts of tax groups

### DIFF
--- a/addons/l10n_fr/data/account_chart_template_data.xml
+++ b/addons/l10n_fr/data/account_chart_template_data.xml
@@ -19,6 +19,8 @@
       <field name="property_account_income_categ_id" ref="pcg_7071"/>
       <field name="income_currency_exchange_account_id" ref="pcg_766"/>
       <field name="expense_currency_exchange_account_id" ref="pcg_666"/>
+      <field name="property_tax_payable_account_id" ref="pcg_44551"/>
+      <field name="property_tax_receivable_account_id" ref="pcg_44567"/>
       <field name="default_pos_receivable_account_id" ref="fr_pcg_recv_pos" />
       <field name="currency_id" ref="base.EUR"/>
     </record>


### PR DESCRIPTION
When creating the `l10n_fr` chart of accounts, the tax payable and tax receivable accounts of the tax groups were missing, and this had other effects like a missing tax report entry.

This commit fixes the issue by setting the property on the template, like in others modules (e.g. [`l10n_be`](https://github.com/odoo/odoo/blob/14.0/addons/l10n_be/data/account_pcmn_belgium_data.xml#L12-L13)).