### PR TITLE
[FIX] mrp: set reference of split SM

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1510,6 +1510,7 @@ class StockMove(models.Model):
         if self.env.context.get('source_location_id'):
             defaults['location_id'] = self.env.context['source_location_id']
         new_move = self.with_context(rounding_method='HALF-UP').copy(defaults)
+        new_move.write({'reference': self.reference})
 
         # FIXME: pim fix your crap
         # Update the original `product_qty` of the move. Use the general product's decimal


### PR DESCRIPTION
When splitting a stock move line, the new one won't have the reference
defined on the original one.

To reproduce the error:
(Need account_accountant. Enable debug mode)
1. In Settings, enable "Multi-Step Routes"
2. Edit the company's warehouse:
    - Manufacture: 3 steps
3. Create 2 products P_compo, P_finished
    - Both storable
    - Both with a cost > 0
    - Qty on Hand of P_compo: 3
4. Create a BoM
    - Product: P_finished
    - Components: 1 x P_compo
5. Create a MO:
    - Product: P_finished
    - Quantity: 3
6. Mark as Todo
7. Validate the incoming transfer
8. Back to MO, Produce 1 P_finished
9. Post Inventory
10. Open associated Product Moves

Error: One stock move line hasn't a correct reference ("New" instead of
"WH/MO/...."). As a result, when producing the two last P_finished and
marking the MO as done, if the user consults the stock valuation layer
of the last two components consumed, the Description will be incorrect
too ("New - <P_compo's name>" instead of "WH/MO/.... - <P_compo's
name>")

The reference of the stock moves (Pre-Production -> Production) is
defined on manufacturing order creation:
https://github.com/odoo/odoo/blob/8e169e4c8ba408dc61a2a1c9cc8847264660c4c5/addons/mrp/models/mrp_production.py#L529-L533

However, when splitting a stock move line, the reference of the new
stock move line is never defined.

OPW-2522697