### PR TITLE
[FIX] web: a few JS docstrings

### DIFF
--- a/addons/web/static/src/core/l10n/currency.js
+++ b/addons/web/static/src/core/l10n/currency.js
@@ -15,7 +15,7 @@ import { session } from "@web/session";
  *    the number of digits that should be used, instead of the default digits precision in the field.
  *    Note: if the currency defines a precision, the currency's one is used.
  *    The first number is always ignored (legacy constraint)
- * @returns The formatted currency
+ * @returns {string} The formatted currency
  */
 export function formatCurrency(value, cid, options = {}) {
     if (value === false) {

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -34,10 +34,11 @@ class LazyTranslatedString extends String {
  * translations are loaded, as class attributes or at the top-level of
  * an Odoo Web module
  *
- * @returns {{toString: () => string}}
+ * @param {string} term
+ * @returns {LazyTranslatedString}
  */
-export function _lt(str) {
-    return new LazyTranslatedString(str);
+export function _lt(term) {
+    return new LazyTranslatedString(term);
 }
 
 /*

--- a/addons/web/static/src/core/notifications/notification_service.js
+++ b/addons/web/static/src/core/notifications/notification_service.js
@@ -12,16 +12,16 @@ const AUTOCLOSE_DELAY = 4000;
  * @typedef {Object} NotificationButton
  * @property {string} name
  * @property {string} [icon]
- * @property {boolean} [primary]
- * @property {() => void} onClick
+ * @property {boolean} [primary=false]
+ * @property {function()} onClick
  *
  * @typedef {Object} NotificationOptions
  * @property {string} [title]
  * @property {"warning" | "danger" | "success" | "info"} [type]
- * @property {boolean} [sticky]
+ * @property {boolean} [sticky=false]
  * @property {string} [className]
- * @property {() => void} [onClose]
- * @property {NotificationButton} [buttons]
+ * @property {function()} [onClose]
+ * @property {NotificationButton[]} [buttons]
  */
 
 export const notificationService = {

--- a/addons/web/static/src/core/popover/popover_hook.js
+++ b/addons/web/static/src/core/popover/popover_hook.js
@@ -24,10 +24,10 @@ export function usePopover() {
          * @param {Object}                  props
          * @param {Object}                  [options]
          * @param {boolean}                 [options.closeOnClickAway=true]
-         * @param {() => void}              [options.onClose]
+         * @param {function()}              [options.onClose]
          * @param {string}                  [options.popoverClass]
          * @param {string}                  [options.position]
-         * @returns {() => void}
+         * @returns {function()}
          */
         add(target, Component, props, options = {}) {
             const newOptions = Object.create(options);

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -23,10 +23,10 @@ export const popoverService = {
          * @param {Object}                  props
          * @param {Object}                  [options]
          * @param {boolean}                 [options.closeOnClickAway=true]
-         * @param {() => void}              [options.onClose]
+         * @param {function()}              [options.onClose]
          * @param {string}                  [options.popoverClass]
          * @param {string}                  [options.position]
-         * @returns {() => void}
+         * @returns {function()}
          */
         function add(target, Component, props, options = {}) {
             const id = ++nextId;


### PR DESCRIPTION
jsdoc apparently doesn't understand arrow functions to indicate
function-valued attributes. Also add some default values in the
notifications typedefs.
