### PR TITLE
Add `flake8-rst-docstrings` and fix those broken in odoo core

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -589,22 +589,21 @@ class IrActionsServer(models.Model):
         :samp:`_run_action_{TYPE}[_multi]` method is called. This allows easy
         overriding of the server actions.
 
-        The `_multi` suffix means the runner can operate on multiple records,
+        The ``_multi`` suffix means the runner can operate on multiple records,
         otherwise if there are multiple records the runner will be called once
-        for each
+        for each.
 
-        :param dict context: context should contain following keys
+        The call context should contain the following keys:
 
-                             - active_id: id of the current object (single mode)
-                             - active_model: current model that should equal the action's model
-
-                             The following keys are optional:
-
-                             - active_ids: ids of the current records (mass mode). If active_ids
-                               and active_id are present, active_ids is given precedence.
-
-        :return: an action_id to be executed, or False is finished correctly without
-                 return action
+        active_id
+            id of the current object (single mode)
+        active_model
+            current model that should equal the action's model
+        active_ids (optional)
+           ids of the current records (mass mode). If ``active_ids`` and
+           ``active_id`` are present, ``active_ids`` is given precedence.
+        :return: an ``action_id`` to be executed, or ``False`` is finished
+                 correctly without return action
         """
         res = False
         for action in self.sudo():

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -198,7 +198,6 @@ class IrActionsReport(models.Model):
         '''Retrieve an attachment for a specific record.
 
         :param record: The record owning of the attachment.
-        :param attachment_name: The optional name of the attachment.
         :return: A recordset of length <=1 or None
         '''
         attachment_name = safe_eval(self.attachment, {'object': record, 'time': time}) if self.attachment else ''
@@ -211,13 +210,14 @@ class IrActionsReport(models.Model):
         ], limit=1)
 
     def _postprocess_pdf_report(self, record, buffer):
-        '''Hook to handle post processing during the pdf report generation.
-        The basic behavior consists to create a new attachment containing the pdf
-        base64 encoded.
+        '''Hook to handle post-processing during the pdf report generation.
 
-        :param record_id: The record that will own the attachment.
-        :param pdf_content: The optional name content of the file to avoid reading both times.
-        :return: A modified buffer if the previous one has been modified, None otherwise.
+        The basic behavior consists of creating a new attachment containing the
+        pdf base64 encoded.
+
+        :param record: The record that will own the attachment.
+        :param io.BytesIO buffer: The PDF content as a bytes buffer.
+        :return: The input buffer.
         '''
         attachment_name = safe_eval(self.attachment, {'object': record, 'time': time})
         if not attachment_name:

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -43,6 +43,9 @@ class IrDefault(models.Model):
             scope (field, user, company) will be replaced. The value is encoded
             in JSON to be stored to the database.
 
+            :param model_name:
+            :param field_name:
+            :param value:
             :param user_id: may be ``False`` for all users, ``True`` for the
                             current user, or any user id
             :param company_id: may be ``False`` for all companies, ``True`` for
@@ -93,6 +96,8 @@ class IrDefault(models.Model):
         """ Return the default value for the given field, user and company, or
             ``None`` if no default is available.
 
+            :param model_name:
+            :param field_name:
             :param user_id: may be ``False`` for all users, ``True`` for the
                             current user, or any user id
             :param company_id: may be ``False`` for all companies, ``True`` for

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -84,6 +84,7 @@ class IrFieldsConverter(models.AbstractModel):
         records matching what :meth:`odoo.osv.orm.Model.write` expects.
 
         :param model: :class:`odoo.osv.orm.Model` for the conversion base
+        :param fromtype:
         :returns: a converter callable
         :rtype: (record: dict, logger: (field, error) -> None) -> dict
         """
@@ -167,11 +168,11 @@ class IrFieldsConverter(models.AbstractModel):
         it returns. The handling of a warning at the upper levels is the same
         as ``ValueError`` above.
 
+        :param model:
         :param field: field object to generate a value for
         :type field: :class:`odoo.fields.Field`
         :param fromtype: type to convert to something fitting for ``field``
         :type fromtype: type | str
-        :param context: odoo request context
         :return: a function (fromtype -> field.write_type), if a converter is found
         :rtype: Callable | None
         """
@@ -345,7 +346,6 @@ class IrFieldsConverter(models.AbstractModel):
                          ``id`` for an external id and ``.id`` for a database
                          id
         :param value: value of the reference to match to an actual record
-        :param context: OpenERP request context
         :return: a pair of the matched database identifier (if any), the
                  translated user-readable name for the field and the list of
                  warnings

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -57,6 +57,7 @@ class IrFilters(models.Model):
     def get_filters(self, model, action_id=None):
         """Obtain the list of filters available for the user on the given model.
 
+        :param int model: id of model to find filters for
         :param action_id: optional ID of action to restrict filters to this action
             plus global filters. If missing only global filters are returned.
             The action does not have to correspond to the model, it may only be

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -351,6 +351,8 @@ class IrMailServer(models.Model):
                                               or 'html'). Default is 'plain'.
            :param list attachments: list of (filename, filecontents) pairs, where filecontents is a string
                                     containing the bytes of the attachment
+           :param message_id:
+           :param references:
            :param list email_cc: optional list of string values for CC header (to be joined with commas)
            :param list email_bcc: optional list of string values for BCC header (to be joined with commas)
            :param dict headers: optional map of headers to set on the outgoing mail (may override the

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -717,9 +717,10 @@ class Environment(Mapping):
     @contextmanager
     def protecting(self, what, records=None):
         """ Prevent the invalidation or recomputation of fields on records.
-            The parameters are either:
-             - ``what`` a collection of fields and ``records`` a recordset, or
-             - ``what`` a collection of pairs ``(fields, records)``.
+        The parameters are either:
+
+        - ``what`` a collection of fields and ``records`` a recordset, or
+        - ``what`` a collection of pairs ``(fields, records)``.
         """
         protected = self._protected
         try:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -861,6 +861,8 @@ class Field(MetaField('DummyField', (object,), {})):
         :meth:`BaseModel.write`. If the value represents a recordset, it should
         be added for prefetching on ``record``.
 
+        :param value:
+        :param record:
         :param bool validate: when True, field-specific validation of ``value``
             will be performed
         """
@@ -886,6 +888,8 @@ class Field(MetaField('DummyField', (object,), {})):
         """ Convert ``value`` from the record format to the format returned by
         method :meth:`BaseModel.read`.
 
+        :param value:
+        :param record:
         :param bool use_name_get: when True, the value's display name will be
             computed using :meth:`BaseModel.name_get`, if relevant for the field
         """
@@ -903,6 +907,8 @@ class Field(MetaField('DummyField', (object,), {})):
         """ Convert ``value`` from the record format to the format returned by
         method :meth:`BaseModel.onchange`.
 
+        :param value:
+        :param record:
         :param names: a tree of field names (for relational fields only)
         """
         return self.convert_to_read(value, record)
