### PR TITLE
[FIX] l10n_ma: Update user_type_id for some account template 

### DIFF
--- a/addons/l10n_ma/data/l10n_ma_chart_data.xml
+++ b/addons/l10n_ma/data/l10n_ma_chart_data.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-15"?>
 <odoo>
         <!--     
-        Plan comptable général pour le Maroc.
+        Plan comptable gÃ©nÃ©ral pour le Maroc.
     Version du fichier : 13-10-2010
-    Mis en place par la société Kazacube - partenaire OpenERP au Maroc
-    Vérifié et validé par le cabinet SEDDIK d'expertise comptable, Casablanca.
+    Mis en place par la sociÃ©tÃ© Kazacube - partenaire OpenERP au Maroc
+    VÃ©rifiÃ© et validÃ© par le cabinet SEDDIK d'expertise comptable, Casablanca.
       --> 
     <menuitem id="account_reports_ma_statements_menu" name="Morocco" parent="account.menu_finance_reports" sequence="0" groups="account.group_account_user"/>
 
@@ -42,13 +42,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1119" model="account.account.template">
-    <field name="name">Actionnaires, capital souscrit-non appelé</field>
+    <field name="name">Actionnaires, capital souscrit-non appelÃ©</field>
     <field name="code">1119</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1121" model="account.account.template">
-    <field name="name">Primes d'émission</field>
+    <field name="name">Primes d'Ã©mission</field>
     <field name="code">1121</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -66,73 +66,73 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1130" model="account.account.template">
-    <field name="name">Écarts de réévaluation</field>
+    <field name="name">Ãcarts de rÃ©Ã©valuation</field>
     <field name="code">1130</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1140" model="account.account.template">
-    <field name="name">Réserve légale</field>
+    <field name="name">RÃ©serve lÃ©gale</field>
     <field name="code">1140</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1151" model="account.account.template">
-    <field name="name">Réserves statutaires ou contractuelles</field>
+    <field name="name">RÃ©serves statutaires ou contractuelles</field>
     <field name="code">1151</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1152" model="account.account.template">
-    <field name="name">Réserves facultatives</field>
+    <field name="name">RÃ©serves facultatives</field>
     <field name="code">1152</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1155" model="account.account.template">
-    <field name="name">Réserves réglementées</field>
+    <field name="name">RÃ©serves rÃ©glementÃ©es</field>
     <field name="code">1155</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1161" model="account.account.template">
-    <field name="name">Report à  nouveau (solde créditeur)</field>
+    <field name="name">Report Ã Â  nouveau (solde crÃ©diteur)</field>
     <field name="code">1161</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1169" model="account.account.template">
-    <field name="name">Report à  nouveau (solde débiteur)</field>
+    <field name="name">Report Ã Â  nouveau (solde dÃ©biteur)</field>
     <field name="code">1169</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1181" model="account.account.template">
-    <field name="name">Résultats nets en instance d'affectation (solde créditeur)</field>
+    <field name="name">RÃ©sultats nets en instance d'affectation (solde crÃ©diteur)</field>
     <field name="code">1181</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1189" model="account.account.template">
-    <field name="name">Résultats nets en instance d'affectation (solde débiteur)</field>
+    <field name="name">RÃ©sultats nets en instance d'affectation (solde dÃ©biteur)</field>
     <field name="code">1189</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1191" model="account.account.template">
-    <field name="name">Résultat net de l'exercice (solde créditeur)</field>
+    <field name="name">RÃ©sultat net de l'exercice (solde crÃ©diteur)</field>
     <field name="code">1191</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1199" model="account.account.template">
-    <field name="name">Résultat net de l'exercice (solde débiteur)</field>
+    <field name="name">RÃ©sultat net de l'exercice (solde dÃ©biteur)</field>
     <field name="code">1199</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1311" model="account.account.template">
-    <field name="name">Subventions d'investissement reçues</field>
+    <field name="name">Subventions d'investissement reÃ§ues</field>
     <field name="code">1311</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -144,7 +144,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1351" model="account.account.template">
-    <field name="name">Provisions pour amortissements dérogatoires</field>
+    <field name="name">Provisions pour amortissements dÃ©rogatoires</field>
     <field name="code">1351</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -174,7 +174,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1358" model="account.account.template">
-    <field name="name">Autres provisions réglementées</field>
+    <field name="name">Autres provisions rÃ©glementÃ©es</field>
     <field name="code">1358</field>
     <field name="user_type_id" ref="account.data_account_type_equity"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -186,7 +186,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1481" model="account.account.template">
-    <field name="name">Emprunts auprès des établissements de crédit</field>
+    <field name="name">Emprunts auprÃšs des Ã©tablissements de crÃ©dit</field>
     <field name="code">1481</field>
     <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -198,7 +198,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1483" model="account.account.template">
-    <field name="name">Dettes rattachées à  des participations</field>
+    <field name="name">Dettes rattachÃ©es Ã Â  des participations</field>
     <field name="code">1483</field>
     <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -210,7 +210,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1485" model="account.account.template">
-    <field name="name">Avances reçues et comptes courants bloqués</field>
+    <field name="name">Avances reÃ§ues et comptes courants bloquÃ©s</field>
     <field name="code">1485</field>
     <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -222,7 +222,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1487" model="account.account.template">
-    <field name="name">Dépôts et cautionnements reçues</field>
+    <field name="name">DÃ©pÃŽts et cautionnements reÃ§ues</field>
     <field name="code">1487</field>
     <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -240,7 +240,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1512" model="account.account.template">
-    <field name="name">Provisions pour garanties données aux clients</field>
+    <field name="name">Provisions pour garanties donnÃ©es aux clients</field>
     <field name="code">1512</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -252,13 +252,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1514" model="account.account.template">
-    <field name="name">Provision pour pertes sur marchés à  terme</field>
+    <field name="name">Provision pour pertes sur marchÃ©s Ã Â  terme</field>
     <field name="code">1514</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1515" model="account.account.template">
-    <field name="name">Provisions pour amendes, double droits, pénalités</field>
+    <field name="name">Provisions pour amendes, double droits, pÃ©nalitÃ©s</field>
     <field name="code">1515</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -276,7 +276,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1551" model="account.account.template">
-    <field name="name">Provisions pour impôts</field>
+    <field name="name">Provisions pour impÃŽts</field>
     <field name="code">1551</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -288,7 +288,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1555" model="account.account.template">
-    <field name="name">Provisions pour charges à  répartir sur plusieurs exercices</field>
+    <field name="name">Provisions pour charges Ã Â  rÃ©partir sur plusieurs exercices</field>
     <field name="code">1555</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -300,19 +300,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1601" model="account.account.template">
-    <field name="name">Comptes de liaison du siège</field>
+    <field name="name">Comptes de liaison du siÃšge</field>
     <field name="code">1601</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1605" model="account.account.template">
-    <field name="name">Comptes de liaison des établissements</field>
+    <field name="name">Comptes de liaison des Ã©tablissements</field>
     <field name="code">1605</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_1710" model="account.account.template">
-    <field name="name">Augmentation des créances immobilisées</field>
+    <field name="name">Augmentation des crÃ©ances immobilisÃ©es</field>
     <field name="code">1710</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -330,7 +330,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2112" model="account.account.template">
-    <field name="name">Frais préalables au démarrage</field>
+    <field name="name">Frais prÃ©alables au dÃ©marrage</field>
     <field name="code">2112</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -342,7 +342,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2114" model="account.account.template">
-    <field name="name">Frais sur opérations de fusions, scissions et transformations</field>
+    <field name="name">Frais sur opÃ©rations de fusions, scissions et transformations</field>
     <field name="code">2114</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -354,13 +354,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2117" model="account.account.template">
-    <field name="name">Frais de publicité</field>
+    <field name="name">Frais de publicitÃ©</field>
     <field name="code">2117</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2118" model="account.account.template">
-    <field name="name">Autres frais préliminaires</field>
+    <field name="name">Autres frais prÃ©liminaires</field>
     <field name="code">2118</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -372,13 +372,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2125" model="account.account.template">
-    <field name="name">Frais d'émission des emprunts</field>
+    <field name="name">Frais d'Ã©mission des emprunts</field>
     <field name="code">2125</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2128" model="account.account.template">
-    <field name="name">Autres charges à  répartir</field>
+    <field name="name">Autres charges Ã Â  rÃ©partir</field>
     <field name="code">2128</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -390,7 +390,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2210" model="account.account.template">
-    <field name="name">Immobilisation en recherche et développement</field>
+    <field name="name">Immobilisation en recherche et dÃ©veloppement</field>
     <field name="code">2210</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -420,13 +420,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2312" model="account.account.template">
-    <field name="name">Terrains aménagés</field>
+    <field name="name">Terrains amÃ©nagÃ©s</field>
     <field name="code">2312</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2313" model="account.account.template">
-    <field name="name">Terrains bâtis</field>
+    <field name="name">Terrains bÃ¢tis</field>
     <field name="code">2313</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -438,7 +438,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2316" model="account.account.template">
-    <field name="name">Agencements et aménagements de terrains</field>
+    <field name="name">Agencements et amÃ©nagements de terrains</field>
     <field name="code">2316</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -450,19 +450,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_23211" model="account.account.template">
-    <field name="name">Bâtiments industriels (A,B,,,)</field>
+    <field name="name">BÃ¢timents industriels (A,B,,,)</field>
     <field name="code">23211</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_23214" model="account.account.template">
-    <field name="name">Bâtiments Administratifs et commerciaux</field>
+    <field name="name">BÃ¢timents Administratifs et commerciaux</field>
     <field name="code">23214</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_23218" model="account.account.template">
-    <field name="name">Autres bâtiments</field>
+    <field name="name">Autres bÃ¢timents</field>
     <field name="code">23218</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -480,7 +480,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2327" model="account.account.template">
-    <field name="name">Agencements et aménagements des constructions</field>
+    <field name="name">Agencements et amÃ©nagements des constructions</field>
     <field name="code">2327</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -498,7 +498,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_23321" model="account.account.template">
-    <field name="name">Matériel</field>
+    <field name="name">MatÃ©riel</field>
     <field name="code">23321</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -510,19 +510,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2333" model="account.account.template">
-    <field name="name">Emballages récupérables identifiables</field>
+    <field name="name">Emballages rÃ©cupÃ©rables identifiables</field>
     <field name="code">2333</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2338" model="account.account.template">
-    <field name="name">Autres installations techniques, matériel et outillage</field>
+    <field name="name">Autres installations techniques, matÃ©riel et outillage</field>
     <field name="code">2338</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2340" model="account.account.template">
-    <field name="name">Matériel de transport</field>
+    <field name="name">MatÃ©riel de transport</field>
     <field name="code">2340</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -534,25 +534,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2352" model="account.account.template">
-    <field name="name">Matériel de bureau</field>
+    <field name="name">MatÃ©riel de bureau</field>
     <field name="code">2352</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2355" model="account.account.template">
-    <field name="name">Matériel informatique</field>
+    <field name="name">MatÃ©riel informatique</field>
     <field name="code">2355</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2356" model="account.account.template">
-    <field name="name">Agencements, installations et aménagements divers (biens n'appartenant pas à  l'entreprise)</field>
+    <field name="name">Agencements, installations et amÃ©nagements divers (biens n'appartenant pas Ã Â  l'entreprise)</field>
     <field name="code">2356</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2358" model="account.account.template">
