### PR TITLE
[IMP]various: avoid duplicate action name

### DIFF
--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -142,7 +142,7 @@
     </record>
 
     <record id='fleet_vehicle_model_action' model='ir.actions.act_window'>
-        <field name="name">Models</field>
+        <field name="name">Vehicle Models</field>
         <field name="res_model">fleet.vehicle.model</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{"search_default_groupby_brand" : True,}</field>

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -327,7 +327,7 @@
     </record>
 
     <record id="website_visitor_view_action" model="ir.actions.act_window">
-        <field name="name">Views</field>
+        <field name="name">Page Views</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">website.track</field>
         <field name="view_mode">tree</field>
@@ -352,7 +352,7 @@
         sequence="1"
         parent="website_visitor_menu"
         action="website.website_visitors_action"/>
-    <menuitem id="menu_visitor_view_menu" name="Views"
+    <menuitem id="menu_visitor_view_menu" name="Page Views"
         sequence="2"
         parent="website_visitor_menu"
         action="website.website_visitor_view_action"/>


### PR DESCRIPTION
PURPOSE

Right now, some menus having frequently accessed the
same name, so it is mixed with technical/../menu while 
searching with name of the menu. this may cause 
user confuse.

SPECIFICATION

in this PR, change the frequent menu name 'Models' to
'Vehicle Models' and 'Views' to 'Page Views'.

TaskId: 2595993
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
