### PR TITLE
[13.0][FIX] stock_account: average unit cost price

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -32,10 +32,11 @@ class StockMove(models.Model):
         """ Returns the unit price to value this stock move """
         self.ensure_one()
         price_unit = self.price_unit
+        precision = self.env['decimal.precision'].precision_get('Product Price')
         # If the move is a return, use the original move's price unit.
         if self.origin_returned_move_id and self.origin_returned_move_id.sudo().stock_valuation_layer_ids:
             price_unit = self.origin_returned_move_id.sudo().stock_valuation_layer_ids[-1].unit_cost
-        return not self.company_id.currency_id.is_zero(price_unit) and price_unit or self.product_id.standard_price
+        return not float_is_zero(price_unit, precision) and price_unit or self.product_id.standard_price
 
     @api.model
     def _get_valued_types(self):


### PR DESCRIPTION
When the cost of a product is set to a value below the currency rounding
the average purchase cost price will be wrongly set to zero.

It can happen for product sold in large quantity, that the cost of one product
must be smaller than the smallest unit of currency.

Instead of doing the zero check with currency precision using the
product price precision, which is the one used for the `standard_price`
fields, makes more sense and fixes the problem.

opw-2601121
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
