### PR TITLE
[FIX] *: add explicit license to all manifest

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -79,4 +79,5 @@ You could use this simplified accounting in case you work with an (external) acc
     'application': True,
     'auto_install': False,
     'post_init_hook': '_auto_install_l10n',
+    'license': 'LGPL-3',
 }

--- a/addons/account_analytic_default/__manifest__.py
+++ b/addons/account_analytic_default/__manifest__.py
@@ -24,4 +24,5 @@ Allows to automatically select analytic accounts based on criterions:
         'views/account_analytic_default_view.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/account_analytic_default_hr_expense/__manifest__.py
+++ b/addons/account_analytic_default_hr_expense/__manifest__.py
@@ -13,4 +13,5 @@ Allows to automatically select analytic accounts based on Product
     """,
     'depends': ['account_analytic_default', 'hr_expense'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/account_analytic_default_purchase/__manifest__.py
+++ b/addons/account_analytic_default_purchase/__manifest__.py
@@ -13,4 +13,5 @@ Allows to automatically select analytic accounts based on Product
     """,
     'depends': ['account_analytic_default', 'purchase'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/account_bank_statement_import/__manifest__.py
+++ b/addons/account_bank_statement_import/__manifest__.py
@@ -20,4 +20,5 @@ OFX and QIF imports are available in Enterprise version.""",
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/account_check_printing/__manifest__.py
+++ b/addons/account_check_printing/__manifest__.py
@@ -21,4 +21,5 @@ The check settings are located in the accounting journals configuration page.
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/account_debit_note/__manifest__.py
+++ b/addons/account_debit_note/__manifest__.py
@@ -19,4 +19,5 @@ The wizard used is similar as the one for the credit note.
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/account_facturx/__manifest__.py
+++ b/addons/account_facturx/__manifest__.py
@@ -10,4 +10,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/account_lock/__manifest__.py
+++ b/addons/account_lock/__manifest__.py
@@ -13,4 +13,5 @@
     """,
     'depends' : ['account'],
     'data': [],
+    'license': 'LGPL-3',
 }

--- a/addons/account_payment/__manifest__.py
+++ b/addons/account_payment/__manifest__.py
@@ -18,4 +18,5 @@ enable payment.
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/account_tax_python/__manifest__.py
+++ b/addons/account_tax_python/__manifest__.py
@@ -18,4 +18,5 @@ A tax defined as python code consists of two snippets of python code which are e
         'views/account_tax_views.xml',
     ],
     'uninstall_hook': "uninstall_hook",
+    'license': 'LGPL-3',
 }

--- a/addons/account_test/__manifest__.py
+++ b/addons/account_test/__manifest__.py
@@ -26,5 +26,6 @@ and print the report from Print button in header area.
         'report/report_account_test_templates.xml',
     ],
     'active': False,
-    'installable': True
+    'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/analytic/__manifest__.py
+++ b/addons/analytic/__manifest__.py
@@ -25,4 +25,5 @@ that have no counterpart in the general financial accounts.
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/association/__manifest__.py
+++ b/addons/association/__manifest__.py
@@ -18,4 +18,5 @@ membership products (schemes).
     'demo': [],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/attachment_indexation/__manifest__.py
