### PR TITLE
[FIX] web: fallback for cache_hashes when http_routing is not installed

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -10,7 +10,7 @@ import { session } from "@web/session";
 export const localizationService = {
     dependencies: ["user"],
     start: async (env, { user }) => {
-        const cacheHashes = session.cache_hashes;
+        const cacheHashes = session.cache_hashes || {};
         const translationsHash = cacheHashes.translations || new Date().getTime().toString();
         const lang = user.lang || null;
         const translationURL = session.translationURL || "/web/webclient/translations";


### PR DESCRIPTION
Previously, loading the login page with no modules installed would
result in a crash, because the translation service assumed that there
was always a cache_hashes key in the session info. This is not the case
when the http_routing module is not installed.

This module fixes that by adding a fallback for those cache_hashes in
the translation service.