### PR TITLE
[FIX] mrp: fix incorrect domain definition

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -90,7 +90,7 @@
             <field name="res_model">mrp.workcenter.productivity</field>
             <field name="view_id" eval="oee_pie_view"/>
             <field name="view_mode">graph,pivot,tree,form</field>
-            <field name="domain">[('workcenter_id','=',active_id')]</field>
+            <field name="domain">[('workcenter_id','=',active_id)]</field>
             <field name="context">{'search_default_thismonth':True}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
A domain used in a ir action in mrp was syntaxically incorrect.
Strangely enough, it was nonetheless accepted by pyjs.  However, pyjs
was recently remade, and is now stricter, so evaluating this domain
correctly throws an error.

This commit simply fixes the domain.

Task ID: 2601818

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
