### PR TITLE
[IMP] *: ux improvements for field service

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from random import randint
+
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
@@ -90,6 +92,9 @@ class ProductAttributeValue(models.Model):
     _order = 'attribute_id, sequence, id'
     _description = 'Attribute Value'
 
+    def _get_default_color(self):
+        return randint(1, 11)
+
     name = fields.Char(string='Value', required=True, translate=True)
     sequence = fields.Integer(string='Sequence', help="Determine the display order", index=True)
     attribute_id = fields.Many2one('product.attribute', string="Attribute", ondelete='cascade', required=True, index=True,
@@ -104,6 +109,7 @@ class ProductAttributeValue(models.Model):
         string='Color',
         help="Here you can set a specific HTML color index (e.g. #ff0000) to display the color if the attribute type is 'Color'.")
     display_type = fields.Selection(related='attribute_id.display_type', readonly=True)
+    color = fields.Integer('Color Index', default=_get_default_color)
 
     _sql_constraints = [
         ('value_company_uniq', 'unique (name, attribute_id)', "You cannot create two values with the same name for the same attribute.")
@@ -387,6 +393,9 @@ class ProductTemplateAttributeValue(models.Model):
     _description = "Product Template Attribute Value"
     _order = 'attribute_line_id, product_attribute_value_id, id'
 
+    def _get_default_color(self):
+        return randint(1, 11)
+
     # Not just `active` because we always want to show the values except in
     # specific case, as opposed to `active_test`.
     ptav_active = fields.Boolean("Active", default=True)
@@ -421,6 +430,7 @@ class ProductTemplateAttributeValue(models.Model):
     html_color = fields.Char('HTML Color Index', related="product_attribute_value_id.html_color")
     is_custom = fields.Boolean('Is custom value', related="product_attribute_value_id.is_custom")
     display_type = fields.Selection(related='product_attribute_value_id.display_type', readonly=True)
+    color = fields.Integer('Color', default=_get_default_color)
 
     _sql_constraints = [
         ('attribute_value_unique', 'unique(attribute_line_id, product_attribute_value_id)', "Each value should be defined only once per attribute per product."),

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -55,7 +55,7 @@
                     <field name="attribute_line_ids" widget="one2many" context="{'show_attribute': False}">
                         <tree string="Variants" editable="bottom">
                             <field name="attribute_id" attrs="{'readonly': [('id', '!=', False)]}"/>
-                            <field name="value_ids" widget="many2many_tags" options="{'no_create_edit': True}" context="{'default_attribute_id': attribute_id, 'show_attribute': False}"/>
+                            <field name="value_ids" widget="many2many_tags" options="{'no_create_edit': True, 'color_field': 'color'}" context="{'default_attribute_id': attribute_id, 'show_attribute': False}"/>
                         </tree>
                     </field>
                         <p class="oe_grey oe_edit_only">

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -369,6 +369,7 @@
                     <field name="id"/>
                     <field name="lst_price"/>
                     <field name="activity_state"/>
+                    <field name="color"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                         <t t-name="kanban-box">
@@ -383,7 +384,7 @@
                                         <small t-if="record.default_code.value">[<field name="default_code"/>]</small>
                                     </strong>
                                     <div class="o_kanban_tags_section">
-                                        <field name="product_template_attribute_value_ids" groups="product.group_product_variant"/>
+                                        <field name="product_template_attribute_value_ids" groups="product.group_product_variant" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                     </div>
                                     <ul>
                                         <li><strong>Price: <field name="lst_price"></field></strong></li>


### PR DESCRIPTION
PURPOSE

Display the color of the attribute value on the product kanban card

SPECIFICATION

Add color field for models `product.attribute.value` and
`product.template.attribute.value`.

Task-2593655

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
