### PR TITLE
[I18N] Improve es_MX translation for VAT name, change from IVA/NIF to RFC

### DIFF
--- a/addons/account/i18n/es_MX.po
+++ b/addons/account/i18n/es_MX.po
@@ -1642,7 +1642,7 @@ msgstr "Añadir"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "Add Credit Note"
-msgstr "Añadir factura rectificativa"
+msgstr "Añadir Nota de Crédito"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__add_sign
@@ -2280,7 +2280,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__tax_exigible
 msgid "Appears in VAT report"
-msgstr "Aparece en el reporte de IVA"
+msgstr "Aparece en el reporte de RFC"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account_tag__applicability
@@ -2331,7 +2331,7 @@ msgstr "Aplicar solo si el cliente tiene un número de identificación fiscal."
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Apply right VAT rates for digital products sold in EU"
 msgstr ""
-"Aplicar los tipos de IVA correctos para productos digitales vendidos en la "
+"Aplicar los tipos de RFC correctos para productos digitales vendidos en la "
 "UE"
 
 #. module: account
@@ -3224,7 +3224,7 @@ msgid ""
 "Changing VAT number is not allowed once invoices have been issued for your "
 "account. Please contact us directly for this operation."
 msgstr ""
-"No está permitido cambiar el número de IVA una vez que se hayan emitido las "
+"No está permitido cambiar el número de RFC una vez que se hayan emitido las "
 "facturas para su cuenta. Por favor, contáctenos directamente para esta "
 "operación."
 
@@ -5103,7 +5103,7 @@ msgstr "Reportes dinámicos"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_l10n_eu_service
 msgid "EU Digital Goods VAT"
-msgstr "IVA de bienes digitales de la UE"
+msgstr "RFC de bienes digitales de la UE"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_EXW
@@ -6218,7 +6218,7 @@ msgid ""
 "telecommunications, and services that are electronically supplied instead of"
 " shipped. Gift cards sent online are not included in the definition."
 msgstr ""
-"Si vende productos digitales a clientes de la UE, debe cobrar el IVA en "
+"Si vende productos digitales a clientes de la UE, debe cobrar el RFC en "
 "función de la ubicación de sus clientes. Esta regla se aplica "
 "independientemente de su ubicación. Los bienes digitales se definen en la "
 "legislación como radiodifusión, telecomunicaciones y servicios que se "
@@ -12014,7 +12014,7 @@ msgid ""
 "will become exigible only when the payment is recorded."
 msgstr ""
 "Campo técnico utilizado para marcar una línea fiscal como exigible en el "
-"informe de IVA o no (solo los apuntes de diario exigibles son mostrados). De"
+"informe de RFC o no (solo los apuntes de diario exigibles son mostrados). De"
 " forma predeterminada, todos los artículos de diario nuevos son exigibles "
 "directamente, pero con la característica de caja en impuestos, algunos serán"
 " exigibles solo cuando se registre el pago."
@@ -14034,7 +14034,7 @@ msgstr "Campo de utilidad para expresar la divisa del importe."
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position__vat_required
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position_template__vat_required
 msgid "VAT required"
-msgstr "Requiere IVA"
+msgstr "Requiere RFC"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_bank_statement_form

--- a/addons/account_edi_ubl/i18n/es_MX.po
+++ b/addons/account_edi_ubl/i18n/es_MX.po
@@ -55,4 +55,4 @@ msgstr "Última modificación el"
 #. module: account_edi_ubl
 #: model_terms:ir.ui.view,arch_db:account_edi_ubl.export_ubl_invoice_partner
 msgid "VAT"
-msgstr "IVA"
+msgstr "RFC"

--- a/addons/base_vat/i18n/es_MX.po
+++ b/addons/base_vat/i18n/es_MX.po
@@ -34,7 +34,7 @@ msgstr ""
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.view_partner_form
 msgid "<span class=\"o_vat_label\">VAT</span>"
-msgstr "<span class=\"o_vat_label\">IVA</span>"
+msgstr "<span class=\"o_vat_label\">RFC</span>"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
@@ -72,7 +72,7 @@ msgid ""
 "VAT number cannot be verified by the European VIES service."
 msgstr ""
 "Si esta casilla de verificación se encuentra seleccionada, no podrá guardar "
-"un contacto si el NIF no es valido para el servicio Europeo VIES."
+"un contacto si el RFC no es valido para el servicio Europeo VIES."
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company____last_update
@@ -99,13 +99,13 @@ msgid ""
 "validation check or did not respect the expected format %(format)s."
 msgstr ""
 "El RFC [%(vat)s] del partner [%(name)s] no pasó la verificación de "
-"validación del NIF VIES o no tiene el formato esperado%(format)s."
+"validación del RFC VIES o no tiene el formato esperado%(format)s."
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.company_form_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.view_partner_form
 msgid "VAT"