@@ -1048,6 +1054,7 @@ class Field(MetaField('DummyField', (object,), {})):
         """ Write the value of ``self`` on ``records``. This method must update
         the cache and prepare database updates.
 
+        :param records:
         :param value: a value in any format
         :return: the subset of `records` that have been modified
         """
@@ -3146,7 +3153,7 @@ class Command(enum.IntEnum):
 
 
 class _RelationalMulti(_Relational):
-    """ Abstract class for relational fields *2many. """
+    r"Abstract class for relational fields \*2many."
     write_sequence = 20
 
     # Important: the cache contains the ids of all the records in the relation,

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1096,8 +1096,7 @@ class OpenERPSession(sessions.Session):
         identifying that action. The method get_action() can be used to get
         back the action.
 
-        :param the_action: The action to save in the session.
-        :type the_action: anything
+        :param action: The action to save in the session.
         :return: A key identifying the saved action.
         :rtype: integer
         """

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -123,11 +123,15 @@ def force_demo(cr):
 def load_module_graph(cr, graph, status=None, perform_checks=True,
                       skip_modules=None, report=None, models_to_check=None):
     """Migrates+Updates or Installs all module nodes from ``graph``
+
+       :param cr:
        :param graph: graph of module nodes to load
        :param status: deprecated parameter, unused, left to avoid changing signature in 8.0
        :param perform_checks: whether module descriptors should be checked for validity (prints warnings
                               for same cases)
        :param skip_modules: optional list of module names (packages) which have previously been loaded and can be skipped
+       :param report:
+       :param set models_to_check:
        :return: list of modules that were installed or updated
     """
     if models_to_check is None:

--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -27,18 +27,21 @@ def load_script(path, module_name):
 
 
 class MigrationManager(object):
-    """
-        This class manage the migration of modules
-        Migrations files must be python files containing a `migrate(cr, installed_version)`
+    """ Manages the migration of modules.
+
+        Migrations files must be python files containing a ``migrate(cr, installed_version)``
         function. These files must respect a directory tree structure: A 'migrations' folder
         which contains a folder by version. Version can be 'module' version or 'server.module'
         version (in this case, the files will only be processed by this version of the server).
-        Python file names must start by `pre-` or `post-` and will be executed, respectively,
-        before and after the module initialisation. `end-` scripts are run after all modules have
+        Python file names must start by ``pre-`` or ``post-`` and will be executed, respectively,
+        before and after the module initialisation. ``end-`` scripts are run after all modules have
         been updated.
-        A special folder named `0.0.0` can contain scripts that will be run on any version change.
-        In `pre` stage, `0.0.0` scripts are run first, while in `post` and `end`, they are run last.
-        Example:
+
+        A special folder named ``0.0.0`` can contain scripts that will be run on any version change.
+        In `pre` stage, ``0.0.0`` scripts are run first, while in ``post`` and ``end``, they are run last.
+
+        Example::
+
             <moduledir>
             `-- migrations
                 |-- 1.0

--- a/odoo/osv/query.py
+++ b/odoo/osv/query.py
@@ -22,14 +22,16 @@ def _from_table(table, alias):
 
 def _generate_table_alias(src_table_alias, link):
     """ Generate a standard table alias name. An alias is generated as following:
+
         - the base is the source table name (that can already be an alias)
         - then, the joined table is added in the alias using a 'link field name'
           that is used to render unique aliases for a given path
         - the name is shortcut if it goes beyond PostgreSQL's identifier limits
 
-        Examples:
-        - src_table_alias='res_users', link='parent_id'
-            alias = 'res_users__parent_id'
+        .. code-block:: pycon
+
+            >>> _generate_table_alias('res_users', link='parent_id')
+            'res_users__parent_id'
 
         :param str src_table_alias: alias of the source table
         :param str link: field name

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -569,19 +569,21 @@ class TestCursor(BaseCursor):
         the transaction open across requests, and simulates committing, rolling
         back, and closing:
 
-              test cursor           | queries on actual cursor
-            ------------------------+---------------------------------------
-              cr = TestCursor(...)  | SAVEPOINT test_cursor_N
-                                    |
-              cr.execute(query)     | query
-                                    |
-              cr.commit()           | RELEASE SAVEPOINT test_cursor_N
-                                    | SAVEPOINT test_cursor_N (lazy)
-                                    |
-              cr.rollback()         | ROLLBACK TO SAVEPOINT test_cursor_N (if savepoint)
-                                    |
-              cr.close()            | ROLLBACK TO SAVEPOINT test_cursor_N (if savepoint)
-                                    | RELEASE SAVEPOINT test_cursor_N (if savepoint)
+        +------------------------+---------------------------------------------------+
+        |  test cursor           | queries on actual cursor                          |
+        +========================+===================================================+
+        |``cr = TestCursor(...)``| SAVEPOINT test_cursor_N                           |
+        +------------------------+---------------------------------------------------+
+        | ``cr.execute(query)``  | query                                             |
+        +------------------------+---------------------------------------------------+
+        |  ``cr.commit()``       | RELEASE SAVEPOINT test_cursor_N                   |
+        |                        | SAVEPOINT test_cursor_N (lazy)                    |
+        +------------------------+---------------------------------------------------+
+        |  ``cr.rollback()``     | ROLLBACK TO SAVEPOINT test_cursor_N (if savepoint)|
+        +------------------------+---------------------------------------------------+
+        |  ``cr.close()``        | ROLLBACK TO SAVEPOINT test_cursor_N (if savepoint)|
+        |                        | RELEASE SAVEPOINT test_cursor_N (if savepoint)    |
+        +------------------------+---------------------------------------------------+
     """
     _cursors_stack = []
     def __init__(self, cursor, lock):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -305,11 +305,10 @@ class MetaCase(type):
 def _normalize_arch_for_assert(arch_string, parser_method="xml"):
     """Takes some xml and normalize it to make it comparable to other xml
     in particular, blank text is removed, and the output is pretty-printed
-    :param arch_string: the string representing an XML arch
-    :type arch_string: str
-    :param parser_method: an string representing which lxml.Parser class to use
+
+    :param str arch_string: the string representing an XML arch
+    :param str parser_method: an string representing which lxml.Parser class to use
         when normalizing both archs. Takes either "xml" or "html"
-    :type parser_method: str
     :return: the normalized arch
     :rtype str:
     """
@@ -671,6 +670,7 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
 
     def _assertXMLEqual(self, original, expected, parser="xml"):
         """Asserts that two xmls archs are equal
+
         :param original: the xml arch to test
         :type original: str
         :param expected: the xml arch of reference
@@ -981,16 +981,24 @@ class ChromeBrowser:
         self._logger.info('Chrome headless temporary user profile dir: %s', self.user_data_dir)
 
     def _json_command(self, command, timeout=3, get_key=None):
