### PR TITLE
[FIX] web_editor: fix unrecognized image upload

### DIFF
--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -24,7 +24,7 @@ models which only purpose is to run tests.""",
     'application': False,
     'assets': {
         'web.assets_frontend': [
-            'test_website/static/src/**/*',
+            'test_website/static/src/js/test_error.js',
         ],
         'web.assets_tests': [
             'test_website/static/tests/**/*',

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -112,5 +112,21 @@
             <a href="/test_website/country/andorra-1">I am a link</a>
         </template>
 
+        <record id="test_image_progress" model="website.page">
+            <field name="name">Test Image Progress</field>
+            <field name="url">/test_image_progress</field>
+            <field name="type">qweb</field>
+            <field name="key">test_website.test_image_progress</field>
+            <field name="arch" type="xml">
+                <t t-call="website.layout">
+                    <t t-set="head">
+                        <script defer="defer" type="text/javascript" src="/test_website/static/src/js/mock_image_widget.js"></script>
+                    </t>
+                    <div id="wrap" class="oe_structure oe_empty"/>
+                </t>
+            </field>
+            <field name="website_indexed" eval="False"/>
+        </record>
+
     </data>
 </odoo>

--- a/addons/test_website/static/src/js/mock_image_widget.js
+++ b/addons/test_website/static/src/js/mock_image_widget.js
@@ -1,0 +1,43 @@
+odoo.define('test_website.mock_image_widgets', function (require) {
+'use strict';
+
+const widgetsMedia = require('wysiwyg.widgets.media');
+
+widgetsMedia.FileWidget.include({
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    _onFileInputChange: function () {
+        console.warn("The `test_website` module is installed, any image upload will use a dummy image instead.");
+
+        function getFileFromB64(fileData) {
+            const binary = atob(fileData[2]);
+            let len = binary.length;
+            const arr = new Uint8Array(len);
+            while (len--) {
+                arr[len] = binary.charCodeAt(len);
+            }
+            return new File([arr], fileData[1], {type: fileData[0]});
+        }
+
+        let files = [
+            getFileFromB64(['image/png', 'image.png', "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAApElEQVR42u3RAQ0AAAjDMO5fNCCDkC5z0HTVrisFCBABASIgQAQEiIAAAQJEQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAREQIAICBABASIgQAQECBAgAgJEQIAIyPcGFY7HnV2aPXoAAAAASUVORK5CYII="]),
+            getFileFromB64(['image/jpeg', 'image.jpeg', "/9j/4AAQSkZJRgABAQAAAQABAAD//gAfQ29tcHJlc3NlZCBieSBqcGVnLXJlY29tcHJlc3P/2wCEAA0NDQ0ODQ4QEA4UFhMWFB4bGRkbHi0gIiAiIC1EKjIqKjIqRDxJOzc7STxsVUtLVWx9aWNpfZeHh5e+tb75+f8BDQ0NDQ4NDhAQDhQWExYUHhsZGRseLSAiICIgLUQqMioqMipEPEk7NztJPGxVS0tVbH1pY2l9l4eHl761vvn5///CABEIAEsASwMBIgACEQEDEQH/xAAVAAEBAAAAAAAAAAAAAAAAAAAABv/aAAgBAQAAAACHAAAAAAAAAAAAAAAAH//EABUBAQEAAAAAAAAAAAAAAAAAAAAH/9oACAECEAAAAKYAAAB//8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/2gAIAQMQAAAAngAAAf/EABQQAQAAAAAAAAAAAAAAAAAAAGD/2gAIAQEAAT8ASf/EABQRAQAAAAAAAAAAAAAAAAAAAED/2gAIAQIBAT8AT//EABQRAQAAAAAAAAAAAAAAAAAAAED/2gAIAQMBAT8AT//Z"]),
+            getFileFromB64(['image/vnd.microsoft.icon', 'icon.ico', "AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAA=="]),
+            getFileFromB64(['image/webp', 'image.webp', "UklGRhwAAABXRUJQVlA4TBAAAAAvE8AEAAfQhuh//wMR0f8A"]),
+        ];
+
+        if (!this.options.multiImages) {
+            if (this.media.classList.contains('o_mock_show_error')) {
+                files = [files[2]];
+            } else {
+                files = [files[0]];
+            }
+        }
+        this.$fileInput = [{'files': files}];
+        return this._super(...arguments);
+    }
+});
+});

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -1,0 +1,161 @@
+odoo.define('test_website.image_upload_progress', function (require) {
+'use strict';
+
+const tour = require('web_tour.tour');
+
+const formatErrorMsg = "format is not supported. Try with: .gif, .jpe, .jpeg, .jpg, .png, .svg";
+
+tour.register('test_image_upload_progress', {
+    url: '/test_image_progress',
+    test: true
+}, [
+    {
+        content: "enter edit mode",
+        trigger: "a[data-action=edit]"
+    }, {
+        content: "drop a snippet",
+        trigger: "#oe_snippets .oe_snippet[name='Text - Image'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+        extra_trigger: "body.editor_enable.editor_has_snippets",
+        moveTrigger: ".oe_drop_zone",
+        run: "drag_and_drop #wrap",
+    }, {
+        content: "drop a snippet",
+        trigger: "#oe_snippets .oe_snippet[name='Image Gallery'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+        extra_trigger: "body.editor_enable.editor_has_snippets",
+        moveTrigger: ".oe_drop_zone",
+        run: "drag_and_drop #wrap",
+    },
+    // 1. Check multi image upload
+    {
+        content: "click on dropped snippet",
+        trigger: "#wrap .s_image_gallery .img",
+    }, {
+        content: "click on add images to open image dialog (in multi mode)",
+        trigger: 'we-customizeblock-option [data-add-images]',
+    }, {
+        content: "manually trigger input change",
+        trigger: ".o_select_media_dialog .o_upload_media_button",
+        run: () => {
+            const fileInput = $('.o_select_media_dialog .o_file_input').first();
+            // This will trigger upload of dummy files for test purpose, as a
+            // test can't select local files to upload into the input.
+            // See `mock_image_widgets`.
+            fileInput.change();
+        },
+    }, {
+        content: "check upload progress bar is correctly shown (1)",
+        trigger: `.o_we_progressbar:contains('icon.ico'):contains('${formatErrorMsg}')`,
+        in_modal: false,
+        run: function () {}, // it's a check
+    }, {
+        content: "check upload progress bar is correctly shown (2)",
+        trigger: `.o_we_progressbar:contains('image.webp'):contains('${formatErrorMsg}')`,
+        in_modal: false,
+        run: function () {}, // it's a check
+    }, {
+        content: "check upload progress bar is correctly shown (3)",
+        trigger: ".o_we_progressbar:contains('image.png'):contains('File has been uploaded')",
+        in_modal: false,
+        run: function () {}, // it's a check
+    }, {
+        content: "check upload progress bar is correctly shown (4)",
+        trigger: ".o_we_progressbar:contains('image.jpeg'):contains('File has been uploaded')",
+        in_modal: false,
+        run: function () {}, // it's a check
+    }, {
+        content: "there should only have one notification toaster",
+        trigger: ".o_notification",
+        in_modal: false,
+        run: () => {
+            const notificationCount = $('.o_notification').length;
+            if (notificationCount !== 1) {
+                console.error("There should be one noficiation toaster opened, and only one.");
+            }
+        }
+    }, {
+        content: "close notification",
+        trigger: '.o_notification_close',
+        in_modal: false,
+    }, {
+        content: "close media dialog",
+        trigger: '.modal-footer .btn-secondary',
+    },
+    // 2. Check success single image upload
+    {
+        content: "click on dropped snippet",
+        trigger: "#wrap .s_text_image .img",
+    }, {
+        content: "click on replace media to open image dialog",
+        trigger: 'we-customizeblock-option [data-replace-media]',
+    }, {
+        content: "manually trigger input change",
+        trigger: ".o_select_media_dialog .o_upload_media_button",
+        in_modal: false,
+        run: () => {
+            const fileInput = $('.o_select_media_dialog .o_file_input').first();
+            // This will trigger upload of dummy files for test purpose, as a
+            // test can't select local files to upload into the input.
+            // See `mock_image_widgets`.
+            fileInput.change();
+        },
+    }, {
+        content: "check upload progress bar is correctly shown",
+        trigger: ".o_we_progressbar:contains('image.png'):contains('File has been uploaded')",
+        in_modal: false,
+        run: function () {}, // it's a check
+    }, {
+        content: "there should only have one notification toaster",
+        trigger: ".o_notification",
+        in_modal: false,
+        run: () => {
+            const notificationCount = $('.o_notification').length;
+            if (notificationCount !== 1) {
+                console.error("There should be one noficiation toaster opened, and only one.");
+            }
+        }
+    }, {
+        content: "close media dialog",
+        trigger: 'button.btn.btn-secondary[type="button"]',
+    }, {
+        content: "toaster should disappear after a few seconds if the uploaded image is successful",
+        trigger: "body:not(:has(.o_we_progressbar))",
+        run: function () {}, // it's a check
+    },
+    // 3. Check error single image upload
+    {
+        content: "click on dropped snippet",
+        trigger: "#wrap .s_text_image .img",
+    }, {
+        content: "click on replace media to open image dialog",
+        trigger: 'we-customizeblock-option [data-replace-media]',
+    }, {
+        content: "manually trigger input change",
+        trigger: ".o_select_media_dialog .o_upload_media_button",
+        in_modal: false,
+        run: () => {
+            $("#wrap .s_text_image .img").addClass('o_mock_show_error');
+            const fileInput = $('.o_select_media_dialog .o_file_input').first();
+            // This will trigger upload of dummy files for test purpose, as a
+            // test can't select local files to upload into the input.
+            // See `mock_image_widgets`.
+            fileInput.change();
+        },
+    }, {
+        content: "check upload progress bar is correctly shown",
+        trigger: `.o_we_progressbar:contains('icon.ico'):contains('${formatErrorMsg}')`,
+        in_modal: false,
+        run: function () {}, // it's a check
+    }, {
+        content: "there should only have one notification toaster",
+        trigger: ".o_notification",
+        in_modal: false,
+        run: () => {
+            const notificationCount = $('.o_notification').length;
+            if (notificationCount !== 1) {
+                console.error("There should be one noficiation toaster opened, and only one.");
+            }
+        }
+    },
+]);
+
+});

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -4,6 +4,7 @@
 from . import test_controller_args
 from . import test_custom_snippet
 from . import test_error
+from . import test_image_upload_progress
 from . import test_is_multilang
 from . import test_multi_company
 from . import test_performance

--- a/addons/test_website/tests/test_image_upload_progress.py
+++ b/addons/test_website/tests/test_image_upload_progress.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestImageUploadProgress(odoo.tests.HttpCase):
+
+    def test_01_image_upload_progress(self):
+        self.start_tour("/test_image_progress", 'test_image_upload_progress', login="admin")

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -173,6 +173,10 @@ class Web_Editor(http.Controller):
                 mimetype = guess_mimetype(b64decode(data))
                 if mimetype not in SUPPORTED_IMAGE_MIMETYPES:
                     return {'error': format_error_msg}
+            except UserError:
+                # considered as an image by the browser file input, but not
+                # recognized as such by PIL, eg .webp
+                return {'error': format_error_msg}
             except ValueError as e:
                 return {'error': e.args[0]}
 


### PR DESCRIPTION
Since 3765ac1f1f16, uploading an image not recognized as such by PIL would not
behaves as it should.

Step to reproduce:
  - Enter edit mode, drag & drop a snippet with an image
  - Double click on the image to open media dialog
  - Upload a local image of type `.webp`
  - 2 toaster are shown:
    1. A progress bar toaster with a generic message "File could not be saved"
    2. A generic warning toaster on top of the previous one with the correct
       error message "[..] format is not supported. Try with: .gif [..]"

Instead, only the progress bar toaster should be shown, and the error message
should be displayed in it.

task-2607393
