### PR TITLE
[FIX] account: anglo saxon entries w/o partner

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -140,6 +140,7 @@ class AccountMove(models.Model):
                 lines_vals_list.append({
                     'name': line.name[:64],
                     'move_id': move.id,
+                    'partner_id': move.commercial_partner_id.id,
                     'product_id': line.product_id.id,
                     'product_uom_id': line.product_uom_id.id,
                     'quantity': line.quantity,
@@ -155,6 +156,7 @@ class AccountMove(models.Model):
                 lines_vals_list.append({
                     'name': line.name[:64],
                     'move_id': move.id,
+                    'partner_id': move.commercial_partner_id.id,
                     'product_id': line.product_id.id,
                     'product_uom_id': line.product_uom_id.id,
                     'quantity': line.quantity,


### PR DESCRIPTION
Effect v14 and v13.

Description of the issue/feature this PR addresses:

To allow bookkeeper easier identify issues in the interim accounts entries needs to keep a partner.

Current behavior before PR:

No partner on journal items

Desired behavior after PR is merged:

Partner on journal items


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
