### PR TITLE
[FIX] website: special character ok in menu label


### DIFF
--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -694,7 +694,7 @@ var EditMenuDialog = weWidgets.Dialog.extend({
             var newMenu = {
                 'fields': {
                     'id': _.uniqueId('new-'),
-                    'name': link.text,
+                    'name': _.unescape(link.text),
                     'url': link.url,
                     'new_window': link.isNewWindow,
                     'is_mega_menu': menuType === 'mega',
@@ -740,7 +740,7 @@ var EditMenuDialog = weWidgets.Dialog.extend({
             }, menu.fields));
             dialog.on('save', this, link => {
                 _.extend(menu.fields, {
-                    'name': link.text,
+                    'name': _.unescape(link.text),
                     'url': link.url,
                     'new_window': link.isNewWindow,
                 });


### PR DESCRIPTION
Edit a website menu label with:

    & < > " ` '

This is what is shown after saving:

   `&amp; &lt; &gt; &quot; &#x60; &#x27;`

This is happening since ea4dbcd240: characters &, <, >, ", `, and ' are
now always escaped. Before that commit, only < and > where escaped and
only when an image was inside the label.

With this change, we unescape the label when we are editing a menu.

opw-2609413