-        """
-        Inspect dev tools with get
+        """Queries browser state using JSON
+
         Available commands:
-            '' : return list of tabs with their id
-            list (or json/): list tabs
-            new : open a new tab
-            activate/ + an id: activate a tab
-            close/ + and id: close a tab
-            version : get chrome and dev tools version
-            protocol : get the full protocol
+
+        ``''``
+            return list of tabs with their id
+        ``list`` (or ``json/``)
+            list tabs
+        ``new``
+            open a new tab
+        :samp:`activate/{id}`
+            activate a tab
+        :samp:`close/{id}`
+            close a tab
+        ``version``
+            get chrome and dev tools version
+        ``protocol``
+            get the full protocol
         """
         command = os.path.join('json', command).strip('/')
         url = werkzeug.urls.url_join('http://%s:%s/' % (HOST, self.devtools_port), command)

--- a/odoo/tools/appdirs.py
+++ b/odoo/tools/appdirs.py
@@ -86,20 +86,26 @@ def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
             of your app to be able to run independently. If used, this
             would typically be "<major>.<minor>".
             Only applied when appname is present.
-        "multipath" is an optional parameter only applicable to *nix
+        "multipath" is an optional parameter only applicable to \*nix
             which indicates that the entire list of data dirs should be
             returned. By default, the first item from XDG_DATA_DIRS is
-            returned, or '/usr/local/share/<AppName>',
-            if XDG_DATA_DIRS is not set
+            returned, or :samp:`/usr/local/share/{AppName}`,
+            if ``XDG_DATA_DIRS`` is not set
 
     Typical user data directories are:
-        Mac OS X:   /Library/Application Support/<AppName>
-        Unix:       /usr/local/share/<AppName> or /usr/share/<AppName>
-        Win XP:     C:\Documents and Settings\All Users\Application Data\<AppAuthor>\<AppName>
-        Vista:      (Fail! "C:\ProgramData" is a hidden *system* directory on Vista.)
-        Win 7:      C:\ProgramData\<AppAuthor>\<AppName>   # Hidden, but writeable on Win 7.
 
-    For Unix, this is using the $XDG_DATA_DIRS[0] default.
+    Mac OS X
+        :samp:`/Library/Application Support/{AppName}`
+    Unix
+        :samp:`/usr/local/share/{AppName}` or :samp:`/usr/share/{AppName}`
+    Win XP
+        :samp:`C:\Documents and Settings\All Users\Application Data\{AppAuthor}\{AppName}`
+    Vista
+        Fail! "C:\ProgramData" is a hidden *system* directory on Vista.
+    Win 7
+        :samp:`C:\ProgramData\{AppAuthor}\{AppName}` (hidden, but writeable on Win 7)
+
+    For Unix, this is using the ``$XDG_DATA_DIRS[0]`` default.
 
     WARNING: Do not use this on Windows. See the Vista-Fail note above for why.
     """
@@ -136,32 +142,36 @@ def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
 
 
 def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
-    r"""Return full path to the user-specific config dir for this application.
+    """Return full path to the user-specific config dir for this application.
 
