### PR TITLE
[IMP] web_editor: Image shapes for themes & website configurator

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -303,9 +303,11 @@ async function activateCropper(image, aspectRatio, dataset) {
  * @param {HTMLImageElement} img the image whose attachment data should be found
  * @param {Function} rpc a function that can be used to make the RPC. Typically
  *   this would be passed as 'this._rpc.bind(this)' from widgets.
+ * @param {string} [attachmentSrc=''] specifies the URL of the corresponding
+ * attachment if it can't be found in the 'src' attribute.
  */
-async function loadImageInfo(img, rpc) {
-    const src = img.getAttribute('src');
+async function loadImageInfo(img, rpc, attachmentSrc = '') {
+    const src = attachmentSrc || img.getAttribute('src');
     // If there is a marked originalSrc, the data is already loaded.
     if (img.dataset.originalSrc || !src) {
         return;

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4211,7 +4211,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     async willStart() {
         const _super = this._super.bind(this);
-        await this._loadImageInfo();
+        await this._initializeImage();
         return _super(...arguments);
     },
     /**
@@ -4418,9 +4418,9 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      *
      * @private
      */
-    async _loadImageInfo() {
+    async _loadImageInfo(attachmentSrc = '') {
         const img = this._getImg();
-        await loadImageInfo(img, this._rpc.bind(this));
+        await loadImageInfo(img, this._rpc.bind(this), attachmentSrc);
         if (!img.dataset.originalId) {
             this.originalId = null;
             this.originalSrc = null;
@@ -4473,6 +4473,12 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     _getImageMimetype(img) {
         return img.dataset.mimetype;
     },
+    /**
+     * @private
+     */
+    async _initializeImage() {
+        return this._loadImageInfo();
+    }
 });
 
 /**
@@ -4583,9 +4589,11 @@ registry.ImageOptimize = ImageHandlerOption.extend({
     async _applyOptions() {
         const img = await this._super(...arguments);
         if (img && img.dataset.shape) {
-            // Reapplying the shape
             await this._loadShape(img.dataset.shape);
-            await this._applyShapeAndColors(true, (img.dataset.shapeColors && img.dataset.shapeColors.split(';')));
+            if (/^data:/.test(img.src)) {
+                // Reapplying the shape
+                await this._applyShapeAndColors(true, (img.dataset.shapeColors && img.dataset.shapeColors.split(';')));
+            }
         }
         return img;
     },
@@ -4629,7 +4637,7 @@ registry.ImageOptimize = ImageHandlerOption.extend({
             // shape's colors by the current palette's
             newColors = oldColors.map((color, i) => color !== null ? this._getCSSColorValue(`o-color-${(i + 1)}`) : null);
         }
-        newColors.forEach((color, i) => shape = shape.replace(new RegExp(oldColors[i], 'g'), color));
+        newColors.forEach((color, i) => shape = shape.replace(new RegExp(oldColors[i], 'g'), this._getCSSColorValue(color)));
         await this._writeShape(shape);
         if (save) {
             img.dataset.shapeColors = newColors.join(';');
@@ -4772,10 +4780,28 @@ registry.ImageOptimize = ImageHandlerOption.extend({
      * @returns {string}
      */
     _getCSSColorValue(color) {
-        if (ColorpickerWidget.isCSSColor(color)) {
+        if (!color || ColorpickerWidget.isCSSColor(color)) {
             return color;
         }
         return weUtils.getCSSVariableValue(color);
+    },
+    /**
+     * Overridden to set attachment data on theme images (with default shapes).
+     *
+     * @override
+     * @private
+     */
+    async _initializeImage() {
+        const img = this._getImg();
+        const match = img.src.match(/\/web_editor\/image_shape\/(\w+\.\w+)/);
+        if (img.dataset.shape && match) {
+            await this._loadImageInfo(`/web/image/${match[1]}`);
+            // Image data-mimetype should be changed to SVG since loadImageInfo()
+            // will set the original attachment mimetype on it.
+            img.dataset.mimetype = 'image/svg+xml';
+            return;
+        }
+        return this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
The goal of this PR is to add a "Python version" of the
shape on image feature using a controller.

Since the whole logic to apply shapes on image is JS based, we need
to use this URL (just like background shapes) when we want to add
a shape by default on images in themes.

When the configurator replaces a snippet image (with default shape),
the shape option should still be applied on the new one.

task-2593454