### PR TITLE
[FIX] website_sale: fix tour when redirect to backend is too slow

### DIFF
--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -71,5 +71,6 @@ odoo.define("website_sale.tour_shop", function (require) {
         content: _t("Open your website app here."),
         extra_trigger: ".o_apps,#oe_applications",
         position: "bottom",
+        timeout: 30000, // ~ 10 secondes to be redirected, due to slow assets generation
     }];
 });


### PR DESCRIPTION
We increase the time (if we can call this a fix) while the switch from frontend
to backend become faster. It seems to be a problem of (useless?) regeneration of
assets + a slow refactoring of scss in backend which use extend that is slow...

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
