### PR TITLE
[FIX] website_forum: display anchor tag instead of link

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -251,6 +251,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
             title: title,
             sticky: false,
             type: "warning",
+            messageIsHtml: true,
         });
     },
     /**


### PR DESCRIPTION
**Purpose**
Anchro tag is display as a string in the notification instead of display link.

**Specification**
Due to not passing the escaping parameter option in displayNotification,
it will display any html tag as a string in the warning.
With this commit, we have passed 'messageIsHtml' as a parameter to properly
display the Link in the warning notification.

Task : 2601633

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
