### PR TITLE
[IMP] core: savepoint semantics and interface

### DIFF
--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -3,17 +3,26 @@
 
 from odoo.tests.common import HttpCase
 
-EXTRA_REQUEST = 5
+EXTRA_REQUEST = 7
 """ During tests, the query on 'base_registry_signaling, base_cache_signaling'
-    won't be executed on hot state, but 6 new queries related to the test cursor
-    will be added:
-        SAVEPOINT "test_cursor_4"
-        SAVEPOINT "test_cursor_4"
-        ROLLBACK TO SAVEPOINT "test_cursor_4"
-        SAVEPOINT "test_cursor_5"
+    won't be executed on hot state, but 9 new queries related to the test cursor
+    will be added::
+
+        -- create cursor
+        SAVEPOINT test_cursor_0
+        -- COMMIT
+        SAVEPOINT test_cursor_0
+        -- ROLLBACK (close)
+        ROLLBACK TO SAVEPOINT test_cursor_0
+        RELEASE SAVEPOINT test_cursor_0
+        -- create cursor
+        SAVEPOINT test_cursor_1
         [.. usual SQL Queries .. ]
-        SAVEPOINT "test_cursor_5"
-        ROLLBACK TO SAVEPOINT "test_cursor_5"
+        -- COMMIT
+        SAVEPOINT test_cursor_2
+        -- ROLLBACK (close)
+        ROLLBACK TO SAVEPOINT test_cursor_2
+        RELEASE SAVEPOINT test_cursor_2
 """
 
 

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -371,6 +371,21 @@ class Cursor(BaseCursor):
         self.sql_log_count = 0
         self.sql_log = False
 
+    @contextmanager
+    def _enable_logging(self):
+        """ Forcefully enables logging for this cursor, restores it afterwards.
+
+        Updates the logger in-place, so not thread-safe.
+        """
+        previous, self.sql_log = self.sql_log, True
+        level = _logger.level
+        _logger.setLevel(logging.DEBUG)
+        try:
+            yield
+        finally:
+            _logger.setLevel(level)
+            self.sql_log = previous
+
     @check
     def close(self):
         return self._close(False)


### PR DESCRIPTION
Ensure savepoints are *always* released when exiting the context: rolling back to a savepoint does not release it, so the savepoint remains "active" forever (just possibly shadowed if an other savepoint of the same name gets created).

Also provide a `Savepoint` object to the user, with the followingfacilities:

* `name`, in case there are useful things the user can do with a savepoint name.
* `rollback` allows the user to rollback the savepoint to the initialisation state at any moment.
* `close` allows the use of `contextlib.closing` as well as closing the savepoint while in the covered span. Closing a savepoint rolls it back by default (like cursors).

  Because there's no such thing as committing a savepoint, it's also possible to close *without* rolling back, which is similar (but not identical).

NOTE: unlike some other constructs, the `Savepoint` object has no effect before the context is entered.

Also make a `flushing` context manager for convenience, and provide a home-grown version of `contextlib.nullcontext` as that requires 3.7.
