### PR TITLE
[FIX] account: Fallback on env.lang if no invoice_user_id.lang on invoice

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -552,7 +552,7 @@ class PurchaseOrder(models.Model):
             'move_type': move_type,
             'narration': self.notes,
             'currency_id': self.currency_id.id,
-            'invoice_user_id': self.user_id and self.user_id.id,
+            'invoice_user_id': self.user_id and self.user_id.id or self.env.user.id,
             'partner_id': partner_invoice_id,
             'fiscal_position_id': (self.fiscal_position_id or self.fiscal_position_id.get_fiscal_position(partner_invoice_id)).id,
             'payment_reference': self.partner_ref or '',


### PR DESCRIPTION
Steps to reproduce:

  - Install purchase and accounting apps
  - Set the database to a language that is not English
  - Create a purchase order
  - Remove purchase representative from PO (otherwise, no issue)
  - Action -> Create Vendor Bill
  - From the vendor bill, print invoice

Issue:

  The pdf is in English (country names, date labels, etc...)

Cause:

  If invoice type is `in_invoice` or `in_refund`, it will use the
  `invoice_user_id` language (object.invoice_user_id.sudo().lang).
  In the above case, there is no invoice_user_id on invoice.

Solution:

  If no lang (because object.invoice_user_id.sudo().lang == False),
  then fallback on object.env.lang .

opw-2510134