### PR TITLE
[FIX] mail: clear email attachments when switching templates

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -405,6 +405,8 @@ class MailComposer(models.TransientModel):
                 attachment_ids.append(Attachment.create(data_attach).id)
             if values.get('attachment_ids', []) or attachment_ids:
                 values['attachment_ids'] = [(5,)] + values.get('attachment_ids', []) + attachment_ids
+            else:
+                values['attachment_ids'] = [(5, 0, 0)]
         else:
             default_values = self.with_context(default_composition_mode=composition_mode, default_model=model, default_res_id=res_id).default_get(['composition_mode', 'model', 'res_id', 'parent_id', 'partner_ids', 'subject', 'body', 'email_from', 'reply_to', 'attachment_ids', 'mail_server_id'])
             values = dict((key, default_values[key]) for key in ['subject', 'body', 'partner_ids', 'email_from', 'reply_to', 'attachment_ids', 'mail_server_id'] if key in default_values)

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -331,13 +331,18 @@ class TestMailTemplate(BaseFunctionalTest, MockEmails, TestRecipients):
             'attachment_ids': False,
             'report_template': report_template.id,
         })
+        template_3 = self.email_template.copy({
+            'attachment_ids': False,
+            'report_template': False,
+        })
 
-        onchange_templates = [template_1, template_2, template_1, False]
+        onchange_templates = [template_1, template_2, template_1, template_3, template_1, False]
         attachments_onchange = [composer.attachment_ids]
         # template_1 has two static attachments and one dynamically generated report,
-        # template_2 only has the report, so we should get 3, 1, 3 attachments
+        # template_2 only has the report,
+        # template_3 has no attachments, so we should get 3, 1, 3, 0, 3 attachments
         # and when there is no template, no attachments
-        attachment_numbers = [0, 3, 1, 3, 0]
+        attachment_numbers = [0, 3, 1, 3, 0, 3, 0]
 
         with self.env.do_in_onchange():
             for template in onchange_templates:


### PR DESCRIPTION
Step to follow

Compose an email
Select a template with an attachment
Switch templates to one without an attachment
The old attachment stays

Cause of the issue

Attachments were only cleared when switching to a template with attachments

opw-2583969