### PR TITLE
[13.0][FIX] resource module: Avoid "Attendances can't overlap' issue 

### DIFF
--- a/addons/resource/data/resource_data.xml
+++ b/addons/resource/data/resource_data.xml
@@ -26,7 +26,7 @@
         <field name="company_id" ref="base.main_company"/>
         <field name="hours_per_day">7.0</field>
         <field name="attendance_ids"
-            eval="[
+            eval="[(5, 0, 0),
                 (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
                 (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
@@ -46,7 +46,7 @@
         <field name="company_id" ref="base.main_company"/>
         <field name="hours_per_day">7.6</field>
         <field name="attendance_ids"
-            eval="[
+            eval="[(5, 0, 0),
                 (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16.6, 'day_period': 'afternoon'}),
                 (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),

--- a/doc/cla/individual/szabolcsmaj.md
+++ b/doc/cla/individual/szabolcsmaj.md
@@ -1,0 +1,11 @@
+Hungary, 2021-07-28
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Szabolcs Máj szabolcs.maj@gmail.com https://github.com/szabolcsmaj


### PR DESCRIPTION
Description of the issue/feature this PR addresses: #45443

Current behavior before PR: Cannot install `resource` module in 13.0

Desired behavior after PR is merged: `resource` module can be installed for 13.0

It's mentioned in #45443 that "Fixed in master but not backported to 13.0". This has been almost 1 year ago and it still persists in 13.0.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
