### PR TITLE
Master log assets time moc

### DIFF
--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_load_menus
 from . import test_profiler
 from . import test_session_info
 from . import test_read_progress_bar
+from . import test_assets

--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -1,0 +1,60 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import time
+
+import odoo
+import odoo.tests
+
+from odoo.modules.module import read_manifest
+from odoo.tools import mute_logger
+
+_logger = logging.getLogger(__name__)
+
+
+class TestAssetsGenerateTimeCommon(odoo.tests.TransactionCase):
+
+    def generate_bundles(self):
+        bundles = set()
+        installed_module_names = self.env['ir.module.module'].search([('state', '=', 'installed')]).mapped('name')
+        for addon_path in odoo.addons.__path__:
+            for addon in installed_module_names:
+                manifest = read_manifest(addon_path, addon) or {}
+                assets = manifest.get('assets')
+                if assets:
+                    bundles |= set(assets.keys())
+
+        for bundle in bundles:
+            start_t = time.time()
+            with mute_logger('odoo.addons.base.models.assetsbundle'):
+                try:
+                    self.env['ir.qweb']._generate_asset_nodes(bundle, options={})
+                    yield (bundle, time.time() - start_t)
+                except ValueError:
+                    _logger.info('Error detected while generating bundle %r', bundle)
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestLogsAssetsGenerateTime(TestAssetsGenerateTimeCommon):
+
+    def test_logs_assets_generate_time(self):
+        """
+        The purpose of this test is to monitor the time of assets bundle generation.
+        This is not meant to test the generation failure, hence the try/except and the mute logger.
+        For example, 'web.assets_qweb' is contains only static xml.
+        """
+        for bundle, duration in self.generate_bundles():
+            _logger.info('Bundle %r generated in %.2fs', bundle, duration)
+
+
+@odoo.tests.tagged('post_install', '-at_install', '-standard', 'bundle_generation')
+class TestAssetsGenerateTime(TestAssetsGenerateTimeCommon):
+    """
+    This test is meant to be run nightly to ensure bundle generation does not exceed
+    a low threshold
+    """
+
+    def test_assets_generate_time(self):
+        for bundle, duration in self.generate_bundles():
+            threshold = 2
+            self.assertLess(duration, threshold, "Bundle %r took more than %s sec" % (bundle, threshold))


### PR DESCRIPTION
From time to time, the bundle generation duration may be unexpectedly
increased by assets modifications.

In order to avoid that, this commit adds two tests that generates all
the bundles. One of the test is only meant to log the duration in order
to monitor it. The other test is ensuring that a bundle generation does
not take more than 2 seconds.

Pay attention that the purpose is not to test the generation of the
bundle, any error during generation is logged as an information.
Also, warnings are silently ignored.
