### PR TITLE
[FIX] mrp: do not set move dest on byproduct

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -577,7 +577,7 @@ class MrpProduction(models.Model):
             'propagate_cancel': self.propagate_cancel,
             'propagate_date': self.propagate_date,
             'propagate_date_minimum_delta': self.propagate_date_minimum_delta,
-            'move_dest_ids': [(4, x.id) for x in self.move_dest_ids],
+            'move_dest_ids': not byproduct_id and [(4, x.id) for x in self.move_dest_ids],
         }
 
     def _generate_finished_moves(self):


### PR DESCRIPTION
If a manufacturing order is created via a make to order move,
The field `move_dest_ids` is set to this mto move. This allow to link
the mto move and the finished product one. The issue is the byproduct
are also created with this link to the mto move. A link between two move
of different products make no sense and can introduce bugs like
bypassing push rules in 3 steps manufacturing.

OPW-2581762

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
