### PR TITLE
[FIX] delivery: correctly access m2m during onchange

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -125,11 +125,11 @@ class DeliveryCarrier(models.Model):
 
     @api.onchange('state_ids')
     def onchange_states(self):
-        self.country_ids = [(6, 0, self.country_ids.ids + self.state_ids.mapped('country_id.id'))]
+        self.country_ids = [(6, 0, self.country_ids.ids + self.state_ids._origin.mapped('country_id.id'))]
 
     @api.onchange('country_ids')
     def onchange_countries(self):
-        self.state_ids = [(6, 0, self.state_ids.filtered(lambda state: state.id in self.country_ids.mapped('state_ids').ids).ids)]
+        self.state_ids = [(6, 0, self.state_ids._origin.filtered(lambda state: state.id in self.country_ids._origin.mapped('state_ids').ids).ids)]
 
     # -------------------------- #
     # API for external providers #


### PR DESCRIPTION
Before this commit, Fields `state_ids` and 'country_ids' was not accessed correctly,
as m2m will return`new` ids during onchange.

With this commit, we are accessing fields correctly.

Fixes #74200

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
