### PR TITLE
[FIX] mrp: traceback on production without BoM

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -445,7 +445,7 @@ class MrpProduction(models.Model):
                 production.state = 'to_close'
             elif any(wo_state in ('progress', 'done') for wo_state in production.workorder_ids.mapped('state')):
                 production.state = 'progress'
-            elif not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
+            elif production.product_uom_id and not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
                 production.state = 'progress'
             elif any(not float_is_zero(move.quantity_done, precision_rounding=move.product_uom.rounding or move.product_id.uom_id.rounding) for move in production.move_raw_ids):
                 production.state = 'progress'


### PR DESCRIPTION
Usecase:
- Create a production order without BoM
- Add a component

-> Traceback precision_rounding should be different than 0

It's due to a compute that try to access the UoM rounding
while the UoM is not yet set in this case

