### PR TITLE
[IMP] account: payment receipt improvements

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -5,31 +5,33 @@
             <t t-set="o" t-value="o.with_context(lang=lang)"/>
             <div class="page">
                 <h3><strong>Payment Receipt: <span t-field="o.name"/></strong></h3>
-                <div class="row mt64">
-                    <div class="col-6" t-if="o.date">
-                        <strong>Payment Date: </strong> <span t-field="o.date"/>
+                <div class="mb-4 mt-3">
+                    <div class="row">
+                        <div class="col-6" t-if="o.date">
+                            Payment Date: <span t-field="o.date"/>
+                        </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-6" t-if="o.partner_type">
-                        <t t-if="o.partner_type == 'customer'">
-                            <strong>Customer: </strong>
-                        </t>
-                        <t t-if="o.partner_type == 'supplier'">
-                            <strong>Vendor: </strong>
-                        </t><span t-field="o.partner_id"/>
+                    <div class="row">
+                        <div class="col-6" t-if="o.partner_type">
+                            <t t-if="o.partner_type == 'customer'">
+                                Customer:
+                            </t>
+                            <t t-if="o.partner_type == 'supplier'">
+                                Vendor:
+                            </t><span t-field="o.partner_id"/>
+                        </div>
+                        <div class="col-6" t-if="o.payment_method_id">
+                            Payment Method: <span t-field="o.payment_method_id.name"/>
+                        </div>
                     </div>
-                    <div class="col-6" t-if="o.payment_method_id">
-                        <strong>Payment Method: </strong><span t-field="o.payment_method_id.name"/>
+                    <div class="row">
+                        <div class="col-6" t-if="o.amount">
+                            Payment Amount: <span t-field="o.amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>
+                         </div>
+                        <div class="col-6" t-if="o.ref">
+                            Memo: <span t-field="o.ref"/>
+                         </div>
                     </div>
-                </div>
-                <div class="row mb64">
-                    <div class="col-6" t-if="o.amount">
-                        <strong>Payment Amount: </strong><span t-field="o.amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/>
-                     </div>
-                    <div class="col-6" t-if="o.ref">
-                        <strong>Memo: </strong><span t-field="o.ref"/>
-                     </div>
                 </div>
                 <table class="table table-sm">
                     <thead>
@@ -37,24 +39,38 @@
                             <th><span>Invoice Date</span></th>
                             <th><span>Invoice Number</span></th>
                             <th><span>Reference</span></th>
-                            <th class="text-right"><span>Original Amount</span></th>
-                            <th class="text-right"><span>Amount Paid</span></th>
-                            <th class="text-right"><span>Balance</span></th>
+                            <th class="text-right"><span>Amount</span></th>
                         </tr>
                     </thead>
                     <tbody>
-                        <tr t-foreach="o.move_id._get_reconciled_invoices_partials()" t-as="rec">
-                            <t t-set="amount" t-value="rec[1]"/>
+                        <t t-foreach="o.move_id._get_reconciled_invoices_partials()" t-as="rec">
+                            <!-- MOVE -->
                             <t t-set="inv" t-value="rec[2].move_id"/>
                             <t t-if="inv.move_type != 'entry'">
-                                <td><span t-field="inv.invoice_date"/></td>
-                                <td><span t-field="inv.name"/></td>
-                                <td><span t-field="inv.ref"/></td>
-                                <td class="text-right"><span t-field="inv.amount_total"/></td>
-                                <td class="text-right"><span t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/></td>
-                                <td class="text-right"><span t-field="inv.amount_residual"/></td>
+                                <tr>
+                                    <td><span t-field="inv.invoice_date"/></td>
+                                    <td><span t-field="inv.name"/></td>
+                                    <td><span t-field="inv.ref"/></td>
+                                    <td class="text-right"><span t-field="inv.amount_total"/></td>
+                                </tr>
+                                <!-- PAYMENTS/REVERSALS -->
+                                <tr t-foreach="inv._get_reconciled_invoices_partials()" t-as="par">
+                                    <t t-set="amount" t-value="par[1]"/>
+                                    <t t-set="payment" t-value="par[2].move_id"/>
+                                    <td><span t-field="payment.date"/></td>
+                                    <td><span t-field="payment.name"/></td>
+                                    <td><span t-field="payment.ref"/></td>
+                                    <td class="text-right">-<span t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"/></td>
+                                </tr>
+                                <!-- BALANCE -->
+                                <tr>
+                                    <td/>
+                                    <td><strong>Due Amount for <span t-field="inv.name"/></strong></td>
+                                    <td/>
+                                    <td class="text-right"><strong><span t-field="inv.amount_residual"/></strong></td>
+                                </tr>
                             </t>
-                        </tr>
+                        </t>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
The current template used to render the payment receipt
lack of details, which cause it to sometimes not make
much sense.

Eg.
    Invoice of  3000
    Reversal of 1000
    Payment of  2000
The receipt won't display information about the reversal,
showing something akin to "3000-2000 = 0"

This will improve the template to give more detail to the
user and avoid possible incomprehension.

Task id #2545590

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