-msgstr "IVA"
+msgstr "RFC"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
@@ -116,4 +116,4 @@ msgstr "Verificar RFC"
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid "Verify VAT numbers using the European VIES service"
-msgstr "Verificar NIF con el servicio europeo VIES"
+msgstr "Verificar RFC con el servicio europeo VIES"

--- a/addons/portal/i18n/es_MX.po
+++ b/addons/portal/i18n/es_MX.po
@@ -330,7 +330,7 @@ msgid ""
 "Changing VAT number is not allowed once document(s) have been issued for "
 "your account. Please contact us directly for this operation."
 msgstr ""
-"No se permite cambiar el número de IVA una vez que se han emitido los "
+"No se permite cambiar el número de RFC una vez que se han emitido los "
 "documentos de su cuenta. Póngase en contacto con nosotros directamente para "
 "esta operación."
 
@@ -1014,7 +1014,7 @@ msgstr "Usuarios"
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_my_details
 msgid "VAT Number"
-msgstr "NIF"
+msgstr "RFC"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_my_security

--- a/addons/pos_restaurant/i18n/es_MX.po
+++ b/addons/pos_restaurant/i18n/es_MX.po
@@ -1366,7 +1366,7 @@ msgstr "Usado para organizar pisos"
 #: code:addons/pos_restaurant/static/src/xml/TipReceipt.xml:0
 #, python-format
 msgid "VAT:"
-msgstr "IVA:"
+msgstr "RFC:"
 
 #. module: pos_restaurant
 #: model:product.product,name:pos_restaurant.pos_food_vege

--- a/addons/purchase/i18n/es_MX.po
+++ b/addons/purchase/i18n/es_MX.po
@@ -1602,7 +1602,7 @@ msgstr "Nombre"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
 msgid "Name, TIN, Email, or Reference"
-msgstr "Nombre, NIF, correo electrónico o referencia"
+msgstr "Nombre, RFC, correo electrónico o referencia"
 
 #. module: purchase
 #: code:addons/purchase/controllers/portal.py:0
@@ -3066,7 +3066,7 @@ msgstr "Sí"
 #: model:ir.model.fields,help:purchase.field_purchase_order_line__partner_id
 msgid "You can find a vendor by its Name, TIN, Email or Internal Reference."
 msgstr ""
-"Puede encontrar un proveedor por su nombre, NIF, correo electrónico o "
+"Puede encontrar un proveedor por su nombre, RFC, correo electrónico o "
 "referencia interna."
 
 #. module: purchase

--- a/addons/purchase_requisition/i18n/es_MX.po
+++ b/addons/purchase_requisition/i18n/es_MX.po
@@ -483,7 +483,7 @@ msgstr "Mis acuerdos"
 #. module: purchase_requisition
 #: model_terms:ir.ui.view,arch_db:purchase_requisition.purchase_order_form_inherit
 msgid "Name, TIN, Email, or Reference"
-msgstr "Nombre, NIF, correo electrónico o referencia."
+msgstr "Nombre, RFC, correo electrónico o referencia."
 
 #. module: purchase_requisition
 #: model_terms:ir.ui.view,arch_db:purchase_requisition.view_purchase_requisition_filter

--- a/addons/website_sale/i18n/es_MX.po
+++ b/addons/website_sale/i18n/es_MX.po
@@ -2914,7 +2914,7 @@ msgstr ""
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.address_b2b
 msgid "TIN / VAT"
-msgstr "NIF"
+msgstr "RFC"
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.snippet_options
@@ -3580,6 +3580,6 @@ msgid ""
 "Changing VAT number is not allowed once document(s) have been issued for "
 "your account. Please contact us directly for this operation."
 msgstr ""
-"No se permite cambiar el número de IVA una vez que se han emitido los "
+"No se permite cambiar el número de RFC una vez que se han emitido los "
 "documentos de su cuenta. Póngase en contacto con nosotros directamente para "
 "esta operación."

--- a/odoo/addons/base/i18n/es_MX.po
+++ b/odoo/addons/base/i18n/es_MX.po
@@ -1726,9 +1726,9 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"* Agrega un libro de reporte de IVA, que es un requisito legal en Argentina. El libro contiene información detallada del IVA de ventas y compras que se hicieron durante un periodo de tiempo. \n"
-"* Agrega un informe de resumen del IVA que se utiliza para analizar la facturación.\n"
-"* Agrega la funcionalidad de un libro digital de IVA que nos permite generar archivos TXT para importarlos a AFIP, estos son los que implementamos:\n"
+"* Agrega un libro de reporte de RFC, que es un requisito legal en Argentina. El libro contiene información detallada del IVA de ventas y compras que se hicieron durante un periodo de tiempo. \n"
+"* Agrega un informe de resumen del RFC que se utiliza para analizar la facturación.\n"
+"* Agrega la funcionalidad de un libro digital de RFC que nos permite generar archivos TXT para importarlos a AFIP, estos son los que implementamos:\n"
 "\n"
 "    * LIBRO_IVA_DIGITAL_VENTAS_CBTE\n"
 "    * LIBRO_IVA_DIGITAL_VENTAS_ALICUOTAS\n"
