### PR TITLE
Fix classToStyle() when a node has two css attributes, where one is a prefix of the other

### DIFF
--- a/addons/web_editor/static/src/js/editor/transcoder.js
+++ b/addons/web_editor/static/src/js/editor/transcoder.js
@@ -338,7 +338,7 @@ function styleToClass($editable) {
         var css = getMatchedCSSRules(node);
         var style = '';
         _.each(css, function (v,k) {
-            if (!(new RegExp('(^|;)\s*' + k).test(style))) {
+            if (!(new RegExp('(^|;)\s*' + k + '\s*:').test(style))) {
                 style = k+':'+v+';'+style;
             }
         });

--- a/doc/cla/corporate/UWine.md
+++ b/doc/cla/corporate/UWine.md
@@ -1,0 +1,15 @@
+France, 2021-08-02
+
+U'Wine SAS agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Etienne Baratte etienne.baratte@uwine.fr https://github.com/uwine-fr
+
+List of contributors:
+
+Etienne Baratte etienne.baratte@uwine.fr https://github.com/uwine-fr


### PR DESCRIPTION
Description of the issue/feature this PR addresses (see issue #74455):

In the "Email Marketing" app, create a mailing with an HTML element and the appropriate css class, such as:

    <style>
        .cool_links {
            text-decoration-thickness: initial;
            text-decoration: none;
        }
    </style>
    <a href="#" class="cool_links">Click</a>

Current behavior before PR:

    <a href="#" class="cool_links" style="text-decoration-thickness: initial;">Click</a>

Desired behavior after PR is merged:

    <a href="#" class="cool_links" style="text-decoration-thickness: initial; text-decoration: none;">Click</a>






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
