### PR TITLE
[IMP] website_blog: display no of views field on form

### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -188,7 +188,7 @@ class BlogPost(models.Model):
     create_uid = fields.Many2one('res.users', 'Created by', readonly=True)
     write_date = fields.Datetime('Last Updated on', readonly=True)
     write_uid = fields.Many2one('res.users', 'Last Contributor', readonly=True)
-    visits = fields.Integer('No of Views', copy=False, default=0)
+    visits = fields.Integer('No of Views', copy=False, default=0, readonly=True)
     website_id = fields.Many2one(related='blog_id.website_id', readonly=True, store=True)
 
     @api.depends('content', 'teaser_manual')

--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -48,7 +48,6 @@
                     <field name="blog_id"/>
                     <field name="website_id" groups="website.group_multi_website"/>
                     <field name="is_published" string="Is Published" optional="hide"/>
-                    <field name="visits" readonly="1"/>
                     <field name="create_uid" invisible="1"/>
                     <field name="write_uid"/>
                     <field name="write_date"/>
@@ -77,6 +76,7 @@
                         <group name="publishing_details" string="Publishing Options">
                             <field name="author_id"/>
                             <field name="create_date" groups="base.group_no_one"/>
+                            <field name="visits"/>
                             <field name="post_date"/>
                             <field name="write_uid"/>
                             <field name="write_date"/>


### PR DESCRIPTION
Before this commit field `visits` was not displayed on form view.

With this commit, Field is not added on form view as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
