### PR TITLE
[FIX] event: Prevents discount to be aplied twice

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -108,6 +108,6 @@ class SaleOrderLine(models.Model):
 
     def _get_display_price(self, product):
         if self.event_ticket_id and self.event_id:
-            return self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id).price_reduce
+            return self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id).price
         else:
             return super()._get_display_price(product)

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -108,6 +108,10 @@ class SaleOrderLine(models.Model):
 
     def _get_display_price(self, product):
         if self.event_ticket_id and self.event_id:
-            return self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id).price
+            ticket = self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id)
+            if self.order_id.pricelist_id.discount_policy == 'with_discount':
+                return ticket.price
+            else:
+                return ticket.price_reduce
         else:
             return super()._get_display_price(product)

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -109,7 +109,7 @@ class SaleOrderLine(models.Model):
     def _get_display_price(self, product):
         if self.event_ticket_id and self.event_id:
             ticket = self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id)
-            if self.order_id.pricelist_id.discount_policy == 'with_discount':
+            if self.order_id.pricelist_id.discount_policy == 'without_discount':
                 return ticket.price
             else:
                 return ticket.price_reduce

--- a/doc/cla/individual/yaazkal.md
+++ b/doc/cla/individual/yaazkal.md
@@ -1,0 +1,11 @@
+Colombia, 2021-07-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Juand David Hurtado G. yaazkal@gmail.com https://github.com/yaazkal

--- a/doc/cla/individual/yaazkal.md
+++ b/doc/cla/individual/yaazkal.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Juand David Hurtado G. yaazkal@gmail.com https://github.com/yaazkal
+Juan David Hurtado G. yaazkal@gmail.com https://github.com/yaazkal


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a price rule or discount is configured for the product configured as the event ticket and the pricelist is configured with the option 'Show public price & discount to the customer' the discount is applied twice at the cart and checkout process.

This PR addresses issue https://github.com/odoo/odoo/issues/73935 

Current behavior before PR:
The discount is applied twice for an event.

Desired behavior after PR is merged:
The discount is applied only once.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
