### PR TITLE
[IMP] web: show technical name in export view

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1636,8 +1636,11 @@
         <t t-set="has_child" t-value="field.children &amp;&amp; (field.id).split('/').length != 3" />
         <div t-att-data-id="field.id" t-attf-class="o_export_tree_item #{has_child ? 'haschild o_expand' : ''}" tabindex="-1" role="treeitem"> <!-- tabindex make the div focusable -->
             <span t-if="has_child" class="o_expand_parent fa fa-chevron-right" role="img" aria-label="Show sub-fields" title="Show sub-fields"/>
-            <div t-attf-class="o_tree_column" t-att-title="debug and field.id or None">
+            <div t-attf-class="o_tree_column">
                 <t t-esc="field.string"/>
+                <t t-if="debug and field.id">
+                    (<t t-esc="field.id"/>)
+                </t>
                 <span title="Select field" class="fa fa-plus pull-right m-1 o_add_field"/>
             </div>
         </div>


### PR DESCRIPTION
Like in debug mode on optional field on tree view, show technical name on export view.
Because in some case the name of field are not relevante.

![image](https://user-images.githubusercontent.com/16716992/125851724-bbd7b9e6-dc91-4b96-adfa-2f2ecc2daba7.png)


![image](https://user-images.githubusercontent.com/16716992/125849459-127516f1-238e-4351-8c2c-3327b1b58fa9.png)

@xmo-odoo 

Note : can be move in master

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