@@ -2264,29 +2264,29 @@ msgid ""
 "This module is compatible with base_vat module in order to be able to validate VAT numbers for each country that have or not have the possibility to manage multiple identification types.\n"
 msgstr ""
 "\n"
-"Agregue un nuevo modelo denominado \"Tipo de identificación\" que amplíe la funcionalidad del campo de número de identificación fiscal (NIF) del contacto y permita que el usuario identifique (eventualmente una factura) a los contactos no solo con su número identificación fiscal fiscal (NIF) sino con otros tipos de identificaciones como documento nacional , pasaporte, identificación extranjera, etc. Con este módulo instalado, verá ahora en la vista de formulario de contactos dos campos:\n"
+"Agregue un nuevo modelo denominado \"Tipo de identificación\" que amplíe la funcionalidad del campo de número de identificación fiscal (RFC) del contacto y permita que el usuario identifique (eventualmente una factura) a los contactos no solo con su número identificación fiscal fiscal (RFC) sino con otros tipos de identificaciones como documento nacional , pasaporte, identificación extranjera, etc. Con este módulo instalado, verá ahora en la vista de formulario de contactos dos campos:\n"
 "\n"
 "* Tipo de identificación\n"
 "* Número de identificación\n"
 "\n"
 "Este comportamiento es un requisito común para algunos países latinoamericanos como Argentina y Chile. Si su localización tiene estos requisitos, entonces debe depender de este módulo y definir en su módulo de localización los tipos de identificación que se utilizan en su país. En general, este tipo de identificaciones son definidas por las autoridades gubernamentales que regulan las operaciones fiscales, por ejemplo:\n"
 "\n"
-"* AFIP en Argentina define el DNI, CUIT (número de identificación fiscal(NIF) para entidades legales), CUIL (número de identificación fiscal(NIF) para personas naturales), y otros 80 tipos de identificación válidos.\n"
+"* AFIP en Argentina define el DNI, CUIT (número de identificación fiscal(RFC) para entidades legales), CUIL (número de identificación fiscal(RFC) para personas naturales), y otros 80 tipos de identificación válidos.\n"
 "\n"
 "Cada identificación contiene esta información:\n"
 "\n"
 "* nombre: nombre corto de la identificación\n"
 "* descripción: podría ser el mismo nombre corto o un nombre largo\n"
 "* id_pais(country_id): el país al que pertenece esta identificación\n"
-"* es_identificacionFiscal(is_vat): identifica este registro como el número de identificación fiscal(NIF) correspondiente para el país específico.\n"
+"* es_identificacionFiscal(is_vat): identifica este registro como el número de identificación fiscal(RFC) correspondiente para el país específico.\n"
 "* secuencia: permítanos ordenar los tipos de identificación según los más utilizados.\n"
 "* activo: podemos activar / desactivar identificaciones para que sea más fácil para nuestros clientes\n"
 "\n"
-"Con el fin de hacer que este módulo sea compatible con entornos de empresas múltiples donde tenemos compañías que no necesitan / no admiten este requisito, hemos agregado tipos de identificación genéricos y reglas genéricas para administrar la información de contacto y hacerla transparente para el usuario cuando solo use el número de identificación fiscal(NIF) como lo conocíamos anteriormente.\n"
+"Con el fin de hacer que este módulo sea compatible con entornos de empresas múltiples donde tenemos compañías que no necesitan / no admiten este requisito, hemos agregado tipos de identificación genéricos y reglas genéricas para administrar la información de contacto y hacerla transparente para el usuario cuando solo use el número de identificación fiscal(RFC) como lo conocíamos anteriormente.\n"
 "\n"
 "Identificaciones genéricas:\n"
 "\n"
-"* identificación Fiscal: la identificación fiscal o el número de identificación fiscal(NIF), de forma predeterminada, se seleccionará como tipo de identificación, por lo que el usuario solo tendrá que agregar el número de identificación fiscal relacionado.\n"
+"* identificación Fiscal: la identificación fiscal o el número de identificación fiscal(RFC), de forma predeterminada, se seleccionará como tipo de identificación, por lo que el usuario solo tendrá que agregar el número de identificación fiscal relacionado.\n"
 "* Pasaporte\n"
 "* Identificación extranjera (Documento nacional extranjero)\n"
 "\n"
