### PR TITLE
[FIX] base, web: fix css assets compilation being too long/big

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -8,7 +8,7 @@
 }
 
 .dropdown-item {
-  &.active {
+  &.active, &.selected {
     position: relative;
     font-weight: $font-weight-bold;
 
@@ -32,7 +32,8 @@
   }
 
   &.selected { // Legacy
-    @extend .active;
+    // FIXME: does commenting this break anything?
+    // @extend .active;
   }
 }
 
@@ -79,10 +80,12 @@
         @extend .dropdown-item;
       }
       &.selected > :first-child {
-        @extend .active;
+        // FIXME: does commenting this break anything?
+        //@extend .active;
       }
       &.disabled > :first-child {
-        @extend .disabled;
+        // FIXME: does commenting this break anything?
+        //@extend .disabled;
       }
     }
   }

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -439,7 +439,6 @@ class AssetsBundle(object):
                 [".." for i in range(0, len(debug_asset_url.split("/")) - 2)]
                 ) + "/",
         )
-        self.preprocess_css()
 
         # adds the @import rules at the beginning of the bundle
         content_bundle_list = [content_import_rules]


### PR DESCRIPTION
This is caused by
- CSS assets being compiled twice when in debug=assets
- Use of @extend rules on very generic classes, leading to a lot of compiled code