### PR TITLE
[FIX] account: postpone and check balance once for all

### DIFF
--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -61,7 +61,6 @@ class TestAccountAccount(AccountTestInvoicingCommon):
 
         # Set the account as reconcile and fully reconcile something.
         account.reconcile = True
-        self.env['account.move.line'].invalidate_cache()
 
         self.assertRecordValues(move.line_ids, [
             {'reconciled': False, 'amount_residual': 100.0, 'amount_residual_currency': 200.0},

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -179,6 +179,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         if not expected_values:
             return
 
+        self.env['account.move.line'].flush(self.env['account.move.line']._fields)
+
         self.cr.execute('''
             SELECT
                 line.account_id,


### PR DESCRIPTION
This costly operation could be postponed until end of transaction to be executed
only once, which may save a lot of time

---

opw-2497288

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
