### PR TITLE
[FIX] l10n_it_edi: relax constraint when you put an empty string

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -22,11 +22,11 @@ class ResPartner(models.Model):
 
     _sql_constraints = [
         ('l10n_it_codice_fiscale',
-            "CHECK(l10n_it_codice_fiscale IS NULL OR LENGTH(l10n_it_codice_fiscale) >= 11)",
+            "CHECK(l10n_it_codice_fiscale IS NULL OR l10n_it_codice_fiscale = '' OR LENGTH(l10n_it_codice_fiscale) >= 11)",
             "Codice fiscale must have between 11 and 16 characters."),
 
         ('l10n_it_pa_index',
-            "CHECK(l10n_it_pa_index IS NULL OR LENGTH(l10n_it_pa_index) >= 6)",
+            "CHECK(l10n_it_pa_index IS NULL OR l10n_it_pa_index = '' OR LENGTH(l10n_it_pa_index) >= 6)",
             "PA index must have between 6 and 7 characters."),
     ]
 


### PR DESCRIPTION
Even in the interface, when we empty a string, the value
in the database is '' and not NULL.  So, we should let the user
put the field to '' again.  (as it is not required)

This will require un update, but otherwise, it just relaxes
the constraint.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
