### PR TITLE
[FIX] product: speed up _get_possible_combinations

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1125,7 +1125,7 @@ class ProductTemplate(models.Model):
             yield necessary_values
 
         product_template_attribute_values_per_line = [
-            ptal.product_template_value_ids
+            ptal.product_template_value_ids._only_active()
             for ptal in attribute_lines
         ]
 


### PR DESCRIPTION
Excluding non-active records decrease number of combinations generated in
_cartesian_product. The excluded combinations have to be rejected anyway [1], so
don't waste time on it.

STEPS:
* activate "Product Configurator"
* create a product with many attributes
* make some `product.template.attribute.value` inactive (ptav_active = False):

  ** create a sale order with that value (e.g. color "Black" in "Customizable Desk (CONFIG)")
  ** delete that value in `product.template` form (tab "Variants")

* add the product to a sale order
* RESULT: `_cartesian_product` doesn't generates combination with archived attribute
* 
[1]

https://github.com/odoo/odoo/blob/f9d26509a714ecd290c42e1d58e416bb01268447/addons/product/models/product_template.py#L839-L841

---

opw-2540675
