### PR TITLE
[IMP] base: remove setting 'Show Full Accounting Features'

### DIFF
--- a/addons/account/models/res_users.py
+++ b/addons/account/models/res_users.py
@@ -25,3 +25,19 @@ class Users(models.Model):
                                         "You should go in General Settings, and choose to display Product Prices\n"
                                         "either in 'Tax-Included' or in 'Tax-Excluded' mode\n"
                                         "(or switch twice the mode if you are already in the desired one)."))
+
+
+class GroupsView(models.Model):
+    _inherit = 'res.groups'
+
+    @api.model
+    def get_application_groups(self, domain):
+        # Overridden in order to remove 'Show Full Accounting Features' and
+        # 'Show Full Accounting Features - Readonly' in the 'res.users' form view to prevent confusion
+        group_account_user = self.env.ref('account.group_account_user', raise_if_not_found=False)
+        if group_account_user and group_account_user.category_id.xml_id == 'base.module_category_hidden':
+            domain += [('id', '!=', group_account_user.id)]
+        group_account_readonly = self.env.ref('account.group_account_readonly', raise_if_not_found=False)
+        if group_account_readonly and group_account_readonly.category_id.xml_id == 'base.module_category_hidden':
+            domain += [('id', '!=', group_account_readonly.id)]
+        return super().get_application_groups(domain)

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -9,7 +9,7 @@
         ```
          group_account_invoice ⇨ group_account_manager   (only those two should be used)
                                ⬂
-        group_account_readonly ⇨ group_account_user      (those two are only visible in debug)
+        group_account_readonly ⇨ group_account_user      (those two are only visible through a server action)
         ```
 
         Invoicing + Accounting:


### PR DESCRIPTION
The goal is to remove confusion between Invoicing and Accounting.

The current setting "Show Full Accounting Features" is confusing
and leads users to believe they have a full accounting package
in community, which is not true.

Task: 2578997

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
