### PR TITLE
[FIX] web: traceback generated by hotkeys

### DIFF
--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -16,7 +16,7 @@ export function isBrowserChrome() {
 }
 
 export function isMacOS() {
-    return Boolean(browser.navigator.platform.match(/Mac/i));
+    return Boolean(browser.navigator.userAgent.match(/Mac/i));
 }
 
 export function isMobileOS() {

--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -88,7 +88,7 @@ export const hotkeyService = {
                 _originalEvent: event,
             };
             dispatch(infos);
-            removeHotkeyOverlays();
+            removeHotkeyOverlays(event);
         }
 
         /**

--- a/addons/web/static/src/webclient/commands/command_palette.scss
+++ b/addons/web/static/src/webclient/commands/command_palette.scss
@@ -60,6 +60,10 @@
       line-height: 1.8em;
       height: 2.8em;
 
+      &.focused {
+        background: #00a09d26;
+      }
+
       kbd {
         background-color: #f4f7f8;
         border-radius: 3px;

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -139,12 +139,6 @@ QUnit.test("hook", async (assert) => {
 QUnit.test("non-MacOS usability", async (assert) => {
     assert.expect(6);
 
-    patchWithCleanup(browser, {
-        navigator: {
-            platform: "OdooOS",
-        },
-    });
-
     const hotkey = env.services.hotkey;
     const key = "q";
 
@@ -186,7 +180,7 @@ QUnit.test("MacOS usability", async (assert) => {
 
     patchWithCleanup(browser, {
         navigator: {
-            platform: "Mac",
+            userAgent: browser.navigator.userAgent.replace(/\([^)]*\)/, "(MacOs)"),
         },
     });
 
@@ -491,12 +485,6 @@ QUnit.test("registrations and elements belong to the correct UI owner", async (a
 QUnit.test("replace the overlayModifier for non-MacOs", async (assert) => {
     assert.expect(3);
 
-    patchWithCleanup(browser, {
-        navigator: {
-            platform: "OdooOS",
-        },
-    });
-
     const hotkeyService = serviceRegistry.get("hotkey");
     patchWithCleanup(hotkeyService, {
         overlayModifier: "alt+shift",
@@ -531,7 +519,7 @@ QUnit.test("replace the overlayModifier for MacOs", async (assert) => {
 
     patchWithCleanup(browser, {
         navigator: {
-            platform: "Mac",
+            userAgent: browser.navigator.userAgent.replace(/\([^)]*\)/, "(MacOs)"),
         },
     });
 

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -175,6 +175,92 @@ QUnit.test("non-MacOS usability", async (assert) => {
     removeHotkey();
 });
 
+QUnit.test("the overlay of hotkeys is correctly displayed", async (assert) => {
+    assert.expect(7);
+
+    const displayHotkeysOverlay = () =>
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "alt", altKey: true }));
+
+    class MyComponent extends Component {
+        onClick(ev) {
+            assert.step(`click ${ev.target.dataset.hotkey}`);
+        }
+    }
+    MyComponent.template = xml`
+        <div>
+        <button t-on-click="onClick" data-hotkey="b"/>
+        <button t-on-click="onClick" data-hotkey="c"/>
+        </div>
+    `;
+    const comp = await mount(MyComponent, { env, target });
+    const getOverlays = () =>
+        [...comp.el.querySelectorAll(".o_web_hotkey_overlay")].map((el) => el.innerText);
+
+    displayHotkeysOverlay();
+    assert.deepEqual(getOverlays(), ["B", "C"], "should display the overlay");
+
+    // apply an existent hotkey
+    triggerHotkey(`alt+b`);
+    await nextTick();
+    assert.verifySteps(["click b"]);
+    assert.deepEqual(getOverlays(), [], "shouldn't display the overlay");
+
+    displayHotkeysOverlay();
+    assert.deepEqual(getOverlays(), ["B", "C"], "should display the overlay");
+
+    // apply a non-existent hotkey
+    triggerHotkey(`alt+x`);
+    await nextTick();
+    assert.deepEqual(getOverlays(), [], "shouldn't display the overlay");
+    assert.verifySteps([]);
+});
+
+QUnit.test("the overlay of hotkeys is correctly displayed on MacOs", async (assert) => {
+    assert.expect(7);
+
+    patchWithCleanup(browser, {
+        navigator: {
+            userAgent: browser.navigator.userAgent.replace(/\([^)]*\)/, "(MacOs)"),
+        },
+    });
+
+    const displayHotkeysOverlay = () =>
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "control", ctrlKey: true }));
+
+    class MyComponent extends Component {
+        onClick(ev) {
+            assert.step(`click ${ev.target.dataset.hotkey}`);
+        }
+    }
+    MyComponent.template = xml`
+        <div>
+        <button t-on-click="onClick" data-hotkey="b"/>
+        <button t-on-click="onClick" data-hotkey="c"/>
+        </div>
+    `;
+    const comp = await mount(MyComponent, { env, target });
+    const getOverlays = () =>
+        [...comp.el.querySelectorAll(".o_web_hotkey_overlay")].map((el) => el.innerText);
+
+    displayHotkeysOverlay();
+    assert.deepEqual(getOverlays(), ["B", "C"], "should display the overlay");
+
+    // apply an existent hotkey
+    triggerHotkey(`alt+b`);
+    await nextTick();
+    assert.verifySteps(["click b"]);
+    assert.deepEqual(getOverlays(), [], "shouldn't display the overlay");
+
+    displayHotkeysOverlay();
+    assert.deepEqual(getOverlays(), ["B", "C"], "should display the overlay");
+
+    // apply a non-existent hotkey
+    triggerHotkey(`alt+x`);
+    await nextTick();
+    assert.deepEqual(getOverlays(), [], "shouldn't display the overlay");
+    assert.verifySteps([]);
+});
+
 QUnit.test("MacOS usability", async (assert) => {
     assert.expect(6);
 

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -199,6 +199,7 @@ export function triggerHotkey(hotkey, addOverlayModParts = false, eventAttrs = {
     }
 
     window.dispatchEvent(new KeyboardEvent("keydown", eventAttrs));
+    window.dispatchEvent(new KeyboardEvent("keyup", eventAttrs));
 }
 
 export async function legacyExtraNextTick() {

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -113,6 +113,9 @@ function patchBrowserWithCleanup() {
                     originalRemoveEventListener(...arguments);
                 });
             },
+            navigator: {
+                userAgent: browser.navigator.userAgent.replace(/\([^)]*\)/, "(X11; Linux x86_64)"),
+            },
             // in tests, we never want to interact with the real url or reload the page
             location: mockLocation,
             history: {

--- a/addons/web/static/tests/webclient/commands/command_service_tests.js
+++ b/addons/web/static/tests/webclient/commands/command_service_tests.js
@@ -406,12 +406,6 @@ QUnit.test("data-command-category", async (assert) => {
 });
 
 QUnit.test("display shortcuts correctly for non-MacOS ", async (assert) => {
-    patchWithCleanup(browser, {
-        navigator: {
-            platform: "OdooOS",
-        },
-    });
-
     class MyComponent extends Component {}
     MyComponent.components = { TestComponent };
     MyComponent.template = xml`
@@ -448,7 +442,7 @@ QUnit.test("display shortcuts correctly for non-MacOS ", async (assert) => {
 QUnit.test("display shortcuts correctly for MacOS ", async (assert) => {
     patchWithCleanup(browser, {
         navigator: {
-            platform: "Mac",
+            userAgent: browser.navigator.userAgent.replace(/\([^)]*\)/, "(MacOs)"),
         },
     });
 
@@ -488,12 +482,6 @@ QUnit.test("display shortcuts correctly for MacOS ", async (assert) => {
 QUnit.test(
     "display shortcuts correctly for non-MacOS with a new overlayModifier",
     async (assert) => {
-        patchWithCleanup(browser, {
-            navigator: {
-                platform: "OdooOS",
-            },
-        });
-
         const hotkeyService = serviceRegistry.get("hotkey");
         patchWithCleanup(hotkeyService, {
             overlayModifier: "alt+control",
@@ -523,7 +511,7 @@ QUnit.test(
 QUnit.test("display shortcuts correctly for MacOS with a new overlayModifier", async (assert) => {
     patchWithCleanup(browser, {
         navigator: {
-            platform: "Mac",
+            userAgent: browser.navigator.userAgent.replace(/\([^)]*\)/, "(MacOs)"),
         },
     });
 


### PR DESCRIPTION
This commit fixes the erroneous tracebacks generated by keyup events
in the hotkey overlay. (alt + key)

TASK-2591069 - BUG 3

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
