### PR TITLE
[FIX] account: check if tax name on copy method

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -972,7 +972,9 @@ class AccountTax(models.Model):
     @api.multi
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):
-        default = dict(default or {}, name=_("%s (Copy)") % self.name)
+        default = dict(default or {})
+        if 'name' not in default:
+            default['name'] = _("%s (Copy)") % self.name
         return super(AccountTax, self).copy(default=default)
 
     def name_get(self):


### PR DESCRIPTION
Impacted versions:
- 12.0, 13.0, 14.0

Description of the issue/feature this PR addresses:
- If we call copy method of `account.tax` object, it will add '(Copy)' word at the end of given name. It should be optional if name given.
- For example,
    >vals = {'rate': 5.2, 'name': 'Odoo New Tax'}
tax_template = self.env['account.tax'].search(domain, limit=1)
new_tax = tax_template.copy(default=vals)

Current behavior before PR:
- new_tax.name => 'Odoo New Tax (Copy)'

Desired behavior after PR is merged:
- new_tax.name => 'Odoo New Tax'




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