+++ b/addons/attachment_indexation/__manifest__.py
@@ -12,4 +12,5 @@ Attachments list and document indexation
 """,
     'depends': ['web'],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/auth_ldap/__manifest__.py
+++ b/addons/auth_ldap/__manifest__.py
@@ -12,5 +12,6 @@
     ],
     'external_dependencies': {
         'python': ['ldap'],
-    }
+    },
+    'license': 'LGPL-3',
 }

--- a/addons/auth_oauth/__manifest__.py
+++ b/addons/auth_oauth/__manifest__.py
@@ -18,4 +18,5 @@ Allow users to login through OAuth2 Provider.
         'views/auth_oauth_templates.xml',
         'security/ir.model.access.csv',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/auth_password_policy/__manifest__.py
+++ b/addons/auth_password_policy/__manifest__.py
@@ -8,5 +8,6 @@
         'views/assets.xml',
         'views/res_users.xml',
         'views/res_config_settings_views.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/auth_password_policy_signup/__manifest__.py
+++ b/addons/auth_password_policy_signup/__manifest__.py
@@ -6,5 +6,6 @@
     'data': [
         'views/assets.xml',
         'views/signup_templates.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/auth_signup/__manifest__.py
+++ b/addons/auth_signup/__manifest__.py
@@ -24,4 +24,5 @@ Allow users to sign up and reset their password
         'views/auth_signup_assets.xml',
     ],
     'bootstrap': True,
+    'license': 'LGPL-3',
 }

--- a/addons/barcodes/__manifest__.py
+++ b/addons/barcodes/__manifest__.py
@@ -13,4 +13,5 @@
     'installable': True,
     'auto_install': False,
     'post_init_hook': '_assign_default_nomeclature_id',
+    'license': 'LGPL-3',
 }

--- a/addons/base_address_city/__manifest__.py
+++ b/addons/base_address_city/__manifest__.py
@@ -18,4 +18,5 @@ This module allows to enforce users to choose the city of a partner inside a giv
         'views/res_country_view.xml',
     ],
     'depends': ['base'],
+    'license': 'LGPL-3',
 }

--- a/addons/base_address_extended/__manifest__.py
+++ b/addons/base_address_extended/__manifest__.py
@@ -21,4 +21,5 @@ with the street name, the house number, and room number.
     ],
     'depends': ['base'],
     'post_init_hook': '_update_street_format',
+    'license': 'LGPL-3',
 }

--- a/addons/base_automation/__manifest__.py
+++ b/addons/base_automation/__manifest__.py
@@ -24,4 +24,5 @@ trigger an automatic reminder email.
     'demo': [
         'data/base_automation_demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/base_gengo/__manifest__.py
+++ b/addons/base_gengo/__manifest__.py
@@ -25,4 +25,5 @@ This wizard will activate the CRON job and the Scheduler and will start the auto
     'test': [],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/base_geolocalize/__manifest__.py
+++ b/addons/base_geolocalize/__manifest__.py
@@ -16,4 +16,5 @@ Partners Geolocation
         'data/data.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/base_iban/__manifest__.py
+++ b/addons/base_iban/__manifest__.py
@@ -16,4 +16,5 @@ with a single statement.
         'views/partner_view.xml'
     ],
     'demo': ['data/res_partner_bank_demo.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/base_import/__manifest__.py
+++ b/addons/base_import/__manifest__.py
@@ -30,4 +30,5 @@ Re-implement Odoo's file import system:
         'views/base_import_templates.xml',
     ],
     'qweb': ['static/src/xml/base_import.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/base_import_module/__manifest__.py
+++ b/addons/base_import_module/__manifest__.py
@@ -14,4 +14,5 @@ for customization purpose.
     'installable': True,
     'auto_install': False,
     'data': ['views/base_import_module_view.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/base_import_module/tests/test_module/__manifest__.py
+++ b/addons/base_import_module/tests/test_module/__manifest__.py
@@ -15,4 +15,5 @@
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/base_setup/__manifest__.py
+++ b/addons/base_setup/__manifest__.py
@@ -29,4 +29,5 @@ Shows you a list of applications features to install from.
     ],
 
     
+    'license': 'LGPL-3',
 }

--- a/addons/base_sparse_field/__manifest__.py
+++ b/addons/base_sparse_field/__manifest__.py
@@ -14,4 +14,5 @@
     'data': [
         'views/views.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/base_vat/__manifest__.py
+++ b/addons/base_vat/__manifest__.py
@@ -40,4 +40,5 @@ only the country code will be validated.
         'views/res_partner_views.xml',
         'views/res_config_settings_views.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/board/__manifest__.py
+++ b/addons/board/__manifest__.py
@@ -20,4 +20,5 @@ Allows users to create custom dashboard.
     ],
     'qweb': ['static/src/xml/board.xml'],
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/bus/__manifest__.py
+++ b/addons/bus/__manifest__.py
@@ -10,4 +10,5 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/calendar/__manifest__.py
+++ b/addons/calendar/__manifest__.py
@@ -37,4 +37,5 @@ If you need to manage your meetings, you should install the CRM module.
     'installable': True,
     'application': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/calendar_sms/__manifest__.py
+++ b/addons/calendar_sms/__manifest__.py
@@ -15,4 +15,5 @@
     ],
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/contacts/__manifest__.py
+++ b/addons/contacts/__manifest__.py
@@ -15,4 +15,5 @@ You can track your vendors, customers and other contacts.
         'views/contact_views.xml',
     ],
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -57,5 +57,6 @@
     'css': ['static/src/css/crm.css'],
     'installable': True,
     'application': True,
-    'auto_install': False
+    'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/crm_iap_lead/__manifest__.py
+++ b/addons/crm_iap_lead/__manifest__.py
@@ -21,5 +21,6 @@
     ],
     'qweb': [
         'static/src/xml/leads_tree_generate_leads_views.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/crm_iap_lead_enrich/__manifest__.py
+++ b/addons/crm_iap_lead_enrich/__manifest__.py
@@ -17,4 +17,5 @@
         'views/res_config_settings_view.xml',
     ],
     'post_init_hook': '_synchronize_cron',
+    'license': 'LGPL-3',
 }

--- a/addons/crm_iap_lead_website/__manifest__.py
+++ b/addons/crm_iap_lead_website/__manifest__.py
@@ -12,5 +12,6 @@
         'views/crm_lead_view.xml',
         'views/crm_reveal_views.xml',
         'views/res_config_settings_views.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/crm_livechat/__manifest__.py
+++ b/addons/crm_livechat/__manifest__.py
@@ -13,5 +13,6 @@
         'im_livechat'
     ],
     'description': 'Create new lead with using /lead command in the channel',
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/crm_sms/__manifest__.py
+++ b/addons/crm_sms/__manifest__.py
@@ -16,4 +16,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/delivery/__manifest__.py
+++ b/addons/delivery/__manifest__.py
@@ -32,4 +32,5 @@ invoices from picking, the system is able to add and compute the shipping line.
     ],
     'demo': ['data/delivery_demo.xml'],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/digest/__manifest__.py
+++ b/addons/digest/__manifest__.py
@@ -24,4 +24,5 @@ Send KPI Digests periodically
         'views/res_config_settings_views.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -36,4 +36,5 @@ Key Features
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/event_sale/__manifest__.py
+++ b/addons/event_sale/__manifest__.py
@@ -33,5 +33,6 @@ this event.
     ],
     'demo': ['data/event_demo.xml'],
     'installable': True,
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/event_sms/__manifest__.py
+++ b/addons/event_sms/__manifest__.py
@@ -17,5 +17,6 @@
     'demo': [
     ],
     'installable': True,
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/fetchmail/__manifest__.py
+++ b/addons/fetchmail/__manifest__.py
@@ -44,4 +44,5 @@ For more specific needs, you may also assign custom-defined actions
     'demo': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/fleet/__manifest__.py
+++ b/addons/fleet/__manifest__.py
@@ -46,4 +46,5 @@ Main Features
 
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/gamification/__manifest__.py
+++ b/addons/gamification/__manifest__.py
@@ -38,4 +38,5 @@ Both goals and badges are flexibles and can be adapted to a large range of modul
     'demo': [
         'data/gamification_karma_rank_demo.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/gamification_sale_crm/__manifest__.py
+++ b/addons/gamification_sale_crm/__manifest__.py
@@ -9,4 +9,5 @@
     'data': ['data/gamification_sale_crm_data.xml'],
     'demo': ['data/gamification_sale_crm_demo.xml'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/google_account/__manifest__.py
+++ b/addons/google_account/__manifest__.py
@@ -12,4 +12,5 @@ The module adds google user in res user.
     'data': [
         'data/google_account_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/google_calendar/__manifest__.py
+++ b/addons/google_calendar/__manifest__.py
@@ -19,4 +19,5 @@
     'demo': [],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/google_drive/__manifest__.py
+++ b/addons/google_drive/__manifest__.py
@@ -24,5 +24,6 @@ Integrate google document to Odoo record.
 
 This module allows you to integrate google documents to any of your Odoo record quickly and easily using OAuth 2.0 for Installed Applications,
 You can configure your google Authorization Code from Settings > Configuration > General Settings by clicking on "Generate Google Authorization Code"
-"""
+""",
+    'license': 'LGPL-3',
 }

--- a/addons/google_spreadsheet/__manifest__.py
+++ b/addons/google_spreadsheet/__manifest__.py
@@ -20,4 +20,5 @@ The module adds the possibility to display data from Odoo in Google Spreadsheets
     'demo': [],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -48,4 +48,5 @@
     'application': True,
     'auto_install': False,
     'qweb': ['static/src/xml/hr_templates.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -35,4 +35,5 @@ actions(Check in/Check out) performed by them.
         "static/src/xml/attendance.xml",
     ],
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_contract/__manifest__.py
+++ b/addons/hr_contract/__manifest__.py
@@ -28,4 +28,5 @@ You can assign several contracts per employee.
     'demo': ['data/hr_contract_demo.xml'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_expense/__manifest__.py
+++ b/addons/hr_expense/__manifest__.py
@@ -49,4 +49,5 @@ This module also uses analytic accounting and is compatible with the invoice on 
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_expense_check/__manifest__.py
+++ b/addons/hr_expense_check/__manifest__.py
@@ -12,4 +12,5 @@
     'data': [
         'views/payment.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/hr_fleet/__manifest__.py
+++ b/addons/hr_fleet/__manifest__.py
@@ -12,4 +12,5 @@
         'views/fleet_vehicle_views.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_gamification/__manifest__.py
+++ b/addons/hr_gamification/__manifest__.py
@@ -20,4 +20,5 @@ Badge received are displayed on the user profile.
         'views/gamification_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -58,4 +58,5 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
     'installable': True,
     'application': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_holidays_attendance/__manifest__.py
+++ b/addons/hr_holidays_attendance/__manifest__.py
@@ -12,4 +12,5 @@ Hides the attendance presence button when an employee is on leave.
     'data': [
         'views/hr_employee_views.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/hr_holidays_calendar/__manifest__.py
+++ b/addons/hr_holidays_calendar/__manifest__.py
@@ -16,4 +16,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_maintenance/__manifest__.py
+++ b/addons/hr_maintenance/__manifest__.py
@@ -17,4 +17,5 @@
     'demo': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_org_chart/__manifest__.py
+++ b/addons/hr_org_chart/__manifest__.py
@@ -21,5 +21,6 @@ This module extend the employee form with a organizational chart.
     ],
     'qweb': [
         'static/src/xml/hr_org_chart.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/hr_presence/__manifest__.py
+++ b/addons/hr_presence/__manifest__.py
@@ -28,4 +28,5 @@ Allows to contact directly the employee in case of unjustified absence.
     'demo': [],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_recruitment/__manifest__.py
+++ b/addons/hr_recruitment/__manifest__.py
@@ -38,4 +38,5 @@
     'installable': True,
     'auto_install': False,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_recruitment_survey/__manifest__.py
+++ b/addons/hr_recruitment_survey/__manifest__.py
@@ -22,4 +22,5 @@
         'data/hr_job_demo.xml',
     ],
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_skills/__manifest__.py
+++ b/addons/hr_skills/__manifest__.py
@@ -32,4 +32,5 @@ This module introduces skills and resumé management for employees.
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_skills_slides/__manifest__.py
+++ b/addons/hr_skills_slides/__manifest__.py
@@ -22,4 +22,5 @@ This module add completed courses to resumé for employees.
         'static/src/xml/resume_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_skills_survey/__manifest__.py
+++ b/addons/hr_skills_survey/__manifest__.py
@@ -22,4 +22,5 @@ This module adds certification to resumé for employees.
         'static/src/xml/resume_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -41,4 +41,5 @@ up a management by affair.
     'installable': True,
     'application': False,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_timesheet_attendance/__manifest__.py
+++ b/addons/hr_timesheet_attendance/__manifest__.py
@@ -15,4 +15,5 @@
         'report/hr_timesheet_attendance_report_view.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/hr_work_entry/__manifest__.py
+++ b/addons/hr_work_entry/__manifest__.py
@@ -20,4 +20,5 @@
     'qweb': [
         "static/src/xml/work_entry_templates.xml",
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/http_routing/__manifest__.py
+++ b/addons/http_routing/__manifest__.py
@@ -15,4 +15,5 @@ base modules simple.
         'views/res_lang_views.xml',
     ],
     'depends': ['web'],
+    'license': 'LGPL-3',
 }

--- a/addons/hw_drivers/__manifest__.py
+++ b/addons/hw_drivers/__manifest__.py
@@ -18,4 +18,5 @@ are found in other modules that must be installed separately.
 
 """,
     'installable': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hw_escpos/__manifest__.py
+++ b/addons/hw_escpos/__manifest__.py
@@ -21,4 +21,5 @@ that would need such functionality.
         'python' : ['pyusb','pyserial','qrcode'],
     },
     'installable': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hw_posbox_homepage/__manifest__.py
+++ b/addons/hw_posbox_homepage/__manifest__.py
@@ -21,4 +21,5 @@ regular Odoo interface anymore.
 """,
     'depends': ['hw_proxy'],
     'installable': False,
+    'license': 'LGPL-3',
 }

--- a/addons/hw_proxy/__manifest__.py
+++ b/addons/hw_proxy/__manifest__.py
@@ -18,4 +18,5 @@ are found in other modules that must be installed separately.
 
 """,
     'installable': False,
+    'license': 'LGPL-3',
 }

--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -24,4 +24,5 @@ This module provides standard tools (account model, context manager and helpers)
         'static/src/xml/iap_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -41,4 +41,5 @@ Help your customers with this chat, and analyse their feedback.
     'installable': True,
     'auto_install': False,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/im_livechat_mail_bot/__manifest__.py
