### PR TITLE
[FIX] mrp: No need to merge components thats why passing merge=false

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1089,7 +1089,7 @@ class MrpProduction(models.Model):
                         'product_uom': move_finish.product_id.uom_id
                     })
             production.move_raw_ids._adjust_procure_method()
-            (production.move_raw_ids | production.move_finished_ids)._action_confirm()
+            (production.move_raw_ids | production.move_finished_ids)._action_confirm(merge=False)
             production.workorder_ids._action_confirm()
         # run scheduler for moves forecasted to not have enough in stock
         self.move_raw_ids._trigger_scheduler()


### PR DESCRIPTION
In the MO same components are merged.there is no need to merge it so we have passed merge=false when Mo confirm.

opw-2583848




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
