### PR TITLE
[IMP] stock: speed up move lines generation for serial products

### DIFF
--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -110,7 +110,7 @@ class StockPutawayRule(models.Model):
                     return location_out
                 continue
 
-            child_locations = self.env['stock.location'].search([('id', 'child_of', location_out.id), ('usage', '=', 'internal')])
+            child_locations = location_out.child_internal_location_ids
             # check if already have the product/package type stored
             for location in child_locations:
                 if location in checked_locations:


### PR DESCRIPTION
No need to make the same query 10 k times during line generation. This saves
about 35% of the execution time

STEPS:
* create a PO for product tracked by serial, set qty=10000
* confirm the PO

PO validation benchmark:

```
BEFORE:
20223 7.007 11.960
20131 7.602 12.442

AFTER:
10159 4.786 8.168
10132 5.035 8.567
```

---

task-2575448
