### PR TITLE
[FIX] Error on choosing database

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -120,7 +120,7 @@ def serialize_exception(f):
 
 def abort_and_redirect(url):
     r = request.httprequest
-    response = request.redirect(url, 302)
+    response = werkzeug.utils.redirect(url, 302)
     response = r.app.get_response(r, response, explicit_session=False)
     werkzeug.exceptions.abort(response)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It raises error on selecting a database in url: e.g., `http://localhost:8069/web?db=a_database`

Current behavior before PR:
Passing db as the url parameter raises `Internal server error`, though the user cannot switch the database.

Desired behavior after PR is merged:
It should not raise error when selecting a database.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