-        "appname" is the name of application.
-            If None, just the system directory is returned.
-        "appauthor" (only required and used on Windows) is the name of the
-            appauthor or distributing body for this application. Typically
-            it is the owning company name. This falls back to appname.
-        "version" is an optional version path element to append to the
-            path. You might want to use this if you want multiple versions
-            of your app to be able to run independently. If used, this
-            would typically be "<major>.<minor>".
-            Only applied when appname is present.
-        "roaming" (boolean, default False) can be set True to use the Windows
-            roaming appdata directory. That means that for users on a Windows
-            network setup for roaming profiles, this user data will be
-            sync'd on login. See
-            <http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx>
-            for a discussion of issues.
+    "appname" is the name of application.
+        If None, just the system directory is returned.
+    "appauthor" (only required and used on Windows) is the name of the
+        appauthor or distributing body for this application. Typically
+        it is the owning company name. This falls back to appname.
+    "version" is an optional version path element to append to the
+        path. You might want to use this if you want multiple versions
+        of your app to be able to run independently. If used, this
+        would typically be "<major>.<minor>".
+        Only applied when appname is present.
+    "roaming" (boolean, default False) can be set True to use the Windows
+        roaming appdata directory. That means that for users on a Windows
+        network setup for roaming profiles, this user data will be
+        sync'd on login. See `managing roaming user data
+        <http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx>`_
+        for a discussion of issues.
 
     Typical user data directories are:
-        Mac OS X:               same as user_data_dir
-        Unix:                   ~/.config/<AppName>     # or in $XDG_CONFIG_HOME, if defined
-        Win *:                  same as user_data_dir
 
-    For Unix, we follow the XDG spec and support $XDG_DATA_HOME.
-    That means, by default "~/.local/share/<AppName>".
+    Mac OS X
+        same as user_data_dir
+    Unix
+        :samp:`~/.config/{AppName}` or in $XDG_CONFIG_HOME, if defined
+    Win *
+        same as user_data_dir
+
+    For Unix, we follow the XDG spec and support ``$XDG_DATA_HOME``.
+    That means, by default :samp:`~/.local/share/{AppName}`.
     """
     if sys.platform in [ "win32", "darwin" ]:
         path = user_data_dir(appname, appauthor, None, roaming)
@@ -177,29 +187,34 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
 def site_config_dir(appname=None, appauthor=None, version=None, multipath=False):
     """Return full path to the user-shared data dir for this application.
 
-        "appname" is the name of application.
-            If None, just the system directory is returned.
-        "appauthor" (only required and used on Windows) is the name of the
-            appauthor or distributing body for this application. Typically
-            it is the owning company name. This falls back to appname.
-        "version" is an optional version path element to append to the
-            path. You might want to use this if you want multiple versions
-            of your app to be able to run independently. If used, this
-            would typically be "<major>.<minor>".
-            Only applied when appname is present.
-        "multipath" is an optional parameter only applicable to *nix
-            which indicates that the entire list of config dirs should be
-            returned. By default, the first item from XDG_CONFIG_DIRS is
-            returned, or '/etc/xdg/<AppName>', if XDG_CONFIG_DIRS is not set
+    "appname" is the name of application.
+        If None, just the system directory is returned.
+    "appauthor" (only required and used on Windows) is the name of the
+        appauthor or distributing body for this application. Typically
+        it is the owning company name. This falls back to appname.
+    "version" is an optional version path element to append to the
+        path. You might want to use this if you want multiple versions
+        of your app to be able to run independently. If used, this
+        would typically be "<major>.<minor>".
+        Only applied when appname is present.
+    "multipath" is an optional parameter only applicable to \*nix
+        which indicates that the entire list of config dirs should be
+        returned. By default, the first item from ``XDG_CONFIG_DIRS`` is
+        returned, or :samp:`/etc/xdg/{AppName}`, if ``XDG_CONFIG_DIRS`` is not set
 
     Typical user data directories are:
-        Mac OS X:   same as site_data_dir
-        Unix:       /etc/xdg/<AppName> or $XDG_CONFIG_DIRS[i]/<AppName> for each value in
-                    $XDG_CONFIG_DIRS
-        Win *:      same as site_data_dir
-        Vista:      (Fail! "C:\ProgramData" is a hidden *system* directory on Vista.)
 
-    For Unix, this is using the $XDG_CONFIG_DIRS[0] default, if multipath=False
+    Mac OS X
+        same as site_data_dir
+    Unix
+        ``/etc/xdg/<AppName>`` or ``$XDG_CONFIG_DIRS[i]/<AppName>`` for each
+        value in ``$XDG_CONFIG_DIRS``
+    Win *
+        same as site_data_dir
+    Vista
+        Fail! "C:\ProgramData" is a hidden *system* directory on Vista.
+
+    For Unix, this is using the ``$XDG_CONFIG_DIRS[0]`` default, if ``multipath=False``
 
     WARNING: Do not use this on Windows. See the Vista-Fail note above for why.
     """
@@ -226,34 +241,41 @@ def site_config_dir(appname=None, appauthor=None, version=None, multipath=False)
 def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
     r"""Return full path to the user-specific cache dir for this application.
 
-        "appname" is the name of application.
-            If None, just the system directory is returned.
-        "appauthor" (only required and used on Windows) is the name of the
-            appauthor or distributing body for this application. Typically
-            it is the owning company name. This falls back to appname.
-        "version" is an optional version path element to append to the
-            path. You might want to use this if you want multiple versions
-            of your app to be able to run independently. If used, this
-            would typically be "<major>.<minor>".
-            Only applied when appname is present.
-        "opinion" (boolean) can be False to disable the appending of
-            "Cache" to the base app data dir for Windows. See
-            discussion below.
+    "appname" is the name of application.
+        If None, just the system directory is returned.
+    "appauthor" (only required and used on Windows) is the name of the
+        appauthor or distributing body for this application. Typically
+        it is the owning company name. This falls back to appname.
+    "version" is an optional version path element to append to the
+        path. You might want to use this if you want multiple versions
+        of your app to be able to run independently. If used, this
+        would typically be "<major>.<minor>".
+        Only applied when appname is present.
+    "opinion" (boolean) can be False to disable the appending of
+        "Cache" to the base app data dir for Windows. See
+        discussion below.
 
     Typical user cache directories are:
-        Mac OS X:   ~/Library/Caches/<AppName>
-        Unix:       ~/.cache/<AppName> (XDG default)
-        Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
-        Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
+
+    Mac OS X
+        ~/Library/Caches/<AppName>
+    Unix
+        ~/.cache/<AppName> (XDG default)
+    Win XP
+        C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
+    Vista
+        C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
 
     On Windows the only suggestion in the MSDN docs is that local settings go in
-    the `CSIDL_LOCAL_APPDATA` directory. This is identical to the non-roaming
-    app data dir (the default returned by `user_data_dir` above). Apps typically
+    the ``CSIDL_LOCAL_APPDATA`` directory. This is identical to the non-roaming
+    app data dir (the default returned by ``user_data_dir`` above). Apps typically
     put cache data somewhere *under* the given dir here. Some examples:
-        ...\Mozilla\Firefox\Profiles\<ProfileName>\Cache
-        ...\Acme\SuperApp\Cache\1.0
-    OPINION: This function appends "Cache" to the `CSIDL_LOCAL_APPDATA` value.
-    This can be disabled with the `opinion=False` option.
+
+    - ...\Mozilla\Firefox\Profiles\<ProfileName>\Cache
+    - ...\Acme\SuperApp\Cache\1.0
+
+    OPINION: This function appends "Cache" to the ``CSIDL_LOCAL_APPDATA`` value.
+    This can be disabled with the ``opinion=False`` option.
     """
     if sys.platform == "win32":
         if appauthor is None:

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -291,7 +291,7 @@ class configmanager(object):
                               "[ipython|ptpython|bpython|python]")
         group.add_option("--stop-after-init", action="store_true", dest="stop_after_init", my_default=False,
                           help="stop the server after its initialization")
-        group.add_option("--osv-memory-count-limit", dest="osv_memory_count_limit", my_default=False,
+        group.add_option("--osv-memory-count-limit", dest="osv_memory_count_limit", my_default=0,
                          help="Force a limit on the maximum number of records kept in the virtual "
                               "osv_memory tables. By default there is no limit.",
                          type="int")

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -216,9 +216,9 @@ def json_default(obj):
 def date_range(start, end, step=relativedelta(months=1)):
     """Date range generator with a step interval.
 
-    :param start datetime: beginning date of the range.
-    :param end datetime: ending date of the range.
-    :param step relativedelta: interval of the range.
+    :param datetime start: beginning date of the range.
+    :param datetime end: ending date of the range.
+    :param relativedelta step: interval of the range.
     :return: a range of datetime from start to end.
     :rtype: Iterator[datetime]
     """

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -162,13 +162,13 @@ def float_compare(value1, value2, precision_digits=None, precision_rounding=None
 
 def float_repr(value, precision_digits):
     """Returns a string representation of a float with the
-       the given number of fractional digits. This should not be
+       given number of fractional digits. This should not be
        used to perform a rounding operation (this is done via
-       :meth:`~.float_round`), but only to produce a suitable
+       :func:`~.float_round`), but only to produce a suitable
        string representation for a float.
 
-        :param int precision_digits: number of fractional digits to
-                                     include in the output
+       :param float value:
+       :param int precision_digits: number of fractional digits to include in the output
     """
     # Can't use str() here because it seems to have an intrinsic
     # rounding to 12 significant digits, which causes a loss of

--- a/odoo/tools/func.py
+++ b/odoo/tools/func.py
@@ -50,7 +50,7 @@ class lazy_classproperty(lazy_property):
 def conditional(condition, decorator):
     """ Decorator for a conditionally applied decorator.
 
-        Example:
+        Example::
 
            @conditional(get_config('use_cache'), ormcache)
            def fn():
@@ -118,12 +118,13 @@ def classproperty(func):
 
 
 class lazy(object):
-    """ A proxy to the (memoized) result of a lazy evaluation::
+    """ A proxy to the (memoized) result of a lazy evaluation:
 
-            foo = lazy(func, arg)           # func(arg) is not called yet
-            bar = foo + 1                   # eval func(arg) and add 1
-            baz = foo + 2                   # use result of func(arg) and add 2
+    .. code-block::
 
+        foo = lazy(func, arg)           # func(arg) is not called yet
+        bar = foo + 1                   # eval func(arg) and add 1
+        baz = foo + 2                   # use result of func(arg) and add 2
     """
     __slots__ = ['_func', '_args', '_kwargs', '_cached_value']
 

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -53,6 +53,7 @@ class ImageProcess():
         """Initialize the `base64_source` image for processing.
 
         :param base64_source: the original image base64 encoded
+
             No processing will be done if the `base64_source` is falsy or if
             the image is SVG.
         :type base64_source: string or bytes
@@ -61,8 +62,6 @@ class ImageProcess():
             excessive before starting to process it. The max allowed resolution is
             defined by `IMAGE_MAX_RESOLUTION`.
         :type verify_resolution: bool
-
-        :return: self
         :rtype: ImageProcess
 
         :raise: ValueError if `verify_resolution` is True and the image is too large
@@ -99,19 +98,16 @@ class ImageProcess():
         and the `output_format` is the same as the original format and the
         quality is not specified.
 
-        :param quality: quality setting to apply. Default to 0.
+        :param int quality: quality setting to apply. Default to 0.
+
             - for JPEG: 1 is worse, 95 is best. Values above 95 should be
-                avoided. Falsy values will fallback to 95, but only if the image
-                was changed, otherwise the original image is returned.
+              avoided. Falsy values will fallback to 95, but only if the image
+              was changed, otherwise the original image is returned.
             - for PNG: set falsy to prevent conversion to a WEB palette.
             - for other formats: no effect.
-        :type quality: int
-
-        :param output_format: the output format. Can be PNG, JPEG, GIF, or ICO.
+        :param str output_format: the output format. Can be PNG, JPEG, GIF, or ICO.
             Default to the format of the original image. BMP is converted to
             PNG, other formats than those mentioned above are converted to JPEG.
-        :type output_format: string
-
         :return: image
         :rtype: bytes or False
         """
@@ -160,19 +156,16 @@ class ImageProcess():
         applied and the `output_format` is the same as the original format and
         the quality is not specified.
 
-        :param quality: quality setting to apply. Default to 0.
+        :param int quality: quality setting to apply. Default to 0.
+
             - for JPEG: 1 is worse, 95 is best. Values above 95 should be
-                avoided. Falsy values will fallback to 95, but only if the image
-                was changed, otherwise the original image is returned.
+              avoided. Falsy values will fallback to 95, but only if the image
+              was changed, otherwise the original image is returned.
             - for PNG: set falsy to prevent conversion to a WEB palette.
             - for other formats: no effect.
-        :type quality: int
-
-        :param output_format: the output format. Can be PNG, JPEG, GIF, or ICO.
+        :param str output_format: the output format. Can be PNG, JPEG, GIF, or ICO.
             Default to the format of the original image. BMP is converted to
             PNG, other formats than those mentioned above are converted to JPEG.
-        :type output_format: string
-
         :return: image base64 encoded or False
         :rtype: bytes or False
         """
@@ -200,12 +193,8 @@ class ImageProcess():
         It is currently not supported for GIF because we do not handle all the
         frames properly.
 
-        :param max_width: max width
-        :type max_width: int
-
-        :param max_height: max height
-        :type max_height: int
-
+        :param int max_width: max width
+        :param int max_height: max height
         :return: self to allow chaining
         :rtype: ImageProcess
         """
@@ -238,20 +227,12 @@ class ImageProcess():
         It is currently not supported for GIF because we do not handle all the
         frames properly.
 
-        :param max_width: max width
-        :type max_width: int
-
-        :param max_height: max height
-        :type max_height: int
-
-        :param center_x: the center of the crop between 0 (left) and 1 (right)
-            Default to 0.5 (center).
-        :type center_x: float
-
-        :param center_y: the center of the crop between 0 (top) and 1 (bottom)
-            Default to 0.5 (center).
-        :type center_y: float
-
+        :param int max_width: max width
+        :param int max_height: max height
+        :param float center_x: the center of the crop between 0 (left) and 1
+            (right). Defaults to 0.5 (center).
+        :param float center_y: the center of the crop between 0 (top) and 1
+            (bottom). Defaults to 0.5 (center).
         :return: self to allow chaining
         :rtype: ImageProcess
         """
@@ -332,25 +313,30 @@ def image_process(base64_source, size=(0, 0), verify_resolution=False, quality=0
 def average_dominant_color(colors, mitigate=175, max_margin=140):
     """This function is used to calculate the dominant colors when given a list of colors
 
-    There are 5 steps :
-        1) Select dominant colors (highest count), isolate its values and remove
-           it from the current color set.
-        2) Set margins according to the prevalence of the dominant color.
-        3) Evaluate the colors. Similar colors are grouped in the dominant set
-           while others are put in the "remaining" list.
-        4) Calculate the average color for the dominant set. This is done by
-           averaging each band and joining them into a tuple.
-        5) Mitigate final average and convert it to hex
+    There are 5 steps:
+
+    1) Select dominant colors (highest count), isolate its values and remove
+       it from the current color set.
+    2) Set margins according to the prevalence of the dominant color.
+    3) Evaluate the colors. Similar colors are grouped in the dominant set
+       while others are put in the "remaining" list.
+    4) Calculate the average color for the dominant set. This is done by
+       averaging each band and joining them into a tuple.
+    5) Mitigate final average and convert it to hex
 
     :param colors: list of tuples having:
-        [0] color count in the image
-        [1] actual color: tuple(R, G, B, A)
-        -> these can be extracted from a PIL image using image.getcolors()
+
+        0. color count in the image
+        1. actual color: tuple(R, G, B, A)
+
+        -> these can be extracted from a PIL image using
+        :meth:`~PIL.Image.Image.getcolors`
     :param mitigate: maximum value a band can reach
     :param max_margin: maximum difference from one of the dominant values
     :returns: a tuple with two items:
-        [0] the average color of the dominant set as: tuple(R, G, B)
-        [1] list of remaining colors, used to evaluate subsequent dominant colors
+
+        0. the average color of the dominant set as: tuple(R, G, B)
+        1. list of remaining colors, used to evaluate subsequent dominant colors
     """
     dominant_color = max(colors)
     dominant_rgb = dominant_color[1][:3]
@@ -409,11 +395,10 @@ def image_fix_orientation(image):
     save the complexity of removing it.
 
     :param image: the source image
-    :type image: PIL.Image
-
+    :type image: ~PIL.Image.Image
     :return: the resulting image, copy of the source, with orientation fixed
         or the source image if no operation was applied
-    :rtype: PIL.Image
+    :rtype: ~PIL.Image.Image
     """
     getexif = getattr(image, 'getexif', None) or getattr(image, '_getexif', None)  # support PIL < 6.0
     if getexif:
@@ -431,10 +416,7 @@ def base64_to_image(base64_source):
 
     :param base64_source: the image base64 encoded
     :type base64_source: string or bytes
-
-    :return: the PIL image
-    :rtype: PIL.Image
-
+    :rtype: ~PIL.Image.Image
     :raise: UserError if the base64 is incorrect or the image can't be identified by PIL
     """
     try:
@@ -446,12 +428,9 @@ def base64_to_image(base64_source):
 def image_apply_opt(image, output_format, **params):
     """Return the given PIL `image` using `params`.
 
-    :param image: the PIL image
-    :type image: PIL.Image
-
-    :param params: params to expand when calling PIL.Image.save()
-    :type params: dict
-
+    :type image: ~PIL.Image.Image
+    :param str output_format: :meth:`~PIL.Image.Image.save`'s ``format`` parameter
+    :param dict params: params to expand when calling :meth:`~PIL.Image.Image.save`
     :return: the image formatted
     :rtype: bytes
     """
@@ -463,12 +442,9 @@ def image_apply_opt(image, output_format, **params):
 def image_to_base64(image, output_format, **params):
     """Return a base64_image from the given PIL `image` using `params`.
 
-    :param image: the PIL image
-    :type image: PIL.Image
-
-    :param params: params to expand when calling PIL.Image.save()
-    :type params: dict
-
+    :type image: ~PIL.Image.Image
+    :param str output_format:
+    :param dict params: params to expand when calling :meth:`~PIL.Image.Image.save`
     :return: the image base64 encoded
     :rtype: bytes
     """
@@ -495,9 +471,7 @@ def image_guess_size_from_field_name(field_name):
 
     If it can't be guessed, return (0, 0) instead.
 
-    :param field_name: the name of a field
-    :type field_name: string
-
+    :param str field_name: the name of a field
     :return: the guessed size
     :rtype: tuple (width, height)
     """

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -2,7 +2,7 @@
 This code is what let us use ES6-style modules in odoo.
 Classic Odoo modules are composed of a top-level :samp:`odoo.define({name},{body_function})` call.
 This processor will take files starting with an `@odoo-module` annotation (in a comment) and convert them to classic modules.
-If any file has the /** odoo-module */ on top of it, it will get processed by this class.
+If any file has the ``/** odoo-module */`` on top of it, it will get processed by this class.
 It performs several operations to get from ES6 syntax to the usual odoo one with minimal changes.
 This is done on the fly, this not a pre-processing tool.
 
@@ -560,9 +560,10 @@ def remove_index(content):
 
 
 def relative_path_to_module_path(url, path_rel):
-    """
-    Convert the relative path into a module path, which is more generic and fancy.
+    """Convert the relative path into a module path, which is more generic and
+    fancy.
 
+    :param str url:
     :param path_rel: a relative path to the current url.
     :return: module path (@module/...)
     """

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -358,16 +358,19 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
 
     return html.strip()
 
-def plaintext2html(text, container_tag=False):
-    """ Convert plaintext into html. Content of the text is escaped to manage
-        html entities, using misc.html_escape().
-        - all \n,\r are replaced by <br />
-        - enclose content into <p>
-        - convert url into clickable link
-        - 2 or more consecutive <br /> are considered as paragraph breaks
+def plaintext2html(text, container_tag=None):
+    r"""Convert plaintext into html. Content of the text is escaped to manage
+    html entities, using :func:`~odoo.tools.misc.html_escape`.
 
-        :param string container_tag: container of the html; by default the
-            content is embedded into a <div>
+    - all ``\n``, ``\r`` are replaced by ``<br/>``
+    - enclose content into ``<p>``
+    - convert url into clickable link
+    - 2 or more consecutive ``<br/>`` are considered as paragraph breaks
+
+    :param str text: plaintext to convert
+    :param str container_tag: container of the html; by default the content is
+        embedded into a ``<div>``
+    :rtype: markupsafe.Markup
     """
     text = misc.html_escape(ustr(text))
 
@@ -391,15 +394,18 @@ def plaintext2html(text, container_tag=False):
         final = '<%s>%s</%s>' % (container_tag, final, container_tag)
     return markupsafe.Markup(final)
 
-def append_content_to_html(html, content, plaintext=True, preserve=False, container_tag=False):
+def append_content_to_html(html, content, plaintext=True, preserve=False, container_tag=None):
     """ Append extra content at the end of an HTML snippet, trying
         to locate the end of the HTML document (</body>, </html>, or
         EOF), and converting the provided content in html unless ``plaintext``
         is False.
+
         Content conversion can be done in two ways:
-        - wrapping it into a pre (preserve=True)
-        - use plaintext2html (preserve=False, using container_tag to wrap the
-            whole content)
+
+        - wrapping it into a pre (``preserve=True``)
+        - use plaintext2html (``preserve=False``, using ``container_tag`` to
+          wrap the whole content)
+
         A side-effect of this method is to coerce all HTML tags to
         lowercase in ``html``, and strip enclosing <html> or <body> tags in
         content if ``plaintext`` is False.
@@ -410,6 +416,8 @@ def append_content_to_html(html, content, plaintext=True, preserve=False, contai
             be wrapped in a <pre/> tag.
         :param bool preserve: if content is plaintext, wrap it into a <pre>
             instead of converting it into html
+        :param str container_tag: tag to wrap the content into, defaults to `div`.
+        :rtype: markupsafe.Markup
     """
     html = ustr(html)
     if plaintext and preserve:
@@ -513,7 +521,8 @@ def email_normalize(text):
 def email_domain_extract(email):
     """ Extract the company domain to be used by IAP services notably. Domain
     is extracted from email information e.g:
-        - info@proximus.be -> proximus.be
+
+    - info@proximus.be -> proximus.be
     """
     normalized_email = email_normalize(email)
     if normalized_email:
@@ -530,7 +539,8 @@ def email_domain_normalize(domain):
 def url_domain_extract(url):
     """ Extract the company domain to be used by IAP services notably. Domain
     is extracted from an URL e.g:
-        - www.info.proximus.be -> proximus.be
+
+    - www.info.proximus.be -> proximus.be
     """
     parser_results = urlparse(url)
     company_hostname = parser_results.hostname

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -181,10 +181,10 @@ def file_open(name, mode="r", filter_ext=None):
 
     Examples::
 
-    >>> file_open('hr/static/description/icon.png')
-    >>> file_open('hr/static/description/icon.png', filter_ext=('.png', '.jpg'))
-    >>> with file_open('/opt/odoo/addons/hr/static/description/icon.png', 'rb') as f:
-    ...     contents = f.read()
+        >>> file_open('hr/static/description/icon.png')
+        >>> file_open('hr/static/description/icon.png', filter_ext=('.png', '.jpg'))
+        >>> with file_open('/opt/odoo/addons/hr/static/description/icon.png', 'rb') as f:
+        ...     contents = f.read()
 
     :param name: absolute or relative path to a file located inside an addon
     :param mode: file open mode, as for `open()`
@@ -240,24 +240,25 @@ def reverse_enumerate(l):
     """Like enumerate but in the other direction
 
     Usage::
-    >>> a = ['a', 'b', 'c']
-    >>> it = reverse_enumerate(a)
-    >>> it.next()
-    (2, 'c')
-    >>> it.next()
-    (1, 'b')
-    >>> it.next()
-    (0, 'a')
-    >>> it.next()
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    StopIteration
+
+        >>> a = ['a', 'b', 'c']
+        >>> it = reverse_enumerate(a)
+        >>> it.next()
+        (2, 'c')
+        >>> it.next()
+        (1, 'b')
+        >>> it.next()
+        (0, 'a')
+        >>> it.next()
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        StopIteration
     """
     return zip(range(len(l)-1, -1, -1), reversed(l))
 
 def partition(pred, elems):
     """ Return a pair equivalent to:
-        ``filter(pred, elems), filter(lambda x: not pred(x), elems)` """
+    ``filter(pred, elems), filter(lambda x: not pred(x), elems)`` """
     yes, nos = [], []
     for elem in elems:
         (yes if pred(elem) else nos).append(elem)
