### PR TITLE
[FIX] stock: Wrong rounding on returning a delivery with different UoM

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -58,7 +58,7 @@ class ReturnPicking(models.TransientModel):
                     move_dest_exists = True
                 quantity = move.product_qty - sum(move.move_dest_ids.filtered(lambda m: m.state in ['partially_available', 'assigned', 'done']).\
                                                   mapped('move_line_ids').mapped('product_qty'))
-                quantity = float_round(quantity, precision_rounding=move.product_uom.rounding)
+                quantity = float_round(quantity, precision_rounding=move.product_id.uom_id.rounding)
                 product_return_moves_data = dict(product_return_moves_data_tmpl)
                 product_return_moves_data.update({
                     'product_id': move.product_id.id,


### PR DESCRIPTION
Issue: When making a return for a transfer, the precision_rounding was taken from the UoM of the product given in the transfer, but the quantity was taken in the UoM of the product defined on its form

Steps to reproduce :
 1) Create a UoM "Hundreds", rounding precision 1 (has to be different than "Dozen"), Bigger than the reference Unit of Measure, ratio 100
 2) Create a test product with "Dozen" as UoM
 3) Inventory > Operations > Transfers > Create
 4) Add test product, Demand=2, Unit of Measure=Hundreds
 5) Validate
 6) Create a Return for that transfer
 7) Quantity is set to 17 Dozen instead of 16.67

 Why is that a bug:
 The quantity to return is `quantity = stock_move.product_qty` (in UoM of the product form) but the rounding is made with rounding precision `stock_move.product_uom.rounding` (in UoM of the line of the transfer) which can be different in case of manual transfer creation for example

opw-2543304