### PR TITLE
[IMP] delivery: Hook allowing to retrieve dict to be used in _get_price_from_picking() function.

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -89,10 +89,21 @@ class ProviderGrid(models.Model):
 
         return self._get_price_from_picking(total, weight, volume, quantity)
 
+    def _get_price_dict(self, total, weight, volume, quantity):
+        '''Hook allowing to retrieve dict to be used in _get_price_from_picking() function.
+        Hook to be overridden when we need to add some field to product and use it in variable factor from price rules. '''
+        return {
+            'price': total,
+            'volume': volume,
+            'weight': weight,
+            'wv': volume * weight,
+            'quantity': quantity
+        }
+
     def _get_price_from_picking(self, total, weight, volume, quantity):
         price = 0.0
         criteria_found = False
-        price_dict = {'price': total, 'volume': volume, 'weight': weight, 'wv': volume * weight, 'quantity': quantity}
+        price_dict = self._get_price_dict(total, weight, volume, quantity)
         if self.free_over and total >= self.amount:
             return 0
         for line in self.price_rule_ids:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
Hook allowing to retrieve dict to be used in `_get_price_from_picking()` function.
Hook to be overridden when we need to add some field to product and use it in variable factor from price rules.

**Desired behavior after PR is merged**:
Is possible to override `price_dict` to add some field and used in `_get_price_from_picking()` function.

**Impacted versions**:
- 13.0
- 14.0

cc @Tecnativa TT30670

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
