### PR TITLE
[IMP] test_lint: add no-const-assign and no-debugger rules

### DIFF
--- a/addons/point_of_sale/static/src/js/ChromeWidgets/ClientScreenButton.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/ClientScreenButton.js
@@ -38,7 +38,7 @@ odoo.define('point_of_sale.ClientScreenButton', function(require) {
         async onClickProxy() {
             try {
                 const renderedHtml = await this.env.pos.render_html_for_customer_facing_display();
-                const ownership = await this.env.pos.proxy.take_ownership_over_client_screen(
+                let ownership = await this.env.pos.proxy.take_ownership_over_client_screen(
                     renderedHtml
                 );
                 if (typeof ownership === 'string') {
@@ -70,7 +70,7 @@ odoo.define('point_of_sale.ClientScreenButton', function(require) {
             async function loop() {
                 if (self.env.pos.proxy.posbox_supports_display) {
                     try {
-                        const ownership = await self.env.pos.proxy.test_ownership_of_client_screen();
+                        let ownership = await self.env.pos.proxy.test_ownership_of_client_screen();
                         if (typeof ownership === 'string') {
                             ownership = JSON.parse(ownership);
                         }

--- a/odoo/addons/test_lint/tests/test_eslint.py
+++ b/odoo/addons/test_lint/tests/test_eslint.py
@@ -11,7 +11,9 @@ from . import lint_case
 
 RULES = ('{'
         '"no-undef": "error",'
-        '"no-restricted-globals": ["error", "event", "self"]'
+        '"no-restricted-globals": ["error", "event", "self"],'
+        '"no-const-assign": ["error"],'
+        '"no-debugger": ["error"]'
         '}'
 )
 PARSER_OPTIONS = '{ecmaVersion: 2019, sourceType: module}'


### PR DESCRIPTION
Assigning to const variable is always a programming error, and we almost
never want to have a debugger in production code (for those cases, an
ignore comment can be added).