### PR TITLE
[FIX] survey: ignore action call for buttons with 'button' type

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -137,7 +137,7 @@
                 <field name="success_count"/>
                 <field name="success_ratio"/>
                 <field name="answer_score_avg"/>
-                <button name="certificate" icon="fa-trophy" title="Certificate" aria-label="Certificate" attrs="{'invisible': [('certificate', '=', False)]}"/>
+                <button name="certificate" type="button" disabled="disabled" icon="fa-trophy" title="Certificate" aria-label="Certificate" attrs="{'invisible': [('certificate', '=', False)]}"/>
                 <!-- Tweak as icons aren't directly supported in xml -->
             </tree>
         </field>

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -326,6 +326,7 @@
             <rng:ref name="modifiable"/>
             <rng:optional><rng:attribute name="attrs"/></rng:optional>
             <rng:optional><rng:attribute name="invisible"/></rng:optional>
+            <rng:optional><rng:attribute name="disabled"/></rng:optional>
             <rng:optional><rng:attribute name="name" /></rng:optional>
             <rng:optional><rng:attribute name="icon" /></rng:optional>
             <rng:optional><rng:attribute name="string" /></rng:optional>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR will fix an error that occurs when the user clicks on a button from a list view that is not linked to an action.

Current behavior before PR:
When the user clicks on a button from a list view, the script will call the action linked to the corresponding button. When the user clicks on a button that is not linked to an action, the script will raise an exception.

Desired behavior after PR is merged:
To solve the issue, we will add the 'disabled' property support for the buttons and we will add that property to the buttons that do not have an action. With this property, the script will bind no listener to the button and it will hence not call the listener causing the error.

task-2612033

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
