### PR TITLE
[IMP] account: Allow partner_id not required in payment form view

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -174,6 +174,7 @@
                         <field name="is_move_sent" invisible="1"/>
                         <field name="is_reconciled" invisible="1"/>
                         <field name="is_matched" invisible="1"/>
+                        <field name="is_partner_required" invisible="1"/>
                         <field name="payment_method_code" invisible="1"/>
                         <field name="show_partner_bank_account" invisible="1"/>
                         <field name="require_partner_bank_account" invisible="1"/>
@@ -242,11 +243,11 @@
                                 <field name="partner_id" context="{'default_is_company': True}" string="Customer"
                                        attrs="{'readonly':[('state', '!=', 'draft')],
                                              'invisible':['|', ('partner_type','!=','customer'), ('is_internal_transfer', '=', True)],
-                                             'required': [('partner_type','=','customer')]}"/>
+                                             'required': [('is_partner_required', '=', True), ('partner_type','=','customer')]}"/>
                                 <field name="partner_id" context="{'default_is_company': True}" string="Vendor"
                                        attrs="{'readonly':[('state', '!=', 'draft')],
                                                'invisible':['|', ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True)],
-                                               'required': [('partner_type','=','supplier')]}"/>
+                                               'required': [('is_partner_required', '=', True), ('partner_type','=','supplier')]}"/>
                                 <label for="amount"/>
                                 <div name="amount_div" class="o_row">
                                     <field name="amount"


### PR DESCRIPTION
- Create a payment without a partner for a receipt
- Go to the form view
- Click on the stats button.
=> Error, 'partner_id' is required

In some cases, having the partner not required on the view is needed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
