### PR TITLE
Patch for Blind SSRF Vulnerability

### DIFF
--- a/doc/cla/individual/aims-khan
+++ b/doc/cla/individual/aims-khan
@@ -1,0 +1,11 @@
+Afghanistan, 2021-07-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Ahmad Khan zuhal.nader@gmail.com https://github.com/aims-khan

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1427,6 +1427,9 @@ class Root(object):
         """
         try:
             httprequest = werkzeug.wrappers.Request(environ)
+            r = httprequest.headers
+            if r.has_key('X-Forwarded-Host') or r.has_key('X-Host') or r.has_key('X-Forwarded-Server'):
+                raise werkzeug.exceptions.BadRequest('Blind SSRF Vulnerability (invalid request headers)')
             httprequest.app = self
             httprequest.parameter_storage_class = werkzeug.datastructures.ImmutableOrderedMultiDict
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I traced blind SSRF Vulnerability in which we can change the host and redirect to any desired host by providing the host IP and port

Current behavior before PR:
We can redirect our url to any host other than the server that the Odoo service is run on

Desired behavior after PR is merged:
Now invalid headers will be stopped from changing the direction of the url and hence the Blink SSRF Vul is patched



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
