### PR TITLE
[FIX] purchase: use Product Price precision in bills

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1137,7 +1137,7 @@ class PurchaseOrderLine(models.Model):
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
             'quantity': self.qty_to_invoice,
-            'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date),
+            'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date, round=False),
             'tax_ids': [(6, 0, self.taxes_id.ids)],
             'analytic_account_id': self.account_analytic_id.id,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],


### PR DESCRIPTION
When the Product Price precision is greater than the currency precision,
it can lead to incorrect data

To reproduce the error:
(Enable debug mode)
1. Settings > Technical > Database Structure > Decimal Accuracy, edit
Product Price:
    - Digits: 3
2. Create a PO
    - Add a product:
        - Quantity: 12
        - Unit Price: 0.001
3. Save, Confirm, Edit the PO:
    - Qty Received: 12
    - (Note that the total is $0.01)
4. Create a bill:
    - Add the PO to the field "Auto-Complete"

Error: The unit price is $0.000 and so does the total

The rounding of the unit price should be based on the Product Price
precision, not the currency precision.

OPW-2601867