@@ -665,22 +666,6 @@ def split_every(n, iterable, piece_maker=tuple):
         yield piece
         piece = piece_maker(islice(iterator, n))
 
-def get_and_group_by_field(cr, uid, obj, ids, field, context=None):
-    """ Read the values of ``field´´ for the given ``ids´´ and group ids by value.
-
-       :param string field: name of the field we want to read and group by
-       :return: mapping of field values to the list of ids that have it
-       :rtype: dict
-    """
-    res = {}
-    for record in obj.read(cr, uid, ids, [field], context=context):
-        key = record[field]
-        res.setdefault(key[0] if isinstance(key, tuple) else key, []).append(record['id'])
-    return res
-
-def get_and_group_by_company(cr, uid, obj, ids, context=None):
-    return get_and_group_by_field(cr, uid, obj, ids, field='company_id', context=context)
-
 # port of python 2.6's attrgetter with support for dotted notation
 def resolve_attr(obj, attr):
     for name in attr.split("."):
@@ -769,7 +754,8 @@ class UnquoteEvalContext(defaultdict):
 
 class mute_logger(logging.Handler):
     """Temporary suppress the logging.
-    Can be used as context manager or decorator.
+
+    Can be used as context manager or decorator::
 
         @mute_logger('odoo.plic.ploc')
         def do_stuff():
@@ -777,7 +763,6 @@ class mute_logger(logging.Handler):
 
         with mute_logger('odoo.foo.bar'):
             do_suff()
-
     """
     def __init__(self, *loggers):
         super().__init__()
