### PR TITLE
[IMP] mail: use thread displayName instead of name

### DIFF
--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -57,7 +57,7 @@ export class Composer extends Component {
                 threadChannelType: thread && thread.channel_type, // for livechat override
                 threadDisplayName: thread && thread.displayName,
                 threadModel: thread && thread.model,
-                threadName: thread && thread.name,
+                threadDisplayName: thread && thread.displayName,
             };
         }, {
             compareDepth: {

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -38,8 +38,8 @@
                                 <b class="text-muted">To: </b>
                                 <em class="text-muted">Followers of </em>
                                 <b>
-                                    <t t-if="composer.thread and composer.thread.name">
-                                        &#32;&quot;<t t-esc="composer.thread.name"/>&quot;
+                                    <t t-if="composer.thread and composer.thread.displayName">
+                                        &#32;&quot;<t t-esc="composer.thread.displayName"/>&quot;
                                     </t>
                                     <t t-else="">
                                         this document

--- a/addons/mail/static/src/components/discuss_sidebar_item/discuss_sidebar_item.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_item/discuss_sidebar_item.xml
@@ -16,7 +16,7 @@
                     <div class="o_DiscussSidebarItem_item o_DiscussSidebarItem_name o-editable">
                         <EditableText
                             class="o_DiscussSidebarItem_nameInput"
-                            placeholder="thread.correspondent ? thread.correspondent.name : thread.name"
+                            placeholder="thread.correspondent ? thread.correspondent.nameOrDisplayName : thread.name"
                             value="thread.displayName"
                             t-on-o-cancel="_onCancelRenaming"
                             t-on-o-clicked="_onClickedEditableText"

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -64,7 +64,7 @@ export class Message extends Component {
                 notifications: message ? message.notifications.map(notif => notif.__state) : [],
                 originThread,
                 originThreadModel: originThread && originThread.model,
-                originThreadName: originThread && originThread.name,
+                originThreadDisplayName: originThread && originThread.displayName,
                 originThreadUrl: originThread && originThread.url,
                 partnerRoot,
                 thread,

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -89,10 +89,10 @@
                             <t t-if="threadView and message.originThread and message.originThread !== threadView.thread">
                                 <div class="o_Message_originThread" t-att-class="{ 'o-message-selected': isSelected }">
                                     <t t-if="message.originThread.model === 'mail.channel'">
-                                        (from <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-if="message.originThread.name">#<t t-esc="message.originThread.name"/></t><t t-else="">channel</t></a>)
+                                        (from <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-if="message.originThread.displayName">#<t t-esc="message.originThread.displayName"/></t><t t-else="">channel</t></a>)
                                     </t>
                                     <t t-else="">
-                                        on <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-if="message.originThread.name"><t t-esc="message.originThread.name"/></t><t t-else="">document</t></a>
+                                        on <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-if="message.originThread.displayName"><t t-esc="message.originThread.displayName"/></t><t t-else="">document</t></a>
                                     </t>
                                 </div>
                             </t>

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -636,8 +636,8 @@ function factory(dependencies) {
                 !thread.isTemporary &&
                 thread.model === 'mail.channel' &&
                 thread.channel_type === 'channel' &&
-                thread.name &&
-                cleanSearchTerm(thread.name).includes(cleanedSearchTerm)
+                thread.displayName &&
+                cleanSearchTerm(thread.displayName).includes(cleanedSearchTerm)
             )];
         }
 


### PR DESCRIPTION
More often than not these 2 fields have the same value, but when they are
different it is `displayName` that holds the expected value (eg. for a DM,
`displayName` would be the custom name or the name of the correspondent).

This commit updates them to avoid confusion and having bad examples in the code.