### PR TITLE
[IMP] account,sale: move tour bubbles on invoice view

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -38,7 +38,7 @@ tour.register('account_tour', {
         trigger: "div[name=partner_id] input",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",
         content: Markup(_t("Write a company name to <b>create one</b> or <b>see suggestions</b>.")),
-        position: "bottom",
+        position: "right",
     }, {
         trigger: ".o_m2o_dropdown_option a:contains('Create')",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -64,7 +64,7 @@ tour.register("sale_quote_tour", {
         trigger: ".o_form_editable .o_field_many2one[name='partner_id']",
         extra_trigger: ".o_sale_order",
         content: _t("Write a company name to create one, or see suggestions."),
-        position: "bottom",
+        position: "right",
         run: function (actions) {
             actions.text("Agrolait", this.$anchor.find("input"));
         },


### PR DESCRIPTION
During the tour, the bubble on the invoice view, placed at the bottom,
made the list slightly difficult to read.

It is a little bit better on the right.

Task: 2476548

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