@@ -978,7 +963,9 @@ def freehash(arg):
             return id(arg)
 
 def clean_context(context):
-    """ This function take a dictionary and remove each entry with its key starting with 'default_' """
+    """ This function take a dictionary and remove each entry with its key
+    starting with ``default_``
+    """
     return {k: v for k, v in context.items() if not k.startswith('default_')}
 
 
@@ -1118,6 +1105,8 @@ class Callbacks:
     """ A simple queue of callback functions.  Upon run, every function is
     called (in addition order), and the queue is emptied.
 
+    ::
+
         callbacks = Callbacks()
 
         # add foo
@@ -1141,6 +1130,8 @@ class Callbacks:
     store anything, but is mostly aimed at aggregating data for callbacks.  The
     dictionary is automatically cleared by ``run()`` once all callback functions
     have been called.
+
+    ::
 
         # register foo to process aggregated data
         @callbacks.add
@@ -1258,6 +1249,8 @@ def get_lang(env, lang_code=False):
     Retrieve the first lang object installed, by checking the parameter lang_code,
     the context and then the company. If no lang is installed from those variables,
     fallback on the first lang installed in the system.
+
+    :param env:
     :param str lang_code: the locale (i.e. en_US)
     :return res.lang: the first lang found that is installed on the system.
     """
@@ -1367,10 +1360,12 @@ def parse_date(env, value, lang_code=False):
 def format_datetime(env, value, tz=False, dt_format='medium', lang_code=False):
     """ Formats the datetime in a given format.
 
-        :param {str, datetime} value: naive datetime to format either in string or in datetime
-        :param {str} tz: name of the timezone  in which the given datetime should be localized
-        :param {str} dt_format: one of “full”, “long”, “medium”, or “short”, or a custom date/time pattern compatible with `babel` lib
-        :param {str} lang_code: ISO code of the language to use to render the given datetime
+    :param env:
+    :param str|datetime value: naive datetime to format either in string or in datetime
+    :param str tz: name of the timezone  in which the given datetime should be localized
+    :param str dt_format: one of “full”, “long”, “medium”, or “short”, or a custom date/time pattern compatible with `babel` lib
+    :param str lang_code: ISO code of the language to use to render the given datetime
+    :rtype: str
     """
     if not value:
         return ''
@@ -1407,6 +1402,7 @@ def format_datetime(env, value, tz=False, dt_format='medium', lang_code=False):
 def format_time(env, value, tz=False, time_format='medium', lang_code=False):
     """ Format the given time (hour, minute and second) with the current user preference (language, format, ...)
 
+        :param env:
         :param value: the time to format
         :type value: `datetime.time` instance. Could be timezoned to display tzinfo according to format (e.i.: 'full' format)
         :param tz: name of the timezone  in which the given datetime should be localized
@@ -1604,7 +1600,7 @@ def get_diff(data_from, data_to, custom_style=False):
 
 
 def traverse_containers(val, type_):
-    """ Yields atoms filtered by specified type_ (or type tuple), traverses
+    """ Yields atoms filtered by specified ``type_`` (or type tuple), traverses
     through standard containers (non-string mappings or sequences) *unless*
     they're selected by the type filter
     """

--- a/odoo/tools/populate.py
+++ b/odoo/tools/populate.py
@@ -124,7 +124,7 @@ def compute(function, seed=None):
     as ``function(values, counter, random)``, where ``values`` is the other field values,
     ``counter`` is an integer, and ``random`` is a pseudo-random number generator.
 
-    :param function function: (values, counter, random) --> field_values
+    :param callable function: (values, counter, random) --> field_values
     :param seed: optional initialization of the random number generator
     :returns: function of the form (iterator, field_name, model_name) -> values
     :rtype: function (iterator, str, str) -> dict
@@ -143,6 +143,7 @@ def randint(a, b, seed=None):
 
     :param int a: minimal random value
     :param int b: maximal random value
