### PR TITLE
master-back 2 basics stock vst

### DIFF
--- a/addons/delivery/__manifest__.py
+++ b/addons/delivery/__manifest__.py
@@ -29,6 +29,8 @@ invoices from picking, the system is able to add and compute the shipping line.
         'wizard/choose_delivery_package_views.xml',
         'wizard/choose_delivery_carrier_views.xml',
         'views/stock_package_type_views.xml',
+        'views/stock_picking_type_views.xml',
+        'views/stock_rule_views.xml',
     ],
     'demo': ['data/delivery_demo.xml'],
     'installable': True,

--- a/addons/delivery/views/stock_picking_type_views.xml
+++ b/addons/delivery/views/stock_picking_type_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_picking_type_form_delivery">
+        <field name="name">stock.picking.type.tree.delivery</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='sequence_code']" position="after">
+                <field name="print_label" attrs="{'invisible': [('code', '!=', 'internal')]}"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/delivery/views/stock_rule_views.xml
+++ b/addons/delivery/views/stock_rule_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_stock_rule_form_delivery" model="ir.ui.view">
+        <field name="name">stock.rule.tree.delivery</field>
+        <field name="model">stock.rule</field>
+        <field name="inherit_id" ref="stock.view_stock_rule_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='propagate_cancel']" position="after">
+                <field name="propagate_carrier" groups="base.group_no_one"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -164,6 +164,18 @@ class StockPicking(models.Model):
         pickings = self.filtered(lambda p: p.picking_type_id != p.picking_type_id.warehouse_id.pos_type_id)
         return super(StockPicking, pickings)._send_confirmation_email()
 
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    @api.depends('warehouse_id')
+    def _compute_hide_reservation_method(self):
+        super()._compute_hide_reservation_method()
+        for picking_type in self:
+            if picking_type == picking_type.warehouse_id.pos_type_id:
+                picking_type.hide_reservation_method = True
+
+
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -613,7 +613,7 @@
                             </group>
                             <group string="Pricelist">
                                 <field name="product_tmpl_id" string="Product" invisible="context.get('visible_product_tmpl_id', True)"/>
-                                <field name="product_id" groups="product.group_product_variant" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_create_edit': True}"/>
+                                <field name="product_id" groups="product.group_product_variant" options="{'no_create': True}"/>
                                 <label for="min_qty"/>
                                 <div class="o_row">
                                     <field name="min_qty"/>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -24,6 +24,7 @@
                 </xpath>
                 <xpath expr="//field[@name='product_id']" position="attributes">
                     <attribute name="readonly">0</attribute>
+                    <attribute name="options">{'no_create': True, 'no_open': True}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='delay']" position="attributes">
                     <attribute name="optional">show</attribute>
@@ -41,7 +42,7 @@
                 </xpath>
                 <group name="purchase" position="before">
                     <field name="seller_ids" context="{'default_product_tmpl_id':context.get('product_tmpl_id',active_id), 'product_template_invisible_variant': True, 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&gt;',1)], 'readonly': [('product_variant_count','&gt;',1)]}"/>
-                    <field name="variant_seller_ids" context="{'default_product_tmpl_id': context.get('product_tmpl_id', active_id), 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&lt;=',1)], 'readonly': [('product_variant_count','&lt;=',1)]}"/>
+                    <field name="variant_seller_ids" context="{'model': active_model, 'active_id': active_id, 'tree_view_ref':'purchase.product_supplierinfo_tree_view2'}" nolabel="1" attrs="{'invisible': [('product_variant_count','&lt;=',1)], 'readonly': [('product_variant_count','&lt;=',1)]}"/>
                 </group>
                 <group name="bill" position="attributes">
                     <attribute name="groups">purchase.group_purchase_manager</attribute>

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -36,7 +36,7 @@ class ResConfigSettings(models.TransientModel):
     ], string='Customer Account', default='b2b', config_parameter='auth_signup.invitation_scope')
 
     module_delivery = fields.Boolean("Delivery Methods")
-    module_delivery_dhl = fields.Boolean("DHL USA Connector")
+    module_delivery_dhl = fields.Boolean("DHL Express Connector")
     module_delivery_fedex = fields.Boolean("FedEx Connector")
     module_delivery_ups = fields.Boolean("UPS Connector")
     module_delivery_usps = fields.Boolean("USPS Connector")