+++ b/addons/im_livechat_mail_bot/__manifest__.py
@@ -12,4 +12,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/im_support/__manifest__.py
+++ b/addons/im_support/__manifest__.py
@@ -20,4 +20,5 @@
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ae/__manifest__.py
+++ b/addons/l10n_ae/__manifest__.py
@@ -25,4 +25,5 @@ United Arab Emirates accounting chart and localization.
              'data/account_chart_template_data.xml',
              'views/report_invoice_templates.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -121,4 +121,5 @@ Master Data:
     'installable': True,
     'auto_install': False,
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_at/__manifest__.py
+++ b/addons/l10n_at/__manifest__.py
@@ -43,4 +43,5 @@ Austrian charts of accounts (Einheitskontenrahmen 2010).
         'data/account_fiscal_position_template.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -31,4 +31,5 @@ Also:
              'data/account_chart_template_configure_data.xml',
              'data/res_currency_data.xml',
              ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_be/__manifest__.py
+++ b/addons/l10n_be/__manifest__.py
@@ -59,4 +59,5 @@ Wizards provided by this module:
         'demo/l10n_be_demo.xml',
     ],
     'post_init_hook': 'load_translations',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_be_edi/__manifest__.py
+++ b/addons/l10n_be_edi/__manifest__.py
@@ -16,4 +16,5 @@ Belgian e-invoicing uses the UBL 2.0 using the e-fff protocol.
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_be_invoice_bba/__manifest__.py
+++ b/addons/l10n_be_invoice_bba/__manifest__.py
@@ -27,4 +27,5 @@ Two algorithms are suggested:
         'data/mail_template_data.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_bo/__manifest__.py
+++ b/addons/l10n_bo/__manifest__.py
@@ -24,4 +24,5 @@ Plan contable boliviano e impuestos de acuerdo a disposiciones vigentes
         "data/account_tax_data.xml",
         "data/account_chart_template_data.xml",
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -54,4 +54,5 @@ come with any additional paid permission for online use of 'private modules'.
         'data/account_tax_template_data.xml',
         'views/account_view.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ca/__manifest__.py
+++ b/addons/l10n_ca/__manifest__.py
@@ -51,4 +51,5 @@ position.
         'views/report_invoice.xml',
     ],
     'post_init_hook': 'load_translations',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ch/__manifest__.py
+++ b/addons/l10n_ch/__manifest__.py
@@ -52,4 +52,5 @@ Here is how it works:
     ],
     'post_init_hook': 'post_init',
 
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ch_qriban/__manifest__.py
+++ b/addons/l10n_ch_qriban/__manifest__.py
@@ -19,4 +19,5 @@ on the bank statements, the old IBAN code is still used.
         'views/swissqr_report.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -49,5 +49,6 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes
     ],
     'demo': [
         'demo/partner_demo.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_cn/__manifest__.py
+++ b/addons/l10n_cn/__manifest__.py
@@ -27,4 +27,5 @@ State Data/省份数据
     'data': [
         'data/account_tax_group_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_cn_city/__manifest__.py
+++ b/addons/l10n_cn_city/__manifest__.py
@@ -18,4 +18,5 @@ City Data/城市数据
     'data': [
         'data/res_city_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_cn_small_business/__manifest__.py
+++ b/addons/l10n_cn_small_business/__manifest__.py
@@ -30,5 +30,6 @@
         'data/account_tax_template_data.xml',
         'data/account_chart_template_data.xml',
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_cn_standard/__manifest__.py
+++ b/addons/l10n_cn_standard/__manifest__.py
@@ -35,4 +35,5 @@ Including the following data in the Accounting Standards for Business Enterprise
         'data/account_tax_template_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_co/__manifest__.py
+++ b/addons/l10n_co/__manifest__.py
@@ -27,4 +27,5 @@
         'data/account_chart_template_configure_data.xml',
         'views/res_partner.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_co_pos/__manifest__.py
+++ b/addons/l10n_co_pos/__manifest__.py
@@ -18,4 +18,5 @@
     'qweb': [
         'static/src/xml/pos.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_cr/__manifest__.py
+++ b/addons/l10n_cr/__manifest__.py
@@ -62,4 +62,5 @@ please go to http://translations.launchpad.net/openerp-costa-rica.
         'data/account_tax_template_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_de/__manifest__.py
+++ b/addons/l10n_de/__manifest__.py
@@ -24,4 +24,5 @@ German accounting chart and localization.
         'report/din5008_report.xml',
         'data/report_layout.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_de_skr03/__manifest__.py
+++ b/addons/l10n_de_skr03/__manifest__.py
@@ -53,5 +53,6 @@ German accounting chart and localization.
         'data/account_reconcile_model_template.xml',
         'data/account_chart_template_data.xml',
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_de_skr04/__manifest__.py
+++ b/addons/l10n_de_skr04/__manifest__.py
@@ -52,4 +52,5 @@ German accounting chart and localization.
         'data/account_reconcile_model_template.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -102,4 +102,5 @@ Copyright 2018 Odoo House ApS
         'data/account_chart_template_configuration_data.xml',
         'data/menuitem_data.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_do/__manifest__.py
+++ b/addons/l10n_do/__manifest__.py
@@ -103,4 +103,5 @@ en Odoo):
         # configuration wizard, views, reports...
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_dz/__manifest__.py
+++ b/addons/l10n_dz/__manifest__.py
@@ -20,4 +20,5 @@ This module applies to companies based in Algeria.
         'data/account_fiscal_position_template_data.xml',
         'data/account_chart_template_configuration_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -27,4 +27,5 @@ Accounting chart and localization for Ecuador.
         'data/account_chart_template_data.xml',
         'data/res.country.state.csv',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -48,4 +48,5 @@ Spanish charts of accounts (PGCE 2008).
         'data/account_fiscal_position_template_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_et/__manifest__.py
+++ b/addons/l10n_et/__manifest__.py
@@ -31,4 +31,5 @@ This is the latest Ethiopian Odoo localization and consists of:
         'data/account_tax_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_eu_service/__manifest__.py
+++ b/addons/l10n_eu_service/__manifest__.py
@@ -30,4 +30,5 @@ Council Implementing Regulation (EU) 2019/2026
     ],
     'post_init_hook': 'l10n_eu_service_post_init',
     'uninstall_hook': 'l10n_eu_service_uninstall',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_fi/__manifest__.py
+++ b/addons/l10n_fi/__manifest__.py
@@ -38,4 +38,5 @@ Set the payment reference type from the Sales Journal.
     ],
     "active": True,
     "installable": True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_fr/__manifest__.py
+++ b/addons/l10n_fr/__manifest__.py
@@ -48,4 +48,5 @@ configuration of their taxes and fiscal positions manually.
         'data/account_chart_template_configure_data.xml',
     ],
     'post_init_hook': '_l10n_fr_post_init_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_fr_fec/__manifest__.py
+++ b/addons/l10n_fr_fec/__manifest__.py
@@ -13,4 +13,5 @@
         'wizard/account_fr_fec_view.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -38,4 +38,5 @@ The module adds following features:
     ],
     'qweb': ['static/src/xml/pos.xml'],
     'post_init_hook': '_setup_inalterability',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_generic_coa/__manifest__.py
+++ b/addons/l10n_generic_coa/__manifest__.py
@@ -25,4 +25,5 @@ Install some generic chart of accounts.
         'demo/account_reconcile_model.xml',
     ],
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_gr/__manifest__.py
+++ b/addons/l10n_gr/__manifest__.py
@@ -28,4 +28,5 @@ Greek accounting chart and localization.
               'data/account_tax_data.xml',
               'data/account_chart_template_configure_data.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_gt/__manifest__.py
+++ b/addons/l10n_gt/__manifest__.py
@@ -38,4 +38,5 @@ taxes and the Quetzal currency.""",
         'data/account_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_hk/__manifest__.py
+++ b/addons/l10n_hk/__manifest__.py
@@ -14,4 +14,5 @@
         'data/l10n_hk_chart_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_hn/__manifest__.py
+++ b/addons/l10n_hn/__manifest__.py
@@ -28,4 +28,5 @@ and the Lempira currency.""",
         'data/account_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_hr/__manifest__.py
+++ b/addons/l10n_hr/__manifest__.py
@@ -57,4 +57,5 @@ Izvori podataka:
         'data/account_chart_template_data.xml',
     ],
     "active": False,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_hu/__manifest__.py
+++ b/addons/l10n_hu/__manifest__.py
@@ -33,4 +33,5 @@ This module consists of:
         'data/account_chart_template_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_id/__manifest__.py
+++ b/addons/l10n_id/__manifest__.py
@@ -21,4 +21,5 @@ This is the latest Indonesian Odoo localisation necessary to run Odoo accounting
         'data/account_chart_template_configuration_data.xml',
         'views/account_reconcile_model_views.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_id_efaktur/__manifest__.py
+++ b/addons/l10n_id_efaktur/__manifest__.py
@@ -39,4 +39,5 @@
     'demo': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ie/__manifest__.py
+++ b/addons/l10n_ie/__manifest__.py
@@ -21,4 +21,5 @@
         'data/account_tax_data.xml',
         'data/account_chart_template_configuration_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_il/__manifest__.py
+++ b/addons/l10n_il/__manifest__.py
@@ -27,4 +27,5 @@ This module consists of:
         'data/account_chart_template_post_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -51,5 +51,6 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'data/product_demo.xml',
         'data/account_payment_demo.xml',
         'data/account_invoice_demo.xml'
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -16,4 +16,5 @@
         'data/product_demo.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in_purchase/__manifest__.py
