### PR TITLE
[14.0][FIX] account: use correct model in field reconciled_statement_ids in account.payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -113,7 +113,7 @@ class AccountPayment(models.Model):
         help="Invoices whose journal items have been reconciled with these payments.")
     reconciled_bills_count = fields.Integer(string="# Reconciled Bills",
         compute="_compute_stat_buttons_from_reconciliation")
-    reconciled_statement_ids = fields.Many2many('account.move', string="Reconciled Statements",
+    reconciled_statement_ids = fields.Many2many('account.bank.statement', string="Reconciled Statements",
         compute='_compute_stat_buttons_from_reconciliation',
         help="Statements matched to this payment")
     reconciled_statements_count = fields.Integer(string="# Reconciled Statements",


### PR DESCRIPTION
The field is supposed to point to account.bank.statement but is pointing to account.move
Now is working because the field is only used in button_open_statements method where the model is defined, but if you want to use this field to report it will get information from account.move with that ID or an error if the move do not exist

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
