### PR TITLE
[FIX] website: flip the TrackPage dependency to resolve an issue for anonymous website users

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -69,7 +69,6 @@
         <script type="text/javascript" src="/website/static/src/js/content/website_root_instance.js"/>
     </xpath>
     <xpath expr="//script[last()]" position="after">
-        <script type="text/javascript" src="/website/static/src/js/set_view_track.js"/>
         <script type="text/javascript" src="/website/static/lib/jstz.min.js"/>
         <script type="text/javascript" src="/website/static/src/js/utils.js"/>
 
@@ -117,6 +116,8 @@
     <t t-call="web._assets_helpers"/>
 
     <link rel="stylesheet" type="text/scss" href="/website/static/src/scss/website.editor.ui.scss"/>
+
+    <script type="text/javascript" src="/website/static/src/js/set_view_track.js"/>
 
     <script type="text/javascript" src="/website/static/src/js/editor/editor_menu.js"/>
     <script type="text/javascript" src="/website/static/src/js/editor/editor_menu_translate.js"/>


### PR DESCRIPTION
https://github.com/odoo/odoo/issues/71842

Anonymous website users do not have access to the Customize menu
obviously, but the `website.set_view_track` widget still attempts to
extend the CustomizeMenu.

The dependency can just be flipped around with the CustomizeMenu
depending on the `website.set_view_track module` instead. It's the only
place that the module is currently being referenced so it's only a
single change.

**Current behavior before PR:**

The JavaScript from Odoo fails if you're not logged in:

**Desired behavior after PR is merged:**

There's no missing dependencies issues causing parts of the JS to crash.

**Technical changes:**

- Moved the `TrackPage` widget to load only in editor assets.
- Included the `_attachTrackPage` functionality directly in the customize menu. No specific reason to have that split into 2 places, keeps the `TrackPage` widget a little more pure, dependencies a little less messy.
- Renamed `set_track_page.js` to `track_page.js` and `website.set_track_page` to `website.trackPage` because it is now only a standalone widget named `TrackPage`. It makes more sense to developers when importing `let TrackPage = require("website.trackPage");` instead of `set_track_page`.

--

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