--- a/addons/sale_stock/tests/test_sale_stock_lead_time.py
+++ b/addons/sale_stock/tests/test_sale_stock_lead_time.py
@@ -197,3 +197,12 @@ class TestSaleStockLeadTime(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertEqual(pack.date_deadline, new_deadline)
         new_deadline -= timedelta(days=pick.move_ids[0].rule_id.delay)
         self.assertEqual(pick.date_deadline, new_deadline)
+
+        # Removes the SO deadline and checks the delivery deadline is updated accordingly.
+        order.commitment_date = False
+        new_deadline = order.expected_date
+        self.assertEqual(out.date_deadline, new_deadline)
+        new_deadline -= timedelta(days=pack.move_ids.rule_id.delay)
+        self.assertEqual(pack.date_deadline, new_deadline)
+        new_deadline -= timedelta(days=pick.move_ids.rule_id.delay)
+        self.assertEqual(pick.date_deadline, new_deadline)

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -31,7 +31,7 @@ class ResConfigSettings(models.TransientModel):
     stock_mail_confirmation_template_id = fields.Many2one(related='company_id.stock_mail_confirmation_template_id', readonly=False)
     module_stock_sms = fields.Boolean("SMS Confirmation")
     module_delivery = fields.Boolean("Delivery Methods")
-    module_delivery_dhl = fields.Boolean("DHL USA Connector")
+    module_delivery_dhl = fields.Boolean("DHL Express Connector")
     module_delivery_fedex = fields.Boolean("FedEx Connector")
     module_delivery_ups = fields.Boolean("UPS Connector")
     module_delivery_usps = fields.Boolean("USPS Connector")

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -99,7 +99,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     _sql_constraints = [
         ('qty_multiple_check', 'CHECK( qty_multiple >= 0 )', 'Qty Multiple must be greater than or equal to zero.'),
-        ('product_location_check', 'unique (product_id, location_id, company_id)', 'The combination of product and location must be unique.'),
+        ('product_location_check', 'unique (product_id, location_id, company_id)', 'A replenishment rule already exists for this product on this location.'),
     ]
 
     @api.depends('warehouse_id')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -82,6 +82,7 @@ class PickingType(models.Model):
     count_picking_waiting = fields.Integer(compute='_compute_picking_count')
     count_picking_late = fields.Integer(compute='_compute_picking_count')
     count_picking_backorders = fields.Integer(compute='_compute_picking_count')
+    hide_reservation_method = fields.Boolean(compute='_compute_hide_reservation_method')
     barcode = fields.Char('Barcode', copy=False)
     company_id = fields.Many2one(
         'res.company', 'Company', required=True,
@@ -127,6 +128,11 @@ class PickingType(models.Model):
                         'company_id': picking_type.env.company.id,
                     })
         return super(PickingType, self).write(vals)
+
+    @api.depends('code')
+    def _compute_hide_reservation_method(self):
+        for rec in self:
+            rec.hide_reservation_method = rec.code == 'incoming'
 
     def _compute_picking_count(self):
         domains = {

--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -195,7 +195,7 @@ const ReplenishReport = clientAction.extend({
                 active_id: this.productId,
                 active_model: this.resModel,
             }, this.context, additionnalContext);
-            return this.do_action(action, {replace_last_action: true});
+            return this.do_action(action, { stackPosition: 'replaceCurrentAction' });
         });
     },
 

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -204,8 +204,8 @@
                             <div>
                                 <field name="product_selectable" class="oe_inline"/>
                             </div>
-                            <label for="packaging_selectable" string="Packagings"/>
-                            <div>
+                            <label for="packaging_selectable" string="Packagings" groups="product.group_stock_packaging"/>
+                            <div groups="product.group_stock_packaging">
                                 <field name="packaging_selectable" class="oe_inline"/>
                             </div>
                         </group>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -226,7 +226,7 @@
                             'default_product_id': parent.product_id,
                         }"
                     />
-                    <field name="lot_name" widget="text" groups="stock.group_production_lot"
+                    <field name="lot_name" string="Lot/Serial Number" widget="text" groups="stock.group_production_lot"
                         placeholder="Write your SN/LN one by one or copy paste a list."
                         attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"
                         invisible="not context.get('show_lots_text')"/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -103,6 +103,8 @@
                 <field name="group_id" groups="stock.group_adv_location"/>
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
+                <filter string="Trigger Manual" name="filter_creation_trigger" domain="[('trigger', '=', 'manual')]"/>
+                <separator/>
                 <filter string="To Reorder" name="filter_to_reorder" domain="[('qty_to_order', '&gt;', 0.0)]"/>
                 <separator/>
                 <filter string="Not Snoozed" name="filter_not_snoozed" domain="['|', ('snoozed_until', '=', False), ('snoozed_until', '&lt;=', datetime.date.today().strftime('%Y-%m-%d'))]"/>
@@ -228,9 +230,9 @@
         <field name="state">code</field>
         <field name="code">
             action = model.with_context(
-                search_default_trigger='manual',
                 search_default_filter_to_reorder=True,
                 search_default_filter_not_snoozed=True,
+                search_default_filter_creation_trigger=True,
                 default_trigger='manual'
             ).action_open_orderpoints()
         </field>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -39,11 +39,12 @@
                         <group>
                             <group>
                                 <field name="active" invisible="1"/>
