### PR TITLE
[FIX] hr_holidays_attendance: fix archived time off

### DIFF
--- a/addons/hr_attendance/models/__init__.py
+++ b/addons/hr_attendance/models/__init__.py
@@ -4,6 +4,7 @@ from . import res_config_settings
 from . import hr_attendance
 from . import hr_attendance_overtime
 from . import hr_employee
+from . import hr_employee_public
 from . import ir_ui_menu
 from . import res_company
 from . import res_users

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -211,14 +211,14 @@ class HrAttendance(models.Model):
                             # consider check_in as planned_start_dt if within threshold
                             # if delta_in < 0: Checked in after supposed start of the day
                             # if delta_in > 0: Checked in before supposed start of the day
-                            local_check_in = emp_tz.localize(attendance.check_in)
+                            local_check_in = pytz.utc.localize(attendance.check_in)
                             delta_in = (planned_start_dt - local_check_in).total_seconds() / 3600.0
 
                             # Started before or after planned date within the threshold interval
                             if (delta_in > 0 and delta_in <= company_threshold) or\
                                 (delta_in < 0 and abs(delta_in) <= employee_threshold):
                                 local_check_in = planned_start_dt
-                            local_check_out = emp_tz.localize(attendance.check_out)
+                            local_check_out = pytz.utc.localize(attendance.check_out)
 
                             # same for check_out as planned_end_dt
                             delta_out = (local_check_out - planned_end_dt).total_seconds() / 3600.0

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -37,7 +37,8 @@ class HrEmployee(models.Model):
     overtime_ids = fields.One2many(
         'hr.attendance.overtime', 'employee_id', groups="hr_attendance.group_hr_attendance_user")
     total_overtime = fields.Float(
-        compute='_compute_total_overtime', groups="hr_attendance.group_hr_attendance_user")
+        compute='_compute_total_overtime', compute_sudo=True,
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
 
     @api.depends('overtime_ids.duration', 'attendance_ids')
     def _compute_total_overtime(self):

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -16,7 +16,7 @@ class HrEmployee(models.Model):
         help='list of attendances for the employee')
     last_attendance_id = fields.Many2one(
         'hr.attendance', compute='_compute_last_attendance_id', store=True,
-        groups="hr_attendance.group_hr_attendance_user")
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
     last_check_in = fields.Datetime(
         related='last_attendance_id.check_in', store=True,
         groups="hr_attendance.group_hr_attendance_user")
@@ -26,11 +26,12 @@ class HrEmployee(models.Model):
     attendance_state = fields.Selection(
         string="Attendance Status", compute='_compute_attendance_state',
         selection=[('checked_out', "Checked out"), ('checked_in', "Checked in")],
-        groups="hr_attendance.group_hr_attendance_user")
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
     hours_last_month = fields.Float(
         compute='_compute_hours_last_month', groups="hr_attendance.group_hr_attendance_user")
     hours_today = fields.Float(
-        compute='_compute_hours_today', groups="hr_attendance.group_hr_attendance_user")
+        compute='_compute_hours_today',
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
     hours_last_month_display = fields.Char(
         compute='_compute_hours_last_month', groups="hr_attendance.group_hr_attendance_user")
     overtime_ids = fields.One2many(

--- a/addons/hr_attendance/models/hr_employee_public.py
+++ b/addons/hr_attendance/models/hr_employee_public.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+class HrEmployeePublic(models.Model):
+    _inherit = 'hr.employee.public'
+
+    # These are required for manual attendance
+    attendance_state = fields.Selection(related='employee_id.attendance_state', readonly=True,
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
+    hours_today = fields.Float(related='employee_id.hours_today', readonly=True,
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
+    last_attendance_id = fields.Many2one(related='employee_id.last_attendance_id', readonly=True,
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")

--- a/addons/hr_attendance/models/hr_employee_public.py
+++ b/addons/hr_attendance/models/hr_employee_public.py
@@ -13,3 +13,5 @@ class HrEmployeePublic(models.Model):
         groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
     last_attendance_id = fields.Many2one(related='employee_id.last_attendance_id', readonly=True,
         groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")
+    total_overtime = fields.Float(related='employee_id.total_overtime', readonly=True,
+        groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance")

--- a/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
+++ b/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
@@ -10,5 +10,8 @@
             <field name="active" eval="False"/>
             <field name="company_id" eval="False"/>
         </record>
+
+        <!-- The record above should be archived if no company has overtime counting enabled, otherwise enabled -->
+        <function model="res.company" name="_check_extra_hours_time_off"/>
     </data>
 </odoo>

--- a/addons/hr_holidays_attendance/models/res_company.py
+++ b/addons/hr_holidays_attendance/models/res_company.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
 
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    def write(self, vals):
-        res = super().write(vals)
-        if 'hr_attendance_overtime' not in vals:
-            return res
+    @api.model
+    def _check_extra_hours_time_off(self):
         extra_hours_time_off_type = self.env.ref('hr_holidays_attendance.holiday_status_extra_hours', raise_if_not_found=False)
         if not extra_hours_time_off_type:
-            return res
+            return
         all_companies = self.env['res.company'].sudo().search([])
         # Unarchive time of type if the feature is enabled
         if any(company.hr_attendance_overtime and not extra_hours_time_off_type.active for company in all_companies):
@@ -21,4 +19,9 @@ class ResCompany(models.Model):
         # Archive time of type if the feature is disabled for all the company
         if all(not company.hr_attendance_overtime and extra_hours_time_off_type.active for company in all_companies):
             extra_hours_time_off_type.toggle_active()
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'hr_attendance_overtime' in vals:
+            self._check_extra_hours_time_off()
         return res

--- a/addons/hr_holidays_attendance/views/res_users_views.xml
+++ b/addons/hr_holidays_attendance/views/res_users_views.xml
@@ -11,7 +11,7 @@
                     name="%(hr_leave_allocation_overtime_action)d"
                     string="Deduct Extra Hours"
                     type="action"
-                    context="{'default_employee_id': employee_id, 'deduct_extra_hours': True}"
+                    context="{'default_employee_id': employee_id, 'deduct_extra_hours': True, 'deduct_extra_hours_allocation_type': 'fixed_allocation'}"
                     attrs="{'invisible': [('request_overtime', '=', False)]}"/>
             </xpath>
         </field>


### PR DESCRIPTION
When installing the `hr_holidays_attendance` module without demo data,
and having the count extra hours options enabled, the extra hours time
off type would remain archived instead of being enabled.
This commit fixes that behaviour and will now start in sync with the
company option(s).

Task ID: 2607436
