### PR TITLE
[FIX] l10n_it_edi_sdicoop: when an edi is successfully sent, it shoul…

### DIFF
--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -219,7 +219,7 @@ class AccountEdiFormat(models.Model):
             elif state == 'notificaEsito':
                 outcome = response_tree.find('Esito').text
                 if outcome == 'EC01':
-                    to_return[invoice] = {'attachment': invoice.l10n_it_edi_attachment_id}
+                    to_return[invoice] = {'attachment': invoice.l10n_it_edi_attachment_id, 'success': True}
                 else:  # ECO2
                     to_return[invoice] = {'error': _('The invoice was refused by the addressee.'), 'blocking_level': 'error'}
             elif state == 'NotificaDecorrenzaTermini':


### PR DESCRIPTION
…d return {'success': True}

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