-    <field name="name">Autres mobilier, matériel de bureau et aménagements divers</field>
+    <field name="name">Autres mobilier, matÃ©riel de bureau et amÃ©nagements divers</field>
     <field name="code">2358</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -570,25 +570,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2393" model="account.account.template">
-    <field name="name">Immobilisations corporelles en cours des installations techniques, matériel et outillage</field>
+    <field name="name">Immobilisations corporelles en cours des installations techniques, matÃ©riel et outillage</field>
     <field name="code">2393</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2394" model="account.account.template">
-    <field name="name">Immobilisations corporelles en cours de matériel de transport</field>
+    <field name="name">Immobilisations corporelles en cours de matÃ©riel de transport</field>
     <field name="code">2394</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2395" model="account.account.template">
-    <field name="name">Immobilisations corporelles en cours de mobilier, matériel de bureau et aménagements divers</field>
+    <field name="name">Immobilisations corporelles en cours de mobilier, matÃ©riel de bureau et amÃ©nagements divers</field>
     <field name="code">2395</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2397" model="account.account.template">
-    <field name="name">Avances et acomptes versés sur commandes d'immobilisations corporelles</field>
+    <field name="name">Avances et acomptes versÃ©s sur commandes d'immobilisations corporelles</field>
     <field name="code">2397</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -600,13 +600,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2411" model="account.account.template">
-    <field name="name">Prêts au personnel</field>
+    <field name="name">PrÃªts au personnel</field>
     <field name="code">2411</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2415" model="account.account.template">
-    <field name="name">Prêts aux associés</field>
+    <field name="name">PrÃªts aux associÃ©s</field>
     <field name="code">2415</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -618,7 +618,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2418" model="account.account.template">
-    <field name="name">Autres prêts</field>
+    <field name="name">Autres prÃªts</field>
     <field name="code">2418</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -630,7 +630,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_24813" model="account.account.template">
-    <field name="name">Bons d'équipement</field>
+    <field name="name">Bons d'Ã©quipement</field>
     <field name="code">24813</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -642,13 +642,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2483" model="account.account.template">
-    <field name="name">Créances rattachées à  des participations</field>
+    <field name="name">CrÃ©ances rattachÃ©es Ã Â  des participations</field>
     <field name="code">2483</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_24861" model="account.account.template">
-    <field name="name">Dépôts</field>
+    <field name="name">DÃ©pÃŽts</field>
     <field name="code">24861</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -660,13 +660,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2487" model="account.account.template">
-    <field name="name">Créances immobilisées</field>
+    <field name="name">CrÃ©ances immobilisÃ©es</field>
     <field name="code">2487</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2488" model="account.account.template">
-    <field name="name">Créances financières diverses</field>
+    <field name="name">CrÃ©ances financiÃšres diverses</field>
     <field name="code">2488</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -690,7 +690,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2710" model="account.account.template">
-    <field name="name">Diminution des créances immobilisées</field>
+    <field name="name">Diminution des crÃ©ances immobilisÃ©es</field>
     <field name="code">2710</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -708,7 +708,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28112" model="account.account.template">
-    <field name="name">Amortissements des frais préliminaires au démarrage</field>
+    <field name="name">Amortissements des frais prÃ©liminaires au dÃ©marrage</field>
     <field name="code">28112</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -720,7 +720,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28114" model="account.account.template">
-    <field name="name">Amortissements des frais sur opérations de fusions, scissions, et transformations</field>
+    <field name="name">Amortissements des frais sur opÃ©rations de fusions, scissions, et transformations</field>
     <field name="code">28114</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -732,13 +732,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28117" model="account.account.template">
-    <field name="name">Amortissements des frais de publicité</field>
+    <field name="name">Amortissements des frais de publicitÃ©</field>
     <field name="code">28117</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28118" model="account.account.template">
-    <field name="name">Amortissements des autres frais préliminaires</field>
+    <field name="name">Amortissements des autres frais prÃ©liminaires</field>
     <field name="code">28118</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -750,19 +750,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28125" model="account.account.template">
-    <field name="name">Amortissements des frais d'émission des emprunts</field>
+    <field name="name">Amortissements des frais d'Ã©mission des emprunts</field>
     <field name="code">28125</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28128" model="account.account.template">
-    <field name="name">Amortissements des autres charges à  répartir</field>
+    <field name="name">Amortissements des autres charges Ã Â  rÃ©partir</field>
     <field name="code">28128</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2821" model="account.account.template">
-    <field name="name">Amortissements de l'immobilisation en recherche et développement</field>
+    <field name="name">Amortissements de l'immobilisation en recherche et dÃ©veloppement</field>
     <field name="code">2821</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -792,13 +792,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28312" model="account.account.template">
-    <field name="name">Amortissements des terrains aménagés</field>
+    <field name="name">Amortissements des terrains amÃ©nagÃ©s</field>
     <field name="code">28312</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28313" model="account.account.template">
-    <field name="name">Amortissements des terrains bâtis</field>
+    <field name="name">Amortissements des terrains bÃ¢tis</field>
     <field name="code">28313</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -810,7 +810,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28316" model="account.account.template">
-    <field name="name">Amortissements des agencements et aménagements de terrains</field>
+    <field name="name">Amortissements des agencements et amÃ©nagements de terrains</field>
     <field name="code">28316</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -822,7 +822,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28321" model="account.account.template">
-    <field name="name">Amortissements des bâtiments</field>
+    <field name="name">Amortissements des bÃ¢timents</field>
     <field name="code">28321</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -840,7 +840,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28327" model="account.account.template">
-    <field name="name">Amortissements des installations, agencements et aménagements des constructions</field>
+    <field name="name">Amortissements des installations, agencements et amÃ©nagements des constructions</field>
     <field name="code">28327</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -858,25 +858,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28332" model="account.account.template">
-    <field name="name">Amortissements du matériel et outillage</field>
+    <field name="name">Amortissements du matÃ©riel et outillage</field>
     <field name="code">28332</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28333" model="account.account.template">
-    <field name="name">Amortissements des emballages récupérables identifiables</field>
+    <field name="name">Amortissements des emballages rÃ©cupÃ©rables identifiables</field>
     <field name="code">28333</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28338" model="account.account.template">
-    <field name="name">Amortissements des autres installations techniques, matériel et outillage</field>
+    <field name="name">Amortissements des autres installations techniques, matÃ©riel et outillage</field>
     <field name="code">28338</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2834" model="account.account.template">
-    <field name="name">Amortissements du matériel de transport</field>
+    <field name="name">Amortissements du matÃ©riel de transport</field>
     <field name="code">2834</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -888,25 +888,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28352" model="account.account.template">
-    <field name="name">Amortissements du matériel de bureau</field>
+    <field name="name">Amortissements du matÃ©riel de bureau</field>
     <field name="code">28352</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28355" model="account.account.template">
-    <field name="name">Amortissements du matériel informatique</field>
+    <field name="name">Amortissements du matÃ©riel informatique</field>
     <field name="code">28355</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28356" model="account.account.template">
-    <field name="name">Amortissements des agencements, installations et aménagements divers</field>
+    <field name="name">Amortissements des agencements, installations et amÃ©nagements divers</field>
     <field name="code">28356</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_28358" model="account.account.template">
-    <field name="name">Amortissements des autres mobilier, matériel de bureau et aménagements divers</field>
+    <field name="name">Amortissements des autres mobilier, matÃ©riel de bureau et amÃ©nagements divers</field>
     <field name="code">28358</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -918,37 +918,37 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2920" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des immobilisations incorporelles</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des immobilisations incorporelles</field>
     <field name="code">2920</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2930" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des immobilisations corporelles</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des immobilisations corporelles</field>
     <field name="code">2930</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2941" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des prêts immobilisés</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des prÃªts immobilisÃ©s</field>
     <field name="code">2941</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2948" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des autres créances financières</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des autres crÃ©ances financiÃšres</field>
     <field name="code">2948</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2951" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des titres de participation</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des titres de participation</field>
     <field name="code">2951</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_2958" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des autres titres immobilisés</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des autres titres immobilisÃ©s</field>
     <field name="code">2958</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -956,246 +956,246 @@
   <record id="pcg_3111" model="account.account.template">
     <field name="name">Marchandises (groupe A)</field>
     <field name="code">3111</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3112" model="account.account.template">
     <field name="name">Marchandises (groupe B)</field>
     <field name="code">3112</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3116" model="account.account.template">
     <field name="name">Marchandises en cours de route</field>
     <field name="code">3116</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3118" model="account.account.template">
     <field name="name">Autres marchandises</field>
     <field name="code">3118</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31211" model="account.account.template">
-    <field name="name">Matières premières (groupe A)</field>
+    <field name="name">MatiÃšres premiÃšres (groupe A)</field>
     <field name="code">31211</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31212" model="account.account.template">
-    <field name="name">Matières premières (groupe B)</field>
+    <field name="name">MatiÃšres premiÃšres (groupe B)</field>
     <field name="code">31212</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31221" model="account.account.template">
-    <field name="name">Matières consommables (groupe A)</field>
+    <field name="name">MatiÃšres consommables (groupe A)</field>
     <field name="code">31221</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31222" model="account.account.template">
-    <field name="name">Matières consommables (groupe B)</field>
+    <field name="name">MatiÃšres consommables (groupe B)</field>
     <field name="code">31222</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31223" model="account.account.template">
     <field name="name">Combustibles</field>
     <field name="code">31223</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31224" model="account.account.template">
     <field name="name">Produits d'entretien</field>
     <field name="code">31224</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31225" model="account.account.template">
     <field name="name">Fournitures d'atelier et d'usine</field>
     <field name="code">31225</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31226" model="account.account.template">
     <field name="name">Fournitures de magasin</field>
     <field name="code">31226</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31227" model="account.account.template">
     <field name="name">Fournitures de bureau</field>
     <field name="code">31227</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31231" model="account.account.template">
     <field name="name">Emballages perdus</field>
     <field name="code">31231</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31232" model="account.account.template">
-    <field name="name">Emballages récupérables non identifiables</field>
+    <field name="name">Emballages rÃ©cupÃ©rables non identifiables</field>
     <field name="code">31232</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31233" model="account.account.template">
-    <field name="name">Emballages à  usage mixte</field>
+    <field name="name">Emballages Ã Â  usage mixte</field>
     <field name="code">31233</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3126" model="account.account.template">
-    <field name="name">Matières et fournitures consommables en cours de route</field>
+    <field name="name">MatiÃšres et fournitures consommables en cours de route</field>
     <field name="code">3126</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3128" model="account.account.template">
-    <field name="name">Autres matières et fournitures consommables</field>
+    <field name="name">Autres matiÃšres et fournitures consommables</field>
     <field name="code">3128</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31311" model="account.account.template">
     <field name="name">Biens produits en cours</field>
     <field name="code">31311</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31312" model="account.account.template">
-    <field name="name">Biens intermédiaires en cours</field>
+    <field name="name">Biens intermÃ©diaires en cours</field>
     <field name="code">31312</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31317" model="account.account.template">
-    <field name="name">Biens résiduels en cours</field>
+    <field name="name">Biens rÃ©siduels en cours</field>
     <field name="code">31317</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31341" model="account.account.template">
     <field name="name">Travaux en cours</field>
     <field name="code">31341</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31342" model="account.account.template">
