### PR TITLE
[IMP] mrp: remove linked attachement on removing mrp document

### DIFF
--- a/addons/mrp/models/mrp_document.py
+++ b/addons/mrp/models/mrp_document.py
@@ -22,3 +22,7 @@ class MrpDocument(models.Model):
         ('1', 'Low'),
         ('2', 'High'),
         ('3', 'Very High')], string="Priority", help='Gives the sequence order when displaying a list of MRP documents.')
+
+    def unlink(self):
+        self.mapped('ir_attachment_id').unlink()
+        return super(MrpDocument, self).unlink()


### PR DESCRIPTION
Steps to Reproduce Bug:

- Add Attachment on Bom Line
- Delete Attachment

Bug:
- Attachment is still present on `ir.attachment`

With this commit, we are removing linked attachment on deleting `mrp.document`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
