### PR TITLE
[FIX] project: improve kanban view of task

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -986,7 +986,7 @@
                                     </div>
                                     <div class="oe_kanban_bottom_right" t-if="!selection_mode">
                                         <field name="kanban_state" widget="state_selection" groups="base.group_user" invisible="context.get('fsm_mode', False)"/>
-                                        <field name="user_id" widget="many2one_avatar_user"/>
+                                        <t t-if="record.user_id.raw_value"><field name="user_id" widget="many2one_avatar_user"/></t>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Purpose of this commit improve kanban_state field
layout in kanban view of task.when user_id doesn't
set on task it show blank div for m2oAvatar which
move kanban_state field to left of that div.

So, In this commit show m2oAvatar only when use_id
is set on that task.

Task Id: 2557892

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
