### PR TITLE
[FIX] point_of_sale: Don't reconcile already reconciled lines

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -643,7 +643,7 @@ class PosSession(models.Model):
                 | combine_cash_receivable_lines[statement]
             )
             accounts = all_lines.mapped('account_id')
-            lines_by_account = [all_lines.filtered(lambda l: l.account_id == account) for account in accounts]
+            lines_by_account = [all_lines.filtered(lambda l: l.account_id == account and not l.reconciled) for account in accounts]
             for lines in lines_by_account:
                 lines.reconcile()
 


### PR DESCRIPTION
At the closing of the POS, we try to reconcile
all lines involved in the closing.
If for any reason, a line is already reconciled
(I.E. Debit=0 and Credit=0 is considered as reconciled),
the closing fails because we cannot reconcile an already
reconciled line.