### PR TITLE
[FIX] web_editor: position correctly the popover in side dropdown menu

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -54,6 +54,7 @@ const LinkPopoverWidget = Widget.extend({
             content: this.$el,
             placement: 'bottom',
             trigger: 'click',
+            boundary: 'viewport',
         })
         .on('show.bs.popover.link_popover', () => {
             this._loadAsyncLinkPreview();


### PR DESCRIPTION
Before this commit, the popover would be displayed on top of the clicked
element if that element was a menu in a dropdown.
Indeed, there was not enough room for the popover to be shown correctly, as the
available space was the dropdown itself.

Note that if there was more than 2 menus in the dropdown, it would work
correctly as it would create enough space for the popover to be shown bellow or
above the menu.

Step to reproduce:
- Create a menu and a submenu
- Click on the menu, it opens a dropdown with the submenu inside it
- Click on the submenu, the popover position is wrong
