### PR TITLE
[FIX] base: Apply the correct order to translations_per_module dict

### DIFF
--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -899,7 +899,7 @@ class IrTranslation(models.Model):
             ('module', 'in', mods), ('lang', '=', lang),
             ('comments', 'like', 'openerp-web'), ('value', '!=', False),
             ('value', '!=', '')],
-            ['module', 'src', 'value', 'lang'], order='module')
+            ['module', 'src', 'value'], order='module, id')
         for mod, msg_group in itertools.groupby(messages, key=operator.itemgetter('module')):
             translations_per_module.setdefault(mod, {'messages': []})
             translations_per_module[mod]['messages'].extend({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Since Odoo 13.0 the translation hash generation is not consistent when you have several records for the same module. In addition, the 'lang' field is requested, which is never used.
The changes applied in this commit maintain a consistent hash generation and avoids requesting the unused field.

Current behavior before PR:
Each time you refresh the page a "new" hash is generated for the translations.

Desired behavior after PR is merged:
Get a new hash only if translations have changed



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
