### PR TITLE
[FIX] website: no bottom scroll bar when use carousel

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review.scss
+++ b/addons/web/static/src/scss/bootstrap_review.scss
@@ -8,3 +8,7 @@
     // They would go over floating elements, which is never what we want.
     clear: both;
 }
+
+.carousel-control-next .sr-only {
+    left: 50%; // Avoid horizontal scrollbar in Chrome
+}


### PR DESCRIPTION
The browser displays the horizontal scroll bar because the size of the
carousel arrows are in percentage and considered offscreen.

opw-2585526
