### PR TITLE
[FIX] mrp : Operation of BOM with duration 0 was set to 60

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -695,7 +695,7 @@ class MrpWorkorder(models.Model):
             if duration_expected_working < 0:
                 duration_expected_working = 0
             return alternative_workcenter.time_start + alternative_workcenter.time_stop + cycle_number * duration_expected_working * 100.0 / alternative_workcenter.time_efficiency
-        time_cycle = self.operation_id and self.operation_id.time_cycle or 60.0
+        time_cycle = self.operation_id.time_cycle
         return self.workcenter_id.time_start + self.workcenter_id.time_stop + cycle_number * time_cycle * 100.0 / self.workcenter_id.time_efficiency
 
     def _get_conflicted_workorder_ids(self):


### PR DESCRIPTION
Issue: When preparing a work order for a product on which the bill of material had a line with duration set to 00:00, the work order expected_duration for that line was set to 60:00

Steps to reproduce :
 1) Enable Work Orders under Manufacturing Settings
 2) Create a Bill of Material for a new product "test"
 3) On the BoM Form, go to Operation, add a line
 4) Set an operation, a work center and for Duration Computation, set it to manually and 00:00 minutes and save
 5) Create a manufacturing order for that product, check the Work Orders tab of the Manufacturing order form, the duration is set to 60:00

Why is that a bug:
 Since we can set a duration of 00:00 in the Bill of Material, it means the work order can take 00:00 as expected duration, however it was set to 60.0 since 00:00 is evaluated as 0, which is considered `False` in a conditional assignment that was catching the case where the variable was `None`, which it can never be since it is a fields.Float that will be 0 in case of a `None` or `False`

opw-2603928