### PR TITLE
[FIX] http_routing: geoip longitude/latitude available


### DIFF
--- a/addons/http_routing/geoipresolver.py
+++ b/addons/http_routing/geoipresolver.py
@@ -55,6 +55,8 @@ class GeoIPResolver(object):
                 'city': r.city.name,
                 'country_code': getattr(country, attr),
                 'country_name': country.name,
+                'latitude': r.location.latitude,
+                'longitude': r.location.longitude,
                 'region': r.subdivisions[0].iso_code if r.subdivisions else None,
                 'time_zone': r.location.time_zone,
             }


### PR DESCRIPTION

In 2018 geoip2 support was added to allow the new database format that
are freely available. But for these, only a subset of properties are
available.

Since Odoo 13 (August 2019), the sign module is using geoip latitude and
longitude for logging access to sign module signatures, but this was
only working for database using the first version of GeoIP databases.

In other use case there would never be any geolocalization recorded.

With this change, latitude and longitude are available in the session if
the right module/database is installed.

opw-2426323
