### PR TITLE
[FIX] sale_coupon: align stat button with act_window results

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -135,8 +135,9 @@ class SaleCouponProgram(models.Model):
             'name': _('Sales Orders'),
             'view_mode': 'tree,form',
             'res_model': 'sale.order',
+            'search_view_id': [self.env.ref('sale.sale_order_view_search_inherit_quotation').id],
             'type': 'ir.actions.act_window',
-            'domain': [('id', 'in', orders.ids), ('state', 'not in', ('draft', 'sent', 'cancel'))],
+            'domain': [('id', 'in', orders.ids)],
             'context': dict(self._context, create=False)
         }
 


### PR DESCRIPTION
Before this commit, the number you saw on the stat button was not
always the same as the number of sale order you would see when you
clicked on it.
Indeed, there was a domain force on the action to only show
confirmed orders, while the stat button was counting quotations too.

Applied the fix done with PR 71826 in version 14, in version 13.

opw-2526701

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
