### PR TITLE
[13.0][FIX] account_facturx: Don't fail if no partner is found

### DIFF
--- a/addons/account_facturx/models/account_move.py
+++ b/addons/account_facturx/models/account_move.py
@@ -105,7 +105,7 @@ class AccountMove(models.Model):
             if not partner:
                 elements = tree.xpath('//ram:%s//ram:URIID[@schemeID=\'SMTP\']' % partner_type, namespaces=tree.nsmap)
                 partner = elements and self.env['res.partner'].search([('email', '=', elements[0].text)], limit=1)
-            return partner
+            return partner or self.env["res.partner"]
 
         amount_total_import = None
 


### PR DESCRIPTION
When searching for partners to fill the move, the refactoring done in `find_partner` for extracting the partner misses the case where no record is found, as Form expects a recordset as entry, not an empty list.

Note that on previous version, this error doesn't happen, as the assignation was done only if the partner was found:

https://github.com/odoo/odoo/blob/e935cf9a/addons/account_facturx/models/account_invoice.py#L118

@Tecnativa TT31272