### PR TITLE
[FIX] http, web: support type URL as location

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -521,7 +521,7 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _redirect(cls, location, code=303):
-        if request and request.db and request.is_frontend:
+        if request and request.db and getattr(request, 'is_frontend', False):
             location = url_for(location)
         return super()._redirect(location, code)
 

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -152,7 +152,7 @@ def ensure_db(redirect='/web/database/selector'):
             query_string = iri_to_uri(r.query_string)
             url_redirect = url_redirect.replace(query=query_string)
         request.session.db = db
-        abort_and_redirect(url_redirect)
+        abort_and_redirect(url_redirect.to_url())
 
     # if db not provided, use the session one
     if not db and request.session.db and http.db_filter([request.session.db]):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -302,6 +302,9 @@ class WebRequest(object):
         raise exception.with_traceback(None) from new_cause
 
     def redirect(self, location, code=303, local=True):
+        # compatibility, Werkzeug support URL as location
+        if isinstance(location, urls.URL):
+            location = location.to_url()
         if local:
             location = urls.url_parse(location).replace(scheme='', netloc='').to_url()
         if request and request.db:


### PR DESCRIPTION
Despite that Werkzeug documentation specify:
    'location (str) – the location the response should redirect to.'

Werkzeug support URL too as location and Odoo use it in some places.

So now Odoo will support URL for request.redirect argument too.

This commit closes #73729



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
