### PR TITLE
[FIX] web_editor: show powerbox and its hints only in appropriate cases

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -145,6 +145,12 @@ export class OdooEditor extends EventTarget {
                 isRootEditable: true,
                 defaultLinkAttributes: {},
                 getContentEditableAreas: () => [],
+                getPowerboxElement: () => {
+                    const selection = document.getSelection();
+                    if (selection.isCollapsed && selection.rangeCount) {
+                        return closestElement(selection.anchorNode, 'P, DIV');
+                    }
+                },
                 _t: string => string,
             },
             options,
@@ -1312,6 +1318,7 @@ export class OdooEditor extends EventTarget {
             onShow: () => {
                 this.commandbarTablePicker.hide();
             },
+            shouldActivate: () => !!this.options.getPowerboxElement(),
             onActivate: () => {
                 this._beforeCommandbarStepIndex = this._historySteps.length - 1;
                 this.observerUnactive();
@@ -1835,11 +1842,10 @@ export class OdooEditor extends EventTarget {
             }
         }
 
-        const selection = document.getSelection();
-        if (!selection.isCollapsed || !selection.rangeCount) return;
-
-        const block = closestElement(selection.anchorNode, 'P, DIV');
-        this._makeHint(block, 'Type "/" for commands', true);
+        const block = this.options.getPowerboxElement();
+        if (block) {
+            this._makeHint(block, 'Type "/" for commands', true);
+        }
     }
     _makeHint(block, text, temporary = false) {
         const content = block && block.innerHTML.trim();

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -151,6 +151,7 @@ export class OdooEditor extends EventTarget {
                         return closestElement(selection.anchorNode, 'P, DIV');
                     }
                 },
+                isHintBlacklisted: () => false,
                 _t: string => string,
             },
             options,
@@ -1838,7 +1839,9 @@ export class OdooEditor extends EventTarget {
 
         for (const [selector, text] of Object.entries(selectors)) {
             for (const el of this.editable.querySelectorAll(selector)) {
-                this._makeHint(el, text);
+                if (!this.options.isHintBlacklisted(el)) {
+                    this._makeHint(el, text);
+                }
             }
         }
 

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -133,7 +133,11 @@ export class Powerbox {
         const selection = document.getSelection();
         if (!selection.isCollapsed || !selection.rangeCount) return;
 
-        if (event.key === '/' && !this._active) {
+        if (
+            event.key === '/' &&
+            !this._active &&
+            (!this.options.shouldActivate || this.options.shouldActivate())
+        ) {
             this.options.onActivate && this.options.onActivate();
 
             const showOnceOnKeyup = () => {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -88,6 +88,10 @@ const Wysiwyg = Widget.extend({
                     return !(node.hasAttribute && node.hasAttribute('data-oe-model')) && node;
                 }
             },
+            isHintBlacklisted: node => {
+                return node.hasAttribute &&
+                    (node.hasAttribute('data-target') || node.hasAttribute('data-oe-model'));
+            },
             noScrollSelector: 'body, .note-editable, .o_content, #wrapwrap',
             commands: commands,
         });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -81,6 +81,13 @@ const Wysiwyg = Widget.extend({
             getContentEditableAreas: this.options.getContentEditableAreas,
             defaultLinkAttributes: this.options.userGeneratedContent ? {rel: 'ugc' } : {},
             getContextFromParentRect: options.getContextFromParentRect,
+            getPowerboxElement: () => {
+                const selection = document.getSelection();
+                if (selection.isCollapsed && selection.rangeCount) {
+                    const node = closestElement(selection.anchorNode, 'P, DIV');
+                    return !(node.hasAttribute && node.hasAttribute('data-oe-model')) && node;
+                }
+            },
             noScrollSelector: 'body, .note-editable, .o_content, #wrapwrap',
             commands: commands,
         });


### PR DESCRIPTION
Powerbox (and its related hint) should not be activable on any Odoo fields.
Also, element hints should not be shown in some technical node.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
