### PR TITLE
[IMP] base, account: simplify multi currency setup

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -147,8 +147,6 @@ class ResConfigSettings(models.TransientModel):
 
     def set_values(self):
         super(ResConfigSettings, self).set_values()
-        if self.group_multi_currency:
-            self.env.ref('base.group_user').write({'implied_ids': [(4, self.env.ref('product.group_sale_pricelist').id)]})
         # install a chart of accounts for the given company (if required)
         if self.env.company == self.company_id and self.chart_template_id and self.chart_template_id != self.company_id.chart_template_id:
             self.chart_template_id._load(15.0, 15.0, self.env.company)

--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -626,6 +626,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.rule_1.write({'match_partner_ids': [(6, 0, partner.ids)], 'match_same_currency': False})
 
         currency_inv = self.env.ref('base.EUR')
+        currency_inv.active = True
         currency_statement = self.env.ref('base.JPY')
 
         currency_statement.active = True

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -65,7 +65,7 @@
                 <menuitem id="menu_action_tax_form" action="action_tax_form" sequence="2"/>
                 <menuitem id="menu_action_account_journal_form" action="action_account_journal_form" groups="account.group_account_manager" sequence="3"/>
                 <menuitem id="account_report_folder" name="Reporting" groups="account.group_account_readonly" sequence="4"/>
-                <menuitem id="menu_action_currency_form" action="base.action_currency_form" name="Currencies" groups="base.group_multi_currency" sequence="4"/>
+                <menuitem id="menu_action_currency_form" action="base.action_currency_form" name="Currencies" sequence="4"/>
                 <menuitem id="menu_action_account_fiscal_position_form" action="action_account_fiscal_position_form" sequence="5"/>
                 <menuitem id="menu_action_account_journal_group_list" action="action_account_journal_group_list" groups="account.group_account_manager" sequence="7"/>
             </menuitem>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -145,23 +145,11 @@
                                         <div class="row mt16">
                                             <label for="currency_id" class="col-lg-3 o_light_label"/>
                                             <field name="currency_id" options="{'no_create_edit': True, 'no_open': True}" context="{'active_test': False}"/>
+                                            <field name="group_multi_currency" invisible="1"/>
                                         </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="record_transactions">
