### PR TITLE
[FIX] account: Allow editing bank statement balances in 'processing' …

### DIFF
--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -171,12 +171,12 @@
                         </group><group>
                             <label for="balance_start"/>
                             <div>
-                                <field name="balance_start" class="oe_inline" attrs="{'readonly': [('state', '!=', 'open')]}"/>
+                                <field name="balance_start" class="oe_inline" attrs="{'readonly': [('state', '=', 'confirm')]}"/>
                                 <button name="open_cashbox_id" attrs="{'invisible': ['|',('state','!=','open'),('journal_type','!=','cash')]}" string="&#8594; Count" type="object" class="oe_edit_only oe_link oe_inline" context="{'balance':'start'}"/>
                             </div>
                             <label for="balance_end_real"/>
                             <div>
-                                <field name="balance_end_real" class="oe_inline" attrs="{'readonly': [('state', '!=', 'open')]}"/>
+                                <field name="balance_end_real" class="oe_inline" attrs="{'readonly': [('state', '=', 'confirm')]}"/>
                                 <button name="open_cashbox_id" attrs="{'invisible': ['|',('state','!=','open'),('journal_type','!=','cash')]}" string="&#8594; Count" type="object" class="oe_edit_only oe_link oe_inline" context="{'balance':'close'}"/>
                             </div>
                         </group>


### PR DESCRIPTION
…state

When using the online synchronization, you could have a wrong balance in 'processing' state.
In that case, don't force the user to reset the whole statement to 'open' and allow him to edit balances directly.

task: 2606857

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
