### PR TITLE
[FIX] point_of_sale : enable translated terms

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -739,6 +739,13 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js:0
+#, python-format
+msgid "Change Customer"
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
 #: code:addons/point_of_sale/static/src/xml/Popups/EditListPopup.xml:0
 #: code:addons/point_of_sale/static/src/xml/Popups/ProductConfiguratorPopup.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenElectronicPayment.xml:0

--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -84,11 +84,11 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
          */
         get nextButton() {
             if (!this.props.client) {
-                return { command: 'set', text: 'Set Customer' };
+                return { command: 'set', text: this.env._t('Set Customer') };
             } else if (this.props.client && this.props.client === this.state.selectedClient) {
-                return { command: 'deselect', text: 'Deselect Customer' };
+                return { command: 'deselect', text: this.env._t('Deselect Customer') };
             } else {
-                return { command: 'set', text: 'Change Customer' };
+                return { command: 'set', text: this.env._t('Change Customer') };
             }
         }
 


### PR DESCRIPTION
Step to reproduce:

- Change the language to any language other than english
- Go to PoS and open a session
- Click on "Client" and select a client
- The button 'Select Customer', 'Deselect Customer' and 'Change Customer'
  are not translated.

Cause of the issue

- The term 'Change Customer' was missing in pos.pot
- Translation was not enabled in JS file

This fix complete the one "done" in commit 00e177b

opw-2596436