### PR TITLE
[14.0][IMP] website: removes google map's unclear message

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2316,7 +2316,12 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 "widget": "contact",
                 "fields": ["name", "address", "phone", "mobile", "email"]}'/>
         <t t-if="not res_company.google_map_img()">
-            <span class="fa fa-map-marker fa-fw mt16" role="img" aria-label="Address" title="Address"/> <a t-att-href="res_company.google_map_link()" target="_BLANK"> Google Maps</a>
+            <span class="fa fa-map-marker fa-fw mt16" role="img" aria-label="Address" title="Address"/>
+            <a t-att-href="res_company.google_map_link()" target="_BLANK"> Google Maps</a>
+            <a t-if="editable"
+                class="fa fa-cog ml-1"
+                href="/web#action=website.action_website_configuration"
+                title="Add your key in the settings."/>
         </t>
     </address>
 </template>
@@ -2327,12 +2332,6 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
             <a t-att-href="res_company.google_map_link()" target="_BLANK">
                 <img class="img-fluid" t-att-src="res_company.google_map_img()" alt="Google Maps"/>
             </a>
-        </t>
-        <t t-elif="editable">
-            <div class="alert alert-warning">
-                <i class="fa fa-plus-circle"/>
-                The Google map option is enabled but <a href="/web#action=website.action_website_configuration">not properly configured</a>.
-            </div>
         </t>
     </xpath>
 </template>

--- a/doc/cla/individual/skeller1.md
+++ b/doc/cla/individual/skeller1.md
@@ -1,0 +1,11 @@
+Germany, 2021-07-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Stephan Keller skeller1 mistk@gmx.de https://github.com/skeller1


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit remove the unclear message from the 'Contact Us' page,
as it could only appear when the google map option is not enabled.

Backport from master #58479

Closes   #73738




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
