### PR TITLE
[IMP] stock, purchase: UI / QoL improvements

### DIFF
--- a/addons/hr_expense/data/hr_expense_demo.xml
+++ b/addons/hr_expense/data/hr_expense_demo.xml
@@ -47,6 +47,7 @@
         <record id="trans_expense_product" model="product.product">
             <field name="name">Flights, train, bus, taxi, parking</field>
             <field name="standard_price">0</field>
+            <field name="type">service</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="uom_po_id" ref="uom.product_uom_unit"/>
             <field name="default_code">TRANS</field>
@@ -69,6 +70,7 @@
         <record id="accomodation_expense_product" model="product.product">
             <field name="name">Accomodation</field>
             <field name="standard_price">0</field>
+            <field name="type">service</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="uom_po_id" ref="uom.product_uom_unit"/>
             <field name="default_code">ACC</field>
@@ -80,6 +82,7 @@
         <record id="allowance_expense_product" model="product.product">
             <field name="name">Daily Allowance</field>
             <field name="standard_price">100</field>
+            <field name="type">service</field>
             <field name="uom_id" ref="uom.product_uom_day"/>
             <field name="uom_po_id" ref="uom.product_uom_day"/>
             <field name="default_code">DAL</field>

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1046,7 +1046,8 @@ class PurchaseOrderLine(models.Model):
     def _unlink_except_purchase_or_done(self):
         for line in self:
             if line.order_id.state in ['purchase', 'done']:
-                raise UserError(_('Cannot delete a purchase order line which is in state \'%s\'.') % (line.state,))
+                state_description = {state_desc[0]: state_desc[1] for state_desc in self._fields['state']._description_selection(self.env)}
+                raise UserError(_('Cannot delete a purchase order line which is in state \'%s\'.') % (state_description.get(line.state),))
 
     @api.model
     def _get_date_planned(self, seller, po=False):

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -626,8 +626,8 @@ class ProductTemplate(models.Model):
         ('lot', 'By Lots'),
         ('none', 'No Tracking')], string="Tracking", help="Ensure the traceability of a storable product in your warehouse.", default='none', required=True)
     description_picking = fields.Text('Description on Picking', translate=True)
-    description_pickingout = fields.Html('Description on Delivery Orders', translate=True)
-    description_pickingin = fields.Html('Description on Receptions', translate=True)
+    description_pickingout = fields.Text('Description on Delivery Orders', translate=True)
+    description_pickingin = fields.Text('Description on Receptions', translate=True)
     qty_available = fields.Float(
         'Quantity On Hand', compute='_compute_quantities', search='_search_qty_available',
         compute_sudo=False, digits='Product Unit of Measure')

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -254,7 +254,11 @@ class Location(models.Model):
             for values in quant_data:
                 qty_by_location[values['location_id'][0]] += values['quantity']
 
