### PR TITLE
[FIX] web_editor: deletebackward contenteditable

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/demo/index.html
+++ b/addons/web_editor/static/lib/odoo-editor/demo/index.html
@@ -173,6 +173,9 @@
                 Nulla placerat orci sed blandit luctus. In ac nisl augue.
                 </i>
             </p>
+            <p>
+                Paragraph containing <b contenteditable="false">not editable inline node</b>.
+            </p>
             <ul>
                 <li>first item</li>
                 <li class="oe-nested">

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
@@ -67,7 +67,12 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false) 
         if (isUnremovable(leftNode)) {
             throw UNREMOVABLE_ROLLBACK_CODE;
         }
-        if (isMediaElement(leftNode)) {
+        if (
+            isMediaElement(leftNode) ||
+            (leftNode.getAttribute &&
+                typeof leftNode.getAttribute('contenteditable') === 'string' &&
+                leftNode.getAttribute('contenteditable').toLowerCase() === 'false')
+        ) {
             leftNode.remove();
             return;
         }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -155,6 +155,24 @@ X[]
                                                 <p>AB[]</p></div></div>`,
                     });
                 });
+                it('should remove contenteditable="false"', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<div><span contenteditable="false">abc</span>[]def</div>`,
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                        },
+                        contentAfter: `<div>[]def</div>`,
+                    });
+                });
+                it('should remove contenteditable="False"', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<div><span contenteditable="False">abc</span>[]def</div>`,
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                        },
+                        contentAfter: `<div>[]def</div>`,
+                    });
+                });
             });
             describe('white spaces', () => {
                 describe('no intefering spaces', () => {


### PR DESCRIPTION
Deleting a node content-editable false did not work.

Related: odoo/odoo#73588

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
