### PR TITLE
[FIX] project: fix project status bubble form display

### DIFF
--- a/addons/project/static/src/scss/project_widgets.scss
+++ b/addons/project/static/src/scss/project_widgets.scss
@@ -15,7 +15,7 @@
     }
     &.o_field_widget {
         span {
-            margin-bottom: 4px;
+            display: inline-block;
         }
     }
 }

--- a/addons/project/static/src/xml/project_templates.xml
+++ b/addons/project/static/src/xml/project_templates.xml
@@ -15,7 +15,7 @@
         </table>
     </t>
 
-    <span t-name="project.statusWithColor" t-att-class="'o_status_bubble o_color_bubble_' + color"></span>
+    <span t-name="project.statusWithColor" t-att-class="'o_status_bubble mr-2 o_color_bubble_' + color"></span>
 
     <div t-name="project.ControlPanel" t-inherit="web.ControlPanel" t-inherit-mode="extension" owl="1">
         <xpath expr="//ol[hasclass('breadcrumb')]" position="inside">


### PR DESCRIPTION
This commit fixes the display of the status bubble inside of the status
button on the project form view. It wasn't visible since the recent css
changes.

Task ID: 2615293
