### PR TITLE
FIX] coupon: multiple emails & wrong translation

### DIFF
--- a/addons/sale_coupon/wizard/sale_coupon_generate.py
+++ b/addons/sale_coupon/wizard/sale_coupon_generate.py
@@ -36,4 +36,4 @@ class SaleCouponGenerate(models.TransientModel):
                 del context
                 template = self.env.ref('sale_coupon.mail_template_sale_coupon', raise_if_not_found=False)
                 if template:
-                    template.send_mail(coupon.id, email_values={'email_to': partner.email, 'email_from': self.env.user.email or '', 'subject': subject,})
+                    template.send_mail(coupon.id, email_values={'email_from': self.env.user.email or '', 'subject': subject})


### PR DESCRIPTION
    On commit 188eb5edc89113aab5fa09e2e5d000c1283860e2,
    we hardcoded values for the Subject instead of using the one
    that are later by the template and
    we sent the email twice due to the values given on the email_values
    that is generating a To (email_to) value, adding to the existing
    given by the template To(Partners) (partner_to).

    Revert of https://github.com/odoo/odoo/pull/68316
    opw-2574046

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
