### PR TITLE
web many2many grouping

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -52,6 +52,7 @@
                         <filter string="Kanban State" name="kanban_state" context="{'group_by': 'kanban_state'}"/>
                         <filter string="Deadline" name="date_deadline" context="{'group_by': 'date_deadline'}"/>
                         <filter string="Creation Date" name="group_create_date" context="{'group_by': 'create_date'}"/>
+                        <filter string="Tags" name="group_tags" context="{'group_by': 'tag_ids'}"/>
                     </group>
                 </search>
             </field>

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -213,6 +213,9 @@ class Base(models.AbstractModel):
                         group_by_value, format=DISPLAY_DATE_FORMATS[group_by_modifier],
                         locale=locale)
 
+            if field_type == 'many2many' and isinstance(group_by_value, list):
+                group_by_value = str(tuple(group_by_value)) or False
+
             record_values[group_by] = group_by_value
             record_values['__count'] = 1
 

--- a/addons/web/static/src/legacy/js/control_panel/groupby_menu.js
+++ b/addons/web/static/src/legacy/js/control_panel/groupby_menu.js
@@ -62,7 +62,7 @@ odoo.define('web.GroupByMenu', function (require) {
          * @returns {boolean}
          */
         _validateField(field) {
-            return field.sortable &&
+            return (field.sortable || field.type === "many2many" && field.store) &&
                 field.name !== "id" &&
                 GROUPABLE_TYPES.includes(field.type);
         }

--- a/addons/web/static/src/legacy/js/control_panel/search_utils.js
+++ b/addons/web/static/src/legacy/js/control_panel/search_utils.js
@@ -151,6 +151,7 @@ odoo.define('web.searchUtils', function (require) {
         'datetime',
         'integer',
         'many2one',
+        'many2many',
         'selection',
     ];
     const DEFAULT_INTERVAL = 'month';

--- a/addons/web/static/src/legacy/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_controller.js
@@ -848,7 +848,17 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         var data = ev && ev.data || {};
         var handle = data.db_id;
         var prom;
-        if (handle) {
+        // Note: In case of grouped view by many2many field then reload whole view as
+        // same record can be in other group
+        const state = this.model.get(this.handle);
+        let isM2MGrouped = false;
+        if (state.groupedBy && state.groupedBy.length) {
+            isM2MGrouped = state.groupedBy.some((group) => {
+                const groupByFieldName = group.split(':')[0];
+                return state.fields[groupByFieldName].type === "many2many";
+            });
+        }
+        if (handle && !isM2MGrouped) {
             // reload the relational field given its db_id
             prom = this.model.reload(handle).then(this._confirmSave.bind(this, handle));
         } else {

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -1189,6 +1189,7 @@ var BasicModel = AbstractModel.extend({
 
                             self.unfreezeOrder(record.id);
 
+                            self.updateSameResIdRecords(record, _changes);
                             // Update the data directly or reload them
                             if (shouldReload) {
                                 self._fetchRecord(record).then(function () {
@@ -1459,6 +1460,13 @@ var BasicModel = AbstractModel.extend({
         list.orderedResIDs = null;
         this._sortList(list);
     },
+    /**
+     * Overridden to update other records with same res_id, it used in case
+     * when datapoint is grouped by many2many and user update one of the record,
+     * in case of many2many same res_id record can be in multiple group, so to
+     * update record this method will be used.
+     */
+    updateSameResIdRecords(record, changes) {},
 
     //--------------------------------------------------------------------------
     // Private

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
@@ -54,6 +54,7 @@ var KanbanColumn = Widget.extend({
         this.quickCreateView = options.quickCreateView;
         this.groupedBy = options.groupedBy;
         this.grouped_by_m2o = options.grouped_by_m2o;
+        this.grouped_by_m2m = options.grouped_by_m2m;
         this.editable = options.editable;
         this.deletable = options.deletable;
         this.archivable = options.archivable;
@@ -77,7 +78,7 @@ var KanbanColumn = Widget.extend({
 
         this.record_options = _.clone(recordOptions);
 
-        if (options.grouped_by_m2o || options.grouped_by_date ) {
+        if (options.grouped_by_m2o || options.grouped_by_date || options.grouped_by_m2m) {
             // For many2one and datetime, a false value means that the field is not set.
             this.title = value ? value : _t('Undefined');
         } else {
@@ -250,6 +251,10 @@ var KanbanColumn = Widget.extend({
      * @return {Promise}
      */
     _addRecord: function (recordState, options) {
+        if (this.grouped_by_m2m) {
+            this.record_options.deletable = false;
+            this.record_options.archivable = false;
+        }
         var record = new this.KanbanRecord(this, recordState, this.record_options);
         this.records.push(record);
         if (options && options.position === 'before') {

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -42,6 +42,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
         this.options = options;
         this.editable = options.editable;
         this.deletable = options.deletable;
+        this.archivable = options.archivable;
         this.read_only_mode = options.read_only_mode;
         this.selectionMode = options.selectionMode;
         this.qweb = options.qweb;

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_renderer.js
@@ -509,6 +509,9 @@ var KanbanRenderer = BasicRenderer.extend({
             if (groupByFieldAttrs.type === "date" || groupByFieldAttrs.type === "datetime") {
                 draggable = false;
                 grouped_by_date = true;
+            } else if (groupByFieldAttrs.type === "many2many") {
+                // do not allow dragging of record if grouped by many2many
+                draggable = false;
             }
             if (groupByFieldAttrs.readonly !== undefined) {
                 readonly = groupByFieldAttrs.readonly;
@@ -524,6 +527,7 @@ var KanbanRenderer = BasicRenderer.extend({
         }
         draggable = !readonly && draggable;
         this.groupedByM2O = groupByFieldAttrs && (groupByFieldAttrs.type === 'many2one');
+        this.groupedByM2M = groupByFieldAttrs && (groupByFieldAttrs.type === 'many2many');
         var relation = this.groupedByM2O && groupByFieldAttrs.relation;
         var groupByTooltip = groupByFieldInfo && groupByFieldInfo.options.group_by_tooltip;
         this.columnOptions = _.extend(this.columnOptions, {
@@ -531,6 +535,7 @@ var KanbanRenderer = BasicRenderer.extend({
             group_by_tooltip: groupByTooltip,
             groupedBy: groupByField,
             grouped_by_m2o: this.groupedByM2O,
+            grouped_by_m2m: this.groupedByM2M,
             grouped_by_date: grouped_by_date,
             relation: relation,
             quick_create: this.quickCreateEnabled && viewUtils.isQuickCreateEnabled(this.state),

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_view.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_view.js
@@ -68,6 +68,7 @@ var KanbanView = BasicView.extend({
         this.rendererParams.record_options = {
             editable: activeActions.edit,
             deletable: activeActions.delete,
+            archivable: activeActions.edit,
             read_only_mode: params.readOnlyMode,
             selectionMode: params.selectionMode,
         };

--- a/addons/web/static/tests/legacy/control_panel/groupby_menu_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/groupby_menu_tests.js
@@ -16,6 +16,7 @@ odoo.define('web.groupby_menu_tests', function (require) {
                 date_field: { string: "Date", type: "date", store: true, sortable: true },
                 float_field: { string: "Float", type: "float", group_operator: 'sum' },
                 foo: { string: "Foo", type: "char", store: true, sortable: true },
+                m2m: { string: "Many2Many", type: "many2many", store: true},
             };
         },
     }, function () {
@@ -37,7 +38,7 @@ odoo.define('web.groupby_menu_tests', function (require) {
         });
 
         QUnit.test('simple rendering with no groupby', async function (assert) {
-            assert.expect(5);
+            assert.expect(6);
 
             const params = {
                 cpModelConfig: { searchMenuTypes },
@@ -55,6 +56,7 @@ odoo.define('web.groupby_menu_tests', function (require) {
             assert.strictEqual(optionEls[0].innerText.trim(), 'Birthday');
             assert.strictEqual(optionEls[1].innerText.trim(), 'Date');
             assert.strictEqual(optionEls[2].innerText.trim(), 'Foo');
+            assert.strictEqual(optionEls[3].innerText.trim(), 'Many2Many');
 
             controlPanel.destroy();
         });

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -542,6 +542,38 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test('prevent deletion when grouped by many2many field', async function (assert) {
+        assert.expect(2);
+
+        this.data.partner.records[0].category_ids = [6, 7];
+        this.data.partner.records[3].category_ids = [7];
+
+        const kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <kanban class="o_kanban_test">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_global_click">
+                                <field name="foo"/>
+                                <t t-if="widget.deletable"><span class="thisisdeletable">delete</span></t>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ['category_ids'],
+        });
+
+        assert.containsNone(kanban, '.thisisdeletable', "records should not be deletable");
+
+        await kanban.reload({ groupBy: ['foo'] });
+        assert.containsN(kanban, '.thisisdeletable', 4, "records should not be deletable");
+
+        kanban.destroy();
+    });
+
     QUnit.test('quick create record without quick_create_view', async function (assert) {
         assert.expect(16);
 
@@ -3120,6 +3152,50 @@ QUnit.module('Views', {
                         "Should remain same records in first column(2 records)");
         assert.strictEqual(kanban.$('.o_kanban_group:nth-child(2) .o_kanban_record').length , 2,
                         "Should remain same records in 2nd column(2 record)");
+        kanban.destroy();
+    });
+
+    QUnit.test('prevent drag and drop if grouped by many2many field', async function (assert) {
+        assert.expect(7);
+
+        this.data.partner.records[0].category_ids = [6, 7];
+        this.data.partner.records[3].category_ids = [7];
+
+        const kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <kanban class="o_kanban_test">
+                    <field name="bar"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="foo"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ['category_ids'],
+        });
+
+        assert.strictEqual(kanban.$('.o_kanban_group').length, 2, "should have 2 columns");
+        assert.strictEqual(kanban.$('.o_kanban_group:first .o_column_title').text(), '6',
+            'first column should have correct title');
+        assert.strictEqual(kanban.$('.o_kanban_group:last .o_column_title').text(), '7',
+            'second column should have correct title');
+        assert.strictEqual(kanban.$('.o_kanban_group:first .o_kanban_record').text(), 'yopblip',
+            "first column should have 2 records");
+        assert.strictEqual(kanban.$('.o_kanban_group:last .o_kanban_record').text(), 'yopgnapblip',
+            "second column should have 3 records");
+
+        // drag&drop a record in another column
+        const $record = kanban.$('.o_kanban_group:nth-child(1) .o_kanban_record:first');
+        const $group = kanban.$('.o_kanban_group:nth-child(2)');
+        await testUtils.dom.dragAndDrop($record, $group);
+        assert.strictEqual(kanban.$('.o_kanban_group:nth-child(1) .o_kanban_record').length, 2,
+            "1st column should contain 2 records");
+        assert.strictEqual(kanban.$('.o_kanban_group:nth-child(2) .o_kanban_record').length, 3,
+            "2nd column should contain 3 records");
+
         kanban.destroy();
     });
 

--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -11,6 +11,20 @@ class TestReadProgressBar(common.TransactionCase):
         super(TestReadProgressBar, self).setUp()
         self.Model = self.env['res.partner']
 
+    def test_read_progress_bar_m2m(self):
+        """ Test that read_progress_bar works with m2m field grouping """
+        progressbar = {
+            'field': 'type',
+            'colors': {
+                'contact': 'success', 'private': 'danger', 'other': 'muted',
+            }
+        }
+        result = self.env['res.partner'].read_progress_bar([], 'category_id', progressbar)
+        # check that it works when grouping by m2m field
+        self.assertTrue(result)
+        # check the null group
+        self.assertIn('False', result)
+
     def test_week_grouping(self):
         """The labels associated to each record in read_progress_bar should match
         the ones from read_group, even in edge cases like en_US locale on sundays

--- a/odoo/addons/test_read_group/tests/test_m2m_grouping.py
+++ b/odoo/addons/test_read_group/tests/test_m2m_grouping.py
@@ -43,22 +43,22 @@ class TestM2MGrouping(common.TransactionCase):
         )
         self.assertEqual(user_by_tasks, [
             {   # first task: both users
-                'task_ids': self.tasks[0].id,
+                'task_ids': (self.tasks[0].id, "Super Mario Bros."),
                 'task_ids_count': 2,
                 'name': ['Mario', 'Luigi'],
-                '__domain': [('task_ids', '=', self.tasks[0].id)],
+                '__domain': [('task_ids', 'in', [self.tasks[0].id])],
             },
             {   # second task: Mario only
-                'task_ids': self.tasks[1].id,
+                'task_ids': (self.tasks[1].id, "Paper Mario"),
                 'task_ids_count': 1,
                 'name': ['Mario'],
-                '__domain': [('task_ids', '=', self.tasks[1].id)],
+                '__domain': [('task_ids', 'in', [self.tasks[1].id])],
             },
             {   # third task: Luigi only
-                'task_ids': self.tasks[2].id,
+                'task_ids': (self.tasks[2].id, "Luigi's Mansion"),
                 'task_ids_count': 1,
                 'name': ['Luigi'],
-                '__domain': [('task_ids', '=', self.tasks[2].id)],
+                '__domain': [('task_ids', 'in', [self.tasks[2].id])],
             },
         ])
 
@@ -71,16 +71,16 @@ class TestM2MGrouping(common.TransactionCase):
         )
         self.assertEqual(task_by_users, [
             {   # task of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 1,
                 'name': ["Super Mario Bros."],
-                '__domain': ['&', ('user_ids', '=', self.users[0].id), ('id', '=', self.tasks[0].id)],
+                '__domain': ['&', ('user_ids', 'in', [self.users[0].id]), ('id', '=', self.tasks[0].id)],
             },
             {   # task of Luigi
-                'user_ids': self.users[1].id,
+                'user_ids': (self.users[1].id, "Luigi"),
                 'user_ids_count': 1,
                 'name': ["Super Mario Bros."],
-                '__domain': ['&', ('user_ids', '=', self.users[1].id), ('id', '=', self.tasks[0].id)],
+                '__domain': ['&', ('user_ids', 'in', [self.users[1].id]), ('id', '=', self.tasks[0].id)],
             },
         ])
 
@@ -92,16 +92,16 @@ class TestM2MGrouping(common.TransactionCase):
         )
         self.assertEqual(task_by_users, [
             {   # tasks of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Paper Mario"]),
-                '__domain': [('user_ids', '=', self.users[0].id)],
+                '__domain': [('user_ids', 'in', [self.users[0].id])],
             },
             {   # tasks of Luigi
-                'user_ids': self.users[1].id,
+                'user_ids': (self.users[1].id, "Luigi"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Luigi's Mansion"]),
-                '__domain': [('user_ids', '=', self.users[1].id)],
+                '__domain': [('user_ids', 'in', [self.users[1].id])],
             },
             {   # tasks of nobody
                 'user_ids': False,
@@ -151,16 +151,16 @@ class TestM2MGrouping(common.TransactionCase):
             )
         self.assertEqual(as_admin, [
             {   # tasks of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Paper Mario"]),
-                '__domain': [('user_ids', '=', self.users[0].id)],
+                '__domain': [('user_ids', 'in', [self.users[0].id])],
             },
             {   # tasks of Luigi
-                'user_ids': self.users[1].id,
+                'user_ids': (self.users[1].id, "Luigi"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Luigi's Mansion"]),
-                '__domain': [('user_ids', '=', self.users[1].id)],
+                '__domain': [('user_ids', 'in', [self.users[1].id])],
             },
             {   # tasks of nobody
                 'user_ids': False,
@@ -203,10 +203,10 @@ class TestM2MGrouping(common.TransactionCase):
             )
         self.assertEqual(as_demo, [
             {   # tasks of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 2,
                 'name': unordered(['Super Mario Bros.', 'Paper Mario']),
-                '__domain': [('user_ids', '=', self.users[0].id)],
+                '__domain': [('user_ids', 'in', [self.users[0].id])],
             },
             {   # tasks of Luigi and no user
                 'user_ids': False,

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2614,8 +2614,8 @@ class BaseModel(metaclass=MetaModel):
         many2manyfields = {field['field'] for field in fields if field['type'] == 'many2many'}
         for field in many2manyfields:
             ids_set = {d[field] for d in data if d[field]}
-            m2o_records = self.env[self._fields[field].comodel_name].browse(ids_set)
-            data_dict = dict(lazy_name_get(m2o_records.sudo()))
+            m2m_records = self.env[self._fields[field].comodel_name].browse(ids_set)
+            data_dict = dict(lazy_name_get(m2m_records.sudo()))
             for d in data:
                 d[field] = (d[field], data_dict[d[field]]) if d[field] else False
 


### PR DESCRIPTION
PURPOSE
Allow to group records by many2many fields.
Use case: turn the user_id m2o field on project.task into a user_ids m2m field in order to assign multiple collaborators on a task

SPEC
Add many2many fields to the 'list of groupable fields'.
When grouping a set of records by a many2many, records linked to multiple records of the comodel will essentially be in multiple 'groups' (even though those are not really 'groups' anymore).
There will also be a "null" group, for records that have an empty value of the many2many, like "unassigned" records.

Example: grouping a project.task linked to 10 res.users by the user_ids many2many field, the project.task will be 'rendered/considered/displayed' 10 times, once per res.users.
Kind of like if we grouped the m2m relation table instead.

When grouping by a m2m field:

* listview
-> editing an instance of a record also updates each other instance (if any) the same goes when scheduling an activity, etc.
-> disable deletion
the risk here is that the user might expected that this will 'unlike' the record from a specific record of the many2many field
* kanban
-> disable drag&drop between groups
-> disable deletion

TASK 2508608