### PR TITLE
[FIX] delivery: is_all_service is false if you have a section line

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -18,7 +18,7 @@ class SaleOrder(models.Model):
     @api.depends('order_line')
     def _compute_is_service_products(self):
         for so in self:
-            so.is_all_service = all(line.product_id.type == 'service' for line in so.order_line)
+            so.is_all_service = all(line.product_id.type == 'service' for line in so.order_line.filtered(lambda x: not x.display_type))
 
     def _compute_amount_total_without_delivery(self):
         self.ensure_one()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If you create a sale order with a section line you see the button add delivery.

**Current behavior before PR:**
![image](https://user-images.githubusercontent.com/16716992/126171927-2f4fef65-0605-419f-94de-d48043f222ea.png)


@JKE-be @tde-banana-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
