### PR TITLE
[IMP] core: enforce explicit license in all manifest

### DIFF
--- a/addons/purchase_requisition_stock_dropshipping/__manifest__.py
+++ b/addons/purchase_requisition_stock_dropshipping/__manifest__.py
@@ -18,4 +18,5 @@ and link with originating sale order.
     ],
     'installable': True,
     'auto_install': True,
+    'license': 'LGPL-3',
 }

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -330,7 +330,6 @@ def load_information_from_description_file(module, mod_path=None):
             'description': '',
             'icon': get_module_icon(module),
             'installable': True,
-            'license': 'LGPL-3',
             'post_load': None,
             'version': '1.0',
             'web': False,
@@ -355,6 +354,9 @@ def load_information_from_description_file(module, mod_path=None):
                 with tools.file_open(readme_path[0]) as fd:
                     info['description'] = fd.read()
 
+        if not info.get('license'):
+            info['license'] = 'LGPL-3'
+            _logger.warning("Missing `license` key in manifest for '%s', defaulting to LGPL-3", module)
 
         # auto_install is either `False` (by default) in which case the module
         # is opt-in, either a list of dependencies in which case the module is


### PR DESCRIPTION
The license was missing in most enterprise manifest so
the decision was taken to make it explicit in all cases.

The missing licenses were add in all version starting from
12.0 in repos odoo, enterprise and design-themes.

Starting from this commit, when a license is not defined,
a warning will be triggered.