### PR TITLE
[FIX] mrp: update the uom in bom line when product changes

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -49,6 +49,12 @@ class ProductTemplate(models.Model):
             'graph_measure': 'product_uom_qty',
         }
         return action
+    
+    def write(self, values):
+       if 'uom_id' in values:
+           for line in self.bom_line_ids:
+               line.product_uom_id = values['uom_id']
+       return super().write(values)
 
 
 class ProductProduct(models.Model):


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two product, e.g: “Product A” and “Product B”
- Go to manufacturing app > Products > Bill of Materials > create a new one
- Select product A as one to be produced
- Add a BOM line with “Product B”
- Go to manufacturing > product > change the  unit of measure of “Product B”
- Go back to the bom

Problem:
The uom of the “product b” in the bom line is not updated

opw-2582828



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
