### PR TITLE
[FIX] mrp: correctly assign finished moves on copy

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -769,7 +769,7 @@ class MrpProduction(models.Model):
     def create(self, values):
         # Remove from `move_finished_ids` the by-product moves and then move `move_byproduct_ids`
         # into `move_finished_ids` to avoid duplicate and inconsistency.
-        if values.get('move_finished_ids', False):
+        if values.get('move_finished_ids', False) and values.get('move_byproduct_ids', False):
             values['move_finished_ids'] = list(filter(lambda move: move[2]['byproduct_id'] is False, values['move_finished_ids']))
         if values.get('move_byproduct_ids', False):
             values['move_finished_ids'] = values.get('move_finished_ids', []) + values['move_byproduct_ids']


### PR DESCRIPTION
Steps to reproduce:

- Create BoM with By Product
- Create MO
- Duplicate it

Bug:
- By products are not added on new MO as move with no `byproduct_id`
are dropped from vals on create method.

Fix:
With this commit, we are assigning `move_finished_ids` if we are getting `move_byproduct_ids` in vals.


Fixes: #70369

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