-                                <div class="o_setting_left_pane">
-                                    <field name="group_multi_currency"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label string="Multi-Currencies" for="group_multi_currency"/>
-                                    <div class="text-muted">
-                                        Record transactions in foreign currencies
-                                    </div>
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('group_multi_currency', '=', False)]}">
-                                    <div class="mt8">
-                                        <button name="%(base.action_currency_all_form)d" icon="fa-arrow-right" type="action" string="Activate Other Currencies" class="btn-link"/>
+                                        <div class="mt8">
+                                            <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="fa-arrow-right"/>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -649,6 +649,8 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             The order will be in a different currency than the company currency.
         """
         # Make sure the company is in USD
+        self.env.ref('base.USD').active = True
+        self.env.ref('base.EUR').active = True
         self.env.cr.execute(
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
             [self.env.ref('base.USD').id, self.env.company.id])

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -51,22 +51,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-6 o_setting_box" id="multicurrencies_setting" title="This adds the choice of a currency on pricelists.">
-                            <div class="o_setting_left_pane">
-                                <field name="group_multi_currency"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="group_multi_currency"/>
-                                <div class="text-muted">
-                                    Record transactions in foreign currencies
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('group_multi_currency', '=', False)]}">
-                                    <div class="mt8">
-                                        <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="fa-arrow-right"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="col-12 col-lg-6 o_setting_box" title="Manage promotion and coupon programs.">
                             <div class="o_setting_left_pane">
                                 <field name="module_pos_coupon"/>

--- a/addons/product/models/__init__.py
+++ b/addons/product/models/__init__.py
@@ -15,4 +15,5 @@ from . import product
 from . import product_attribute
 from . import product_pricelist
 from . import res_company
+from . import res_currency
 from . import res_partner

--- a/addons/product/models/res_config_settings.py
+++ b/addons/product/models/res_config_settings.py
@@ -50,11 +50,6 @@ class ResConfigSettings(models.TransientModel):
         if self.module_sale_product_configurator and not self.group_product_variant:
             self.group_product_variant = True
 
-    @api.onchange('group_multi_currency')
-    def _onchange_group_multi_currency(self):
-        if self.group_multi_currency:
-            self.group_product_pricelist = True
-
     @api.onchange('group_product_pricelist')
     def _onchange_group_sale_pricelist(self):
         if not self.group_product_pricelist and self.group_sale_pricelist:

--- a/addons/product/models/res_currency.py
+++ b/addons/product/models/res_currency.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResCurrency(models.Model):
+    _inherit = 'res.currency'
+
+    def _activate_group_multi_currency(self):
+        # for Sale/ POS - Multi currency flows require pricelists
+        super()._activate_group_multi_currency()
+        group_user = self.env.ref('base.group_user').sudo()
+        group_user._apply_group(self.env.ref('product.group_product_pricelist'))

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -248,6 +248,8 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         Account = cls.env['account.account']
         cls.usd_currency = cls.env.ref('base.USD')
         cls.eur_currency = cls.env.ref('base.EUR')
+        cls.usd_currency.active = True
+        cls.eur_currency.active = True
 
         cls.stock_input_account = Account.create({
             'name': 'Stock Input',

--- a/addons/sale/security/sale_security.xml
+++ b/addons/sale/security/sale_security.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="base.group_multi_currency" model="res.groups">
-        <!--
-            Sales multi-currency is based on pricelists, if multi-currency is enabled,
-            enable pricelists.
-        -->
-        <field name="implied_ids" eval="[(4, ref('product.group_product_pricelist'))]"/>
-    </record>
-
      <record id="group_auto_done_setting" model="res.groups">
         <field name="name">Lock Confirmed Sales</field>
         <field name="category_id" ref="base.module_category_hidden"/>

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -34,6 +34,8 @@ class TestSaleMrpKitBom(TransactionCase):
         # ----------------------------------------------
 
         self.env.user.company_id.anglo_saxon_accounting = True
+        self.env.ref('base.USD').active = True
+
         self.stock_input_account = self.env['account.account'].create({
             'name': 'Stock Input',
             'code': 'StockIn',

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -50,6 +50,7 @@ class TestStockValuation(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestStockValuation, cls).setUpClass()
+        cls.env.ref('base.EUR').active = True
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
         cls.customer_location = cls.env.ref('stock.stock_location_customers')
         cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -23,6 +23,7 @@ class TestStockValuationCommon(TransactionCase):
         })
         cls.picking_type_in = cls.env.ref('stock.picking_type_in')
         cls.picking_type_out = cls.env.ref('stock.picking_type_out')
+        cls.env.ref('base.EUR').active = True
 
     def setUp(self):
         super(TestStockValuationCommon, self).setUp()

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -149,6 +149,7 @@ var BasicModel = AbstractModel.extend({
         'ir.actions.act_window',
         'ir.filters',
         'ir.ui.view',
+        'res.currency',
     ],
 
     /**

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -133,22 +133,6 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-12 col-lg-6 o_setting_box" id="multicurrencies_setting" title="This adds the choice of a currency on pricelists.">
-                        <div class="o_setting_left_pane">
-                            <field name="group_multi_currency"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_multi_currency"/>
-                            <div class="text-muted">
-                                Sell in several currencies
-                            </div>
-                            <div class="content-group" attrs="{'invisible': [('group_multi_currency', '=', False)]}">
-                                <div class="mt8">
-                                    <button type="action" name="%(base.action_currency_form)d" string="Currencies" class="btn-link" icon="fa-arrow-right"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                     <div class="col-12 col-lg-6 o_setting_box"
                         id="promotion_coupon_programs"
                         title="Boost your sales with two kinds of discount programs: promotions and coupon codes. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products.">

--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -8,6 +8,7 @@
             <field name="symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
+            <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
         </record>
@@ -36,6 +37,7 @@
             <field name="name">CHF</field>
             <field name="full_name">Swiss franc</field>
             <field name="symbol">CHF</field>
+            <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -235,6 +237,7 @@
             <field name="name">HKD</field>
             <field name="full_name">Hong Kong dollar</field>
             <field name="symbol">$</field>
+            <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -340,6 +343,7 @@
             <field name="symbol">RM</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
+            <field name="position">before</field>
             <field name="currency_unit_label">Ringgit</field>
             <field name="currency_subunit_label">Sen</field>
         </record>
@@ -358,7 +362,7 @@
         <record id="PHP" model="res.currency">
             <field name="name">PHP</field>
             <field name="full_name">Philippine peso</field>
-            <field name="symbol">Php</field>
+            <field name="symbol">₱</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Peso</field>
@@ -885,6 +889,7 @@
             <field name="name">ILS</field>
             <field name="full_name">Israeli new shekel</field>
             <field name="symbol">₪</field>
+            <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shekel</field>
@@ -1256,6 +1261,7 @@
             <field name="full_name">Euro</field>
             <field name="symbol">€</field>
             <field name="rounding">0.01</field>
+            <field name="active" eval="False"/>
             <field name="currency_unit_label">Euros</field>
             <field name="currency_subunit_label">Cents</field>
         </record>

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -577,10 +577,9 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 if self[name] == current_settings[name]:
                     continue
                 if int(self[name]):
-                    groups.write({'implied_ids': [Command.link(implied_group.id)]})
+                    groups._apply_group(implied_group)
                 else:
-                    groups.write({'implied_ids': [Command.unlink(implied_group.id)]})
-                    implied_group.write({'users': [Command.unlink(user.id) for user in groups.users]})
+                    groups._remove_group(implied_group)
 
         # config fields: store ir.config_parameters
         IrConfigParameter = self.env['ir.config_parameter'].sudo()

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1091,6 +1091,21 @@ class GroupsImplied(models.Model):
             self._check_one_user_type()
         return res
 
+    def _apply_group(self, implied_group):
+        """ Add the given group to the groups implied by the current group
+        :param implied_group: the implied group to add
+        """
+        if implied_group not in self.implied_ids:
+            self.write({'implied_ids': [Command.link(implied_group.id)]})
+
+    def _remove_group(self, implied_group):
+        """ Remove the given group from the implied groups of the current group
+        :param implied_group: the implied group to remove
+        """
+        if implied_group in self.implied_ids:
+            self.write({'implied_ids': [Command.unlink(implied_group.id)]})
+            implied_group.write({'users': [Command.unlink(user.id) for user in self.users]})
+
 class UsersImplied(models.Model):
     _inherit = 'res.users'
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -18,6 +18,7 @@ class TestExpression(SavepointCaseWithUserDemo):
     def setUpClass(cls):
         super(TestExpression, cls).setUpClass()
         cls._load_partners_set()
+        cls.env['res.currency'].with_context({'active_test': False}).search([('name', 'in', ['EUR', 'USD'])]).write({'active': True})
 
     def _search(self, obj, domain, init_domain=[]):
         sql = obj.search(domain)

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -188,13 +188,6 @@
             <field name="search_view_id" ref="view_currency_search"/>
             <field name="context">{'active_test': False}</field>
         </record>
-        <record id="action_currency_all_form" model="ir.actions.act_window">
-            <field name="name">Currencies</field>
-            <field name="res_model">res.currency</field>
-            <field name="view_mode">tree,kanban,form</field>
-            <field name="search_view_id" ref="view_currency_search"/>
-            <field name="context">{'active_test': False}</field>
-        </record>
 
     </data>
 </odoo>


### PR DESCRIPTION
[IMP] base, account: simplify multi currency setup
Automatically activate `group_multi_currency` if there is more than one active currency,
deactivate it if there is only one active currency

This mean the group_multi_currency field is hidden on the `res.config.settings` view

Task 2610735

[IMP] base: improve currency data
Improve currency symbols and their positions

Task 2610735
