### PR TITLE
[FIX] l10n_it_edi: allow to create customer w/o tva


### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
 
     @api.model
     def _l10n_it_normalize_codice_fiscale(self, codice):
-        if re.match(r'^IT[0-9]{11}$', codice):
+        if codice and re.match(r'^IT[0-9]{11}$', codice):
             return codice[2:13]
         return codice
 


### PR DESCRIPTION

Take into account the case where vat of a customer is not set, otherwise
with l10n_it_edi installed (after 3741e141e5) it's not possible to
create them.

opw-2608759
opw-2607887
opw-2608008
opw-2608759
opw-2608031
opw-2608697
opw-2608698
opw-2608814
