### PR TITLE
[FIX] stock: bypass optionnal delay description

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -152,7 +152,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends('rule_ids', 'product_id.seller_ids', 'product_id.seller_ids.delay')
     def _compute_lead_days(self):
-        for orderpoint in self:
+        for orderpoint in self.with_context(bypass_delay_description=True):
             if not orderpoint.product_id or not orderpoint.location_id:
                 orderpoint.lead_days_date = False
                 continue


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fine tuning of https://github.com/odoo/odoo/commit/c7b32e0795bc1573d81563f31a75fa44c64b39c2

@Whenrow it is a fine tuning to compute more fast qty_forecast, qty_to_order and _get_orderpoint_action()

@amoyaux 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
