### PR TITLE
[FIX] account: do not set deprecated account as default

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -402,6 +402,7 @@ class AccountPayment(models.Model):
                     pay.destination_account_id = self.env['account.account'].search([
                         ('company_id', '=', pay.company_id.id),
                         ('internal_type', '=', 'receivable'),
+                        ('deprecated', '=', False),
                     ], limit=1)
             elif pay.partner_type == 'supplier':
                 # Send money to pay a bill or receive money to refund it.
@@ -411,6 +412,7 @@ class AccountPayment(models.Model):
                     pay.destination_account_id = self.env['account.account'].search([
                         ('company_id', '=', pay.company_id.id),
                         ('internal_type', '=', 'payable'),
+                        ('deprecated', '=', False),
                     ], limit=1)
 
     @api.depends('partner_bank_id', 'amount', 'ref', 'currency_id', 'journal_id', 'move_id.state',


### PR DESCRIPTION
Before this commit, It was setting first available account as default regardless
of it is deprecated or not.

With this commit, we are excluding deprecated account as default.

Fixes #74280

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
