### PR TITLE
[FIX] sale: pass invoice origin as string instead of list

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -606,7 +606,7 @@ class SaleOrder(models.Model):
                 'default_partner_id': self.partner_id.id,
                 'default_partner_shipping_id': self.partner_shipping_id.id,
                 'default_invoice_payment_term_id': self.payment_term_id.id or self.partner_id.property_payment_term_id.id or self.env['account.move'].default_get(['invoice_payment_term_id']).get('invoice_payment_term_id'),
-                'default_invoice_origin': self.mapped('name'),
+                'default_invoice_origin': self.name,
                 'default_user_id': self.user_id.id,
             })
         action['context'] = context


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The commit https://github.com/odoo/odoo/commit/f5596bb8fe6998083194dd54027ae6adff802f14 ensured that the context of the action_view_invoice from SO was only passed when there was a single SO. However, for some reason it was wrongly changed to pass the invoice origin as a mapped of self on the order name, causing the invoice origin to appear as a list.

![image](https://user-images.githubusercontent.com/71635103/127811786-4f8e461d-2297-43d1-9488-d9b354b17b49.png)

Current behavior before PR:
Currently, the default invoice origin for the sale action_view_invoice
is being passed as a list by using the mapped method. This causes that,
when an invoice is created from this view, the origin is set to ['SOXXXXX'].

Desired behavior after PR is merged:
With the fix, we properly pass the origin as a string so the origin is set
as SOXXXXX, which should be the expected. Notice also that the context is
only passed when dealing with a single SO.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
