### PR TITLE
[FIX] purchase_stock: reuse cache on recomputing fields

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -10,7 +10,8 @@ class StockPicking(models.Model):
 
     purchase_id = fields.Many2one('purchase.order', related='move_lines.purchase_line_id.order_id',
         string="Purchase Orders", readonly=True)
-
+    # Technical field to activate cache mechanism on aggregating computed fields to recompute
+    purchase_ids = fields.Many2many('purchase.order',  string="Inversed field for purchase.order")
 
 class StockMove(models.Model):
     _inherit = 'stock.move'


### PR DESCRIPTION
Adding this non-stored Many2many fields allows ORM to use cache in
`_modified_triggers` and skip costly search:

```
records |= model.search([(key.name, 'in', real_records.ids)], order='id')
```
---

opw-2507143
similar update in accounting: #73884
