### PR TITLE
[FIX] website_slides: correctly hide tag from kanban

### DIFF
--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -238,7 +238,9 @@
                                             </a>
                                         </div>
                                         <div t-if="record.tag_ids">
-                                            <field name="tag_ids" widget="many2many_tags"/>
+                                            <span class="oe_kanban_list_many2many">
+                                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                            </span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Before this commit, Tags with "Hide in Kanban" was always displayed
in Kanban view.

With this commit, Tags are hidden correctly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
