### PR TITLE
[FIX] mrp: fix recursive procurement handling in orderpoint

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1109,8 +1109,9 @@ class MrpProduction(models.Model):
             production.move_raw_ids._adjust_procure_method()
             (production.move_raw_ids | production.move_finished_ids)._action_confirm()
             production.workorder_ids._action_confirm()
-            # run scheduler for moves forecasted to not have enough in stock
-            production.move_raw_ids._trigger_scheduler()
+
+        # run scheduler for moves forecasted to not have enough in stock
+        self.move_raw_ids._trigger_scheduler()
         return True
 
     def action_assign(self):


### PR DESCRIPTION
Have 3 products:
- Product A, manufactured from Product B, RR min 20 max 200
- Product B, manufactured from Product C, RR min 20 max 200
- Product C, stored, not manufactured, RR min 20 max 200

1. When triggering the scheduler, reordering rule are evaluated in
batch, so procurements will be generated both for A and B.
2. The manufacture orders are created from procurement values:
2.A When manufacturing A, B is needed: the RR is triggered again and
will evaluate again ALL the quantity needed for B (400, including the
quantity already processed at step 1, but not yet written in a MO)
2.B Manufacture order for B is created from procurement values at step1,
 creating a MO for another 200 units

We end up manufacturing 600 instead of 400 of Product B

Fix by partially backporting bf5e1debf9c684c1bbf3ca440a87001fd7faf9fa
along with a test

opw-2509399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
