### PR TITLE
[FIX] web_editor: start snippet widgets after creating its options 

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2343,7 +2343,6 @@ var SnippetsMenu = Widget.extend({
                         await self._scrollToSnippet($target);
 
                         _.defer(async function () {
-                            self.trigger_up('snippet_dropped', {$target: $target});
                             self._disableUndroppableSnippets();
 
                             dragAndDropResolve();
@@ -2351,6 +2350,7 @@ var SnippetsMenu = Widget.extend({
                             await self._callForEachChildSnippet($target, function (editor, $snippet) {
                                 return editor.buildSnippet();
                             });
+                            self.trigger_up('snippet_dropped', {$target: $target});
                             $target.trigger('content_changed');
                             await self._updateInvisibleDOM();
 


### PR DESCRIPTION
ISSUE
Since 14.4, dropping the image gallery to a website was causing a
traceback.

CAUSE
The bug appeared when new options were added to i.fa elements (such as
Alignment, Shape, Padding). It was an issue for the image gallery as in
the start method of the snippet widget, o_indicators_left and
o_indicators_right elements are removed if not necessary. They are
removed and not only hidden in order to keep the snippet responsive.

In that situation, there was a concurrency issue, as an editor of a
child snippet removed from the DOM (here in the chevrons, removed in the
start method of the parent snippet) was created and initializing options
for an element that was not there anymore.

SOLUTION
When a snippet is dropped on a page, we wait for its options to be
created before starting its widgets.

task-2604383

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
