### PR TITLE
[IMP] mrp, stock: improve MO usability

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -69,7 +69,7 @@ class MrpProduction(models.Model):
 
     @api.model
     def _get_default_is_locked(self):
-        return self.user_has_groups('mrp.group_locked_by_default')
+        return not self.user_has_groups('mrp.group_unlocked_by_default')
 
     name = fields.Char(
         'Reference', copy=False, readonly=True, default=lambda x: _('New'))
@@ -501,7 +501,11 @@ class MrpProduction(models.Model):
     @api.depends('state')
     def _compute_show_lock(self):
         for order in self:
-            order.show_lock = self.env.user.has_group('mrp.group_locked_by_default') and order.id is not False and order.state not in {'cancel', 'draft'}
+            order.show_lock = order.state == 'done' or (
+                not self.env.user.has_group('mrp.group_unlocked_by_default')
+                and order.id is not False
+                and order.state not in {'cancel', 'draft'}
+            )
 
     @api.depends('state','move_raw_ids')
     def _compute_show_lot_ids(self):

--- a/addons/mrp/models/res_config_settings.py
+++ b/addons/mrp/models/res_config_settings.py
@@ -19,7 +19,7 @@ class ResConfigSettings(models.TransientModel):
     module_mrp_subcontracting = fields.Boolean("Subcontracting")
     group_mrp_routings = fields.Boolean("MRP Work Orders",
         implied_group='mrp.group_mrp_routings')
-    group_locked_by_default = fields.Boolean("Lock Quantities To Consume", implied_group='mrp.group_locked_by_default')
+    group_unlocked_by_default = fields.Boolean("Unlock Manufacturing Orders", implied_group='mrp.group_unlocked_by_default')
 
     @api.onchange('use_manufacturing_lead')
     def _onchange_use_manufacturing_lead(self):
@@ -38,3 +38,11 @@ class ResConfigSettings(models.TransientModel):
             self.module_mrp_workorder = True
         else:
             self.module_mrp_workorder = False
+
+    @api.onchange('group_unlocked_by_default')
+    def _onchange_group_unlocked_by_default(self):
+        """ When changing this setting, we want existing MOs to automatically update to match setting. """
+        if self.group_unlocked_by_default:
+            self.env['mrp.production'].search([('state', 'not in', ('cancel', 'done')), ('is_locked', '=', True)]).is_locked = False
+        else:
+            self.env['mrp.production'].search([('state', 'not in', ('cancel', 'done')), ('is_locked', '=', False)]).is_locked = True

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -419,3 +419,10 @@ class StockMove(models.Model):
             candidate_moves_list.append(production.move_raw_ids)
         for production in self.mapped('production_id'):
             candidate_moves_list.append(production.move_finished_ids)
+
+    def _multi_line_quantity_done_set(self, quantity_done):
+        if self.raw_material_production_id:
+            self.move_line_ids.filtered(lambda ml: ml.state not in ('done', 'cancel')).qty_done = 0
+            self.move_line_ids = self._set_quantity_done_prepare_vals(quantity_done)
+        else:
+            super()._multi_line_quantity_done_set(quantity_done)

--- a/addons/mrp/security/mrp_security.xml
+++ b/addons/mrp/security/mrp_security.xml
@@ -30,8 +30,8 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
-    <record id="group_locked_by_default" model="res.groups">
-        <field name="name">Locked by default</field>
+    <record id="group_unlocked_by_default" model="res.groups">
+        <field name="name">Unlocked by default</field>
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 

--- a/addons/mrp/static/src/scss/mrp_fields.scss
+++ b/addons/mrp/static/src/scss/mrp_fields.scss
@@ -9,3 +9,11 @@
 .o_should_consume{
     padding-left: 0.3em;
 }
+
+.btn-link.o_optional_button{
+    color: gray;
+
+    &:hover {
+        filter: brightness(0.9);
+    }
+}

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -396,6 +396,7 @@ class TestMrpOrder(TestMrpCommon):
         production = production_form.save()
         production.action_confirm()
         production.action_assign()
+        production.is_locked = False
         production_form = Form(production)
         # change the quantity producing and the initial demand
         # in the same transaction
@@ -1027,6 +1028,7 @@ class TestMrpOrder(TestMrpCommon):
 
         mo.bom_id.consumption = 'flexible'  # Because we'll over-consume with a product not defined in the BOM
         mo.action_assign()
+        mo.is_locked = False
 
         mo_form = Form(mo)
         mo_form.qty_producing = 3

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -467,6 +467,7 @@ class TestProcurement(TestMrpCommon):
 
         self.assertEqual(len(mo), 1, "Manufacture order was not automatically created")
         mo.action_assign()
+        mo.is_locked = False
         self.assertEqual(mo.move_raw_ids.reserved_availability, 0, "No components should be reserved yet")
         self.assertEqual(mo.product_qty, 15, "Quantity to produce should be picking demand + reordering rule max qty")
 

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -297,7 +297,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         production = production_form.save()
 
         production.action_confirm()
