### PR TITLE
[FIX] Internationalization, point_of_sale : translation issue

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -915,6 +915,13 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js:0
+#, python-format
+msgid "Change Customer"
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
 #: code:addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js:0
 #, python-format
 msgid "Change Tip"

--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -84,11 +84,11 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
          */
         get nextButton() {
             if (!this.props.client) {
-                return { command: 'set', text: 'Set Customer' };
+                return { command: 'set', text: this.env._t('Set Customer') };
             } else if (this.props.client && this.props.client === this.state.selectedClient) {
-                return { command: 'deselect', text: 'Deselect Customer' };
+                return { command: 'deselect', text: this.env._t('Deselect Customer') };
             } else {
-                return { command: 'set', text: 'Change Customer' };
+                return { command: 'set', text: this.env._t('Change Customer') };
             }
         }
 


### PR DESCRIPTION
The term "Change Customer" was missing in point_of_sale.pot

Also call _t on terms to be sure it's properly translated

This fix completes the one made in PR #73770

opw-2596436

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
