### PR TITLE
[13.0] [FIX] sale_stock: Permissions error when accessing lot_id

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -68,18 +68,19 @@ class AccountMove(models.Model):
 
         lot_values = []
         for lot, qty in qties_per_lot.items():
-            if float_is_zero(invoiced_qties[lot.product_id], precision_rounding=lot.product_uom_id.rounding) \
-                    or float_compare(qty, 0, precision_rounding=lot.product_uom_id.rounding) <= 0:
+            lot_sudo = lot.sudo()
+            if float_is_zero(invoiced_qties[lot_sudo.product_id], precision_rounding=lot_sudo.product_uom_id.rounding) \
+                    or float_compare(qty, 0, precision_rounding=lot_sudo.product_uom_id.rounding) <= 0:
                 continue
-            invoiced_lot_qty = min(qty, invoiced_qties[lot.product_id])
-            invoiced_qties[lot.product_id] -= invoiced_lot_qty
+            invoiced_lot_qty = min(qty, invoiced_qties[lot_sudo.product_id])
+            invoiced_qties[lot_sudo.product_id] -= invoiced_lot_qty
             lot_values.append({
-                'product_name': lot.product_id.display_name,
+                'product_name': lot_sudo.product_id.display_name,
                 'quantity': formatLang(self.env, invoiced_lot_qty, dp='Product Unit of Measure'),
-                'uom_name': lot.product_uom_id.name,
-                'lot_name': lot.name,
+                'uom_name': lot_sudo.product_uom_id.name,
+                'lot_name': lot_sudo.name,
                 # The lot id is needed by localizations to inherit the method and add custom fields on the invoice's report.
-                'lot_id': lot.id,
+                'lot_id': lot_sudo.id,
             })
 
         return lot_values


### PR DESCRIPTION
Before this patch, when we try to print an invoice without belonging to the group stock.group_stock_user, we get an Access Error.

![imagen](https://user-images.githubusercontent.com/35952655/128298374-d42d3118-e137-43c4-ade2-212b4f5fc45c.png)


Doing this patch, we are allowed to print the invoices as we skipped the mentioned ACL.

cc @Tecnativa TT31296

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
