### PR TITLE
[FIX] l10n_it_edi: fixed zip code check for the buyer

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -90,7 +90,7 @@ class AccountEdiFormat(models.Model):
             errors.append(_("%s must have a street.", buyer.display_name))
         if not buyer.zip:
             errors.append(_("%s must have a post code.", buyer.display_name))
-        if len(buyer.zip) != 5 and buyer.country_id.code == 'IT':
+        elif len(buyer.zip) != 5 and buyer.country_id.code == 'IT':
             errors.append(_("%s must have a post code of length 5.", buyer.display_name))
         if not buyer.city:
             errors.append(_("%s must have a city.", buyer.display_name))


### PR DESCRIPTION
If the buyer is Italian, it must have a zip code of length 5.
If the buyer is not Italian, the zip code is optional

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
