### PR TITLE
[FIX] web: fix property assignment in pivot view

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_model.js
+++ b/addons/web/static/src/js/views/pivot/pivot_model.js
@@ -975,14 +975,15 @@ var PivotModel = AbstractModel.extend({
                     acc.push(measure);
                     return acc;
                 }
-                var field = self.fields[measure];
-                if (field.type === 'many2one') {
-                    field.group_operator = 'count_distinct';
+                var type = self.fields[measure].type;
+                var groupOperator = self.fields[measure].group_operator;
+                if (type === 'many2one') {
+                    groupOperator = 'count_distinct';
                 }
-                if (field.group_operator === undefined) {
+                if (groupOperator === undefined) {
                     throw new Error("No aggregate function has been provided for the measure '" + measure + "'");
                 }
-                acc.push(measure + ':' + field.group_operator);
+                acc.push(measure + ':' + groupOperator);
                 return acc;
             },
             []


### PR DESCRIPTION
Sales > Reporting > Sales
Select the measure "Customer (count)"

TypeError: Cannot add property group_operator, object is not extensible

As the ovject is immutable we need to workaround the assignment

opw-2606424

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
