### PR TITLE
[FIX] mrp: assign date_planned_finished when needed

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -452,7 +452,7 @@ class MrpProduction(models.Model):
             'date': self.date_planned_start,
             'date_expected': self.date_planned_start,
         })
-        if not self.routing_id:
+        if self.date_planned_start and not self.routing_id:
             self.date_planned_finished = self.date_planned_start + datetime.timedelta(hours=1)
 
     @api.onchange('bom_id', 'product_id', 'product_qty', 'product_uom_id')


### PR DESCRIPTION
Before this commit there would be trackback (ypeError: unsupported operand type(s) for +: 'bool' and 'relativedelta' ) when you will try to remove field `date_planned_start` as we are using the field to compute `date_planned_finished`.

With this commit, we compute `date_planned_finished` when `date_planned_start` field is present.

Fixes: #74287

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
