### PR TITLE
[FIX] slides: Do not show a traceback when the user provides an invalid video link

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -13,7 +13,7 @@ from werkzeug import urls
 
 from odoo import api, fields, models, _
 from odoo.addons.http_routing.models.ir_http import slug
-from odoo.exceptions import Warning, UserError, AccessError
+from odoo.exceptions import UserError, AccessError
 from odoo.http import request
 from odoo.addons.http_routing.models.ir_http import url_for
 
@@ -338,10 +338,10 @@ class Slide(models.Model):
         if self.url:
             res = self._parse_document_url(self.url)
             if res.get('error'):
-                raise Warning(_('Could not fetch data from url. Document or access right not available:\n%s') % res['error'])
+                raise UserError(_('Could not fetch data from url. Document or access right not available:\n%s') % res['error'])
             values = res['values']
             if not values.get('document_id'):
-                raise Warning(_('Please enter valid Youtube or Google Doc URL'))
+                raise UserError(_('Please enter valid Youtube or Google Doc URL'))
             for key, value in values.items():
                 self[key] = value
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the user creates a new content for a course and specify an invalid video link, the system will display a traceback when the 'onchange' hook of the field is triggered (i.e: when the user unfocus the field). This commit aims to replace the trackback modal with a standard one.

Current behavior before PR:
When the user provides an invalid video link and the 'onchange' hook is trigger, the system shows a traceback.

Desired behavior after PR is merged:
When the user provides an invalid video link and the 'onchange' hook is triggered, the system shows a user friendly modal with the error message (without any code related debugging information).

Task id: 2607238

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
