### PR TITLE
[FIX] base: XML-RPC serialization error on HTML fields

### DIFF
--- a/odoo/addons/base/controllers/rpc.py
+++ b/odoo/addons/base/controllers/rpc.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 from xmlrpc.client import dumps, loads
 import xmlrpc.client
 
+from markupsafe import Markup
 from werkzeug.wrappers import Response
 
 from odoo.http import Controller, dispatch_rpc, request, route
@@ -35,6 +36,7 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
     dispatch[lazy] = dump_lazy
 
     dispatch[Command] = dispatch[int]
+    dispatch[Markup] = dispatch[str]
 
 
 # monkey-patch xmlrpc.client's marshaller

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -18,6 +18,12 @@ class TestXMLRPC(common.HttpCase):
         super(TestXMLRPC, self).setUp()
         self.admin_uid = self.env.ref('base.user_admin').id
 
+    def xmlrpc(self, model, method, *args, **kwargs):
+        return self.xmlrpc_object.execute_kw(
+            common.get_db_name(), self.admin_uid, 'admin',
+            model, method, args, kwargs
+        )
+
     def test_01_xmlrpc_login(self):
         """ Try to login on the common service. """
         db_name = common.get_db_name()
@@ -44,6 +50,11 @@ class TestXMLRPC(common.HttpCase):
             common.get_db_name(), self.admin_uid, 'admin',
             'res.partner', 'name_search', "admin"
         )
+
+    def test_xmlrpc_html_field(self):
+        pid = self.xmlrpc('res.partner', 'create', {'name': 'bob', 'comment': 'sucks'})
+        [p] = self.xmlrpc('res.partner', 'read', pid, ['comment'])
+        self.assertEqual(p['comment'], 'sucks')
 
     def test_jsonrpc_read_group(self):
         self._json_call(


### PR DESCRIPTION
In 01875541b1a8131cb0c5459f18670e9a97713135, HTML fields (and various
methods) were made to return markupsafe.Markup objects.

However at the time I didn't consider that XML-RPC serialization
remains based on type *identity*, and thus the `Markup` object would
not serialize outbound through XML-RPC, and would blow up instead.

This should fix the issue, by serializing Markup objects as str.
