### PR TITLE
[FIX] wesbite: fix wrong encoding from page generated by configurator

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -370,7 +370,7 @@ class Website(models.Model):
                 try:
                     view_id = self.env['website'].with_context(website_id=website.id).viewref(snippet)
                     if view_id:
-                        el = html.fromstring(view_id._render(values=cta_data))
+                        el = html.fromstring(view_id._render(values=cta_data).decode())
 
                         # Add the data-snippet attribute to identify the snippet
                         # for compatibility code


### PR DESCRIPTION
Before this commit, some snippets that contains special charactere like –
was wrongly displayed, since we removed the call to pycompat that did a
decode('utf-8') in previous version.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