@@ -2300,7 +2300,7 @@ msgstr ""
 "\n"
 "Todos los tipos de identificación definidos se pueden revisar y activar / desactivar en el menú \"Contactos / Configuración / Tipo de identificación\".\n"
 "\n"
-"Este módulo es compatible con el módulo base_vat para poder validar los números de identificación fiscal(NIF) para cada país que tenga o no la posibilidad de administrar múltiples tipos de identificación.\n"
+"Este módulo es compatible con el módulo base_vat para poder validar los números de identificación fiscal(RFC) para cada país que tenga o no la posibilidad de administrar múltiples tipos de identificación.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_delivery
@@ -8814,23 +8814,23 @@ msgid ""
 "    "
 msgstr ""
 "\n"
-"Validación del número de identificación fiscal (NIF) de los contactos.\n"
+"Validación del número de identificación fiscal (RFC) de los contactos.\n"
 "=========================================\n"
 "\n"
-"Tras instalar este módulo, se validarán los valores introducidos en el campo de número de identificación fiscal(NIF) de los\n"
+"Tras instalar este módulo, se validarán los valores introducidos en el campo de número de identificación fiscal(RFC) de los\n"
 "contactos para todos los países admitidos. Se deduce el país por las 2 letras del código que\n"
-"preceden al número de número de identificación fiscal (NIF). Por ejemplo, \"BE0477472701\" se validará usando la normativa\n"
+"preceden al número de número de identificación fiscal (RFC). Por ejemplo, \"BE0477472701\" se validará usando la normativa\n"
 "de Bélgica.\n"
 "\n"
-"Hay dos niveles diferentes para validar el número de identificación fiscal (NIF):\n"
+"Hay dos niveles diferentes para validar el número de identificación fiscal (RFC):\n"
 "--------------------------------------------------------\n"
 "* Por defecto, se realiza una simple comprobación sin conexión usando las reglas de\n"
 "validación conocidas de un país, normalmente mediante una sencilla comprobación de\n"
 "dígitos. Es rápido y se puede hacer en cualquier momento, pero admite números que quizá\n"
 "no estén realmente asociados o que ya no sean válidos.\n"
 "\n"
-"* Cuando se habilita la opción de \"Comprobación del número de identificación fiscal (NIF) en VIES\" (en la configuración de la\n"
-"empresa del usuario), los números del número de identificación fiscal (NIF) se enviarán en su lugar a la base electrónica de\n"
+"* Cuando se habilita la opción de \"Comprobación del número de identificación fiscal (RFC) en VIES\" (en la configuración de la\n"
+"empresa del usuario), los números del número de identificación fiscal (RFC) se enviarán en su lugar a la base electrónica de\n"
 "datos VIES de la Unión Europea, que verificará realmente si el número es válido y si\n"
 "actualmente está asociado a una empresa. Esto es un poco más lento que una simple\n"
 "comprobación sin conexión, pues requiere tener conexión a internet y puede que no esté\n"
@@ -10154,7 +10154,7 @@ msgid ""
 "ID</span></span> already exists ("
 msgstr ""
 "Ya existe un contacto con el mismo <span><span class=\"o_vat_label\">número "
-"de identificación fiscal (NIF)</span></span> ("
+"de identificación fiscal (RFC)</span></span> ("
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_base_partner_merge_automatic_wizard__exclude_contact
@@ -28577,7 +28577,7 @@ msgstr "Registros de tareas"
 #: model:ir.model.fields,field_description:base.field_res_partner__vat
 #: model:ir.model.fields,field_description:base.field_res_users__vat
 msgid "Tax ID"
-msgstr "NIF"
+msgstr "RFC"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_taxcloud_delivery
@@ -30727,7 +30727,7 @@ msgstr "Use el formato \"%s\""
 #. module: base
 #: model:ir.model.fields,help:base.field_res_country__vat_label
 msgid "Use this field if you want to change vat label."
-msgstr "Utilice este campo si quiere cambiar la etiqueta del IVA."
+msgstr "Utilice este campo si quiere cambiar la etiqueta del RFC."
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_country__address_view_id
@@ -30914,12 +30914,12 @@ msgstr "Uzbekistán"
 #: model:res.country,vat_label:base.uk
 #, python-format
 msgid "VAT"
-msgstr "IVA"
+msgstr "RFC"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_base_vat
 msgid "VAT Number Validation"
-msgstr "Validación de número de IVA"
+msgstr "Validación de número de RFC"
 
 #. module: base
 #: model:ir.module.category,name:base.module_category_productivity_voip
@@ -31030,7 +31030,7 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_country__vat_label
 msgid "Vat Label"
-msgstr "Etiqueta IVA"
+msgstr "Etiqueta RFC"
 
 #. module: base
 #: model:res.partner.category,name:base.res_partner_category_0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR translate the correct term for VAT in Mexico that is RFC

@mart-e Could you help me to review this PR 🙏 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