+                                <field name="hide_reservation_method" invisible="1"/>
                                 <field name="name"/>
                                 <field name="sequence_id" groups="base.group_no_one"/>
                                 <field name="sequence_code"/>
                                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
-                                <field name="reservation_method" attrs="{'invisible': [('code', '=', 'incoming')]}" widget="radio"/>
+                                <field name="reservation_method" attrs="{'invisible': [('hide_reservation_method', '=', True)]}" widget="radio"/>
                                 <field name="auto_show_reception_report" attrs="{'invisible': [('code', 'not in', ['incoming', 'internal'])]}" groups="stock.group_reception_report"/>
                                 <label for="reservation_days_before" string="Reserve before scheduled date" attrs="{'invisible': ['|', ('code', '=', 'incoming'), ('reservation_method', '!=', 'by_date')]}"/>
                                 <div class="o_row" attrs="{'invisible': ['|', ('code', '=', 'incoming'), ('reservation_method', '!=', 'by_date')]}">

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -43,7 +43,6 @@
                                 <field name="sequence_id" groups="base.group_no_one"/>
                                 <field name="sequence_code"/>
                                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
-                                <field name="print_label" attrs="{'invisible': [('code', '!=', 'internal')]}"/>
                                 <field name="reservation_method" attrs="{'invisible': [('code', '=', 'incoming')]}" widget="radio"/>
                                 <field name="auto_show_reception_report" attrs="{'invisible': [('code', 'not in', ['incoming', 'internal'])]}" groups="stock.group_reception_report"/>
                                 <label for="reservation_days_before" string="Reserve before scheduled date" attrs="{'invisible': ['|', ('code', '=', 'incoming'), ('reservation_method', '!=', 'by_date')]}"/>

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -98,7 +98,6 @@
                                 <field name="group_propagation_option"/>
                                 <field name="group_id" attrs="{'invisible': [('group_propagation_option', '!=', 'fixed')], 'required': [('group_propagation_option', '=', 'fixed')]}"/>
                                 <field name="propagate_cancel"/>
-                                <field name="propagate_carrier" groups="base.group_no_one"/>
                                 <field name="propagate_warehouse_id"/>
                             </group>
                             <group string="Options" attrs="{'invisible': [('action', 'not in', ['pull', 'push', 'pull_push'])]}">

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -28,6 +28,10 @@ class ProductReplenish(models.TransientModel):
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     company_id = fields.Many2one('res.company')
 
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        self.quantity = abs(self.product_id.virtual_available) if self.product_id.virtual_available < 0 else 1
+
     @api.model
     def default_get(self, fields):
         res = super(ProductReplenish, self).default_get(fields)

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -24,12 +24,7 @@ class UoMCategory(models.Model):
         else:
             reference_count = sum(uom.uom_type == 'reference' for uom in self.uom_ids)
             if reference_count == 0 and self._origin.id:
-                return {
-                    'warning': {
-                        'title': _('Warning!'),
-                        'message': _("UoM category %s should have a reference unit of measure.") % self.name
-                    }
-                }
+                raise UserError(_('UoM category %s must have at least one reference unit of measure.', self.name))
             if self.reference_uom_id:
                 new_reference = self.uom_ids.filtered(lambda o: o.uom_type == 'reference' and o._origin.id != self.reference_uom_id.id)
             else:

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -230,7 +230,7 @@
                             <field name="module_delivery_dhl" widget="upgrade_boolean"/>
                         </div>
                         <div class="o_setting_right_pane">
-                            <label string="DHL" for="module_delivery_dhl"/>
+                            <label string="DHL Express Connector" for="module_delivery_dhl"/>
                             <div class="text-muted" id="website_delivery_dhl">
                                 Compute shipping costs and ship with DHL
                             </div>


### PR DESCRIPTION
In this commit:
==================================
1. Added domain to display only product related variants in the product view 
2. Added a Trigger Manual filter in the existing filter list of Replenishment view
3. Added a logic to set deadline date of DO based on the SO deadline date in sale 
4. Changed the error message string if the same product record already exists in the replenishment
5. Changed the string of lot_name field  in the stock move
6. Fixed Forecast Report breadcrumbs issue
7. Fixed Lost label of product on replenishment report while reserve/unreserve the quantity  of product 
8. Added logic to force user to set at least one unit as a Reference Unit in UoM category units
9. Changed the string of dhl delivery module from DHL USA to DHL Express
10. Added logic to set default product quantity value in product replenishment wizard
11. Fixed the issue of Manufacturing Order link showing html tag instead of link in replenishment view
12. Added a two view files to delivery module
    1. stock_rule_view: to display the propagate_carrier field
    2. stock_picking_type_view: to display the print_label field
13. Fixed the issue of Purchase Order link showing html tag instead of link in replenishment view
14.  Fixed the issue of showing html tag in line
15. Moved propagate_carrier field to delivery module.


TaskID - 2581265

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
