### PR TITLE
[IMP] base: avoid unused reading

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -115,7 +115,10 @@ class IrActions(models.Model):
                 if action_model and not IrModelAccess.check(action_model, mode='read', raise_exception=False):
                     # the user won't be able to read records
                     continue
-                result[binding_type].append(action.read()[0])
+                fields = ['name', 'binding_view_types']
+                if 'sequence' in action._fields:
+                    fields.append('sequence')
+                result[binding_type].append(action.read(fields)[0])
             except (AccessError, MissingError):
                 continue
 

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -251,7 +251,7 @@ class TestServerActions(TestServerActionsBase):
         self.env.user.write({'groups_id': [Command.link(group0.id)]})
 
         bindings = Actions.get_bindings('res.country')
-        self.assertItemsEqual(bindings.get('action'), self.action.read())
+        self.assertItemsEqual(bindings.get('action'), self.action.read(['name', 'sequence', 'binding_view_types']))
 
         self.action.with_context(self.context).run()
         self.assertEqual(self.test_country.vat_label, 'VatFromTest', 'vat label should be changed to VatFromTest')

--- a/odoo/addons/test_action_bindings/tests/test_bindings.py
+++ b/odoo/addons/test_action_bindings/tests/test_bindings.py
@@ -23,12 +23,12 @@ class TestActionBindings(common.TransactionCase):
         bindings = Actions.get_bindings('res.partner')
         self.assertItemsEqual(
             bindings['action'],
-            (action1 + action2).read(),
+            (action1 + action2).read(['name', 'binding_view_types']),
             "Wrong action bindings",
         )
         self.assertItemsEqual(
             bindings['report'],
-            action3.read(),
+            action3.read(['name', 'binding_view_types']),
             "Wrong action bindings",
         )
 
@@ -40,12 +40,12 @@ class TestActionBindings(common.TransactionCase):
         bindings = Actions.get_bindings('res.partner')
         self.assertItemsEqual(
             bindings['action'],
-            action1.read(),
+            action1.read(['name', 'binding_view_types']),
             "Wrong action bindings",
         )
         self.assertItemsEqual(
             bindings['report'],
-            action3.read(),
+            action3.read(['name', 'binding_view_types']),
             "Wrong action bindings",
         )
 


### PR DESCRIPTION
`load_views` calls `get_bindings` to render Action and Print menu. Before this
update, it read all action fields, including heavy computed fields
like `search_view` (which calls fields_view_get). But in fact just few fields
are used.

This slighly improves response time and data size.
