### PR TITLE
[FIX] website: traceback on non html page set as a link

### DIFF
--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -14,15 +14,20 @@ var qweb = core.qweb;
  */
 function loadAnchors(url) {
     return new Promise(function (resolve, reject) {
-        if (url !== window.location.pathname && url[0] !== '#') {
-            $.get(window.location.origin + url).then(resolve, reject);
-        } else {
+        if (url === window.location.pathname || url[0] === '#') {
             resolve(document.body.outerHTML);
+        } else if (url.length && !url.startsWith("http")) {
+            $.get(window.location.origin + url).then(resolve, reject);
+        } else { // avoid useless query
+            resolve();
         }
     }).then(function (response) {
         return _.map($(response).find('[id][data-anchor=true]'), function (el) {
             return '#' + el.id;
         });
+    }).catch(error => {
+        console.debug(error);
+        return [];
     });
 }
 


### PR DESCRIPTION
**PURPOSE**
when you add a link in any of the buttons on the website with
non HTML/XML page, it will raise the traceback as we fetch the content to find
id to propose as a list of anchors.

Reproduction Steps:
1) Add a button on the website using the editor.
2) Add link in URL (i.e. /robots.txt)
3) Traceback

**SPECIFICATION**
We are handling the catch if it will raise the traceback.

task-2596392

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
