### PR TITLE
[IMP] website_sale: filter products by price with custom range input

### DIFF
--- a/addons/website/static/lib/multirange/LICENSE
+++ b/addons/website/static/lib/multirange/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Lea Verou
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/addons/website/static/lib/multirange/multirange_custom.js
+++ b/addons/website/static/lib/multirange/multirange_custom.js
@@ -1,0 +1,345 @@
+/**
+ * This code has been more that widely inspired by the multirange library
+ * which can be found on https://github.com/LeaVerou/multirange.
+ *
+ * The license file can be found in the same folder as this file.
+ */
+
+odoo.define('website_sale.multirange', function () {
+'use strict';
+
+/**
+ * The multirange library will display the two values as one range input with
+ * two cursors linked by a background. This is to be used with Bootstrap
+ * custom-range inputs.
+ *
+ * There is 2 number inputs on the right and left of the multirange to
+ * display and allow quick and precise value modifications. They are
+ * initialized with the same value provided to the input (min, max, step).
+ *
+ * There is 2 events that are added to the input:
+ * - oldRangeValue: Triggered when the user clicks on a cursor or on focus
+ *                  of the right or left number input.
+ * - newRangeValue: Triggered when the user release a cursor or on focus
+ *                  out of the right or left number input.
+ *
+ * The options available for the multirange are :
+ * - On range input or as multirange method options:
+ *     - min: minimal value of the range. Default: 0.
+ *     - max: maximal value of the range. Default: 100.
+ *     - step: precision of the range. Default: 1.
+ *     - currency: symbol preceding the displayed values. Default: Empty.
+ *     - currencyPosition: currency before/after value. Default: "after".
+ *     - value: the current value of the range. Default: "0,100".
+ *
+ * - As multirange method options only:
+ *     - displayCounterInput: if we display the value. Default: true.
+ *
+ * Initialization of a multiple range input can be done in two ways:
+ *
+ * Having the inputs with the options as properties and the multiple
+ * property set will let the library initialize it just after DOM loaded.
+ *
+ * <input type="range" multiple="multiple" class="custom-range
+ * range-with-input" min=2 max=10 step=0.5 data-currency="€"
+ * data-currency-position="before" value="4,8"/>
+ *
+ * Providing a HTMLElement and an Object with the desired options.
+ *
+ * <input id="multi" type="range" class="custom-range"/>
+ *
+ * multirange(document.querySelector('#multi'), {
+ *     min: 2,
+ *     max: 10,
+ *     step: 0.5,
+ *     currency: "€",
+ *     currencyPosition: "before",
+ *     value: "4,8"
+ *     rangeWithInput: true,
+ * });
+ */
+
+const HTMLInputElement = window.HTMLInputElement;
+const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
+
+class Multirange {
+    constructor(input, options = {}) {
+        const self = this;
+
+        /* Set default and optionnal values */
+        this.input = input;
+        this.rangeWithInput = options.rangeWithInput === true || this.input.classList.contains('range-with-input');
+        const value = options.value || this.input.getAttribute("value");
+        const values = value === null ? [] : value.split(",");
+        this.input.min = this.min = options.min || this.input.min || 0;
+        this.input.max = this.max = options.max || this.input.max || 100;
+        this.input.step = this.step = options.step || this.input.step || 1;
+        this.currency = options.currency || this.input.dataset.currency || '';
+        this.currencyPosition = options.currencyPosition || this.input.dataset.currencyPosition || 'after';
+
+        /* Wrap the input and add its ghost */
+        this.rangeDiv = document.createElement("div");
+        this.rangeDiv.classList = "multirange-wrapper";
+        this.input.parentNode.insertBefore(this.rangeDiv, this.input.nextSibling);
+        this.rangeDiv.appendChild(this.input);
+        this.ghost = this.input.cloneNode();
+        this.rangeDiv.appendChild(this.ghost);
+
+        this.input.classList.add("multirange", "original");
+        this.ghost.classList.add("multirange", "ghost");
+        this.input.value = values[0] || this.min;
+        this.ghost.value = values[1] || this.max;
+
+        this.inputTipLocator = document.createElement("div");
+        this.inputTipLocator.classList = "tip-locator";
+        this.ghostTipLocator = document.createElement("div");
+        this.ghostTipLocator.classList = "tip-locator";
+        this.rangeDiv.insertBefore(this.ghostTipLocator, this.input.nextSibling);
+        this.rangeDiv.insertBefore(this.inputTipLocator, this.ghost.nextSibling);
+        this.leftCounter = document.createElement("span");
+        this.leftCounter.classList = "multirange-min";
+        this.rightCounter = document.createElement("span");
+        this.rightCounter.classList = "multirange-max";
+        this.tipLocatorOptions = {
+            container: this.rangeDiv,
+            html: true,
+        };
+        $(this.inputTipLocator).popover(Object.assign(
+            this.tipLocatorOptions,
+            {
+                placement: 'top',
+                content: this.leftCounter
+            })
+        );
+        $(this.ghostTipLocator).popover(Object.assign(
+            this.tipLocatorOptions,
+            {
+                placement: 'bottom',
+                content: this.rightCounter
+            })
+        );
+
+        $(this.inputTipLocator).add($(this.ghostTipLocator)).popover('show');
+        /* Add the counterInput */
+        if (this.rangeWithInput) {
+            this.leftInput = document.createElement("input");
+            this.leftInput.type = "number";
+            this.leftInput.style.display = "none";
+            this.leftInput.min = this.min;
+            this.leftInput.max = this.max;
+            this.leftInput.step = this.step;
+            this.rightInput = this.leftInput.cloneNode();
+
+            this.leftInput.classList = "multirange-min";
+            this.rightInput.classList = "multirange-max";
+
+            this.leftCounter.parentNode.appendChild(this.leftInput);
+            this.rightCounter.parentNode.appendChild(this.rightInput);
+        }
+
+        /* Define new properties on range input to link it with ghost, especially for Safari compatibility*/
+        Object.defineProperty(this.input, "originalValue", descriptor.get ? descriptor : {
+            get: function () {
+                return this.value;
+            },
+            set: function (v) {
+                this.value = v;
+            }
+        });
+
+        Object.defineProperties(this.input, {
+            valueLow: {
+                get: function () {
+                    return Math.min(this.originalValue, self.ghost.value);
+                },
+                set: function (v) {
+                    this.originalValue = v;
+                },
+                enumerable: true
+            },
+            valueHigh: {
+                get: function () {
+                    return Math.max(this.originalValue, self.ghost.value);
+                },
+                set: function (v) {
+                    self.ghost.value = v;
+                },
+                enumerable: true
+            }
+        });
+
+        if (descriptor.get) {
+            Object.defineProperty(this.input, "value", {
+                get: function () {
+                    return this.valueLow + "," + this.valueHigh;
+                },
+                set: function (v) {
+                    const values = v.split(",");
+                    this.valueLow = values[0];
+                    this.valueHigh = values[1];
+                    this.update();
+                },
+                enumerable: true
+            });
+        }
+
+        if (typeof this.input.oninput === "function") {
+            this.ghost.oninput = this.input.oninput.bind(this.input);
+        }
+
+        this.input.addEventListener("input", this.update.bind(this));
+        this.ghost.addEventListener("input", this.update.bind(this));
+
+        this.input.addEventListener("touchstart", this.saveOldValues.bind(this));
+        this.ghost.addEventListener("touchstart", this.saveOldValues.bind(this));
+        this.input.addEventListener("mousedown", this.saveOldValues.bind(this));
+        this.ghost.addEventListener("mousedown", this.saveOldValues.bind(this));
+
+        this.input.addEventListener("touchend", this.dispatchNewValueEvent.bind(this));
+        this.ghost.addEventListener("touchend", this.dispatchNewValueEvent.bind(this));
+        this.input.addEventListener("mouseup", this.dispatchNewValueEvent.bind(this));
+        this.ghost.addEventListener("mouseup", this.dispatchNewValueEvent.bind(this));
+
+        if (this.rangeWithInput) {
+            this.leftCounter.addEventListener("click", this.counterInputSwitch.bind(this));
+            this.rightCounter.addEventListener("click", this.counterInputSwitch.bind(this));
+
+            this.leftInput.addEventListener("blur", this.counterInputSwitch.bind(this));
+            this.rightInput.addEventListener("blur", this.counterInputSwitch.bind(this));
+
+            this.leftInput.addEventListener("keypress", this.elementBlurOnEnter.bind(this));
+            this.rightInput.addEventListener("keypress", this.elementBlurOnEnter.bind(this));
+
+            this.leftInput.addEventListener("focus", this.selectAllFocus.bind(this));
+            this.rightInput.addEventListener("focus", this.selectAllFocus.bind(this));
+        }
+        this.update();
+        $(this.rangeDiv).addClass('visible');
+
+    }
+
+    update() {
+        const low = 100 * (this.input.valueLow - this.min) / (this.max - this.min);
+        const high = 100 * (this.input.valueHigh - this.min) / (this.max - this.min);
+        const tipOffsetLow = 8 - (low * 0.15);
+        const tipOffsetHigh = 8 - (high * 0.15);
+        this.rangeDiv.style.setProperty("--low", low + '%');
+        this.rangeDiv.style.setProperty("--high", high + '%');
+        $(this.inputTipLocator).css({
+            'left': `calc(${low}% + (${tipOffsetLow}px))`,
+            'top': '3px'
+        });
+        $(this.ghostTipLocator).css({
+            'left': `calc(${high}% + (${tipOffsetHigh}px))`,
+            'top': '18px'
+        });
+        $(this.inputTipLocator).add($(this.ghostTipLocator)).popover('update');
+        this.counterInputUpdate();
+    }
+
+    counterInputUpdate() {
+        if (this.rangeWithInput) {
+            this.leftCounter.innerText = this.formatNumber(this.input.valueLow);
+            this.rightCounter.innerText = this.formatNumber(this.input.valueHigh);
+            this.leftInput.value = this.input.valueLow;
+            this.rightInput.value = this.input.valueHigh;
+        }
+    }
+
+    counterInputSwitch(ev) {
+        let counter = this.rightCounter;
+        let input = this.rightInput;
+        if (ev.currentTarget.classList.contains('multirange-min')) {
+            counter = this.leftCounter;
+            input = this.leftInput;
+        }
+        if (counter.style.display === "none") {
+            this.input.valueLow = this.leftInput.value;
+            this.input.valueHigh = this.rightInput.value;
+            this.dispatchNewValueEvent();
+            this.update();
+            counter.style.display = "";
+            input.style.display = "none";
+        } else {
+            counter.style.display = "none";
+            input.style.display = "";
+            this.saveOldValues();
+            // Hack because firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1057858
+            window.setTimeout(function () {
+                input.focus();
+            }, 1);
+        }
+    }
+
+    elementBlurOnEnter(ev) {
+        if (ev.key === "Enter") {
+            ev.currentTarget.blur();
+        }
+    }
+
+    selectAllFocus(ev) {
+        ev.currentTarget.select();
+    }
+
+    dispatchNewValueEvent() {
+        if (this._previousMaxPrice !== this.input.valueHigh || this._previousMinPrice !== this.input.valueLow) {
+            this.input.dispatchEvent(new CustomEvent("newRangeValue", {
+                bubbles: true,
+            }));
+        }
+    }
+
+    saveOldValues() {
+        this._previousMinPrice = this.input.valueLow;
+        this._previousMaxPrice = this.input.valueHigh;
+    }
+
+    formatNumber(number) {
+        number = String(number).split('.');
+        if (number[1] && number[1].length === 1) {
+            number[1] += '0';
+        }
+        let formatedNumber = number[0].replace(/(?=(?:\d{3})+$)(?!\b)/g, ',') + (number[1] ? '.' + number[1] : '.00');
+        if (this.currency.length) {
+            if (this.currencyPosition === 'after') {
+                formatedNumber = formatedNumber + ' ' + this.currency;
+            } else {
+                formatedNumber = this.currency + ' ' + formatedNumber;
+            }
+        }
+        return formatedNumber;
+    }
+}
+
+function multirange(input, options) {
+    if (input.classList.contains('multirange')) {
+        return;
+    }
+    new Multirange(input, options);
+}
+
+return {
+    Multirange: Multirange,
+    init: multirange,
+};
+});
+
+odoo.define('website_sale.multirange.instance', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+const multirange = require('website_sale.multirange');
+
+publicWidget.registry.WebsiteMultirangeInputs = publicWidget.Widget.extend({
+    selector: 'input[type=range][multiple]:not(.multirange)',
+
+    /**
+     * @override
+     */
+    start() {
+        return this._super.apply(this, arguments).then(() => {
+            multirange.init(this.el);
+        });
+    },
+});
+});

