### PR TITLE
[FIX] mail_plugin: fix an error during the authentication

### DIFF
--- a/addons/mail_plugin/controllers/authenticate.py
+++ b/addons/mail_plugin/controllers/authenticate.py
@@ -50,7 +50,7 @@ class Authenticate(http.Controller):
         else:
             params.update({'success': 0, 'state': kw.get('state', '')})
         updated_redirect = parsed_redirect.replace(query=werkzeug.urls.url_encode(params))
-        return request.redirect(updated_redirect.to_url())
+        return request.redirect(updated_redirect.to_url(), local=False)
 
     # In this case, an exception will be thrown in case of preflight request if only POST is allowed.
     @http.route(['/mail_client_extension/auth/access_token', '/mail_plugin/auth/access_token'], type='json', auth="none", cors="*",


### PR DESCRIPTION
Bug
===
Since 478068c82999eaf77fd2b68659bb3fb3d3c2872f we wanted to use the Odoo redirection function everywhere.

But this function work only if we redirect the user to the same site.

The mail plugin need to redirect outside of Odoo and so we can not use this function.