### PR TITLE
[FIX] web_editor: Allow internal users to copy/paste

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1392,7 +1392,7 @@ export class OdooEditor extends EventTarget {
         } else {
             return (
                 item.nodeType === Node.TEXT_NODE ||
-                item.matches(CLIPBOARD_WHITELISTS.nodes.join(','))
+                (item.matches && item.matches(CLIPBOARD_WHITELISTS.nodes.join(',')))
             );
         }
     }


### PR DESCRIPTION
On windows when you copy paste text in and into Odoo (for example in the description when creating a ticket) a traceback occurs.
There is an isWhitelist function which verifies that a node is indeed in the authorized items via the following instruction

`item.matches (CLIPBOARD_WHITELISTS.nodes.join (','))`

But on windows there is a comment node containing `<--StartFragment-->`

Here is the clipboard data on linux and on windows for the same copied text (Hello):

- Linux

```
  <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">
  <span style=\"color: rgb(102, 102, 102); font-family: &quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;\">Hello</span>
```

- Windows

```
	<html>
		<body>
			<!--StartFragment--><span style="color: rgb(102, 102, 102); font-family: &quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">Hello</span><!--EndFragment-->
		</body>
	</html>
```
Except for this additional comment on Windows, the `.matches()` method does not exist.

This PR uses the `Array.includes` function on the item's `nodeName`, which should work in all cases while keeping the same behavior.

opw-2591597