### PR TITLE
[FIX] hr_expense: don't submit expense report on creation

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -330,7 +330,6 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
 
     def action_submit_expenses(self):
         sheet = self._create_sheet_from_expenses()
-        sheet.action_submit_sheet()
         return {
             'name': _('New Expense Report'),
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Steps to reproduce:

    - Install Expenses module
    - Go to Expenses (list view)
    - Select multiple expense in `To Submit` stage
    - Click on Action -> Create report

Issue:

    Report is directly in Submitted stage.

Cause:

    Submitting report on creation.

Solution:

    Do not sumbit report on creation.

opw-2586184