### PR TITLE
[FIX] website_livechat: adapt visitor kanban to fix scss styling

### DIFF
--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -40,9 +40,10 @@
                 <div t-if="record.livechat_operator_id.raw_value">
                     Speaking With
                     <div name="livechat_operator_id"
-                         class="o_field_many2one_avatar o_field_widget font-weight-bold float-right d-inline-block">
-                        <img t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
-                             alt="Operator Avatar" class="o_m2o_avatar"/>
+                        class="font-weight-bold float-right d-inline-block">
+                        <img class="oe_avatar rounded-circle" width="19" height="19"
+                            t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
+                            alt="Operator Avatar"/>
                         <field name="livechat_operator_name"/>
                     </div>
                 </div>
@@ -58,10 +59,11 @@
                     <div>Chats</div>
                 </div>
                 <div class="col mx-2">
-                    <div t-if="record.livechat_operator_id.raw_value"
-                         class="o_field_many2one_avatar o_field_widget font-weight-bold" name="livechat_operator_id">
-                        <img t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
-                             alt="Operator Avatar" class="o_m2o_avatar"/>
+                    <div t-if="record.livechat_operator_id.raw_value" class="font-weight-bold">
+                        <img name="livechat_operator_id"
+                            class="oe_avatar rounded-circle" width="19" height="19"
+                            t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
+                            alt="Operator Avatar"/>
                         <field name="livechat_operator_name"/>
                     </div>
                     <div t-if="record.livechat_operator_id.raw_value">Speaking With</div>


### PR DESCRIPTION
The commit fixes a small UI glitch in the website.visitors kanban view when
website_livechat is installed.

Since 5a0a1e76b372d80adc1bad6ad29a20bedf764100
The img element requires to be wrapped inside another element with the
"o_m2o_avatar" class to receive the appropriate css styling (small round icon).

We simply add this wrapper element around the img to fix the layout.

Task-2612936

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
