### PR TITLE
[FIX] survey: enable previous pages loading for the pages containing unanswered mandatory questions

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -406,7 +406,8 @@ class Survey(http.Controller):
                 errors.update(question.validate_question(post, answer_tag))
 
         ret = {}
-        if len(errors):
+        go_back = post.get('button_submit', False) == 'previous'
+        if len(errors) and not go_back:
             # Return errors messages to webpage
             ret['errors'] = errors
         else:
@@ -415,12 +416,10 @@ class Survey(http.Controller):
                     answer_tag = "%s_%s" % (survey_sudo.id, question.id)
                     request.env['survey.user_input_line'].sudo().save_lines(answer_sudo.id, question, post, answer_tag)
 
-            go_back = False
             vals = {}
             if answer_sudo.is_time_limit_reached or survey_sudo.questions_layout == 'one_page':
                 answer_sudo._mark_done()
             elif 'button_submit' in post:
-                go_back = post['button_submit'] == 'previous'
                 next_page, last = request.env['survey.survey'].next_page_or_question(answer_sudo, page_or_question_id, go_back=go_back)
                 vals = {'last_displayed_page_id': page_or_question_id}
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR will fix a bug preventing the user to load the previous page of a survey.

Current behavior before PR:
When the administrator creates a new survey with multiple pages, enables the 'Previous question' button and sets a question as mandatory, the user will not be able to load the previous page if (1) the current page contains a mandatory question and (2) the user does not provide any answer for that question. In that case, the system will show an alert containing the error message: 'This question requires an answer.'.

Desired behavior after PR is merged:
The system should save all answered questions and allow the user to go back to the previous page even if the page contains an unanswered mandatory question.

Task id: 2605657

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
