### PR TITLE
[FIX] payment: `_inverse_journal_id` behaviour when missing a payment…

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -184,8 +184,8 @@ class PaymentAcquirer(models.Model):
             if acquirer.journal_id:
                 if not payment_method:
                     self.env['account.payment.method.line'].create({
-                        'payment_method_id': self._get_default_payment_method(),
-                        'journal_id': self.journal_id.id,
+                        'payment_method_id': acquirer._get_default_payment_method(),
+                        'journal_id': acquirer.journal_id.id,
                     })
                 else:
                     payment_method.journal_id = acquirer.journal_id


### PR DESCRIPTION
When computing the inverse of `journal_id` on a batch of
`payment.acquirer`, a payment method is created if there isn't any.
As this process can only be done for one acquirer at a time, we must
populate the data accordingly.
