### PR TITLE
[FIX] delivery: demo Delivery Products pulled into invoice

### DIFF
--- a/addons/delivery/data/delivery_demo.xml
+++ b/addons/delivery/data/delivery_demo.xml
@@ -11,6 +11,7 @@
             <field name="categ_id" ref="delivery.product_category_deliveries"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
+            <field name="invoice_policy">order</field>
             <field name="list_price">20.0</field>
             <field name="invoice_policy">order</field>
         </record>
@@ -30,6 +31,7 @@
             <field name="categ_id" ref="delivery.product_category_deliveries"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
+            <field name="invoice_policy">order</field>
             <field name="list_price">10.0</field>
         </record>
 


### PR DESCRIPTION
How to reproduce the problem:
- Install the delivery module
- Create an SO and add a product. Click on Add Shipping.
- Choose one of the demo Shipping methods
- Deliver the main product.
- Create an invoice: the Delivery Product is not present in the invoice, unless previously manually set as delivered in the SO.

Cause of the problem : the demo values were having their Invoicing Policy set to Delivered Quantity instead of Ordered Quantity (due to the Sale app changing the default Invoicing Policy in 14.0)

Solution : The demo products now have their Invoicing Policy set to Ordered Quantity manually.
No further modification are needed in the normal creation of Delivery Products, as they are created with the correct values (when created from the Shipping Method form)

opw-2496202