### PR TITLE
[FIX] web: fix quick edit text selection test

### DIFF
--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -11181,7 +11181,7 @@ QUnit.module('Views', {
 
         // double click selecting text doesn't start quick edit
         window.getSelection().removeAllRanges();
-        await testUtils.dom.click(form.$('.o_field_widget[name="display_name"]'));
+        testUtils.dom.click(form.$('.o_field_widget[name="display_name"]'));
         range.selectNode(form.$('.o_field_widget[name="display_name"]')[0]);
         window.getSelection().addRange(range);
         await testUtils.dom.click(form.$('.o_field_widget[name="display_name"]'));


### PR DESCRIPTION
Before this commit, it could happen that the test fails.
We may be waiting too long on the second click in the test and so
the form switches to edit mode too early.
Now, we don't await the click to keep sync.