### PR TITLE
[FIX] l10n_in_sale: only take GSTIN from shipping address if shipping_gstin is set

### DIFF
--- a/addons/l10n_in_sale/models/account_move.py
+++ b/addons/l10n_in_sale/models/account_move.py
@@ -13,4 +13,4 @@ class AccountMove(models.Model):
 
     @api.model
     def _l10n_in_get_shipping_partner_gstin(self, shipping_partner):
-        return shipping_partner.l10n_in_shipping_gstin or shipping_partner.vat
+        return shipping_partner.l10n_in_shipping_gstin


### PR DESCRIPTION
When there is a bill to ship to and ship to is the third party then GSTIN is set from the customer address(partner_id), not from the shipping address(partner_shipping_id)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
