### PR TITLE
[FIX] payment: Fix payment access rights for not admin users

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -44,7 +44,6 @@ class AccountPaymentMethod(models.Model):
         self.ensure_one()
         information = self._get_payment_method_information().get(self.code)
 
-        unique = information.get('mode') == 'unique'
         currency_id = information.get('currency_id')
         country_id = information.get('country_id')
         default_domain = [('type', 'in', ('bank', 'cash'))]
@@ -58,11 +57,6 @@ class AccountPaymentMethod(models.Model):
 
         if country_id:
             domains += [[('company_id.account_fiscal_country_id', '=', country_id)]]
-
-        if unique:
-            company_ids = self.env['payment.acquirer'].search([('provider', '=', self.code)]).mapped('company_id')
-            if company_ids:
-                domains += [[('company_id', 'in', company_ids.ids)]]
 
         return expression.AND(domains)
 

--- a/addons/payment/models/account_journal.py
+++ b/addons/payment/models/account_journal.py
@@ -26,8 +26,8 @@ class AccountJournal(models.Model):
             AND apml.id IS NULL
         ''')
         ids = [r[0] for r in self._cr.fetchall()]
-        acquirers = self.env['payment.acquirer'].browse(ids)
-        if acquirers:
+        if ids:
+            acquirers = self.env['payment.acquirer'].sudo().browse(ids)
             raise UserError(_("You can't delete a payment method that is linked to an acquirer in the enabled or test state.\n"
                               "Linked acquirer(s): %s", ', '.join(a.display_name for a in acquirers)))
 
@@ -40,7 +40,7 @@ class AccountJournal(models.Model):
     def _compute_available_payment_method_ids(self):
         super()._compute_available_payment_method_ids()
 
-        installed_acquirers = self.env['payment.acquirer'].search([])
+        installed_acquirers = self.env['payment.acquirer'].sudo().search([])
         method_information = self.env['account.payment.method']._get_payment_method_information()
         pay_methods = self.env['account.payment.method'].search([('code', 'in', list(method_information.keys()))])
         pay_method_by_code = {x.code + x.payment_type: x for x in pay_methods}

--- a/addons/payment/models/account_payment_method.py
+++ b/addons/payment/models/account_payment_method.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.osv import expression
 
 
 class AccountPaymentMethodLine(models.Model):
@@ -18,7 +19,7 @@ class AccountPaymentMethodLine(models.Model):
 
     @api.depends('payment_method_id')
     def _compute_payment_acquirer_id(self):
-        acquirers = self.env['payment.acquirer'].search([
+        acquirers = self.env['payment.acquirer'].sudo().search([
             ('provider', 'in', self.mapped('code')),
             ('company_id', 'in', self.journal_id.company_id.ids),
         ])
@@ -27,6 +28,19 @@ class AccountPaymentMethodLine(models.Model):
             code = line.payment_method_id.code
             company = line.journal_id.company_id
             line.payment_acquirer_id = acquirers_map.get((code, company), False)
+
+    def _get_payment_method_domain(self):
+        # OVERRIDE
+        domain = super()._get_payment_method_domain()
+        information = self._get_payment_method_information().get(self.code)
+
+        unique = information.get('mode') == 'unique'
+        if unique:
+            company_ids = self.env['payment.acquirer'].sudo().search([('provider', '=', self.code)]).mapped('company_id')
+            if company_ids:
+                domain = expression.AND([domain, [('company_id', 'in', company_ids.ids)]])
+
+        return domain
 
     def action_open_acquirer_form(self):
         self.ensure_one()

--- a/addons/payment/views/account_journal_views.xml
+++ b/addons/payment/views/account_journal_views.xml
@@ -9,8 +9,12 @@
             <xpath expr="//field[@name='inbound_payment_method_line_ids']//field[@name='payment_account_id']" position="after">
                 <field name="payment_acquirer_id" invisible="1"/>
                 <field name="payment_acquirer_state" invisible="1"/>
-                <button name="action_open_acquirer_form" type="object" string="SETUP" class="float-right btn-secondary"
-                        attrs="{'invisible': [('payment_acquirer_id', '=', False)]}"/>
+                <button name="action_open_acquirer_form"
+                        type="object"
+                        string="SETUP"
+                        class="float-right btn-secondary"
+                        attrs="{'invisible': [('payment_acquirer_id', '=', False)]}"
+                        groups="base.group_system"/>
             </xpath>
             <xpath expr="//field[@name='inbound_payment_method_line_ids']/tree" position="attributes">
                 <attribute name="decoration-muted">payment_acquirer_state == 'disabled'</attribute>


### PR DESCRIPTION
The journal needs to access the payment acquirers to determine with payment method is still available.
Since the acquirers can't be accessed only for admin users, an accountant doesn't any right to read them, and then, an access error was raised when opening the journal form view.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
