### PR TITLE
[IMP] mail: remove heading color from message author name

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -24,7 +24,6 @@
 }
 
 .o_Message_authorName {
-    color: $headings-color;
     margin-inline-end: map-get($spacers, 2);
 }
 


### PR DESCRIPTION
Following design update with new web client, the heading color is too strong
to be kept on author. The default color now does just fine actually.