### PR TITLE
[FIX] mrp: filter mo based on selected bom_id

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -74,14 +74,16 @@ class MrpUnbuild(models.Model):
         ('done', 'Done')], string='Status', default='draft', index=True)
     allowed_mo_ids = fields.One2many('mrp.production', compute='_compute_allowed_mo_ids')
 
-    @api.depends('company_id', 'product_id')
+    @api.depends('company_id', 'product_id', 'bom_id')
     def _compute_allowed_mo_ids(self):
         for unbuild in self:
             domain = [
                     ('state', '=', 'done'),
                     ('company_id', '=', unbuild.company_id.id)
                 ]
-            if unbuild.product_id:
+            if unbuild.bom_id:
+                domain = expression.AND([domain, [('bom_id', '=', unbuild.bom_id.id)]])
+            elif unbuild.product_id:
                 domain = expression.AND([domain, [('product_id', '=', unbuild.product_id.id)]])
             allowed_mos = self.env['mrp.production'].search_read(domain, ['id'])
             if allowed_mos:


### PR DESCRIPTION
Before this commit, MOs were not filtered based on selected BoM.

With this commit, We are filtering MOs to selected based on BoM.

Fixes #70215

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
