### PR TITLE
[FIX] mrp: always display loss_id

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -168,7 +168,7 @@
                                 <field name="user_id"/>
                                 <field name="workcenter_id" invisible="1"/>
                                 <field name="company_id" invisible="1"/>
-                                <field name="loss_id" string="Productivity" optional="hide"/>
+                                <field name="loss_id" string="Productivity"/>
                             </tree>
                             <form>
                                 <group>


### PR DESCRIPTION
Field `loss_id` is required field and is hidden in the list view, Due to which it is
impossible to add a new line without adding value for `loss_id`.

With this commit, Field  `loss_id` is always visible.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
