### PR TITLE
[FIX] payment_stripe: display clearer customer description

### DIFF
--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -140,7 +140,7 @@ class PaymentTransaction(models.Model):
                 'address[line1]': self.partner_address or None,
                 'address[postal_code]': self.partner_zip or None,
                 'address[state]': self.partner_state_id.name or None,
-                'description': f'ODOO_PARTNER_{self.partner_id.id}',
+                'description': f'Odoo Partner: {self.partner_id.name} (id: {self.partner_id.id})',
                 'email': self.partner_email,
                 'name': self.partner_name,
                 'phone': self.partner_phone or None,


### PR DESCRIPTION
Issue:

  Payouts reference on Stripe are display as:
  `SUB123 - ODOO_PARTNER_456789`.

Cause:

  When making a Stripe request to create new customer, the description
  is formated as : `ODOO_PARTNER_456789` .

Solution:

  Replace customer description format as :
  `Partner: Mitchel Admin (id:456789)` .
  Inspired by: https://github.com/odoo/odoo/commit/3bc1e0175d85a70806999109e928c234e8cc2ca4

opw-2593621