### PR TITLE
[FIX] hr_timesheet: fix incorrect company on timesheet report

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -2,6 +2,7 @@
     <template id="report_timesheet">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
+                <t t-set="company" t-value="docs.mapped('project_id')[0].company_id if len(docs.mapped('project_id')) == 1 else docs.env.company"/>
                 <t t-set="show_task" t-value="bool(docs.mapped('task_id'))"/>
                 <t t-set="show_project" t-value="len(docs.mapped('project_id')) > 1"/>
                 <div class="page">


### PR DESCRIPTION
- Create 2 companies (i.e. Company A & Company B)
- Create user with access to both companies and default company set to Company B
- Log with created user
- Switch to Company A
- Go to Project and create a new Project (i.e. Project X)
- Go to Timesheets and add a line for Project X
- Display all timesheets in list view
- Select created timesheet and print "Timesheet Entries"
Logo and address printed on timesheet report are from Company B.

Company used for timesheet report is default company of current user.

This fix will use company linked to the project if it is unique.
Otherwise, it will use current company.

opw-2502182
opw-2509463

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
