### PR TITLE
[FIX] l10n_cl: Fix cannot post invoice with a contact as a partner

### DIFF
--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -23,6 +23,10 @@ class ResPartner(models.Model):
              '3 - End consumer (only receipts)\n'
              '4 - Foreigner')
 
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + ['l10n_cl_sii_taxpayer_type']
+
     def _format_vat_cl(self, values):
         identification_types = [self.env.ref('l10n_latam_base.it_vat').id, self.env.ref('l10n_cl.it_RUT').id,
                                 self.env.ref('l10n_cl.it_RUN').id]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
An invoice cannot be posted with a contact as a partner.
Steps to reproduce:

1. Create a new partner with company flag and End Consumer as taxpayer type 
2. Create a contact. The taxpayer type will not be modifiable
3. Create an invoice with the contact as partner
4. Confirm the invoice

Current behavior before PR:
UserError with message:
Los Tipos de documentos para clientes extranjeros deben ser de tipo exportación (codes 110, 111 or 112) o Ud.                              debería definir el cliente como consumidor final y utilizar boletas (codes 39 or 41)

Desired behavior after PR is merged:
The invoice is posted.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
