### PR TITLE
[FIX] web_editor: fix traceback in applyColor

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -457,10 +457,12 @@ export const editorCommands = {
             if (font && font.nodeName === 'FONT') {
                 // Partially selected <font>: split it.
                 const selectedChildren = children.filter(child => selectedNodes.includes(child));
-                const after = selectedChildren[selectedChildren.length - 1].nextSibling;
-                font = after ? splitElement(font, childNodeIndex(after))[0] : font;
-                const before = selectedChildren[0].previousSibling;
-                font = before ? splitElement(font, childNodeIndex(before) + 1)[1] : font;
+                if (selectedChildren.length) {
+                    const after = selectedChildren[selectedChildren.length - 1].nextSibling;
+                    font = after ? splitElement(font, childNodeIndex(after))[0] : font;
+                    const before = selectedChildren[0].previousSibling;
+                    font = before ? splitElement(font, childNodeIndex(before) + 1)[1] : font;
+                }
             } else if (node.nodeType === Node.TEXT_NODE && isVisibleStr(node)) {
                 // Node is a visible text node: wrap it in a <font>.
                 const previous = node.previousSibling;


### PR DESCRIPTION
When the selectedChildren array was empty it generated an error and a traceback appeared in Odoo.

[Task-2580158](https://www.odoo.com/web#id=2580158&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