+    :param int seed:
     :returns: function of the form (iterator, field_name, model_name) -> values
     :rtype: function (iterator, str, str) -> dict
     """
@@ -163,12 +164,13 @@ def randdatetime(*, base_date=None, relative_before=None, relative_after=None, s
     to a random datetime between relative_before and relative_after, relatively to
     base_date
 
-    :param base_date (datetime): override the default base date if needed.
-    :param relative_after (relativedelta, timedelta): range up which we can go after the
+    :param datetime base_date: override the default base date if needed.
+    :param relativedelta|timedelta relative_after: range up which we can go after the
          base date. If not set, defaults to 0, i.e. only in the past of reference.
-    :param relative_before (relativedelta, timedelta): range up which we can go before the
+    :param relativedelta|timedelta relative_before: range up which we can go before the
          base date. If not set, defaults to 0, i.e. only in the future of reference.
-    :return (generator): iterator for random dates inside the defined range
+    :param seed:
+    :return: iterator for random dates inside the defined range
     """
     base_date = base_date or datetime(2020, 1, 1)
     seconds_before = relative_before and ((base_date + relative_before) - base_date).total_seconds() or 0

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -254,7 +254,7 @@ def pg_varchar(size=0):
       'infinite' VARCHAR
     * Otherwise return a VARCHAR(n)
 
-    :type int size: varchar size, optional
+    :param int size: varchar size, optional
     :rtype: str
     """
     if size:

--- a/odoo/tools/test_reports.py
+++ b/odoo/tools/test_reports.py
@@ -76,9 +76,12 @@ def try_report_action(cr, uid, action_id, active_model=None, active_ids=None,
                 context=None, our_module=None):
     """Take an ir.actions.act_window and follow it until a report is produced
 
+        :param cr:
+        :param uid:
         :param action_id: the integer id of an action, or a reference to xml id
                 of the act_window (can search [our_module.]+xml_id
-        :param active_model, active_ids: call the action as if it had been launched
+        :param active_model:
+        :param active_ids: call the action as if it had been launched
                 from that model+ids (tree/form view action)
         :param wiz_data: a dictionary of values to use in the wizard, if needed.
                 They will override (or complete) the default values of the
@@ -86,6 +89,7 @@ def try_report_action(cr, uid, action_id, active_model=None, active_ids=None,
         :param wiz_buttons: a list of button names, or button icon strings, which
                 should be preferred to press during the wizard.
                 Eg. 'OK' or 'fa-print'
+        :param context:
         :param our_module: the name of the calling module (string), like 'account'
     """
     if not our_module and isinstance(action_id, str):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -170,6 +170,7 @@ avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UN
 def translate_xml_node(node, callback, parse, serialize):
     """ Return the translation of the given XML/HTML node.
 
+        :param node:
         :param callback: callback(text) returns translated text or None
         :param parse: parse(text) returns a node (text is unicode)
         :param serialize: serialize(node) returns unicode text
@@ -1135,6 +1136,7 @@ def trans_load_data(cr, fileobj, fileformat, lang,
                     verbose=True, create_empty_translation=False, overwrite=False):
     """Populates the ir_translation table.
 
+    :param cr:
     :param fileobj: buffer open to a translation file
     :param fileformat: format of the `fielobj` file, one of 'po' or 'csv'
     :param lang: language code of the translations contained in `fileobj`
@@ -1237,10 +1239,12 @@ def resetlocale():
 
 def load_language(cr, lang):
     """ Loads a translation terms for a language.
+
     Used mainly to automate language loading at db initialization.
 
-    :param lang: language ISO code with optional _underscore_ and l10n flavor (ex: 'fr', 'fr_BE', but not 'fr-BE')
-    :type lang: str
+    :param cr:
+    :param str lang: language ISO code with optional underscore (``_``) and
+        l10n flavor (ex: 'fr', 'fr_BE', but not 'fr-BE')
     """
     env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
     installer = env['base.language.install'].create({'lang': lang})

--- a/odoo/tools/xml_utils.py
+++ b/odoo/tools/xml_utils.py
@@ -30,10 +30,11 @@ def _check_with_xsd(tree_or_str, stream, env=None):
 
     This will raise a UserError if the XML file is not valid according to the
     XSD file.
-    :param tree_or_str (etree, str): representation of the tree to be checked
-    :param stream (io.IOBase, str): the byte stream used to build the XSD schema.
+
+    :param str | etree._Element tree_or_str: representation of the tree to be checked
+    :param io.IOBase | str stream: the byte stream used to build the XSD schema.
         If env is given, it can also be the name of an attachment in the filestore
-    :param env (odoo.api.Environment): If it is given, it enables resolving the
+    :param odoo.api.Environment env: If it is given, it enables resolving the
         imports of the schema in the filestore with ir.attachments.
     """
     if not isinstance(tree_or_str, etree._Element):
@@ -58,10 +59,12 @@ def create_xml_node_chain(first_parent_node, nodes_list, last_node_value=None):
 
     Each new node being the child of the previous one based on the tags contained
     in `nodes_list`, under the given node `first_parent_node`.
-    :param first_parent_node (etree._Element): parent of the created tree/chain
-    :param nodes_list (iterable<str>): tag names to be created
-    :param last_node_value (str): if specified, set the last node's text to this value
-    :returns (list<etree._Element>): the list of created nodes
+
+    :param etree._Element first_parent_node: parent of the created tree/chain
+    :param iterable[str] nodes_list: tag names to be created
+    :param str last_node_value: if specified, set the last node's text to this value
+    :returns: the list of created nodes
+    :rtype: list[etree._Element]
     """
     res = []
     current_node = first_parent_node
@@ -77,9 +80,9 @@ def create_xml_node_chain(first_parent_node, nodes_list, last_node_value=None):
 def create_xml_node(parent_node, node_name, node_value=None):
     """Create a new node.
 
-    :param parent_node (etree._Element): parent of the created node
-    :param node_name (str): name of the created node
-    :param node_value (str): value of the created node (optional)
-    :returns (etree._Element):
+    :param etree._Element parent_node: parent of the created node
+    :param str node_name: name of the created node
+    :param str node_value: value of the created node (optional)
+    :rtype: etree._Element
     """
     return create_xml_node_chain(parent_node, [node_name], node_value)[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,36 @@ requires =
   python3-xlwt
   python3-xlrd
   python3-zeep
+
+[flake8]
+exclude =
+  .git,
+  .tx,
+  addons,
+  debian,
+  doc,
+  setup,
+select =
+  RST
+rst-directives =
+  function,
+  attribute,
+  seealso,
+  deprecated,
+  versionadded,
+  versionchanged,
+  todo
+rst-roles =
+  ref,
+  mod,
+  class,
+  py:meth,
+  meth,
+  attr,
+  data,
+  const,
+  func,
+  exc,
+  term,
+  samp,
+  program


### PR DESCRIPTION
Lots of docstrings are wrong in the details with invalid rST, documenting parameters which don't exist (anymore), *not* documenting parameters which do, fucking up info fields, specifying types incorrectly, ...

This PR is a stab at fixing some of those issues and trying to make things last a bit, by enabling a checker to try and prevent broken docstrings from being committed. Note that the checker is currently configured to only check the core (odoo and the `base` module): this is already a fair amount of changes, so to avoid Extreme Conflicts I think it'd be a good idea to get that merged, then start expanding the scope of the checker.