### PR TITLE
[FIX] stock_account: split COGS correction entry

### DIFF
--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -35,7 +35,8 @@ class StockMoveLine(models.Model):
                 diff = vals['qty_done'] - move_line.qty_done
                 if float_is_zero(diff, precision_rounding=rounding):
                     continue
-                self._create_correction_svl(move, diff)
+                self._create_correction_svl(move, -move_line.qty_done)
+                self._create_correction_svl(move, vals['qty_done'])
         return super(StockMoveLine, self).write(vals)
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Create a MO for a product with automated inventory valuation
Set to done
Unlock
Modify consumption on component line

The change is registered with a new correction layer. This should not be
the case as we should revert the old layer and create a new one with the
updated quantity

opw-2491009

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
