### PR TITLE
[IMP] account: only generate email and pdf once on send&print invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2779,7 +2779,8 @@ class AccountMove(models.Model):
             mark_invoice_as_sent=True,
             custom_layout="mail.mail_notification_paynow",
             model_description=self.with_context(lang=lang).type_name,
-            force_email=True
+            force_email=True,
+            wizard_opened=True
         )
         return {
             'name': _('Send Invoice'),

--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -93,7 +93,8 @@ class AccountInvoiceSend(models.TransientModel):
                 self.composer_id.composition_mode = 'comment' if len(res_ids) == 1 else 'mass_mail'
                 self.composer_id.template_id = self.template_id.id
                 self._compute_composition_mode()
-            self.composer_id.onchange_template_id_wrapper()
+            if not self.env.context.get("wizard_opened"):
+                self.composer_id.onchange_template_id_wrapper()
 
     @api.onchange('is_email')
     def _compute_invoice_without_email(self):


### PR DESCRIPTION
action_invoice_sent() triggers two onchanges which normally don't happen at the same time. Added a check to one of them (onchange_is_email()), so that on action_invoice_sent(), only one of them calls the computationally expensive onchange_template_id_wrapper(), effectively halving the time taken.

Time for executing the action for one invoice dropped from over 3 seconds to a bit over 1.