### PR TITLE
[FIX] mail: properly handle undefined in js compute related

### DIFF
--- a/addons/mail/static/src/model/model_field.js
+++ b/addons/mail/static/src/model/model_field.js
@@ -1,7 +1,7 @@
 odoo.define('mail/static/src/model/model_field.js', function (require) {
 'use strict';
 
-const { FieldCommand } = require('mail/static/src/model/model_field_command.js');
+const { clear, FieldCommand } = require('mail/static/src/model/model_field_command.js');
 
 /**
  * Class whose instances represent field on a model.
@@ -295,18 +295,15 @@ class ModelField {
             const OtherModel = otherRecord.constructor;
             const otherField = OtherModel.__fieldMap[relatedFieldName];
             const newVal = otherField.get(otherRecord);
+            if (newVal === undefined) {
+                return clear();
+            }
             if (this.fieldType === 'relation') {
-                if (newVal) {
-                    return [['replace', newVal]];
-                } else {
-                    return [['unlink-all']];
-                }
+                return [['replace', newVal]];
             }
             return newVal;
         }
-        if (this.fieldType === 'relation') {
-            return [];
-        }
+        return clear();
     }
 
     /**

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -145,7 +145,7 @@ function factory(dependencies) {
          * @private
          */
         _onThreadIsLoadingAttachmentsChanged() {
-            if (!this.thread.isLoadingAttachments) {
+            if (!this.thread || !this.thread.isLoadingAttachments) {
                 this._stopAttachmentsLoading();
                 return;
             }


### PR DESCRIPTION
The value of the related field should be cleared:
- If the other record no longer exists.
- If the target value is undefined.

This might fix hard to understand bugs, such as task-2410314