### PR TITLE
[FIX] payment_authorize: confirm refunded validation transactions

### DIFF
--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -132,7 +132,10 @@ class PaymentTransaction(models.Model):
                 if self.tokenize and not self.token_id:
                     self._authorize_tokenize()
             elif status_type == 'void':
-                self._set_canceled()
+                if self.operation == 'validation':  # Validation txs are authorized and then voided
+                    self._set_done()  # If the refund went through, the validation tx is confirmed
+                else:
+                    self._set_canceled()
         elif status_code == '2':  # Declined
             self._set_canceled()
         elif status_code == '4':  # Held for Review


### PR DESCRIPTION
As validation transactions are authorized rather than captured, they are
refunded with a void request. Before this commit, a voided validation
transaction was mistakenly flagged as canceled while it should have been
confirmed.

This commit makes the distinction between a voided regular transaction
and a validation transaction.

task-2612977
