### PR TITLE
[IMP] base: improve settings no content helper

### DIFF
--- a/addons/web/static/src/legacy/scss/base_settings.scss
+++ b/addons/web/static/src/legacy/scss/base_settings.scss
@@ -140,13 +140,6 @@
                 }
             }
 
-            .notFound {
-                color : $text-muted;
-                text-align: center;
-                font-size: 25px;
-                padding-top: 50px;
-            }
-
             .highlighter {
                 background: yellow;
             }

--- a/odoo/addons/base/views/res_config_settings_views.xml
+++ b/odoo/addons/base/views/res_config_settings_views.xml
@@ -24,7 +24,17 @@
                     <div class="o_setting_container">
                         <div class="settings_tab"/>
                         <div class="settings">
-                            <div class="notFound o_hidden">No Record Found</div>
+                            <div class="notFound o_hidden">
+                                <div class="o_view_nocontent">
+                                    <div class="o_nocontent_help">
+                                        <p class="o_view_nocontent_empty_folder">
+                                            No setting found
+                                        </p><p>
+                                            Try searching for another keyword
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
PURPOSE

Currently, empty screen of the settings is not very sexy
without helper and decoration. it return only `no record found` 
message when the search for a setting does not return anything.

SPECIFICATION

after this PR replace the `No record found` message by
an actual content helper with title `No setting found` and
description `Try searching for another keyword`.

TaskID: 2588387

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
