### PR TITLE
[IMP] base,hr: add tests for avatar mixin

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -7,6 +7,20 @@ from odoo.addons.hr.tests.common import TestHrCommon
 
 class TestHrEmployee(TestHrCommon):
 
+    def setUp(self):
+        super().setUp()
+        self.user_without_image = self.env['res.users'].create({
+            'name': 'Marc Demo',
+            'email': 'mark.brown23@example.com',
+            'image_1920': False,
+            'login': 'demo_1',
+            'password': 'demo_123'
+        })
+        self.employee_without_image = self.env['hr.employee'].create({
+            'user_id': self.user_without_image.id,
+            'image_1920': False
+        })
+
     def test_employee_resource(self):
         _tz = 'Pacific/Apia'
         self.res_users_hr_officer.company_id.resource_calendar_id.tz = _tz
@@ -45,3 +59,13 @@ class TestHrEmployee(TestHrCommon):
         self.assertEqual(employee.name, 'Raoul Grosbedon')
         self.assertEqual(employee.work_email, self.res_users_hr_officer.email)
         self.assertEqual(employee.tz, _tz)
+
+    def test_employee_has_avatar_even_if_it_has_no_image(self):
+        self.assertTrue(self.employee_without_image.avatar_128)
+        self.assertTrue(self.employee_without_image.avatar_256)
+        self.assertTrue(self.employee_without_image.avatar_512)
+        self.assertTrue(self.employee_without_image.avatar_1024)
+        self.assertTrue(self.employee_without_image.avatar_1920)
+
+    def test_employee_has_same_avatar_as_corresponding_user(self):
+        self.assertEqual(self.employee_without_image.avatar_1920, self.user_without_image.avatar_1920)

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_float
 from . import test_func
 from . import test_http_case
 from . import test_image
+from . import test_avatar_mixin
 from . import test_ir_actions
 from . import test_ir_attachment
 from . import test_ir_cron

--- a/odoo/addons/base/tests/test_avatar_mixin.py
+++ b/odoo/addons/base/tests/test_avatar_mixin.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from base64 import b64decode
+
+from odoo.tests.common import TransactionCase
+
+class TestAvatarMixin(TransactionCase):
+
+    """ tests the avatar mixin """
+    def setUp(self):
+        super().setUp()
+        self.user_without_image = self.env['res.users'].create({
+            'name': 'Marc Demo',
+            'email': 'mark.brown23@example.com',
+            'image_1920': False,
+            'create_date': '2015-11-12 00:00:00',
+            'login': 'demo_1',
+            'password': 'demo_1'
+        })
+        self.user_without_image.partner_id.create_date = '2015-11-12 00:00:00'
+
+        self.user_without_name = self.env['res.users'].create({
+            'name': '',
+            'email': 'marc.grey25@example.com',
+            'image_1920': False,
+            'login': 'marc_1',
+            'password': 'marc_1',
+        })
+        self.external_partner = self.env['res.partner'].create({
+            'name': 'Josh Demo',
+            'email': 'josh.brown23@example.com',
+            'image_1920': False
+        })
+
+    def test_partner_has_avatar_even_if_it_has_no_image(self):
+        self.assertTrue(self.user_without_image.partner_id.avatar_128)
+        self.assertTrue(self.user_without_image.partner_id.avatar_256)
+        self.assertTrue(self.user_without_image.partner_id.avatar_512)
+        self.assertTrue(self.user_without_image.partner_id.avatar_1024)
+        self.assertTrue(self.user_without_image.partner_id.avatar_1920)
+
+    def test_content_of_generated_partner_avatar(self):
+        expectedAvatar = (
+            "<?xml version='1.0' encoding='UTF-8' ?>"
+            "<svg height='180' width='180' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>"
+            "<rect fill='hsl(184, 40%, 45%)' height='180' width='180'/>"
+            "<text fill='#ffffff' font-size='96' text-anchor='middle' x='90' y='125' font-family='sans-serif'>M</text>"
+            "</svg>"
+        )
+        self.assertEqual(expectedAvatar, b64decode(self.user_without_image.partner_id.avatar_1920).decode('utf-8'))
+
+    def test_partner_without_name_has_default_placeholder_image_as_avatar(self):
+        self.assertEqual(self.user_without_name.partner_id._avatar_get_placeholder(), self.user_without_name.partner_id.avatar_1920)
+
+    def test_external_partner_has_default_placeholder_image_as_avatar(self):
+        self.assertEqual(self.external_partner._avatar_get_placeholder(), self.external_partner.avatar_1920)
+
+    def test_partner_and_user_have_the_same_avatar(self):
+        self.assertEqual(self.user_without_image.partner_id.avatar_1920, self.user_without_image.avatar_1920)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In task 2404630 the avatar feature was created and no tests were written due to
the iminent freeze. This PR implements tests for the avatar feature, such as
avatar generation and placeholder logic.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
