### PR TITLE
[FIX] web: pdfjs: restore download button in attachment viewer

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -263,10 +263,10 @@ function webViewerLoad() {
   // Hide Open Button
   config.toolbar.openFile.setAttribute('hidden', 'true');
   config.secondaryToolbar.openFileButton.setAttribute('hidden', 'true');
-  // Hide Download Button
-  config.toolbar.download.setAttribute('hidden', 'true');
-  config.secondaryToolbar.downloadButton.setAttribute('hidden', 'true');
   if (isAndroid || isIOS) {
+    // Hide Download Button
+    config.toolbar.download.setAttribute('hidden', 'true');
+    config.secondaryToolbar.downloadButton.setAttribute('hidden', 'true');
     // Hide Print Button
     config.toolbar.print.setAttribute('hidden', 'true');
     config.secondaryToolbar.printButton.setAttribute('hidden', 'true');


### PR DESCRIPTION
Due to the following PR: https://github.com/odoo/odoo/pull/70092
the download icon wasn't present in the document viewer.
We had to do this to avoid crash in mobile apps (Android and iOS).

But even if there are multiple other ways to download file, some
of our users are used to use pdf js download button that was previously
hidden.

So in this commit, we restore it on desktop as we can now correctly
handle the error on Android tablets and hide this button on iOS tablets.

Note that pdfjs button is not needed on mobile as we doesnt' have
attachements preview on small screens. Another button is available
when you open the file.

Steps to reproduce:
- Go to Accounting
- Customer Invoices
- After printing it once, the download icon wasn't present in pdfjs preview

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