+++ b/addons/l10n_in_purchase/__manifest__.py
@@ -17,4 +17,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in_purchase_stock/__manifest__.py
+++ b/addons/l10n_in_purchase_stock/__manifest__.py
@@ -24,5 +24,6 @@
     'data': [
         'views/stock_warehouse_views.xml',
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in_sale/__manifest__.py
+++ b/addons/l10n_in_sale/__manifest__.py
@@ -20,4 +20,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in_sale_stock/__manifest__.py
+++ b/addons/l10n_in_sale_stock/__manifest__.py
@@ -24,5 +24,6 @@
     'data': [
         'views/stock_warehouse_views.xml',
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_in_stock/__manifest__.py
+++ b/addons/l10n_in_stock/__manifest__.py
@@ -19,4 +19,5 @@
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_it/__manifest__.py
+++ b/addons/l10n_it/__manifest__.py
@@ -27,4 +27,5 @@ Italian accounting chart and localization.
         'data/account.chart.template.csv',
         'data/account_chart_template_data.xml',
         ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -20,4 +20,5 @@ E-invoice implementation
         'data/account_invoice_demo.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_it_stock_ddt/__manifest__.py
+++ b/addons/l10n_it_stock_ddt/__manifest__.py
@@ -31,4 +31,5 @@ invoice line to export in the FatturaPA XML.
     ],
     'auto_install': True,
     'post_init_hook': '_create_picking_seq',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_jp/__manifest__.py
+++ b/addons/l10n_jp/__manifest__.py
@@ -40,4 +40,5 @@ circumstances, you might not need to use those at all.
         'data/account.fiscal.position.tax.template.csv',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_latam_base/__manifest__.py
+++ b/addons/l10n_latam_base/__manifest__.py
@@ -59,4 +59,5 @@ This module is compatible with base_vat module in order to be able to validate V
     'auto_install': False,
     'application': False,
     'post_init_hook': '_set_default_identification_type',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_latam_invoice_document/__manifest__.py
+++ b/addons/l10n_latam_invoice_document/__manifest__.py
@@ -40,4 +40,5 @@ If your localization needs this logic will then need to add this module as depen
         'security/ir.model.access.csv',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_lu/__manifest__.py
+++ b/addons/l10n_lu/__manifest__.py
@@ -45,4 +45,5 @@ Notes:
         'data/account_chart_template_data.xml',
     ],
     'post_init_hook': '_post_init_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ma/__manifest__.py
+++ b/addons/l10n_ma/__manifest__.py
@@ -25,4 +25,5 @@ Seddik au cours du troisième trimestre 2010.""",
         'data/account_tax_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_mn/__manifest__.py
+++ b/addons/l10n_mn/__manifest__.py
@@ -27,4 +27,5 @@ Financial requirement contributor: Baskhuu Lodoikhuu. BumanIT LLC
         'data/account.chart.template.csv',
         'data/account_chart_template_configuration_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_multilang/__manifest__.py
+++ b/addons/l10n_multilang/__manifest__.py
@@ -13,4 +13,5 @@
           templates to target objects.
     """,
     'depends': ['account'],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -48,4 +48,5 @@ With this module you will have:
         "views/res_config_settings_views.xml",
         "views/account_views.xml",
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -32,4 +32,5 @@
     'demo': [],
     'auto_install': False,
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_no/__manifest__.py
+++ b/addons/l10n_no/__manifest__.py
@@ -24,4 +24,5 @@ Updated for Odoo 9 by Bringsvor Consulting AS <www.bringsvor.com>
              ],
     "active": False,
     'post_init_hook': '_preserve_tag_on_taxes',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_nz/__manifest__.py
+++ b/addons/l10n_nz/__manifest__.py
@@ -30,4 +30,5 @@ Also:
              'data/account_chart_template_configure_data.xml',
              'data/res_currency_data.xml',
              ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_pa/__manifest__.py
+++ b/addons/l10n_pa/__manifest__.py
@@ -23,4 +23,5 @@ Con la Colaboración de
         "data/account_tax_data.xml",
         "data/account_chart_template_data.xml",
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_pl/__manifest__.py
+++ b/addons/l10n_pl/__manifest__.py
@@ -36,4 +36,5 @@ Wewnętrzny numer wersji OpenGLOBE 1.02
               'data/account_chart_template_data.xml'
     ],
     'post_init_hook': '_preserve_tag_on_taxes',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -23,4 +23,5 @@
            'data/account_tax_data.xml',
            'data/account_chart_template_configure_data.xml',
            ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ro/__manifest__.py
+++ b/addons/l10n_ro/__manifest__.py
@@ -34,4 +34,5 @@ Romanian accounting chart and localization.
              'data/account_chart_template_data.xml',
              'data/res.bank.csv',
              ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -22,4 +22,5 @@ In future this module will include some payroll rules for ME .
         'data/account_chart_template_configure_data.xml',
     ],
     'post_init_hook': 'load_translations',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_se/__manifest__.py
+++ b/addons/l10n_se/__manifest__.py
@@ -18,4 +18,5 @@
         "data/account_fiscal_position_tax_template.xml",
         "data/account_chart_template_configuration.xml",
     ],
+    'license': 'LGPL-3',
  }

--- a/addons/l10n_se_ocr/__manifest__.py
+++ b/addons/l10n_se_ocr/__manifest__.py
@@ -23,4 +23,5 @@ For Vendor Bill support for Default Vendor Specific OCR is added and validation 
         'views/account_journal_view.xml'
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_sg/__manifest__.py
+++ b/addons/l10n_sg/__manifest__.py
@@ -30,4 +30,5 @@ This module add, for accounting:
         'views/res_partner_view.xml',
     ],
     'post_init_hook': '_preserve_tag_on_taxes',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_si/__manifest__.py
+++ b/addons/l10n_si/__manifest__.py
@@ -26,4 +26,5 @@
         "data/account.fiscal.position.tax.template.csv",
         "data/account_chart_template_data.xml",
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_syscohada/__manifest__.py
+++ b/addons/l10n_syscohada/__manifest__.py
@@ -34,4 +34,5 @@ Countries that use OHADA are the following:
         'data/account_tax_template_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_th/__manifest__.py
+++ b/addons/l10n_th/__manifest__.py
@@ -24,4 +24,5 @@ Thai accounting chart and localization.
         'data/account_chart_template_data.xml',
     ],
     'post_init_hook': '_preserve_tag_on_taxes',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_tr/__manifest__.py
+++ b/addons/l10n_tr/__manifest__.py
@@ -26,4 +26,5 @@ Bu modül kurulduktan sonra, Muhasebe yapılandırma sihirbazı çalışır
         'data/account_tax_template_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ua/__manifest__.py
+++ b/addons/l10n_ua/__manifest__.py
@@ -21,4 +21,5 @@ Ukraine - Chart of accounts.
         'data/account_tax_template.xml',
         'data/account_chart_template_config.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_uk/__manifest__.py
+++ b/addons/l10n_uk/__manifest__.py
@@ -31,4 +31,5 @@ This is the latest UK Odoo localisation necessary to run Odoo accounting for UK 
         'data/account_chart_template_data.xml',
     ],
     'demo' : ['demo/l10n_uk_demo.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_us/__manifest__.py
+++ b/addons/l10n_us/__manifest__.py
@@ -14,4 +14,5 @@ United States - Chart of accounts.
         'data/res_company_data.xml',
         'views/res_partner_bank_views.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_uy/__manifest__.py
+++ b/addons/l10n_uy/__manifest__.py
@@ -23,4 +23,5 @@ Provide Templates for Chart of Accounts, Taxes for Uruguay.
         'data/account_tax_data.xml',
         'data/account_chart_template_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_ve/__manifest__.py
+++ b/addons/l10n_ve/__manifest__.py
@@ -50,4 +50,5 @@ but you will need set manually account defaults for taxes.
              'data/account_tax_data.xml',
              'data/account_chart_template_data.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_vn/__manifest__.py
+++ b/addons/l10n_vn/__manifest__.py
@@ -34,4 +34,5 @@ with Chart of account under Circular No. 200/2014/TT-BTC
          'views/account_reconcile_model_views.xml',
     ],
     'post_init_hook': '_preserve_tag_on_taxes',
+    'license': 'LGPL-3',
 }

--- a/addons/l10n_za/__manifest__.py
+++ b/addons/l10n_za/__manifest__.py
@@ -24,4 +24,5 @@ This is the latest basic South African localisation necessary to run Odoo in ZA:
         'data/account_chart_template_post_data.xml',
         'data/account_chart_template_configure_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/link_tracker/__manifest__.py
+++ b/addons/link_tracker/__manifest__.py
@@ -14,4 +14,5 @@ Shorten URLs and use them to track clicks and UTMs
         'views/utm_campaign_views.xml',
         'security/ir.model.access.csv',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/lunch/__manifest__.py
+++ b/addons/lunch/__manifest__.py
@@ -43,4 +43,5 @@ If you want to save your employees' time and avoid them to always have coins in 
     'installable': True,
     'application': True,
     'certificate': '001292377792581874189',
+    'license': 'LGPL-3',
 }

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -61,4 +61,5 @@
         'static/src/xml/user_menu.xml',
         'static/src/xml/web_kanban_activity.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -22,4 +22,5 @@
     'qweb': [
         'views/discuss.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/maintenance/__manifest__.py
+++ b/addons/maintenance/__manifest__.py
@@ -23,4 +23,5 @@
     'demo': ['data/maintenance_demo.xml'],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -48,4 +48,5 @@
         'static/src/xml/*.xml',
     ],
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_crm/__manifest__.py
+++ b/addons/mass_mailing_crm/__manifest__.py
@@ -15,4 +15,5 @@
         'data/mass_mailing_demo.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_event/__manifest__.py
+++ b/addons/mass_mailing_event/__manifest__.py
@@ -17,4 +17,5 @@ Bridge module adding UX requirements to ease mass mailing of event attendees.
         'views/event_views.xml'
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_event_sms/__manifest__.py
+++ b/addons/mass_mailing_event_sms/__manifest__.py
@@ -21,4 +21,5 @@ Bridge module adding UX requirements to ease SMS marketing o, event attendees.
     'data': [
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_event_track/__manifest__.py
+++ b/addons/mass_mailing_event_track/__manifest__.py
@@ -17,4 +17,5 @@ Bridge module adding UX requirements to ease mass mailing of event track speaker
         'views/event_views.xml'
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_event_track_sms/__manifest__.py
+++ b/addons/mass_mailing_event_track_sms/__manifest__.py
@@ -22,4 +22,5 @@ speakers..
     'data': [
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_sale/__manifest__.py
+++ b/addons/mass_mailing_sale/__manifest__.py
@@ -15,4 +15,5 @@
         'data/mass_mailing_demo.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_slides/__manifest__.py
+++ b/addons/mass_mailing_slides/__manifest__.py
@@ -17,4 +17,5 @@ Bridge module adding UX requirements to ease mass mailing of course members.
         'views/slide_channel_views.xml'
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_sms/__manifest__.py
+++ b/addons/mass_mailing_sms/__manifest__.py
@@ -33,4 +33,5 @@
         'data/mailing_demo.xml',
     ],
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/membership/__manifest__.py
+++ b/addons/membership/__manifest__.py
@@ -33,4 +33,5 @@ invoice and send propositions for membership renewal.
     'test': [
         '../account/test/account_minimal_test.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -49,4 +49,5 @@
     'pre_init_hook': '_pre_init_mrp',
     'post_init_hook': '_create_warehouse_data',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/mrp_account/__manifest__.py
+++ b/addons/mrp_account/__manifest__.py
@@ -28,4 +28,5 @@ If the automated inventory valuation is active, the necessary accounting entries
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -22,4 +22,5 @@
         'data/mrp_subcontracting_demo.xml',
     ],
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/mrp_subcontracting_account/__manifest__.py
+++ b/addons/mrp_subcontracting_account/__manifest__.py
@@ -11,4 +11,5 @@
     'depends': ['mrp_subcontracting', 'mrp_account'],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/mrp_subcontracting_dropshipping/__manifest__.py
+++ b/addons/mrp_subcontracting_dropshipping/__manifest__.py
@@ -12,4 +12,5 @@
     'depends': ['mrp_subcontracting', 'stock_dropshipping'],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/note/__manifest__.py
+++ b/addons/note/__manifest__.py
@@ -32,4 +32,5 @@
     'installable': True,
     'application': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/note_pad/__manifest__.py
+++ b/addons/note_pad/__manifest__.py
@@ -24,4 +24,5 @@ Use for update your text memo in real time with the following user that you invi
     'installable': True,
     'application': False,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/odoo_referral/__manifest__.py
+++ b/addons/odoo_referral/__manifest__.py
@@ -13,4 +13,5 @@
         "static/src/xml/systray.xml",
     ],
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/odoo_referral_portal/__manifest__.py
+++ b/addons/odoo_referral_portal/__manifest__.py
@@ -9,5 +9,6 @@
     'data': [
         'views/referral_template.xml',
     ],
-    'auto_install': False, # As deprecated
+    'auto_install': False, # As deprecated,
+    'license': 'LGPL-3',
 }

--- a/addons/pad/__manifest__.py
+++ b/addons/pad/__manifest__.py
@@ -19,5 +19,6 @@ pads (by default, http://etherpad.com/).
     ],
     'demo': ['data/pad_demo.xml'],
     'web': True,
-    'qweb': ['static/src/xml/pad.xml']
+    'qweb': ['static/src/xml/pad.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/pad_project/__manifest__.py
+++ b/addons/pad_project/__manifest__.py
@@ -17,4 +17,5 @@ This module adds a PAD in all project form views.
         'views/project_views.xml'
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -23,4 +23,5 @@
         'static/src/xml/partner_autocomplete.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/partner_autocomplete_address_extended/__manifest__.py
+++ b/addons/partner_autocomplete_address_extended/__manifest__.py
@@ -9,4 +9,5 @@ Correct address formating when both partner_autocomplete and base_address_extend
     'version': '1.0',
     'depends': ['partner_autocomplete', 'base_address_extended'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -27,4 +27,5 @@
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/payment_adyen/__manifest__.py
+++ b/addons/payment_adyen/__manifest__.py
@@ -15,4 +15,5 @@
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_alipay/__manifest__.py
+++ b/addons/payment_alipay/__manifest__.py
@@ -13,4 +13,5 @@
         'data/payment_acquirer_data.xml',
     ],
     'post_init_hook': 'create_missing_journal_for_acquirers',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_authorize/__manifest__.py
+++ b/addons/payment_authorize/__manifest__.py
@@ -15,4 +15,5 @@
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_buckaroo/__manifest__.py
+++ b/addons/payment_buckaroo/__manifest__.py
@@ -15,4 +15,5 @@
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_ingenico/__manifest__.py
+++ b/addons/payment_ingenico/__manifest__.py
@@ -15,4 +15,5 @@
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_paypal/__manifest__.py
+++ b/addons/payment_paypal/__manifest__.py
@@ -16,4 +16,5 @@
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_payulatam/__manifest__.py
+++ b/addons/payment_payulatam/__manifest__.py
@@ -13,4 +13,5 @@
         'data/payment_acquirer_data.xml',
     ],
     'post_init_hook': 'create_missing_journal_for_acquirers',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_payumoney/__manifest__.py
+++ b/addons/payment_payumoney/__manifest__.py
@@ -18,4 +18,5 @@
     ],
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_sips/__manifest__.py
+++ b/addons/payment_sips/__manifest__.py
@@ -22,4 +22,5 @@ payments acquirer using Worldline SIPS.""",
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_stripe/__manifest__.py
+++ b/addons/payment_stripe/__manifest__.py
@@ -16,4 +16,5 @@
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_stripe_checkout_webhook/__manifest__.py
+++ b/addons/payment_stripe_checkout_webhook/__manifest__.py
@@ -26,4 +26,5 @@ useless notifications.""",
     ],
     'images': ['static/description/icon.png'],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/payment_test/__manifest__.py
+++ b/addons/payment_test/__manifest__.py
@@ -17,4 +17,5 @@ not use it in production environment.
     ],
     'installable': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
+    'license': 'LGPL-3',
 }

--- a/addons/payment_transfer/__manifest__.py
+++ b/addons/payment_transfer/__manifest__.py
@@ -16,4 +16,5 @@
     'auto_install': True,
     'post_init_hook': 'create_missing_journal_for_acquirers',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/phone_validation/__manifest__.py
+++ b/addons/phone_validation/__manifest__.py
@@ -32,4 +32,5 @@ It adds two mixins :
         'mail',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -48,4 +48,5 @@
     'application': True,
     'qweb': ['static/src/xml/pos.xml'],
     'website': 'https://www.odoo.com/page/point-of-sale-shop',
+    'license': 'LGPL-3',
 }

--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -27,4 +27,5 @@ a dependency towards website edition and customization capabilities.""",
         'static/src/xml/portal_chatter.xml',
         'static/src/xml/portal_signature.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/pos_adyen/__manifest__.py
+++ b/addons/pos_adyen/__manifest__.py
@@ -15,5 +15,5 @@
     'depends': ['point_of_sale'],
     'qweb': ['static/src/xml/pos.xml'],
     'installable': True,
-    'license': 'OEEL-1',
+    'license': 'LGPL-3',
 }

--- a/addons/pos_cache/__manifest__.py
+++ b/addons/pos_cache/__manifest__.py
@@ -18,5 +18,6 @@ time it takes to load a POS session with a lot of products.
         'security/ir.model.access.csv',
         'views/pos_cache_views.xml',
         'views/pos_cache_templates.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/pos_cash_rounding/__manifest__.py
+++ b/addons/pos_cash_rounding/__manifest__.py
@@ -22,4 +22,5 @@
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_discount/__manifest__.py
+++ b/addons/pos_discount/__manifest__.py
@@ -23,4 +23,5 @@ discount to a customer.
         'static/src/xml/discount_templates.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_epson_printer/__manifest__.py
+++ b/addons/pos_epson_printer/__manifest__.py
@@ -19,4 +19,5 @@ Use Epson ePOS Printers without the IoT Box in the Point of Sale
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_epson_printer_restaurant/__manifest__.py
+++ b/addons/pos_epson_printer_restaurant/__manifest__.py
@@ -19,4 +19,5 @@ Use Epson Printers as Order Printers in the Point of Sale without the IoT Box
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_hr/__manifest__.py
+++ b/addons/pos_hr/__manifest__.py
@@ -22,4 +22,5 @@ The actual till still requires one user but an unlimited number of employees can
     'installable': True,
     'auto_install': True,
     'qweb': ['static/src/xml/pos.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/pos_kitchen_printer/__manifest__.py
+++ b/addons/pos_kitchen_printer/__manifest__.py
@@ -15,4 +15,5 @@
     'depends': ['pos_restaurant'],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_mercury/__manifest__.py
+++ b/addons/pos_mercury/__manifest__.py
@@ -39,4 +39,5 @@ following:
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_reprint/__manifest__.py
+++ b/addons/pos_reprint/__manifest__.py
@@ -21,4 +21,5 @@ Allow cashier to reprint receipts
         'static/src/xml/reprint.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -37,4 +37,5 @@ This module adds several features to the Point of Sale that are specific to rest
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_sale/__manifest__.py
+++ b/addons/pos_sale/__manifest__.py
@@ -22,4 +22,5 @@ This module adds a custom Sales Team for the Point of Sale. This enables you to 
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/pos_six/__manifest__.py
+++ b/addons/pos_six/__manifest__.py
@@ -13,5 +13,5 @@
     ],
     'depends': ['point_of_sale'],
     'installable': True,
-    'license': 'OEEL-1',
+    'license': 'LGPL-3',
 }

--- a/addons/procurement_jit/__manifest__.py
+++ b/addons/procurement_jit/__manifest__.py
@@ -27,4 +27,5 @@ still unreserve a picking.
     'test': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/product/__manifest__.py
+++ b/addons/product/__manifest__.py
@@ -48,4 +48,5 @@ Print product labels with barcode.
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/product_email_template/__manifest__.py
+++ b/addons/product_email_template/__manifest__.py
@@ -14,5 +14,6 @@ For instance when invoicing a training, the training agenda and materials will a
     'data': [
         'views/product_views.xml',
         'views/mail_template_views.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/product_expiry/__manifest__.py
+++ b/addons/product_expiry/__manifest__.py
@@ -21,4 +21,5 @@ Also implements the removal strategy First Expiry First Out (FEFO) widely used, 
              'views/product_template_views.xml',
              'views/stock_quant_views.xml',
              'data/product_expiry_data.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/product_margin/__manifest__.py
+++ b/addons/product_margin/__manifest__.py
@@ -17,4 +17,5 @@ The wizard to launch the report has several options to help you get the data you
         'wizard/product_margin_view.xml',
         'views/product_product_views.xml'
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/product_matrix/__manifest__.py
+++ b/addons/product_matrix/__manifest__.py
@@ -21,5 +21,6 @@ Please refer to Sale Matrix or Purchase Matrix for the use of this module.
     ],
     'demo': [
         'data/product_matrix_demo.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -44,4 +44,5 @@
     'installable': True,
     'auto_install': False,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/project_timesheet_holidays/__manifest__.py
+++ b/addons/project_timesheet_holidays/__manifest__.py
@@ -24,4 +24,5 @@ on leaves. Project and task can be configured company-wide.
     'installable': True,
     'auto_install': True,
     'post_init_hook': 'post_init',
+    'license': 'LGPL-3',
 }

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -34,4 +34,5 @@
     'installable': True,
     'auto_install': False,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/purchase_mrp/__manifest__.py
+++ b/addons/purchase_mrp/__manifest__.py
@@ -16,4 +16,5 @@ from purchase order.
     'depends': ['mrp', 'purchase_stock'],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/purchase_product_matrix/__manifest__.py
+++ b/addons/purchase_product_matrix/__manifest__.py
@@ -18,4 +18,5 @@
         'report/purchase_quotation_templates.xml',
         'report/purchase_order_templates.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/purchase_requisition/__manifest__.py
+++ b/addons/purchase_requisition/__manifest__.py
@@ -24,4 +24,5 @@ are agreements you have with vendors to benefit from a predetermined pricing.
         'report/purchase_requisition_report.xml',
         'report/report_purchaserequisition.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/purchase_requisition_stock/__manifest__.py
+++ b/addons/purchase_requisition_stock/__manifest__.py
@@ -19,4 +19,5 @@
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -28,4 +28,5 @@
     'installable': True,
     'auto_install': True,
     'post_init_hook': '_create_buy_rules',
+    'license': 'LGPL-3',
 }

--- a/addons/rating/__manifest__.py
+++ b/addons/rating/__manifest__.py
@@ -16,4 +16,5 @@ This module allows a customer to give rating.
      ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -39,4 +39,5 @@ The following topics are covered by this module:
     'installable': True,
     'auto_install': False,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/resource/__manifest__.py
+++ b/addons/resource/__manifest__.py
@@ -23,4 +23,5 @@ associated to every resource. It also manages the leaves of every resource.
     ],
     'demo': [
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -45,5 +45,6 @@ This module contains all the common features of Sales Management and eCommerce.
         "static/src/xml/account_reconciliation.xml",
     ],
     'installable': True,
-    'auto_install': False
+    'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_coupon/__manifest__.py
+++ b/addons/sale_coupon/__manifest__.py
@@ -22,4 +22,5 @@
     'demo': [
         'data/sale_coupon_demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/sale_coupon_delivery/__manifest__.py
+++ b/addons/sale_coupon_delivery/__manifest__.py
@@ -12,4 +12,5 @@
     'demo': [
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_crm/__manifest__.py
+++ b/addons/sale_crm/__manifest__.py
@@ -26,5 +26,6 @@ modules.
         'wizard/crm_opportunity_to_quotation_views.xml'
     ],
     'auto_install': True,
-    'uninstall_hook': 'uninstall_hook'
+    'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/sale_expense/__manifest__.py
+++ b/addons/sale_expense/__manifest__.py
@@ -25,4 +25,5 @@ This module allow to reinvoice employee expense, by setting the SO directly on t
     'test': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_management/__manifest__.py
+++ b/addons/sale_management/__manifest__.py
@@ -55,4 +55,5 @@ The Dashboard for the Sales Manager will include
     'application': True,
     'uninstall_hook': 'uninstall_hook',
     'post_init_hook': 'post_init_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/sale_margin/__manifest__.py
+++ b/addons/sale_margin/__manifest__.py
@@ -15,4 +15,5 @@ Price and Cost Price.
     'depends':['sale_management'],
     'demo':['data/sale_margin_demo.xml'],
     'data':['security/ir.model.access.csv','views/sale_margin_view.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/sale_mrp/__manifest__.py
+++ b/addons/sale_mrp/__manifest__.py
@@ -20,4 +20,5 @@ from sales order. It adds sales name and sales Reference on production order.
     'demo': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_product_configurator/__manifest__.py
+++ b/addons/sale_product_configurator/__manifest__.py
@@ -23,4 +23,5 @@ It also enables the "optional products" feature.
     'demo': [
         'data/sale_demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/sale_product_matrix/__manifest__.py
+++ b/addons/sale_product_matrix/__manifest__.py
@@ -18,5 +18,6 @@
     ],
     'demo': [
         'data/product_matrix_demo.xml'
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/sale_purchase/__manifest__.py
+++ b/addons/sale_purchase/__manifest__.py
@@ -23,4 +23,5 @@ by external providers and will automatically generate purchase orders directed t
     'demo': [
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_quotation_builder/__manifest__.py
+++ b/addons/sale_quotation_builder/__manifest__.py
@@ -17,4 +17,5 @@
         'views/sale_order_views.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_stock/__manifest__.py
+++ b/addons/sale_stock/__manifest__.py
@@ -38,4 +38,5 @@ Preferences
     'qweb': ['static/src/xml/qty_at_date.xml'],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -35,4 +35,5 @@ have real delivered quantities in sales orders.
     ],
     'auto_install': True,
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/sale_timesheet_purchase/__manifest__.py
+++ b/addons/sale_timesheet_purchase/__manifest__.py
@@ -13,4 +13,5 @@ Allows to access purchase orders from Project Overview
     'data': [],
     'demo': [],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/sales_team/__manifest__.py
+++ b/addons/sales_team/__manifest__.py
@@ -21,4 +21,5 @@ Using this application you can manage Sales Teams  with CRM and/or Sales
     'demo': ['data/sales_team_demo.xml'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -36,4 +36,5 @@ The service is provided by the In App Purchase Odoo platform.
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/snailmail/__manifest__.py
+++ b/addons/snailmail/__manifest__.py
@@ -22,4 +22,5 @@ Allows users to send documents by post
         'static/src/xml/thread.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/snailmail_account/__manifest__.py
+++ b/addons/snailmail_account/__manifest__.py
@@ -14,4 +14,5 @@ Allows users to send invoices by post
         'wizard/account_invoice_send_views.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/social_media/__manifest__.py
+++ b/addons/social_media/__manifest__.py
@@ -18,5 +18,6 @@ social media configuration for any other module that might need it.
     ],
     'demo': [
         'demo/res_company_demo.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -88,4 +88,5 @@
     'pre_init_hook': 'pre_init_hook',
     'post_init_hook': '_assign_default_mail_template_picking_id',
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/stock_account/__manifest__.py
+++ b/addons/stock_account/__manifest__.py
@@ -39,4 +39,5 @@ Dashboard / Reports for Warehouse Management includes:
     'installable': True,
     'auto_install': True,
     'post_init_hook': '_configure_journals',
+    'license': 'LGPL-3',
 }

--- a/addons/stock_dropshipping/__manifest__.py
+++ b/addons/stock_dropshipping/__manifest__.py
@@ -24,4 +24,5 @@ internal transfer document is needed.
     'data': ['data/stock_data.xml', 'views/sale_order_views.xml'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/stock_landed_costs/__manifest__.py
+++ b/addons/stock_landed_costs/__manifest__.py
@@ -27,4 +27,5 @@ This module allows you to easily add extra costs on pickings and decide the spli
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/stock_picking_batch/__manifest__.py
+++ b/addons/stock_picking_batch/__manifest__.py
@@ -22,4 +22,5 @@ This module adds the batch transfer option in warehouse management
         'data/stock_picking_batch_demo.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/stock_sms/__manifest__.py
+++ b/addons/stock_sms/__manifest__.py
@@ -18,4 +18,5 @@
     'application': False,
     'auto_install': True,
     'post_init_hook': '_assign_default_sms_template_picking_id',
+    'license': 'LGPL-3',
 }

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -49,4 +49,5 @@ sent mails with personal token for the invitation of the survey.
     'auto_install': False,
     'application': True,
     'sequence': 105,
+    'license': 'LGPL-3',
 }

--- a/addons/test_mail/__manifest__.py
+++ b/addons/test_mail/__manifest__.py
@@ -22,4 +22,5 @@ tests independently to functional aspects of other models. """,
     ],
     'installable': True,
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/test_mail_full/__manifest__.py
+++ b/addons/test_mail_full/__manifest__.py
@@ -27,4 +27,5 @@ real applications. """,
     ],
     'installable': True,
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/test_mass_mailing/__manifest__.py
+++ b/addons/test_mass_mailing/__manifest__.py
@@ -17,4 +17,5 @@ test_mail. """,
     ],
     'installable': True,
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -21,4 +21,5 @@ models which only purpose is to run tests.""",
     ],
     'installable': True,
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/test_website_slides_full/__manifest__.py
+++ b/addons/test_website_slides_full/__manifest__.py
@@ -23,4 +23,5 @@ certification flow including purchase, certification, failure and success.
         'views/assets.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/test_xlsx_export/__manifest__.py
+++ b/addons/test_xlsx_export/__manifest__.py
@@ -9,4 +9,5 @@
     'data': ['ir.model.access.csv'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/theme_bootswatch/__manifest__.py
+++ b/addons/theme_bootswatch/__manifest__.py
@@ -16,4 +16,5 @@
         'static/description/bootswatch_screenshot.jpg',
     ],
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/theme_default/__manifest__.py
+++ b/addons/theme_default/__manifest__.py
@@ -15,4 +15,5 @@
         'static/description/theme_default_screenshot.jpg',
     ],
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/addons/transifex/__manifest__.py
+++ b/addons/transifex/__manifest__.py
@@ -25,4 +25,5 @@ project.
         'data/ir_translation_view.xml',
     ],
     'depends': ['base'],
+    'license': 'LGPL-3',
 }

--- a/addons/uom/__manifest__.py
+++ b/addons/uom/__manifest__.py
@@ -18,4 +18,5 @@ This is the base module for managing Units of measure.
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/utm/__manifest__.py
+++ b/addons/utm/__manifest__.py
@@ -18,4 +18,5 @@ Enable management of UTM trackers: campaign, medium, source.
     ],
     'demo': [],
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -30,5 +30,6 @@ This module provides the core of the Odoo Web Client.
         "static/src/xml/report.xml",
         "static/src/xml/web_calendar.xml",
     ],
-    'bootstrap': True,  # load translations for login screen
+    'bootstrap': True,  # load translations for login screen,
+    'license': 'LGPL-3',
 }

--- a/addons/web_diagram/__manifest__.py
+++ b/addons/web_diagram/__manifest__.py
@@ -18,4 +18,5 @@ Openerp Web Diagram view.
         'static/src/xml/*.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -18,5 +18,6 @@ Odoo Web Editor widget.
     'qweb': [
         'static/src/xml/*.xml',
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/web_kanban_gauge/__manifest__.py
+++ b/addons/web_kanban_gauge/__manifest__.py
@@ -15,4 +15,5 @@ This widget allows to display gauges using d3 library.
     'qweb': [
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/web_tour/__manifest__.py
+++ b/addons/web_tour/__manifest__.py
@@ -23,5 +23,6 @@ Odoo Web tours.
     'qweb': [
         "static/src/xml/debug_manager.xml",
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/web_unsplash/__manifest__.py
+++ b/addons/web_unsplash/__manifest__.py
@@ -12,4 +12,5 @@
         'views/web_unsplash_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -41,4 +41,5 @@
     'qweb': ['static/src/xml/website.backend.xml'],
     'application': True,
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -29,4 +29,5 @@
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_crm/__manifest__.py
+++ b/addons/website_crm/__manifest__.py
@@ -23,4 +23,5 @@ This module includes contact phone and mobile numbers validation.""",
     'qweb': ['static/src/xml/*.xml'],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_crm_livechat/__manifest__.py
