### PR TITLE
[FIX] sale_crm: create "customer" partner when converting leads to qu…

### DIFF
--- a/addons/sale_crm/wizard/crm_opportunity_to_quotation_views.xml
+++ b/addons/sale_crm/wizard/crm_opportunity_to_quotation_views.xml
@@ -13,7 +13,8 @@
                 </group>
                 <group>
                     <group>
-                        <field name="partner_id" attrs="{'invisible': [('action','!=','exist')], 'required':[('action', '=','exist')]}"/>
+                        <field name="partner_id" attrs="{'invisible': [('action','!=','exist')], 'required':[('action', '=','exist')]}"
+                               context="{'res_partner_search_mode': 'customer'}" />
                     </group>
                 </group>
                 <footer>


### PR DESCRIPTION
…otations

When creating a new partner on the fly at lead convert time we should created
a customer-oriented partner. This is done through the use of a specific
``res_partner_search_mode`` context key allowing to handle creation of a
partner flagged as "customer".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
