### PR TITLE
[FIX] sale_coupon: Reapply promotion after invoice

### DIFF
--- a/addons/sale_coupon/tests/test_sale_invoicing.py
+++ b/addons/sale_coupon/tests/test_sale_invoicing.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 @tagged('post_install', '-at_install')
 class TestSaleInvoicing(TestSaleCouponCommon):
 
-    def test_invoicing_order_with_promotions(self):
+    def test_01_invoicing_order_with_promotions(self):
         discount_coupon_program = self.env['sale.coupon.program'].create({
             'name': '10% Discount', # Default behavior
             'program_type': 'coupon_program',
@@ -50,3 +50,88 @@ class TestSaleInvoicing(TestSaleCouponCommon):
         self.assertEqual(order.order_line, invoiceable_lines)
         account_move = order._create_invoices()
         self.assertEqual(len(account_move.invoice_line_ids), 2)
+
+    def test_02_double_invoice_order_with_order_percentage_discount(self):
+        discount_coupon_program = self.env['sale.coupon.program'].create({
+            'name': '10% Discount',
+            'program_type': 'coupon_program',
+            'reward_type': 'discount',
+            'discount_apply_on': 'on_order',
+            'promo_code_usage': 'no_code_needed',
+        })
+        product = self.env['product.product'].create({
+            'invoice_policy': 'order',
+            'name': 'Product invoiced on order',
+            'lst_price': 800,
+        })
+
+        order = self.empty_order
+        order.write({
+            'order_line': [
+                (0, 0, {
+                    'product_id': product.id,
+                })
+            ]
+        })
+
+        order.recompute_coupon_lines()
+        order.action_confirm()
+
+        account_move = order._create_invoices()
+        self.assertEqual(len(account_move.invoice_line_ids), 2, "We should have 2 lines as we now have one discount line")
+        self.assertEqual(account_move.amount_untaxed, (product.list_price - discount_coupon_program.discount_percentage * product.list_price / 100.0), "The invoice untaxed amount should be equal to the sale order uninvoiced price with a 10% discount applied")
+
+        order.write({
+            'order_line': [
+                (0, 0, {
+                    'product_id': product.id,
+                })
+            ]
+        })
+
+        order.recompute_coupon_lines()
+
+        second_account_move = order._create_invoices()
+        self.assertEqual(len(second_account_move.invoice_line_ids), 2, "We should have 2 lines as we now have one discount line")
+        self.assertEqual(second_account_move.amount_untaxed, (product.list_price - discount_coupon_program.discount_percentage * product.list_price / 100.0), "The invoice untaxed amount should be equal to the sale order uninvoiced price with a 10% discount applied")
+
+    def test_03_double_invoice_order_with_free_product(self):
+        order = self.empty_order
+        product = self.env['product.product'].create({
+            'invoice_policy': 'order',
+            'name': 'Product invoiced on order',
+            'lst_price': 800,
+        })
+        self.env['sale.coupon.program'].create({
+            'name': 'Buy 4 Large Desks, one is free',
+            'reward_type': 'product',
+            'reward_product_id': product.id,
+            'rule_products_domain': "[('id', 'in', [%s])]" % (product.id),
+            'discount_apply_on': 'on_order',
+            'promo_code_usage': 'no_code_needed',
+            'rule_min_quantity': 3.0,
+        })
+        self.env['sale.order.line'].create({
+            'product_id': product.id,
+            'product_uom_qty': 4.0,
+            'order_id': order.id,
+        })
+
+        order.recompute_coupon_lines()
+        order.action_confirm()
+
+        account_move = order._create_invoices()
+        self.assertEqual(len(account_move.invoice_line_ids), 2, "We should have 2 lines as we now have one 'Free Large Cabinet' line as we bought 4 of them")
+        self.assertEqual(account_move.amount_untaxed, 3 * product.list_price, "The invoice untaxed amount should be equal to 3 times the product price, as the promo should 'render' one free")
+
+        self.env['sale.order.line'].create({
+            'product_id': product.id,
+            'product_uom_qty': 4.0,
+            'order_id': order.id,
+        })
+
+        order.recompute_coupon_lines()
+
+        second_account_move = order._create_invoices()
+        self.assertEqual(len(second_account_move.invoice_line_ids), 2, "We should have 2 lines as we now have one 'Free Large Cabinet' line as we bought 4 of them")
+        self.assertEqual(second_account_move.amount_untaxed, 3 * product.list_price, "The invoice untaxed amount should be equal to 3 times the product price, as the promo should 'render' one free")


### PR DESCRIPTION
How to reproduce the problem:
- Install the sale_coupon module
- Create a promotion with a discount on the order (in Sales -> Products -> Promotion Programs)
- Create a SO with a product that can trigger the promotion.
- Click on Promotions.
- Create an invoice.
- Go back to the SO -> Edit and add a line with the same product than before. Click on Promotion.
- Create an invoice: the amount of that invoice does not take the promotion discount into account.

Cause of the problem : when the promotion was applied for the second time, the discount amount is added to the previously created discount order line, but as that line was already counted as invoiced, it is not added to the new invoice.

Solution : With this fix, instead of updating an already invoiced promotion order line, it will create a new order line.

opw-2447991