### PR TITLE
[FIX] l10n_eu_service: specify country on tax creation

### DIFF
--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -68,6 +68,7 @@ class Company(models.Model):
                                 'type_tax_use': 'sale',
                                 'description': "%s%%" % tax_amount,
                                 'tax_group_id': self.env.ref('l10n_eu_service.oss_tax_group_%s' % str(tax_amount).replace('.','_')).id,
+                                'country_id': company.country_id.id,
                                 'sequence': 1000,
                                 'company_id': company.id,
                             })


### PR DESCRIPTION
account_tax.country_id is not correctly set for the new taxes created. Explicitly set the country_id to prevent issues.

Issue identified in task 2591541

