### PR TITLE
[12.0] Backport account: be able to found the proper transfer account

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -250,7 +250,7 @@ class AccountChartTemplate(models.Model):
 
         # Set the transfer account on the company
         company.transfer_account_id = self.env['account.account'].search([
-            ('code', '=like', self.transfer_account_code_prefix + '%'), ('company_id', '=', company.id)])
+            ('code', '=like', self.transfer_account_code_prefix + '%'), ('company_id', '=', company.id)], limit=1)
 
         # Create Bank journals
         self._create_bank_journals(company, acc_template_ref)

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -249,7 +249,8 @@ class AccountChartTemplate(models.Model):
         acc_template_ref, taxes_ref = self._install_template(company, code_digits=self.code_digits)
 
         # Set the transfer account on the company
-        company.transfer_account_id = self.env['account.account'].search([('code', '=like', self.transfer_account_code_prefix + '%')])[:1]
+        company.transfer_account_id = self.env['account.account'].search([
+            ('code', '=like', self.transfer_account_code_prefix + '%'), ('company_id', '=', company.id)])
 
         # Create Bank journals
         self._create_bank_journals(company, acc_template_ref)


### PR DESCRIPTION
Backport of 

- d38228836b8944740f04ca355c997c4b6a346e48
- aab5cb4ce6d7850a042203d62915dcc37f4d8bd9

Fixing the proper transfer account assignment when a new company is created. From the original commits:

Properly set the transfer account in the company taking account the accounts defined in th company domain.  We found this error because in l10n_ar module we have 3 chart of accounts based on the company AFIP responsability which actually have same transfer_account_code_prefix. For that reason it was setting a transfer account to the company which is not belongs to the current company (d38228836b8944740f04ca355c997c4b6a346e48)

With the commit some time ago #d382288, I removed to take the first,
but you can have multiple transfer accounts in one company. The best way is to just do a limit=1 (aab5cb4ce6d7850a042203d62915dcc37f4d8bd9)


TT31099 cc @Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
