### PR TITLE
[FIX] tool: wrong argument of add_worksheet

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -399,15 +399,14 @@ try:
     # as the sheet name is often translatable, can not control the input
     class PatchedXlsxWorkbook(xlsxwriter.Workbook):
 
-        # TODO when xlsxwriter bump to 0.9.8, add worksheet_class=None parameter instead of kw
-        def add_worksheet(self, name=None, **kw):
+        def add_worksheet(self, name=None, worksheet_class=None):
             if name:
                 # invalid Excel character: []:*?/\
                 name = re.sub(r'[\[\]:*?/\\]', '', name)
 
                 # maximum size is 31 characters
                 name = name[:31]
-            return super(PatchedXlsxWorkbook, self).add_worksheet(name, **kw)
+            return super(PatchedXlsxWorkbook, self).add_worksheet(name, worksheet_class)
 
     xlsxwriter.Workbook = PatchedXlsxWorkbook
 


### PR DESCRIPTION
Odoo use XlsxWriter==1.1.2, and the argument of the method add_worksheet is now (name=None, worksheet_class=None).

https://github.com/jmcnamara/XlsxWriter/blob/main/xlsxwriter/workbook.py#L173

@odony @rco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
