### PR TITLE
[FIX] crm_iap_lead: readonly contact number qty

### DIFF
--- a/addons/crm_iap_lead/views/crm_iap_lead_views.xml
+++ b/addons/crm_iap_lead/views/crm_iap_lead_views.xml
@@ -86,7 +86,7 @@
 
                     <group name="contacts" attrs="{'invisible': [('search_type', '!=', 'people')]}">
                         <div>
-                            <field name="contact_number" attrs="{'readonly': [('state', '!=', 'draft')], 'required': [('search_type', '=', 'people')]}" nolabel="1" class="col-md-1"/>
+                            <field name="contact_number" attrs="{'readonly': [('state', '=', 'done')], 'required': [('search_type', '=', 'people')]}" nolabel="1" class="col-md-1"/>
                              <span class="col-md-6">Extra contacts per Company</span>
                         </div>
                     </group>


### PR DESCRIPTION
PURPOSE

Right now, for the lead mining request, `contact_number` field is only
editable when the request is in draft state. However, like the most
other fields, this one should be editable for the failed request so
that user can decide how many contacts should be fetched before
submitting the request again.

SPECIFICATION

This commit fixes the behavior by making `contact_number` field
readonly for the successfully completed mining request only.

Task-ID: 2605708

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
