### PR TITLE
[IMP]hr_timesheet, sale_timesheet: portal improvements

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -27,10 +27,10 @@ class TimesheetCustomerPortal(CustomerPortal):
     def _get_searchbar_inputs(self):
         return {
             'all': {'input': 'all', 'label': _('Search in All')},
-            'project': {'input': 'project', 'label': _('Search in Project')},
-            'name': {'input': 'name', 'label': _('Search in Description')},
             'employee': {'input': 'employee', 'label': _('Search in Employee')},
-            'task': {'input': 'task', 'label': _('Search in Task')}
+            'project': {'input': 'project', 'label': _('Search in Project')},
+            'task': {'input': 'task', 'label': _('Search in Task')},
+            'name': {'input': 'name', 'label': _('Search in Description')},
         }
 
     def _task_get_searchbar_sortings(self):
@@ -67,6 +67,15 @@ class TimesheetCustomerPortal(CustomerPortal):
             'date': 'date'
         }
 
+    def _get_searchbar_sortings(self):
+        return {
+            'date': {'label': _('Newest'), 'order': 'date desc'},
+            'employee': {'label': _('Employee'), 'order': 'employee_id'},
+            'project': {'label': _('Project'), 'order': 'project_id'},
+            'task': {'label': _('Task'), 'order': 'task_id'},
+            'name': {'label': _('Description'), 'order': 'name'},
+        }
+
     @http.route(['/my/timesheets', '/my/timesheets/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_timesheets(self, page=1, sortby=None, filterby=None, search=None, search_in='all', groupby='none', **kw):
         Timesheet = request.env['account.analytic.line']
@@ -76,10 +85,7 @@ class TimesheetCustomerPortal(CustomerPortal):
         values = self._prepare_portal_layout_values()
         _items_per_page = 100
 
-        searchbar_sortings = {
-            'date': {'label': _('Newest'), 'order': 'date desc'},
-            'name': {'label': _('Description'), 'order': 'name'},
-        }
+        searchbar_sortings = self._get_searchbar_sortings()
 
         searchbar_inputs = self._get_searchbar_inputs()
 

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -31,16 +31,16 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
     def _get_searchbar_inputs(self):
         searchbar_inputs = super()._get_searchbar_inputs()
         searchbar_inputs.update(
-            sol={'input': 'sol', 'label': _('Search in Sales Order Item')},
             so={'input': 'so', 'label': _('Search in Sales Order')},
+            sol={'input': 'sol', 'label': _('Search in Sales Order Item')},
             invoice={'input': 'invoice', 'label': _('Search in Invoice')})
         return searchbar_inputs
 
     def _get_searchbar_groupby(self):
         searchbar_groupby = super()._get_searchbar_groupby()
         searchbar_groupby.update(
-            sol={'input': 'sol', 'label': _('Sales Order Item')},
             so={'input': 'so', 'label': _('Sales Order')},
+            sol={'input': 'sol', 'label': _('Sales Order Item')},
             invoice={'input': 'invoice', 'label': _('Invoice')})
         return searchbar_groupby
 
@@ -63,6 +63,12 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
             so='order_id',
             invoice='timesheet_invoice_id')
         return groupby_mapping
+
+    def _get_searchbar_sortings(self):
+        searchbar_sortings = super()._get_searchbar_sortings()
+        searchbar_sortings.update(
+            sol={'label': _('Sales Order Item'), 'order': 'so_line'})
+        return searchbar_sortings
 
     def _task_get_page_view_values(self, task, access_token, **kwargs):
         values = super()._task_get_page_view_values(task, access_token, **kwargs)

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -78,7 +78,7 @@
             </t>
         </xpath>
         <xpath expr="//thead/tr/th[@t-if='is_uom_day']" position="before">
-            <th t-if="not groupby == 'sol'">Sale Order Item</th>
+            <th t-if="not groupby == 'sol'">Sales Order Item</th>
         </xpath>
         <xpath expr="//tbody//td[hasclass('text-right')]" position="before">
             <td t-if="not groupby == 'sol'"><span t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span></td>


### PR DESCRIPTION
The purpose of this is to improve the generic UX of the portal.

In this commit,
   - We add a sort by employee, project, task, sales order item
   - rename 'sale order item' into 'sales order item'
   - In search, we reorder the fields in the following order:
        Employee, Project, Task, Description, Sales Order, Sales Order Item, Invoice
   - In group by, we switch the SO/SOL fields from place

Task-Id: 2531322
PR: #73699

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
