### PR TITLE
[FIX] website_forum: display anchor tag instead of link

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -230,28 +230,35 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onKarmaRequiredClick: function (ev) {
-        var $karma = $(ev.currentTarget);
-        var karma = $karma.data('karma');
-        var forum_id = $('#wrapwrap').data('forum_id');
+        const karma = parseInt(ev.currentTarget.dataset.karma);
         if (!karma) {
             return;
         }
+
         ev.preventDefault();
-        var msg = karma + ' ' + _t("karma is required to perform this action. ");
-        var title = _t("Karma Error");
-        if (forum_id) {
-            msg += '<a class="alert-link" href="/forum/' + forum_id + '/faq">' + _t("Read the guidelines to know how to gain karma.") + '</a>';
-        }
-        if (session.is_website_user) {
-            msg = _t("Sorry you must be logged in to perform this action");
-            title = _t("Access Denied");
-        }
-        this.call('crash_manager', 'show_warning', {
-            message: msg,
-            title: title,
-        }, {
+        const forumID = parseInt(document.getElementById('wrapwrap').dataset.forum_id);
+        const notifOptions = {
+            type: "warning",
             sticky: false,
-        });
+        };
+        if (session.is_website_user) {
+            notifOptions.title = _t("Access Denied");
+            notifOptions.message = _t("Sorry you must be logged in to perform this action");
+        } else {
+            notifOptions.title = _t("Karma Error");
+            // FIXME this translation is bad, the number should be part of the
+            // translation, to fix in the appropriate version
+            notifOptions.message = `${karma} ${_t("karma is required to perform this action. ")}`;
+            if (forumID) {
+                notifOptions.messageIsHtml = true;
+                const linkLabel = _.escape(_t("Read the guidelines to know how to gain karma."));
+                notifOptions.message = `
+                    ${_.escape(notifOptions.message)}<br/>
+                    <a class="alert-link" href="/forum/${forumID}/faq">${linkLabel}</a>
+                `;
+            }
+        }
+        this.displayNotification(notifOptions);
     },
     /**
      * @private


### PR DESCRIPTION
Due to not passing the escaping parameter option in displayNotification,
it will display any html tag as a string in the warning.
With this commit, we have passed 'messageIsHtml' as a parameter to properly
display the Link in the warning notification.

task-2601633

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