-        return putaway_rules._get_putaway_location(product, quantity, package, qty_by_location) or self
+        putaway_location = putaway_rules._get_putaway_location(product, quantity, package, qty_by_location)
+        if not putaway_location:
+            putaway_location = locations[0] if locations and self.usage == 'view' else self
+
+        return putaway_location
 
     def _get_next_inventory_date(self):
         """ Used to get the next inventory date for a quant located in this location. It is

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -221,7 +221,7 @@ class StockMove(models.Model):
         for move in self:
             if not move.product_id:
                 move.show_details_visible = False
-            elif len(move.move_line_ids) > 1:
+            elif len(move._get_move_lines()) > 1:
                 move.show_details_visible = True
             else:
                 move.show_details_visible = (((consignment_enabled and move.picking_code != 'incoming') or

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -176,6 +176,7 @@ class StockMove(models.Model):
     reservation_date = fields.Date('Date to Reserve', compute='_compute_reservation_date', store=True,
         help="This is a technical field for calculating when a move should be reserved")
     product_packaging_id = fields.Many2one('product.packaging', 'Packaging', domain="[('product_id', '=', product_id)]", check_company=True)
+    from_immediate_transfer = fields.Boolean(related="picking_id.immediate_transfer")
 
     @api.depends('has_tracking', 'picking_type_id.use_create_lots', 'picking_type_id.use_existing_lots', 'state')
     def _compute_display_assign_serial(self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -54,8 +54,8 @@ class StockMoveLine(models.Model):
         'res.partner', 'From Owner',
         check_company=True,
         help="When validating the transfer, the products will be taken from this owner.")
-    location_id = fields.Many2one('stock.location', 'From', check_company=True, required=True)
-    location_dest_id = fields.Many2one('stock.location', 'To', check_company=True, required=True)
+    location_id = fields.Many2one('stock.location', 'From', domain="[('usage', '!=', 'view')]", check_company=True, required=True)
+    location_dest_id = fields.Many2one('stock.location', 'To', domain="[('usage', '!=', 'view')]", check_company=True, required=True)
     lots_visible = fields.Boolean(compute='_compute_lots_visible')
     picking_code = fields.Selection(related='picking_id.picking_type_id.code', readonly=True)
     picking_type_use_create_lots = fields.Boolean(related='picking_id.picking_type_id.use_create_lots', readonly=True)

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -206,6 +206,16 @@ class PickingType(models.Model):
         if self.show_operations and self.code != 'incoming':
             self.show_reserved = True
 
+    @api.model
+    def action_view_picking_type(self):
+        action = self.env["ir.actions.actions"]._for_xml_id("stock.stock_picking_type_action")
+        if self.user_has_groups('stock.group_stock_multi_locations'):
+            context = literal_eval(action['context'])
+            context['search_default_groupby_warehouse_id'] = True
+            action['context'] = context
+
+        return action
+
     def _get_action(self, action_xmlid):
         action = self.env["ir.actions.actions"]._for_xml_id(action_xmlid)
         if self:

--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -108,6 +108,13 @@ class ProductionLot(models.Model):
                 ))
         return super(ProductionLot, self).write(vals)
 
+    def copy(self, default=None):
+        if default is None:
+            default = {}
+        if 'name' not in default:
+            default['name'] = _("(copy of) %s", self.name)
+        return super().copy(default)
+
     @api.depends('quant_ids', 'quant_ids.quantity')
     def _product_qty(self):
         for lot in self:

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -14,11 +14,13 @@
                         groups="stock.group_stock_multi_locations"/>
                 </div>
                 <group name="first" position="after">
-                    <group string="Logistics">
-                        <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location"/>
-                        <field name="total_route_ids" widget="many2many_tags" groups="stock.group_adv_location" attrs="{'invisible': [('parent_id', '=', False)]}"/>
-                        <field name="removal_strategy_id" options="{'no_create': True}"/>
-                        <field name="packaging_reserve_method" widget="radio" groups="product.group_stock_packaging"/>
+                    <group>
+                        <group name="logistics" string="Logistics">
+                            <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location"/>
+                            <field name="total_route_ids" widget="many2many_tags" groups="stock.group_adv_location" attrs="{'invisible': [('parent_id', '=', False)]}"/>
+                            <field name="removal_strategy_id" options="{'no_create': True}"/>
+                            <field name="packaging_reserve_method" widget="radio" groups="product.group_stock_packaging"/>
+                        </group>
                     </group>
                 </group>
             </field>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -140,20 +140,22 @@
                     <field name="is_locked" invisible="1"/>
                     <field name="picking_type_entire_packs" invisible="1"/>
                     <field name="display_assign_serial" invisible="1"/>
+                    <field name="from_immediate_transfer" invisible="1"/>
+                    <field name="product_uom_category_id" invisible="1"/>
                     <group>
                         <group>
                             <field name="product_id" readonly="1"/>
-                            <label for="product_uom_qty"/>
-                            <div class="o_row">
+                            <label for="product_uom_qty" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}"/>
+                            <div class="o_row" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}">
                                 <span><field name="product_uom_qty" readonly="1" nolabel="1"/></span>
                                 <span><field name="product_uom" readonly="1" nolabel="1"/></span>
                             </div>
                             <label for="quantity_done"/>
                             <div class="o_row">
                                 <span><field name="quantity_done" readonly="1" nolabel="1"/></span>
-                                <span attrs="{'invisible': [('state', '=', 'done')]}"> / </span>
-                                <span><field name="reserved_availability" nolabel="1" attrs="{'invisible': [('state', '=', 'done')]}" /></span>
-                                <span><field name="product_uom" readonly="1" nolabel="1"/></span>
+                                <span attrs="{'invisible': ['|', ('state', '=', 'done'), ('from_immediate_transfer', '=', True)]}"> / </span>
+                                <span><field name="reserved_availability" nolabel="1" attrs="{'invisible': ['|', ('state', '=', 'done'), ('from_immediate_transfer', '=', True)]}" /></span>
+                                <span><field name="product_uom" readonly="1" nolabel="1" attrs="{'invisible': [('from_immediate_transfer', '=', True)]}"/></span>
                             </div>
                             <field name="next_serial"
                                 attrs="{'invisible': [('display_assign_serial', '=', False)]}"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -213,8 +213,8 @@
                     <field name="product_uom_category_id" invisible="1"/>
                     <field name="product_id" invisible="1"/>
                     <field name="package_level_id" invisible="1"/>
-                    <field name="location_id" options="{'no_create': True}" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_source_location')" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]" groups="stock.group_stock_multi_locations"/>
-                    <field name="location_dest_id" width="0.75" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_destination_location')" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]" groups="stock.group_stock_multi_locations"/>
+                    <field name="location_id" options="{'no_create': True}" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_source_location')" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]" groups="stock.group_stock_multi_locations"/>
+                    <field name="location_dest_id" width="0.75" attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}" invisible="not context.get('show_destination_location')" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]" groups="stock.group_stock_multi_locations"/>
                     <field name="lot_id" groups="stock.group_production_lot"
                         attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"
                         invisible="not context.get('show_lots_m2o')"
@@ -253,8 +253,8 @@
                     <field name="move_id" invisible="1"/>
                     <field name="picking_id" invisible="1"/>
                     <field name="product_uom_category_id" invisible="1"/>
-                    <field name="location_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]"/>
-                    <field name="location_dest_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]"/>
+                    <field name="location_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
+                    <field name="location_dest_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
                     <field name="package_id" groups="stock.group_tracking_lot"/>
                     <field name="result_package_id" groups="stock.group_tracking_lot"/>
                     <field name="lots_visible" invisible="1"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -209,7 +209,7 @@
                     <field name="backorder_id" optional="hide"/>
                     <field name="picking_type_id" optional="hide"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
-                    <field name="state" optional="show" widget="badge" decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')"/>
+                    <field name="state" optional="show" widget="badge" decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel', 'draft')" decoration-muted="state == 'draft'"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                     <field name="json_popover" nolabel="1" widget="stock_rescheduling_popover" attrs="{'invisible': [('json_popover', '=', False)]}"/>
                 </tree>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -97,6 +97,16 @@
             </field>
         </record>
 
+        <record id="stock_picking_type_menu_action" model="ir.actions.server">
+            <field name="name">Overview</field>
+            <field name="model_id" ref="stock.model_stock_picking_type"/>
+            <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
+            <field name="state">code</field>
+            <field name="code">
+                action = model.action_view_picking_type()
+            </field>
+        </record>
+
         <record id="action_picking_type_list" model="ir.actions.act_window">
             <field name="name">Operations Types</field>
             <field name="res_model">stock.picking.type</field>
@@ -113,7 +123,7 @@
         </record>
 
         <menuitem
-            action="stock_picking_type_action"
+            action="stock_picking_type_menu_action"
             id="stock_picking_type_menu"
             parent="menu_stock_root" sequence="0"
             name="Overview"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -374,7 +374,7 @@
                                     <field name="reserved_availability" string="Reserved" attrs="{'column_invisible': (['|','|', ('parent.state','=', 'done'), ('parent.picking_type_code', 'in', ['incoming', 'outgoing']), ('parent.immediate_transfer', '=', True)])}"/>
                                     <field name="product_qty" invisible="1" readonly="1"/>
                                     <field name="forecast_expected_date" invisible="1" />
-                                    <field name="forecast_availability" string="Reserved" attrs="{'column_invisible': ['|', ('parent.picking_type_code', '!=', 'outgoing'), ('parent.state','=', 'done')]}" widget="forecast_widget"/>
+                                    <field name="forecast_availability" string="Reserved" attrs="{'column_invisible': ['|', '|', ('parent.picking_type_code', '!=', 'outgoing'), ('parent.state','=', 'done'), ('parent.immediate_transfer', '=', True)]}" widget="forecast_widget"/>
                                     <field name="quantity_done" string="Done" attrs="{'readonly': [('is_quantity_done_editable', '=', False)]}"/>
                                     <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                                     <field name="lot_ids" widget="many2many_tags"

--- a/addons/stock/views/stock_production_lot_views.xml
+++ b/addons/stock/views/stock_production_lot_views.xml
@@ -31,7 +31,7 @@
                 </div>
                 <group name="main_group">
                     <group>
-                        <field name="product_id" context="{'default_type': 'product'}" readonly="context.get('set_product_readonly', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
+                        <field name="product_id" context="{'default_type': 'product', 'default_tracking': 'lot'}" readonly="context.get('set_product_readonly', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
                         <label for="product_qty" attrs="{'invisible': [('display_complete', '=', False)]}"/>
                         <div class="o_row" attrs="{'invisible': [('display_complete', '=', False)]}">
                             <field name="product_qty"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -129,7 +129,7 @@
                 <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}"
                        readonly="context.get('single_product', False)" force_save="1"
                        options="{'no_create': True}"/>
-                <field name="product_categ_id" optional="show"/>
+                <field name="product_categ_id" optional="hide"/>
                 <field name="location_id" attrs="{'readonly': [('id', '!=', False)]}"
                        invisible="context.get('hide_location', False)"
                        options="{'no_create': True}"/>

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -15,7 +15,7 @@
         <record id="view_category_property_form" model="ir.ui.view">
             <field name="name">product.category.stock.property.form.inherit</field>
             <field name="model">product.category</field>
-            <field name="inherit_id" ref="account.view_category_property_form"/>
+            <field name="inherit_id" ref="stock.product_category_form_view_inherit"/>
             <field name="arch" type="xml">
                 <group name="account_property" position="inside">
                     <group name="account_stock_property" string="Account Stock Properties" groups="account.group_account_readonly" attrs="{'invisible':[('property_valuation', '=', 'manual_periodic')]}">
@@ -28,12 +28,10 @@
                         </div>
                     </group>
                 </group>
-                <group name="account_property" position="before">
-                    <group>
-                        <group string="Inventory Valuation">
-                            <field name="property_cost_method"/>
-                            <field name="property_valuation" groups="account.group_account_readonly,stock.group_stock_manager"/>
-                        </group>
+                <group name="logistics" position="after">
+                    <group string="Inventory Valuation">
+                        <field name="property_cost_method"/>
+                        <field name="property_valuation" groups="account.group_account_readonly,stock.group_stock_manager"/>
                     </group>
                 </group>
             </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
1. Lot selection shouldn't be visible in picking form when the product is not tracked
2. In case of an immediate transfer
  2.1. Hide the reserved column in picking form
  2.2. Hide the initial demand in the lot picking form
3. The inventory overview should use the 'warehouse' group_by as long as the 'storage locations' setting is on.
4. When activating dropship in settings, need to activate multi-step routes as well.
5. Do not allow to select views as destination or source location in a picking.
6. When in the production.lot form, creating a product on the fly should set tracking by lot by default. Also, duplicates shoud create different lot/serial number as this would immediately raise an error.
7. The raised error currently displays the internal state (e.g. 'purchase' instead of 'Purchase Order') and therefore is not translated.
8. The product category is not relevant on-hand quantity list and needs to be hidden by default (Can still be selected on the right).
9. The 'Logistics' and 'Inventory Valuation' blocs should be regrouped into two columns on the product_category form
10. Colors are not clear enough for picking states in list view, draft should be in grey.
11. Set expense demo products as 'service' instead of 'consumables' so they are not shown anymore in inventory products.
12. When creating a delivery slip for a reception, internal notes are printed . this document is often given to the transporter/vendor, so it shouldn't be present there

Desired behavior after PR is merged:

Task-2428819

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
