### PR TITLE
[FIX] sale: round 'untaxed amount to invoice' after computations

### DIFF
--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -411,3 +411,41 @@ class TestSaleOrder(TestCommonSaleNoChart):
         self.assertEqual(so_line_1.price_unit, 100.0)
         self.assertEqual(so_line_2.discount, 10)
         self.assertEqual(so_line_2.price_unit, 20)
+
+    def test_discount_and_untaxed_subtotal(self):
+        """When adding a discount on a SO line, this test ensures that the untaxed amount to invoice is
+        equal to the untaxed subtotal"""
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_customer_usd.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_deliver.id,
+                'product_uom_qty': 38,
+                'price_unit': 541.26,
+                'discount': 2.00,
+            })]
+        })
+        sale_order.action_confirm()
+        line = sale_order.order_line
+        self.assertEqual(line.untaxed_amount_to_invoice, 0)
+
+        line.qty_delivered = 38
+        # (541.26 - 0.02 * 541.26) * 38 = 20156.5224 ~= 20156.52
+        self.assertEqual(line.price_subtotal, 20156.52)
+        self.assertEqual(line.untaxed_amount_to_invoice, line.price_subtotal)
+
+        # Same with an included-in-price tax
+        sale_order = sale_order.copy()
+        line = sale_order.order_line
+        line.tax_id = [(0, 0, {
+            'name': 'Super Tax',
+            'amount_type': 'percent',
+            'amount': 15.0,
+            'price_include': True,
+        })]
+        sale_order.action_confirm()
+        self.assertEqual(line.untaxed_amount_to_invoice, 0)
+
+        line.qty_delivered = 38
+        # (541,26 / 1,15) * ,98 * 38 = 17527,410782609 ~= 17527.41
+        self.assertEqual(line.price_subtotal, 17527.41)
+        self.assertEqual(line.untaxed_amount_to_invoice, line.price_subtotal)


### PR DESCRIPTION
Suppose such a SO line:
- Unit Price: 541.26
- Qty: 38
- Discount: 2%

The line amount is computed thanks to application of the discount on the
price, then the multiplication of the result with the quantity. The
rounding eventually happens after these steps:
https://github.com/odoo/odoo/blob/254b2a0840d3e817cc6062c483b5213c10088af5/addons/sale/models/sale.py#L1013-L1024
https://github.com/odoo/odoo/blob/b76e9ef658bde0178fa1660b6ad27b880e91632a/addons/account/models/account.py#L1138
Therefore, in the above case, we have:
```
Total = round(541.26 * 0.98 * 38)
      = round(530.4348 * 38)
      = round(20156.5224)
      = 20156.5224
```

However, when confirming the SO and setting the delivered quantity, the
Untaxed Amount To Invoice is computed using the unit price with both the
discount and the rounding already applied:
```
Total = round(541.26 * 0.98) * 38
      = round(530.4348) * 38
      = 530.43 * 38
      = 20156.34
```
As a result, the amount is not the same than the first one, this is
incorrect.

OPW-2525975