### PR TITLE
[IMP] project: track dependencies in tasks

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -36,6 +36,7 @@
         'views/res_config_settings_views.xml',
         'views/mail_activity_views.xml',
         'views/project_portal_templates.xml',
+        'views/project_task_templates.xml',
         'data/ir_cron_data.xml',
         'data/mail_data.xml',
         'data/mail_template_data.xml',

--- a/addons/project/data/mail_data.xml
+++ b/addons/project/data/mail_data.xml
@@ -31,6 +31,12 @@
         <field name="res_model">project.task</field>
         <field name="default" eval="True"/>
     </record>
+    <record id="mt_task_dependency_change" model="mail.message.subtype">
+        <field name="name">Task Dependency Changes</field>
+        <field name="res_model">project.task</field>
+        <field name="default" eval="False"/>
+        <field name="hidden" eval="True"/>
+    </record>
     <!-- Project-related subtypes for messaging / Chatter -->
     <record id="mt_project_task_new" model="mail.message.subtype">
         <field name="name">Task Created</field>
@@ -71,5 +77,14 @@
         <field name="default" eval="True"/>
         <field name="parent_id" ref="mt_task_rating"/>
         <field name="relation_field">project_id</field>
+    </record>
+    <record id="mt_project_task_dependency_change" model="mail.message.subtype">
+        <field name="name">Task Dependency Changes</field>
+        <field name="sequence">15</field>
+        <field name="res_model">project.project</field>
+        <field name="default" eval="False"/>
+        <field name="parent_id" ref="mt_task_dependency_change"/>
+        <field name="relation_field">project_id</field>
+        <field name="hidden" eval="True"/>
     </record>
 </odoo>

--- a/addons/project/models/res_config_settings.py
+++ b/addons/project/models/res_config_settings.py
@@ -44,4 +44,11 @@ class ResConfigSettings(models.TransientModel):
         # update for basic projects
         update_projects(projects.filtered_domain(self._get_basic_project_domain()), basic_project_features)
 
+        # Hide the task dependency changes subtype when the dependency setting is disabled
+        task_dep_change_subtype_id = self.env.ref('project.mt_task_dependency_change')
+        project_task_dep_change_subtype_id = self.env.ref('project.mt_project_task_dependency_change')
+        if task_dep_change_subtype_id.hidden != (not self['group_project_task_dependencies']):
+            task_dep_change_subtype_id.hidden = not self['group_project_task_dependencies']
+            project_task_dep_change_subtype_id.hidden = not self['group_project_task_dependencies']
+
         super(ResConfigSettings, self).set_values()

--- a/addons/project/views/project_task_templates.xml
+++ b/addons/project/views/project_task_templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="task_track_depending_tasks">
+        <span>Task: <a href="#" data-oe-model="project.task" t-att-data-oe-id="child.id" t-esc="child.name"/></span>
+        <br/>
+        <t t-if="child_subtype">
+            <span><t t-esc="child_subtype"/></span><br/>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
Tasks that are blocked by other tasks don't get any other information
from those tasks.
In order to get updates on the state of the blocking tasks we now track
some fields (determined by the `task_dependency_tracking` attribute) in
the parent's chatter.

Task ID: 2601448