### PR TITLE
[FIX] hr_recruitment: Add user_id to alias defaults

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -109,8 +109,17 @@ class Job(models.Model):
                 'job_id': self.id,
                 'department_id': self.department_id.id,
                 'company_id': self.department_id.company_id.id if self.department_id else self.company_id.id,
+                'user_id': self.user_id.id,
             })
         return values
+
+    def write(self, vals):
+        res = super(Job, self).write(vals)
+        if 'user_id' in vals:
+            alias_defaults = ast.literal_eval(self.alias_defaults or "{}")
+            alias_defaults['user_id'] = self.user_id.id
+            self.alias_defaults = str(alias_defaults)
+        return res
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
Steps:
1. Create a recruitment with a recruiter set and an email alias
2. Send an email to the alias

The created hr.applicant record does not have a recruiter/user_id field despite the owner being set on the alias.

opw-2521189