### PR TITLE
[IMP] project: basic improvement of field service module

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -29,7 +29,6 @@ class ProjectTaskType(models.Model):
     sequence = fields.Integer(default=1)
     project_ids = fields.Many2many('project.project', 'project_task_type_rel', 'type_id', 'project_id', string='Projects',
         default=_get_default_project_ids)
-    project_ids_readonly = fields.Boolean(help="Are project ids readonly.")
     legend_blocked = fields.Char(
         'Red Kanban Label', default=lambda s: _('Blocked'), translate=True, required=True,
         help='Override the default value displayed for the blocked state for kanban selection when the task or issue is in that stage.')

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -29,6 +29,7 @@ class ProjectTaskType(models.Model):
     sequence = fields.Integer(default=1)
     project_ids = fields.Many2many('project.project', 'project_task_type_rel', 'type_id', 'project_id', string='Projects',
         default=_get_default_project_ids)
+    project_ids_readonly = fields.Boolean(help="Are project ids readonly.")
     legend_blocked = fields.Char(
         'Red Kanban Label', default=lambda s: _('Blocked'), translate=True, required=True,
         help='Override the default value displayed for the blocked state for kanban selection when the task or issue is in that stage.')

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -108,7 +108,6 @@
                                 <field name="fold"/>
                                 <field name="is_closed" groups="base.group_no_one"/>
                                 <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}" groups="base.group_no_one"/>
-                                <field name="project_ids_readonly" invisible="1"/>
                             </group>
                         </group>
                         <group string="Stage Description and Tooltips">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -108,6 +108,7 @@
                                 <field name="fold"/>
                                 <field name="is_closed" groups="base.group_no_one"/>
                                 <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}" groups="base.group_no_one"/>
+                                <field name="project_ids_readonly" invisible="1"/>
                             </group>
                         </group>
                         <group string="Stage Description and Tooltips">


### PR DESCRIPTION
Purpose

In Configuration menu of Field Service module, add menu "stages" to manage
stages in list view like it exists in Project module.

SPECIFICATION

- Adding the "stages" menu below "project" menu item.
- The menu is accessible for Admin user as exists in project module.
- All created stage will be automatically added to the "Field service" project.

Task-2455754