### PR TITLE
[IMP] payment, website_sale: Connection loss or no redirection issue

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -167,6 +167,10 @@ odoo.define('payment.payment_form', function (require) {
                             'callback_method': self.options.callbackMethod,
                             'order_id': self.options.orderId,
                         }).then(function (result) {
+                            if(result.redirect){
+                                window.location = result.redirect;
+                                return;
+                            }
                             if (result) {
                                 // if the server sent us the html form, we create a form element
                                 var newForm = document.createElement('form');

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -893,6 +893,9 @@ class WebsiteSale(ProductConfiguratorController):
 
         assert order.partner_id.id != request.website.partner_id.id
 
+        if order.transaction_ids.filtered(lambda t: t.state == 'done' and not t.is_processed):
+            return {'redirect': '/payment/process'}
+
         # Create transaction
         vals = {'acquirer_id': acquirer_id,
                 'return_url': '/shop/payment/validate'}


### PR DESCRIPTION
In some cases with dsp2 authentication, some payment intents are not well redirected to odoo.
So after paying from his bank, the customer had the message saying: "the operation hasn't been finished
due to connection issue but the payment was released.

To avoid the customer makes a new payment intent for an already paid order.
When clicking on 'Pay now' button, Odoo will check that no transaction is in state 'done'.
Otherwise Odoo will redirect the customer to /payment/process

opw:2451463