### PR TITLE
[IMP] event_sale: re-arrange 'Sales' stat button on event form view

### DIFF
--- a/addons/event_crm/views/event_event_views.xml
+++ b/addons/event_crm/views/event_event_views.xml
@@ -4,6 +4,7 @@
         <field name="name">event.event.form.inherit.event.crm</field>
         <field name="model">event.event</field>
         <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="priority" eval="30"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='%(event.act_event_registration_from_event)d']" position="after">
                 <button name="%(crm_lead_action_from_event)d" class="oe_stat_button" type="action" icon="fa-star"

--- a/addons/event_sale/views/event_views.xml
+++ b/addons/event_sale/views/event_views.xml
@@ -5,8 +5,9 @@
         <field name="name">event.form.inherit</field>
         <field name="model">event.event</field>
         <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="priority" eval="20"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+            <xpath expr="//button[@name='%(event.act_event_registration_from_event)d']" position="after">
                 <field name="currency_id" invisible="1"/>
                 <button name="action_view_linked_orders"
                         type="object" class="oe_stat_button" icon="fa-dollar"

--- a/addons/website_event_meet/views/event_event_views.xml
+++ b/addons/website_event_meet/views/event_event_views.xml
@@ -5,6 +5,7 @@
         <field name="name">event.event.view.form.inherit.meet</field>
         <field name="model">event.event</field>
         <field name="inherit_id" ref="website_event.event_event_view_form"/>
+        <field name="priority" eval="10"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='is_published']" position="before">
                 <button class="oe_stat_button" context="{'default_event_id': active_id, 'search_default_event_id': active_id}" icon="fa-comments-o" name="%(event_meeting_room_action)d" type="action">


### PR DESCRIPTION

PURPOSE

The publish management stat button should be the last one.
The purpose of this commit is to re-arrange 'Sales' stat button 
and set the publish management button position to the last.

SPECIFICATIONS

Currently, if the event_sale module is installed after website_event,
the 'Sales' stat button is placed after the publish management related
stat button on the event form view.
This improves the x-path of the 'Sales' stat button by placing
it at the second last position, instead of the last one.

This is the goal of this commit.

LINKS

PR #74203
TaskID-2585998
