### PR TITLE
[FIX] website_sale: markupSafe (list_)price from autocomplete search

### DIFF
--- a/addons/website_sale/static/src/snippets/s_products_searchbar/000.js
+++ b/addons/website_sale/static/src/snippets/s_products_searchbar/000.js
@@ -71,8 +71,16 @@ publicWidget.registry.productsSearchBar = publicWidget.Widget.extend({
                 },
             },
         });
-        if (this.displayDescription) {
-            res.products.forEach(p => {p.description_sale = Markup(p.description_sale);});
+        if (this.displayDescription || this.displayPrice) {
+            res.products.forEach(p => {
+                if (this.displayDescription) {
+                    p.description_sale = Markup(p.description_sale);
+                }
+                if (this.displayPrice) {
+                    p.list_price = Markup(p.list_price);
+                    p.price = Markup(p.price);
+                }
+            });
         }
         return res;
     },


### PR DESCRIPTION
/shop/products/autocomplete return price already rendered with monetary
widget, so it is plain html like:
    "$ <span class=\"oe_currency_value\">12.00</span>"

It need to be marked MarkupSafe to avoid the escaping.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
