### PR TITLE
[FIX] account: accounting date of customer invoice before tax lock

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -390,11 +390,14 @@ class AccountMove(models.Model):
         """
         tax_lock_date = self.company_id.tax_lock_date
         today = fields.Date.today()
-        if invoice_date and tax_lock_date and has_tax and invoice_date <= tax_lock_date:
+        lock_violated = invoice_date and tax_lock_date and has_tax and invoice_date <= tax_lock_date
+        if lock_violated:
             invoice_date = tax_lock_date + timedelta(days=1)
 
         if self.is_sale_document(include_receipts=True):
-            return max(invoice_date, today)
+            if lock_violated:
+                return max(invoice_date, today)
+            return invoice_date
         elif self.is_purchase_document(include_receipts=True):
             highest_name = self.highest_name or self._get_last_sequence(relaxed=True)
             number_reset = self._deduce_sequence_number_reset(highest_name)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -145,9 +145,9 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
     @freeze_time('2020-01-15')
     def test_out_invoice_onchange_invoice_date(self):
         for tax_date, invoice_date, accounting_date in [
-            ('2019-03-31', '2019-05-12', '2020-01-15'),
+            ('2019-03-31', '2019-05-12', '2019-05-12'),
             ('2019-03-31', '2019-02-10', '2020-01-15'),
-            ('2019-05-31', '2019-06-15', '2020-01-15'),
+            ('2019-05-31', '2019-06-15', '2019-06-15'),
         ]:
             self.invoice.company_id.tax_lock_date = tax_date
             with Form(self.invoice) as move_form:


### PR DESCRIPTION
Bad forward port of
https://github.com/odoo/odoo/commit/3b4c6c71aadc7fc60f4698517e479f3f4f741e23
While going over
https://github.com/odoo/odoo/commit/85f2c8b58ab195b115b7f612b9a4454347349a80

We want the accounting date of customer invoices to be today only when
it was violating the tax lock date constraint.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
