### PR TITLE
[IMP] base: check access rights in batch

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1737,36 +1737,46 @@ class IrModelAccess(models.Model):
         """ % access_mode, [model_name])
         return [('%s/%s' % x) if x[0] else x[1] for x in self._cr.fetchall()]
 
-    # The context parameter is useful when the method translates error messages.
-    # But as the method raises an exception in that case,  the key 'lang' might
-    # not be really necessary as a cache key, unless the `ormcache_context`
-    # decorator catches the exception (it does not at the moment.)
-    @api.model
-    @tools.ormcache_context('self.env.uid', 'self.env.su', 'model', 'mode', 'raise_exception', keys=('lang',))
-    def check(self, model, mode='read', raise_exception=True):
+    def check_multi(self, all_models, mode='read'):
         if self.env.su:
-            # User root have all accesses
-            return True
+            return
 
-        assert isinstance(model, str), 'Not a model name: %s' % (model,)
+        for model in all_models:
+            assert isinstance(model, str), 'Not a model name: %s' % (model,)
+            # TransientModel records have no access rights, only an implicit access rule
+            if model not in self.env:
+                _logger.error('Missing model %s', model)
+
         assert mode in ('read', 'write', 'create', 'unlink'), 'Invalid access mode'
-
-        # TransientModel records have no access rights, only an implicit access rule
-        if model not in self.env:
-            _logger.error('Missing model %s', model)
 
         self.flush(self._fields)
 
         # We check if a specific or generic rule exists
-        self._cr.execute("""SELECT BOOL_OR(perm_{mode})
+        self._cr.execute("""SELECT m.model, BOOL_OR(perm_{mode})
                               FROM ir_model_access a
                               JOIN ir_model m ON (m.id = a.model_id)
                          LEFT JOIN res_groups_users_rel gu ON (gu.gid = a.group_id)
-                             WHERE m.model = %s
+                             WHERE m.model in %s
                                AND (a.group_id IS NULL OR gu.uid = %s)
-                               AND a.active IS TRUE""".format(mode=mode),
-                         (model, self._uid,))
-        r = self._cr.fetchone()[0]
+                               AND a.active IS TRUE
+                             GROUP BY m.model
+                         """.format(mode=mode),
+                         (tuple(all_models), self._uid,))
+        model2value = dict(self._cr.fetchall())
+
+        return model2value
+
+    @api.model
+    @tools.ormcache('self.env.uid', 'self.env.su', 'model', 'mode', 'raise_exception')
+    def check(self, model, mode='read', raise_exception=True, check_multi=None):
+        if self.env.su:
+            # User root have all accesses
+            return True
+
+        if not check_multi:
+            check_multi = self.check_multi([model], mode)
+
+        r = check_multi.get(model)
 
         if not r and raise_exception:
             groups = '\n'.join('\t- %s' % g for g in self.group_names_with_access(model, mode))

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -73,7 +73,6 @@ class IrUiMenu(models.Model):
             raise ValidationError(_('Error! You cannot create recursive menus.'))
 
     @api.model
-    @tools.ormcache('frozenset(self.env.user.groups_id.ids)', 'debug')
     def _visible_menu_ids(self, debug=False):
         """ Return the ids of the menu items visible to the user. """
         # retrieve all menus, and determine which ones are visible
@@ -109,16 +108,22 @@ class IrUiMenu(models.Model):
             'ir.actions.server': 'model_name',
         }
 
+        all_models = []
         # performance trick: determine the ids to prefetch by type
         prefetch_ids = defaultdict(list)
         for action in action_menus.mapped('action'):
             prefetch_ids[action._name].append(action.id)
+            model_name = action._name in MODEL_BY_TYPE and action[MODEL_BY_TYPE[action._name]]
+            if model_name:
+                all_models.append(model_name)
+
+        check_multi = access.check_multi(all_models, 'read')
 
         for menu in action_menus:
             action = menu.action
             action = action.with_prefetch(prefetch_ids[action._name])
             model_name = action._name in MODEL_BY_TYPE and action[MODEL_BY_TYPE[action._name]]
-            if not model_name or access.check(model_name, 'read', False):
+            if not model_name or access.check(model_name, 'read', False, check_multi):
                 # make menu visible, and its folder ancestors, too
                 visible += menu
                 menu = menu.parent_id


### PR DESCRIPTION
This commit optimizes `_visible_menu_ids` by checking access rights in batch and by
reading menu actions in batch. It saves about 200-300 ms and `ormcache` is not
needed anymore.

This commit also removes lang key from ormcache decorator for `.check` method.
It was not needed even without this refactoring. See deleted comments for details