### PR TITLE
[FIX] delivery: fix singleton error on carrier_id

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -19,8 +19,9 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
-        carrier_id = self.group_id.sale_id.carrier_id.id
-        vals['carrier_id'] = self.rule_id.propagate_carrier and carrier_id
+        carrier_ids = self.mapped('group_id.sale_id.carrier_id')
+        carrier_id = len(carrier_ids) == 1 and carrier_ids.id or False
+        vals['carrier_id'] = all(self.mapped('rule_id.propagate_carrier')) and carrier_id
         return vals
 
     def _key_assign_picking(self):


### PR DESCRIPTION
Multiple values are there so we cannot fetch carrier_id and propagate_carrier values.so we used mapped for both.

opw-2610493




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
