### PR TITLE
[FIX] base: add an alias for iso-8859-8-i == iso-8859-8

### DIFF
--- a/odoo/loglevels.py
+++ b/odoo/loglevels.py
@@ -17,6 +17,7 @@ def get_encodings(hint_encoding='utf-8'):
     fallbacks = {
         'latin1': 'latin9',
         'iso-8859-1': 'iso8859-15',
+        'iso-8859-8-i': 'iso8859-8',
         'cp1252': '1252',
     }
     if hint_encoding:


### PR DESCRIPTION
Steps to reproduce:

  - Install "Sales" module (for test purpose)
  - Active `External Email Servers` email feature and set an alias
  - Go to any Sale Team, and set an Email Alias
  - Send an email (from outside Odoo) to the sale team email alias
    - Write the body text in hebrew
    - !must ensure that the mail is encoded in iso-8859-8-i.
  - Go to Settings -> Technical -> Messages and open the receveid mail

Issue:

  Hebrew character are replaced by `�`.

Cause:

  Python does not have -e and -i codecs.
  More info here: https://bugs.python.org/issue18624

Solution:

  Create an alias for iso-8859-8-i == iso-8859-8.

opw-2482579