### PR TITLE
[FIX][14.0] #44362 avoid vat details from section/note lines

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1595,8 +1595,8 @@ class AccountMove(models.Model):
             lang_env = move.with_context(lang=move.partner_id.lang).env
             balance_multiplicator = -1 if move.is_inbound() else 1
 
-            tax_lines = move.line_ids.filtered('tax_line_id')
-            base_lines = move.line_ids.filtered('tax_ids')
+            tax_lines = move.line_ids.filtered(lambda r: r.tax_line_id and not r.display_type)
+            base_lines = move.line_ids.filtered(lambda r: r.tax_ids and not r.display_type)
 
             tax_group_mapping = defaultdict(lambda: {
                 'base_lines': set(),

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Do not display VAT details for section/line note in account invoice (report)

## Current behavior before PR:

Somehow accounting user have created account invoice with section/note lines
that contains VAT. Probably generated from sale order and may have default values...

Then account manager discover that was the wrong tax and changed it before posted the invoice

In VAT details the old VAT was still present due to the section line related to the old
VAT that the account manager couldn't change in the UI.

## Desired behaviour after PR is merged:

Do not display tax group from section or note lines that users can't change.

--

In this RP I suggest to ignore account move lines with display_type defined while
computing amount_by_group to display useful VAT group in account invoice.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
