### PR TITLE
[FIX] sale_mrp: filter cancelled moves when getting the related BoM

### DIFF
--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -22,7 +22,7 @@ class SaleOrderLine(models.Model):
         super(SaleOrderLine, self)._compute_qty_delivered()
         for order_line in self:
             if order_line.qty_delivered_method == 'stock_move':
-                boms = order_line.move_ids.mapped('bom_line_id.bom_id')
+                boms = order_line.move_ids.filtered(lambda m: m.state != 'cancel').mapped('bom_line_id.bom_id')
                 dropship = False
                 if not boms and any([m._is_dropshipped() for m in order_line.move_ids]):
                     boms = boms._bom_find(product=order_line.product_id, company_id=order_line.company_id.id, bom_type='phantom')


### PR DESCRIPTION
Description of the issue/feature this PR addresses: The method to compute the quantity delivered of a sales order line considers the cancelled moves when fetching the related BoM for kits.

Current behavior before PR: The current behaviour does not filter the cancelled moves when getting the related BoM. This implies that, if a new BoM is created for the same product but with some changes, and the original delivery is cancelled, the sale order line will still consider the previous BoM.

Desired behavior after PR is merged: After the fix, the cancelled moves will not be considered when finding the BoM, as this is what should be expected from cancelled operations.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
