### PR TITLE
[FIX] event_sale : unable to delete multiple SO

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -25,7 +25,7 @@ class SaleOrder(models.Model):
         return res
 
     def unlink(self):
-        self.order_line._unlink_associated_registrations()
+        self.mapped('order_line')._unlink_associated_registrations()
         super(SaleOrder, self).unlink()
 
 


### PR DESCRIPTION
Step to reproduce:

- go to sale app
- select several SO
- action menu > delete
- got a traceback

Change the unlink definition to get multiple elements with mapped

opw-2605699

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
