### PR TITLE
[FIX] google_calendar: Don't raise traceback on delete response error

### DIFF
--- a/addons/google_calendar/models/google_calendar.py
+++ b/addons/google_calendar/models/google_calendar.py
@@ -297,6 +297,7 @@ class GoogleCalendar(models.AbstractModel):
             if e.response.status_code != 403:
                 raise e
             _logger.info("Could not delete Google event %s" % event_id)
+            return False
         return response
 
     def get_calendar_primary_id(self):


### PR DESCRIPTION
Steps to reproduce:

  - Install "Google Calendar" module
  - Go to Settings
  - Set your google calendar credentials
  - Go to Calendar
  - Create an event X, then sync with Google
    (event should be available in the Google Calendar website)
  - Delete the event X, then sync with Google (! to trigger the issue,
    I had to simulate I had a wrong google response to
    my delete request)

Issue:

  Traceback raised.

Cause:

  Returning response even if not set due to request error.

opw-2613395