### PR TITLE
[IMP]Timesheets : improved  access rights

### DIFF
--- a/addons/hr_timesheet/models/__init__.py
+++ b/addons/hr_timesheet/models/__init__.py
@@ -4,6 +4,7 @@
 from . import hr_employee
 from . import hr_timesheet
 from . import ir_http
+from . import ir_ui_menu
 from . import res_company
 from . import res_config_settings
 from . import project

--- a/addons/hr_timesheet/models/ir_ui_menu.py
+++ b/addons/hr_timesheet/models/ir_ui_menu.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    def _load_menus_blacklist(self):
+        res = super()._load_menus_blacklist()
+        if self.env.user.has_group('hr_timesheet.group_hr_timesheet_approver'):
+            res.append(self.env.ref('hr_timesheet.timesheet_menu_activity_user').id)
+        return res

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -7,14 +7,14 @@
         </record>
 
         <record id="group_hr_timesheet_user" model="res.groups">
-            <field name="name">See own timesheets</field>
+            <field name="name">User: own timesheets only</field>
             <field name="category_id" ref="base.module_category_services_timesheets"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
         <record id="group_hr_timesheet_approver" model="res.groups">
-            <field name="name">Approver</field>
+            <field name="name">User: all timesheets</field>
             <field name="category_id" ref="base.module_category_services_timesheets"/>
             <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]"/>
         </record>

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -12,6 +12,7 @@
         <menuitem id="menu_hr_time_tracking"
             name="Timesheets"
             parent="timesheet_menu_root"
+            groups = "group_hr_timesheet_approver"
             sequence="5"/>
 
         <!--
@@ -304,7 +305,14 @@
 
         <menuitem id="timesheet_menu_activity_mine"
             name="My Timesheets"
+            groups="group_hr_timesheet_approver"
             parent="menu_hr_time_tracking"
+            action="act_hr_timesheet_line"/>
+
+        <menuitem id="timesheet_menu_activity_user"
+            name="My Timesheets"
+            groups="group_hr_timesheet_user"
+            parent="timesheet_menu_root"
             action="act_hr_timesheet_line"/>
 
         <record id="timesheet_action_task" model="ir.actions.act_window">


### PR DESCRIPTION
Before this commit:
The approver can access all timesheets which is not coherent.

After this commit:

improved the labelling of the timesheet app's roles, modified the menu according
to the role of User.Approver now can access his own timesheets only by click only
available option  'My timesheets'.

Task - 2531321

Description of the issue/feature this PR addresses:

Current behaviour before PR:

Desired behaviour after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
