### PR TITLE
[FIX] hr_timesheet: improve performances of _compute_total_timesheet_time

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -3,6 +3,8 @@
 import re
 from lxml import etree
 
+from collections import defaultdict
+
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
 
@@ -44,12 +46,29 @@ class Project(models.Model):
 
     @api.depends('timesheet_ids')
     def _compute_total_timesheet_time(self):
+        timesheets_read_group = self.env['account.analytic.line'].read_group(
+            [('project_id', 'in', self.ids)],
+            ['project_id', 'unit_amount', 'product_uom_id'],
+            ['project_id', 'product_uom_id'],
+            lazy=False)
+        timesheet_time_dict = defaultdict(list)
+        uom_ids = set(self.timesheet_encode_uom_id.ids)
+
+        for result in timesheets_read_group:
+            uom_id = result['product_uom_id'] and result['product_uom_id'][0]
+            if uom_id:
+                uom_ids.add(uom_id)
+            timesheet_time_dict[result['project_id'][0]].append((uom_id, result['unit_amount']))
+
+        uoms_dict = {uom.id: uom for uom in self.env['uom.uom'].browse(uom_ids)}
         for project in self:
-            total_time = 0.0
-            for timesheet in project.timesheet_ids:
-                # Timesheets may be stored in a different unit of measure, so first
-                # we convert all of them to the reference unit
-                total_time += timesheet.unit_amount * timesheet.product_uom_id.factor_inv
+            # Timesheets may be stored in a different unit of measure, so first
+            # we convert all of them to the reference unit
+            # if the timesheet has no product_uom_id then we take the one of the project
+            total_time = sum([
+                unit_amount * uoms_dict.get(product_uom_id, project.timesheet_encode_uom_id).factor_inv
+                for product_uom_id, unit_amount in timesheet_time_dict[project.id]
+            ], 0.0)
             # Now convert to the proper unit of measure set in the settings
             total_time *= project.timesheet_encode_uom_id.factor
             project.total_timesheet_time = int(round(total_time))


### PR DESCRIPTION
Before this commit, since we use `total_timesheet_time` field to see if
any timesheets exist for each project in the kanban view.
The render of this view is slower because of the compute of this field.

This commit improves the performances of this compute.

X-original-commit: 642fb2e6dd1f0fc02428e5e6717f070598cb682c

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
