### PR TITLE
[FIX] purchase_stock: reuse cache on recomputing fields

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -10,6 +10,8 @@ class StockPicking(models.Model):
 
     purchase_id = fields.Many2one('purchase.order', related='move_lines.purchase_line_id.order_id',
         string="Purchase Orders", readonly=True)
+    # Technical field to activate cache mechanism on aggregating computed fields to recompute
+    purchase_ids = fields.Many2many('purchase.order', string="Inversed field for purchase.order")
 
 
 class StockMove(models.Model):


### PR DESCRIPTION
Adding this non-stored Many2many fields allows ORM to use cache in
`_modified_triggers` and skip costly search:

```
records |= model.search([(key.name, 'in', real_records.ids)], order='id')
```
---

opw-2507143
similar update in accounting: #73884

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
