### PR TITLE
[FIX] slides: Prevent the # anchors of the PDF controllers from triggering a scroll jump

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -103,17 +103,17 @@
                                         </div>
                                     </div>
                                     <div class="col text-center">
-                                        <a id="first" href="#" class="text-decoration-none mr-1 mr-sm-2" title="First slide" role="button" aria-label="First slide"> <i class="fa fa-step-backward"/> </a>
-                                        <a id="previous" href="#" class="text-decoration-none mx-1 mx-sm-2" title="Previous slide" aria-label="Previous slide" role="button"> <i class="fa fa-arrow-circle-left"/> </a>
-                                        <a id="next" href="#" class="text-decoration-none mx-1 mx-sm-2" title="Next slide" aria-label="Next slide" role="button"> <i class="fa fa-arrow-circle-right"/> </a>
-                                        <a id="last" href="#" class="text-decoration-none ml-1 ml-sm-2" title="Last slide" aria-label="Last slide" role="button"> <i class="fa fa-step-forward"/> </a>
+                                        <a id="first" href="#" onclick="return false;" class="text-decoration-none mr-1 mr-sm-2" title="First slide" role="button" aria-label="First slide"> <i class="fa fa-step-backward"/> </a>
+                                        <a id="previous" href="#" onclick="return false;" class="text-decoration-none mx-1 mx-sm-2" title="Previous slide" aria-label="Previous slide" role="button"> <i class="fa fa-arrow-circle-left"/> </a>
+                                        <a id="next" href="#" onclick="return false;" class="text-decoration-none mx-1 mx-sm-2" title="Next slide" aria-label="Next slide" role="button"> <i class="fa fa-arrow-circle-right"/> </a>
+                                        <a id="last" href="#" onclick="return false;" class="text-decoration-none ml-1 ml-sm-2" title="Last slide" aria-label="Last slide" role="button"> <i class="fa fa-step-forward"/> </a>
                                     </div>
                                     <div class="col-2 flex-grow-0 text-right">
                                         <a id="download" t-attf-href="/web/content/slide.slide/#{slide.id}/datas?download=true"
                                            class="text-decoration-none mr-1 mr-sm-2" title="Download Content" role="img" aria-label="Download">
                                             <i class="fa fa-download" />
                                         </a>
-                                        <a id="fullscreen" href="#" title="View fullscreen" role="img" aria-label="Fullscreen"> <i class="fa fa-arrows-alt"/> </a>
+                                        <a id="fullscreen" href="#" onclick="return false;" title="View fullscreen" role="img" aria-label="Fullscreen"> <i class="fa fa-arrows-alt"/> </a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The PDF controllers have empty anchor links. When the user clicks on one of those links, the browsers based on Chromium will trigger a scroll jump which is quite annoying when the PDF document does not fit entirely on screen. This PR aims to remove this behavior by setting an empty click event listener on each link.

Current behavior before PR:
When the user clicks on a PDF controller, the browser trigger a scroll jump.

Desired behavior after PR is merged:
When the user clicks on a PDF controller, the browser should no longer trigger a scroll jump.

Task id: 2500574

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr