### PR TITLE
[IMP] hr_recruitment: assign default recruiter with mail alias

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -109,6 +109,7 @@ class Job(models.Model):
                 'job_id': self.id,
                 'department_id': self.department_id.id,
                 'company_id': self.department_id.company_id.id if self.department_id else self.company_id.id,
+                'user_id': self.user_id.id,
             })
         return values
 
@@ -124,6 +125,18 @@ class Job(models.Model):
             }
             self.env['hr.recruitment.source'].create(source_vals)
         return new_job
+
+    def write(self, vals):
+        res = super().write(vals)
+        # Since the alias is created upon record creation, the default values do not reflect the current values unless
+        # specifically rewritten
+        # List of fields to keep synched with the alias
+        alias_fields = {'department_id', 'user_id'}
+        if any(field for field in alias_fields if field in vals):
+            for job in self:
+                alias_default_vals = job._alias_get_creation_values().get('alias_defaults', '{}')
+                job.alias_defaults = alias_default_vals
+        return res
 
     def _creation_subtype(self):
         return self.env.ref('hr_recruitment.mt_job_new')


### PR DESCRIPTION
Assign the job recruiter to applications created through the email
alias.
Previously the email alias did not contain the recruiter's ID and the
application would not be assigned to anyone. This commit changes that
behaviour and also updated the alias creation values when the right
fields change, such as department_id.
The Alias should be kept synchronized with the job configuration.

Task ID: 2608541

