### PR TITLE
[FIX] point_of_sale: Parse quantity like a float

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -274,7 +274,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 startingValue: 0,
                 title: this.env._t('Set the new quantity'),
             });
-            let newQuantity = inputNumber !== ""? inputNumber: null;
+            let newQuantity = inputNumber !== "" ? parse.float(inputNumber) : null;
             if (confirmed && newQuantity !== null) {
                 let order = this.env.pos.get_order();
                 let selectedLine = this.env.pos.get_order().get_selected_orderline();


### PR DESCRIPTION
Steps to reproduce:

  - Install "Point of sale" and "l10n_fr" modules
  - Switch to french Company
  - Go to user preference and change language to "French"
  - Create a new POS with french certification installed
  - Run the POS
  - Try to change quantity of a product

Issue:

  Impossible to encode a quantity with decimals (add a line at 0 instead)

Cause:

  The popup return value is a string.
  The value is used before converting it to float.

Solution:

  Parse quantity value like a float before using it.

opw-2608707