### PR TITLE
[FIX] core: Incorrect ISO 8601 week number in reports

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2164,6 +2164,13 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     value = value[0]
                 elif ftype in ('date', 'datetime'):
                     locale = get_lang(self.env).code
+
+                    # For ISO 8601 week numbering, we select a locale with monday as the first day of the week
+                    # https://en.wikipedia.org/wiki/ISO_8601#Week_dates
+                    # https://en.wikipedia.org/wiki/ISO_week_date
+                    if gb['groupby'] == 'date:week':
+                        locale = 'fr_BE'
+
                     fmt = DEFAULT_SERVER_DATETIME_FORMAT if ftype == 'datetime' else DEFAULT_SERVER_DATE_FORMAT
                     tzinfo = None
                     range_start = value


### PR DESCRIPTION
Step to follow

Select a user with a locale having a week starting on a day other than monday
Create a report and group it by week
The week number could be off by one depending on the year

Cause of the issue

According to the [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date), the week number is computed with a monday
being the first day of the week. The locale doesn't affect this.

Solution

Pass the locale fr_BE to babel.dates

opw-2609234