### PR TITLE
[FIX] sale_timesheet: visibility attrs on Sale Order button

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -9,6 +9,9 @@
             <div class="oe_button_box" position="inside">
                 <button string="Project Overview" class="oe_stat_button" type="object" name="action_view_timesheet" icon="fa-puzzle-piece" attrs="{'invisible': [('allow_billable', '=', False)]}"/>
             </div>
+            <xpath expr="//button[@name='action_view_so']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('bill_type', '!=', 'customer_project')]}</attribute>
+              </xpath>
             <xpath expr="//header" position="inside">
                 <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>
             </xpath>


### PR DESCRIPTION
This is a fix of this fix: https://github.com/odoo/odoo/pull/73239

As the button has been moved to another module, the attrs were less coherent with the current (sale_timesheet) module.
An inheritance was made to add the correct attrs when this module is installed.

opw-2530161