### PR TITLE
[FIX] account: Add layout to action send and print

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2746,6 +2746,7 @@ class AccountMove(models.Model):
                 # ir.actions.act_window works
                 'active_id': self.ids[0],
                 'active_ids': self.ids,
+                'custom_layout': 'mail.mail_notification_paynow',
             },
             'target': 'new',
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
When sending the same invoice from Invoices > list view > select an invoice > action > Send and print, the email received by the client does not contain the header and the link to the invoice

This PR adds the custom_layout attribute to the context of "Send & Print" action

opw-2544654