### PR TITLE
[FIX] web_editor: double insert link on paste

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2148,8 +2148,8 @@ export class OdooEditor extends EventTarget {
                         },
                     ];
 
-                    this.execCommand('insertText', splitAroundUrl[i]);
                     if (['jpg', 'jpeg', 'png', 'gif'].includes(urlFileExtention)) {
+                        this.execCommand('insertText', splitAroundUrl[i]);
                         this.commandBar.open({
                             commands: [
                                 {
@@ -2171,6 +2171,7 @@ export class OdooEditor extends EventTarget {
                             ].concat(baseEmbedCommand),
                         });
                     } else if (youtubeUrl) {
+                        this.execCommand('insertText', splitAroundUrl[i]);
                         this.commandBar.open({
                             commands: [
                                 {


### PR DESCRIPTION
When pasting text containing url, the url was pasted twice.
One being simple text and the other one being a link.

Task ID: 2602785

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