-
+        production.is_locked = False
         production_form = Form(production)
         with production_form.move_raw_ids.new() as move:
             move.product_id = new_product

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -94,7 +94,7 @@
                     <button name="button_scrap" type="object" string="Scrap" attrs="{'invisible': [('state', 'in', ('cancel', 'draft'))]}" data-hotkey="z"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,progress,done"/>
                     <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', False)]}" string="Unlock" groups="mrp.group_mrp_manager" type="object" help="Unlock the manufacturing order to adjust what has been consumed or produced." data-hotkey="l"/>
-                    <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', True)]}" string="Lock" groups="mrp.group_mrp_manager" type="object" help="Lock the manufacturing order to prevent changes to what has been consumed or produced." data-hotkey="l"/>/>
+                    <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('show_lock', '=', False), ('is_locked', '=', True)]}" string="Lock" groups="mrp.group_mrp_manager" type="object" help="Lock the manufacturing order to prevent changes to what has been consumed or produced." data-hotkey="l"/>
                     <button name="action_cancel" type="object" string="Cancel" data-hotkey="z"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('state', 'in', ('done', 'cancel')), ('confirm_cancel', '=', True)]}"/>
                     <button name="action_cancel" type="object" string="Cancel" data-hotkey="z"
@@ -232,8 +232,8 @@
                                 context="{'default_date': date_planned_start, 'default_date_deadline': date_deadline, 'default_location_id': location_src_id, 'default_location_dest_id': production_location_id, 'default_state': 'draft', 'default_raw_material_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}"
                                 attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" editable="bottom">
-                                    <field name="product_id" force_save="1" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '|', ('has_move_lines', '=', True), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
-
+                                    <field name="product_id" force_save="1" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '|', ('move_lines_count', '&gt;', 0), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
+                                    <field name="location_id" string="From" readonly="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="move_line_ids" invisible="1">
                                         <tree>
                                             <field name="lot_id" invisible="1"/>
@@ -271,7 +271,7 @@
                                     <field name="location_id" invisible="1"/>
                                     <field name="warehouse_id" invisible="1"/>
                                     <field name="is_locked" invisible="1"/>
-                                    <field name="has_move_lines" invisible="1"/>
+                                    <field name="move_lines_count" invisible="1"/>
                                     <field name="location_dest_id" domain="[('id', 'child_of', parent.location_dest_id)]" invisible="1"/>
                                     <field name="state" invisible="1" force_save="1"/>
                                     <field name="should_consume_qty" invisible="1"/>
@@ -285,7 +285,7 @@
                                     <field name="quantity_done" string="Consumed"
                                         decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"
                                         decoration-warning="not is_done and (quantity_done - should_consume_qty &gt; 0.0001)"
-                                        attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('show_details_visible', '=', True)]}"/>
+                                        attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('has_tracking', '!=','none')]}"/>
                                     <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
@@ -296,7 +296,8 @@
                                         domain="[('product_id','=',product_id)]"
                                     />
                                     <field name="group_id" invisible="1"/>
-                                    <button name="action_show_details" type="object" icon="fa-list" context="{'default_product_uom_qty': 0}" attrs="{'invisible': [('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button name="action_show_details" type="object" icon="fa-list" context="{'default_product_uom_qty': 0}" attrs="{'invisible': ['|', ('show_details_visible', '=', False), ('has_tracking', '=','none')]}" options="{&quot;warn&quot;: true}"/>
+                                    <button class="o_optional_button" name="action_show_details" type="object" icon="fa-list" context="{'default_product_uom_qty': 0}" attrs="{'invisible': ['|', ('has_tracking', '!=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
                                 </tree>
                             </field>
                         </page>
@@ -308,6 +309,7 @@
                                 <tree default_order="is_done,sequence" decoration-muted="is_done" editable="bottom">
                                     <field name="byproduct_id" invisible="1"/>
                                     <field name="product_id" context="{'default_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
+                                    <field name="location_dest_id" string="To" readonly="1" groups="stock.group_stock_multi_locations"/>
 
                                     <field name="move_line_ids" invisible="1">
                                         <tree>
@@ -343,7 +345,7 @@
                                     <field name="location_id" invisible="1"/>
                                     <field name="warehouse_id" invisible="1"/>
                                     <field name="is_locked" invisible="1"/>
-                                    <field name="has_move_lines" invisible="1"/>
+                                    <field name="move_lines_count" invisible="1"/>
                                     <field name="location_dest_id" domain="[('id', 'child_of', parent.location_dest_id)]" invisible="1"/>
                                     <field name="state" invisible="1" force_save="1"/>
                                     <field name="product_uom_qty" string="To Produce" attrs="{'readonly': ['&amp;', ('parent.state', '!=', 'draft'), '|', '&amp;', ('parent.state', 'not in', ('confirmed', 'progress', 'to_close')), ('parent.is_planned', '!=', True), ('parent.is_locked', '=', True)]}"/>
