### PR TITLE
[FIX] web: fix no_open attr in tree x2many field

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1461,7 +1461,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
                 addCreateLine: this._hasCreateLine(),
                 addTrashIcon: this._hasTrashIcon(),
                 isMany2Many: this.isMany2Many,
-                no_open: (this.isReadonly && !this.hasReadonlyModifier) &&
+                no_open: (this.isReadonly && !this.hasReadonlyModifier) ||
                     (this._canQuickEdit || toBoolElse(arch.attrs.no_open || '', false)),
                 columnInvisibleFields: this.currentColInvisibleFields,
             });

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -485,6 +485,90 @@ QUnit.module('relational_fields', {
         form.destroy();
     });
 
+    QUnit.test('prevent the dialog in not editable x2many tree view with option no_open True', async function (assert) {
+        assert.expect(5);
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <sheet>
+                        <field name="turtles">
+                            <tree no_open="True">
+                                <field name="turtle_foo"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                </form>
+            `,
+            res_id: 1,
+            mockRPC(route) {
+                assert.step(route);
+                return this._super(...arguments);
+            },
+        });
+        assert.containsOnce(
+            form,
+            '.o_data_row:contains("blip")',
+            "There should be one record in x2many list view"
+        );
+        await testUtils.dom.click(form.$('.o_data_row:first'));
+        assert.verifySteps([
+            "/web/dataset/call_kw/partner/read",
+            "/web/dataset/call_kw/turtle/read",
+            // if there is a third rpc then it means that we ask to open a dialog.
+        ]);
+        assert.strictEqual(
+            $('.modal-dialog').length,
+            0,
+            "There is should be no dialog open on click of readonly list row"
+        );
+        form.destroy();
+    });
+
+    QUnit.test('prevent the dialog in x2many tree view in readonly form with option no_open True', async function (assert) {
+        assert.expect(5);
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form edit="0">
+                    <sheet>
+                        <field name="turtles">
+                            <tree no_open="True">
+                                <field name="turtle_foo"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                </form>
+            `,
+            res_id: 1,
+            mockRPC(route) {
+                assert.step(route);
+                return this._super(...arguments);
+            },
+        });
+        assert.containsOnce(
+            form,
+            '.o_data_row:contains("blip")',
+            "There should be one record in x2many list view"
+        );
+        await testUtils.dom.click(form.$('.o_data_row:first'));
+        assert.verifySteps([
+            "/web/dataset/call_kw/partner/read",
+            "/web/dataset/call_kw/turtle/read",
+            // if there is a third rpc then it means that we ask to open a dialog.
+        ]);
+        assert.strictEqual(
+            $('.modal-dialog').length,
+            0,
+            "There is should be no dialog open on click of readonly list row"
+        );
+        form.destroy();
+    });
+
     QUnit.test('delete a record while adding another one in a multipage', async function (assert) {
         // in a many2one with at least 2 pages, add a new line. Delete the line above it.
         // (the onchange makes it so that the virtualID is inserted in the middle of the currentResIDs.)


### PR DESCRIPTION
Before this commit, when the tree view in a x2many field was set
readonly by a modifier, clicking on a line could open the form dialog
even if the no_open attr was set to a truthy value.