### PR TITLE
[FIX] l10n_in_purchase_stock: GST Treatment on purchase_order with reordering rules

### DIFF
--- a/addons/l10n_in_purchase/models/purchase_order.py
+++ b/addons/l10n_in_purchase/models/purchase_order.py
@@ -18,7 +18,7 @@ class PurchaseOrder(models.Model):
             ('overseas', 'Overseas'),
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export')
-        ], string="GST Treatment", states=Purchase.READONLY_STATES)
+        ], string="GST Treatment", states=Purchase.READONLY_STATES, compute="_compute_l10n_in_gst_treatment", store=True)
     l10n_in_company_country_code = fields.Char(related='company_id.country_id.code', string="Country code")
 
     @api.onchange('company_id')
@@ -29,8 +29,15 @@ class PurchaseOrder(models.Model):
             if journal:
                 self.l10n_in_journal_id = journal.id
 
-    @api.onchange('partner_id', 'company_id')
-    def onchange_partner_id(self):
-        if self.l10n_in_company_country_code == 'IN':
-            self.l10n_in_gst_treatment = self.partner_id.l10n_in_gst_treatment
-        return super().onchange_partner_id()
+    @api.depends('partner_id')
+    def _compute_l10n_in_gst_treatment(self):
+        for order in self:
+            # set default value as False so CacheMiss error never occurs for this field.
+            order.l10n_in_gst_treatment = False
+            if order.l10n_in_company_country_code == 'IN':
+                l10n_in_gst_treatment = order.partner_id.l10n_in_gst_treatment
+                if not l10n_in_gst_treatment and order.partner_id.country_id and order.partner_id.country_id.code != 'IN':
+                    l10n_in_gst_treatment = 'overseas'
+                if not l10n_in_gst_treatment:
+                    l10n_in_gst_treatment = order.partner_id.vat and 'regular' or 'consumer'
+                order.l10n_in_gst_treatment = l10n_in_gst_treatment


### PR DESCRIPTION
When a purchase order is generated via the scheduler with a reordering rule, the gst_treatment is not retrieved

opw-2540090