### PR TITLE
[IMP] web: allow extra class in legacy popover

### DIFF
--- a/addons/web/static/src/legacy/js/core/popover.js
+++ b/addons/web/static/src/legacy/js/core/popover.js
@@ -313,6 +313,10 @@ odoo.define('web.Popover', function (require) {
         position: 'bottom',
     };
     Popover.props = {
+        popoverClass: {
+            type: String,
+            optional: true,
+        },
         position: {
             type: String,
             validate: (p) => ['top', 'bottom', 'left', 'right'].includes(p),

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -509,7 +509,7 @@
     <div t-att-class="{ 'o_is_open': state.displayed }" t-on-click="_onClick" t-on-o-popover-compute="_onPopoverCompute" t-on-o-popover-close="_onPopoverClose">
         <t t-slot="default"/>
         <Portal t-if="state.displayed" target="'body'">
-            <div role="tooltip" class="o_popover" t-ref="popover">
+            <div role="tooltip" class="o_popover" t-att-class="props.popoverClass" t-ref="popover">
                 <div class="arrow"/>
                 <h3 t-if="props.title" class="o_popover_header"><t t-esc="props.title"/></h3>
                 <div class="popover-body">


### PR DESCRIPTION
Popover has some style by default (eg. padding), but it is not always desirable
(eg. if the content has a scrollbar, having padding to the right of the
scrollbar is not good).

-> Add a class to allow overriding the default style in the legacy popover.

Note: the new popover already has this prop.