### PR TITLE
[FIX] web: on m20 focus out it is still dirty

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -827,6 +827,7 @@ var FieldMany2One = AbstractField.extend({
             new M2ODialog(this, this.string, this.$input.val()).open();
         } else {
             this.$input.val("");
+            this.reinitialize(false);
         }
     },
     /**


### PR DESCRIPTION
PURPOSE

Currently, if M2O has no create access and user type something
in M2O field and focus out from that field (means click on
somewhere else) than the value of that field is set to null but
the value of isDrity is not Change.

SPECIFICATION

in this PR, we fix the issue of dirty field by calling
reinitialize method with the false value.

TaskId: 2092853

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
