### PR TITLE
lighten pivot border color

### DIFF
--- a/addons/web/static/src/legacy/scss/pivot_view.scss
+++ b/addons/web/static/src/legacy/scss/pivot_view.scss
@@ -34,7 +34,7 @@
         }
 
         th, td {
-            border-color: gray('400');
+            border-color: #c9ccd2;
             border-width: 0 $border-width $border-width 0;
         }
 


### PR DESCRIPTION
PURPOSE
The design overhaul that came with the new wowl framework increases contrast
across the odoo UI. The border of pivot cells is a bit too contrasted.
The purpose of this task is to simply lighten the pivot border color.

SPECIFICATION
Update the border color to the #c9ccd2

TASK 2611031



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
