### PR TITLE
[FIX] stock_dropshipping : edit order qty with differents UoM

### DIFF
--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -15,7 +15,8 @@ class SaleOrderLine(models.Model):
         if purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
             qty = 0.0
             for po_line in purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
-                qty += po_line.product_uom._compute_quantity(po_line.product_qty, self.product_uom, rounding_method='HALF-UP')
+                amount = fields.float_round(po_line.product_qty, precision_rounding=po_line.product_uom.rounding, rounding_method='HALF-UP')
+                qty += amount
             return qty
         else:
             return super(SaleOrderLine, self)._get_qty_procurement(previous_product_uom_qty=previous_product_uom_qty)

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -121,3 +121,65 @@ class TestDropship(common.TransactionCase):
             ('location_dest_id', '=', self.env.ref('stock.stock_location_customers').id),
             ('product_id', '=', drop_shop_product.id)])
         self.assertEquals(len(move_line.ids), 1, 'There should be exactly one move line')
+
+    def test_01_dropship_with_different_uom(self):
+        
+        location = self.env.ref('stock.stock_location_stock')
+        
+        # Create a vendor
+        supplier_dropship = self.env['res.partner'].create({'name': 'Vendor of Dropshipping test'})
+        
+        # Create a product
+        test_product = self.env['product.template'].create({"name": "Product"})
+        
+        # Create a component with UoM Liters with dropshipping route
+        dropshipping_route = self.env.ref('stock_dropshipping.route_drop_shipping')
+        component_liter = self.env['product.template'].create({
+            "name": "component liter",
+            "route_ids": [(6, 0, [dropshipping_route.id])],
+            "seller_ids": [(0, 0, {
+                'delay': 1,
+                'name': supplier_dropship.id,
+                'min_qty': 1.0
+            })],
+            "uom_id": 11,
+            "uom_po_id": 11,
+        })
+        
+        # Create an other component with UoM Units without dropshipping route
+        component_unit = self.env['product.template'].create({
+            "name": "component liter",
+            "type": "product",
+            "uom_id": 1,
+            "uom_po_id": 1,
+        })
+        
+        self.env['stock.quant']._update_available_quantity(component_unit.product_variant_id, location, 100)
+        
+        # Create a BoM for the product with the two components
+        self.env['mrp.bom'].create({
+            "product_tmpl_id": test_product.id,
+            "product_id": False,
+            "product_qty": 1,
+            "type": "phantom",
+            "bom_line_ids": [
+                [0, 0, {"product_id": component_liter.product_variant_id.id, "product_qty": 1}],
+                [0, 0, {"product_id": component_unit.product_variant_id.id, "product_qty": 1}],
+            ]
+        })
+        
+        # Create a sales order with a line of 1 test_product
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.env.ref('base.res_partner_2')
+        so_form.payment_term_id = self.env.ref('account.account_payment_term_end_following_month')
+        with so_form.order_line.new() as line:
+            line.product_id = test_product.product_variant_id
+            line.product_uom_qty = 1
+            line.price_unit = 1.00
+        sale_order = so_form.save()
+        sale_order.action_confirm()
+        
+        # Modify the quantity on sale order line
+        sale_order.write({'order_line': [[1, sale_order.order_line.id, {'product_uom_qty': 2.00}]]})
+        
+        self.assertEqual(sale_order.order_line.product_uom_qty, 2)


### PR DESCRIPTION
Step to reproduce :

- Create a product
- Create a BoM (type: kit) for the product with two components:
    - One with dropship route, a vendor and UoM Liters
    - An other with UoM Units
- Create a Sale Order for the product, save and confirm
- Edit, change the quantity on the order line and save

Current behavior :

An UserError is displayed

Expected behavior :

After this commit, we're able to change the quantity without any
trouble.
A test is also added to be sure the flow will not break in the future.

opw-2613535

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
