### PR TITLE
[FIX] point_of_sale: fix fp not taken into account for unit price on receipt

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1922,11 +1922,13 @@ exports.Orderline = Backbone.Model.extend({
             var taxes_ids = product.taxes_id;
             var taxes =  this.pos.taxes;
             var product_taxes = [];
+            var self = this;
 
             _(taxes_ids).each(function(el){
-                product_taxes.push(_.detect(taxes, function(t){
+                var tax = _.detect(taxes, function(t) {
                     return t.id === el;
-                }));
+                });
+                product_taxes.push.apply(product_taxes, self._map_tax_fiscal_position(tax, self.order));
             });
 
             var all_taxes = this.pos.compute_all(product_taxes, price_unit, 1, this.pos.currency.rounding);


### PR DESCRIPTION
- Create 2 sales taxes (i.e. Tax 15% and Tax 0%)
- Create a fiscal position mapping Tax 15% => Tax 0% (i.e. FP X)
- Create a product with customer taxes set to Tax 15% (i.e. Product X)
- Configure Point of Sale:
  * Fiscal Position: FP X
  * Product Prices: Tax-Included Price
- In POS session, create an order in FP X with 2 Product X (Total: $200)
- Process payment
On the receipt, the details of the order line is showing an incorrect
unit price (2 x 115.00 = 200.00)

The function computing the unit price to display on the receipt is not
taking into account the fiscal position set on the order.

opw-2591355




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
