### PR TITLE
[IMP] hotkey_service prefer physical keys over local keyboard layout

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -218,6 +218,10 @@ export const hotkeyService = {
             if (ev.code && ev.code.indexOf("Digit") === 0) {
                 key = ev.code.slice(-1);
             }
+            // Prefer physical keys for non-latin keyboard layout.
+            if (!AUTHORIZED_KEYS.has(key) && ev.code && ev.code.indexOf("Key") === 0) {
+                key = ev.code.slice(-1).toLowerCase();
+            }
             // Make sure we do not duplicate a modifier key
             if (!MODIFIERS.has(key)) {
                 hotkey.push(key);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When users work with odoo with local keyboard layout most of shortcuts don't work.
This is happened because of hotkey_service uses `event.key` to determine shortcut. But with non-latin keyboard layout `event.key` is localized.
Non-english users have to switch keyboard layout to english to use shortcut, then they have to switch back to enter text. It's annoying. Some users just think that shortcuts in odoo doesn't work at all because they use english layout very rarely.
This PR changes hostkey_service so it uses `event.code` to determine pressed key.

Current behavior before PR:
With non-latin keyboard layout most of shotcuts don't work. F.x. `Alt+S` doesn't work for russian keyboard layout becase hotkey_service interprets this shortcut as `Alt+Ы`.

Desired behavior after PR is merged:
Shortcuts registered in hotkey_service don't depend on keyboard layout.
So pressing `Alt+S` on any keyboard layout will trigger appropriate event listener.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
