### PR TITLE
[FIX] mail: The chatter does not take all the space for the big screen

### DIFF
--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.scss
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.scss
@@ -11,6 +11,12 @@
     width: 100%;
 }
 
+@include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
+    .o_FormRenderer_chatterContainer {
+        width: auto;
+    }
+}
+
 // FIX to hide chatter in dialogs when they are opened from an action returned by python code
 .modal .modal-dialog .o_form_view .o_FormRenderer_chatterContainer {
     display: none;


### PR DESCRIPTION
The css with 100% is applied to chat him when he is down. However for the
big screen it is on the right and should not take up all the space.

opw-2517726
opw-2547527
