### PR TITLE
[FIX] survey: enable previous pages loading for the pages containing unanswered mandatory questions.

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -476,7 +476,7 @@ class Survey(http.Controller):
             if not errors.get(question.id):
                 answer_sudo.save_lines(question, answer, comment)
 
-        if errors and not (answer_sudo.survey_time_limit_reached or answer_sudo.question_time_limit_reached):
+        if errors and 'previous_page_id' not in post and not (answer_sudo.survey_time_limit_reached or answer_sudo.question_time_limit_reached):
             return {'error': 'validation', 'fields': errors}
 
         if not answer_sudo.is_session_answer:

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -263,6 +263,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend({
         var $target = $(event.currentTarget);
         if ($target.val() === 'previous') {
             options.previousPageId = $target.data('previousPageId');
+            options.skipValidation = true;
         } else if ($target.val() === 'finish') {
             options.isFinish = true;
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR will fix a bug preventing the user to load the previous page of a survey.

Current behavior before PR:
When the administrator creates a new survey with multiple pages, enables the 'go back' button and sets a question as mandatory, the user will not be able to load the previous page if (1) the current page contains a mandatory question and (2) the user does not provide any answer for that question. In that case, the system will show an alert containing the error message: 'This question requires an answer.'.

Desired behavior after PR is merged:
The system should save all answered questions and allow the user to go back to the previous page even if the page contains an unanswered mandatory question.

Task id: 2605657

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
