### PR TITLE
[REM] l10n_au, l10n_nz: Removing the 100000000% tax amount from standard

### DIFF
--- a/addons/l10n_au/data/account.tax.group.csv
+++ b/addons/l10n_au/data/account.tax.group.csv
@@ -1,4 +1,4 @@
 id,name
 tax_group_gst_0,GST 0%
 tax_group_gst_10,GST 10%
-tax_group_gst_100000000,GST 100000000%
+tax_group_gst_import,GST on Import

--- a/addons/l10n_au/data/account_tax_template_data.xml
+++ b/addons/l10n_au/data/account_tax_template_data.xml
@@ -764,131 +764,6 @@
         <field name="children_tax_ids" eval="[(6,0,[ref('au_tax_purchase_0_service_tpar'), ref('au_tax_witheld')])]"/>
         <field name="tax_group_id" ref="tax_group_gst_10"/>
     </record>
-    <record id="au_tax_purchase_taxable_import" model="account.tax.template">
-        <field name="chart_template_id" ref="l10n_au_chart_template"/>
-        <field name="name">Purch (Taxable Imports)</field>
-        <field name="sequence">5</field>
-        <field name="description">Purchase (Taxable Imports) - Tax Paid Separately</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_scope">consu</field>
-        <field name="amount_type">percent</field>
-        <field name="amount">100000000000</field>
-        <!--
-          The tax percentage is so high because on imported goods we
-          needed to link the tax line acknowledgment (not to be paid)
-          on the customer invoice and what need to actually be
-          paid from another invoice given by a clearance house
-          (i.e. customs)
-          For more info see the complete discussion below
-          https://github.com/odoo/odoo/pull/48700#issuecomment-607586417
-        -->
-        <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g14')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g14')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-            ]"/>
-    </record>
-    <record id="au_tax_purchase_taxable_import_service" model="account.tax.template">
-        <field name="chart_template_id" ref="l10n_au_chart_template"/>
-        <field name="name">Purch (Taxable Imports)</field>
-        <field name="sequence">5</field>
-        <field name="description">Purchase (Taxable Imports) - Tax Paid Separately</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_scope">service</field>
-        <field name="amount_type">percent</field>
-        <field name="amount">100000000000</field>
-        <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g14')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g14')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-            ]"/>
-    </record>
-    <record id="au_tax_purchase_taxable_import_service_tpar" model="account.tax.template">
-        <field name="chart_template_id" ref="l10n_au_chart_template"/>
-        <field name="name">Purch (Taxable Imports) TPAR</field>
-        <field name="sequence">5</field>
-        <field name="description">Purchase (Taxable Imports) - Tax Paid Separately</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_scope">service</field>
-        <field name="amount_type">percent</field>
-        <field name="amount">100000000000</field>
-        <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="tax_group_gst_100000000"/>
-        <field name="invoice_repartition_line_ids" eval="[
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g14')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'tag_ids': [(4, ref('service_tag'))],
-                }),
-            ]"/>
-        <field name="refund_repartition_line_ids" eval="[
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                    'minus_report_line_ids': [ref('account_tax_report_gstrpt_g11'), ref('account_tax_report_gstrpt_g14')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'tag_ids': [(4, ref('service_tag'))],
-                }),
-            ]"/>
-    </record>
-    <record id="au_tax_purchase_taxable_import_service_tpar_no_abn" model="account.tax.template">
-        <field name="chart_template_id" ref="l10n_au_chart_template"/>
-        <field name="name">Purch (Taxable Imports) TPAR without ABN</field>
-        <field name="sequence">5</field>
-        <field name="description">Purchase (Taxable Imports) - Tax Paid Separately</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="tax_scope">service</field>
-        <field name="amount">100</field>
-        <field name="amount_type">group</field>
-        <field name="children_tax_ids" eval="[(6,0,[ref('au_tax_purchase_taxable_import_service_tpar'), ref('au_tax_witheld')])]"/>
-        <field name="tax_group_id" ref="tax_group_gst_10"/>
-    </record>
     <record id="au_tax_purchase_input" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Purch for Input Sales</field>
@@ -1141,18 +1016,14 @@
         <field name="type_tax_use">purchase</field>
         <field name="tax_scope">consu</field>
         <field name="amount_type">percent</field>
