### PR TITLE
add copied notification popover in error dialog

### DIFF
--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 import { errorService } from "@web/core/errors/error_service";
 import { dialogService } from "@web/core/dialog/dialog_service";
 import { notificationService } from "@web/core/notifications/notification_service";
+import { popoverService } from "@web/core/popover/popover_service";
 import { uiService } from "@web/core/ui/ui_service";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
@@ -29,6 +30,7 @@ QUnit.module("base_automation", {}, function () {
             serviceRegistry.add("ui", uiService);
             serviceRegistry.add("error", errorService);
             serviceRegistry.add("hotkey", hotkeyService);
+            serviceRegistry.add("popover", popoverService);
             serviceRegistry.add("localization", makeFakeLocalizationService());
             serviceRegistry.add("action", { start: () => {} });
             serviceRegistry.add("orm", { start: () => {} });

--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -5,10 +5,12 @@ import { Dialog } from "../dialog/dialog";
 import { _lt } from "../l10n/translation";
 import { registry } from "../registry";
 import { useService } from "@web/core/utils/hooks";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { capitalize } from "../utils/strings";
 
-const { hooks } = owl;
+const { Component, hooks } = owl;
 const { useState } = hooks;
+const { xml } = owl.tags;
 
 export const odooExceptionTitleMap = new Map(
     Object.entries({
@@ -33,8 +35,15 @@ export class ErrorDialog extends Dialog {
         this.state = useState({
             showTraceback: false,
         });
+        this.popover = usePopover();
     }
     onClickClipboard() {
+        // show copied popover and close it after 1 second so user can know text is copied
+        class Comp extends Component { }
+        Comp.template = xml`<div class="p-1" t-att-id="props.id">Copied !</div>`;
+        const closeFn = this.popover.add(this.el.querySelector('.btn-primary'), Comp, { id: "copied" });
+        browser.setTimeout(() => { closeFn("copied"); }, 1000);
+
         browser.navigator.clipboard.writeText(
             `${this.props.name}\n${this.props.message}\n${this.props.traceback}`
         );
@@ -67,6 +76,7 @@ export class RPCErrorDialog extends ErrorDialog {
         if (this.props.data && this.props.data.debug) {
             this.traceback = `${this.props.data.debug}`;
         }
+        this.popover = usePopover();
     }
     inferTitle() {
         // If the server provides an exception name that we have in a registry.
@@ -90,6 +100,12 @@ export class RPCErrorDialog extends ErrorDialog {
     }
 
     onClickClipboard() {
+        // show copied popover and close it after 1 second so user can know text is copied
+        class Comp extends Component { }
+        Comp.template = xml`<div class="p-1" t-att-id="props.id">Copied !</div>`;
+        const closeFn = this.popover.add(this.el.querySelector('.btn-primary'), Comp, { id: "copied" });
+        browser.setTimeout(() => { closeFn("copied"); }, 1000);
+
         browser.navigator.clipboard.writeText(
             `${this.props.name}\n${this.props.message}\n${this.traceback}`
         );

--- a/addons/web/static/tests/core/dialog_service_tests.js
+++ b/addons/web/static/tests/core/dialog_service_tests.js
@@ -7,6 +7,7 @@ import { registry } from "@web/core/registry";
 import { notificationService } from "@web/core/notifications/notification_service";
 import { uiService } from "@web/core/ui/ui_service";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
+import { popoverService } from "@web/core/popover/popover_service";
 import { registerCleanup } from "../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService, makeFakeRPCService } from "../helpers/mock_services";
@@ -245,6 +246,7 @@ QUnit.test("dialog component crashes", async (assert) => {
     serviceRegistry.add("notification", notificationService);
     serviceRegistry.add("error", errorService);
     serviceRegistry.add("localization", makeFakeLocalizationService());
+    serviceRegistry.add("popover", popoverService);
 
     pseudoWebClient = await mount(PseudoWebClient, { env, target });
 


### PR DESCRIPTION
PURPOSE
Make sure the user know their click on the button made something.
Which they cannot if they're not provided with some basic feedback.

SPEC
On click, a "copied" dialog box appears as shown here

TASK 2583984



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
