### PR TITLE
[FIX] sale_coupon: fix 100% percentage discount with tax included

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -155,7 +155,11 @@ class SaleOrder(models.Model):
             }]
         reward_dict = {}
         lines = self._get_paid_order_lines()
-        amount_total = sum(self._get_base_order_lines(program).mapped('price_subtotal'))
+        base_lines = self._get_base_order_lines(program)
+        if any(base_lines.mapped('tax_id.price_include')):
+            amount_total = sum(base_lines.mapped('price_total'))
+        else:
+            amount_total = sum(base_lines.mapped('price_subtotal'))
         if program.discount_apply_on == 'cheapest_product':
             line = self._get_cheapest_line()
             if line:


### PR DESCRIPTION
Configure a promotion giving 100% percentage discount on order
Have in a sale order a line with tax included
Use the promotion
The total will be wrong

This occur because the tax in not taken into account while computing the
maximum amount of the discount

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
