### PR TITLE
[FIX] survey: fix the warning message on share button

### DIFF
--- a/addons/survey/i18n/survey.pot
+++ b/addons/survey/i18n/survey.pot
@@ -2979,6 +2979,18 @@ msgstr ""
 #. module: survey
 #: code:addons/survey/models/survey_survey.py:0
 #, python-format
+msgid "You cannot send an invitation for a \"One page per section\" survey if the survey has no sections."
+msgstr ""
+
+#. module: survey
+#: code:addons/survey/models/survey_survey.py:0
+#, python-format
+msgid "You cannot send an invitation for a \"One page per section\" survey if the survey only contains empty sections."
+msgstr ""
+
+#. module: survey
+#: code:addons/survey/models/survey_survey.py:0
+#, python-format
 msgid "You cannot send invitations for closed surveys."
 msgstr ""
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -422,9 +422,16 @@ class Survey(models.Model):
 
     def action_send_survey(self):
         """ Open a window to compose an email, pre-filled with the survey message """
-        # Ensure that this survey has at least one page with at least one question.
-        if (not self.page_ids and self.questions_layout == 'page_per_section') or not self.question_ids:
+        # Ensure that this survey has at least one question.
+        if not self.question_ids:
             raise UserError(_('You cannot send an invitation for a survey that has no questions.'))
+
+        # Ensure that this survey has at least one section with question(s), if question layout is 'One page per section'.
+        if self.questions_layout == 'page_per_section':
+            if not self.page_ids:
+                raise UserError(_('You cannot send an invitation for a "One page per section" survey if the survey has no sections.'))
+            if not self.page_ids.mapped('question_ids'):
+                raise UserError(_('You cannot send an invitation for a "One page per section" survey if the survey only contains empty sections.'))
 
         if self.state == 'closed':
             raise UserError(_("You cannot send invitations for closed surveys."))


### PR DESCRIPTION
PURPOSE

The error message should be displayed correctly while 
sharing a survey.
The purpose of this commit is to correct the error message.

SPECIFICATIONS

Currently, while sending an invitation with the 'one page per section' 
layout. If the survey has a question but not has section, 
then the popup is displayed 
"You cannot send an invitation for a survey that has no questions."
This improves the error message like below.
"You cannot send an invitation to a 'One page per section' 
survey if the survey has no section."

This is the goal of this commit.

PR #74430
TaskID-2611996