-    <field name="name">Études en cours</field>
+    <field name="name">Ãtudes en cours</field>
     <field name="code">31342</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31343" model="account.account.template">
     <field name="name">Prestations en cours</field>
     <field name="code">31343</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3138" model="account.account.template">
     <field name="name">Autres produits en cours</field>
     <field name="code">3138</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31411" model="account.account.template">
-    <field name="name">Produits intermédiaires (groupe A)</field>
+    <field name="name">Produits intermÃ©diaires (groupe A)</field>
     <field name="code">31411</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31412" model="account.account.template">
-    <field name="name">Produits intermédiaires (groupe B)</field>
+    <field name="name">Produits intermÃ©diaires (groupe B)</field>
     <field name="code">31412</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31451" model="account.account.template">
-    <field name="name">Déchets</field>
+    <field name="name">DÃ©chets</field>
     <field name="code">31451</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31452" model="account.account.template">
     <field name="name">Rebuts</field>
     <field name="code">31452</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_31453" model="account.account.template">
-    <field name="name">Matières de récupération</field>
+    <field name="name">MatiÃšres de rÃ©cupÃ©ration</field>
     <field name="code">31453</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3148" model="account.account.template">
-    <field name="name">Autres produits intermédiaires et produits résiduels</field>
+    <field name="name">Autres produits intermÃ©diaires et produits rÃ©siduels</field>
     <field name="code">3148</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3151" model="account.account.template">
     <field name="name">Produits finis (groupe A)</field>
     <field name="code">3151</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3152" model="account.account.template">
     <field name="name">Produits finis (groupe B)</field>
     <field name="code">3152</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3156" model="account.account.template">
     <field name="name">Produits finis en cours de route</field>
     <field name="code">3156</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3158" model="account.account.template">
     <field name="name">Autres produits finis</field>
     <field name="code">3158</field>
-    <field name="user_type_id" ref="account.data_account_type_revenue"/>
+    <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3411" model="account.account.template">
-    <field name="name">Fournisseurs - avances et acomptes versés sur commandes d'exploitation</field>
+    <field name="name">Fournisseurs - avances et acomptes versÃ©s sur commandes d'exploitation</field>
     <field name="code">3411</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3413" model="account.account.template">
-    <field name="name">Fournisseurs - créances pour emballages et matériel à  rendre</field>
+    <field name="name">Fournisseurs - crÃ©ances pour emballages et matÃ©riel Ã Â  rendre</field>
     <field name="code">3413</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3417" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes à  obtenir - avoirs non encore reçus</field>
+    <field name="name">Rabais, remises et ristournes Ã Â  obtenir - avoirs non encore reÃ§us</field>
     <field name="code">3417</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3418" model="account.account.template">
-    <field name="name">Autres fournisseurs débiteurs</field>
+    <field name="name">Autres fournisseurs dÃ©biteurs</field>
     <field name="code">3418</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34211" model="account.account.template">
-    <field name="name">Clients - catégorie A</field>
+    <field name="name">Clients - catÃ©gorie A</field>
     <field name="code">34211</field>
     <field name="user_type_id" ref="account.data_account_type_receivable"/>
     <field name="reconcile" eval='True'/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34212" model="account.account.template">
-    <field name="name">Clients - catégorie B</field>
+    <field name="name">Clients - catÃ©gorie B</field>
     <field name="code">34212</field>
     <field name="user_type_id" ref="account.data_account_type_receivable"/>
     <field name="reconcile" eval='True'/>
@@ -1214,25 +1214,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3425" model="account.account.template">
-    <field name="name">Clients - effets à  recevoir</field>
+    <field name="name">Clients - effets Ã Â  recevoir</field>
     <field name="code">3425</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34271" model="account.account.template">
-    <field name="name">Clients - factures à  établir</field>
+    <field name="name">Clients - factures Ã Â  Ã©tablir</field>
     <field name="code">34271</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34272" model="account.account.template">
-    <field name="name">Créances sur travaux non encore facturés</field>
+    <field name="name">CrÃ©ances sur travaux non encore facturÃ©s</field>
     <field name="code">34272</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3428" model="account.account.template">
-    <field name="name">Autres clients et comptes rattachés</field>
+    <field name="name">Autres clients et comptes rattachÃ©s</field>
     <field name="code">3428</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1244,177 +1244,177 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3438" model="account.account.template">
-    <field name="name">Personnel - autres débiteurs</field>
+    <field name="name">Personnel - autres dÃ©biteurs</field>
     <field name="code">3438</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34511" model="account.account.template">
-    <field name="name">Subventions d'investissement à  recevoir</field>
+    <field name="name">Subventions d'investissement Ã Â  recevoir</field>
     <field name="code">34511</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34512" model="account.account.template">
-    <field name="name">Subventions d'exploitation à  recevoir</field>
+    <field name="name">Subventions d'exploitation Ã Â  recevoir</field>
     <field name="code">34512</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34513" model="account.account.template">
-    <field name="name">Subventions d'équilibre à  recevoir</field>
+    <field name="name">Subventions d'Ã©quilibre Ã Â  recevoir</field>
     <field name="code">34513</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3453" model="account.account.template">
-    <field name="name">Acomptes sur impôts sur les résultats</field>
+    <field name="name">Acomptes sur impÃŽts sur les rÃ©sultats</field>
     <field name="code">3453</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_34551" model="account.account.template">
-    <field name="name">Etat - TVA récupérable sur immobilisations</field>
+    <field name="name">Etat - TVA rÃ©cupÃ©rable sur immobilisations</field>
     <field name="code">34551</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3455207" model="account.account.template">
-    <field name="name">Etat - TVA récupérable sur charges 7%</field>
+    <field name="name">Etat - TVA rÃ©cupÃ©rable sur charges 7%</field>
     <field name="code">3455207</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3455210" model="account.account.template">
-    <field name="name">Etat - TVA récupérable sur charges 10%</field>
+    <field name="name">Etat - TVA rÃ©cupÃ©rable sur charges 10%</field>
     <field name="code">3455210</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3455214" model="account.account.template">
-    <field name="name">Etat - TVA récupérable sur charges 14%</field>
+    <field name="name">Etat - TVA rÃ©cupÃ©rable sur charges 14%</field>
     <field name="code">3455214</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3455220" model="account.account.template">
-    <field name="name">Etat - TVA récupérable sur charges 20%</field>
+    <field name="name">Etat - TVA rÃ©cupÃ©rable sur charges 20%</field>
     <field name="code">3455220</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3456" model="account.account.template">
-    <field name="name">Etat - crédit de TVA (suivant déclaration)</field>
+    <field name="name">Etat - crÃ©dit de TVA (suivant dÃ©claration)</field>
     <field name="code">3456</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3458" model="account.account.template">
-    <field name="name">Etat - autres comptes débiteurs</field>
+    <field name="name">Etat - autres comptes dÃ©biteurs</field>
     <field name="code">3458</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3461" model="account.account.template">
-    <field name="name">Associés - comptes d'apport en société</field>
+    <field name="name">AssociÃ©s - comptes d'apport en sociÃ©tÃ©</field>
     <field name="code">3461</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3462" model="account.account.template">
-    <field name="name">Actionnaires - capital souscrit et appelé non versé</field>
+    <field name="name">Actionnaires - capital souscrit et appelÃ© non versÃ©</field>
     <field name="code">3462</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3463" model="account.account.template">
-    <field name="name">Comptes courants des associés débiteurs</field>
+    <field name="name">Comptes courants des associÃ©s dÃ©biteurs</field>
     <field name="code">3463</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3464" model="account.account.template">
-    <field name="name">Associés - opérations faites en commun</field>
+    <field name="name">AssociÃ©s - opÃ©rations faites en commun</field>
     <field name="code">3464</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3467" model="account.account.template">
-    <field name="name">Créances rattachées aux comptes d'associés</field>
+    <field name="name">CrÃ©ances rattachÃ©es aux comptes d'associÃ©s</field>
     <field name="code">3467</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3468" model="account.account.template">
-    <field name="name">Autres comptes d'associés débiteurs</field>
+    <field name="name">Autres comptes d'associÃ©s dÃ©biteurs</field>
     <field name="code">3468</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3481" model="account.account.template">
-    <field name="name">Créances sur cessions d'immobilisations</field>
+    <field name="name">CrÃ©ances sur cessions d'immobilisations</field>
     <field name="code">3481</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3482" model="account.account.template">
-    <field name="name">Créances sur cessions d'éléments d'actif circulant</field>
+    <field name="name">CrÃ©ances sur cessions d'Ã©lÃ©ments d'actif circulant</field>
     <field name="code">3482</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3487" model="account.account.template">
-    <field name="name">Créances rattachées aux autres débiteurs</field>
+    <field name="name">CrÃ©ances rattachÃ©es aux autres dÃ©biteurs</field>
     <field name="code">3487</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3488" model="account.account.template">
-    <field name="name">Divers débiteurs</field>
+    <field name="name">Divers dÃ©biteurs</field>
     <field name="code">3488</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="reconcile" eval='True'/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3489" model="account.account.template">
-    <field name="name">Divers débiteurs (PoS)</field>
+    <field name="name">Divers dÃ©biteurs (PoS)</field>
     <field name="code">3489</field>
     <field name="user_type_id" ref="account.data_account_type_receivable"/>
     <field name="reconcile" eval='True'/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3491" model="account.account.template">
-    <field name="name">Charges constatées d'avance</field>
+    <field name="name">Charges constatÃ©es d'avance</field>
     <field name="code">3491</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3493" model="account.account.template">
-    <field name="name">Intérêts courus et non échus à  percevoir</field>
+    <field name="name">IntÃ©rÃªts courus et non Ã©chus Ã Â  percevoir</field>
     <field name="code">3493</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3495" model="account.account.template">
-    <field name="name">Comptes de répartition périodique des charges</field>
+    <field name="name">Comptes de rÃ©partition pÃ©riodique des charges</field>
     <field name="code">3495</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3497" model="account.account.template">
-    <field name="name">Comptes transitoires ou d'attente - débiteurs</field>
+    <field name="name">Comptes transitoires ou d'attente - dÃ©biteurs</field>
     <field name="code">3497</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3501" model="account.account.template">
-    <field name="name">Actions, partie libérée</field>
+    <field name="name">Actions, partie libÃ©rÃ©e</field>
     <field name="code">3501</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3502" model="account.account.template">
-    <field name="name">Actions, partie non libérée</field>
+    <field name="name">Actions, partie non libÃ©rÃ©e</field>
     <field name="code">3502</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1432,7 +1432,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_35062" model="account.account.template">
-    <field name="name">Bons de trésor</field>
+    <field name="name">Bons de trÃ©sor</field>
     <field name="code">35062</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1444,7 +1444,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3701" model="account.account.template">
-    <field name="name">Diminution des créances circulantes</field>
+    <field name="name">Diminution des crÃ©ances circulantes</field>
     <field name="code">3701</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1456,67 +1456,67 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3911" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des marchandises</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des marchandises</field>
     <field name="code">3911</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3912" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des matières et fournitures</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des matiÃšres et fournitures</field>
     <field name="code">3912</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3913" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des produits en cours</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des produits en cours</field>
     <field name="code">3913</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3914" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des produits intermédiaires</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des produits intermÃ©diaires</field>
     <field name="code">3914</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3915" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des produits finis</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des produits finis</field>
     <field name="code">3915</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3941" model="account.account.template">
