### PR TITLE
[IMP] mass_mailing: improve the mailing list contacts form view

### DIFF
--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -156,6 +156,7 @@
         <field name="priority">10</field>
         <field name="arch" type="xml">
             <form string="Mailing List Contacts">
+                <field name="id" invisible="1"/>
                 <sheet>
                     <div class="oe_title">
                         <label for="name" string="Contact Name"/>
@@ -163,7 +164,7 @@
                             <field class="o_text_overflow" name="name" placeholder="e.g. John Smith"/>
                         </h1>
                         <div>
-                            <field name="tag_ids" widget="many2many_tags" placeholder="Tags" style="width: 100%%"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%%"/>
                         </div>
                     </div>
                     <group>
@@ -182,8 +183,8 @@
                             <field name="country_id" options="{'no_open': True, 'no_create': True}"/>
                         </group>
                         <group>
-                            <field name="create_date" readonly="1"/>
-                            <field name="message_bounce"/>
+                            <field name="create_date" attrs="{'invisible': [('id', '=', False)]}" readonly="1"/>
+                            <field name="message_bounce" attrs="{'invisible': [('id', '=', False)]}" readonly="1"/>
                         </group>
                     </group>
                     <field name="subscription_list_ids">


### PR DESCRIPTION
This PR will improve the form view of 'Mailing List Contacts'. It will:
- Add a color picker on the tag ('tag_ids').
- Make the bouncing counter ('message_bounce') unmodifiable.
- Make the creation date ('create_date') and the bouncing counter ('message_bounce') invisible when the user creates a new record.

task-2611112

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
