### PR TITLE
[FIX] account, hr_expense: fix reconciliation function

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -598,13 +598,20 @@ class AccountPartialReconcile(models.Model):
         moves._post(soft=False)
 
         # Reconcile the tax lines being on a reconcile tax basis transfer account.
-        for line, move_index, sequence in to_reconcile_after:
+        for lines, move_index, sequence in to_reconcile_after:
+
+            # In expenses, all move lines are created manually without any grouping on tax lines.
+            # In that case, 'lines' could be already reconciled.
+            lines = lines.filtered(lambda x: not x.reconciled)
+            if not lines:
+                continue
+
             counterpart_line = moves[move_index].line_ids.filtered(lambda line: line.sequence == sequence)
 
             # When dealing with tiny amounts, the line could have a zero amount and then, be already reconciled.
             if counterpart_line.reconciled:
                 continue
 
-            (line + counterpart_line).reconcile()
+            (lines + counterpart_line).reconcile()
 
         return moves


### PR DESCRIPTION
Steps to reproduce the bug:
- Install Accounting and Expense app
- Go to accounting settings > enable cash basis option
- Go to accounting > configuration > accounting > taxes
- Create a new tax or choose an existing one e.g “Tax abc”:
Tax Computation = `”Percentage of Price”`
Tax Type = `”Purchases”`
Choose any value for amount
Select "Based on Payment" in tax due
choose an account with the "Allow Reconciliation" option activated in the Cash Basis Transition Account field
Save

- Go to expenses > Expense Reports > All reports > Create a new one :
	- Add 2 expense and for both set up the taxes to "Tax abc" and unit price > 0
- Submit to manager
- Approve
- Post journal entries
- Register a payment

Problem:
A user error with the following message is triggered: “You are trying to reconcile some entries that are already reconciled”

In the use case we have two expenses and for each, an `" account.partial.reconcile "` will be created,
so we will loop twice and therefore add twice all the `”account.move.line”` linked to the taxes
in the dict `" to_reconcile_after "`: https://github.com/odoo/odoo/blob/beccf82e09d536255d9d9cb9bfe58ebae2559843/addons/account/models/account_partial_reconcile.py#L585

Then we loop to reconcile all the `" account.move.line "` which are in the dict `" to_reconcile_after "`,
but since we added them all twice, at each turn of the loop we give them all as a parameter
of the “reconcile” function without checking whether they are already reconciled or not.

opw-2565934




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
