### PR TITLE
[FIX] account_followup: delete call to "reload_mail_field" event

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -573,7 +573,15 @@ var Activity = BasicActivity.extend({
      * @param {Object} fieldsToReload
      */
     _reload: function (fieldsToReload) {
-        this.trigger_up('reload_mail_fields', fieldsToReload);
+        const thread = owl.Component.env.models['mail.thread'].findFromIdentifyingData({
+            id: this.state.res_id,
+            model: this.state.model,
+        });
+        if (thread) {
+            thread.refresh();
+            thread.refreshActivities();
+            thread.refreshFollowers();
+        }
     },
     /**
      * @override


### PR DESCRIPTION
Steps to follow to reproduce the bug:

- Go accounting > configuration > Follow-up Levels
- Enable 'Manual Action' for the first reminder
- Go to the "Manual action" tab
- Select any entry in the "Manual Action Type" field
- Add any name in the "action to do" field
- Go to any customer having invoice “Due”
- Run the action newly added
- An error is triggered

Problem :
The Chatter widget was removed and so "reload_mail_fields" event doesn’t exist anymore : https://github.com/odoo/odoo/commit/3fea5b2136627c1d7e83b2a5e111952fe3eb10a1

opw-2439998


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