-    <field name="name">Provisions pour dépréciation - fournisseurs débiteurs, avances et acomptes</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation - fournisseurs dÃ©biteurs, avances et acomptes</field>
     <field name="code">3941</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3942" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des clients et comptes rattachés</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des clients et comptes rattachÃ©s</field>
     <field name="code">3942</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3943" model="account.account.template">
-    <field name="name">Provisions pour dépréciation du personnel - débiteur</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation du personnel - dÃ©biteur</field>
     <field name="code">3943</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3946" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des comptes d'associés débiteurs</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des comptes d'associÃ©s dÃ©biteurs</field>
     <field name="code">3946</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3948" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des autres débiteurs</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des autres dÃ©biteurs</field>
     <field name="code">3948</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_3950" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des titres et valeurs de placement</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des titres et valeurs de placement</field>
     <field name="code">3950</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1535,7 +1535,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4415" model="account.account.template">
-    <field name="name">Fournisseurs - effets à  payer</field>
+    <field name="name">Fournisseurs - effets Ã Â  payer</field>
     <field name="code">4415</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1547,43 +1547,43 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4418" model="account.account.template">
-    <field name="name">Autres fournisseurs et comptes rattachés</field>
+    <field name="name">Autres fournisseurs et comptes rattachÃ©s</field>
     <field name="code">4418</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4421" model="account.account.template">
-    <field name="name">Clients - avances et acomptes reçus sur commandes en cours</field>
+    <field name="name">Clients - avances et acomptes reÃ§us sur commandes en cours</field>
     <field name="code">4421</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4425" model="account.account.template">
-    <field name="name">Clients - dettes pour emballages et matériel consignés</field>
+    <field name="name">Clients - dettes pour emballages et matÃ©riel consignÃ©s</field>
     <field name="code">4425</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4427" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes à  accorder - avoirs à  établir</field>
+    <field name="name">Rabais, remises et ristournes Ã Â  accorder - avoirs Ã Â  Ã©tablir</field>
     <field name="code">4427</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4428" model="account.account.template">
-    <field name="name">Autres clients créditeurs</field>
+    <field name="name">Autres clients crÃ©diteurs</field>
     <field name="code">4428</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4432" model="account.account.template">
-    <field name="name">Rémunérations dues au personnel</field>
+    <field name="name">RÃ©munÃ©rations dues au personnel</field>
     <field name="code">4432</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4433" model="account.account.template">
-    <field name="name">Dépôts du personnel créditeurs</field>
+    <field name="name">DÃ©pÃŽts du personnel crÃ©diteurs</field>
     <field name="code">4433</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1595,13 +1595,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4437" model="account.account.template">
-    <field name="name">Charges du personnel à  payer</field>
+    <field name="name">Charges du personnel Ã Â  payer</field>
     <field name="code">4437</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4438" model="account.account.template">
-    <field name="name">Personnel - autres créditeurs</field>
+    <field name="name">Personnel - autres crÃ©diteurs</field>
     <field name="code">4438</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1625,7 +1625,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4447" model="account.account.template">
-    <field name="name">Charges sociales à  payer</field>
+    <field name="name">Charges sociales Ã Â  payer</field>
     <field name="code">4447</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1637,7 +1637,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_44521" model="account.account.template">
-    <field name="name">Etat, taxe urbaine et taxe d'édilité</field>
+    <field name="name">Etat, taxe urbaine et taxe d'Ã©dilitÃ©</field>
     <field name="code">44521</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1655,85 +1655,85 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4453" model="account.account.template">
-    <field name="name">Etat, impôts sur les résultats</field>
+    <field name="name">Etat, impÃŽts sur les rÃ©sultats</field>
     <field name="code">4453</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_445507" model="account.account.template">
-    <field name="name">Etat, TVA facturée 7%</field>
+    <field name="name">Etat, TVA facturÃ©e 7%</field>
     <field name="code">445507</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_445510" model="account.account.template">
-    <field name="name">Etat, TVA facturée 10%</field>
+    <field name="name">Etat, TVA facturÃ©e 10%</field>
     <field name="code">445510</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_445514" model="account.account.template">
-    <field name="name">Etat, TVA facturée 14%</field>
+    <field name="name">Etat, TVA facturÃ©e 14%</field>
     <field name="code">445514</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_445520" model="account.account.template">
-    <field name="name">Etat, TVA facturée 20%</field>
+    <field name="name">Etat, TVA facturÃ©e 20%</field>
     <field name="code">445520</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4456" model="account.account.template">
-    <field name="name">Etat, TVA due (suivant déclarations)</field>
+    <field name="name">Etat, TVA due (suivant dÃ©clarations)</field>
     <field name="code">4456</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4457" model="account.account.template">
-    <field name="name">Etat, impôts et taxes à  payer</field>
+    <field name="name">Etat, impÃŽts et taxes Ã Â  payer</field>
     <field name="code">4457</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4458" model="account.account.template">
-    <field name="name">Etat - autres comptes créditeurs</field>
+    <field name="name">Etat - autres comptes crÃ©diteurs</field>
     <field name="code">4458</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4461" model="account.account.template">
-    <field name="name">Associés - capital à  rembourser</field>
+    <field name="name">AssociÃ©s - capital Ã Â  rembourser</field>
     <field name="code">4461</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4462" model="account.account.template">
-    <field name="name">Associés - versements reçus sur augmentation de capital</field>
+    <field name="name">AssociÃ©s - versements reÃ§us sur augmentation de capital</field>
     <field name="code">4462</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4463" model="account.account.template">
-    <field name="name">Comptes courants des associés créditeurs</field>
+    <field name="name">Comptes courants des associÃ©s crÃ©diteurs</field>
     <field name="code">4463</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4464" model="account.account.template">
-    <field name="name">Associés - opérations faites en commun</field>
+    <field name="name">AssociÃ©s - opÃ©rations faites en commun</field>
     <field name="code">4464</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4465" model="account.account.template">
-    <field name="name">Associés - dividendes à  payer</field>
+    <field name="name">AssociÃ©s - dividendes Ã Â  payer</field>
     <field name="code">4465</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4468" model="account.account.template">
-    <field name="name">Autres comptes d'associés - créditeurs</field>
+    <field name="name">Autres comptes d'associÃ©s - crÃ©diteurs</field>
     <field name="code">4468</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1751,50 +1751,50 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4484" model="account.account.template">
-    <field name="name">Obligations échues à  rembourser</field>
+    <field name="name">Obligations Ã©chues Ã Â  rembourser</field>
     <field name="code">4484</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4485" model="account.account.template">
-    <field name="name">Obligations, coupons à  payer</field>
+    <field name="name">Obligations, coupons Ã Â  payer</field>
     <field name="code">4485</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4487" model="account.account.template">
-    <field name="name">Dettes rattachées aux autres créanciers</field>
+    <field name="name">Dettes rattachÃ©es aux autres crÃ©anciers</field>
     <field name="code">4487</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4488" model="account.account.template">
-    <field name="name">Divers créanciers</field>
+    <field name="name">Divers crÃ©anciers</field>
     <field name="code">4488</field>
     <field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
     <field name="reconcile" eval='True'/>
   </record>
   <record id="pcg_4491" model="account.account.template">
-    <field name="name">Produits constatés d'avance</field>
+    <field name="name">Produits constatÃ©s d'avance</field>
     <field name="code">4491</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4493" model="account.account.template">
-    <field name="name">Intérêts courus et non échus à payer</field>
+    <field name="name">IntÃ©rÃªts courus et non Ã©chus Ã  payer</field>
     <field name="code">4493</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4495" model="account.account.template">
-    <field name="name">Comptes de répartition périodique des produits</field>
+    <field name="name">Comptes de rÃ©partition pÃ©riodique des produits</field>
     <field name="code">4495</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4497" model="account.account.template">
-    <field name="name">Comptes transitoires ou d'attente - créditeurs</field>
+    <field name="name">Comptes transitoires ou d'attente - crÃ©diteurs</field>
     <field name="code">4497</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1806,13 +1806,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4502" model="account.account.template">
-    <field name="name">Provisions pour garanties données aux clients</field>
+    <field name="name">Provisions pour garanties donnÃ©es aux clients</field>
     <field name="code">4502</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4505" model="account.account.template">
-    <field name="name">Provisions pour amendes, doubles droits et pénalités</field>
+    <field name="name">Provisions pour amendes, doubles droits et pÃ©nalitÃ©s</field>
     <field name="code">4505</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1824,7 +1824,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4507" model="account.account.template">
-    <field name="name">Provisions pour impôts</field>
+    <field name="name">Provisions pour impÃŽts</field>
     <field name="code">4507</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1836,7 +1836,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_4701" model="account.account.template">
-    <field name="name">Augmentation des créances circulantes</field>
+    <field name="name">Augmentation des crÃ©ances circulantes</field>
     <field name="code">4701</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1848,73 +1848,73 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_51111" model="account.account.template">
-    <field name="name">Chèques en portefeuille</field>
+    <field name="name">ChÃšques en portefeuille</field>
     <field name="code">51111</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_51112" model="account.account.template">
-    <field name="name">Chèques à  l'encaissement</field>
+    <field name="name">ChÃšques Ã Â  l'encaissement</field>
     <field name="code">51112</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_51131" model="account.account.template">
-    <field name="name">Effets échus à  encaisser</field>
+    <field name="name">Effets Ã©chus Ã Â  encaisser</field>
     <field name="code">51131</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_51132" model="account.account.template">
-    <field name="name">Effets à  l'encaissement</field>
+    <field name="name">Effets Ã Â  l'encaissement</field>
     <field name="code">51132</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5118" model="account.account.template">
-    <field name="name">Autres valeurs à  encaisser</field>
+    <field name="name">Autres valeurs Ã Â  encaisser</field>
     <field name="code">5118</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5146" model="account.account.template">
-    <field name="name">Chèques postaux</field>
+    <field name="name">ChÃšques postaux</field>
     <field name="code">5146</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5148" model="account.account.template">
-    <field name="name">Autres établissements financiers et assimilés (soldes débiteurs)</field>
+    <field name="name">Autres Ã©tablissements financiers et assimilÃ©s (soldes dÃ©biteurs)</field>
     <field name="code">5148</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5165" model="account.account.template">
-    <field name="name">Régies d'avances et accréditifs</field>
+    <field name="name">RÃ©gies d'avances et accrÃ©ditifs</field>
     <field name="code">5165</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5520" model="account.account.template">
-    <field name="name">Crédits d'escompte</field>
+    <field name="name">CrÃ©dits d'escompte</field>
     <field name="code">5520</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5530" model="account.account.template">
-    <field name="name">Crédits de trésorerie</field>
+    <field name="name">CrÃ©dits de trÃ©sorerie</field>
     <field name="code">5530</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5548" model="account.account.template">
-    <field name="name">Autres établissements financiers et assimilés (soldes créditeurs)</field>
+    <field name="name">Autres Ã©tablissements financiers et assimilÃ©s (soldes crÃ©diteurs)</field>
     <field name="code">5548</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_5900" model="account.account.template">
