### PR TITLE
[IMP] sms: list view improvement

### DIFF
--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -71,7 +71,10 @@ class SmsSms(models.Model):
                 notifications.mail_message_id._notify_message_notification_update()
 
     def action_set_outgoing(self):
-        self.state = 'outgoing'
+        self.write({
+            'state': 'outgoing',
+            'failure_type': False
+        })
         notifications = self.env['mail.notification'].sudo().search([
             ('sms_id', 'in', self.ids),
             # sent is sent -> cannot reset

--- a/addons/sms/views/sms_sms_views.xml
+++ b/addons/sms/views/sms_sms_views.xml
@@ -34,11 +34,14 @@
         <field name="name">sms.sms.view.tree</field>
         <field name="model">sms.sms</field>
         <field name="arch" type="xml">
-            <tree string="SMS Templates" decoration-muted="state == 'canceled'" decoration-info="state == 'outgoing'" decoration-danger="state == 'error'">
+            <tree string="SMS Templates">
                 <field name="number"/>
                 <field name="partner_id"/>
-                <field name="state"/>
                 <field name="failure_type"/>
+                <field name="state" widget="badge" decoration-info="state == 'outgoing'" decoration-muted="state == 'canceled'" decoration-success="state == 'sent'" decoration-danger="state == 'error'"/>
+                <button name="send" string="Send Now" type="object" icon="fa-paper-plane" states="outgoing"/>
+                <button name="action_set_outgoing" string="Retry" type="object" icon="fa-repeat" states="error,canceled"/>
+                <button name="action_set_canceled" string="Cancel" type="object" icon="fa-times-circle" states="error,outgoing"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Generic UX improvements:
- better visualization of the status of the SMS
- buttons to directly retry, send or cancel an SMS from the list view

* move the 'sms status' field to the right of the 'error code' one
* use the badge widget for the status
* remove the colors on the whole lines
* add an 'fa-paper-plane send now' button
    only visible if the status is 'in queue'
    clicking on this button should effectively send the SMS
* add an 'fa-times-circle cancel' button
    only visible if the status is 'in queue' or 'error'
    clicking on this button should switch the sms to the 'canceled' state
* add an 'fa-repeat retry' button
    only visible if the status is 'error' or 'canceled'
    clicking on this button should switch the sms to the 'in queue' state

taskid: 2535005

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
