### PR TITLE
[FIX] l10n_fr_pos_cert: bind disallowLineQuantityChange

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -36,7 +36,7 @@ models.PosModel = models.PosModel.extend({
     },
 
     disallowLineQuantityChange() {
-        let result = _super_posmodel.disallowLineQuantityChange();
+        let result = _super_posmodel.disallowLineQuantityChange.bind(this)();
         return this.is_french_country() || result;
     }
 });


### PR DESCRIPTION
When using several certification together, there was an issue
when we tried to modify the quantity of an orderline.
The "this" context was lost and we were unable to call the function
anymore.

In order to fix that, we bind the context when calling the function.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
