### PR TITLE
[FIX] expression: Don't return records with active = False on one2many

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -787,7 +787,11 @@ class expression(object):
                     if inverse_field.store and not (inverse_is_int and domain):
                         # rewrite condition to match records with/without lines
                         op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
-                        subquery = f'SELECT "{inverse_field.name}" FROM "{comodel._table}" WHERE "{inverse_field.name}" IS NOT NULL'
+                        if comodel._active_name:
+                            active = field.context.get("active_test", True)
+                            subquery = f'SELECT "{inverse_field.name}" FROM "{comodel._table}" WHERE "{inverse_field.name}" IS NOT NULL AND "{comodel._active_name}" = {active}'
+                        else:
+                            subquery = f'SELECT "{inverse_field.name}" FROM "{comodel._table}" WHERE "{inverse_field.name}" IS NOT NULL'
                         push(('id', op1, (subquery, [])), model, alias, internal=True)
                     else:
                         comodel_domain = [(inverse_field.name, '!=', False)]


### PR DESCRIPTION
In subqueries for relational fields, the inselect/notinselect should
not return records with active = False

Description of the issue/feature this PR addresses:

* Solves one2many fields searches()

Current behavior before PR:

* Record A has a one2many field that contains an active field.
* Record B is the relational record (Record A => Record B)
* Record B is active = False
* Search ('one2many_field', '!=', False) return Record A and should not.

Desired behavior after PR is merged:

* Search ('one2many_field', '!=', False) does not return Record A


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
