### PR TITLE
[FIX] mrp_subcontracting: no operation if subcontracting


### DIFF
--- a/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
+++ b/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
@@ -311,6 +311,12 @@ msgid "Warehouse"
 msgstr ""
 
 #. module: mrp_subcontracting
+#: code:addons/mrp_subcontracting/models/mrp_bom.py:0
+#, python-format
+msgid "You can not set a Bill of Material with operations as subcontracting."
+msgstr ""
+
+#. module: mrp_subcontracting
 #: code:addons/mrp_subcontracting/models/mrp_production.py:0
 #, python-format
 msgid "You must enter a serial number for each line of %s"

--- a/addons/mrp_subcontracting/models/mrp_bom.py
+++ b/addons/mrp_subcontracting/models/mrp_bom.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 from odoo.osv.expression import AND
 
 class MrpBom(models.Model):
@@ -19,3 +20,8 @@ class MrpBom(models.Model):
             return self.search(domain, order='sequence, product_id', limit=1)
         else:
             return self.env['mrp.bom']
+
+    @api.constrains('operation_ids', 'type')
+    def _check_subcontracting_no_operation(self):
+        if self.filtered_domain([('type', '=', 'subcontract'), ('operation_ids', '!=', False)]):
+            raise ValidationError(_('You can not set a Bill of Material with operations as subcontracting.'))


### PR DESCRIPTION

When setting a Bill or Material to subcontracting, the "Operations" tab
is hidden. But it still effect eg. BoM Structure & Cost report.

With this changeset, we get an error when we save a subcontracting BoM
that has operations.

opw-2513637
