### PR TITLE
[MIG][IMP] l10n_es: Add taxes for 'Retención 24%'

### DIFF
--- a/addons/l10n_es/data/account_data.xml
+++ b/addons/l10n_es/data/account_data.xml
@@ -51,6 +51,9 @@
         <record id="tax_group_retenciones_20" model="account.tax.group">
             <field name="name">Retenciones 20%</field>
         </record>
+        <record id="tax_group_retenciones_24" model="account.tax.group">
+            <field name="name">Retenciones 24%</field>
+        </record>
         <record id="tax_group_iva_21" model="account.tax.group">
             <field name="name">IVA 21%</field>
         </record>

--- a/addons/l10n_es/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_es/data/account_fiscal_position_template_data.xml
@@ -98,6 +98,11 @@
             <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
 
+        <record id="fp_irpf24" model="account.fiscal.position.template">
+            <field name="name">Retención IRPF 24%</field>
+            <field name="chart_template_id" ref="account_chart_template_common"/>
+        </record>
+
         <record id="fp_irpf20a" model="account.fiscal.position.template">
             <field name="name">Retención 20% arrendamientos</field>
             <field name="chart_template_id" ref="account_chart_template_common"/>
@@ -1802,6 +1807,213 @@
             <field name="position_id" ref="fp_irpf20"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva4_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_irpf20"/>
+        </record>
+
+        <!-- Retenciones IRPF 24% -->
+
+        <record id="fptt_irpf24sale_21b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva21b"/>
+        </record>
+        <record id="fptt_irpf24sale_21b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_21isp"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21isp"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva21isp"/>
+        </record>
+        <record id="fptt_irpf24sale_21isp_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21isp"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_21s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva21s"/>
+        </record>
+        <record id="fptt_irpf24sale_21s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva21s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_10b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva10b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva10b"/>
+        </record>
+        <record id="fptt_irpf24sale_10b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva10b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_10s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva10s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva10s"/>
+        </record>
+        <record id="fptt_irpf24sale_10s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva10s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_4b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva4b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva4b"/>
+        </record>
+        <record id="fptt_irpf24sale_4b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva4b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_4s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva4s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva4s"/>
+        </record>
+        <record id="fptt_irpf24sale_4s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva4s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_ex"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva0"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0"/>
+        </record>
+        <record id="fptt_irpf24sale_ex_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva0"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24sale_0_ns"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_ns"/>
+        </record>
+        <record id="ptt_irpf24sale_0_ns_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_21b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva21_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva21_bc"/>
+        </record>
+        <record id="fptt_irpf24_21b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva21_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_21s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva21_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva21_sc"/>
+        </record>
+        <record id="fptt_irpf24_21s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva21_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_10b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva10_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva10_bc"/>
+        </record>
+        <record id="fptt_irpf24_10b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva10_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_10s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva10_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva10_sc"/>
+        </record>
+        <record id="fptt_irpf24_10s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva10_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_4b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva4_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva4_bc"/>
+        </record>
+        <record id="fptt_irpf24_4b_2" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva4_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_4s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva4_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva4_sc"/>
+        </record>
+        <record id="fptt_irpf24_4s_2" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva4_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24_0" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva0_bc"/>
+        </record>
+        <record id="fptt_irpf24_0_2" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24purchase_0_ns_b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_ns_b"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva0_ns_b"/>
+        </record>
+        <record id="fptt_irpf24purchase_0_ns_b_2" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_ns_b"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
+        </record>
+        <record id="fptt_irpf24purchase_0_ns"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva0_ns"/>
+        </record>
+        <record id="fptt_irpf24purchase_0_ns_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_irpf24"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_ns"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_irpf24"/>
         </record>
 
         <!-- Retenciones IRPF 15% -->

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -1072,6 +1072,18 @@
         <field name="tax_group_id" ref="tax_group_retenciones_9"/>
         <field name="tag_ids" eval="[(6, False, [ref('mod_111_08'), ref('mod_111_09')])]"/>
     </record>
+    <record id="account_tax_template_p_irpf24" model="account.tax.template">
+        <field name="description">P_IRPF24</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_4751"/>
+        <field name="name">Retenciones IRPF 24%</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_4751"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="-24"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_retenciones_24"/>
+        <field name="tag_ids" eval="[(6, False, [ref('mod_111_08'), ref('mod_111_09')])]"/>
+    </record>
     <record id="account_tax_template_s_irpf20" model="account.tax.template">
         <field name="description">S_IRPF20</field>
         <field name="type_tax_use">sale</field>
@@ -1093,6 +1105,17 @@
         <field name="amount" eval="-20"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_retenciones_20"/>
+    </record>
+    <record id="account_tax_template_s_irpf24" model="account.tax.template">
+        <field name="description">S_IRPF24</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_473"/>
+        <field name="name">Retenciones a cuenta IRPF 24%</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_473"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="-24"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_retenciones_24"/>
     </record>
     <record id="account_tax_template_p_iva12_agr" model="account.tax.template">
         <field name="description">P_IVA12_AGR</field>


### PR DESCRIPTION
In https://www.agenciatributaria.es/AEAT.internet/Inicio/La_Agencia_Tributaria/Campanas/Retenciones/Cuadro_informativo_tipos_de_retencion_aplicables__2020_.shtml
we can check that this retention fee is applied for
'Rendimientos del art. 75.2.b): cesión derecho de imagen   (art. 101.1 RIRPF)'

It's not the regular retention, but there are cases where it can be
used, so we need to support it the same as others.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
