### PR TITLE
[FIX] account: fix fiscal position with delivery address

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -168,11 +168,10 @@ class AccountFiscalPosition(models.Model):
         # This can be easily overridden to apply more complex fiscal rules
         PartnerObj = self.env['res.partner']
         partner = PartnerObj.browse(partner_id)
+        delivery = PartnerObj.browse(delivery_id)
 
-        # if no delivery use invoicing
-        if delivery_id:
-            delivery = PartnerObj.browse(delivery_id)
-        else:
+        # If partner and delivery have the same vat prefix, use invoicing
+        if not delivery.vat or (partner.vat and delivery.vat[:2] == partner.vat[:2]):
             delivery = partner
 
         # partner manually set fiscal position always win


### PR DESCRIPTION
The goal is to take into consideration that in case the TAX ID
is issued by the same member state as the vendor's,
then VAT charge is not reversed.

The VAT ID must be foreign as from the vendor's point of view.

Task: 2596204

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
