### PR TITLE
[FIX] account: payment method line deletion/constrains

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -103,7 +103,7 @@ class AccountPaymentMethodLine(models.Model):
                             "'|', ('user_type_id', '=', %s), ('id', '=', parent.default_account_id)]"
                             % self.env.ref('account.data_account_type_current_assets').id
     )
-    journal_id = fields.Many2one(comodel_name='account.journal', ondelete="set null")
+    journal_id = fields.Many2one(comodel_name='account.journal', ondelete="cascade")
 
     # == Display purpose fields ==
     code = fields.Char(related='payment_method_id.code')
@@ -124,6 +124,7 @@ class AccountPaymentMethodLine(models.Model):
             SELECT apml.name, apm.payment_type
             FROM account_payment_method_line apml
             JOIN account_payment_method apm ON apml.payment_method_id = apm.id
+            WHERE apml.journal_id IS NOT NULL
             GROUP BY apml.name, journal_id, apm.payment_type
             HAVING count(apml.id) > 1
         ''')


### PR DESCRIPTION
Set the payment method line to cascade when deleting a journal.
This way, we do not keep unneeded lines, and it is not an issue
since we cannot delete journals linked to a payment/move anyway.

Also add a check on the journal id in the constrains checking their
name to avoid taking into account lines without journals.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
