### PR TITLE
[IMP] tools: improve error message for elements that cannot be located

### DIFF
--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -239,14 +239,19 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                 )
 
         else:
-            attrs = ''.join([
-                ' %s="%s"' % (attr, html_escape(spec.get(attr)))
-                for attr in spec.attrib
-                if attr != 'position'
-            ])
-            tag = "<%s%s>" % (spec.tag, attrs)
+            def element_repr(elem):
+                attrs = ''.join([
+                    ' %s="%s"' % (attr, elem.get(attr))
+                    for attr in elem.attrib
+                    if attr != 'position'
+                ])
+                if elem.tag == 'xpath':
+                    return "<%s%s />" % (elem.tag, attrs)
+                else:
+                    children = '\n'.join(element_repr(c) for c in elem.getchildren())
+                    return "<%s%s>%s</%s>" % (elem.tag, attrs, children, elem.tag)
             raise ValueError(
-                _("Element '%s' cannot be located in parent view", tag)
+                _("Element '%s' cannot be located in parent view:\n%s") % (element_repr(spec), element_repr(source))
             )
 
     return source


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Error messages for not found xpaths only showed the xpath that was not found:
```
Element '<xpath expr="//link[@href='/theme_enark/static/src/scss/primary_variables.scss']" />' cannot be located in parent view
```
Which was not always as helpfull as it could be in case one made some wrong assumptions about the view it was searched in (especially in emails with translated templates, or in theme.ir.ui.views)

With this patch the error looks like this, which makes it clear that the inherit_id did not find the parent template as expected:
```
odoo.tools.convert.ParseError: "Element '<xpath expr="//link[@href='/theme_enark/static/src/scss/primary_variables.scss']" />' cannot be located in parent view:
<form string="Module Category"><group col="4"><field name="name"></field>
<field name="parent_id"></field>
<field name="sequence"></field></group>
<field name="description"></field></form>
```

Current behavior before PR:

Error message only shows the xpath / element that was not found.

Desired behavior after PR is merged:

Error message shows the xpath / element that was not found and the reconstructed template source it was not found in.


Info @wt-io-it




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
