### PR TITLE
[IMP] contact: Add a color picker on the 'Contact Tags' sections

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -76,7 +76,7 @@ class PartnerCategory(models.Model):
         return randint(1, 11)
 
     name = fields.Char(string='Tag Name', required=True, translate=True)
-    color = fields.Integer(string='Color Index', default=_get_default_color)
+    color = fields.Integer(string='Color', default=_get_default_color)
     parent_id = fields.Many2one('res.partner.category', string='Parent Category', index=True, ondelete='cascade')
     child_ids = fields.One2many('res.partner.category', 'parent_id', string='Child Tags')
     active = fields.Boolean(default=True, help="The active field allows you to hide the category without removing it.")

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -614,9 +614,10 @@
                 <form string="Contact Tag">
                     <sheet>
                         <group col="4">
-                            <field name="name"/>
-                            <field name="active" widget="boolean_toggle"/>
+                            <field name="name" placeholder='e.g. "Consulting Services"'/>
+                            <field name="color" widget="color_picker"/>
                             <field name="parent_id"/>
+                            <field name="active" widget="boolean_toggle"/>
                         </group>
                     </sheet>
                 </form>
@@ -630,6 +631,7 @@
             <field name="arch" type="xml">
                 <tree string="Contact Tags">
                     <field name="display_name"/>
+                    <field name="color" widget="color_picker"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR applies some minor changes to the 'Contact' module: It will (1) add a color picker to the 'Contact Tags' sections, (2) update the placeholder of the field `name` and (3) update the label of the field `color`.

Current behavior before PR:
The list view and the form view of the 'Contact Tags' sections do not have a color picker.

Desired behavior after PR is merged:
The list view and the form view of the 'Contact Tags' sections have a color picker.

Task id: 2608410

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
