### PR TITLE
discard record when onchange in progress

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -567,8 +567,9 @@ var FormController = BasicController.extend({
      *
      * @private
      */
-    _onDiscard: function () {
+    _onDiscard: async function () {
         this._disableButtons();
+        await this.model.mutex.getUnlockedDef();
         this._discardChanges()
             .then(this._enableButtons.bind(this))
             .guardedCatch(this._enableButtons.bind(this));

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -4372,23 +4372,27 @@ QUnit.module('Views', {
         await testUtils.dom.click(form.$('.o_form_button_update'));
     });
 
-    QUnit.test('onchanges that complete after discarding', async function (assert) {
+    QUnit.test('discarding wait for onchanges to complete', async function (assert) {
         assert.expect(6);
 
-        var def1 = testUtils.makeTestPromise();
+        const def1 = testUtils.makeTestPromise();
 
         this.data.partner.onchanges = {
             foo: function (obj) {
                 obj.int_field = obj.foo.length + 1000;
             },
         };
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
-            arch: '<form>' +
-                    '<group><field name="foo"/><field name="int_field"/></group>' +
-                '</form>',
+            arch:
+                `<form>
+                    <group>
+                        <field name="foo"/>
+                        <field name="int_field"/>
+                    </group>
+                </form>`,
             res_id: 2,
             mockRPC: function (route, args) {
                 var result = this._super.apply(this, arguments);
@@ -4413,7 +4417,7 @@ QUnit.module('Views', {
         // discard changes
         await testUtils.form.clickDiscard(form);
         assert.containsNone(form, '.modal');
-        assert.strictEqual(form.$('span[name="foo"]').text(), "blip",
+        assert.strictEqual(form.$('input[name="foo"]').val(), "1234",
             "field foo should still be displayed to initial value");
 
         // complete the onchange


### PR DESCRIPTION
PURPOSE
When editable o2m field has onchange, changing value of that field and directly clicking discard button without losing o2m
field focus throws traceback, because before onchange return result, record is discarded locally and record._changes are null meanwhile.
Traceback should not raise.

SPEC
Discard should wait to finish onchanges before discarding local datapoint, so clicking directly on discard while we change o2m field value and focus is on o2m field will not raise traceback.

TASK 2618195


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
