### PR TITLE
[IMP] payment(_authorize): rework validation transactions refund flow

### DIFF
--- a/addons/payment/static/src/js/manage_form.js
+++ b/addons/payment/static/src/js/manage_form.js
@@ -208,6 +208,7 @@ odoo.define('payment.manage_form', require => {
             this._disableButton(true); // Disable until it is needed again
             if (flow !== 'token') { // Creation of a new token
                 this.txContext.tokenizationRequested = true;
+                this.txContext.isValidation = true;
                 this._processPayment(provider, paymentOptionId, flow);
             } else if (this.txContext.allowTokenSelection) { // Assignation of a token to a record
                 this._assignToken(paymentOptionId);

--- a/addons/payment/static/src/js/payment_form_mixin.js
+++ b/addons/payment/static/src/js/payment_form_mixin.js
@@ -301,9 +301,8 @@ odoo.define('payment.payment_form_mixin', require => {
                     ? parseInt(this.txContext.invoiceId) : null,
                 'flow': flow,
                 'tokenization_requested': this.txContext.tokenizationRequested,
-                'validation_route': this.txContext.validationRoute
-                    ? this.txContext.validationRoute : null,
                 'landing_route': this.txContext.landingRoute,
+                'is_validation': this.txContext.isValidation,
                 'access_token': this.txContext.accessToken
                     ? this.txContext.accessToken : undefined,
                 'csrf_token': core.csrf_token,

--- a/addons/payment/static/src/js/post_processing.js
+++ b/addons/payment/static/src/js/post_processing.js
@@ -80,11 +80,7 @@ odoo.define('payment.post_processing', function (require) {
                 // In almost every cases there will be a single transaction to display. If there are
                 // more than one transaction, the last one will most likely be the one that was
                 // confirmed. We use this one to redirect the user to the final page.
-                if (display_values_list[0].is_validation) {
-                    window.location = display_values_list[0].validation_route;
-                } else {
-                    window.location = display_values_list[0].landing_route;
-                }
+                window.location = display_values_list[0].landing_route;
                 return;
             }
 

--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -178,19 +178,3 @@ class PaymentHttpCommon(PaymentTestUtils, HttpCase):
 
         resp_content = json.loads(response.content)
         return resp_content['result']
-
-    # payment/validation #
-    ######################
-    def portal_validate_transaction(self, tx):
-        """/payment/validation feedback, for a given tx (and its validation_route)
-
-        NOTE: the validation route is restricted to logged users
-
-        If you are not logged in, the route won't be called
-        but it won't raise/log, the response will be a redirection to the login page.
-        """
-        uri = tx.validation_route
-        url = self._build_url(uri)
-        # No params since all GET arguments are already specified in the validation route.
-        # no returned value, validation response = redirect
-        return self._make_http_get_request(url, {})

--- a/addons/payment/tests/test_multicompany_flows.py
+++ b/addons/payment/tests/test_multicompany_flows.py
@@ -51,7 +51,6 @@ class TestMultiCompanyFlows(PaymentMultiCompanyCommon, PaymentHttpCommon):
             'flow': 'direct',
             'payment_option_id': self.acquirer_company_b.id,
             'tokenization_requested': False,
-            'validation_route': False,
         })
         with mute_logger('odoo.addons.payment.models.payment_transaction'):
             processing_values = self.get_processing_values(**validation_values)

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -151,8 +151,6 @@
                                      enables the token assignation mechanisms: creation of a new
                                      token through a refunded transaction and assignation of an
                                      existing token
-            - 'validation_route' - The route the user is redirected to in order to refund the
-                                   validation transaction
             - 'landing_route' - The route the user is redirected to at then end of the flow
             - 'footer_template_id' - The template id for the submit button. Optional
         -->
@@ -164,7 +162,6 @@
               t-att-data-invoice-id="invoice_id"
               t-att-data-transaction-route="transaction_route"
               t-att-data-assign-token-route="assign_token_route"
-              t-att-data-validation-route="validation_route"
               t-att-data-landing-route="landing_route"
               t-att-data-allow-token-selection="bool(assign_token_route)">
             <t t-set="acquirer_count" t-value="len(acquirers) if acquirers else 0"/>

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -131,6 +131,7 @@ class PaymentTransaction(models.Model):
                 self._set_authorized()
                 if self.tokenize and not self.token_id:
                     self._authorize_tokenize()
+                self._send_refund_request()  # In last step because it calls _handle_feedback_data()
             elif status_type == 'void':
                 if self.operation == 'validation':  # Validation txs are authorized and then voided
                     self._set_done()  # If the refund went through, the validation tx is confirmed


### PR DESCRIPTION
Before this commit, the validation flow with verification (payment of a
small amount with immediate refund) was performed with the use of
validation routes: after payment, the customer was redirected to the
validation route stored on the transaction to trigger the refund. This
implementation had an issue: if the customer never reached the
validation route, they were not refunded their validation amount. This
could happen if the customer closed the tab after paying with an
acquirer offering payments with redirection, or if the validation
payment was asynchronously confirmed through a webhook notification.

This commit gets rid of validation routes and requires acquirers to
immediately refund the validation amount when the payment is confirmed.
This way, a payment confirmation coming from a webhook can trigger the
refund too.

As the only acquirer that implements the validation with verification
flow, Authorize.net now voids validation transactions as soon as they
are authorized.

While we're at it, the logging of processing values is adapted to only
log specific rendering values if a redirect form is rendered.

task-2612977

Enterprise PR: https://github.com/odoo/enterprise/pull/20060
Upgrade PR: https://github.com/odoo/upgrade/pull/2710