### PR TITLE
[FIX] event_sale : attendees not computed on cancel order

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -23,10 +23,14 @@ class SaleOrder(models.Model):
                     .with_context(default_sale_order_id=so.id) \
                     .for_xml_id('event_sale', 'action_sale_order_event_registration')
         return res
+    
+    def action_cancel(self):
+        self.mapped('order_line')._cancel_associated_registrations()
+        return super(SaleOrder, self).action_cancel()
 
     def unlink(self):
         self.mapped('order_line')._unlink_associated_registrations()
-        super(SaleOrder, self).unlink()
+        return super(SaleOrder, self).unlink()
 
 
 class SaleOrderLine(models.Model):
@@ -90,6 +94,9 @@ class SaleOrderLine(models.Model):
     def unlink(self):
         self._unlink_associated_registrations()
         super(SaleOrderLine, self).unlink()
+
+    def _cancel_associated_registrations(self):
+        self.env['event.registration'].search([('sale_order_line_id', 'in', self.ids)]).button_reg_cancel()
 
     def _unlink_associated_registrations(self):
         self.env['event.registration'].search([('sale_order_line_id', 'in', self.ids)]).unlink()

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -145,3 +145,13 @@ class EventSaleTest(TransactionCase):
         self.assertEqual(event.seats_expected, 1)
         self.sale_order.order_line.unlink()
         self.assertEqual(event.seats_expected, 0)
+        
+    @users('user_salesman')
+    def test_cancel_so(self):
+        """ This test ensures that when canceling a sale order, if the latter is linked to an event registration,
+        the number of expected seats will be correctly updated """
+        event = self.env['event.event'].browse(self.event.ids)
+        self.register_person.action_make_registration()
+        self.assertEqual(event.seats_expected, 1)
+        self.sale_order.action_cancel()
+        self.assertEqual(event.seats_expected, 0)


### PR DESCRIPTION
When creatig a sale order with an event registration,
the expected attendees was well computed on confirmation, but not
on sale order cancel.

opw-2576790

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
