### PR TITLE
[14.0][FIX] base: ensure ir.sequence:next_by_code() always relies on the same sequence

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -279,7 +279,7 @@ class IrSequence(models.Model):
         """
         self.check_access_rights('read')
         company_id = self.env.company.id
-        seq_ids = self.search([('code', '=', sequence_code), ('company_id', 'in', [company_id, False])], order='company_id')
+        seq_ids = self.search([('code', '=', sequence_code), ('company_id', 'in', [company_id, False])], order='company_id,id')
         if not seq_ids:
             _logger.debug("No ir.sequence has been found for code '%s'. Please make sure a sequence is set for current company." % sequence_code)
             return False


### PR DESCRIPTION
*Description of the issue/feature this PR addresses:*

There is currently no `unique(company_id, code)` constraint on sequences (should it be added in master?). So modules can create n sequences with the same code (they should not, but it can happen). Unfortunately, this will lead to non-deterministic bugs, hard to debug. That's because [`ir.sequence:next_by_code`](https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/ir_sequence.py#L282) relies on a non-deterministic SELECT query, as it's not ordered by id.

This PR fixes that.

We faced this case [here](https://github.com/OCA/sale-workflow/issues/1658#issuecomment-884330074), with travis ci jobs failing randomly 1 time out of 2.

Regards,

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
