### PR TITLE
[FIX] point_of_sale: impossible to print sale details

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -956,7 +956,7 @@ class ReportSaleDetails(models.AbstractModel):
                 products_sold[key] += line.qty
 
                 if line.tax_ids_after_fiscal_position:
-                    line_taxes = line.tax_ids_after_fiscal_position.compute_all(line.price_unit * (1-(line.discount or 0.0)/100.0), currency, line.qty, product=line.product_id, partner=line.order_id.partner_id or False)
+                    line_taxes = line.tax_ids_after_fiscal_position.sudo().compute_all(line.price_unit * (1-(line.discount or 0.0)/100.0), currency, line.qty, product=line.product_id, partner=line.order_id.partner_id or False)
                     for tax in line_taxes['taxes']:
                         taxes.setdefault(tax['id'], {'name': tax['name'], 'tax_amount':0.0, 'base_amount':0.0})
                         taxes[tax['id']]['tax_amount'] += tax['amount']


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- create a pos config with a printer
- connect the printer
- open a new pos session with an user with only group 'group_pos_user'
- click on the printer
--> An error is raise

If you a user with only group 'group_pos_user' it is not possible to print the sale details.
Because during the compute_all of the taxe, account.account.tag need read access.
This PR allow 'group_pos_user' to print the sale details.

Current behavior before PR:

![image](https://user-images.githubusercontent.com/16716992/127170618-74f1ade4-3d26-4f7c-beb3-a14bcdfdb9bd.png)

@pimodoo @caburj 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
