### PR TITLE
add kanban_attachment_image for kanban view

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2547,6 +2547,10 @@ var PriorityWidget = AbstractField.extend({
 
 var AttachmentImage = AbstractField.extend({
     className: 'o_attachment_image',
+    // Remove event handlers on this widget to ensure that the kanban 'global
+    // click' opens the clicked record, click on abstractField is useful in
+    // Form and List view only.
+    events: _.omit(AbstractField.prototype.events, 'click'),
 
     //--------------------------------------------------------------------------
     // Private

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -7332,7 +7332,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('set cover image', async function (assert) {
-        assert.expect(6);
+        assert.expect(7);
 
         var kanban = await createView({
             View: KanbanView,
@@ -7341,7 +7341,7 @@ QUnit.module('Views', {
             arch: '<kanban class="o_kanban_test">' +
                     '<templates>' +
                         '<t t-name="kanban-box">' +
-                            '<div>' +
+                            '<div class="oe_kanban_global_click">' +
                                 '<field name="name"/>' +
                                 '<div class="o_dropdown_kanban dropdown">' +
                                     '<a class="dropdown-toggle o-no-caret btn" data-toggle="dropdown" href="#">' +
@@ -7365,6 +7365,16 @@ QUnit.module('Views', {
                 }
                 return this._super(route, args);
             },
+            intercepts: {
+                switch_view: function (event) {
+                    assert.deepEqual(_.pick(event.data, 'mode', 'model', 'res_id', 'view_type'), {
+                        mode: 'readonly',
+                        model: 'partner',
+                        res_id: 1,
+                        view_type: 'form',
+                    }, "should trigger an event to open the clicked record in a form view");
+                },
+            },
         });
 
         var $firstRecord = kanban.$('.o_kanban_record:first');
@@ -7382,6 +7392,7 @@ QUnit.module('Views', {
         $('.modal').find("img[data-id='2']").dblclick();
         await testUtils.nextTick();
         assert.containsOnce(kanban, 'img[data-src*="/web/image/2"]');
+        await testUtils.dom.click(kanban.$('.o_kanban_record:first .o_attachment_image'));
         assert.verifySteps(["1", "2"], "should writes on both kanban records");
 
         kanban.destroy();


### PR DESCRIPTION
PURPOSE
Clicking on kanban cover image do not open kanban record, clicking on cover image should open record.

SPEC
Clicking on kanban cover image should open record.

TASK 2524022


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
