### PR TITLE
[FIX] web: remove tabindex on inactive modal

### DIFF
--- a/addons/web/static/src/legacy/js/core/owl_dialog.js
+++ b/addons/web/static/src/legacy/js/core/owl_dialog.js
@@ -199,6 +199,7 @@ odoo.define('web.OwlDialog', function (require) {
                     // Legacy dialog
                     activeDialog.$modal[0];
                 activeDialogEl.classList.add('o_inactive_modal');
+                activeDialogEl.removeAttribute("tabindex");
             }
             // Push dialog
             this.displayed.push(dialog);
@@ -224,6 +225,7 @@ odoo.define('web.OwlDialog', function (require) {
                     // Legacy dialog
                     lastDialog.$modal[0];
                 modalEl.classList.remove('o_inactive_modal');
+                modalEl.setAttribute("tabindex", "-1");
             } else {
                 document.body.classList.remove('modal-open');
             }


### PR DESCRIPTION
In the case we have a legacy dialog calling a new dialog,
tabindex set on the legacy dialog prevents the new dialog
to get focused as well as its children.
Because of this, we cannot select text or focus text input/area
in the new dialog.
