### PR TITLE
[REF] point_of_sale: create template for receipt order lines

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -47,61 +47,7 @@
             <!-- Orderlines -->
 
             <div class="orderlines">
-                <t t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
-                    <t t-if="isSimple(line)">
-                        <div>
-                            <t t-esc="line.product_name_wrapped[0]" />
-                            <span t-esc="env.pos.format_currency_no_symbol(line.price_display)" class="price_display pos-receipt-right-align"/>
-                        </div>
-                        <WrappedProductNameLines line="line" />
-                    </t>
-                    <t t-else="">
-                        <div t-esc="line.product_name_wrapped[0]" />
-                        <WrappedProductNameLines line="line" />
-                        <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
-                            <div class="pos-receipt-left-padding">
-                                <t t-esc="env.pos.format_currency_no_symbol(line.price_lst)" />
-                                ->
-                                <t t-esc="env.pos.format_currency_no_symbol(line.price)" />
-                            </div>
-                        </t>
-                        <t t-elif="line.discount !== 0">
-                            <div class="pos-receipt-left-padding">
-                                <t t-if="env.pos.config.iface_tax_included === 'total'">
-                                    <t t-esc="env.pos.format_currency_no_symbol(line.price_with_tax_before_discount)"/>
-                                </t>
-                                <t t-else="">
-                                    <t t-esc="env.pos.format_currency_no_symbol(line.price)"/>
-                                </t>
-                            </div>
-                        </t>
-                        <t t-if="line.discount !== 0">
-                            <div class="pos-receipt-left-padding">
-                                Discount: <t t-esc="line.discount" />%
-                            </div>
-                        </t>
-                        <div class="pos-receipt-left-padding">
-                            <t t-esc="Math.round(line.quantity * Math.pow(10, env.pos.dp['Product Unit of Measure'])) / Math.pow(10, env.pos.dp['Product Unit of Measure'])"/>
-                            <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
-                            x
-                            <t t-esc="env.pos.format_currency_no_symbol(line.price_display_one)" />
-                            <span class="price_display pos-receipt-right-align">
-                                <t t-esc="env.pos.format_currency_no_symbol(line.price_display)" />
-                            </span>
-                        </div>
-                    </t>
-                    <t t-if="line.pack_lot_lines">
-                        <div class="pos-receipt-left-padding">
-                            <ul>
-                                <t t-foreach="line.pack_lot_lines" t-as="lot" t-key="lot.cid">
-                                    <li>
-                                        SN <t t-esc="lot.attributes['lot_name']"/>
-                                    </li>
-                                </t>
-                            </ul>
-                        </div>
-                    </t>
-                </t>
+                <t t-call="OrderLinesReceipt"/>
             </div>
 
             <!-- Subtotal -->
@@ -206,6 +152,63 @@
             </div>
 
         </div>
+    </t>
+    <t t-name="OrderLinesReceipt" owl="1">
+        <t t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
+            <t t-if="isSimple(line)">
+                <div>
+                    <t t-esc="line.product_name_wrapped[0]" />
+                    <span t-esc="env.pos.format_currency_no_symbol(line.price_display)" class="price_display pos-receipt-right-align"/>
+                </div>
+                <WrappedProductNameLines line="line" />
+            </t>
+            <t t-else="">
+                <div t-esc="line.product_name_wrapped[0]" />
+                <WrappedProductNameLines line="line" />
+                <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
+                    <div class="pos-receipt-left-padding">
+                        <t t-esc="env.pos.format_currency_no_symbol(line.price_lst)" />
+                        ->
+                        <t t-esc="env.pos.format_currency_no_symbol(line.price)" />
+                    </div>
+                </t>
+                <t t-elif="line.discount !== 0">
+                    <div class="pos-receipt-left-padding">
+                        <t t-if="env.pos.config.iface_tax_included === 'total'">
+                            <t t-esc="env.pos.format_currency_no_symbol(line.price_with_tax_before_discount)"/>
+                        </t>
+                        <t t-else="">
+                            <t t-esc="env.pos.format_currency_no_symbol(line.price)"/>
+                        </t>
+                    </div>
+                </t>
+                <t t-if="line.discount !== 0">
+                    <div class="pos-receipt-left-padding">
+                        Discount: <t t-esc="line.discount" />%
+                    </div>
+                </t>
+                <div class="pos-receipt-left-padding">
+                    <t t-esc="Math.round(line.quantity * Math.pow(10, env.pos.dp['Product Unit of Measure'])) / Math.pow(10, env.pos.dp['Product Unit of Measure'])"/>
+                    <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+                    x
+                    <t t-esc="env.pos.format_currency_no_symbol(line.price_display_one)" />
+                    <span class="price_display pos-receipt-right-align">
+                        <t t-esc="env.pos.format_currency_no_symbol(line.price_display)" />
+                    </span>
+                </div>
+            </t>
+            <t t-if="line.pack_lot_lines">
+                <div class="pos-receipt-left-padding">
+                    <ul>
+                        <t t-foreach="line.pack_lot_lines" t-as="lot" t-key="lot.cid">
+                            <li>
+                                SN <t t-esc="lot.attributes['lot_name']"/>
+                            </li>
+                        </t>
+                    </ul>
+                </div>
+            </t>
+        </t>
     </t>
 
 </templates>


### PR DESCRIPTION
We are getting the order lines out of the main receipt template, to be
able to override it the sweden localissation module, and so having lines
separated depending on the type of products.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
