### PR TITLE
[IMP] l10n_pe: New identification types requested by the SUNAT

### DIFF
--- a/addons/l10n_pe/data/l10n_latam_identification_type_data.xml
+++ b/addons/l10n_pe/data/l10n_latam_identification_type_data.xml
@@ -65,4 +65,17 @@
         <field name='l10n_pe_vat_code'>E</field>
         <field name='sequence'>125</field>
     </record>
+    <record model='l10n_latam.identification.type' id='it_PTP'>
+        <field name='name'>PTP</field>
+        <field name='description'>Temporary Residence Permit</field>
+        <field name='country_id' ref='base.pe'/>
+        <field name='l10n_pe_vat_code'>F</field>
+        <field name='sequence'>130</field>
+    </record>
+    <record model='l10n_latam.identification.type' id='it_SP'>
+        <field name='name'>Safe Passage</field>
+        <field name='country_id' ref='base.pe'/>
+        <field name='l10n_pe_vat_code'>G</field>
+        <field name='sequence'>135</field>
+    </record>
 </odoo>

--- a/addons/l10n_pe/i18n/es.po
+++ b/addons/l10n_pe/i18n/es.po
@@ -158,7 +158,12 @@ msgstr "IVAP - Impuesto a la Venta Arroz Pilado"
 #. module: l10n_pe
 #: model:l10n_latam.identification.type,name:l10n_pe.it_IDCR
 msgid "Identity document of the country of residence"
-msgstr "Documento de identidad del país de recidencia"
+msgstr "Documento de identidad del país de residencia"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_SP
+msgid "Safe Passage"
+msgstr "Salvoconducto"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type__l10n_pe_vat_code

--- a/addons/l10n_pe/i18n/l10n_pe.pot
+++ b/addons/l10n_pe/i18n/l10n_pe.pot
@@ -163,6 +163,11 @@ msgid "Identity document of the country of residence"
 msgstr ""
 
 #. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_SP
+msgid "Safe Passage"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type__l10n_pe_vat_code
 msgid "L10N Pe Vat Code"
 msgstr ""


### PR DESCRIPTION
By Sunat regulations from 08/01/2021 two new types of identity documents
will be accepted: Temporary Residence Permit and Safe Passage.

Legal ref:

Website: https://cpe.sunat.gob.pe/node/88
Document with Catalog Update No. 8:
https://cpe.sunat.gob.pe/sites/default/files/inline-files/AjustesValidacionesCPEv20210727%20%28ultimo%29.xlsx

Replaces #74342

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
