### PR TITLE
[FIX] hr_payroll: make the paid field clickable

### DIFF
--- a/addons/hr_payroll/views/hr_payslip_views.xml
+++ b/addons/hr_payroll/views/hr_payslip_views.xml
@@ -247,7 +247,7 @@
                                 <field name="payslip_run_id" domain="[('state','=','draft')]"/>
                             </group>
                             <group name="accounting" string="Accounting">
-                                <field name="paid" readonly="1"/>
+                                <field name="paid"/>
                             </group>
                         </group>
                         <div colspan="4">


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Payroll app > Payslips > To Pay
- Choose any Payslip
- Go to the Accounting Information tab

Problem:
`”Made Payment Order ?”` field is always readonly when it should be clickable when the status is in draft or in verify
according to the rule defined in the python code. It doesn't make sense to always put it in readonly in xml
because it overrides the python rule : https://github.com/odoo/enterprise/blob/faf69b3de1d7fc955e3f6271fd24b901310fe5e4/hr_payroll/models/hr_payslip.py#L58-L59

opw-2608818



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