-    <field name="name">Provisions pour dépréciation des comptes de trésorerie</field>
+    <field name="name">Provisions pour dÃ©prÃ©ciation des comptes de trÃ©sorerie</field>
     <field name="code">5900</field>
     <field name="user_type_id" ref="account.data_account_type_current_assets"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1938,7 +1938,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6118" model="account.account.template">
-    <field name="name">Achats revendus de marchandises des exercices antérieurs</field>
+    <field name="name">Achats revendus de marchandises des exercices antÃ©rieurs</field>
     <field name="code">6118</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -1950,25 +1950,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61211" model="account.account.template">
-    <field name="name">Achats de matières premières A</field>
+    <field name="name">Achats de matiÃšres premiÃšres A</field>
     <field name="code">61211</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61212" model="account.account.template">
-    <field name="name">Achats de matières premières B</field>
+    <field name="name">Achats de matiÃšres premiÃšres B</field>
     <field name="code">61212</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61221" model="account.account.template">
-    <field name="name">Achats de matières et fournitures A</field>
+    <field name="name">Achats de matiÃšres et fournitures A</field>
     <field name="code">61221</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61222" model="account.account.template">
-    <field name="name">Achats de matières et fournitures B</field>
+    <field name="name">Achats de matiÃšres et fournitures B</field>
     <field name="code">61222</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2010,25 +2010,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61232" model="account.account.template">
-    <field name="name">Achats d'emballages récupérables non identifiables</field>
+    <field name="name">Achats d'emballages rÃ©cupÃ©rables non identifiables</field>
     <field name="code">61232</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61233" model="account.account.template">
-    <field name="name">Achats d'emballages à  usage mixte</field>
+    <field name="name">Achats d'emballages Ã Â  usage mixte</field>
     <field name="code">61233</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61241" model="account.account.template">
-    <field name="name">Variation des stocks de matières premières</field>
+    <field name="name">Variation des stocks de matiÃšres premiÃšres</field>
     <field name="code">61241</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61242" model="account.account.template">
-    <field name="name">Variation des stocks de matières et fournitures consommables</field>
+    <field name="name">Variation des stocks de matiÃšres et fournitures consommables</field>
     <field name="code">61242</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2040,7 +2040,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61251" model="account.account.template">
-    <field name="name">Achats de fournitures non stockables (eau, électricité,,)</field>
+    <field name="name">Achats de fournitures non stockables (eau, Ã©lectricitÃ©,,)</field>
     <field name="code">61251</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2052,7 +2052,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61253" model="account.account.template">
-    <field name="name">Achats de petit outillage et petit équipement</field>
+    <field name="name">Achats de petit outillage et petit Ã©quipement</field>
     <field name="code">61253</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2070,7 +2070,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61262" model="account.account.template">
-    <field name="name">Achats des études</field>
+    <field name="name">Achats des Ã©tudes</field>
     <field name="code">61262</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2082,19 +2082,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6128" model="account.account.template">
-    <field name="name">Achats de matières et de fournitures des exercices antérieurs</field>
+    <field name="name">Achats de matiÃšres et de fournitures des exercices antÃ©rieurs</field>
     <field name="code">6128</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61291" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes obtenus sur achats de matières premières</field>
+    <field name="name">Rabais, remises et ristournes obtenus sur achats de matiÃšres premiÃšres</field>
     <field name="code">61291</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61292" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes obtenus sur achats de matières et fournitures consommables</field>
+    <field name="name">Rabais, remises et ristournes obtenus sur achats de matiÃšres et fournitures consommables</field>
     <field name="code">61292</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2106,19 +2106,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61295" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes obtenus sur achats non stockés</field>
+    <field name="name">Rabais, remises et ristournes obtenus sur achats non stockÃ©s</field>
     <field name="code">61295</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61296" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes obtenus sur achats de travaux, études et prestations de service</field>
+    <field name="name">Rabais, remises et ristournes obtenus sur achats de travaux, Ã©tudes et prestations de service</field>
     <field name="code">61296</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61298" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes obtenus sur achats de matières et fournitures des exercices antérieurs</field>
+    <field name="name">Rabais, remises et ristournes obtenus sur achats de matiÃšres et fournitures des exercices antÃ©rieurs</field>
     <field name="code">61298</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2136,25 +2136,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61313" model="account.account.template">
-    <field name="name">Locations de matériel et d'outillage</field>
+    <field name="name">Locations de matÃ©riel et d'outillage</field>
     <field name="code">61313</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61314" model="account.account.template">
-    <field name="name">Locations de mobilier et de matériel de bureau</field>
+    <field name="name">Locations de mobilier et de matÃ©riel de bureau</field>
     <field name="code">61314</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61315" model="account.account.template">
-    <field name="name">Locations de matériel informatique</field>
+    <field name="name">Locations de matÃ©riel informatique</field>
     <field name="code">61315</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61316" model="account.account.template">
-    <field name="name">Locations de matériel de transport</field>
+    <field name="name">Locations de matÃ©riel de transport</field>
     <field name="code">61316</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2172,19 +2172,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61321" model="account.account.template">
-    <field name="name">Redevances de crédit-bail - mobilier et matériel</field>
+    <field name="name">Redevances de crÃ©dit-bail - mobilier et matÃ©riel</field>
     <field name="code">61321</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61331" model="account.account.template">
-    <field name="name">Entretien et réparations des biens immobiliers</field>
+    <field name="name">Entretien et rÃ©parations des biens immobiliers</field>
     <field name="code">61331</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61332" model="account.account.template">
-    <field name="name">Entretien et réparations des biens mobiliers</field>
+    <field name="name">Entretien et rÃ©parations des biens mobiliers</field>
     <field name="code">61332</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2208,25 +2208,25 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61345" model="account.account.template">
-    <field name="name">Assurances - Matériel de transport</field>
+    <field name="name">Assurances - MatÃ©riel de transport</field>
     <field name="code">61345</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61351" model="account.account.template">
-    <field name="name">Rémunérations du personnel occasionnel</field>
+    <field name="name">RÃ©munÃ©rations du personnel occasionnel</field>
     <field name="code">61351</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61352" model="account.account.template">
-    <field name="name">Rémunérations du personnel intérimaire</field>
+    <field name="name">RÃ©munÃ©rations du personnel intÃ©rimaire</field>
     <field name="code">61352</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61353" model="account.account.template">
-    <field name="name">Rémunérations du personnel détaché ou prêté à  l'entreprise</field>
+    <field name="name">RÃ©munÃ©rations du personnel dÃ©tachÃ© ou prÃªtÃ© Ã Â  l'entreprise</field>
     <field name="code">61353</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2262,7 +2262,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61411" model="account.account.template">
-    <field name="name">Études générales</field>
+    <field name="name">Ãtudes gÃ©nÃ©rales</field>
     <field name="code">61411</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2274,7 +2274,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61415" model="account.account.template">
-    <field name="name">Documentation générale</field>
+    <field name="name">Documentation gÃ©nÃ©rale</field>
     <field name="code">61415</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2310,13 +2310,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61431" model="account.account.template">
-    <field name="name">Voyages et déplacements</field>
+    <field name="name">Voyages et dÃ©placements</field>
     <field name="code">61431</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61433" model="account.account.template">
-    <field name="name">Frais de déménagement</field>
+    <field name="name">Frais de dÃ©mÃ©nagement</field>
     <field name="code">61433</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2328,7 +2328,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61436" model="account.account.template">
-    <field name="name">Réceptions</field>
+    <field name="name">RÃ©ceptions</field>
     <field name="code">61436</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2340,7 +2340,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61442" model="account.account.template">
-    <field name="name">Échantillons, catalogues et imprimés publicitaires</field>
+    <field name="name">Ãchantillons, catalogues et imprimÃ©s publicitaires</field>
     <field name="code">61442</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2352,7 +2352,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61444" model="account.account.template">
-    <field name="name">Primes de publicité</field>
+    <field name="name">Primes de publicitÃ©</field>
     <field name="code">61444</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2364,13 +2364,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61447" model="account.account.template">
-    <field name="name">Cadeaux à  la clientèle</field>
+    <field name="name">Cadeaux Ã Â  la clientÃšle</field>
     <field name="code">61447</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61448" model="account.account.template">
-    <field name="name">Autres charges de publicité et relations publiques</field>
+    <field name="name">Autres charges de publicitÃ© et relations publiques</field>
     <field name="code">61448</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2382,7 +2382,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61456" model="account.account.template">
-    <field name="name">Frais de télex et de télégrammes</field>
+    <field name="name">Frais de tÃ©lex et de tÃ©lÃ©grammes</field>
     <field name="code">61456</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2424,7 +2424,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61611" model="account.account.template">
-    <field name="name">Taxe urbaine et taxe d'édilité</field>
+    <field name="name">Taxe urbaine et taxe d'Ã©dilitÃ©</field>
     <field name="code">61611</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2442,7 +2442,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6165" model="account.account.template">
-    <field name="name">Impôts et taxes directs</field>
+    <field name="name">ImpÃŽts et taxes directs</field>
     <field name="code">6165</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2460,13 +2460,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61678" model="account.account.template">
-    <field name="name">Autres impôts, taxes et droits assimilés</field>
+    <field name="name">Autres impÃŽts, taxes et droits assimilÃ©s</field>
     <field name="code">61678</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6168" model="account.account.template">
-    <field name="name">Impôts et taxes des exercices antérieurs</field>
+    <field name="name">ImpÃŽts et taxes des exercices antÃ©rieurs</field>
     <field name="code">6168</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2478,13 +2478,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_617121" model="account.account.template">
-    <field name="name">Primes de représentation</field>
+    <field name="name">Primes de reprÃ©sentation</field>
     <field name="code">617121</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_617132" model="account.account.template">
-    <field name="name">Indemnités de déplacement</field>
+    <field name="name">IndemnitÃ©s de dÃ©placement</field>
     <field name="code">617132</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2496,13 +2496,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61715" model="account.account.template">
-    <field name="name">Rémunérations des administrateurs, gérants et associés</field>
+    <field name="name">RÃ©munÃ©rations des administrateurs, gÃ©rants et associÃ©s</field>
     <field name="code">61715</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61741" model="account.account.template">
-    <field name="name">Cotisations de sécurité sociale</field>
+    <field name="name">Cotisations de sÃ©curitÃ© sociale</field>
     <field name="code">61741</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2550,19 +2550,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61764" model="account.account.template">
-    <field name="name">Habillement et vêtements de travail</field>
+    <field name="name">Habillement et vÃªtements de travail</field>
     <field name="code">61764</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61765" model="account.account.template">
-    <field name="name">Indemnités de préavis et de licenciement</field>
+    <field name="name">IndemnitÃ©s de prÃ©avis et de licenciement</field>
     <field name="code">61765</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61766" model="account.account.template">
-    <field name="name">Médecine de travail, pharmacie</field>
+    <field name="name">MÃ©decine de travail, pharmacie</field>
     <field name="code">61766</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2586,55 +2586,55 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6178" model="account.account.template">
-    <field name="name">Charges du personnel des exercices antérieurs</field>
+    <field name="name">Charges du personnel des exercices antÃ©rieurs</field>
     <field name="code">6178</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6181" model="account.account.template">