-        <field name="amount">100000000</field>
-        <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="tax_group_gst_100000000"/>
+        <field name="amount">0</field>
+        <field name="price_include" eval="0"/>
+        <field name="tax_group_id" ref="tax_group_gst_import"/>
+        <field name="is_base_affected" eval="1"/>
         <field name="invoice_repartition_line_ids" eval="[
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('au_21330'),
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
@@ -1160,11 +1031,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('au_21330'),
                     'minus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
@@ -1177,18 +1043,14 @@
         <field name="type_tax_use">purchase</field>
         <field name="tax_scope">service</field>
         <field name="amount_type">percent</field>
-        <field name="amount">100000000</field>
-        <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="tax_group_gst_100000000"/>
+        <field name="amount">0</field>
+        <field name="price_include" eval="0"/>
+        <field name="tax_group_id" ref="tax_group_gst_import"/>
+        <field name="is_base_affected" eval="1"/>
         <field name="invoice_repartition_line_ids" eval="[
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('au_21330'),
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
@@ -1196,11 +1058,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('au_21330'),
                     'minus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                 }),
             ]"/>
@@ -1213,18 +1070,14 @@
         <field name="type_tax_use">purchase</field>
         <field name="tax_scope">service</field>
         <field name="amount_type">percent</field>
-        <field name="amount">100000000</field>
-        <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="tax_group_gst_100000000"/>
+        <field name="amount">0</field>
+        <field name="price_include" eval="0"/>
+        <field name="tax_group_id" ref="tax_group_gst_import"/>
+        <field name="is_base_affected" eval="1"/>
         <field name="invoice_repartition_line_ids" eval="[
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('au_21330'),
                     'plus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                     'tag_ids': [(4, ref('service_tag'))],
                 }),
@@ -1233,11 +1086,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('au_21330'),
                     'minus_report_line_ids': [ref('account_tax_report_gstrpt_gstonly'), ref('account_tax_report_gstrpt_comparison_gl')],
                     'tag_ids': [(4, ref('service_tag'))],
                 }),

--- a/addons/l10n_nz/data/account.tax.group.csv
+++ b/addons/l10n_nz/data/account.tax.group.csv
@@ -2,4 +2,4 @@ id,name
 tax_group_0,TAX 0%
 tax_group_gst_15,GST 15%
 tax_group_15,TAX 15%
-tax_group_100000000,GST 100000000%
+tax_group_import,GST import

--- a/addons/l10n_nz/data/account_tax_template_data.xml
+++ b/addons/l10n_nz/data/account_tax_template_data.xml
@@ -264,40 +264,20 @@
         <field name="description">GST Only on Imports</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
-        <field name="amount">100000000000</field>
-        <!--
-          The tax percentage is so high because on imported goods we
-          needed to link the tax line acknowledgment (not to be paid)
-          on the customer invoice and what need to actually be
-          paid from another invoice given by a clearance house
-          (i.e. customs)
-          For more info see the complete discussion below
-          https://github.com/odoo/odoo/pull/48700#issuecomment-607586417
-        -->
-        <field name="price_include">TRUE</field>
-        <field name="tax_group_id" ref="tax_group_100000000"/>
+        <field name="amount">0</field>
+        <field name="price_include">FALSE</field>
+        <field name="tax_group_id" ref="tax_group_import"/>
+        <field name="is_base_affected" eval="1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('nz_21330'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('nz_21330'),
             }),
         ]"/>
     </record>


### PR DESCRIPTION
The taxes amounting to 100000000% are removed from the standard, as they are a workaround to allow customers to correctly link the customer invoice and the customs clearance they will get for the imported goods. Unfortunately this works as long as the PriceIncluded is below a certain amount.

**l10n_au**
* The au_tax_purchase_taxable_import taxes are removed
* The au_tax_purchase_gst_only are converted to 0% amount with tax tags on the base line.
   Price_include is removed and is_base_affected is set.
* The tax_group_100000000 is renamed to tax_group_import

**l10n_nz**
* The nz_tax_purchase_gst_only is converted to 0% amount 
   Price_include is removed and is_base_affected is set.
* The tax_group_100000000 is renamed to tax_group_import

Task link: https://www.odoo.com/web#id=2278230&model=project.task