### PR TITLE
[FIX] web: make polling restart correctly when server is killed

### DIFF
--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -116,7 +116,7 @@ let connectionLostNotifRemove = null;
  * @param {Error} originalError
  * @returns {boolean}
  */
-function lostConnectionHandler(env, error, originalError) {
+export function lostConnectionHandler(env, error, originalError) {
     if (!(error instanceof UncaughtPromiseError)) {
         return false;
     }

--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -6,6 +6,7 @@ import {
     ConnectionAbortedError,
     RPCError,
     makeErrorFromResponse,
+    ConnectionLostError,
 } from "../core/network/rpc_service";
 import { ErrorDialog } from "../core/errors/error_dialogs";
 
@@ -151,7 +152,7 @@ export function mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv) {
                 jsonrpc.abort();
             };
             jsonrpc.then(resolve).catch((reason) => {
-                if (reason instanceof RPCError) {
+                if (reason instanceof RPCError || reason instanceof ConnectionLostError) {
                     // we do not reject an error here because we want to pass through
                     // the legacy guardedCatch code
                     reject({ message: reason, event: $.Event(), legacy: true });


### PR DESCRIPTION
Previously, when killing the server, the longpolling bus stopped but
didn't start polling again after a few seconds, this was caused by the
fact that ConnectionLostError wasn't treated like a legacy error and
remapped to an object with a message, meaning it didn't trigger
guardedCatch callbacks.

Since ConnectionLostErrors should be handled much the same way as
RPCError when interacting with legacy code this commit simply adds
ConnectionLostError in the same places we already have RPCError during
error handling of legacy errors.
