### PR TITLE
[FIX] web: imprecise callback signatures

### DIFF
--- a/addons/web/static/src/core/notifications/notification_service.js
+++ b/addons/web/static/src/core/notifications/notification_service.js
@@ -13,14 +13,14 @@ const AUTOCLOSE_DELAY = 4000;
  * @property {string} name
  * @property {string} [icon]
  * @property {boolean} [primary=false]
- * @property {function()} onClick
+ * @property {function(): void} onClick
  *
  * @typedef {Object} NotificationOptions
  * @property {string} [title]
  * @property {"warning" | "danger" | "success" | "info"} [type]
  * @property {boolean} [sticky=false]
  * @property {string} [className]
- * @property {function()} [onClose]
+ * @property {function(): void} [onClose]
  * @property {NotificationButton[]} [buttons]
  */
 

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -23,10 +23,10 @@ export const popoverService = {
          * @param {Object}                  props
          * @param {Object}                  [options]
          * @param {boolean}                 [options.closeOnClickAway=true]
-         * @param {function()}              [options.onClose]
+         * @param {function(): void}        [options.onClose]
          * @param {string}                  [options.popoverClass]
          * @param {string}                  [options.position]
-         * @returns {function()}
+         * @returns {function(): void}
          */
         function add(target, Component, props, options = {}) {
             const id = ++nextId;


### PR DESCRIPTION
odoo/odoo#74003 updated a few docstrings, half of them being the
typing of callbacks to not use the TypeScript syntax /
extension. However in doing so it dropped critical parts of the
signature (namely the specific type of the return value -- or the lack
thereof).

Update this error to restore the information that the callbacks have
no return value.
