### PR TITLE
[FIX] web, auth_signup: reset head for layout

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -38,6 +38,7 @@
 
         <template id="auth_signup.signup" name="Sign up login">
             <t t-call="web.login_layout">
+                <t t-set="head" t-value="" />
                 <form class="oe_signup_form" role="form" method="post" t-if="not message">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
@@ -61,6 +62,7 @@
 
         <template id="auth_signup.reset_password" name="Reset password">
             <t t-call="web.login_layout">
+                <t t-set="head" t-value="" />
                 <div t-if="message">
                     <p class="alert alert-success" t-if="message" role="status">
                         <t t-esc="message"/>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -378,6 +378,7 @@
 
     <template id="web.login" name="Login">
         <t t-call="web.login_layout">
+            <t t-set="head" t-value="" />
             <form class="oe_login_form" role="form" t-attf-action="/web/login{{ '?debug' if debug else '' }}" method="post" onsubmit="this.action = this.action + location.hash">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 


### PR DESCRIPTION
**Current behavior before PR:**
Render issue in case of dirty head

**Desired behavior after PR is merged:**
No render issue in case of dirty head

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
