### PR TITLE
[FIX] account: Block archival of journals with auto post entries

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13394,6 +13394,18 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_journal.py:0
+#, python-format
+msgid ""
+"You can not archive a journal containing draft journal entries.\n"
+"\n"
+"To proceed:\n"
+"1/ click on the top-right button 'Journal Entries' from this journal form\n"
+"2/ then filter on 'Draft' entries\n"
+"3/ select them all and post or delete them through the action menu"
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_payment_term.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -323,6 +323,21 @@ class AccountJournal(models.Model):
             if journal.type in ('sale', 'purchase') and journal.default_account_id.user_type_id.type in ('receivable', 'payable'):
                 raise ValidationError(_("The type of the journal's default credit/debit account shouldn't be 'receivable' or 'payable'."))
 
+    @api.constrains('active')
+    def _check_auto_post_draft_entries(self):
+        for journal in self:
+            pending_moves = self.env['account.move'].search([
+                ('journal_id', '=', journal.id),
+                ('state', '=', 'draft')
+            ], limit=1)
+
+            if pending_moves:
+                raise ValidationError(_("You can not archive a journal containing draft journal entries.\n\n"
+                                        "To proceed:\n"
+                                        "1/ click on the top-right button 'Journal Entries' from this journal form\n"
+                                        "2/ then filter on 'Draft' entries\n"
+                                        "3/ select them all and post or delete them through the action menu"))
+
     @api.onchange('type')
     def _onchange_type(self):
         self.refund_sequence = self.type in ('sale', 'purchase')


### PR DESCRIPTION
At the moment, it is possible to archive a journal for which some
entries are still waiting to be auto-posted in the future.
Add a constrains to avoid make sure that it is no longer possible,
since it shouldn't.

Task id #2585454

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
