### PR TITLE
[IMP] core: enable top level await in odoo modules

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -14,14 +14,14 @@ class TestJsTranspiler(TransactionCase):
         input_content = """/** @odoo-module alias=test_assetsbundle.Alias **/"""
         result = transpile_javascript("/test_assetsbundle/static/src/alias.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/alias', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/alias', async function (require) {
 'use strict';
 let __exports = {};
 /** @odoo-module alias=test_assetsbundle.Alias **/
 return __exports;
 });
 
-odoo.define(`test_assetsbundle.Alias`, function(require) {
+odoo.define(`test_assetsbundle.Alias`, async function(require) {
                         return require('@test_assetsbundle/alias')[Symbol.for("default")];
                         });
 """
@@ -32,14 +32,14 @@ odoo.define(`test_assetsbundle.Alias`, function(require) {
         input_content = """/** @odoo-module alias=test_assetsbundle.Alias default=False **/"""
         result = transpile_javascript("/test_assetsbundle/static/src/alias.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/alias', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/alias', async function (require) {
 'use strict';
 let __exports = {};
 /** @odoo-module alias=test_assetsbundle.Alias default=False **/
 return __exports;
 });
 
-odoo.define(`test_assetsbundle.Alias`, function(require) {
+odoo.define(`test_assetsbundle.Alias`, async function(require) {
                         return require('@test_assetsbundle/alias');
                         });
 """
@@ -49,14 +49,14 @@ odoo.define(`test_assetsbundle.Alias`, function(require) {
         input_content = """/** @odoo-module alias=test_assetsbundle.Alias default=0 **/"""
         result = transpile_javascript("/test_assetsbundle/static/src/alias.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/alias', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/alias', async function (require) {
 'use strict';
 let __exports = {};
 /** @odoo-module alias=test_assetsbundle.Alias default=0 **/
 return __exports;
 });
 
-odoo.define(`test_assetsbundle.Alias`, function(require) {
+odoo.define(`test_assetsbundle.Alias`, async function(require) {
                         return require('@test_assetsbundle/alias');
                         });
 """
@@ -66,14 +66,14 @@ odoo.define(`test_assetsbundle.Alias`, function(require) {
         input_content = """/** @odoo-module alias=test_assetsbundle.Alias default=false **/"""
         result = transpile_javascript("/test_assetsbundle/static/src/alias.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/alias', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/alias', async function (require) {
 'use strict';
 let __exports = {};
 /** @odoo-module alias=test_assetsbundle.Alias default=false **/
 return __exports;
 });
 
-odoo.define(`test_assetsbundle.Alias`, function(require) {
+odoo.define(`test_assetsbundle.Alias`, async function(require) {
                         return require('@test_assetsbundle/alias');
                         });
 """
@@ -93,7 +93,7 @@ export const Ferrari = class Ferrari extends Car {};
 """
         result = transpile_javascript("/test_assetsbundle/static/src/classes.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/classes', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/classes', async function (require) {
 'use strict';
 let __exports = {};
 const Nice = __exports[Symbol.for("default")] = class Nice {}
@@ -146,7 +146,7 @@ const aaa = "keep!";
 """
         result = transpile_javascript("/test_assetsbundle/static/src/comments.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/comments', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/comments', async function (require) {
 'use strict';
 let __exports = {};
 /**
@@ -206,7 +206,7 @@ export default function sayHelloDefault() {
 """
         result = transpile_javascript("/test_assetsbundle/static/src/functions.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/functions', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/functions', async function (require) {
 'use strict';
 let __exports = {};
 const sayHello = __exports.sayHello = function sayHello() {
@@ -262,7 +262,7 @@ import Line16 from "test.Dialog.error";
 """
         result = transpile_javascript("/test_assetsbundle/static/src/import.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/import', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/import', async function (require) {
 'use strict';
 let __exports = {};
 /**
@@ -308,7 +308,7 @@ import c from "@tests/dir/index/";
 import d from "@tests";"""
         result = transpile_javascript("/test_assetsbundle/static/src/index.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle', async function (require) {
 'use strict';
 let __exports = {};
 const a = __exports.a = 5;
@@ -350,7 +350,7 @@ export * from "@tests/Dialog";
 """
         result = transpile_javascript("/test_assetsbundle/static/src/list.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/list', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/list', async function (require) {
 'use strict';
 let __exports = {};
 Object.assign(__exports, {a,  b});
@@ -397,7 +397,7 @@ export default a;
 """
         result = transpile_javascript("/test_assetsbundle/static/src/variables.js", input_content)
 
-        expected_result = """odoo.define('@test_assetsbundle/variables', function (require) {
+        expected_result = """odoo.define('@test_assetsbundle/variables', async function (require) {
 'use strict';
 let __exports = {};
 const v = __exports.v = 5;

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -60,7 +60,7 @@ URL_RE = re.compile(r"""
 
 def url_to_module_path(url):
     """
-    Odoo modules each have a name. (odoo.define("<the name>", function (require) {...});
+    Odoo modules each have a name. (odoo.define("<the name>", async function (require) {...});
     It is used in to be required later. (const { something } = require("<the name>").
     The transpiler transforms the url of the file in the project to this name.
     It takes the module name and add a @ on the start of it, and map it to be the source of the static/src (or
@@ -95,7 +95,7 @@ def wrap_with_odoo_define(module_path, content):
     Wraps the current content (source code) with the odoo.define call.
     Should logically be called once all other operations have been performed.
     """
-    return f"""odoo.define({module_path!r}, function (require) {{
+    return f"""odoo.define({module_path!r}, async function (require) {{
 'use strict';
 let __exports = {{}};
 {content}
@@ -567,7 +567,7 @@ def get_aliased_odoo_define_content(module_path, content):
     we have a problem when we will have converted to module to ES6: its new name will be more like
     "web/chrome/abstract_action". So the require would fail !
     So we add a second small modules, an alias, as such:
-    > odoo.define("web/chrome/abstract_action", function(require) {
+    > odoo.define("web/chrome/abstract_action", async function(require) {
     >  return require('web.AbstractAction')[Symbol.for("default")];
     > });
 
@@ -597,11 +597,11 @@ def get_aliased_odoo_define_content(module_path, content):
         alias = matchobj['alias']
         if alias:
             if matchobj['default']:
-                return """\nodoo.define(`%s`, function(require) {
+                return """\nodoo.define(`%s`, async function(require) {
                         return require('%s');
                         });\n""" % (alias, module_path)
             else:
-                return """\nodoo.define(`%s`, function(require) {
+                return """\nodoo.define(`%s`, async function(require) {
                         return require('%s')[Symbol.for("default")];
                         });\n""" % (alias, module_path)
 


### PR DESCRIPTION
Transpile odoo-modules into async functions rather than simple functions.
The aim of this change is to support top-level await.
