### PR TITLE
[REM] payment_ogone: remove unused Flexcheckout views

### DIFF
--- a/addons/payment_ogone/views/payment_ogone_templates.xml
+++ b/addons/payment_ogone/views/payment_ogone_templates.xml
@@ -26,25 +26,4 @@
         </form>
     </template>
 
-    <template id="redirect_form_validation">
-        <form t-att-action="api_url" method="post">
-            <input type="hidden" name="ACCOUNT.PSPID" t-att-value="ACCOUNT_PSPID"/>
-            <input type="hidden" name="ALIAS.ALIASID" t-att-value="ALIAS_ALIASID"/>
-            <input type="hidden" name="ALIAS.ORDERID" t-att-value="ALIAS_ORDERID"/>
-            <input type="hidden" name="ALIAS.STOREPERMANENTLY" t-att-value="ALIAS_STOREPERMANENTLY"/>
-            <input type="hidden" name="CARD.PAYMENTMETHOD" t-att-value="CARD_PAYMENTMETHOD"/>
-            <input type="hidden" name="LAYOUT.LANGUAGE" t-att-value="LAYOUT_LANGUAGE"/>
-            <input type="hidden" name="PARAMETERS.ACCEPTURL" t-att-value="PARAMETERS_ACCEPTURL"/>
-            <input type="hidden" name="PARAMETERS.EXCEPTIONURL" t-att-value="PARAMETERS_EXCEPTIONURL"/>
-            <input type="hidden" name="SHASIGNATURE.SHASIGN" t-att-value="SHASIGNATURE_SHASIGN"/>
-        </form>
-    </template>
-
-    <template id="directlink_feedback" name="Payment processing page">
-        <t t-call="web.layout">
-            <t t-call-assets="web.assets_common"/>
-            <t t-out="redirect_html"/>
-        </t>
-    </template>
-
 </odoo>


### PR DESCRIPTION
Commit 3d90d02 removed the integration with the Flexcheckout API but the
dedicated views were left behind, as it was not possible to remove them
in stable version.

This commit removes the unused views in master.

Upgrade PR: https://github.com/odoo/upgrade/pull/2699

task-2494916
