### PR TITLE
[FIX] point_of_sale: Don't fail when manually running scheduler

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1004,7 +1004,7 @@ class PosSession(models.Model):
     def _alert_old_session(self):
         # If the session is open for more then one week,
         # log a next activity to close the session.
-        sessions = self.search([('start_at', '<=', (fields.datetime.now() - timedelta(days=7))), ('state', '!=', 'closed')])
+        sessions = self.sudo().search([('start_at', '<=', (fields.datetime.now() - timedelta(days=7))), ('state', '!=', 'closed')])
         for session in sessions:
             if self.env['mail.activity'].search_count([('res_id', '=', session.id), ('res_model', '=', 'pos.session')]) == 0:
                 session.activity_schedule('point_of_sale.mail_activity_old_session',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When running the scheduler manually with a user who has no read access on pos.session (and point_of_sale is installed),
the run fails silently for the user, and shows an error in the logs.
"_alert_old_session" runs with the user's rights, who might have POS access.

This commits runs the problematic search with sudo to work around this
issue.

Current behavior before PR:

Scheduler silently fails.

Desired behavior after PR is merged:

Scheduler runs normally


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
