### PR TITLE
[FIX] account_edi: do not browse are recordset

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -434,8 +434,8 @@ class AccountMoveLine(models.Model):
 
             vals['tax_amount_currency'] += tax_vals['amount']
             vals['tax_amount_currency_closing'] += tax_vals['amount'] if tax_rep.use_in_tax_closing else 0
-            for tag_id in tax_rep.tag_ids:
-                vals['tag_ids'].add(tag_id)
+            for tag in tax_rep.tag_ids:
+                vals['tag_ids'].add(tag.id)
 
         res['tax_detail_vals_list'] = []
         for tax_detail_vals in tax_detail_per_tax.values():


### PR DESCRIPTION
Issue
-----

When an invoice with taxes that have repartition lines with tag is
exported, the tags are wrongly formatted:
 - tag_ids is a recordset instead of a set of ids
 - tags is a recordset of recordset

The latter cause error when you try to access a field on the tags.

Solution
--------
Make sure tag_ids is a set of ids




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