-    <field name="name">Jetons de présence</field>
+    <field name="name">Jetons de prÃ©sence</field>
     <field name="code">6181</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6182" model="account.account.template">
-    <field name="name">Pertes sur créances irrécouvrables</field>
+    <field name="name">Pertes sur crÃ©ances irrÃ©couvrables</field>
     <field name="code">6182</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6185" model="account.account.template">
-    <field name="name">Pertes sur opérations faites en commun</field>
+    <field name="name">Pertes sur opÃ©rations faites en commun</field>
     <field name="code">6185</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6186" model="account.account.template">
-    <field name="name">Transfert de profits sur opérations faites en commun</field>
+    <field name="name">Transfert de profits sur opÃ©rations faites en commun</field>
     <field name="code">6186</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6188" model="account.account.template">
-    <field name="name">Autres charges d'exploitation des exercices antérieurs</field>
+    <field name="name">Autres charges d'exploitation des exercices antÃ©rieurs</field>
     <field name="code">6188</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61911" model="account.account.template">
-    <field name="name">D.E.A. des frais préliminaires</field>
+    <field name="name">D.E.A. des frais prÃ©liminaires</field>
     <field name="code">61911</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61912" model="account.account.template">
-    <field name="name">D.E.A. des charges à  répartir</field>
+    <field name="name">D.E.A. des charges Ã Â  rÃ©partir</field>
     <field name="code">61912</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61921" model="account.account.template">
-    <field name="name">D.E.A. de l'immobilisation en recherche et développement</field>
+    <field name="name">D.E.A. de l'immobilisation en recherche et dÃ©veloppement</field>
     <field name="code">61921</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2670,19 +2670,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61933" model="account.account.template">
-    <field name="name">D.E.A. des installations techniques, matériel et outillage</field>
+    <field name="name">D.E.A. des installations techniques, matÃ©riel et outillage</field>
     <field name="code">61933</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61934" model="account.account.template">
-    <field name="name">D.E.A. du matériel de transport</field>
+    <field name="name">D.E.A. du matÃ©riel de transport</field>
     <field name="code">61934</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61935" model="account.account.template">
-    <field name="name">D.E.A. des mobiliers, matériels de bureau et aménagements divers</field>
+    <field name="name">D.E.A. des mobiliers, matÃ©riels de bureau et amÃ©nagements divers</field>
     <field name="code">61935</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2694,13 +2694,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61942" model="account.account.template">
-    <field name="name">D.E.P. pour dépréciation des immobilisations incorporelles</field>
+    <field name="name">D.E.P. pour dÃ©prÃ©ciation des immobilisations incorporelles</field>
     <field name="code">61942</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61943" model="account.account.template">
-    <field name="name">D.E.P. pour dépréciation des immobilisations corporelles</field>
+    <field name="name">D.E.P. pour dÃ©prÃ©ciation des immobilisations corporelles</field>
     <field name="code">61943</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2712,67 +2712,67 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61957" model="account.account.template">
-    <field name="name">D.E.P. pour risques et charges momentanés</field>
+    <field name="name">D.E.P. pour risques et charges momentanÃ©s</field>
     <field name="code">61957</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61961" model="account.account.template">
-    <field name="name">D.E.P. pour dépréciation des stocks</field>
+    <field name="name">D.E.P. pour dÃ©prÃ©ciation des stocks</field>
     <field name="code">61961</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61964" model="account.account.template">
-    <field name="name">D.E.P. pour dépréciation des créances de l'actif circulant</field>
+    <field name="name">D.E.P. pour dÃ©prÃ©ciation des crÃ©ances de l'actif circulant</field>
     <field name="code">61964</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61981" model="account.account.template">
-    <field name="name">D.E. aux amortissements des exercices antérieurs</field>
+    <field name="name">D.E. aux amortissements des exercices antÃ©rieurs</field>
     <field name="code">61981</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_61984" model="account.account.template">
-    <field name="name">D.E. aux provisions des exercices antérieurs</field>
+    <field name="name">D.E. aux provisions des exercices antÃ©rieurs</field>
     <field name="code">61984</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_63111" model="account.account.template">
-    <field name="name">Intérêts des emprunts</field>
+    <field name="name">IntÃ©rÃªts des emprunts</field>
     <field name="code">63111</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_63113" model="account.account.template">
-    <field name="name">Intérêts des dettes rattachées à  des participations</field>
+    <field name="name">IntÃ©rÃªts des dettes rattachÃ©es Ã Â  des participations</field>
     <field name="code">63113</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_63114" model="account.account.template">
-    <field name="name">Intérêts des comptes courants et dépôts créditeurs</field>
+    <field name="name">IntÃ©rÃªts des comptes courants et dÃ©pÃŽts crÃ©diteurs</field>
     <field name="code">63114</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_63115" model="account.account.template">
-    <field name="name">Intérêts bancaires et sur opérations de financement</field>
+    <field name="name">IntÃ©rÃªts bancaires et sur opÃ©rations de financement</field>
     <field name="code">63115</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_63118" model="account.account.template">
-    <field name="name">Autres intérêts des emprunts et dettes</field>
+    <field name="name">Autres intÃ©rÃªts des emprunts et dettes</field>
     <field name="code">63118</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6318" model="account.account.template">
-    <field name="name">Charges d'intérêts des exercices antérieurs</field>
+    <field name="name">Charges d'intÃ©rÃªts des exercices antÃ©rieurs</field>
     <field name="code">6318</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2784,19 +2784,19 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6331" model="account.account.template">
-    <field name="name">Pertes de change propres à  l'exercice</field>
+    <field name="name">Pertes de change propres Ã Â  l'exercice</field>
     <field name="code">6331</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6338" model="account.account.template">
-    <field name="name">Pertes de change des exercices antérieurs</field>
+    <field name="name">Pertes de change des exercices antÃ©rieurs</field>
     <field name="code">6338</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6382" model="account.account.template">
-    <field name="name">Pertes sur créances liées à  des participations</field>
+    <field name="name">Pertes sur crÃ©ances liÃ©es Ã Â  des participations</field>
     <field name="code">6382</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2808,13 +2808,13 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6386" model="account.account.template">
-    <field name="name">Escomptes accordés</field>
+    <field name="name">Escomptes accordÃ©s</field>
     <field name="code">6386</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6388" model="account.account.template">
-    <field name="name">Autres charges financières des exercices antérieurs</field>
+    <field name="name">Autres charges financiÃšres des exercices antÃ©rieurs</field>
     <field name="code">6388</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2826,103 +2826,103 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6392" model="account.account.template">
-    <field name="name">Dotations aux provisions pour dépréciations des immobilisations financières</field>
+    <field name="name">Dotations aux provisions pour dÃ©prÃ©ciations des immobilisations financiÃšres</field>
     <field name="code">6392</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6393" model="account.account.template">
-    <field name="name">Dotations aux provisions pour risques et charges financières</field>
+    <field name="name">Dotations aux provisions pour risques et charges financiÃšres</field>
     <field name="code">6393</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6394" model="account.account.template">
-    <field name="name">Dotation aux provisions pour dépréciation des titres et valeurs de placement</field>
+    <field name="name">Dotation aux provisions pour dÃ©prÃ©ciation des titres et valeurs de placement</field>
     <field name="code">6394</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6396" model="account.account.template">
-    <field name="name">Dotations aux provisions pour dépréciation des comptes de trésorerie</field>
+    <field name="name">Dotations aux provisions pour dÃ©prÃ©ciation des comptes de trÃ©sorerie</field>
     <field name="code">6396</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6398" model="account.account.template">
-    <field name="name">Dotations financières des exercices antérieurs</field>
+    <field name="name">Dotations financiÃšres des exercices antÃ©rieurs</field>
     <field name="code">6398</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6512" model="account.account.template">
-    <field name="name">VNA des immobilisations incorporelles cédées</field>
+    <field name="name">VNA des immobilisations incorporelles cÃ©dÃ©es</field>
     <field name="code">6512</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6513" model="account.account.template">
-    <field name="name">VNA des immobilisations corporelles cédées</field>
+    <field name="name">VNA des immobilisations corporelles cÃ©dÃ©es</field>
     <field name="code">6513</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6514" model="account.account.template">
-    <field name="name">VNA provisions des immobilisations financières cédées (droits de propriété)</field>
+    <field name="name">VNA provisions des immobilisations financiÃšres cÃ©dÃ©es (droits de propriÃ©tÃ©)</field>
     <field name="code">6514</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6518" model="account.account.template">
-    <field name="name">VNA des immobilisations cédées des exercices antérieurs</field>
+    <field name="name">VNA des immobilisations cÃ©dÃ©es des exercices antÃ©rieurs</field>
     <field name="code">6518</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6561" model="account.account.template">
-    <field name="name">Subventions accordées de l'exercice</field>
+    <field name="name">Subventions accordÃ©es de l'exercice</field>
     <field name="code">6561</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6568" model="account.account.template">
-    <field name="name">Subventions accordées des exercices antérieurs</field>
+    <field name="name">Subventions accordÃ©es des exercices antÃ©rieurs</field>
     <field name="code">6568</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65811" model="account.account.template">
-    <field name="name">Pénalités sur marchés</field>
+    <field name="name">PÃ©nalitÃ©s sur marchÃ©s</field>
     <field name="code">65811</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65812" model="account.account.template">
-    <field name="name">Dédits</field>
+    <field name="name">DÃ©dits</field>
     <field name="code">65812</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6582" model="account.account.template">
-    <field name="name">Rappels d'impôts (autres que l'impôt sur les résultats)</field>
+    <field name="name">Rappels d'impÃŽts (autres que l'impÃŽt sur les rÃ©sultats)</field>
     <field name="code">6582</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65831" model="account.account.template">
-    <field name="name">Pénalités et amendes fiscales</field>
+    <field name="name">PÃ©nalitÃ©s et amendes fiscales</field>
     <field name="code">65831</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65833" model="account.account.template">
-    <field name="name">Pénalités et amendes pénales</field>
+    <field name="name">PÃ©nalitÃ©s et amendes pÃ©nales</field>
     <field name="code">65833</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6585" model="account.account.template">
-    <field name="name">Créances devenues irrécouvrables</field>
+    <field name="name">CrÃ©ances devenues irrÃ©couvrables</field>
     <field name="code">6585</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2934,7 +2934,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65862" model="account.account.template">
-    <field name="name">Libéralités</field>
+    <field name="name">LibÃ©ralitÃ©s</field>
     <field name="code">65862</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2946,7 +2946,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6588" model="account.account.template">
-    <field name="name">Autres charges non courantes des exercices antérieurs</field>
+    <field name="name">Autres charges non courantes des exercices antÃ©rieurs</field>
     <field name="code">6588</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -2970,7 +2970,7 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65941" model="account.account.template">
-    <field name="name">D.N.C. pour amortissements dérogatoires</field>
+    <field name="name">D.N.C. pour amortissements dÃ©rogatoires</field>
     <field name="code">65941</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -3006,43 +3006,43 @@
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65957" model="account.account.template">
-    <field name="name">D.N.C. aux provisions pour risques et charges momentanés</field>
+    <field name="name">D.N.C. aux provisions pour risques et charges momentanÃ©s</field>
     <field name="code">65957</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65962" model="account.account.template">
