### PR TITLE
[FIX] point_of_sale,pos_restaurant: do not reset bill if printed

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2977,8 +2977,12 @@ exports.Order = Backbone.Model.extend({
         line.set_unit_price(line.compute_fixed_price(line.price));
     },
 
+    _should_be_reset: function(){
+        return this._printed;
+    },
+
     add_product: function(product, options){
-        if(this._printed){
+        if(this._should_be_reset()){
             this.destroy();
             return this.pos.get_order().add_product(product, options);
         }

--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -77,6 +77,9 @@ models.Order = models.Order.extend({
         json.customer_count = this.get_customer_count();
         return json;
     },
+    _should_be_reset: function() {
+        return _super_order._should_be_reset.apply(this, arguments) && !this.pos.config.module_pos_restaurant;
+    },
     get_customer_count: function(){
         return this.customer_count;
     },


### PR DESCRIPTION
When using a POS for a restaurant, if the user prints the bill and then
tries to add a product, the order will disappear and an error will be
raised

To reproduce the error:
(Use demo data. Need an Epson printer)
1. In Point of Sale, open Bar's settings:
    - Enable "Direct Devices" and enter Epson's IP address
2. Start a session
3. Select a table T
4. Add a product
5. Bill > Print, Ok
6. Back to the order, add a product

Error: An Odoo Client Error is displayed "this.pos.get_order() is
null[...]". The screen is redirected to the restaurant's map and table T
has no more an order (the latter is lost)

When adding a product, if the order is printed, it will be destroyed:
https://github.com/odoo/odoo/blob/3e8d921318e86631b73c8c92c2e462fd0d761582/addons/point_of_sale/static/src/js/models.js#L2981-L2984

In the case of a restaurant, the order should still be available.

OPW-2555272