### PR TITLE
[FIX] payment_stripe_checkout_webhook: Json request not available

### DIFF
--- a/addons/payment_stripe_checkout_webhook/controllers/main.py
+++ b/addons/payment_stripe_checkout_webhook/controllers/main.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 
 from odoo.http import request
@@ -12,5 +13,6 @@ class StripeController(http.Controller):
 
     @http.route('/payment/stripe/webhook', type='json', auth='public', csrf=False)
     def stripe_webhook(self, **kwargs):
-        request.env['payment.acquirer'].sudo()._handle_stripe_webhook(request.jsonrequest)
+        data = json.loads(request.httprequest.data)
+        request.env['payment.acquirer'].sudo()._handle_stripe_webhook(data)
         return 'OK'


### PR DESCRIPTION
Json request was not availalble since it's not a json rpc request from Odoo
but a request from Stripe

opw:2449738