### PR TITLE
[FIX] Project:translation buttons layout on stages

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -120,19 +120,25 @@
                                     <label for="legend_normal" string=" " class="o_status mt4"
                                         title="Task in progress. Click to block or set as done."
                                         aria-label="Task in progress. Click to block or set as done." role="img"/>
-                                    <field name="legend_normal" class="col-11 pl-0" nolabel="1"/>
+                                    <div class="col-11 pl-0">
+                                        <field name="legend_normal"/>
+                                    </div>
                                 </div>
                                 <div class="row ml-1" colspan="2">
                                     <label for="legend_blocked" string=" " class="o_status o_status_red mt4"
                                         title="Task is blocked. Click to unblock or set as done."
                                         aria-label="Task is blocked. Click to unblock or set as done." role="img"/>
-                                    <field name="legend_blocked" class="col-11 pl-0" nolabel="1"/>
+                                    <div class="col-11 pl-0">
+                                        <field name="legend_blocked"/>
+                                    </div>
                                 </div>
                                 <div class="row ml-1" colspan="2">
                                     <label for="legend_done" string=" " class="o_status o_status_green mt4"
                                         title="This step is done. Click to block or set in progress."
                                         aria-label="This step is done. Click to block or set in progress." role="img"/>
-                                    <field name="legend_done" class="col-11 pl-0" nolabel="1"/>
+                                    <div class="col-11 pl-0">
+                                        <field name="legend_done"/>
+                                    </div>
                                 </div>
 
                                 <p class="text-muted mt-2" colspan="2">


### PR DESCRIPTION
to fix the lay translation buttons layout on stages form view, this commit
change the xml to display translation buttons in the alignment of the kanban
state label fields

Task: 2605763

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
