### PR TITLE
[FIX] delivery: delivery should be recomputed if you change the shipping address

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -30,8 +30,9 @@ class SaleOrder(models.Model):
         for order in self:
             order.delivery_set = any(line.is_delivery for line in order.order_line)
 
-    @api.onchange('order_line', 'partner_id')
+    @api.onchange('order_line', 'partner_id', 'partner_shipping_id')
     def onchange_order_line(self):
+        self.ensure_one()
         delivery_line = self.order_line.filtered('is_delivery')
         if delivery_line:
             self.recompute_delivery_price = True


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Before this commit if you update the field partner_shipping_id, recompute_delivery_price is not updated.
It is logical that if you change the shipping address you should recompute delivery price.

**Current behavior before PR:**
https://user-images.githubusercontent.com/16716992/126178344-7806c89f-010b-4deb-8419-9ca61db6d1b0.mov


@JKE-be @tde-banana-odoo



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
