### PR TITLE
[FIX] payment_stripe: consistency fixes

### DIFF
--- a/addons/payment_stripe/models/payment_acquirer.py
+++ b/addons/payment_stripe/models/payment_acquirer.py
@@ -27,18 +27,6 @@ class PaymentAcquirer(models.Model):
              "authenticate the messages sent from Stripe to Odoo.",
         groups='base.group_system')
 
-    def _get_validation_amount(self):
-        """ Override of payment to return the amount for Stripe validation operations.
-
-        :return: The validation amount
-        :rtype: float
-        """
-        res = super()._get_validation_amount()
-        if self.provider != 'stripe':
-            return res
-
-        return 1.0
-
     def _stripe_make_request(self, endpoint, payload=None, method='POST', offline=False):
         """ Make a request to Stripe API at the specified endpoint.
 

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -116,7 +116,8 @@ class PaymentTransaction(models.Model):
         else:  # 'validation'
             # {CHECKOUT_SESSION_ID} is a template filled by Stripe when the Session is created
             return_url = f'{urls.url_join(base_url, StripeController._validation_return_url)}' \
-                         f'?reference={urls.url_quote_plus(self.reference)}&checkout_session_id={{CHECKOUT_SESSION_ID}}'
+                         f'?reference={urls.url_quote_plus(self.reference)}' \
+                         f'&checkout_session_id={{CHECKOUT_SESSION_ID}}'
             checkout_session = self.acquirer_id._stripe_make_request(
                 'checkout/sessions', payload={
                     **common_session_values,

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -27,6 +27,3 @@ class StripeTest(StripeCommon):
 
         self.assertEqual(processing_values['publishable_key'], self.stripe.stripe_publishable_key)
         self.assertEqual(processing_values['session_id'], dummy_session_id)
-
-    def test_validation_amount(self):
-        self.assertEqual(self.stripe._get_validation_amount(), 1.0)


### PR DESCRIPTION
**[FIX] payment_stripe: always answer with empty string to webhook events**

Prior to this commit, not all operations of the Stripe webhook were
encapsulated in a try/except clause. If a `ValidationError` was raised
outside of that clause, it was returned as-is to Stripe.

This commit encapsulates the whole webhook event processing with a
try/except clause to make sure that only an empty string is returned to
Stripe, hence properly acknowledging events.

**[FIX] payment_stripe: never assign one currency unit to validation txs**

Before this commit, the payment function `_get_validation_amount` was
overridden by Stripe to specify a validation amount of one currency unit
while that amount was in fact never passed to Stripe in the validation
flow. The amount stored on the transaction was therefore incorrect.

This commits removes the override to let the default amount of 0 being
set on validation transactions.

--------
task-2612977