### PR TITLE
[FIX] hr_holidays: prevent converting date in user's utc

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -164,7 +164,7 @@
                     attrs="{'invisible': [('allocation_type', '=', 'regular')]}"/>
                 <div attrs="{'invisible': [('allocation_type', '=', 'regular')]}">
                     <div class="o_row">
-                        Run until <field name="date_to" string="Run Until" help="If no value set, runs indefinitely" class="ml-2" widget="date"/>
+                        Run until <field name="date_to" string="Run Until" help="If no value set, runs indefinitely" class="ml-2"/>
                     </div>
                     <div class="o_row">
                         <span>Add</span>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to your computer's date settings
- Change region, e.g: (US or choose a region with a negative UTC)
- Go to the preferences settings in odoo > Change the timezone to US too
- Go to Time Off app > Manager > Allocations > Create a new one
    - Allocation type : "Accrual Allocation"
    - Set the end date to, e.g: "04/07/2021"
    - save

Problem:
The end date moves back by one day.
The field `" date_to "` is of `”datetime”` type, so we use in the view `"widget="date"`
Therefore, the user can only choose the date. We save the time in the database at" 00: 00:00 ".
But as we use in the view `"widget="date"`, after saving the record,
the datetime will be converted to a date, based on the user's UTC.

For example, in our case:
in database, date_to = "2021-07-04 00:00:00"
user UTC = "UTC-6"
result = "2021-07-04 00:00:00" - 06:00:00 → "2021-07-03 00:18:00"

Solution:
Add two date type fields to use them in the view and convert them after saving the record
without applying the user's UTC to datetime in an inverse function

opw-2607082


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
