### PR TITLE
[FIX] account: issue with internal payments account

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -330,7 +330,8 @@ class AccountPayment(models.Model):
         for pay in self:
             available_partner_bank_accounts = pay.partner_id.bank_ids.filtered(lambda x: x.company_id in (False, pay.company_id))
             if available_partner_bank_accounts:
-                pay.partner_bank_id = available_partner_bank_accounts[0]._origin
+                if pay.partner_bank_id not in available_partner_bank_accounts:
+                    pay.partner_bank_id = available_partner_bank_accounts[0]._origin
             else:
                 pay.partner_bank_id = False
 


### PR DESCRIPTION
Step to follow

- Create a journal of type Bank named Bank with an account 02
- Create another journal of type Bank named Banco with an account 01
- Make an internal transfer from Bank with 01 as a recipient bank
  account
- When saving, 01 is modified to 02

Cause of the issue

A default partner bank is recomputed when saving a record

Solution

Skip the computation if one has already been chosen

opw-2538417