### PR TITLE
[IMP] product: validate start and end date for pricelist items

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -5,7 +5,7 @@ from itertools import chain
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import float_repr
+from odoo.tools import float_repr, format_datetime
 from odoo.tools.misc import get_lang
 
 
@@ -450,6 +450,13 @@ class PricelistItem(models.Model):
     def _check_recursion(self):
         if any(item.base == 'pricelist' and item.pricelist_id and item.pricelist_id == item.base_pricelist_id for item in self):
             raise ValidationError(_('You cannot assign the Main Pricelist as Other Pricelist in PriceList Item'))
+
+    @api.constrains('date_start', 'date_end')
+    def _check_date_range(self):
+        for item in self:
+            if item.date_start and item.date_end and item.date_start >= item.date_end:
+                raise ValidationError(_('%s : end date (%s) should be greater than start date (%s)', item.display_name, format_datetime(self.env, item.date_end), format_datetime(self.env, item.date_start)))
+        return True
 
     @api.constrains('price_min_margin', 'price_max_margin')
     def _check_margin(self):

--- a/doc/cla/individual/skeller1.md
+++ b/doc/cla/individual/skeller1.md
@@ -1,0 +1,11 @@
+Germany, 2021-07-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Stephan Keller skeller1 mistk@gmx.de https://github.com/skeller1


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

date range validation for pricelist item records in pricelist

Current behavior before PR:

It is possible to enter invalid date ranges (start and end date) for pricelist items in pricelists.
![grafik](https://user-images.githubusercontent.com/226753/125665193-e4d378b4-d89e-4cfc-911e-04ae8da908fb.png)



Desired behavior after PR is merged:

It is not possible to enter invalid date ranges for pricelist items in pricelists.

Valid date ranges:

- end date is set
- start date is set
- end date is greater than start_date

![grafik](https://user-images.githubusercontent.com/226753/125664008-9d3aa269-d3a1-4e8b-875b-c01489524b33.png)

Invalid date ranges:

- start date is greater than end date
- start date and end date are the same

![grafik](https://user-images.githubusercontent.com/226753/125664230-40d8f91d-0270-4a44-b3ba-0e9357719fd3.png)


Validation message example:
![grafik](https://user-images.githubusercontent.com/226753/125761400-9684ac74-4b24-450d-aa6f-72b838b72ede.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
