### PR TITLE
[13.0][FIX] l10n_es: Make non deductible taxes to propagate analytic

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -1813,6 +1813,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="21"/>
         <field name="amount_type">percent</field>
+        <field name="analytic" eval="True"/>
         <field name="tax_group_id" ref="tax_group_iva_nd"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -1844,6 +1845,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="10"/>
         <field name="amount_type">percent</field>
+        <field name="analytic" eval="True"/>
         <field name="tax_group_id" ref="tax_group_iva_nd"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -1875,6 +1877,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="4"/>
         <field name="amount_type">percent</field>
+        <field name="analytic" eval="True"/>
         <field name="tax_group_id" ref="tax_group_iva_nd"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {


### PR DESCRIPTION
When you are using non deductible taxes, the tax amount is handled as an expense increase, using the same expense account than the invoice line. But not having the analytic option, this expense increase is not classified in the same analytic account.

Thus, a sane default for the initial chart of accounts is to set it to True.

@Tecnativa TT31062