-    <field name="name">D.N.C. aux provisions pour dépréciation de l'actif immobilisé</field>
+    <field name="name">D.N.C. aux provisions pour dÃ©prÃ©ciation de l'actif immobilisÃ©</field>
     <field name="code">65962</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_65963" model="account.account.template">
-    <field name="name">D.N.C. aux provisions pour dépréciation de l'actif circulant</field>
+    <field name="name">D.N.C. aux provisions pour dÃ©prÃ©ciation de l'actif circulant</field>
     <field name="code">65963</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6598" model="account.account.template">
-    <field name="name">Dotations non courantes des exercices antérieurs</field>
+    <field name="name">Dotations non courantes des exercices antÃ©rieurs</field>
     <field name="code">6598</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6701" model="account.account.template">
-    <field name="name">Impôts sur les bénéfices</field>
+    <field name="name">ImpÃŽts sur les bÃ©nÃ©fices</field>
     <field name="code">6701</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6705" model="account.account.template">
-    <field name="name">Imposition minimale annuelle des sociétés</field>
+    <field name="name">Imposition minimale annuelle des sociÃ©tÃ©s</field>
     <field name="code">6705</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_6708" model="account.account.template">
-    <field name="name">Rappels et dégrèvements d'impôts sur les résultats</field>
+    <field name="name">Rappels et dÃ©grÃšvements d'impÃŽts sur les rÃ©sultats</field>
     <field name="code">6708</field>
     <field name="user_type_id" ref="account.data_account_type_expenses"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
@@ -3050,685 +3050,685 @@
   <record id="pcg_7111" model="account.account.template">
     <field name="name">Ventes de marchandises au Maroc</field>
     <field name="code">7111</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7113" model="account.account.template">
-    <field name="name">Ventes de marchandises à  l'étranger</field>
+    <field name="name">Ventes de marchandises Ã Â  l'Ã©tranger</field>
     <field name="code">7113</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7118" model="account.account.template">
-    <field name="name">Ventes de marchandises des exercices antérieurs</field>
+    <field name="name">Ventes de marchandises des exercices antÃ©rieurs</field>
     <field name="code">7118</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7119" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes accordés par l'entreprise</field>
+    <field name="name">Rabais, remises et ristournes accordÃ©s par l'entreprise</field>
     <field name="code">7119</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71211" model="account.account.template">
     <field name="name">Ventes de produits finis</field>
     <field name="code">71211</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71212" model="account.account.template">
-    <field name="name">Ventes de produits intermédiaires</field>
+    <field name="name">Ventes de produits intermÃ©diaires</field>
     <field name="code">71212</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71217" model="account.account.template">
-    <field name="name">Ventes de produits résiduels</field>
+    <field name="name">Ventes de produits rÃ©siduels</field>
     <field name="code">71217</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71221" model="account.account.template">
     <field name="name">Ventes de produits finis</field>
     <field name="code">71221</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71222" model="account.account.template">
-    <field name="name">Ventes de produits intermédiaires</field>
+    <field name="name">Ventes de produits intermÃ©diaires</field>
     <field name="code">71222</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71241" model="account.account.template">
     <field name="name">Travaux</field>
     <field name="code">71241</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71242" model="account.account.template">
     <field name="name">Etudes</field>
     <field name="code">71242</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71243" model="account.account.template">
     <field name="name">Prestations de services</field>
     <field name="code">71243</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71251" model="account.account.template">
     <field name="name">Travaux</field>
     <field name="code">71251</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71252" model="account.account.template">
     <field name="name">Etudes</field>
     <field name="code">71252</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71253" model="account.account.template">
     <field name="name">Prestations de services</field>
     <field name="code">71253</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7126" model="account.account.template">
     <field name="name">Redevances pour brevets, marques, droits et valeurs similaires</field>
     <field name="code">7126</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71271" model="account.account.template">
-    <field name="name">Locations divers es reçues</field>
+    <field name="name">Locations divers es reÃ§ues</field>
     <field name="code">71271</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71272" model="account.account.template">
-    <field name="name">Commissions et courtages reçus</field>
+    <field name="name">Commissions et courtages reÃ§us</field>
     <field name="code">71272</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71273" model="account.account.template">
-    <field name="name">Produits de services exploités dans l'intérêt du personnel</field>
+    <field name="name">Produits de services exploitÃ©s dans l'intÃ©rÃªt du personnel</field>
     <field name="code">71273</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71275" model="account.account.template">
-    <field name="name">Bonis sur reprises d'emballages consignés</field>
+    <field name="name">Bonis sur reprises d'emballages consignÃ©s</field>
     <field name="code">71275</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71276" model="account.account.template">
-    <field name="name">Ports et frais accessoires facturés</field>
+    <field name="name">Ports et frais accessoires facturÃ©s</field>
     <field name="code">71276</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71278" model="account.account.template">
     <field name="name">Autres ventes et produits accessoires</field>
     <field name="code">71278</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7128" model="account.account.template">
-    <field name="name">Ventes de biens et services produits des exercices antérieurs</field>
+    <field name="name">Ventes de biens et services produits des exercices antÃ©rieurs</field>
     <field name="code">7128</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71291" model="account.account.template">
-    <field name="name">R,R,R accordées sur ventes au Maroc des biens produits</field>
+    <field name="name">R,R,R accordÃ©es sur ventes au Maroc des biens produits</field>
     <field name="code">71291</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71292" model="account.account.template">
-    <field name="name">R,R,R accordées sur ventes à  l'étranger des biens produits</field>
+    <field name="name">R,R,R accordÃ©es sur ventes Ã Â  l'Ã©tranger des biens produits</field>
     <field name="code">71292</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71294" model="account.account.template">
-    <field name="name">R,R,R accordées sur ventes au Maroc des services produits</field>
+    <field name="name">R,R,R accordÃ©es sur ventes au Maroc des services produits</field>
     <field name="code">71294</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71295" model="account.account.template">
-    <field name="name">R,R,R accordées sur ventes à  l'étranger des services produits</field>
+    <field name="name">R,R,R accordÃ©es sur ventes Ã Â  l'Ã©tranger des services produits</field>
     <field name="code">71295</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71298" model="account.account.template">
-    <field name="name">Rabais, remises et ristournes accordés sur ventes de B et S produits des exercices antérieurs</field>
+    <field name="name">Rabais, remises et ristournes accordÃ©s sur ventes de B et S produits des exercices antÃ©rieurs</field>
     <field name="code">71298</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71311" model="account.account.template">
     <field name="name">Variation des stocks de biens produits en cours</field>
     <field name="code">71311</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71312" model="account.account.template">
-    <field name="name">Variation des stocks de produits intermédiaires en cours</field>
+    <field name="name">Variation des stocks de produits intermÃ©diaires en cours</field>
     <field name="code">71312</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71317" model="account.account.template">
-    <field name="name">Variation des stocks de produits résiduels en cours</field>
+    <field name="name">Variation des stocks de produits rÃ©siduels en cours</field>
     <field name="code">71317</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71321" model="account.account.template">
     <field name="name">Variation des stocks de produits finis</field>
     <field name="code">71321</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71322" model="account.account.template">
-    <field name="name">Variation des stocks de produits intermédiaires</field>
+    <field name="name">Variation des stocks de produits intermÃ©diaires</field>
     <field name="code">71322</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71327" model="account.account.template">
-    <field name="name">Variation des stocks de produits résiduels</field>
+    <field name="name">Variation des stocks de produits rÃ©siduels</field>
     <field name="code">71327</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71341" model="account.account.template">
     <field name="name">Variation des stocks de travaux en cours</field>
     <field name="code">71341</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71342" model="account.account.template">
-    <field name="name">Variation des stocks d'études en cours</field>
+    <field name="name">Variation des stocks d'Ã©tudes en cours</field>
     <field name="code">71342</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71343" model="account.account.template">
     <field name="name">Variation des stocks de prestations en cours</field>
     <field name="code">71343</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7141" model="account.account.template">
     <field name="name">Immobilisation en non valeurs produite</field>
     <field name="code">7141</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7142" model="account.account.template">
     <field name="name">Immobilisations incorporelles produites</field>
     <field name="code">7142</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7143" model="account.account.template">
     <field name="name">Immobilisations corporelles produites</field>
     <field name="code">7143</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7148" model="account.account.template">
-    <field name="name">Immobilisations produites des exercices antérieurs</field>
+    <field name="name">Immobilisations produites des exercices antÃ©rieurs</field>
     <field name="code">7148</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7161" model="account.account.template">
-    <field name="name">Subventions d'exploitations reçues de l'exercice</field>
+    <field name="name">Subventions d'exploitations reÃ§ues de l'exercice</field>
     <field name="code">7161</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7168" model="account.account.template">
-    <field name="name">Subventions d'exploitation reçues des exercices antérieurs</field>
+    <field name="name">Subventions d'exploitation reÃ§ues des exercices antÃ©rieurs</field>
     <field name="code">7168</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7181" model="account.account.template">
-    <field name="name">Jetons de présence reçus</field>
+    <field name="name">Jetons de prÃ©sence reÃ§us</field>
     <field name="code">7181</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7182" model="account.account.template">
-    <field name="name">Revenus des immeubles non affectés à  l'exploitation</field>
+    <field name="name">Revenus des immeubles non affectÃ©s Ã Â  l'exploitation</field>
     <field name="code">7182</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7185" model="account.account.template">
-    <field name="name">Profits sur opérations faites en commun</field>
+    <field name="name">Profits sur opÃ©rations faites en commun</field>
     <field name="code">7185</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7186" model="account.account.template">
-    <field name="name">Transfert de pertes sur opérations faites en commun</field>
+    <field name="name">Transfert de pertes sur opÃ©rations faites en commun</field>
     <field name="code">7186</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7188" model="account.account.template">
-    <field name="name">Autres produits d'exploitation des exercices antérieurs</field>
+    <field name="name">Autres produits d'exploitation des exercices antÃ©rieurs</field>
     <field name="code">7188</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7191" model="account.account.template">
     <field name="name">Reprises sur amortissements de l'immobilisation en non valeurs</field>
     <field name="code">7191</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7192" model="account.account.template">
     <field name="name">Reprises sur amortissements des immobilisations incorporelles</field>
     <field name="code">7192</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7193" model="account.account.template">
     <field name="name">Reprises sur amortissements des immobilisations corporelles</field>
     <field name="code">7193</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7194" model="account.account.template">
-    <field name="name">Reprises sur provisions pour dépréciation des immobilisations</field>
+    <field name="name">Reprises sur provisions pour dÃ©prÃ©ciation des immobilisations</field>
     <field name="code">7194</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7195" model="account.account.template">
     <field name="name">Reprises sur provisions pour risques et charges</field>
     <field name="code">7195</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7196" model="account.account.template">
-    <field name="name">Reprises sur provisions pour dépréciation de l'actif circulant</field>
+    <field name="name">Reprises sur provisions pour dÃ©prÃ©ciation de l'actif circulant</field>
     <field name="code">7196</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71971" model="account.account.template">
     <field name="name">T,C,E - Achats de marchandises</field>
     <field name="code">71971</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71972" model="account.account.template">
-    <field name="name">T,C,E - Achats consommés de matières et fournitures</field>
+    <field name="name">T,C,E - Achats consommÃ©s de matiÃšres et fournitures</field>
     <field name="code">71972</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71973" model="account.account.template">
     <field name="name">T,C,E-Autres charges externes</field>
     <field name="code">71973</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71975" model="account.account.template">
