### PR TITLE
[FIX] point_of_sale: extract UID from POS reference

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -6,6 +6,7 @@ from functools import partial
 
 import psycopg2
 import pytz
+import re
 
 from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round
@@ -684,7 +685,7 @@ class PosOrder(models.Model):
             'lines': [[0, 0, line] for line in order.lines.export_for_ui()],
             'statement_ids': [[0, 0, payment] for payment in order.payment_ids.export_for_ui()],
             'name': order.pos_reference,
-            'uid': order.pos_reference[6:],
+            'uid': re.search('([0-9]|-){14}', order.pos_reference).group(0),
             'amount_paid': order.amount_paid,
             'amount_total': order.amount_total,
             'amount_tax': order.amount_tax,


### PR DESCRIPTION
When using another language than English, the UID of a POS order may be
incorrect

To reproduce the error:
1. Open a POS's configuration and enable "Manage Orders"
2. In Settings > Languages, add ans switch to:
    - French (BE) / Français (BE)
3. Start a POS session
4. Process an order
5. Open the orders managers

Error: the processed order is named "Commande de 00001-001-0001", the
"de" in the middle shouldn't be present

This is the combination of "Commande" and the UID of the order. The
latter is extract from the POS reference, which looks like "Commande
00001-001-0001" by removing the first 6 characters. It's ok in English:
from "Order 00001-001-0001", we have "00001-001-0001". But this won't
work in all other languages (specially for RTL languages)

The unique identifier of an order is a sequence of 12 digits:
https://github.com/odoo/odoo/blob/3e8d921318e86631b73c8c92c2e462fd0d761582/addons/point_of_sale/static/src/js/models.js#L2865-L2868
Knowing this, we can easily extract the UID from a POS reference

OPW-2538645
closes #71181
closes #71182