### PR TITLE
[FIX] mrp: Close workorder form view on button clik

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -282,7 +282,7 @@
                             </field>
                         </page>
                         <page string="Work Orders" name="operations" groups="mrp.group_mrp_routings">
-                            <field name="workorder_ids" attrs="{'readonly': [('state', 'in', ['cancel', 'done'])]}" context="{'tree_view_ref': 'mrp.mrp_production_workorder_tree_editable_view', 'form_view_ref': 'mrp.mrp_production_workorder_form_view_inherit', 'default_product_uom_id': product_uom_id, 'default_consumption': consumption, 'default_company_id': company_id}"/>
+                            <field name="workorder_ids" attrs="{'readonly': [('state', 'in', ['cancel', 'done'])]}" context="{'tree_view_ref': 'mrp.mrp_production_workorder_tree_editable_view', 'default_product_uom_id': product_uom_id, 'default_consumption': consumption, 'default_company_id': company_id}"/>
                         </page>
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids" context="{'default_date': date_planned_finished, 'default_date_deadline': date_deadline, 'default_location_id': production_location_id, 'default_location_dest_id': location_src_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -125,6 +125,7 @@
             <header>
                 <field name="state" widget="statusbar" statusbar_visible="pending,ready,progress,done"/>
             </header>
+            <sheet>
                 <div class="oe_button_box" name="button_box">
                     <button class="oe_stat_button" name="action_see_move_scrap" type="object" icon="fa-arrows-v" attrs="{'invisible': [('scrap_count', '=', 0)]}">
                         <div class="o_field_widget o_stat_info">
@@ -195,23 +196,8 @@
                     <field name="operation_note" attrs="{'invisible': [('worksheet_type', '!=', 'text')]}"/>
                 </page>
                 </notebook>
+            </sheet>
             </form>
-        </field>
-    </record>
-
-    <record id="mrp_production_workorder_form_view_inherit_editable" model="ir.ui.view">
-        <field name="name">mrp.production.work.order.tree</field>
-        <field name="model">mrp.workorder</field>
-        <field name="mode">primary</field>
-        <field name="priority" eval="10"/>
-        <field name="inherit_id" ref="mrp.mrp_production_workorder_form_view_inherit"/>
-        <field name="arch" type="xml">
-            <xpath expr="//notebook" position="after">
-                <footer>
-                    <button string="Save" special="save" class="btn-primary"/>
-                    <button string="Discard" special="cancel"/>
-                </footer>
-            </xpath>
         </field>
     </record>
 
@@ -445,7 +431,7 @@
         <field name="res_model">mrp.workorder</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
-        <field name="view_id" ref="mrp_production_workorder_form_view_inherit_editable"/>
+        <field name="view_id" ref="mrp_production_workorder_form_view_inherit"/>
     </record>
 
     <record model="ir.actions.act_window" id="mrp_workorder_todo">


### PR DESCRIPTION
This PR reverts this one https://github.com/odoo/odoo/pull/54364

because it introduces the following problem:
It is no longer possible to close the dialog when it is opened from a gantt view, because the buttons are overridden and they no longer close the window after the action.

In addition to the fact that this fix no longer makes sense at the moment

opw-2591597