### PR TITLE
[IMP] sales: limit downpayment percentage to 100%

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -119,6 +119,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
         if (self.advance_payment_method == 'percentage' and self.amount <= 0.00) or (self.advance_payment_method == 'fixed' and self.fixed_amount <= 0.00):
             raise UserError(_('The value of the down payment amount must be positive.'))
 
+        if self.advance_payment_method == 'percentage' and self.amount > 100.0:
+            raise UserError(_('Use a fixed amount if you would like to invoice a down payment greater than the Sales Order value'))
+
         amount, name = self._get_advance_details(order)
 
         invoice_vals = self._prepare_invoice_values(order, name, amount, so_line)

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -9,6 +9,10 @@
                         Invoices will be created in draft so that you can review
                         them before validation.
                     </p>
+                    <div class="alert alert-warning mb-0" role="alert"
+                         attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}">
+                        Down payment percentage exceeds 100%.
+                    </div>
                     <group>
                         <field name="count" attrs="{'invisible': [('count','=', 1)]}" readonly="True"/>
                         <field name="advance_payment_method" class="oe_inline" widget="radio"
@@ -43,11 +47,13 @@
                     <footer>
                         <button name="create_invoices" id="create_invoice_open" string="Create and View Invoice" type="object"
                             context="{'open_invoices': True}" class="btn-primary" attrs="{'invisible': [('amount','&gt;','100')]}"/>
+                        <!--hack to ensure user sees warning message -->
                         <button name="create_invoices" id="create_invoice_open" string="Create and View Invoice" type="object"
-                            context="{'open_invoices': True}" class="btn-primary" attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}" confirm="Down payment percentage exceeds 100%, do you want to continue?"/>
+                            context="{'open_invoices': True}" class="btn-primary" attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}"/>
 
                         <button name="create_invoices" id="create_invoice" string="Create Invoice" type="object" attrs="{'invisible': [('amount','&gt;','100')]}"/>
-                        <button name="create_invoices" id="create_invoice" string="Create Invoice" type="object" attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}" confirm="Downpayment percentage exceeds 100%, do you want to continue?"/>
+                        <!--hack to ensure user sees warning message -->
+                        <button name="create_invoices" id="create_invoice" string="Create Invoice" type="object" attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}"/>
                         <button string="Cancel" class="btn-secondary" special="cancel"/>
                     </footer>
                 </form>

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -42,8 +42,12 @@
                     </group>
                     <footer>
                         <button name="create_invoices" id="create_invoice_open" string="Create and View Invoice" type="object"
-                            context="{'open_invoices': True}" class="btn-primary"/>
-                        <button name="create_invoices" id="create_invoice" string="Create Invoice" type="object"/>
+                            context="{'open_invoices': True}" class="btn-primary" attrs="{'invisible': [('amount','&gt;','100')]}"/>
+                        <button name="create_invoices" id="create_invoice_open" string="Create and View Invoice" type="object"
+                            context="{'open_invoices': True}" class="btn-primary" attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}" confirm="Down payment percentage exceeds 100%, do you want to continue?"/>
+
+                        <button name="create_invoices" id="create_invoice" string="Create Invoice" type="object" attrs="{'invisible': [('amount','&gt;','100')]}"/>
+                        <button name="create_invoices" id="create_invoice" string="Create Invoice" type="object" attrs="{'invisible': [('amount','&gt;=','0'), ('amount','&lt;=','100')]}" confirm="Downpayment percentage exceeds 100%, do you want to continue?"/>
                         <button string="Cancel" class="btn-secondary" special="cancel"/>
                     </footer>
                 </form>


### PR DESCRIPTION
When using the create invoice wizard to create a down payment invoice, users are able to capture a percentage > 100% which may cause downstream issues. This commit gives a non-blocking warning.

Task 2484894
