### PR TITLE
[IMP] hr_contract: prevent dialog opening on contract history

### DIFF
--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -77,14 +77,15 @@
                     </group>
                     <notebook>
                         <page string="Contract History" name="contract_history">
-                            <field name="contract_ids" widget="one2many">
+                            <field name="contract_ids" widget="one2many" readonly="0">
                                 <tree string="Current Contracts"
                                       decoration-primary="state == 'open'"
                                       decoration-muted="state == 'close'"
                                       decoration-bf="id == parent.contract_id"
                                       default_order = "date_start desc, state desc"
                                       editable="bottom"
-                                      no_open="1">
+                                      no_open="1"
+                                      create="0" delete="0">
                                     <button name="action_open_contract_form" type="object" icon="fa-external-link"/>
                                     <field name="id" invisible="1"/>
                                     <field name="name" string="Contract Name"/>


### PR DESCRIPTION
clicking on the row of contract history opens the formViewDialog

so this commit fixes the issue by adding the readonly attributes
on the field so that clicking on the row of the contract history
doesn't open the formViewDialog

TaskID-2578874

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
