### PR TITLE
[IMP] account_reports: Allow to easily generate accrued entries from purchase orders & Sales orders.

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -76,6 +76,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/account_menuitem.xml',
         'views/account_analytic_default_view.xml',
         'wizard/account_tour_upload_bill.xml',
+        'wizard/accrued_orders.xml',
     ],
     'demo': [
         'demo/account_demo.xml',

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -148,3 +148,5 @@ access_account_analytic_default_analytic,account.analytic.default analytic,model
 access_account_analytic_default_invoice,account.analytic.default invoice,model_account_analytic_default,account.group_account_invoice,1,1,1,1
 access_account_tour_upload_bill,account.tour.upload.bill,model_account_tour_upload_bill,account.group_account_manager,1,1,1,0
 access_account_tour_upload_bill_email_confirm,account.tour.upload.bill.email.confirm,model_account_tour_upload_bill_email_confirm,account.group_account_manager,1,1,1,0
+
+access_account_accrued_orders_wizard,account.account.accrued.orders.wizard,account.model_account_accrued_orders_wizard,group_account_user,1,1,1,0

--- a/addons/account/wizard/__init__.py
+++ b/addons/account/wizard/__init__.py
@@ -17,3 +17,4 @@ from . import account_invoice_send
 from . import base_document_layout
 from . import account_payment_register
 from . import account_tour_upload_bill
+from . import accrued_orders

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from dateutil.relativedelta import relativedelta
+from collections import defaultdict
+import json
+from odoo import models, fields, api, _, Command
+from odoo.tools import format_date
+from odoo.exceptions import UserError
+
+
+class AccruedExpenseRevenue(models.TransientModel):
+    _name = 'account.accrued.orders.wizard'
+    _description = 'Accrued Orders Wizard'
+
+    def _get_account_domain(self):
+        if self.env.context.get('active_model') == 'purchase.order':
+            return [('user_type_id', '=', self.env.ref('account.data_account_type_current_liabilities').id), ('company_id', '=', self._get_default_company())]
+        else:
+            return [('user_type_id', '=', self.env.ref('account.data_account_type_current_assets').id), ('company_id', '=', self._get_default_company())]
+
+    def _get_default_company(self):
+        if not self._context.get('active_model'):
+            return
+        orders = self.env[self._context['active_model']].browse(self._context['active_ids'])
+        return orders and orders[0].company_id.id
+
+    company_id = fields.Many2one('res.company', default=_get_default_company)
+    journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        compute='_compute_journal_id',
+        domain="[('type', '=', 'general'), ('company_id', '=', company_id)]",
+        readonly=False,
+        required=True,
+        check_company=True,
+        string='Journal',
+    )
+    date = fields.Date(default=fields.Date.today, required=True)
+    reversal_date = fields.Date(
+        compute="_compute_reversal_date",
+        required=True,
+        readonly=False,
+    )
+    amount = fields.Monetary(string='Amount', help="Specify an arbitrary value that will be accrued on a \
+        default account for the entire order, regardless of the products on the different lines.")
+    currency_id = fields.Many2one(related='company_id.currency_id', string='Company Currency',
+        readonly=True, store=True,
+        help='Utility field to express amount currency')
+    account_id = fields.Many2one(
+        comodel_name='account.account',
+        required=True,
+        string='Accrual Account',
+        check_company=True,
+        domain=_get_account_domain,
+    )
+    preview_data = fields.Text(compute='_compute_preview_data')
+    display_amount = fields.Boolean(compute='_compute_display_amount')
+
+    @api.depends('journal_id')
+    def _compute_display_amount(self):
+        single_order = len(self._context['active_ids']) == 1
+        orders = self.env[self._context['active_model']].browse(self._context['active_ids'])
+        for record in self:
+            lines = orders and orders[0].order_line.filtered(
+                lambda l: fields.Float.compare(
+                    l.qty_to_invoice,
+                    0,
+                    precision_digits=l.product_uom.rounding,
+                ) == 1
+            )
+            record.display_amount = single_order and not lines
+
+    @api.depends('date')
+    def _compute_reversal_date(self):
+        for record in self:
+            if not record.reversal_date or record.reversal_date <= record.data:
+                record.reversal_date = record.date + relativedelta(days=1)
+            else:
+                record.reversal_date = record.reversal_date
+
+    @api.depends('company_id')
+    def _compute_journal_id(self):
+        journal = self.env['account.journal'].search(
+            [('type', '=', 'general'), ('company_id', '=', self.company_id.id)], limit=1
+        )
+        for record in self:
+            record.journal_id = journal
+
+    @api.depends('date', 'journal_id', 'account_id', 'amount')
+    def _compute_preview_data(self):
+        for record in self:
+            preview_vals = [self.env['account.move']._move_dict_to_preview_vals(
+                self._compute_move_vals()[0],
+                record.company_id.currency_id,
+            )]
+            preview_columns = [
+                {'field': 'account_id', 'label': _('Account')},
+                {'field': 'name', 'label': _('Label')},
+                {'field': 'debit', 'label': _('Debit'), 'class': 'text-right text-nowrap'},
+                {'field': 'credit', 'label': _('Credit'), 'class': 'text-right text-nowrap'},
+            ]
+            record.preview_data = json.dumps({
+                'groups_vals': preview_vals,
+                'options': {
+                    'columns': preview_columns,
+                },
+            })
+
+    def _compute_move_vals(self):
+        def _get_aml_vals(order, balance, amount_currency, account_id):
+            if not is_purchase:
+                balance *= -1
+                amount_currency *= -1
+            values = {
+                'name': _('Accrued for %s', order.name),
+                'debit': balance if balance > 0 else 0.0,
+                'credit': balance * -1 if balance < 0 else 0.0,
+                'account_id': account_id,
+            }
+            if self.company_id.currency_id != order.currency_id:
+                values.update({
+                    'amount_currency': amount_currency,
+                    'currency_id': order.currency_id.id,
+                })
+            return values
+
+        self.ensure_one()
+        move_lines = []
+        is_purchase = self.env.context.get('active_model') == 'purchase.order'
+        orders = self.env[self._context['active_model']].with_company(self.company_id).browse(self._context['active_ids'])
+
+        if orders.filtered(lambda o: o.company_id != self.company_id):
+            raise UserError(_('Entries can only be created for a single company at a time.'))
+
+        orders_with_entries = []
+        for order in orders:
+            total_balance = 0.0
+            total_amount_currency = 0.0
+            inc_exp_accounts = defaultdict(lambda: defaultdict(float))
+            if len(orders) == 1 and self.amount:
+                total_balance = self.amount
+                order_line = order.order_line[0]
+                if is_purchase:
+                    account = order_line.product_id.property_account_expense_id or order_line.product_id.categ_id.property_account_expense_categ_id
+                else:
+                    account = order_line.product_id.property_account_income_id or order_line.product_id.categ_id.property_account_income_categ_id
+                inc_exp_accounts[account]['amount'] += self.amount
+            else:
+                lines = order.order_line.filtered(
+                    lambda l: fields.Float.compare(
+                        l.qty_to_invoice,
+                        0,
+                        precision_digits=l.product_uom.rounding,
+                    ) == 1
+                )
+                other_currency = self.company_id.currency_id != order.currency_id
+                rate = order.currency_id._get_rates(self.company_id, self.date).get(order.currency_id.id) if other_currency else 1.0
+                for order_line in lines:
+                    if is_purchase:
+                        account = order_line.product_id.property_account_expense_id or order_line.product_id.categ_id.property_account_expense_categ_id
+                        amount = self.company_id.currency_id.round(order_line.qty_to_invoice * order_line.price_unit / rate)
+                        amount_currency = order_line.currency_id.round(order_line.qty_to_invoice * order_line.price_unit)
+                    else:
+                        account = order_line.product_id.property_account_income_id or order_line.product_id.categ_id.property_account_income_categ_id
+                        amount = self.company_id.currency_id.round(order_line.untaxed_amount_to_invoice / rate)
+                        amount_currency = order_line.untaxed_amount_to_invoice
+                    inc_exp_accounts[account]['amount'] += amount
+                    inc_exp_accounts[account]['amount_currency'] += amount_currency
+                    total_balance += amount
+                    total_amount_currency += amount_currency
+
+            if not self.company_id.currency_id.is_zero(total_balance):
+                orders_with_entries.append(order)
+                # create an aml for each different account that will be used for the products
+                for inc_exp_account, amounts in inc_exp_accounts.items():
+                    balance = amounts['amount']
+                    amount_currency = amounts.get('amount_currency', 0.0)
+                    values = _get_aml_vals(order, balance, amount_currency, inc_exp_account.id)
+                    move_lines.append(Command.create(values))
+
+                # globalized counterpart for the whole order
+                values = _get_aml_vals(order, -total_balance, -total_amount_currency, self.account_id.id)
+                move_lines.append(Command.create(values))
+
+        move_type = _('Expense') if is_purchase else _('Revenue')
+        move_vals = {
+            'ref': _('Accrued %s entry as of %s', move_type, format_date(self.env, self.date)),
+            'journal_id': self.journal_id.id,
+            'date': self.date,
+            'line_ids': move_lines,
+        }
+        return move_vals, orders_with_entries
+
+    def create_entries(self):
+        self.ensure_one()
+
+        if self.reversal_date <= self.date:
+            raise UserError(_('Reversal date must be posterior to date.'))
+
+        move_vals, orders_with_entries = self._compute_move_vals()
+        move = self.env['account.move'].create(move_vals)
+        move._post()
+        reverse_move = move._reverse_moves(default_values_list=[{
+            'ref': _('Reversal of: %s', move.ref),
+            'date': self.reversal_date,
+        }])
+        reverse_move._post()
+        for order in orders_with_entries:
+            body = _('Accrual entry created on %s: <a href=# data-oe-model=account.move data-oe-id=%d>%s</a>.\
+                    And its <a href=# data-oe-model=account.move data-oe-id=%d>reverse entry</a>.') % (
+                self.date,
+                move.id,
+                move.name,
+                reverse_move.id,
+            )
+            order.message_post(body=body)
+        return {
+            'name': _('Accrual Moves'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.move',
+            'view_mode': 'tree,form',
+            'domain': [('id', 'in', (move.id, reverse_move.id))],
+        }

--- a/addons/account/wizard/accrued_orders.xml
+++ b/addons/account/wizard/accrued_orders.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_accrued_orders_wizard" model="ir.ui.view">
+        <field name="name">account.accrued.orders.wizard.view</field>
+        <field name="model">account.accrued.orders.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Make Accrual Entries">
+                <field name="company_id" invisible="1"/>
+                <group>
+                    <div class="alert alert-info" colspan="4" role="alert" attrs="{'invisible': [('display_amount', '!=', True)]}">
+                      There doesn't appear to be anything to invoice for the selected order. However, you can use the amount field to force an accrual entry.
+                    </div>
+                  <group>
+                    <field name="journal_id"/>
+                    <field name="account_id"/>
+                    <field name="amount" attrs="{'invisible': [('display_amount', '!=', True)]}"/>
+                    <field name="display_amount" invisible="1"/>
+                  </group>
+                  <group>
+                    <field name="date"/>
+                    <field name="reversal_date"/>
+                  </group>
+                </group>
+                <field name="preview_data" widget="grouped_view_widget"/>
+                <footer>
+                    <button string='Create Entry' name="create_entries" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_purchase
 from . import test_purchase_order_report
 from . import test_purchase_invoice
 from . import test_access_rights
+from . import test_accrued_purchase_orders

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        uom_unit = cls.env.ref('uom.product_uom_unit')
+        uom_hour = cls.env.ref('uom.product_uom_hour')
+        cls.alt_exp_account = cls.company_data['default_account_expense'].copy()
+        cls.currency_a = cls.env['res.currency'].create({
+            'name': 'CUR',
+            'symbol': 'c',
+            'rounding': 0.01,
+        })
+        cls.env['res.currency.rate'].create({
+            'currency_id': cls.currency_a.id,
+            'rate': 1.5,
+        })
+        product_order = cls.env['product.product'].create({
+            'name': "Product",
+            'list_price': 30.0,
+            'type': 'consu',
+            'uom_id': uom_unit.id,
+            'uom_po_id': uom_unit.id,
+            'purchase_method': 'receive',
+            'property_account_expense_id': cls.alt_exp_account.id,
+        })
+        service_order = cls.env['product.product'].create({
+            'name': "Service",
+            'list_price': 50.0,
+            'type': 'service',
+            'uom_id': uom_hour.id,
+            'uom_po_id': uom_hour.id,
+            'purchase_method': 'receive',
+        })
+        cls.purchase_order = cls.env['purchase.order'].with_context(tracking_disable=True).create({
+            'partner_id': cls.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': product_order.name,
+                    'product_id': product_order.id,
+                    'product_qty': 10.0,
+                    'product_uom': product_order.uom_id.id,
+                    'price_unit': product_order.list_price,
+                    'taxes_id': False,
+                }),
+                Command.create({
+                    'name': service_order.name,
+                    'product_id': service_order.id,
+                    'product_qty': 10.0,
+                    'product_uom': service_order.uom_id.id,
+                    'price_unit': service_order.list_price,
+                    'taxes_id': False,
+                }),
+            ],
+        })
+        cls.purchase_order.button_confirm()
+        cls.account_revenue = cls.company_data['default_account_revenue']
+        cls.account_expense = cls.company_data['default_account_expense']
+        cls.wizard = cls.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'purchase.order',
+            'active_ids': cls.purchase_order.ids
+        }).create({
+            'account_id': cls.account_revenue.id,
+        })
+
+    def test_accrued_order(self):
+        # nothing to bill : no entries to be created
+        with self.assertRaises(UserError):
+            self.wizard.create_entries()
+
+        # 5 qty of each product billeable
+        self.purchase_order.order_line.qty_received = 5
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.alt_exp_account.id, 'debit': 0, 'credit': 150},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 250},
+            {'account_id': self.account_revenue.id, 'debit': 400, 'credit': 0},
+            # move lines
+            {'account_id': self.alt_exp_account.id, 'debit': 150, 'credit': 0},
+            {'account_id': self.account_expense.id, 'debit': 250, 'credit': 0},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 400},
+        ])
+
+        # received products billed, nothing to bill left
+        move = self.env['account.move'].browse(self.purchase_order.action_create_invoice()['res_id'])
+        move.invoice_date = fields.Date.today()
+        move.action_post()
+        with self.assertRaises(UserError):
+            self.wizard.create_entries()
+
+    def test_multi_currency_accrued_order(self):
+        # 5 qty of each product billeable
+        self.purchase_order.order_line.qty_received = 5
+        # set currency != company currency
+        self.purchase_order.currency_id = self.currency_a
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.alt_exp_account.id, 'debit': 0, 'credit': 150 / 1.5, 'amount_currency': -150},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 250 / 1.5, 'amount_currency': -250},
+            {'account_id': self.account_revenue.id, 'debit': 400 / 1.5, 'credit': 0, 'amount_currency': 400},
+            # move lines
+            {'account_id': self.alt_exp_account.id, 'debit': 150 / 1.5, 'credit': 0, 'amount_currency': 150},
+            {'account_id': self.account_expense.id, 'debit': 250 / 1.5, 'credit': 0, 'amount_currency': 250},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 400 / 1.5, 'amount_currency': -400},
+        ])

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -769,7 +769,17 @@
                 action = records._send_reminder_mail(send_single=True)
         </field>
     </record>
