### PR TITLE
[FIX] web: disable horizontal scrollbar on wrapwrap

### DIFF
--- a/addons/web/static/src/js/core/smooth_scroll_on_drag.js
+++ b/addons/web/static/src/js/core/smooth_scroll_on_drag.js
@@ -90,6 +90,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
      * @param {jQuery} [options.offsetElements.$left] Visible left offset element which width
      *        will be taken into account when triggering scroll at the left side of the
      *        $scrollTarget.
+     * @param {boolean} [options.disableHorizontalScroll = false] Disable horizontal scroll if not needed.
      */
     init(parent, $element, $scrollTarget, options = {}) {
         mixins.ParentedMixin.init.call(this);
@@ -126,6 +127,7 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
         };
 
         this.options.jQueryDraggableOptions.scroll = false;
+        this.options.disableHorizontalScroll = this.options.disableHorizontalScroll || false;
         const draggableOptions = Object.assign({}, this.options.jQueryDraggableOptions, {
             start: (ev, ui) => this._onSmoothDragStart(ev, ui, this.options.jQueryDraggableOptions.start),
             drag: (ev, ui) => this._onSmoothDrag(ev, ui, this.options.jQueryDraggableOptions.drag),
@@ -203,10 +205,12 @@ const SmoothScrollOnDrag = Class.extend(mixins.ParentedMixin, {
                     this.$scrollTarget.scrollTop() +
                     this.verticalDelta
                 );
-                this.$scrollTarget.scrollLeft(
-                    this.$scrollTarget.scrollLeft() +
-                    this.horizontalDelta
-                );
+                if (!this.options.disableHorizontalScroll) {
+                    this.$scrollTarget.scrollLeft(
+                        this.$scrollTarget.scrollLeft() +
+                        this.horizontalDelta
+                    );
+                }
             },
             this.options.scrollTimerInterval
         );

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1968,6 +1968,7 @@ var SnippetsMenu = Widget.extend({
                 greedy: true,
                 scroll: false,
             }, options.jQueryDraggableOptions),
+            disableHorizontalScroll: true,
         });
     },
     /**


### PR DESCRIPTION
This commit adds an option to disable horizontal scrolling in the
smoothScrollOnDrag feature options and use it when dragging and
dropping a snippet into the editor to prevent the wrapwrap from
scrolling horizontally when an element overflow the page (e.g. an
animated element)

task-2215118

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
