### PR TITLE
[FIX] crm: invite partners on quick creation of meeting

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -900,6 +900,7 @@ class Lead(models.Model):
             'default_opportunity_id': self.id if self.type == 'opportunity' else False,
             'default_partner_id': self.partner_id.id,
             'default_partner_ids': partner_ids,
+            'default_attendee_ids': [(0, 0, {'partner_id': pid}) for pid in partner_ids],
             'default_team_id': self.team_id.id,
             'default_name': self.name,
         }

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -99,6 +99,7 @@ class Partner(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("calendar.action_calendar_event")
         action['context'] = {
             'default_partner_ids': partner_ids,
+            'default_attendee_ids': [(0, 0, {'partner_id': pid}) for pid in partner_ids],
         }
         action['domain'] = ['|', ('id', 'in', self._compute_meeting()[self.id]), ('partner_ids', 'in', self.ids)]
         return action


### PR DESCRIPTION
When creating a meeting from a partner/lead, the invitations won't be
created/sent

To reproduce the error:
1. Open a lead
2. Click on Meeting
3. Create a meeting
    - On meeting creation, directly click on "Create", not "Edit"

Error: No invitation has been sent. When editing the created event,
there isn't any invitation on Invitations tab. Same error will happen
when opening the form of a customer instead of a lead (step 1)

For an attendee to be created, the partners associated with the meeting
must be explicitly listed in the creation values:
https://github.com/odoo/odoo/blob/3e20e68f0790a0b0f3b5c4d43f59f235b7d20fef/addons/calendar/models/calendar_event.py#L710-L713
However, in the above use case, the partners identifiers are given
through the context. This explains why the attendees are not created.

OPW-2531496