### PR TITLE
[FIX] l10n_eu_service: set country on new taxes

### DIFF
--- a/addons/l10n_eu_service/models/res_company.py
+++ b/addons/l10n_eu_service/models/res_company.py
@@ -69,6 +69,7 @@ class Company(models.Model):
                                 'type_tax_use': 'sale',
                                 'description': "%s%%" % tax_amount,
                                 'tax_group_id': self.env.ref('l10n_eu_service.%s' % tax_group_fid).id,
+                                'country_id': company.account_fiscal_country_id.id,
                                 'sequence': 1000,
                                 'company_id': company.id,
                             })


### PR DESCRIPTION
Since 14.3, Taxes have a country field. Newly created taxes don't always have the correct country set, thereby making the tax unusable.

Issue identified in task 2591541
