### PR TITLE
[web] image reload fix

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2370,7 +2370,7 @@ var AttachmentImage = AbstractField.extend({
     _render: function () {
         if (this.value) {
             this.$el.empty().append($('<img>/', {
-                src: "/web/image/" + this.value.data.id + "?unique=1",
+                src: "/web/image/" + this.value.data.id + "?unique=" + new Date(),
                 title: this.value.data.display_name,
                 alt: _t("Image")
             }));


### PR DESCRIPTION
Currently, when the user updates the task to add an image, the new image not
going to visible in the kanban view once an image is uploaded without forcing the
user to reload the page

This is happening because of the same URL for the images. Due to cache, it will
display the old one instead newly uploaded one.

With this commit, put a unique URL and now a new image will
going to be visible in the kanban view once an image is uploaded without forcing
the user to reload the page


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
