### PR TITLE
[FIX] website: fix anchor display + remove useless query

### DIFF
--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -466,7 +466,7 @@
                         <input type="text" name="label" class="form-control" id="o_link_dialog_label_input" required="required" t-att-value="widget.data.text"/>
                     </div>
                 </div>
-                <div t-attf-class="form-group row o_url_input#{widget.isButton ? ' d-none' : ''}">
+                <div id="o_url_input" t-attf-class="form-group row o_url_input#{widget.isButton ? ' d-none' : ''}">
                     <label class="col-form-label col-md-3" for="o_link_dialog_url_input">URL or Email</label>
                     <div class="col-md-9">
                         <input type="text" name="url" class="form-control" id="o_link_dialog_url_input" required="required"/>

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -50,20 +50,25 @@ weWidgets.LinkDialog.include({
         var $selectMenu = this.$('select[name="link_anchor"]');
         var $anchorsLoading = this.$('.o_anchors_loading');
 
-        $anchorsLoading.removeClass('d-none');
-        $pageAnchor.toggleClass('d-none', !isFromWebsite);
-        $selectMenu.empty();
-        wUtils.loadAnchors(urlInputValue).then(function (anchors) {
-            _.each(anchors, function (anchor) {
-                $selectMenu.append($('<option>', {text: anchor}));
-            });
+        if ($selectMenu.data("anchor-for") !== urlInputValue) { // avoid useless query
+            $anchorsLoading.removeClass('d-none');
+            $pageAnchor.toggleClass('d-none', !isFromWebsite);
+            $selectMenu.empty();
+            wUtils.loadAnchors(urlInputValue).then(function (anchors) {
+                _.each(anchors, function (anchor) {
+                    $selectMenu.append($('<option>', {text: anchor}));
+                });
+                always();
+            }).guardedCatch(always);
+        } else {
             always();
-        }).guardedCatch(always);
+        }
 
         function always() {
             $anchorsLoading.addClass('d-none');
             $selectMenu.prop("selectedIndex", -1);
         }
+        $selectMenu.data("anchor-for", urlInputValue);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -68,6 +68,9 @@ function autocompleteWithPages(self, $input, options) {
                 loadAnchors(request.term).then(function (anchors) {
                     response(anchors);
                 });
+            } else if (request.term.startsWith('http') || request.term.length === 0) {
+                // avoid useless call to /website/get_suggested_links
+                response();
             } else {
                 return self._rpc({
                     route: '/website/get_suggested_links',
@@ -90,6 +93,8 @@ function autocompleteWithPages(self, $input, options) {
             }
         },
         select: function (ev, ui) {
+            // choose url in dropdown with arrow change ev.target.value without trigger_up
+            // so cannot check here if value has been updated
             ev.target.value = ui.item.value;
             self.trigger_up('website_url_chosen');
             ev.preventDefault();

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -35,7 +35,7 @@
         <t t-jquery="#o_link_dialog_url_input" t-operation="after">
             <small class="form-text text-muted">Hint: Type '/' to search an existing page and '#' to link to an anchor.</small>
         </t>
-        <t t-jquery="div.o_url_input" t-operation="after">
+        <t t-jquery="div#o_url_input" t-operation="after">
             <div class="form-group row o_link_dialog_page_anchor d-none">
                 <label class="col-form-label col-md-3" for="o_link_dialog_anchor_input">Page Anchor</label>
                 <div class="col-md-9">


### PR DESCRIPTION
Before this commit, anchor select on link dialig was never shown
-> xpath done on attribute class but t-attf-class is used

Now we show the anchor input.

This commit also avoid useless anchor detection for empty url and external url.
Or in case of the selected url is the same than the last one loaded.

E.g. type /contactus -> load anchor -> choose one identicalfrom list
     before -> reload anchor
     now -> we don't refresh anchor screen

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
