### PR TITLE
[FIX] l10n_it_edi_sdicoop: ignore 'not_found' state when it was previ…

### DIFF
--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -196,6 +196,9 @@ class AccountEdiFormat(models.Model):
                 proxy_acks.append(id_transaction)
                 continue
             elif state == 'not_found':
+                # state was previously fetched.
+                if invoice._get_edi_document(self).error:
+                    continue
                 # Invoice does not exist on proxy. Either it does not belong to this proxy_user or it was not created correctly when
                 # it was sent to the proxy.
                 to_return[invoice] = {'error': _('You are not allowed to check the status of this invoice.'), 'blocking_level': 'error'}


### PR DESCRIPTION
…ously fetched when checking the state of a transmission

When the state is fetched, an ack is sent. When checked again, if the state hasn't changed, the proxy will return a 'not_found' error. This is problematic if the state of the invoice doesn't change between two checks. With this commit we ignore 'not_found' if we previously checked the state of the transmission.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
