### PR TITLE
[FIX] mrp_subcontracting: record components

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -4,7 +4,7 @@
 from datetime import timedelta
 
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_compare, float_is_zero
+from odoo.tools.float_utils import float_compare
 
 
 class StockPicking(models.Model):
@@ -22,19 +22,9 @@ class StockPicking(models.Model):
             if not picking._is_subcontract():
                 picking.display_action_record_components = False
                 continue
-            # Hide if no components are track
-            subcontracted_productions = picking._get_subcontracted_productions()
-            component_sub_moves = subcontracted_productions.mapped('move_raw_ids')
-            if all(subcontracted_move.has_tracking == 'none' for subcontracted_move in component_sub_moves):
-                picking.display_action_record_components = False
-                continue
-            # Hide if all tracked product move line have a lot and all productions are in rigth state
-            tracked_move_line = component_sub_moves.filtered(lambda sm: sm.has_tracking != 'none').move_line_ids
-            if all(sub_mo.state in ('to_close', 'done') for sub_mo in subcontracted_productions)\
-                    and all(sub_sml.lot_id for sub_sml in tracked_move_line):
-                picking.display_action_record_components = False
-                continue
-            picking.display_action_record_components = True
+            # Hide if all tracked product move lines are already recorded.
+            picking.display_action_record_components = any(
+                move._has_components_to_record() for move in picking.move_lines)
 
     # -------------------------------------------------------------------------
     # Action methods
@@ -88,14 +78,8 @@ class StockPicking(models.Model):
     def action_record_components(self):
         self.ensure_one()
         for move in self.move_lines:
-            if not move._has_tracked_subcontract_components():
-                continue
-            productions = move.move_orig_ids.production_id
-            productions_to_done = productions._subcontracting_filter_to_done()
-            production = (productions - productions_to_done)[-1:]
-            if not production:
-                continue
-            return move._action_record_components()
+            if move._has_components_to_record():
+                return move._action_record_components()
 
     # -------------------------------------------------------------------------
     # Subcontract helpers

--- a/addons/mrp_subcontracting/tests/__init__.py
+++ b/addons/mrp_subcontracting/tests/__init__.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
 
 from . import test_subcontracting
-

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -7,6 +7,7 @@ from odoo.addons.mrp_subcontracting.tests.common import TestMrpSubcontractingCom
 
 from odoo.tests import tagged
 
+
 @tagged('post_install', '-at_install')
 class TestSubcontractingBasic(TransactionCase):
     def test_subcontracting_location_1(self):
@@ -16,6 +17,7 @@ class TestSubcontractingBasic(TransactionCase):
         company2 = self.env['res.company'].create({'name': 'Test Company'})
         self.assertTrue(company2.subcontracting_location_id)
         self.assertTrue(self.env.company.subcontracting_location_id != company2.subcontracting_location_id)
+
 
 class TestSubcontractingFlows(TestMrpSubcontractingCommon):
     def test_flow_1(self):


### PR DESCRIPTION
Before this commit, for a subcontracted product with reserved available tracked components, if at least one component is recorded but not all, the "Record components" button isn't available anymore.

How to reproduce:
  - Create a product and create a subcontracting BOM for this product;
  - Add a tracked component for this product;
  - Add some qty. for the tracked component in the subcontracting loc.;
  - Create a receipt for the subcontracted product (for demand qty. more than 1) with the subcontractor as partner and confirm it:
    => The "Record components" button should be visible.
  - Record a part of the demand qty. then click on "Continue", then on "Discard":
    => The "Record components" button is now hidden.

It's because the button is hidden if all the MO are done or to close (they are) and if all the tracked move lines have a SN/LN (they have as they are reserved).

task-2604728
