### PR TITLE
[FIX] coupon: multiple emails & wrong translation

### DIFF
--- a/addons/sale_coupon/i18n/sale_coupon.pot
+++ b/addons/sale_coupon/i18n/sale_coupon.pot
@@ -45,12 +45,6 @@ msgid "10% Discount"
 msgstr ""
 
 #. module: sale_coupon
-#: code:addons/sale_coupon/wizard/sale_coupon_generate.py:35
-#, python-format
-msgid "%s, a coupon has been generated for you"
-msgstr ""
-
-#. module: sale_coupon
 #: model:product.product,name:sale_coupon.product_product_10_percent_discount
 #: model:product.template,name:sale_coupon.product_product_10_percent_discount_product_template
 msgid "10.0% discount on total amount"

--- a/addons/sale_coupon/wizard/sale_coupon_generate.py
+++ b/addons/sale_coupon/wizard/sale_coupon_generate.py
@@ -31,9 +31,6 @@ class SaleCouponGenerate(models.TransientModel):
             for partner in self.env['res.partner'].search(safe_eval(self.partners_domain)):
                 vals.update({'partner_id': partner.id})
                 coupon = self.env['sale.coupon'].create(vals)
-                context = dict(lang=partner.lang)
-                subject = _('%s, a coupon has been generated for you') % (partner.name)
-                del context
                 template = self.env.ref('sale_coupon.mail_template_sale_coupon', raise_if_not_found=False)
                 if template:
-                    template.send_mail(coupon.id, email_values={'email_to': partner.email, 'email_from': self.env.user.email or '', 'subject': subject,})
+                    template.send_mail(coupon.id)


### PR DESCRIPTION
    On commit 188eb5edc89113aab5fa09e2e5d000c1283860e2,
    we hardcoded values for the Subject instead of using the one
    that are later by the template and
    we sent the email twice due to the values given on the email_values
    that is generating a To (email_to) value, adding to the existing
    given by the template To(Partners) (partner_to).

    Revert of https://github.com/odoo/odoo/pull/68316
    opw-2574046