### PR TITLE
[FIX] calendar: expected singleton error with _find_attendee

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -787,7 +787,7 @@ class Meeting(models.Model):
 
         my_attendee = self.attendee_ids.filtered(lambda att: att.partner_id == self.env.user.partner_id)
         if my_attendee:
-            return my_attendee
+            return my_attendee[:1]
 
         event_checked_attendees = self.env['calendar.contacts'].search([
             ('user_id', '=', self.env.user.id),
@@ -795,10 +795,10 @@ class Meeting(models.Model):
             ('partner_checked', '=', True)
         ]).mapped('partner_id')
         if self.partner_id in event_checked_attendees and self.partner_id in self.attendee_ids.partner_id:
-            return self.attendee_ids.filtered(lambda attendee: attendee.partner_id == self.partner_id)
+            return self.attendee_ids.filtered(lambda attendee: attendee.partner_id == self.partner_id)[:1]
 
         attendee = self.attendee_ids.filtered(lambda att: att.partner_id in event_checked_attendees and att.state != "needsAction")
-        return attendee
+        return attendee[:1]
 
     def _get_start_date(self):
         """Return the event starting date in the event's timezone.


### PR DESCRIPTION
Issue
-----

Opening the calendar view may lead to an expected singleton error
because _find_attendee my return a recordset with a len > 1

Solution
--------
Return the first element of the filtered list to match the behavior
described in the doc string





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
