### PR TITLE
[FIX] web: order items by sequence globally instead of by category

### DIFF
--- a/addons/web/static/src/core/debug/debug_context.js
+++ b/addons/web/static/src/core/debug/debug_context.js
@@ -44,18 +44,19 @@ class DebugContext {
 
     async getItems(env) {
         const accessRights = await getAccessRights(this.orm);
-        return [...this.categories.entries()].flatMap(([category, contexts]) => {
-            return debugRegistry
-                .category(category)
-                .getAll()
-                .map((factory) => factory(Object.assign({ env, accessRights }, ...contexts)))
-                .filter(Boolean)
-                .sort((x, y) => {
-                    const xSeq = x.sequence || 1000;
-                    const ySeq = y.sequence || 1000;
-                    return xSeq - ySeq;
-                });
-        });
+        return [...this.categories.entries()]
+            .flatMap(([category, contexts]) => {
+                return debugRegistry
+                    .category(category)
+                    .getAll()
+                    .map((factory) => factory(Object.assign({ env, accessRights }, ...contexts)));
+            })
+            .filter(Boolean)
+            .sort((x, y) => {
+                const xSeq = x.sequence || 1000;
+                const ySeq = y.sequence || 1000;
+                return xSeq - ySeq;
+            });
     }
 }
 


### PR DESCRIPTION
Before this commit, all items from the same category were grouped
together because we were sorting items within categories rather than
sorting all items after getting them from the various categories.
