### PR TITLE
[FIX] hr_holidays: half day outside of working hours

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -596,7 +596,7 @@ class HolidaysRequest(models.Model):
         if employee_id:
             employee = self.env['hr.employee'].browse(employee_id)
             result = employee._get_work_days_data_batch(date_from, date_to)[employee.id]
-            if self.request_unit_half:
+            if self.request_unit_half and result['hours'] > 0:
                 result['days'] = 0.5
             return result
 

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -33,8 +33,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 0.5)
-            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
 
     def test_single_attendance_on_morning_and_afternoon(self):
         calendar = self.env['resource.calendar'].create({
@@ -167,14 +167,15 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
             leave_form.holiday_status_id = self.leave_type
+            # does not work on mondays
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
 
-            self.assertEqual(leave_form.number_of_days_display, 0.5)
-            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
@@ -196,14 +197,15 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
             leave_form.holiday_status_id = self.leave_type
+            # does not work on tuesdays
             leave_form.request_date_from = date(2019, 9, 3)
             leave_form.request_date_to = date(2019, 9, 3)
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
 
-            self.assertEqual(leave_form.number_of_days_display, 0.5)
-            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 3, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 3, 10, 0, 0))
 
@@ -285,7 +287,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 0.5)
-            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))


### PR DESCRIPTION
Fixes taking a half day outside of working hours counting as half a day
instead of nothing.

See odoo/odoo#68977

Manual fw-port of https://github.com/odoo/odoo/pull/71135

cc @tivisse 