### PR TITLE
[FIX] fleet: compute start/end dates of costs report

### DIFF
--- a/addons/fleet/report/fleet_report.py
+++ b/addons/fleet/report/fleet_report.py
@@ -42,8 +42,8 @@ WITH service_costs AS (
         fleet_vehicle ve
     CROSS JOIN generate_series((
             SELECT
-                min(acquisition_date)
-                FROM fleet_vehicle), CURRENT_DATE, '1 month') d
+                min(date)
+                FROM fleet_vehicle_log_services), CURRENT_DATE, '1 month') d
         LEFT JOIN fleet_vehicle_log_services se ON se.vehicle_id = ve.id
             AND date_trunc('month', se.date) = date_trunc('month', d)
     WHERE

--- a/addons/fleet/report/fleet_report.py
+++ b/addons/fleet/report/fleet_report.py
@@ -43,7 +43,7 @@ WITH service_costs AS (
     CROSS JOIN generate_series((
             SELECT
                 min(date)
-                FROM fleet_vehicle_log_services), CURRENT_DATE, '1 month') d
+                FROM fleet_vehicle_log_services), CURRENT_DATE + '1 month'::interval, '1 month') d
         LEFT JOIN fleet_vehicle_log_services se ON se.vehicle_id = ve.id
             AND date_trunc('month', se.date) = date_trunc('month', d)
     WHERE
@@ -74,7 +74,7 @@ contract_costs AS (
     CROSS JOIN generate_series((
             SELECT
                 min(acquisition_date)
-                FROM fleet_vehicle), CURRENT_DATE, '1 month') d
+                FROM fleet_vehicle), CURRENT_DATE + '1 month'::interval, '1 month') d
         LEFT JOIN fleet_vehicle_log_contract co ON co.vehicle_id = ve.id
             AND date_trunc('month', co.date) = date_trunc('month', d)
         LEFT JOIN fleet_vehicle_log_contract cod ON cod.vehicle_id = ve.id


### PR DESCRIPTION
**First commit**
When adding some services to a vehicle that does not have any immatriculation date, the costs report does not consider these services.

To reproduce the error:
(DB without any demo data)
1. Create a vehicle V
    - Remove the Immatriculation Date
2. Add a service for V
    - The category of the service type does not matter
    - Cost > 0
    - Date: today
3. Fleet > Reporting > Costs

Error: Costs Analysis is empty, the service is not considered

In the SQL view, the date used as start point is the oldest immatriculation date. Therefore, if the vehicle doesn't have this date, the report lines won't be generated.

**Second commit**
When consulting the costs reports, if the beginning of the dates range has a day greater than the day of today (e.g., start date: 2021/02/25, today: 2021/07/10 => 25 > 10), the costs of the current month won't be include in the report.

To reproduce the issue:
(DB without any demo data. Let X be the day of the month for today)
1. Create a vehicle V
2. Add a service S1 for V
    - The category of the service type does not matter
    - Cost: 500
    - Date: today
3. Add a second service S2 for V
    - Same service type
    - Cost: 250
    - Date: Last month with a day > X (so if today is 2021/07/26, date could be 2021/06/27)
4. Fleet > Reporting > Costs

Error: The report does not include S1

When generating the dates range, the current date is used as the end of the interval. Since the interval step is '1 month', it will lead to an issue in the above case: 
Suppose today is 2021/07/26, the interval starts on 2021/06/27. Then, if we add one month to this date, we have 2021/07/27, which is after the end of the interval (2021/07/26), so the date is ignored. As a result, current month won't be included in the report.

Note: A similar issue can happen with the contracts

OPW-2477004