### PR TITLE
[FIX] account, payment: Various fixes for account payments/method lines

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -383,16 +383,13 @@ class AccountPayment(models.Model):
         This field is not computed in '_compute_payment_method_fields' because it's a stored editable one.
         '''
         for pay in self:
-            if pay.payment_type == 'inbound':
-                available_payment_methods = pay.journal_id.inbound_payment_method_line_ids
-            else:
-                available_payment_methods = pay.journal_id.outbound_payment_method_line_ids
+            available_payment_method_lines = pay.journal_id._get_available_payment_method_lines(pay.payment_type)
 
             # Select the first available one by default.
-            if pay.payment_method_line_id in available_payment_methods:
+            if pay.payment_method_line_id in available_payment_method_lines:
                 pay.payment_method_line_id = pay.payment_method_line_id
-            elif available_payment_methods:
-                pay.payment_method_line_id = available_payment_methods[0]._origin
+            elif available_payment_method_lines:
+                pay.payment_method_line_id = available_payment_method_lines[0]._origin
             else:
                 pay.payment_method_line_id = False
 

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -81,7 +81,7 @@ class AccountPaymentMethod(models.Model):
 class AccountPaymentMethodLine(models.Model):
     _name = "account.payment.method.line"
     _description = "Payment Methods"
-    _order = 'sequence'
+    _order = 'sequence, id'
 
     # == Business fields ==
     name = fields.Char(compute='_compute_name', readonly=False, store=True)

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -304,14 +304,11 @@ class AccountPaymentRegister(models.TransientModel):
     @api.depends('payment_type', 'journal_id')
     def _compute_payment_method_line_id(self):
         for wizard in self:
-            if wizard.payment_type == 'inbound':
-                available_payment_methods = wizard.journal_id.inbound_payment_method_line_ids
-            else:
-                available_payment_methods = wizard.journal_id.outbound_payment_method_line_ids
+            available_payment_method_lines = wizard.journal_id._get_available_payment_method_lines(wizard.payment_type)
 
             # Select the first available one by default.
-            if available_payment_methods:
-                wizard.payment_method_line_id = available_payment_methods[0]._origin
+            if available_payment_method_lines:
+                wizard.payment_method_line_id = available_payment_method_lines[0]._origin
             else:
                 wizard.payment_method_line_id = False
 

--- a/addons/payment/models/account_journal.py
+++ b/addons/payment/models/account_journal.py
@@ -24,7 +24,7 @@ class AccountJournal(models.Model):
             SELECT acquirer.id
             FROM payment_acquirer acquirer
             JOIN account_payment_method apm ON apm.code = acquirer.provider
-            LEFT JOIN account_payment_method_line apml ON apm.id = apml.payment_method_id
+            LEFT JOIN account_payment_method_line apml ON apm.id = apml.payment_method_id AND apml.journal_id IS NOT NULL
             WHERE acquirer.state IN ('enabled', 'test') AND apm.payment_type = 'inbound'
             AND apml.id IS NULL
             AND acquirer.company_id IN %(company_ids)s

--- a/addons/payment/wizards/account_payment_register.py
+++ b/addons/payment/wizards/account_payment_register.py
@@ -42,11 +42,12 @@ class AccountPaymentRegister(models.TransientModel):
                         | wizard.partner_id.commercial_partner_id.child_ids
                 )._origin
 
-                wizard.suitable_payment_token_ids = self.env['payment.token'].search([
+                wizard.suitable_payment_token_ids = self.env['payment.token'].sudo().search([
                     ('company_id', '=', wizard.company_id.id),
                     ('acquirer_id.capture_manually', '=', False),
                     ('partner_id', 'in', related_partner_ids.ids),
-                ]).filtered(lambda t: t.acquirer_id.journal_id == wizard.journal_id.id)
+                    ('acquirer_id.journal_id', '=', wizard.journal_id.id),
+                ])
             else:
                 wizard.suitable_payment_token_ids = [Command.clear()]
 
@@ -60,13 +61,21 @@ class AccountPaymentRegister(models.TransientModel):
 
     @api.onchange('can_edit_wizard', 'payment_method_line_id', 'journal_id')
     def _compute_payment_token_id(self):
+        codes = [key for key in dict(self.env['payment.acquirer']._fields['provider']._description_selection(self.env))]
         for wizard in self:
+            related_partner_ids = (
+                    wizard.partner_id
+                    | wizard.partner_id.commercial_partner_id
+                    | wizard.partner_id.commercial_partner_id.child_ids
+            )._origin
             if wizard.can_edit_wizard \
-                    and wizard.payment_method_line_id.code == 'electronic' \
+                    and wizard.payment_method_line_id.code in codes \
                     and wizard.journal_id \
-                    and wizard.suitable_payment_token_partner_ids:
-                wizard.payment_token_id = self.env['payment.token'].search([
-                    ('partner_id', 'in', wizard.suitable_payment_token_partner_ids.ids),
+                    and related_partner_ids:
+
+                wizard.payment_token_id = self.env['payment.token'].sudo().search([
+                    ('company_id', '=', wizard.company_id.id),
+                    ('partner_id', 'in', related_partner_ids.ids),
                     ('acquirer_id.capture_manually', '=', False),
                     ('acquirer_id.journal_id', '=', wizard.journal_id.id),
                  ], limit=1)


### PR DESCRIPTION
There is an issue when computing the suitable payment token ids making it impossible to
open a payment for a user without access to payment acquirers.

Also, the default computation of payment token was wrong and would never set it
correctly.

The compute for the method lines in payment would not filter unavailable acquirers
line and thus select them by default if they were first in line.

Also fix an issue with the ordering of payment method lines

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
