### PR TITLE
[IMP] mail: remove static mention suggestions

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -261,7 +261,6 @@ class MailController(http.Controller):
             'channel_slots': request.env['mail.channel'].channel_fetch_slot(),
             'mail_failures': request.env['mail.message'].message_fetch_failed(),
             'commands': request.env['mail.channel'].get_mention_commands(),
-            'mention_partner_suggestions': request.env['res.partner'].get_static_mention_suggestions(),
             'shortcodes': request.env['mail.shortcode'].sudo().search_read([], ['source', 'substitution', 'description']),
             'menu_id': request.env['ir.model.data'].xmlid_to_res_id('mail.menu_root_discuss'),
             'partner_root': request.env.ref('base.partner_root').sudo().mail_partner_format(),

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -113,19 +113,6 @@ class Partner(models.Model):
         return 0
 
     @api.model
-    def get_static_mention_suggestions(self):
-        """ Returns static mention suggestions of partners, loaded once at webclient initialization
-            and stored client side. All the internal users are returned.
-            The return format is a list of partner data (as per returned by `mail_partner_format()`).
-        """
-        partners = self.env['res.partner']
-        try:
-            partners = self.env.ref('base.group_user').users.partner_id
-        except AccessError:
-            pass
-        return [partner.mail_partner_format() for partner in partners]
-
-    @api.model
     def get_mention_suggestions(self, search, limit=8, channel_id=None):
         """ Return 'limit'-first partners' such that the name or email matches a 'search' string.
             Prioritize partners that are also users, and then extend the research to all partners.

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -70,7 +70,6 @@ function factory(dependencies) {
          * @param {Object} param0.current_partner
          * @param {integer} param0.current_user_id
          * @param {Object} [param0.mail_failures={}]
-         * @param {Object[]} [param0.mention_partner_suggestions=[]]
          * @param {integer} [param0.needaction_inbox_counter=0]
          * @param {Object} param0.partner_root
          * @param {Object[]} param0.public_partners
@@ -83,7 +82,6 @@ function factory(dependencies) {
             current_partner,
             current_user_id,
             mail_failures = {},
-            mention_partner_suggestions = [],
             menu_id,
             needaction_inbox_counter = 0,
             partner_root,
@@ -108,7 +106,6 @@ function factory(dependencies) {
             // various suggestions in no particular order
             this._initCannedResponses(shortcodes);
             this._initCommands(commands);
-            this._initMentionPartnerSuggestions(mention_partner_suggestions);
             // channels when the rest of messaging is ready
             await this.async(() => this._initChannels(channel_slots));
             // failures after channels
@@ -201,16 +198,6 @@ function factory(dependencies) {
                 }
             }));
             this.messaging.notificationGroupManager.computeGroups();
-        }
-
-        /**
-         * @private
-         * @param {Object[]} mentionPartnerSuggestionsData
-         */
-        async _initMentionPartnerSuggestions(mentionPartnerSuggestionsData) {
-            return executeGracefully(mentionPartnerSuggestionsData.map(partnerData => () => {
-                this.env.models['mail.partner'].insert(this.env.models['mail.partner'].convertData(partnerData));
-            }));
         }
 
         /**

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -398,7 +398,6 @@ MockServer.include({
             current_partner: currentPartnerFormat,
             current_user_id: this.currentUserId,
             mail_failures: mailFailures,
-            mention_partner_suggestions: [],
             menu_id: false,
             needaction_inbox_counter,
             partner_root: partnerRootFormat,


### PR DESCRIPTION
Returning all the users at init does not scale. Mention suggestion code is good
enough now that this is no longer necessary.