### PR TITLE
[FIX] web_editor: do missing update of .pot file for transform button

### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -2139,7 +2139,7 @@ msgstr ""
 #: code:addons/web_editor/static/src/xml/editor.xml:0
 #: model_terms:ir.ui.view,arch_db:web_editor.snippet_options
 #, python-format
-msgid "Transform the picture (click twice to reset transformation)"
+msgid "Transform the picture"
 msgstr ""
 
 #. module: web_editor


### PR DESCRIPTION
This was forgotten when merging https://github.com/odoo/odoo/pull/71847
