### PR TITLE
[12.0][FIX] stock: allow to use already defined SN

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -396,9 +396,14 @@ class StockMoveLine(models.Model):
                             # the fly before assigning it to the move line if the user checked both
                             # `use_create_lots` and `use_existing_lots`.
                             if ml.lot_name and not ml.lot_id:
-                                lot = self.env['stock.production.lot'].create(
-                                    {'name': ml.lot_name, 'product_id': ml.product_id.id}
-                                )
+                                lot = self.env['stock.production.lot'].search([
+                                    ('product_id', '=', ml.product_id.id),
+                                    ('name', '=', ml.lot_name),
+                                ], limit=1)
+                                if not lot:
+                                    lot = self.env['stock.production.lot'].create(
+                                        {'name': ml.lot_name, 'product_id': ml.product_id.id}
+                                    )
                                 ml.write({'lot_id': lot.id})
                         elif not picking_type_id.use_create_lots and not picking_type_id.use_existing_lots:
                             # If the user disabled both `use_create_lots` and `use_existing_lots`


### PR DESCRIPTION
Backport of:

- https://github.com/odoo/odoo/pull/70097

Original commit description (09a1252b8a5bc194ffccd6c2437985328d08ba08)

- Define a [DEMO] prod with tracking by SN and add some SNs
- Activate "use existing lot/serial number" on the receipt picking type
- Create a purchase order for [DEMO]
- Process the receipt in the barcode app:
  * Scan the product
  * Scan the SN barcode
  * Validate

User will get an error.
It seems that Odoo is trying to create this SN instead of
matching the existing one

opw-2474347

closes odoo/odoo#70097

Related: odoo/enterprise#18277
Signed-off-by: Rémy Voet <ryv-odoo@users.noreply.github.com>


cc @Tecnativa TT30997

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
