### PR TITLE
[FIX] website: configurator set custom image as public

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -380,6 +380,7 @@ class Website(models.Model):
                         'key': image['name'],
                         'type': 'binary',
                         'raw': response.content,
+                        'public': True,
                     })
 
         website = self.get_current_website()


### PR DESCRIPTION
Before this commit, overrided images was not visible if not logged in.

How to reproduce
----------------
Install a theme with configurator to have custom image of industries.
Log out
You have original image instead of industries

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
