### PR TITLE
[FIX] pos_restaurant: don't mark order as printed

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/BillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/BillScreen.js
@@ -13,6 +13,13 @@ odoo.define('pos_restaurant.BillScreen', function (require) {
             whenClosing() {
                 this.confirm();
             }
+            /**
+             * @override
+             */
+            async printReceipt() {
+                await super.printReceipt();
+                this.currentOrder._printed = false;
+            }
         }
         BillScreen.template = 'BillScreen';
         return BillScreen;

--- a/addons/pos_restaurant/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -20,13 +20,6 @@ odoo.define('pos_restaurant.ReceiptScreen', function(require) {
                     return super.nextScreen;
                 }
             }
-            /**
-             * @override
-             */
-            async _printWeb() {
-                await super._printWeb();
-                this.currentOrder._printed = false;
-            }
         };
 
     Registries.Component.extend(ReceiptScreen, PosResReceiptScreen);


### PR DESCRIPTION
When the final receipt of an order is printed, the order is marked as
printed, as it can be then removed, and nothing can be added to it
anymore.

When the Bill is printed, we should not mark it as printed, as there
can be some modifications made after the bill is printed.

So as the bill receipt is an inherited object from the final receipt, we
have to change the behavior for the bill receipt to not mark the order
as printed.

OPW-2555272

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
