### PR TITLE
[FIX] hr_contract: make timezone clickable again

### DIFF
--- a/addons/hr_contract/static/src/scss/calendar_mismatch.scss
+++ b/addons/hr_contract/static/src/scss/calendar_mismatch.scss
@@ -7,6 +7,7 @@
         display: block;
         height: 0;
         opacity: 0;
+        pointer-events: none;
     }
 
     .o_calendar_warning:hover + .o_calendar_warning_tooltip {


### PR DESCRIPTION
The `tz` field was no longer clickable on the employee form
because the warning tooltip was getting the click event even
though it was not visible.

TaskID: 2591003

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
