### PR TITLE
[FIX] point_of_sale: don't auto select wrong customer

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -97,14 +97,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
         // We declare this event handler as a debounce function in
         // order to lower its trigger rate.
         updateClientList(event) {
-            this.state.query = event.target.value;
-            const clients = this.clients;
-            if (event.code === 'Enter' && clients.length === 1) {
-                this.state.selectedClient = clients[0];
-                this.clickNext();
-            } else {
-                this.render();
-            }
+            this.render();
         }
         clickClient(event) {
             let partner = event.detail.client;


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- Go to POS
- create an new customer Martin Robert
- make an order
- a other customer arrive in shop, this name is Martin Laurent and Martin Laurent doesn't exist in database
- You search Martin (because you don't know if customer is in DB)    
--> Issue Martin Robert is selected

**Desired behavior after PR is merged:**
Don't auto select customer.

@pimodoo @caburj 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
