### PR TITLE
[FIX] web: avoid pushing state when ActionAdapter is in dialog

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -68,6 +68,9 @@ class ActionAdapter extends ComponentAdapter {
     }
 
     pushState(state) {
+        if (this.wowlEnv.inDialog) {
+            return;
+        }
         const query = objectToQuery(state);
         if (this.tempQuery) {
             Object.assign(this.tempQuery, query);


### PR DESCRIPTION
Previously, push_state events triggered from withing window actions
inside dialogs would bubble push their state into the URL even while
within a dialog, this is undesirable as this can cause the URL to become
invalid (eg by pushing the id of a record from an entirely different
model)

This commit fixes that by simply checking whether we are in a dialog
within the adapter before calling pushState.

task-2602458
