### PR TITLE
[FIX] mail: fix wrong escaping of html entities when create link

### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -71,7 +71,7 @@ function linkify(text, attrs) {
 
 function addLink(node, transformChildren) {
     if (node.nodeType === 3) {  // text node
-        const linkified = linkify(node.data);
+        const linkified = linkify(_.escape(node.data));
         if (linkified !== node.data) {
             const div = document.createElement('div');
             div.innerHTML = linkified;

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -824,8 +824,11 @@ function factory(dependencies) {
                     const escapedSource = String(source).replace(
                         /([.*+?=^!:${}()|[\]/\\])/g,
                         '\\$1');
+                    const escapedEntitiesSource = String(_.escape(source)).replace(
+                        /([.*+?=^!:${}()|[\]/\\])/g,
+                        '\\$1');
                     const regexp = new RegExp(
-                        '(\\s|^)(' + escapedSource + ')(?=\\s|$)',
+                        '(\\s|^)(' + escapedSource + '|' + escapedEntitiesSource + ')(?=\\s|$)',
                         'g');
                     htmlString = htmlString.replace(regexp, '$1' + emoji.unicode);
                 }

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -35,6 +35,13 @@ QUnit.test('add_link utility function', function (assert) {
     });
 });
 
+QUnit.test('add_link utility function and icons', function (assert) {
+    assert.expect(1);
+    // 'https://test.example.com/test?&currency_id' without escaping, the innerHTML from the browser convert into 'https://test.example.com/test?¤cy_id'
+    var output = utils.parseAndTransform('<p>https://test.example.com/test?&amp;currency_id</p>', utils.addLink);
+    assert.strictEqual(output, '<p><a target="_blank" rel="noreferrer noopener" href="https://test.example.com/test?&amp;currency_id">https://test.example.com/test?&amp;currency_id</a></p>');
+});
+
 QUnit.test('addLink: linkify inside text node (1 occurrence)', function (assert) {
     assert.expect(5);
 


### PR DESCRIPTION
Issue: `node.data` is an unescape text content and used as an escaped
content just after (set `innerHTML`). The emoji will be search on
unescaped and escaped content to post a message.

opw-2525028