### PR TITLE
[IMP] mail_plugin: enrich existing companies on the Gmail plugin

### DIFF
--- a/addons/mail_plugin/static/src/to_translate/translations_gmail.xml
+++ b/addons/mail_plugin/static/src/to_translate/translations_gmail.xml
@@ -15,6 +15,7 @@
     <string>Search contact</string>
     <string>No contact found.</string>
     <string>Company</string>
+    <string>Company Insights</string>
     <string>Description</string>
     <string>Address</string>
     <string>Phones</string>
@@ -40,7 +41,7 @@
     <string>Error during enrichment</string>
     <string>Our IAP server is down, please come back later.</string>
     <string>Oops, looks like you have exhausted your free enrichment requests. Please log in to try again.</string>
-    <string>No data found for this email address.</string>
+    <string>No insights found for this address.</string>
     <string>Something bad happened. Please, try again later.</string>
     <string>Invalid URL</string>
     <string>No company attached to this contact.</string>
@@ -53,4 +54,7 @@
     <string>Odoo Server URL</string>
     <string>Odoo Access Token</string>
     <string>Clear Translations Cache</string>
+    <string>Enrich Company</string>
+    <string>No insights for this company.</string>
+    <string>Read more</string>
 </resources>


### PR DESCRIPTION
Purpose
=======
Allow users to enrich and update existing Odoo company from the Gmail
plugin so they can have more information on their contact.

Add translations for the new strings in the plugin.

If the partner was removed after the user open the email on the Gmail
side, return a clean error message instead of raising a traceback.

Links
=====
Task-2567566
See /pull/73762
See odoo/mail-client-extensions/pull/15