-    
+
+    <record id="action_accrued_expense_entry" model="ir.actions.act_window">
+        <field name="name">Accrued Expense Entry</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">account.accrued.orders.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="binding_model_id" ref="purchase.model_purchase_order"/>
+        <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
+        <field name="target">new</field>
+    </record>
+
     <!-- Dashboard action buttons -->
     <!-- Dashboard action buttons: End in List view -->
     <record id="purchase_action_dashboard_list" model="ir.actions.act_window">

--- a/addons/sale/tests/__init__.py
+++ b/addons/sale/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_access_rights
 from . import test_sale_refund
 from . import test_sale_signature
 from . import test_sale_flow
+from . import test_accrued_sale_orders

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAccruedSaleOrders(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        uom_unit = cls.env.ref('uom.product_uom_unit')
+        uom_hour = cls.env.ref('uom.product_uom_hour')
+        cls.alt_inc_account = cls.company_data['default_account_revenue'].copy()
+        cls.currency_a = cls.env['res.currency'].create({
+            'name': 'CUR',
+            'symbol': 'c',
+            'rounding': 0.01,
+        })
+        cls.env['res.currency.rate'].create({
+            'currency_id': cls.currency_a.id,
+            'rate': 1.5,
+        })
+        cls.product_order = cls.env['product.product'].create({
+            'name': "Product",
+            'list_price': 30.0,
+            'type': 'consu',
+            'uom_id': uom_unit.id,
+            'uom_po_id': uom_unit.id,
+            'invoice_policy': 'delivery',
+            'property_account_income_id': cls.alt_inc_account.id,
+        })
+        cls.service_order = cls.env['product.product'].create({
+            'name': "Service",
+            'list_price': 50.0,
+            'type': 'service',
+            'uom_id': uom_hour.id,
+            'uom_po_id': uom_hour.id,
+            'invoice_policy': 'delivery',
+        })
+        cls.sale_order = cls.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': cls.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': cls.product_order.name,
+                    'product_id': cls.product_order.id,
+                    'product_uom_qty': 10.0,
+                    'product_uom': cls.product_order.uom_id.id,
+                    'price_unit': cls.product_order.list_price,
+                    'tax_id': False,
+                }),
+                Command.create({
+                    'name': cls.service_order.name,
+                    'product_id': cls.service_order.id,
+                    'product_uom_qty': 10.0,
+                    'product_uom': cls.service_order.uom_id.id,
+                    'price_unit': cls.service_order.list_price,
+                    'tax_id': False,
+                })
+            ]
+        })
+        cls.sale_order.action_confirm()
+        cls.account_expense = cls.company_data['default_account_expense']
+        cls.account_revenue = cls.company_data['default_account_revenue']
+        cls.wizard = cls.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': cls.sale_order.ids,
+        }).create({
+            'account_id': cls.account_expense.id,
+        })
+
+    def test_accrued_order(self):
+        # nothing to invoice : no entries to be created
+        with self.assertRaises(UserError):
+            self.wizard.create_entries()
+
+        # 5 qty of each product invoiceable
+        self.sale_order.order_line.qty_delivered = 5
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.alt_inc_account.id, 'debit': 150, 'credit': 0},
+            {'account_id': self.account_revenue.id, 'debit': 250, 'credit': 0},
+            {'account_id': self.wizard.account_id.id, 'debit': 0, 'credit': 400},
+            # move lines
+            {'account_id': self.alt_inc_account.id, 'debit': 0, 'credit': 150},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 250},
+            {'account_id': self.wizard.account_id.id, 'debit': 400, 'credit': 0},
+        ])
+
+        # delivered products invoiced, nothing to invoice left
+        self.sale_order._create_invoices().action_post()
+        with self.assertRaises(UserError):
+            self.wizard.create_entries()['res_id']
+
+    def test_multi_currency_accrued_order(self):
+        # 5 qty of each product billeable
+        self.sale_order.order_line.qty_delivered = 5
+        # set currency != company currency
+        self.sale_order.currency_id = self.currency_a
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.alt_inc_account.id, 'debit': 150 / 1.5, 'credit': 0, 'amount_currency': 150},
+            {'account_id': self.account_revenue.id, 'debit': 250 / 1.5, 'credit': 0, 'amount_currency': 250},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 400 / 1.5, 'amount_currency': -400},
+            # move lines
+            {'account_id': self.alt_inc_account.id, 'debit': 0, 'credit': 150 / 1.5, 'amount_currency': -150},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 250 / 1.5, 'amount_currency': -250},
+            {'account_id': self.account_expense.id, 'debit': 400 / 1.5, 'credit': 0, 'amount_currency': 400},
+        ])

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -899,6 +899,16 @@
             <field name="code">action = records.action_quotation_sent()</field>
         </record>
 
+        <record id="action_accrued_revenue_entry" model="ir.actions.act_window">
+            <field name="name">Accrued Revenue Entry</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">account.accrued.orders.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="binding_model_id" ref="sale.model_sale_order"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
+            <field name="target">new</field>
+        </record>
+
         <menuitem id="menu_sale_invoicing"
             name="To Invoice"
             parent="sale_menu_root"


### PR DESCRIPTION
Accrued liabilities, or accrued expenses, occur when you incur an expense that you haven’t been billed for (aka a debt).
For example, you receive a good now and pay for it later (e.g., when you receive an invoice). The same opposite approach for sales.

Why do accountants need such entries ?
- Accounting must give a fair view of the financial situation of a company. The loss/profit must be booked regarding the effective deliveries of goods/services, not on the paperwork only.
- On a fiscal point of view, if you want to be allowed to deduct a loss from your taxable basis, it has to be in the right period. If you didn't announce it on time, the loss might be rejected by fiscal authorities. Same goes for the augmentation of the taxable basis, it has to reflect real deliveries and not only paperwork.

Task: 2555642