### PR TITLE
[IMP] mrp: set qty producing also when using lots/serials

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -343,7 +343,8 @@ class StockMove(models.Model):
         # Do not update extra product quantities
         if float_is_zero(self.product_uom_qty, precision_rounding=self.product_uom.rounding):
             return True
-        if self.has_tracking != 'none' or self.state == 'done':
+        if self.has_tracking != 'none' and not float_is_zero(self.quantity_done, precision_rounding=self.product_uom.rounding):
+            # If some serial/lot has been selected to be consumed we don't change the selection.
             return True
         return False
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Set qty producing also when using lots/serials. I think this is a good UX improvement.

The only constraint is that ther is nothing selected to be consumed before adding a new final product lot.

For my examples below I have the following product structure:
TEST-FP-01-S, parent product, tracked by serial numbers and made out of:
- 1x TEST PS-01, tracked by serial numbers.
- 1x TEST PS-02, tracked by serial numbers.
- 1x TEST PP-03, no tracking.

**Current behavior before PR:**
You are forced to always select the serial/lot numbers manually even if there is a reservation.
![Peek 2021-07-26 18-18](https://user-images.githubusercontent.com/23449160/127023962-b20d925e-73f5-4224-a0e0-4e324b7a550a.gif)

**Desired behavior after PR is merged:**
If there is nothing selected use what it is already reserved
![Peek 2021-07-26 18-20](https://user-images.githubusercontent.com/23449160/127024104-76ee9d0e-bc22-4d8b-b21a-ef3b0c12d6d4.gif)

I case I selected a lot manually it is respected:
![Peek 2021-07-26 18-14](https://user-images.githubusercontent.com/23449160/127024220-2e1a6738-2a09-47ed-bb5f-19781e758846.gif)


@ForgeFlow

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
