### PR TITLE
[IMP] pos_*: Use the POS in http under specific conditions

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -601,6 +601,8 @@ class PosConfig(models.Model):
          }
 
     def _force_http(self):
+        if self.other_devices:
+            return True
         return False
 
     def _get_pos_base_url(self):

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -31,6 +31,11 @@ class PosConfig(models.Model):
         if not self.iface_tipproduct:
             self.set_tip_after_payment = False
 
+    def _force_http(self):
+        if self.printer_ids.filtered(lambda pt: pt.printer_type == 'epson_epos'):
+            return True
+        return super(PosConfig, self)._force_http()
+
     def get_tables_order_count(self):
         """         """
         self.ensure_one()


### PR DESCRIPTION
Because there are some restrictions with the HTTPS and trusted certificates
We forward, in some cases,  the POS and the POS RESTAURANT to a specific url.

HTTPS: /pos/ui
HTTP: /pos/web

To allow rules for webserver

We make this change when we check 'Direct Devices'
And when we use a 'Order Printer' type 'epson_epos'

Tasks: 2597021

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
