### PR TITLE
[FIX] account: reuse cache on checking fields for recomputations

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -252,6 +252,11 @@ class AccountMove(models.Model):
         check_company=True)
     reversal_move_id = fields.One2many('account.move', 'reversed_entry_id')
 
+    # ==== Hacky fields ====
+    # Technical fields to activate cache mechanism on aggregating computed fields to recompute
+    payment_ids = fields.One2many('account.payment', 'move_id', string='Inversed field for account.payment')
+    statement_line_ids = fields.One2many('account.bank.statement.line', 'move_id', string='Inversed field for account.bank.statement.line')
+
     # =========================================================
     # Invoice related fields
     # =========================================================


### PR DESCRIPTION
Adding these non-stored One2many fields allows ORM to use cache in
`_modified_triggers` and skip costly search:

```
                        records |= model.search([(key.name, 'in', real_records.ids)], order='id')
```

STEPS:

* create batch of `account.move` via shell (e.g. 10 records)
* check for the search quieries via --logs-sql or by adding breakpoint:

```
                        records |= model.search([(key.name, 'in', real_records.ids)], order='id')
                        if str(key) == 'account.payment.move_id' and len(real_records.ids) == 10:
                            import wdb; wdb.set_trace()
```

BEFORE: 3 useless queries
AFTER: no of those quieres

opw-2497288