### PR TITLE
[FIX] {mass_mailing}_sms: fix campaign rights for internal users

### DIFF
--- a/addons/mass_mailing/models/utm.py
+++ b/addons/mass_mailing/models/utm.py
@@ -13,8 +13,12 @@ class UtmCampaign(models.Model):
     mailing_mail_ids = fields.One2many(
         'mailing.mailing', 'campaign_id',
         domain=[('mailing_type', '=', 'mail')],
-        string='Mass Mailings')
-    mailing_mail_count = fields.Integer('Number of Mass Mailing', compute="_compute_mailing_mail_count")
+        string='Mass Mailings',
+        groups="mass_mailing.group_mass_mailing_user")
+    mailing_mail_count = fields.Integer('Number of Mass Mailing',
+        compute="_compute_mailing_mail_count",
+        groups="mass_mailing.group_mass_mailing_user")
+    is_mailing_campaign_activated = fields.Boolean(compute="_compute_is_mailing_campaign_activated")
 
     # A/B Testing
     ab_testing_mailings_count = fields.Integer("A/B Test Mailings #", compute="_compute_mailing_mail_count")
@@ -124,6 +128,9 @@ class UtmCampaign(models.Model):
                 }
 
             campaign.update(vals)
+
+    def _compute_is_mailing_campaign_activated(self):
+        self.is_mailing_campaign_activated = self.env.user.has_group('mass_mailing.group_mass_mailing_campaign')
 
     def _get_mailing_recipients(self, model=None):
         """Return the recipients of a mailing campaign. This is based on the statistics

--- a/addons/mass_mailing/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing/report/mailing_trace_report_views.xml
@@ -98,6 +98,5 @@
 
        <menuitem name="Reporting" id="menu_mass_mailing_report" sequence="99"
             parent="mass_mailing_menu_root"
-            action="mailing_trace_report_action_mail"
-            groups="mass_mailing.group_mass_mailing_user"/>
+            action="mailing_trace_report_action_mail"/>
 </odoo>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -685,7 +685,6 @@
         <menuitem name="Mailings" id="mass_mailing_menu"
             parent="mass_mailing_menu_root"
             sequence="1"
-            action="mailing_mailing_action_mail"
-            groups="mass_mailing.group_mass_mailing_user"/>
+            action="mailing_mailing_action_mail"/>
 
 </odoo>

--- a/addons/mass_mailing/views/mailing_mailing_views_menus.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views_menus.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- Marketing / Mailing -->
-    <menuitem name="Email Marketing" id="mass_mailing_menu_root" sequence="115" web_icon="mass_mailing,static/description/icon.png"/>
+    <menuitem name="Email Marketing" id="mass_mailing_menu_root" sequence="115" web_icon="mass_mailing,static/description/icon.png" groups="mass_mailing.group_mass_mailing_user"/>
     <menuitem name="Mailing Lists" id="mass_mailing_mailing_list_menu"
-        parent="mass_mailing_menu_root" sequence="2" groups="mass_mailing.group_mass_mailing_user"/>
+        parent="mass_mailing_menu_root" sequence="2"/>
 
     <!-- Marketing / Configuration -->
     <menuitem name="Configuration" id="mass_mailing_configuration"
         parent="mass_mailing_menu_root"
-        sequence="100"
-        groups="mass_mailing.group_mass_mailing_user"/>
+        sequence="100"/>
 
     <!-- Configuration / Blacklist -->
     <menuitem id="mail_blacklist_mm_menu" name="Blacklisted Email Addresses"

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -6,17 +6,23 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                    <button name="%(action_create_mass_mailings_from_campaign)d" type="action" class="oe_highlight" groups="mass_mailing.group_mass_mailing_campaign" string="Send new Mailing"/>
+                <field name="is_mailing_campaign_activated" invisible="1"/>
+                <button name="%(action_create_mass_mailings_from_campaign)d"
+                    type="action" class="oe_highlight" attrs="{'invisible': [('is_mailing_campaign_activated', '=', False)]}"
+                    groups="mass_mailing.group_mass_mailing_user" string="Send new Mailing"/>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button name="%(action_view_mass_mailings_from_campaign)d"
                     type="action" class="oe_stat_button order-9" icon="fa-envelope-o"
-                    attrs="{'invisible': [('mailing_mail_count', '=', 0)]}" groups="mass_mailing.group_mass_mailing_campaign">
+                    attrs="{'invisible': ['|', ('mailing_mail_count', '=', 0), ('is_mailing_campaign_activated', '=', False)]}"
+                    groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_mail_count" widget="statinfo" string="Mailings"/>
                 </button>
             </xpath>
             <xpath expr="//notebook" position="inside">
-                <page string="Mailings" name="mailings" attrs="{'invisible': [('mailing_mail_count', '=', 0)]}">
+                <page string="Mailings" name="mailings"
+                    attrs="{'invisible': ['|', ('mailing_mail_count', '=', 0), ('is_mailing_campaign_activated', '=', False)]}"
+                    groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_mail_ids" readonly="1" nolabel="1">
                         <tree>
                             <field name="subject"/>
@@ -78,12 +84,14 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position="after">
-                <field name="mailing_mail_ids"/>
+                <field name="mailing_mail_ids" groups="mass_mailing.group_mass_mailing_user"/>
+                <field name="is_mailing_campaign_activated"/>
             </xpath>
             <xpath expr="//ul[@id='o_utm_actions']">
                 <a name="%(action_view_mass_mailings_from_campaign)d" type="action"
                     t-attf-class="oe_mailings #{record.mailing_mail_ids.raw_value.length === 0 ? 'text-muted' : ''}"
-                    groups="mass_mailing.group_mass_mailing_campaign">
+                    t-if="record.is_mailing_campaign_activated.raw_value"
+                    groups="mass_mailing.group_mass_mailing_user">
                     <t t-out="record.mailing_mail_ids.raw_value.length"/> Mailings
                 </a>
             </xpath>

--- a/addons/mass_mailing_sms/models/utm.py
+++ b/addons/mass_mailing_sms/models/utm.py
@@ -10,8 +10,11 @@ class UtmCampaign(models.Model):
     mailing_sms_ids = fields.One2many(
         'mailing.mailing', 'campaign_id',
         domain=[('mailing_type', '=', 'sms')],
-        string='Mass SMS')
-    mailing_sms_count = fields.Integer('Number of Mass SMS', compute="_compute_mailing_sms_count")
+        string='Mass SMS',
+        groups="mass_mailing.group_mass_mailing_user")
+    mailing_sms_count = fields.Integer('Number of Mass SMS',
+        compute="_compute_mailing_sms_count",
+        groups="mass_mailing.group_mass_mailing_user")
 
     # A/B Testing
     ab_testing_sms_winner_selection = fields.Selection([

--- a/addons/mass_mailing_sms/views/utm_campaign_views.xml
+++ b/addons/mass_mailing_sms/views/utm_campaign_views.xml
@@ -6,19 +6,23 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <button name="action_create_mass_sms" type="object"  class="oe_highlight" string="Send SMS"/>
+                <button name="action_create_mass_sms" type="object"  class="oe_highlight" string="Send SMS"
+                    attrs="{'invisible': [('is_mailing_campaign_activated', '=', False)]}"
+                    groups="mass_mailing.group_mass_mailing_user"/>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button name="action_redirect_to_mailing_sms"
                  type="object"
                  class="oe_stat_button order-11"
-                 attrs="{'invisible': [('mailing_sms_count', '=', 0)]}"
-                 icon="fa-mobile">
+                 attrs="{'invisible': ['|', ('mailing_sms_count', '=', 0), ('is_mailing_campaign_activated', '=', False)]}"
+                 icon="fa-mobile" groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_sms_count" widget="statinfo" string="SMS"/>
                 </button>
             </xpath>
             <xpath expr="//notebook" position="inside">
-                <page string="SMS" name="sms" attrs="{'invisible': [('mailing_sms_count', '=', 0)]}">
+                <page string="SMS" name="sms"
+                    attrs="{'invisible': ['|', ('mailing_sms_count', '=', 0), ('is_mailing_campaign_activated', '=', False)]}"
+                    groups="mass_mailing.group_mass_mailing_user">
                     <group>
                         <field name="mailing_sms_ids" readonly="1" nolabel="1">
                             <tree>
@@ -42,11 +46,13 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position="after">
-                <field name="mailing_sms_count"/>
+                <field name="mailing_sms_count" groups="mass_mailing.group_mass_mailing_user"/>
             </xpath>
             <xpath expr="//ul[@id='o_utm_actions']">
                 <a name="action_redirect_to_mailing_sms" type="object"
-                    t-attf-class="oe_mailings #{record.mailing_sms_count.raw_value === 0 ? 'text-muted' : ''}">
+                    t-attf-class="oe_mailings #{record.mailing_sms_count.raw_value === 0 ? 'text-muted' : ''}"
+                    t-if="record.is_mailing_campaign_activated.raw_value"
+                    groups="mass_mailing.group_mass_mailing_user">
                     <t t-out="record.mailing_sms_count.raw_value"/> SMS
                 </a>
             </xpath>


### PR DESCRIPTION
PURPOSE
To fix campaign rights for internal users.

SPECIFICATION:
Current:

If user has no rights of mass_mailing and tries to access campaign from utm or social it gets user error that "You have no rights of mailing.mailing". But any internal user can access campaign it doesn't matter if you have rights of mailing.mailing or not.

To be:

Fix campaign rights for non marketing users.

Task id: 241799

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr