### PR TITLE
[FIX] website: remove ir.asset specific on unlink

### DIFF
--- a/addons/website/models/ir_asset.py
+++ b/addons/website/models/ir_asset.py
@@ -8,7 +8,7 @@ class IrAsset(models.Model):
     _inherit = 'ir.asset'
 
     key = fields.Char(copy=False, help='Technical field used to resolve multiple assets in a multi-website environment.')
-    website_id = fields.Many2one('website')
+    website_id = fields.Many2one('website', ondelete='cascade')
 
     def _get_related_assets(self, domain):
         website = self.env['website'].get_current_website(fallback=False)


### PR DESCRIPTION
New system of ir.asset doesn't clear specific website asset on uninstall.
Now when we delete a website, we delete relate ir.asset.

task-2611030

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