+++ b/addons/website_crm_livechat/__manifest__.py
@@ -12,4 +12,5 @@
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_crm_partner_assign/__manifest__.py
+++ b/addons/website_crm_partner_assign/__manifest__.py
@@ -40,4 +40,5 @@ The automatic assignation is figured from the weight of partner levels and the g
     ],
     'qweb': ['static/src/xml/*.xml'],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_crm_sms/__manifest__.py
+++ b/addons/website_crm_sms/__manifest__.py
@@ -11,4 +11,5 @@
     'data': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_customer/__manifest__.py
+++ b/addons/website_customer/__manifest__.py
@@ -26,4 +26,5 @@ Publish your customers as business references on your website to attract new pot
     ],
     'qweb': [],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -21,4 +21,5 @@
         'data/event_demo.xml'
     ],
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_event_questions/__manifest__.py
+++ b/addons/website_event_questions/__manifest__.py
@@ -13,4 +13,5 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_event_sale/__manifest__.py
+++ b/addons/website_event_sale/__manifest__.py
@@ -15,5 +15,6 @@ Sell event tickets through eCommerce app.
         'security/ir.model.access.csv',
         'security/website_event_sale_security.xml',
     ],
-    'auto_install': True
+    'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_event_track/__manifest__.py
+++ b/addons/website_event_track/__manifest__.py
@@ -20,4 +20,5 @@
     'demo': [
         'data/event_demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_form/__manifest__.py
+++ b/addons/website_form/__manifest__.py
@@ -18,4 +18,5 @@
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_form_project/__manifest__.py
+++ b/addons/website_form_project/__manifest__.py
@@ -16,4 +16,5 @@ Generate tasks in Project app from a form published on your website. This module
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_forum/__manifest__.py
+++ b/addons/website_forum/__manifest__.py
@@ -37,4 +37,5 @@ Ask questions, get answers, no distractions
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_gengo/__manifest__.py
+++ b/addons/website_gengo/__manifest__.py
@@ -14,5 +14,6 @@ This module allows to send website content to Gengo translation service in a sin
     ],
     'data': [
         'views/website_gengo_templates.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_google_map/__manifest__.py
+++ b/addons/website_google_map/__manifest__.py
@@ -13,4 +13,5 @@ Show your company address/partner address on Google Maps. Configure an API key i
         'views/google_map_templates.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_hr_recruitment/__manifest__.py
+++ b/addons/website_hr_recruitment/__manifest__.py
@@ -22,4 +22,5 @@
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_links/__manifest__.py
+++ b/addons/website_links/__manifest__.py
@@ -16,4 +16,5 @@ Those trackers can be used in Google Analytics to track clicks and visitors, or 
     ],
     'qweb': ['static/src/xml/*.xml'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -23,4 +23,5 @@ Allow website visitors to chat with the collaborators. This module also brings a
     'qweb': [
         'static/src/xml/thread.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_mail/__manifest__.py
+++ b/addons/website_mail/__manifest__.py
@@ -18,4 +18,5 @@ It is responsible of comments moderation for published documents (forum, slides,
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_mail_channel/__manifest__.py
+++ b/addons/website_mail_channel/__manifest__.py
@@ -13,4 +13,5 @@ Visitors can join public mail channels managed in the Discuss app in order to ge
         'views/website_mail_channel_templates.xml',
         'views/snippets.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -22,4 +22,5 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
         'static/src/xml/*.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_membership/__manifest__.py
+++ b/addons/website_membership/__manifest__.py
@@ -20,4 +20,5 @@ Publish your members/association directory publicly.
     'demo': ['data/membership_demo.xml'],
     'qweb': ['static/src/xml/*.xml'],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_partner/__manifest__.py
+++ b/addons/website_partner/__manifest__.py
@@ -20,4 +20,5 @@ This is a base module. It holds website-related stuff for Contact model (res.par
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -17,4 +17,5 @@ This is a bridge module which integrates payment acquirers with Website app.
         'views/payment_acquirer.xml',
     ],
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/website_profile/__manifest__.py
+++ b/addons/website_profile/__manifest__.py
@@ -18,4 +18,5 @@
         'security/ir.model.access.csv',
     ],
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/addons/website_rating/__manifest__.py
+++ b/addons/website_rating/__manifest__.py
@@ -16,4 +16,5 @@ Bridge module for rating on website stuff.
         'views/rating_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -32,4 +32,5 @@
     'installable': True,
     'application': True,
     'uninstall_hook': 'uninstall_hook',
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_comparison/__manifest__.py
+++ b/addons/website_sale_comparison/__manifest__.py
@@ -24,4 +24,5 @@ Finally, the module comes with an option to display an attribute summary table i
         'data/website_sale_comparison_demo.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_coupon/__manifest__.py
+++ b/addons/website_sale_coupon/__manifest__.py
@@ -17,4 +17,5 @@ Coupon & promotion programs can be edited in the Catalog menu of the Website app
         'views/sale_coupon_program_views.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_coupon_delivery/__manifest__.py
+++ b/addons/website_sale_coupon_delivery/__manifest__.py
@@ -11,4 +11,5 @@
         'views/website_sale_coupon_delivery_templates.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_delivery/__manifest__.py
+++ b/addons/website_sale_delivery/__manifest__.py
@@ -20,4 +20,5 @@ Configure your own methods with a pricing grid or integrate with carriers for a 
     'qweb': [],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_digital/__manifest__.py
+++ b/addons/website_sale_digital/__manifest__.py
@@ -21,4 +21,5 @@ Once the order is paid, the file is made available in the order confirmation pag
     'demo': [
         'data/product_demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_management/__manifest__.py
+++ b/addons/website_sale_management/__manifest__.py
@@ -17,4 +17,5 @@ Display orders to invoice in website dashboard.
     'demo': [
     ],
     'qweb': ['static/src/xml/*.xml'],
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_product_configurator/__manifest__.py
+++ b/addons/website_sale_product_configurator/__manifest__.py
@@ -16,4 +16,5 @@
     'demo': [
         'data/demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_slides/__manifest__.py
+++ b/addons/website_sale_slides/__manifest__.py
@@ -21,4 +21,5 @@
         'data/slide_demo.xml',
         'data/sale_order_demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_stock/__manifest__.py
+++ b/addons/website_sale_stock/__manifest__.py
@@ -25,4 +25,5 @@ Then it can be made specific at the product level.
         'data/website_sale_stock_demo.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_stock_product_configurator/__manifest__.py
+++ b/addons/website_sale_stock_product_configurator/__manifest__.py
@@ -13,4 +13,5 @@
     'data': [
         'views/product_configurator_templates.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_sale_wishlist/__manifest__.py
+++ b/addons/website_sale_wishlist/__manifest__.py
@@ -16,4 +16,5 @@ Allow shoppers of your eCommerce store to create personalized collections of pro
         'views/website_sale_wishlist_template.xml',
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -59,4 +59,5 @@ Featuring
     ],
     'installable': True,
     'application': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_slides_forum/__manifest__.py
+++ b/addons/website_slides_forum/__manifest__.py
@@ -24,4 +24,5 @@
         'data/slide_channel_demo.xml',
     ],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_slides_survey/__manifest__.py
+++ b/addons/website_slides_survey/__manifest__.py
@@ -29,4 +29,5 @@
         'data/slide_slide_demo.xml',
         'data/survey.user_input_line.csv',
     ],
+    'license': 'LGPL-3',
 }

--- a/addons/website_sms/__manifest__.py
+++ b/addons/website_sms/__manifest__.py
@@ -13,4 +13,5 @@
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_theme_install/__manifest__.py
+++ b/addons/website_theme_install/__manifest__.py
@@ -12,4 +12,5 @@
     ],
     'depends': ['website'],
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/addons/website_twitter/__manifest__.py
+++ b/addons/website_twitter/__manifest__.py
@@ -17,4 +17,5 @@ This module adds a Twitter scroller building block to the website builder, so th
         'views/website_twitter_snippet_templates.xml'
     ],
     'installable': True,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -87,4 +87,5 @@ The kernel of Odoo, needed for all installation.
     'installable': True,
     'auto_install': True,
     'post_init_hook': 'post_init',
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_access_rights/__manifest__.py
+++ b/odoo/addons/test_access_rights/__manifest__.py
@@ -8,4 +8,5 @@
         'security.xml',
         'data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_action_bindings/__manifest__.py
