### PR TITLE
[FIX] website_slides : share embed showing by default

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -65,7 +65,8 @@ def werkzeugRaiseNotFound(*args, **kwargs):
 def MockRequest(
         env, *, routing=True, multilang=True,
         context=None,
-        cookies=None, country_code=None, website=None, sale_order_id=None
+        cookies=None, country_code=None, website=None, sale_order_id=None,
+        headers=None
 ):
     router = MagicMock()
     match = router.return_value.bind.return_value.match
@@ -94,6 +95,7 @@ def MockRequest(
             app=odoo.http.root,
             environ={'REMOTE_ADDR': '127.0.0.1'},
             cookies=cookies or {},
+            headers=headers or {},
             referrer='',
         ),
         lang=env['res.lang']._lang_get(lang_code),

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1117,7 +1117,11 @@ class WebsiteSlides(WebsiteProfile):
         # determine if it is embedded from external web page
         referrer_url = request.httprequest.headers.get('Referer', '')
         base_url = request.env['ir.config_parameter'].sudo().get_param('web.base.url')
-        is_embedded = referrer_url and not bool(base_url in referrer_url) or False
+        is_embedded = False
+        if referrer_url:
+            websites = request.env['website'].search([])
+            web_domains = [wb.domain for wb in websites if wb.domain] + [base_url, request.httprequest.host]
+            is_embedded = not any(domain in referrer_url for domain in web_domains)
         # try accessing slide, and display to corresponding template
         try:
             slide = request.env['slide.slide'].browse(slide_id)

--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_security
 from . import test_slide_utils
 from . import test_statistics
 from . import test_ui_wslides
+from . import test_embed_detection

--- a/addons/website_slides/tests/test_embed_detection.py
+++ b/addons/website_slides/tests/test_embed_detection.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_slides.tests import common as slides_common
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_slides.controllers.main import WebsiteSlides
+
+
+class TestEmbedDetection(slides_common.SlidesCase):
+
+    def setUp(self):
+        super(TestEmbedDetection, self).setUp()
+
+        self.website = self.env['website'].search([])[0]
+        self.website.domain = "https://example.com/"
+        self.slide = self.slide_3
+
+    def test_embed_no_referer(self):
+        with MockRequest(self.env, website=self.website):
+            embeds = self.env['slide.embed'].search([])
+            WebsiteSlides().slides_embed(self.slide.id)
+            new_embeds = self.env['slide.embed'].search([])
+            self.assertEqual(embeds, new_embeds, "There is no referrer url, we will assume that the slide is not embedded")
+
+    def test_embed_db_url_referer(self):
+        with MockRequest(self.env, website=self.website, headers={'Referer': 'https://google.com/'}):
+            embeds = self.env['slide.embed'].search([])
+            WebsiteSlides().slides_embed(self.slide.id)
+            new_embeds = self.env['slide.embed'].search([])
+            self.assertEqual(len(embeds), len(new_embeds) - 1, "The referer is https://google.com/ which is not in the domains, so the slide is embedded")
+
+    def test_embed_inside_domain_url_referer(self):
+        with MockRequest(self.env, website=self.website, headers={'Referer': 'https://example.com/'}):
+            embeds = self.env['slide.embed'].search([])
+            WebsiteSlides().slides_embed(self.slide.id)
+            new_embeds = self.env['slide.embed'].search([])
+            self.assertEqual(embeds, new_embeds, "The referer is the same as the domain of the website, so the slide is not embedded")


### PR DESCRIPTION
Issue: When viewing the slides via an embedded pdf view on another website, Odoo detects that and enable a small banner to allow for sharing via e-mail or to have the embed source code to put on our own website. That code is viewed by default and hides the pdf behind the <iframe> tag and the code inside it

Steps to reproduce :
 1) Run a local odoo server with the website_slides module
 2) Go to the usual http://localhost:8069/ to access your database and navigate to a PDF slide in eLearning
 3) Change the localhost in the URL to 127.0.0.1 (Example http://localhost:8069/slides/slide/gardening-the-know-how-1 becomes http://127.0.0.1:8069/slides/slide/gardening-the-know-how-1) and press Enter to go to the new URL
 4) Change back the 127.0.0.1 to localhost and press Enter to go to the new URL
 5) You might have to repeat the back and forth between the two domains
 6) You now see a banner with Share, Email, Embed on the top right and some text that says "Embed in your website" with a textarea containing a iframe tag

Why is that a bug:
 When loading the page, we shouldn't see the popup rendered since it is a sharing option, also it hides the PDF behind it in a pretty ugly way

Side Note:
 The steps to reproduce might look weird at first because it is the only way found to trigger the variable `is_embedded` to be False. With a fairly recent change to default settings of chrome <https://developers.google.com/web/updates/2020/07/referrer-policy-new-chrome-default>, the referrer_url is empty when browsing with a default google chrome, so Odoo will almost never detect that the iframe is embedded, so the problematic banner won't show up very often.

 Also, the fact we are able to trigger it with multiple domains is because of the way the variable `base_url` in method `slides_embed` in `controllers/main.py` is computed as it does not accurately represents the current URL used to access that view and the assignation at line 1119 should be replaced with `base_url = request.httprequest.host or request.env['ir.config_parameter'].sudo().get_param('web.base.url')` as discussed here <https://discord.com/channels/678381219515465750/687337739129323543/872466577382072420>

opw-2499110