### PR TITLE
[FIX] website_sale: fix disabled confirmation button for free order

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_payment.js
+++ b/addons/website_sale/static/src/js/website_sale_payment.js
@@ -94,6 +94,16 @@ odoo.define('website_sale.payment', require => {
                 'change #checkbox_tc': '_onClickTCCheckbox',
             },
 
+            /**
+             * @override
+             */
+            start: function () {
+                this.$checkbox = this.$('#checkbox_tc');
+                this.$submitButton = this.$('button[name="o_payment_submit_button"]');
+                this._onClickTCCheckbox();
+                return this._super(...arguments);
+            },
+
             //--------------------------------------------------------------------------
             // Handlers
             //--------------------------------------------------------------------------


### PR DESCRIPTION
- Go to website shop
- Add free product or discount to cart to make sure that total amount is 0
- Try to confirm order
It will not be possible because the "Confirm Order" button is disabled by
default and there is no way to enable it.

opw-2577089




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
