### PR TITLE
[FIX] l10n_pe: add zip to Peru address format

### DIFF
--- a/addons/l10n_pe/data/res_country_data.xml
+++ b/addons/l10n_pe/data/res_country_data.xml
@@ -32,7 +32,7 @@
     <record id="base.pe" model="res.country">
         <field name="enforce_cities" eval="1" />
         <field name="address_view_id" ref="pe_partner_address_form" />
-        <field name="address_format" eval="'%(street)s\n%(city)s\n%(state_name)s\n%(country_name)s'"/>
+        <field name="address_format" eval="'%(street)s\n%(zip)s%(city)s\n%(state_name)s\n%(country_name)s'"/>
         <field name="street_format" eval="'%(street_name)s %(street_number)s, %(street_number2)s'"/>
     </record>
 </odoo>


### PR DESCRIPTION
Steps to reproduce the bug:
- Install eCommerce and l10n_pe
- Go as website visitor
- Add anything to your cart
- Continue with checkout to go to the address page
- Select country Peru and fill in all the required fields
- Validate
- You will get an error message telling you that you forgot to fill in a required field.

Problem:
You cannot validate the address because zip code is not displayed, but required.
This field is based on the country format address to be displayed before or after the `" City "` field
and is not displayed if `" zip "` is not present in the country format address.

https://github.com/odoo/odoo/blob/b1107cba38e296f17d03d9919be67e6789a407be/addons/website_sale/views/templates.xml#L1208

https://github.com/odoo/odoo/blob/15fe3d43b4b925a32b42eb46048a33987e10336b/openerp/addons/base/res/res_country.py#L77

Solution:
"zip" is required for the Peru country, so it must be added in the address format

opw-2600526





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
