### PR TITLE
[IMP] mail: enable tracking on important partner fields

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -11,7 +11,7 @@ from stdnum.util import clean
 
 import logging
 
-from odoo import api, models, tools, _
+from odoo import api, models, fields, tools, _
 from odoo.tools.misc import ustr
 from odoo.exceptions import ValidationError
 
@@ -82,6 +82,8 @@ _region_specific_vat_codes = {
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
+
+    vat = fields.Char(string="VAT/Tax ID")
 
     def _split_vat(self, vat):
         vat_country, vat_number = vat[:2].lower(), vat[2:].replace(' ', '')

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -14,10 +14,12 @@ class Partner(models.Model):
     _inherit = ['res.partner', 'mail.activity.mixin', 'mail.thread.blacklist']
     _mail_flat_thread = False
 
-    # override to add tracking
+    # override to add and order tracking
     email = fields.Char(tracking=1)
     phone = fields.Char(tracking=2)
-    user_id = fields.Many2one(tracking=True)
+    parent_id = fields.Many2one(tracking=3)
+    user_id = fields.Many2one(tracking=4)
+    vat = fields.Char(tracking=5)
     # channels
     channel_ids = fields.Many2many('mail.channel', 'mail_channel_partner', 'partner_id', 'channel_id', string='Channels', copy=False)
 


### PR DESCRIPTION
This PR enables tracking on vat, parent_id, and portal_access
(stored compute field introduced with this commit) for the contact,
because the impact of changes in these fields are very important.

Task: https://www.odoo.com/web#id=2586195&action=4043&model=project.task&view_type=form&cids=2&menu_id=4720

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
