### PR TITLE
[FIX] web : dark purple color doesn't work

### DIFF
--- a/addons/web/static/src/scss/secondary_variables.scss
+++ b/addons/web/static/src/scss/secondary_variables.scss
@@ -15,7 +15,7 @@ $o-colors-secondary: #aa4b6b, #30C381, #97743a, #F7CD1F, #4285F4, #8E24AA,
 
 // UI custom colors, complete list
 $o-colors-complete: join(
-    set-nth(set-nth($o-colors, 1, #134E5E), 6, #3daec3),
+    set-nth($o-colors, 1, #134E5E),
     $o-colors-secondary
 )!default;
 


### PR DESCRIPTION
Step to reproduce

- go to planning app
- configuration > roles
- set the color of a role to dark purple
- schedule > by role

The dark purple is not set, instead of that, #3daec3 is displayed.

opw-2601898

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
