### PR TITLE
[FIX] hr_skills: wrong field name in resume_line_view_search

### DIFF
--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -6,7 +6,7 @@
         <field name="model">hr.resume.line</field>
         <field name="arch" type="xml">
             <search string="Résume">
-                <filter string="Resumé line type" name="group_by_resume_line_type" context="{'group_by':'line_type'}"/>
+                <filter string="Resumé line type" name="group_by_resume_line_type" context="{'group_by':'line_type_id'}"/>
             </search>
         </field>
     </record>


### PR DESCRIPTION
The right name should be `line_type_id`. There is no field named `line_type` in the model `hr.resume.line`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
