### PR TITLE
[FIX] web_editor: properly set the url for youtube embed

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2185,7 +2185,7 @@ export class OdooEditor extends EventTarget {
                                         video.setAttribute('height', '315');
                                         video.setAttribute(
                                             'src',
-                                            'https://www.youtube.com/embed/${youtubeUrl[1]}',
+                                            `https://www.youtube.com/embed/${youtubeUrl[1]}`,
                                         );
                                         video.setAttribute('title', 'YouTube video player');
                                         video.setAttribute('frameborder', '0');


### PR DESCRIPTION
There was a typo setting the url of youtube when pasting
youtube url and trying to embed it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
