### PR TITLE
[FIX] mrp: fix the qty must be positive issue

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1481,6 +1481,9 @@ class MrpProduction(models.Model):
             productions_not_to_backorder = self
             productions_to_backorder = self.env['mrp.production']
 
+        if not self.move_finished_ids:
+            self._onchange_move_finished()
+
         self.workorder_ids.button_finish()
 
         productions_not_to_backorder._post_inventory(cancel_backorder=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Fix tends to prevent the qty must positive issue caused by a non-existent finished move

Current behavior before PR:

- After migration v13 to v14 some finished moves get unlinked and afterwards the MO will be blocked and won't be closed.
- When a backorder is created the finished move is not generated and therefore the backorder will be blocked and won't get closed.

Desired behavior after PR is merged:

- The user will be able to validate/close MOs and Backorders

opw-2613010
opw-2610070
opw-2609932
opw-2608122
opw-2606499
