### PR TITLE
[IMP] pos: added possibility to add line with good quantity in one time

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1649,7 +1649,7 @@ exports.Orderline = Backbone.Model.extend({
         }
         this.product = options.product;
         this.set_product_lot(this.product);
-        this.set_quantity(1);
+        this.set_quantity(options.quantity || 1);
         this.discount = 0;
         this.discountStr = '0';
         this.selected = false;
@@ -2993,7 +2993,7 @@ exports.Order = Backbone.Model.extend({
         }
         this.assert_editable();
         options = options || {};
-        var line = new exports.Orderline({}, {pos: this.pos, order: this, product: product});
+        var line = new exports.Orderline({}, {pos: this.pos, order: this, product: product, quantity: options.quantity || null});
         this.fix_tax_included_price(line);
 
         if(options.quantity !== undefined){


### PR DESCRIPTION
if we want create pos line with 2 units, actually odoo call twice set_quantity method,
with the quantity in options in add_product method, it's possible in one time.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
