### PR TITLE
[FIX] web: hexadecimal color in 8 digits not supported

### DIFF
--- a/addons/web/static/src/webclient/commands/command_palette.scss
+++ b/addons/web/static/src/webclient/commands/command_palette.scss
@@ -61,7 +61,7 @@
       height: 2.8em;
 
       &.focused {
-        background: #00a09d26;
+        background: rgba(0, 160, 157, 0.15);
       }
 
       kbd {


### PR DESCRIPTION
Some scss compilers are not supporting the colors written in hexadecimal
with 8 digits.

So to keep the the color and transparency, we have re-written the color
in rgba.

Issue introduced in: https://github.com/odoo/odoo/commit/a1c983250e9547c383ef677fb411b0bc589efa89

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
