### PR TITLE
[FIX] website: flip the TrackPage dependency to resolve an issue for anonymous website users

### DIFF
--- a/addons/website/static/src/js/menu/customize.js
+++ b/addons/website/static/src/js/menu/customize.js
@@ -5,8 +5,10 @@ var core = require('web.core');
 var Widget = require('web.Widget');
 var websiteNavbarData = require('website.navbar');
 var WebsiteAceEditor = require('website.ace');
+var TrackPage = require('website.trackPage');
 
 var qweb = core.qweb;
+
 
 var CustomizeMenu = Widget.extend({
     xmlDependencies: ['/website/static/src/xml/website.editor.xml'],
@@ -74,7 +76,9 @@ var CustomizeMenu = Widget.extend({
         }
         this.__customizeOptionsLoaded = true;
 
+        var self = this;
         var $menu = this.$el.children('.dropdown-menu');
+
         return this._rpc({
             route: '/website/get_switchable_related_views',
             params: {
@@ -98,7 +102,19 @@ var CustomizeMenu = Widget.extend({
                 $a.find('input').prop('checked', !!item.active);
                 $menu.append($a);
             });
+            self._attachTrackPage();
         });
+    },
+
+    /**
+     * @private
+     */
+    _attachTrackPage: function () {
+        if (!this.__trackpageLoaded) {
+            this.__trackpageLoaded = true;
+            this.trackPage = new TrackPage(this);
+            this.trackPage.appendTo(this.$el.children('.dropdown-menu'));
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/js/menu/track_page.js
+++ b/addons/website/static/src/js/menu/track_page.js
@@ -1,4 +1,4 @@
-odoo.define('website.set_view_track', function (require) {
+odoo.define('website.trackPage', function (require) {
 "use strict";
 
 var Widget = require('web.Widget');

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -77,7 +77,6 @@
         <script type="text/javascript" src="/website/static/src/js/content/website_root_instance.js"/>
     </xpath>
     <xpath expr="//script[last()]" position="after">
-        <script type="text/javascript" src="/website/static/src/js/set_view_track.js"/>
         <script type="text/javascript" src="/website/static/src/js/utils.js"/>
 
         <script type="text/javascript" src="/website/static/src/js/content/website_root.js"/>
@@ -163,6 +162,7 @@
     <script type="text/javascript" src="/website/static/src/js/menu/mobile_view.js"/>
     <script type="text/javascript" src="/website/static/src/js/menu/new_content.js"/>
     <script type="text/javascript" src="/website/static/src/js/menu/seo.js"/>
+    <script type="text/javascript" src="/website/static/src/js/menu/track_page.js"/>
     <script type="text/javascript" src="/website/static/src/js/menu/translate.js"/>
     <script type="text/javascript" src="/website/static/src/js/tours/homepage.js"/>
     <script type="text/javascript" src="/website/static/src/js/tours/tour_utils.js"/>


### PR DESCRIPTION
https://github.com/odoo/odoo/issues/71842

Anonymous website users do not have access to the Customize menu
obviously, but the `website.set_view_track` widget still attempts to
extend the CustomizeMenu.

The dependency can just be flipped around with the CustomizeMenu
depending on the `website.set_view_track module` instead. It's the only
place that the module is currently being referenced so it's only a
single change.

**Current behavior before PR:**

The JavaScript from Odoo fails if you're not logged in:

**Desired behavior after PR is merged:**

There's no missing dependencies issues causing parts of the JS to crash.

--

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