--- a/addons/website/static/lib/multirange/multirange_custom.scss
+++ b/addons/website/static/lib/multirange/multirange_custom.scss
@@ -1,0 +1,85 @@
+// This code has been more that widely inspired by the multirange library
+// which can be found on https://github.com/LeaVerou/multirange.
+// The license file can be found in the same folder as this file.
+
+ input[type="range"][multiple] {
+    pointer-events: none;
+    visibility: hidden;
+
+    &::-webkit-slider-thumb {
+        pointer-events: auto;
+    }
+
+    &::-moz-range-thumb {
+        pointer-events: auto;
+    }
+
+    &.reverse {
+        direction: rtl;
+    }
+
+    &.multirange {
+        width: 100%;
+        padding: 0;
+        margin: 0;
+        display: inline-block;
+        vertical-align: top;
+
+
+        &::-webkit-slider-thumb {
+            height: 16px;
+            width: 16px;
+        }
+
+        &.original {
+            position: absolute;
+
+            &::-webkit-slider-thumb {
+                position: relative;
+                z-index: 2;
+            }
+
+            &::-moz-range-thumb {
+                transform: scale(1); /* Firefox doesn't apply position it seems */
+                z-index: 1;
+            }
+        }
+
+        &::-moz-range-track {
+            border-color: transparent; /* needed to switch Firefox to "styleable" control */
+        }
+
+        &.ghost {
+            border-radius: 45%;
+            position: relative;
+            background: var(--track-background);
+            --track-background: linear-gradient(to right, transparent var(--low), #{theme-color('primary')} var(--low) var(--high), transparent 0) no-repeat 50% / 100% 35%;
+
+            &::-webkit-slider-runnable-track {
+                background: var(--track-background);
+            }
+
+            &::-moz-range-track {
+                background: var(--track-background);
+            }
+        }
+    }
+}
+
+.multirange-wrapper {
+    position: relative;
+    margin: 3rem 0;
+    visibility: hidden;
+
+    input[type="range"][multiple] {
+        visibility: initial;
+    }
+
+    [x-out-of-boundaries] {
+        display: none;
+    }
+}
+
+.tip-locator {
+    position: absolute;
+}

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -43,6 +43,7 @@
             'website_sale/static/src/scss/website_sale.scss',
             'website_sale/static/src/scss/website_mail.scss',
             'website_sale/static/src/scss/website_sale_frontend.scss',
+            'website/static/lib/multirange/multirange_custom.scss',
             'sale/static/src/scss/sale_portal.scss',
             'sale/static/src/scss/product_configurator.scss',
             'sale/static/src/js/variant_mixin.js',
@@ -53,6 +54,7 @@
             'website_sale/static/src/js/website_sale_validate.js',
             'website_sale/static/src/js/website_sale_recently_viewed.js',
             'website_sale/static/src/js/website_sale_tracking.js',
+            'website/static/lib/multirange/multirange_custom.js',
         ],
         'web._assets_primary_variables': [
             'website_sale/static/src/scss/primary_variables.scss',

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -962,3 +962,38 @@ publicWidget.registry.websiteSaleProductPageReviews = publicWidget.Widget.extend
     },
 });
 });
