### PR TITLE
Flush only required fields in name search

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -762,9 +762,9 @@ class Partner(models.Model):
         self = self.with_user(name_get_uid) if name_get_uid else self
         # as the implementation is in SQL, we force the recompute of fields if necessary
         self.recompute(['display_name'])
-        self.flush()
         if args is None:
             args = []
+        self._flush_search(args, fields=['display_name', 'email', 'ref', 'vat'])
         order_by_rank = self.env.context.get('res_partner_search_mode') 
         if (name or order_by_rank) and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
             self.check_access_rights('read')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Automated actions may search on customer's name by using ilike operator. The performance can become bad when there is such an automated action and a lot of computed-stored fields.

Current behavior before PR:
When automated actions are triggered, a search using ('partner_id', 'ilike', 'test') will trigger a flush(), which recomputes computed-stored fields and automated actions are triggered for every computed field and do flushes, etc.

Desired behavior after PR is merged:
Flush only necessary fields when searching on res.partner.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
