### PR TITLE
[FIX] account: fix account resequence for "other" lines

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -65,7 +65,7 @@ class ReSequenceWizard(models.TransientModel):
                  or (self.sequence_number_reset == 'year' and line['server-date'][0:4] != previous_line['server-date'][0:4])\
                  or (self.sequence_number_reset == 'month' and line['server-date'][0:7] != previous_line['server-date'][0:7]):
                     if in_elipsis:
-                        changeLines.append({'current_name': _('... (%s other)', in_elipsis), 'new_by_name': '...', 'new_by_date': '...', 'date': '...'})
+                        changeLines.append({'id': 'other_' + str(line['id']), 'current_name': _('... (%s other)', in_elipsis), 'new_by_name': '...', 'new_by_date': '...', 'date': '...'})
                         in_elipsis = 0
                     changeLines.append(line)
                 else:


### PR DESCRIPTION
Linked to commit https://github.com/odoo/odoo/commit/3e6b7dfd4854069724dde2df43ab2eb7d850e9b5

Resequence wizard will not show if "other" lines are generated to reduce the set
to display in preview, because those lines don't have "id" to be used as t-key in
the resequence template.

opw-2590273
opw-2581306



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