-    <field name="name">T,C,E - Impôts et taxes</field>
+    <field name="name">T,C,E - ImpÃŽts et taxes</field>
     <field name="code">71975</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71976" model="account.account.template">
     <field name="name">T,C,E - Charges de personnel</field>
     <field name="code">71976</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71978" model="account.account.template">
     <field name="name">T,C,E - Autres charges d'exploitation</field>
     <field name="code">71978</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71981" model="account.account.template">
-    <field name="name">Reprises sur amortissements des exercices antérieurs</field>
+    <field name="name">Reprises sur amortissements des exercices antÃ©rieurs</field>
     <field name="code">71981</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_71984" model="account.account.template">
-    <field name="name">Reprises sur provisions des exercices antérieurs</field>
+    <field name="name">Reprises sur provisions des exercices antÃ©rieurs</field>
     <field name="code">71984</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7321" model="account.account.template">
     <field name="name">Revenus des titres de participation</field>
     <field name="code">7321</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7325" model="account.account.template">
-    <field name="name">Revenus des titres immobilisés</field>
+    <field name="name">Revenus des titres immobilisÃ©s</field>
     <field name="code">7325</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7328" model="account.account.template">
-    <field name="name">Produits des titres de participation et des autres titres immobilisés des exercices antérieurs</field>
+    <field name="name">Produits des titres de participation et des autres titres immobilisÃ©s des exercices antÃ©rieurs</field>
     <field name="code">7328</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_733" model="account.account.template">
     <field name="name">Gains de change</field>
     <field name="code">733</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7331" model="account.account.template">
-    <field name="name">Gains de change propres à  l'exercice</field>
+    <field name="name">Gains de change propres Ã Â  l'exercice</field>
     <field name="code">7331</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7338" model="account.account.template">
-    <field name="name">Gains de change des exercices antérieurs</field>
+    <field name="name">Gains de change des exercices antÃ©rieurs</field>
     <field name="code">7338</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_73811" model="account.account.template">
-    <field name="name">Intérêts des prêts</field>
+    <field name="name">IntÃ©rÃªts des prÃªts</field>
     <field name="code">73811</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_73813" model="account.account.template">
-    <field name="name">Revenus des autres créances financières</field>
+    <field name="name">Revenus des autres crÃ©ances financiÃšres</field>
     <field name="code">73813</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7383" model="account.account.template">
-    <field name="name">Revenus des créances rattachées à  des participations</field>
+    <field name="name">Revenus des crÃ©ances rattachÃ©es Ã Â  des participations</field>
     <field name="code">7383</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7384" model="account.account.template">
     <field name="name">Revenus des titres et valeurs de placement</field>
     <field name="code">7384</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7385" model="account.account.template">
     <field name="name">Produits nets sur cessions de titres et valeurs de placement</field>
     <field name="code">7385</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7386" model="account.account.template">
     <field name="name">Escomptes obtenus</field>
     <field name="code">7386</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7388" model="account.account.template">
-    <field name="name">Intérêts et autres produits financiers des exercices antérieurs</field>
+    <field name="name">IntÃ©rÃªts et autres produits financiers des exercices antÃ©rieurs</field>
     <field name="code">7388</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7391" model="account.account.template">
     <field name="name">Reprises sur amortissements des primes de remboursement des obligations</field>
     <field name="code">7391</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7392" model="account.account.template">
-    <field name="name">Reprises sur provisions pour dépréciation des immobilisations financières</field>
+    <field name="name">Reprises sur provisions pour dÃ©prÃ©ciation des immobilisations financiÃšres</field>
     <field name="code">7392</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7393" model="account.account.template">
-    <field name="name">Reprises sur provisions pour risques et charges financières</field>
+    <field name="name">Reprises sur provisions pour risques et charges financiÃšres</field>
     <field name="code">7393</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7394" model="account.account.template">
-    <field name="name">Reprise sur provisions pour dépréciation des titres et valeurs de placement</field>
+    <field name="name">Reprise sur provisions pour dÃ©prÃ©ciation des titres et valeurs de placement</field>
     <field name="code">7394</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7396" model="account.account.template">
-    <field name="name">Reprises sur provisions pour dépréciation des comptes de trésorerie</field>
+    <field name="name">Reprises sur provisions pour dÃ©prÃ©ciation des comptes de trÃ©sorerie</field>
     <field name="code">7396</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_73971" model="account.account.template">
-    <field name="name">Transfert - Charges d'intérêts</field>
+    <field name="name">Transfert - Charges d'intÃ©rÃªts</field>
     <field name="code">73971</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_73973" model="account.account.template">
     <field name="name">Transfert - Pertes de change</field>
     <field name="code">73973</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_73978" model="account.account.template">
-    <field name="name">Transfert - Autres charges financières</field>
+    <field name="name">Transfert - Autres charges financiÃšres</field>
     <field name="code">73978</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7398" model="account.account.template">
-    <field name="name">Reprises sur dotations financières des exercices antérieurs</field>
+    <field name="name">Reprises sur dotations financiÃšres des exercices antÃ©rieurs</field>
     <field name="code">7398</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7512" model="account.account.template">
     <field name="name">Produits des cessions des immobilisations incorporelles</field>
     <field name="code">7512</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7513" model="account.account.template">
     <field name="name">Produits des cessions des immobilisations corporelles</field>
     <field name="code">7513</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7514" model="account.account.template">
-    <field name="name">Produits des cessions des immobilisations financières (droits de propriété)</field>
+    <field name="name">Produits des cessions des immobilisations financiÃšres (droits de propriÃ©tÃ©)</field>
     <field name="code">7514</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7518" model="account.account.template">
-    <field name="name">Produits des cessions des immobilisations des exercices antérieurs</field>
+    <field name="name">Produits des cessions des immobilisations des exercices antÃ©rieurs</field>
     <field name="code">7518</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7561" model="account.account.template">
-    <field name="name">Subventions d'équilibre reçues de l'exercice</field>
+    <field name="name">Subventions d'Ã©quilibre reÃ§ues de l'exercice</field>
     <field name="code">7561</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7568" model="account.account.template">
-    <field name="name">Subventions d'équilibre reçues des exercices antérieurs</field>
+    <field name="name">Subventions d'Ã©quilibre reÃ§ues des exercices antÃ©rieurs</field>
     <field name="code">7568</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7577" model="account.account.template">
     <field name="name">Reprises sur subventions d'investissement de l'exercice</field>
     <field name="code">7577</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7578" model="account.account.template">
-    <field name="name">Reprises sur subventions d'investissement des exercices antérieurs</field>
+    <field name="name">Reprises sur subventions d'investissement des exercices antÃ©rieurs</field>
     <field name="code">7578</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75811" model="account.account.template">
-    <field name="name">Pénalités reçues sur marchés</field>
+    <field name="name">PÃ©nalitÃ©s reÃ§ues sur marchÃ©s</field>
     <field name="code">75811</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75812" model="account.account.template">
-    <field name="name">Dédits reçus</field>
+    <field name="name">DÃ©dits reÃ§us</field>
     <field name="code">75812</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7582" model="account.account.template">
-    <field name="name">Dégrèvement d'impôts (autres que l'impôt sur les résultats)</field>
+    <field name="name">DÃ©grÃšvement d'impÃŽts (autres que l'impÃŽt sur les rÃ©sultats)</field>
     <field name="code">7582</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7585" model="account.account.template">
-    <field name="name">Rentrées sur créances soldées</field>
+    <field name="name">RentrÃ©es sur crÃ©ances soldÃ©es</field>
     <field name="code">7585</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75861" model="account.account.template">
     <field name="name">Dons</field>
     <field name="code">75861</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75862" model="account.account.template">
-    <field name="name">Libéralités</field>
+    <field name="name">LibÃ©ralitÃ©s</field>
     <field name="code">75862</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75863" model="account.account.template">
     <field name="name">Lots</field>
     <field name="code">75863</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7588" model="account.account.template">
-    <field name="name">Autres produits non courants des exercices antérieurs</field>
+    <field name="name">Autres produits non courants des exercices antÃ©rieurs</field>
     <field name="code">7588</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75911" model="account.account.template">
     <field name="name">R,A,E des immobilisations en non valeur</field>
     <field name="code">75911</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75912" model="account.account.template">
     <field name="name">R,A,E des immobilisations incorporelles</field>
     <field name="code">75912</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75913" model="account.account.template">
     <field name="name">R,A,E des immobilisations corporelles</field>
     <field name="code">75913</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75941" model="account.account.template">
-    <field name="name">Reprises sur amortissements dérogatoires</field>
+    <field name="name">Reprises sur amortissements dÃ©rogatoires</field>
     <field name="code">75941</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75942" model="account.account.template">
     <field name="name">Reprises sur plus-values en instance d'imposition</field>
     <field name="code">75942</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75944" model="account.account.template">
     <field name="name">Reprises sur provisions pour investissements</field>
     <field name="code">75944</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75945" model="account.account.template">
     <field name="name">Reprises sur provisions pour reconstitution de gisements</field>
     <field name="code">75945</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75946" model="account.account.template">
     <field name="name">Reprises sur provisions pour acquisition et construction de logements</field>
     <field name="code">75946</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75955" model="account.account.template">
     <field name="name">Reprises sur provisions pour risques et charges durables</field>
     <field name="code">75955</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75957" model="account.account.template">
-    <field name="name">Reprises sur provisions pour risques et charges momentanés</field>
+    <field name="name">Reprises sur provisions pour risques et charges momentanÃ©s</field>
     <field name="code">75957</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75962" model="account.account.template">
-    <field name="name">R,N,C sur provisions pour dépréciation de l'actif immobilisé</field>
+    <field name="name">R,N,C sur provisions pour dÃ©prÃ©ciation de l'actif immobilisÃ©</field>
     <field name="code">75962</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_75963" model="account.account.template">
-    <field name="name">R,N,C sur provisions pour dépréciation de l'actif circulant</field>
+    <field name="name">R,N,C sur provisions pour dÃ©prÃ©ciation de l'actif circulant</field>
     <field name="code">75963</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7597" model="account.account.template">
     <field name="name">Transferts de charges non courantes</field>
     <field name="code">7597</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
   <record id="pcg_7598" model="account.account.template">
-    <field name="name">Reprises non courantes des exercices antérieurs.</field>
+    <field name="name">Reprises non courantes des exercices antÃ©rieurs.</field>
     <field name="code">7598</field>
-    <field name="user_type_id" ref="account.data_account_type_other_income"/>
+    <field name="user_type_id" ref="account.data_account_type_revenue"/>
     <field name="chart_template_id" ref="l10n_kzc_temp_chart"/>
   </record>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Update user_type_id for some account template

Current behavior before PR:
Wrong setting of account type

Desired behavior after PR is merged:
Correct account type current assets and revenu type

Class 3 accounts linked to stock should be considered as "current assets" and not as "other income". The balance of these accounts must be reported from one year to the next on the balance.

For class 7 accounts, there is no need to use 2 account types "Income" and "Another income". It just creates confusion

hereafter the Moroccan chart of accounts: https://cpa.enset-media.ac.ma/Fixe/Plan%20cptable%20Maroc.pdf


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