+++ b/odoo/addons/test_action_bindings/__manifest__.py
@@ -5,4 +5,5 @@
         'ir.model.access.csv',
         'test_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_assetsbundle/__manifest__.py
+++ b/odoo/addons/test_assetsbundle/__manifest__.py
@@ -11,4 +11,5 @@
         "views/views.xml",
     ],
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_convert/__manifest__.py
+++ b/odoo/addons/test_convert/__manifest__.py
@@ -8,5 +8,6 @@
     'category': 'Tests',
     'data': [
         'ir.model.access.csv',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_converter/__manifest__.py
+++ b/odoo/addons/test_converter/__manifest__.py
@@ -10,4 +10,5 @@
     'data': ['ir.model.access.csv'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_exceptions/__manifest__.py
+++ b/odoo/addons/test_exceptions/__manifest__.py
@@ -9,4 +9,5 @@
     'data': ['view.xml', 'ir.model.access.csv'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_impex/__manifest__.py
+++ b/odoo/addons/test_impex/__manifest__.py
@@ -8,4 +8,5 @@
     'data': ['ir.model.access.csv'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherit/__manifest__.py
+++ b/odoo/addons/test_inherit/__manifest__.py
@@ -11,4 +11,5 @@
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherits/__manifest__.py
+++ b/odoo/addons/test_inherits/__manifest__.py
@@ -13,4 +13,5 @@
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherits_depends/__manifest__.py
+++ b/odoo/addons/test_inherits_depends/__manifest__.py
@@ -9,4 +9,5 @@
     'data': [],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_limits/__manifest__.py
+++ b/odoo/addons/test_limits/__manifest__.py
@@ -9,4 +9,5 @@
     'data': ['ir.model.access.csv'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_lint/__manifest__.py
+++ b/odoo/addons/test_lint/__manifest__.py
@@ -8,5 +8,6 @@
     'depends': ['base'],
     'installable': True,
     'auto_install': False,
-    'pre_init_hook': 'uninstall_test_pylint'
+    'pre_init_hook': 'uninstall_test_pylint',
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_main_flows/__manifest__.py
+++ b/odoo/addons/test_main_flows/__manifest__.py
@@ -14,4 +14,5 @@ It will install some main apps and will try to execute the most important action
     ],
     'installable': True,
     'post_init_hook': '_auto_install_enterprise_dependencies',
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_mimetypes/__manifest__.py
+++ b/odoo/addons/test_mimetypes/__manifest__.py
@@ -4,4 +4,5 @@
     'version': '0.1',
     'category': 'Tests',
     'description': """A module to generate exceptions.""",
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_new_api/__manifest__.py
+++ b/odoo/addons/test_new_api/__manifest__.py
@@ -16,4 +16,5 @@
     'demo': [
         'demo_data.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_performance/__manifest__.py
+++ b/odoo/addons/test_performance/__manifest__.py
@@ -10,4 +10,5 @@
     'demo': [
         'demo/demo.xml',
     ],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_read_group/__manifest__.py
+++ b/odoo/addons/test_read_group/__manifest__.py
@@ -8,4 +8,5 @@
 
     'depends': ['base'],
     'data': ['ir.model.access.csv'],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_rpc/__manifest__.py
+++ b/odoo/addons/test_rpc/__manifest__.py
@@ -8,4 +8,5 @@
     "installable": True,
     "auto_install": False,
     "data": ["ir.model.access.csv"],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_testing_utilities/__manifest__.py
+++ b/odoo/addons/test_testing_utilities/__manifest__.py
@@ -11,5 +11,6 @@ supposed to do
     'data': [
         'ir.model.access.csv',
         'menu.xml',
-    ]
+    ],
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_translation_import/__manifest__.py
+++ b/odoo/addons/test_translation_import/__manifest__.py
@@ -8,4 +8,5 @@
     'data': ['view.xml'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }

--- a/odoo/addons/test_uninstall/__manifest__.py
+++ b/odoo/addons/test_uninstall/__manifest__.py
@@ -9,4 +9,5 @@
     'data': ['ir.model.access.csv'],
     'installable': True,
     'auto_install': False,
+    'license': 'LGPL-3',
 }


### PR DESCRIPTION
The license is missing in most enterprise manifest so
the decision was taken to make it explicit in all cases.
When not defined, a warning will be triggered starting from
14.0 when falling back on the default LGPL-3.
