### PR TITLE
[FIX] point_of_sale: Translate the popup number buttons

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -1111,6 +1111,13 @@ msgid "Confirm"
 msgstr ""
 
 #. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Popups/NumberPopup.js:0
+#, python-format
+msgid "Confirm ?"
+msgstr ""
+
+#. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Connect devices to your PoS directly without an IoT Box"
 msgstr ""

--- a/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
@@ -1,5 +1,7 @@
 odoo.define('point_of_sale.NumberPopup', function(require) {
     'use strict';
+    var core = require('web.core');
+    var _t = core._t;
 
     const { useState } = owl;
     const AbstractAwaitablePopup = require('point_of_sale.AbstractAwaitablePopup');
@@ -62,9 +64,9 @@ odoo.define('point_of_sale.NumberPopup', function(require) {
     }
     NumberPopup.template = 'NumberPopup';
     NumberPopup.defaultProps = {
-        confirmText: 'Ok',
-        cancelText: 'Cancel',
-        title: 'Confirm ?',
+        confirmText: _t('Ok'),
+        cancelText: _t('Cancel'),
+        title: _t('Confirm ?'),
         body: '',
         cheap: false,
         startingValue: null,


### PR DESCRIPTION
Steps to reproduce the bug:
- Change the language in odoo preferences (e.g: FR)
- Go to pos app > Configuration > Point of sale
- Choose anyone > Edit > Enable “Global discounts” option
- Open new session with the same pos
- Click on “Discount”
- The button "cancel", “confirm” and "ok" are not translated

opw-2615309


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
