### PR TITLE
[FIX] point_of_sale : prevent 'message is undefined'

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -5,6 +5,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
     const { useListener } = require('web.custom_hooks');
+    const { isRpcError } = require('point_of_sale.utils');
 
     /**
      * Render this screen using `showTempScreen` to select client.
@@ -160,7 +161,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
                 this.state.detailIsShown = false;
                 this.render();
             } catch (error) {
-                if (error.message.code < 0) {
+                if (isRpcError(error) && error.message.code < 0) {
                     await this.showPopup('OfflineErrorPopup', {
                         title: this.env._t('Offline'),
                         body: this.env._t('Unable to save changes.'),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In some rare case the error is not an RPC error.
Use the same mecanisme of https://github.com/odoo/odoo/blob/14.0/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/ControlButtons/InvoiceButton.js#L132

Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/125473301-79980fb8-236a-4e54-bac5-43f5adea88a7.png)


@pimodoo @rhe-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
