### PR TITLE
[FIX] stock: prevent to copy reservation on stock.move.line

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -25,9 +25,11 @@ class StockMoveLine(models.Model):
     product_id = fields.Many2one('product.product', 'Product', ondelete="cascade")
     product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', required=True)
     product_qty = fields.Float(
-        'Real Reserved Quantity', digits=0,
+        'Real Reserved Quantity', digits=0, copy=False,
         compute='_compute_product_qty', inverse='_set_product_qty', store=True)
-    product_uom_qty = fields.Float('Reserved', default=0.0, digits=dp.get_precision('Product Unit of Measure'), required=True)
+    product_uom_qty = fields.Float(
+        'Reserved', default=0.0, digits=dp.get_precision('Product Unit of Measure'),
+        copy=False, required=True)
     qty_done = fields.Float('Done', default=0.0, digits=dp.get_precision('Product Unit of Measure'), copy=False)
     package_id = fields.Many2one('stock.quant.package', 'Source Package', ondelete='restrict')
     package_level_id = fields.Many2one('stock.package_level', 'Package Level')

--- a/addons/stock/tests/test_wise_operator.py
+++ b/addons/stock/tests/test_wise_operator.py
@@ -129,8 +129,7 @@ class TestWiseOperator(TransactionCase):
         # put the move lines from delivery_order_wise2 into delivery_order_wise1
         for pack_id2 in pack_ids2:
             new_pack_id1 = pack_id2.copy(default={'picking_id': delivery_order_wise1.id, 'move_id': move1.id})
-            new_pack_id1.qty_done = new_pack_id1.product_qty
-            new_pack_id1.with_context(bypass_reservation_update=True).product_uom_qty = 0
+            new_pack_id1.qty_done = pack_id2.product_qty
 
         new_move_lines = delivery_order_wise1.move_line_ids.filtered(lambda p: p.qty_done)
         self.assertEqual(sum(new_move_lines.mapped('product_qty')), 0)
@@ -141,8 +140,7 @@ class TestWiseOperator(TransactionCase):
 
         # put the move line from delivery_order_wise1 into delivery_order_wise2
         new_pack_id2 = pack_ids1.copy(default={'picking_id': delivery_order_wise2.id, 'move_id': move2.id})
-        new_pack_id2.qty_done = new_pack_id2.product_qty
-        new_pack_id2.with_context(bypass_reservation_update=True).product_uom_qty = 0
+        new_pack_id2.qty_done = pack_ids1.product_qty
 
         new_move_lines = delivery_order_wise2.move_line_ids.filtered(lambda p: p.qty_done)
         self.assertEqual(len(new_move_lines), 1)


### PR DESCRIPTION
Usecase:
- Product A 10 units in stock
- Do a planned transfer of 7 units to customer
- Reserve
- Do an rpc or execute code to call `copy` on the `stock.move.line`

It will result with 2 `stock.move.line` that have 14 units reserve and 7 units
reserved on `stock.quant`

It's the same result if you call `create()` twice on the `stock.move.line` without
updating the `stock.quant` at the same time. However in stable we
try to only use `_update_reserved_quantity` on `stock.move` or some
override in create/write method for 'done' stock.move.line in unlock
cases.

So the `copy()` method is never use in stable and define the basic
behavior as 'we don't copy the reservation' could prevent some cases
where the update on the `stock.quant` is forgotten after.

