### PR TITLE
[FIX] hr_timesheet: use the timesheet_ids to know if there are timesheets

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -239,10 +239,10 @@
             <field name="arch" type="xml">
                 <field name="partner_id" position="after">
                     <field name="allow_timesheets" invisible="1"/>
-                    <field name="total_timesheet_time" invisible="1"/>
+                    <field name="timesheet_ids" invisible="1"/>
                 </field>
                 <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
-                    <div role="menuitem" t-if="record.allow_timesheets.raw_value and record.total_timesheet_time.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div role="menuitem" t-if="record.allow_timesheets.raw_value and record.timesheet_ids.raw_value.length" groups="hr_timesheet.group_hr_timesheet_user">
                         <a name="%(act_hr_timesheet_line_by_project)d" type="action">Timesheets</a>
                     </div>
                 </xpath>


### PR DESCRIPTION
Before this commit, we use the `total_timesheet_time` field in the kanban
view of `project.project` to know if there are some timesheets into each
project. The problem is this field is computed and its compute method
take more execution time than just use `timesheet_ids` field to allow if
a project has at least one timesheet.

This commit replaces the using of `total_timesheet_time` field by the
`timesheet_ids` field in project kanban view to check if the project
has at least one timesheet.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