+
+odoo.define('website_sale.price_range_option', function (require) {
+'use strict';
+
+const publicWidget = require('web.public.widget');
+
+publicWidget.registry.multirangePriceSelector = publicWidget.Widget.extend({
+    selector: '#o_wsale_price_range_option',
+    events: {
+        'newRangeValue input[type="range"]': '_onPriceRangeSelected',
+    },
+
+    //----------------------------------------------------------------------
+    // Handlers
+    //----------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onPriceRangeSelected(ev) {
+        const range = ev.currentTarget;
+        const search = $.deparam(window.location.search.substring(1));
+        delete search.min_price;
+        delete search.max_price;
+        if (parseFloat(range.min) !== range.valueLow) {
+            search['min_price'] = range.valueLow;
+        }
+        if (parseFloat(range.max) !== range.valueHigh) {
+            search['max_price'] = range.valueHigh;
+        }
+        window.location.search = $.param(search);
+    },
+});
+});

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -541,6 +541,22 @@
         </xpath>
     </template>
 
+    <template id="filter_products_price" inherit_id="website_sale.products" active="False" customize_show="True" name="Filter by Prices">
+        <xpath expr="//div[@id='products_grid_before']" position="before">
+            <t t-set="enable_left_column" t-value="True"/>
+        </xpath>
+        <xpath expr="//div[@id='products_grid_before']" position="inside">
+            <div t-if="available_min_price != available_max_price" id="o_wsale_price_range_option">
+                <label>Price</label>
+                <input type="range" multiple="multiple" class="custom-range range-with-input"
+                       t-att-data-currency="pricelist.currency_id.symbol"
+                       t-att-data-currency-position="pricelist.currency_id.position"
+                       t-att-step="pricelist.currency_id.rounding" t-att-min="'%f' % (available_min_price)"
+                       t-att-max="'%f' % (available_max_price)" t-att-value="'%f,%f' % (min_price, max_price)"/>
+            </div>
+        </xpath>
+    </template>
+
     <template id="products_list_view" inherit_id="website_sale.products" active="False" customize_show="True" name="List View (by default)">
         <xpath expr="//div[@id='products_grid']" position="after">
             <!-- Nothing to do, this view is only meant to allow the server -->


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When browsing the eCommerce part of the website, customers
should be able to filter shop products based on base sale price.

Desired behavior after PR is merged:
The filter slider can be enabled through the customize menu and it only
filters using the product's base price (for performance reason) and takes
into account currency conversions, not pricelists and discounts. It uses a
custom-built library for the range input with 2 cursors (min. price and max. price).

A more advanced version of this implementation would enable the filtering to
take more factors into account.

task-2603014

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
