### PR TITLE
[IMP] website_forum: adapt tours

### DIFF
--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -60,7 +60,7 @@ odoo.define("website_forum.tour_forum", function (require) {
         trigger: ".modal-header button.close",
         auto: true,
     }, {
-        trigger: ".o_wforum_validate_toggler[data-karma=\"20\"]:first",
+        trigger: ".o_wforum_validate_toggler[data-karma]:first",
         content: _t("Click here to accept this answer."),
         position: "right",
     }]);

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -56,7 +56,7 @@ odoo.define('website_forum.tour_forum_question', function (require) {
     }, {
         content: "Click here to accept this answer.",
         extra_trigger: '#wrap:has(".o_wforum_validate_toggler")',
-        trigger: '.o_wforum_validate_toggler[data-karma="20"]:first',
+        trigger: '.o_wforum_validate_toggler[data-karma]:first',
     }, {
         content: "Congratulations! You just created and post your first question and answer.",
         trigger: '#wrap:has(".o_wforum_answer_correct")',


### PR DESCRIPTION
[IMP] website_forum: adapt tours 

The enterprise module website_helpdesk_forum changes the demo data
karma_answer value to 0 for the default Help forum thus breaks the tour.

odoo/enterprise#19870
odoo/upgrade#2681

TaskID: 2499623

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
