### PR TITLE
[IMP] core,account: postpone checking some account contstrain

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1705,7 +1705,7 @@ class AccountMove(models.Model):
     # CONSTRAINT METHODS
     # -------------------------------------------------------------------------
 
-    @api.constrains('name', 'journal_id', 'state')
+    @api.constrains('name', 'journal_id', 'state', precommit=True)
     def _check_unique_sequence_number(self):
         moves = self.filtered(lambda move: move.state == 'posted')
         if not moves:

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -278,7 +278,7 @@ class TestSequenceMixin(AccountTestInvoicingCommon):
         self.assertEqual(copies[5].name, 'XMISC/2019/00004')
 
         # Can't have twice the same name
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError, flush=True):
             copies[0].name = 'XMISC/2019/00001'
 
         # Lets remove the order by date

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -98,7 +98,7 @@ def propagate(method1, method2):
     return method2
 
 
-def constrains(*args):
+def constrains(*args, precommit=False):
     """Decorate a constraint checker.
 
     Each argument must be a field name used in the check::
@@ -110,6 +110,8 @@ def constrains(*args):
                     raise ValidationError("Fields name and description must be different")
 
     Invoked on the records on which one of the named fields has been modified.
+
+    If precommit is True, the check will be postponed until the end of transaction.
 
     Should raise :exc:`~odoo.exceptions.ValidationError` if the
     validation failed.
@@ -133,7 +135,7 @@ def constrains(*args):
     """
     if args and callable(args[0]):
         args = args[0]
-    return attrsetter('_constrains', args)
+    return attrsetter('_constrains', (args, precommit))
 
 
 def ondelete(*, at_uninstall):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -409,7 +409,7 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
             self.env = self.env(user=self.uid)
 
     @contextmanager
-    def _assertRaises(self, exception, *, msg=None):
+    def _assertRaises(self, exception, *, msg=None, flush=None):
         """ Context manager that clears the environment upon failure. """
         with super(BaseCase, self).assertRaises(exception, msg=msg) as cm:
             if hasattr(self, 'env'):
@@ -417,6 +417,10 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
                     yield cm
             else:
                 yield cm
+
+            if flush:
+                self.env.user.flush()
+                self.env.cr.precommit.run()
 
     def assertRaises(self, exception, func=None, *args, **kwargs):
         if func:


### PR DESCRIPTION
Accounting constrain `_check_unique_sequence_number` passes in majority cases,
while it could take significant time (e.g. on inventory validation). To speed it
up, the commit postpones execution until the end of transaction to make the
query once for all records.

---

opw-2613219
