### PR TITLE
[IMP] website_blog: display no of views field on form

### DIFF
--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -78,6 +78,7 @@
                             <field name="author_id"/>
                             <field name="create_date" groups="base.group_no_one"/>
                             <field name="post_date"/>
+                            <field name="visits" readonly="1"/>
                             <field name="write_uid"/>
                             <field name="write_date"/>
                         </group>


### PR DESCRIPTION
Before this commit field `visits` was not displayed on form view.

With this commit, Field is not added on form view as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
