### PR TITLE
[FIX] website: do not auto-fill the forms with 'false'

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -113,7 +113,7 @@ odoo.define('website.s_website_form', function (require) {
                     if (!$field.val() && _.has(dataForValues, field) && dataForValues[field]) {
                         $field.val(dataForValues[field]);
                     } else if (!$field.val() && $field.data('fill-with')) {
-                        $field.val(self.preFillValues[$field.data('fill-with')]);
+                        $field.val(self.preFillValues[$field.data('fill-with')] || '');
                     }
                     $field.data('website_form_original_default_value', $field.val());
                 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On the 'Contact us' form of the 'website' module, the client can auto-fill the fields with the 'false' text string when the logged partner has some missing values.

Current behavior before PR:
The client will issue an RPC call to retrieve the values of the logged partner. The server will then load the data and set all missing values to 'false'. The client will then automatically fill the form with the loaded values.

Desired behavior after PR is merged:
The client will replace the falsy values with an empty string before updating the form fields.

Task id: 2610948

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
