### PR TITLE
[FIX] fleet: add a missing decorator in the create function

### DIFF
--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -181,7 +181,8 @@ class FleetVehicleLogContract(models.Model):
     def _onchange_vehicle(self):
         if self.vehicle_id:
             self.odometer_unit = self.vehicle_id.odometer_unit
-
+    
+    @api.model
     def create(self, vals):
         res = super(FleetVehicleLogContract, self).create(vals)
         res.cost_id.write({'contract_id': res.id})


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to fleet app
- Choose any car > Contracts
- Create a new one > save

Problem:
A traceback is triggered with the following message: `”create() missing 1 required positional argument: 'vals'”`
Because the create method in the model `fleet.vehicle.log.contract` is not called

Bug introduced by this commit: https://github.com/odoo/odoo/commit/ec8a66c2efd91b06c27d365e7cc1b2a127e690a5

opw-2618453


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
