### PR TITLE
[FIX] account: keep modified amount on payment

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -308,6 +308,9 @@ class AccountPaymentRegister(models.TransientModel):
     @api.depends('source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date')
     def _compute_amount(self):
         for wizard in self:
+            if wizard.amount:
+                continue
+
             if wizard.source_currency_id == wizard.currency_id:
                 # Same currency.
                 wizard.amount = wizard.source_amount_currency


### PR DESCRIPTION
How to reproduce the problem:
- Install the Invoicing app
- On an invoice -> Register payment
- Change the Amount then change the Payment Date
- The amount is back to its original value

Cause of the problem : the amount is recomputed everytime the date is changed instead of the first time the amount has to be displayed

Solution : Once the amount is set, it is not automatically changed anymore

opw-2585057