### PR TITLE
[FIX] stock: Exception are not correctly logged

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -544,6 +544,9 @@ class ProcurementGroup(models.Model):
                 self = self.with_env(self.env(cr=cr))  # TDE FIXME
 
             self._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
+        except Exception:
+            _logger.error("Error during stock scheduler", exc_info=True)
+            raise
         finally:
             if use_new_cursor:
                 try:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Il during the scheduler an exception append, the error is not correctly logged.
This PR allow to catch the error with logger analyser (like sentry).

- Install stock and base_automation
- create a wrongly automatized action (for exemple during create of picking)
- execute the scheduler

**Current behavior before PR:**
in log you see
```
Exception in thread Thread-11:
Traceback (most recent call last):
  File "/Users/florentdelabarre/git/simplyfeu_140_lab/odoo/odoo/tools/safe_eval.py", line 330, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "", line 15, in <module>
NameError: name 'lines_content_str' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
```

**Desired behavior after PR is merged:**
Now you see :
```
2021-07-15 03:54:57,336 98238 ERROR database odoo.addons.stock.models.stock_rule: Error during stock scheduler :
Traceback (most recent call last):
  File "/odoo/odoo/tools/safe_eval.py", line 330, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "", line 15, in <module>
NameError: name 'lines_content_str' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...

```

@rco-odoo @amoyaux 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
