### PR TITLE
[FIX] point_of_sale: fix hitting backspace on 0 quantity line

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -171,7 +171,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                     });
                     return;
                 }
-                const parsedInput = parse.float(event.detail.buffer) || 0
+                const parsedInput = event.detail.buffer && parse.float(event.detail.buffer) || 0;
                 if(lastId != selectedLine.cid)
                     this._showDecreaseQuantityPopup();
                 else if(currentQuantity < parsedInput)


### PR DESCRIPTION
Fine tuning of 02d9b51e43904420afe31e1f65ea455e3ed2c8ea

Steps:
- Install l10n_fr_pos_cert
- Open POS session with French company
- Add product
- Hit backspace: set new quantity to 0
- Hit backspace again

Error will be shown. This occur because `event.detail.buffer` might be null

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
