### PR TITLE
[IMP][13.0] website_slides: Remove duplicated warning message when leaving paid courses

### DIFF
--- a/addons/website_sale_slides/static/src/xml/website_slides_unsubscribe.xml
+++ b/addons/website_sale_slides/static/src/xml/website_slides_unsubscribe.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-extend="slides.course.unsubscribe.modal.leave">
-        <t t-jquery="p" t-operation="after">
+        <t t-jquery="p:last" t-operation="after">
             <t t-if="widget.enroll === 'payment'">
                 <p class="alert alert-warning">
                     <i class="fa fa-exclamation-triangle fa-3x float-left mr-3"></i>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When leaving paid courses this warning message  will be displayed two times after each `<p> `tag.

![image](https://user-images.githubusercontent.com/48803268/128724439-7668af2d-5e1f-4b93-a388-b3c5b2fe203c.png)
      
Current behavior before PR:
Warning  message displayed two times.

Desired behavior after PR is merged:
Display warning message only once.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