@@ -358,7 +360,8 @@
                                         context="{'default_company_id': company_id, 'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"
                                     />
-                                    <button name="action_show_details" type="object" icon="fa-list" attrs="{'invisible': [('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button name="action_show_details" type="object" icon="fa-list" attrs="{'invisible': ['|', ('has_tracking', '=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
+                                    <button class="o_optional_button" name="action_show_details" type="object" icon="fa-list" attrs="{'invisible': ['|', ('has_tracking', '!=','none'), ('show_details_visible', '=', False)]}" options="{&quot;warn&quot;: true}"/>
                                 </tree>
                             </field>
                         </page>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -65,12 +65,12 @@
                             </div>
                             <div class="col-lg-6 col-12 o_setting_box" id="mrp_lock" title="Makes confirmed manufacturing orders locked rather than unlocked by default. This only applies to new manufacturing orders, not previously created ones.">
                                 <div class="o_setting_left_pane">
-                                    <field name="group_locked_by_default"/>
+                                    <field name="group_unlocked_by_default"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="group_locked_by_default"/>
+                                    <label for="group_unlocked_by_default"/>
                                     <div class="text-muted">
-                                        Prevent manufacturing users from modifying quantities to consume, unless a manager has unlocked the document
+                                        Allow manufacturing users to modify quantities to consume, without the need for prior approval
                                     </div>
                                 </div>
                             </div>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -66,10 +66,10 @@
                     <field name="show_reserved_availability" invisible="1"/>
                     <field name="show_operations" invisible="1" readonly="1"/>
                     <field name="additional" invisible="1"/>
-                    <field name="has_move_lines" invisible="1"/>
+                    <field name="move_lines_count" invisible="1"/>
                     <field name="is_locked" invisible="1"/>
                     <field name="product_uom_category_id" invisible="1"/>
-                    <field name="product_id" required="1" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('has_move_lines', '=', True)]}"/>
+                    <field name="product_id" required="1" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('move_lines_count', '&gt;', 0)]}"/>
                     <field name="is_initial_demand_editable" invisible="1"/>
                     <field name="is_quantity_done_editable" invisible="1"/>
                     <field name="product_uom_qty" string="Demand" attrs="{'readonly': [('is_initial_demand_editable', '=', False)]}"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -351,12 +351,12 @@
                                     <field name="show_reserved_availability" invisible="1"/>
                                     <field name="show_operations" invisible="1" readonly="1"/>
                                     <field name="additional" invisible="1"/>
-                                    <field name="has_move_lines" invisible="1"/>
+                                    <field name="move_lines_count" invisible="1"/>
                                     <field name="is_locked" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <field name="has_tracking" invisible="1"/>
                                     <field name="display_assign_serial" invisible="1"/>
-                                    <field name="product_id" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('has_move_lines', '=', True)]}"/>
+                                    <field name="product_id" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('move_lines_count', '&gt;', 0)]}"/>
                                     <field name="description_picking" string="Description" optional="hide"/>
                                     <field name="date" invisible="1"/>
                                     <field name="date_deadline" optional="hide"/>
@@ -395,9 +395,9 @@
                                     <group>
                                         <field name="product_uom_category_id" invisible="1"/>
                                         <field name="additional" invisible="1"/>
-                                        <field name="has_move_lines" invisible="1"/>
+                                        <field name="move_lines_count" invisible="1"/>
                                         <field name="company_id" invisible="1"/>
-                                        <field name="product_id" required="1" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('has_move_lines', '=', True)]}"/>
+                                        <field name="product_id" required="1" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('move_lines_count', '&gt;', 0)]}"/>
                                         <field name="is_initial_demand_editable" invisible="1"/>
                                         <field name="is_quantity_done_editable" invisible="1"/>
                                         <field name="product_uom_qty" attrs="{'invisible': [('parent.immediate_transfer', '=', True)], 'readonly': [('is_initial_demand_editable', '=', False)]}"/>


### PR DESCRIPTION
We are doing 2 things to improve MO usability:

1.Setting update:  We are reversing the purpose of the existing `group_locked_by_default` setting so that it now does the opposite (make it so everything is locked by default when setting is not active and setting makes everything unlocked by default when active). Previous setting was confusing for users and made it easier for users to accidentally edit component's Qty to Consume rather than the Consumed Qty. Whether (not 'Done') MOs are locked or not now matches the setting as well (i.e. when setting is activated, existing MOs lock status will be updated to match).
2. Consumed Qty easing: We no longer require a component's consumed qty to be done via the detailed operations widget when product is not tracked and multi-location is active. It now follows same logic as when consumed qtys are auto-updated when `qty_producing` is changed (i.e. reversed move line amounts are used up first, then additional values will be taken from MO's default component's location).

Task: 2518523
ENT PR (only fixes test): odoo/enterprise#19732
Upgrade PR: odoo/upgrade#2655