### PR TITLE
[IMP] account: Don't undo reconciliation when re-opening a bank state…

### DIFF
--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1358,6 +1358,23 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
                 {'name': 'whatever', 'account_id': random_acc_1.id, 'balance': -100.0},
             ])
 
+        # Reset the statement to the 'open' state.
+        self.statement.button_reopen()
+
+        self.assertRecordValues(self.statement_line, [{
+            'state': 'open',
+            'is_reconciled': True,
+        }])
+        self.assertRecordValues(self.statement_line.move_id, [{'state': 'posted'}])
+
+        self.statement_line.button_undo_reconciliation()
+
+        self.assertRecordValues(self.statement_line, [{
+            'state': 'open',
+            'is_reconciled': False,
+        }])
+        self.assertRecordValues(self.statement_line.move_id, [{'state': 'draft'}])
+
     def test_reconciliation_statement_line_with_generated_payments(self):
         self.statement.button_post()
 

--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -203,25 +203,26 @@
                                     <!-- Visible fields -->
                                     <field name="sequence" widget="handle"/>
                                     <field name="date"
-                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
-                                    <field name="payment_ref"/>
+                                           attrs="{'readonly': ['|', ('is_reconciled', '=', True), ('parent.state', '!=', 'open')]}"/>
+                                    <field name="payment_ref"
+                                           attrs="{'readonly': [('is_reconciled', '=', True)]}"/>
                                     <field name="partner_id"
-                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"
+                                           attrs="{'readonly': ['|', ('is_reconciled', '=', True), ('parent.state', '!=', 'open')]}"
                                            domain="['|', ('parent_id','=', False), ('is_company','=',True)]"/>
                                     <field name="ref" optional="hidden"/>
                                     <field name="transaction_type" optional="hidden"/>
                                     <field name="narration" string="Notes" optional="hidden"/>
                                     <field name="amount"
-                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
+                                           attrs="{'readonly': ['|', ('is_reconciled', '=', True), ('parent.state', '!=', 'open')]}"/>
                                     <field name="amount_currency" optional="hidden" groups="base.group_multi_currency"
-                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
+                                           attrs="{'readonly': ['|', ('is_reconciled', '=', True), ('parent.state', '!=', 'open')]}"/>
                                     <field name="account_number" optional="hidden"/>
                                     <field name="foreign_currency_id" optional="hidden" groups="base.group_multi_currency"
-                                           attrs="{'readonly': [('parent.state', '!=', 'open')]}"/>
+                                           attrs="{'readonly': ['|', ('is_reconciled', '=', True), ('parent.state', '!=', 'open')]}"/>
 
                                     <!-- Buttons -->
                                     <button name="button_undo_reconciliation" type="object"
-                                            attrs="{'invisible': [('is_reconciled', '=', False)], 'column_invisible': [('parent.state', '!=', 'posted')]}"
+                                            attrs="{'invisible': [('is_reconciled', '=', False)]}"
                                             string="Revert reconciliation" icon="fa-undo"/>
                                 </tree>
                             </field>


### PR DESCRIPTION
…ment

- Create a bank statement with some lines
- Post it (everything is posted)
- Perform some reconciliation
- Reset the statement to new: All reconciliation were undo that was annoying for some users.

task: 2606857

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
