### PR TITLE
[IMP] l10n_it_edi_sdicoop: normalize codice fiscale.

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -1,8 +1,11 @@
 # -*- coding:utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError, ValidationError
+
+import re
+
 
 class ResPartner(models.Model):
     _name = 'res.partner'
@@ -26,3 +29,23 @@ class ResPartner(models.Model):
             "CHECK(l10n_it_pa_index IS NULL OR LENGTH(l10n_it_pa_index) >= 6)",
             "PA index must have between 6 and 7 characters."),
     ]
+
+    @api.model
+    def _l10n_it_normalize_codice_fiscale(self, codice):
+        if re.match(r'^IT[0-9]{11}$', codice):
+            return codice[2:13]
+        elif re.match(r'^[0-9]{11}$', codice):
+            return codice
+        return codice
+
+    @api.onchange('vat')
+    def _l10n_it_onchange_vat(self):
+        if not self.l10n_it_codice_fiscale:
+            self.l10n_it_codice_fiscale = self._l10n_it_normalize_codice_fiscale(self.vat)
+
+    @api.constrains('l10n_it_codice_fiscale')
+    def validate_codice_fiscale(self):
+        p = re.compile(r'^([A-Za-z]{6}[0-9]{2}[A-Za-z]{1}[0-9]{2}[A-Za-z]{1}[0-9]{3}[A-Za-z]{1}$)|([0-9]{11})')
+        for record in self:
+            if not p.match(record.l10n_it_codice_fiscale):
+                raise UserError(_("Invalid Codice Fiscale '%s': should be like 'MRTMTT91D08F205J' for physical person or '12345678901' for businesses (11 characters without 'IT')", codice))

--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -253,7 +253,7 @@ class AccountEdiFormat(models.Model):
         if not company.l10n_it_codice_fiscale:
             raise UserError(_('Please fill your codice fiscale to be able to receive invoices from FatturaPA'))
 
-        return company.l10n_it_codice_fiscale
+        return self.env['res.partner']._l10n_it_normalize_codice_fiscale(company.l10n_it_codice_fiscale)
 
     def _l10n_it_edi_upload(self, files, proxy_user):
         '''Upload files to fatturapa.


### PR DESCRIPTION
Codice Fiscale can be 16 length (letters + digits) for physical people.
Codice Fiscale can be 11 digits prefixed or not with 'IT' for companies.

An error is raised if the codice fiscale is not saved in the correct format. When registering to l10n_it_edi_proxy, we try to normalize the Codice Fiscale if possible.

Also, when entering the vat in the partner, the Codice Fiscale is automatically set normalized.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
