### PR TITLE
[IMP] website_slides: Add the `partner_id` field on the listview.

### DIFF
--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -25,6 +25,7 @@
                 <tree string="Attendees" editable="top">
                     <field name="channel_id" string="Course Name"/>
                     <field name="channel_user_id"/>
+                    <field name="partner_id" string="Contact"/>
                     <field name="partner_email" string="Email"/>
                     <field name="create_date" string="Enrolled On"/>
                     <field name="write_date" string="Last Action On"/>


### PR DESCRIPTION
In v14.3, it was possible to add an attendee the related listview. We
lost this behaviour with https://github.com/odoo/odoo/commit/d70af67954241c6bb75b341c9997ee536d3d632b

Without the mandatory field `partner_id` in the view, you can't create
an attendee anymore, even if the presence of the "create" button
suggests otherwise.
