### PR TITLE
[FIX] sale: product.product shown inside order lines instead of produ…

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1198,6 +1198,7 @@ class SaleOrderLine(models.Model):
     discount = fields.Float(string='Discount (%)', digits=dp.get_precision('Discount'), default=0.0)
 
     product_id = fields.Many2one('product.product', string='Product', domain=[('sale_ok', '=', True)], change_default=True, ondelete='restrict')
+    product_template_id = fields.Many2one('product.template', string='Product Template', related="product_id.product_tmpl_id", domain=[('sale_ok', '=', True)])
     product_updatable = fields.Boolean(compute='_compute_product_updatable', string='Can Edit Product', readonly=True, default=True)
     product_uom_qty = fields.Float(string='Ordered Quantity', digits=dp.get_precision('Product Unit of Measure'), required=True, default=1.0)
     product_uom = fields.Many2one('uom.uom', string='Unit of Measure')

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -307,6 +307,16 @@
                                                     'readonly': [('product_updatable', '=', False)],
                                                     'required': [('display_type', '=', False)],
                                                 }"
+                                                groups="product.group_product_variant"
+                                                force_save="1"
+                                               />
+                                            <field name="product_template_id"
+                                                context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
+                                                attrs="{
+                                                    'readonly': [('product_updatable', '=', False)],
+                                                    'required': [('display_type', '=', False)],
+                                                }"
+                                                groups="!product.group_product_variant"
                                                 force_save="1"
                                                />
                                             <field name="invoice_status" invisible="1"/>


### PR DESCRIPTION
…ct.template when variants are disabled

Step to follow

Disable product variants
Click on the product in the order lines
You will be redirected to the product.product page
On that page, only logs and messages related to the product are shown
and not the ones related to the template (accessed via the products tab)

Solution

Show the product template when variants are disabled because the
product.product isn't needed in that case

opw-2610272