### PR TITLE
[FIX] rename return

### DIFF
--- a/addons/website_event_meet/static/src/js/website_event_create_meeting_room_button.js
+++ b/addons/website_event_meet/static/src/js/website_event_create_meeting_room_button.js
@@ -54,6 +54,6 @@ publicWidget.registry.websiteEventCreateMeetingRoom = publicWidget.Widget.extend
     },
 });
 
-return publicWidget.registry.websiteEventMeetingRoom;
+return publicWidget.registry.websiteEventCreateMeetingRoom;
 
 });


### PR DESCRIPTION
Impacted versions: 14
Steps to reproduce: [view source code](https://github.com/odoo/odoo/search?q=websiteEventMeetingRoom)

I was checking the operation of website_event_meet and I find that website_event_meeting_room.js and website_event_create_meeting_room_button.js return publicWidget.registry.websiteEventMeetingRoom. Should website_event_create_meeting_room_button.js not return publicWidget.registry.websiteEventCreateMeetingRoom ?.

![website_event_meet](https://user-images.githubusercontent.com/1509489/127412679-61e18383-0815-4c8c-9a65-f7dfe5cc7a32.PNG)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
