### PR TITLE
[FIX] mrp: prevent crash if no date_end

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -165,7 +165,10 @@ class MrpWorkorder(models.Model):
             if order.working_user_ids:
                 order.last_working_user_id = order.working_user_ids[-1]
             elif order.time_ids:
-                order.last_working_user_id = order.time_ids.sorted('date_end')[-1].user_id
+                order.last_working_user_id = order.time_ids.filtered('date_end').sorted('date_end')[-1].user_id if order.time_ids.filtered('date_end') else order.time_ids[-1].user_id
+            else:
+                order.last_working_user_id = False
+
             if order.time_ids.filtered(lambda x: (x.user_id.id == self.env.user.id) and (not x.date_end) and (x.loss_type in ('productive', 'performance'))):
                 order.is_user_working = True
             else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- If there is no `date_end`, sorting will crash.

Current behavior before PR:

- Can't open MRP -> Operations -> Work Orders

Desired behavior after PR is merged:

- Be able to open Work Orders


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
