### PR TITLE
[FIX] account: Wrong currency symbol in payment receipt report

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -51,7 +51,7 @@
                                 <td><span t-field="inv.name"/></td>
                                 <td><span t-field="inv.ref"/></td>
                                 <td class="text-right"><span t-field="inv.amount_total"/></td>
-                                <td class="text-right"><span t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': inv.currency_id}"/></td>
+                                <td class="text-right"><span t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/></td>
                                 <td class="text-right"><span t-field="inv.amount_residual"/></td>
                             </t>
                         </tr>


### PR DESCRIPTION
Steps to reproduce the bug:

Enable Multi Currency > Accounting > Create Customer Invoice in USD > Pay Invoice in EUR > click on payment and print payment receipt

Bug:

The currency symbol next to "Amount Paid" was in $ instead €

opw:2506868