### PR TITLE
[FIX] hr_holidays: Allow overlapping if not employee

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -452,9 +452,9 @@ class HolidaysRequest(models.Model):
             else:
                 holiday.can_approve = True
 
-    @api.constrains('date_from', 'date_to')
+    @api.constrains('date_from', 'date_to', 'state', 'employee_id')
     def _check_date(self):
-        for holiday in self:
+        for holiday in self.filtered('employee_id'):
             domain = [
                 ('date_from', '<', holiday.date_to),
                 ('date_to', '>', holiday.date_from),


### PR DESCRIPTION
Issue:

    When creating a leave there is an error when you use by "employee tag"
    but it works when you use "by employee".

Solution:

  cherry-pick of:
  odoo@394eedc
  odoo@c89c0e7

opw-2525086