### PR TITLE
[FIX] purchase: Purchase Analysis menu under Reporting menu

### DIFF
--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -67,6 +67,7 @@
         <field name="target">current</field>
     </record>
 
-    <menuitem id="purchase_report" name="Reporting" parent="purchase.menu_purchase_root" sequence="99" groups="purchase.group_purchase_manager" action="action_purchase_order_report_all"/>
+    <menuitem id="purchase_report" name="Reporting" parent="purchase.menu_purchase_root" sequence="99" groups="purchase.group_purchase_manager"/>
+    <menuitem id="purchase_analysis_report" name="Purchase Analysis" parent="purchase.purchase_report" sequence="0" action="action_purchase_order_report_all"/>
 
 </odoo>


### PR DESCRIPTION
Move purchase analysis menu is under reporting menu

![Selection_346](https://user-images.githubusercontent.com/24691983/125773023-07f9563e-8298-4544-8add-60a45413f40b.png)
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
