### PR TITLE
[FIX] web_editor: paste multiline

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -93,7 +93,7 @@ function insert(editor, data, isText = true) {
         } else {
             startNode.after(nodeToInsert);
         }
-        if (isShrunkBlock(startNode)) {
+        if (startNode.tagName !== 'BR' && isShrunkBlock(startNode)) {
             startNode.remove();
         }
         startNode = nodeToInsert;


### PR DESCRIPTION
Inserting text that contain multiline does not work.
One "\n" is removed.
Two "\n" become only one.

Task ID: 2602881

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
