### PR TITLE
[CLA] Add desdelinux as new contributor in vauxoo

### DIFF
--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -52,3 +52,4 @@ Randall Castro randall@vauxoo.com https://github.com/randall-vx
 Alejandro Santillan asantillan@vauxoo.com https://github.com/R4Alex
 Williams Estrada williams@vauxoo.com https://github.com/WR-96
 Fernanda Hernández fernanda@vauxoo.com https://github.com/fernandahf
+Luigys Toro luigys@vauxoo.com https://github.com/desdelinux


### PR DESCRIPTION
Incorporate Luigys TOro (desdelinux) as Vauxoo's contributor




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
