### PR TITLE
[FIX] account: Add layout to action send and print

### DIFF
--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -83,6 +83,7 @@
            <field name="context" eval="{
                 'default_template_id': ref('account.email_template_edi_invoice'),
                 'mark_invoice_as_sent': True,
+                'custom_layout': 'mail.mail_notification_paynow',
             }"/>
            <field name="binding_model_id" ref="model_account_move"/>
            <field name="binding_view_types">list</field>


### PR DESCRIPTION
When sending the same invoice from Invoices > list view > select an invoice > action > Send and print, the email received by the client does not contain the header and the link to the invoice

This PR adds the custom_layout attribute to the context of "Send & Print" action

opw-2544654