### PR TITLE
[IMP] mail: fix mail access

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -28,10 +28,14 @@
                             <field name="email_cc"/>
                             <field name="reply_to"/>
                             <field name="scheduled_date"/>
+                            <field name="can_read_content" invisible="1"/>
                         </group>
                         <notebook>
                             <page string="Body" name="body">
-                                <field name="body_html" widget="html" options="{'style-inline': true}"/>
+                                <field name="body_html_access" widget="html" options="{'style-inline': true}" attrs="{'invisible': [('can_read_content', '=', False)]}"/>
+                                <h3 class="text-info" attrs="{'invisible': [('can_read_content', '=', True)]}">
+                                    You don't have enough access to read the contents of this email.
+                                </h3>
                             </page>
                             <page string="Advanced" name="advanced" groups="base.group_no_one">
                                 <group>
@@ -51,7 +55,7 @@
                                 </group>
                             </page>
                             <page string="Attachments" name="attachments">
-                                <field name="attachment_ids"/>
+                                <field name="attachment_access_ids" attrs="{'readonly': [('can_read_content', '=', False)]}"/>
                             </page>
                             <page string="Failure Reason" name="failure_reason" attrs="{'invisible': [('state', '!=', 'exception')]}">
                                 <field name="failure_reason"/>

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -94,8 +94,8 @@ tour.register('shop_mail', {
     },
     {
         content: "check it's the correct email, and the URL is correct too",
-        trigger: 'div.oe_form_field_html[name="body_html"] p:contains("Your"):contains("order")',
-        extra_trigger: 'div.oe_form_field_html[name="body_html"] a[href^="https://my-test-domain.com"]',
+        trigger: 'div.oe_form_field_html[name="body_html_access"] p:contains("Your"):contains("order")',
+        extra_trigger: 'div.oe_form_field_html[name="body_html_access"] a[href^="https://my-test-domain.com"]',
     },
 ]);
 });


### PR DESCRIPTION
Before this PR,
admin can't open the emails for which they don't have message access

After this PR,
admin can open the mail if they don't have access, they won't see the
inaccessible data

Task: https://www.odoo.com/web#id=2464212&action=4043&model=project.task&view_type=form&cids=2&menu_id=4720

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
