### PR TITLE
[FIX] stock: date and float are not correctly show

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -13,7 +13,7 @@ from odoo import SUPERUSER_ID, _, api, fields, models, registry
 from odoo.addons.stock.models.stock_rule import ProcurementException
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import add, float_compare, frozendict, split_every
+from odoo.tools import add, float_compare, frozendict, split_every, format_date
 
 _logger = logging.getLogger(__name__)
 
@@ -128,6 +128,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends('rule_ids', 'product_id.seller_ids', 'product_id.seller_ids.delay')
     def _compute_json_popover(self):
+        FloatConverter = self.env['ir.qweb.field.float']
         for orderpoint in self:
             if not orderpoint.product_id or not orderpoint.location_id:
                 orderpoint.json_lead_days_popover = False
@@ -137,14 +138,14 @@ class StockWarehouseOrderpoint(models.Model):
                 'title': _('Replenishment'),
                 'icon': 'fa-area-chart',
                 'popoverTemplate': 'stock.leadDaysPopOver',
-                'lead_days_date': fields.Date.to_string(orderpoint.lead_days_date),
+                'lead_days_date': format_date(self.env, orderpoint.lead_days_date),
                 'lead_days_description': lead_days_description,
-                'today': fields.Date.to_string(fields.Date.today()),
+                'today': format_date(self.env, fields.Date.today()),
                 'trigger': orderpoint.trigger,
-                'qty_forecast': orderpoint.qty_forecast,
-                'qty_to_order': orderpoint.qty_to_order,
-                'product_min_qty': orderpoint.product_min_qty,
-                'product_max_qty': orderpoint.product_max_qty,
+                'qty_forecast': FloatConverter.value_to_html(orderpoint.qty_forecast, {'decimal_precision': 'Product Unit of Measure'}),
+                'qty_to_order': FloatConverter.value_to_html(orderpoint.qty_to_order, {'decimal_precision': 'Product Unit of Measure'}),
+                'product_min_qty': FloatConverter.value_to_html(orderpoint.product_min_qty, {'decimal_precision': 'Product Unit of Measure'}),
+                'product_max_qty': FloatConverter.value_to_html(orderpoint.product_max_qty, {'decimal_precision': 'Product Unit of Measure'}),
                 'product_uom_name': orderpoint.product_uom_name,
                 'virtual': orderpoint.trigger == 'manual' and orderpoint.create_uid.id == SUPERUSER_ID,
             })


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the popover date and float are wrongly formatted. This PR format date and float according to the user language.

Current behavior before PR:
![image](https://user-images.githubusercontent.com/16716992/126279142-a5cfb57c-91bf-42f3-992a-31a677e7f3f6.png)


Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/16716992/126279169-e873e2d5-28a8-4477-bb9a-e8e6f40b8c0e.png)


@amoyaux 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
