### PR TITLE
[FIX] base: print layout of reports from CRON contains assets

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -17,7 +17,7 @@ from threading import Thread
 import time
 
 from odoo import _, http
-from odoo.modules import get_resource_path, module
+from odoo import modules
 
 _logger = logging.getLogger(__name__)
 
@@ -240,15 +240,16 @@ def load_iot_handlers():
     And execute these python drivers and interfaces
     """
     for directory in ['interfaces', 'drivers']:
-        path = get_resource_path('hw_drivers', 'iot_handlers', directory)
+        path = modules.get_resource_path('hw_drivers', 'iot_handlers', directory)
         filesList = os.listdir(path)
         for file in filesList:
             path_file = os.path.join(path, file)
             spec = util.spec_from_file_location(file, path_file)
             if spec:
-                spec.loader.exec_module(util.module_from_spec(spec))
-    module.addons_manifest = {}
-    module.load_addons_manifest()
+                module = util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+    modules.module.addons_manifest = {}
+    modules.module.load_addons_manifest()
     http.root = http.Root()
 
 def odoo_restart(delay):

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -17,7 +17,7 @@ from threading import Thread
 import time
 
 from odoo import _, http
-from odoo.modules.module import get_resource_path
+from odoo.modules import get_resource_path, module
 
 _logger = logging.getLogger(__name__)
 
@@ -246,9 +246,9 @@ def load_iot_handlers():
             path_file = os.path.join(path, file)
             spec = util.spec_from_file_location(file, path_file)
             if spec:
-                module = util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-    http.addons_manifest = {}
+                spec.loader.exec_module(util.module_from_spec(spec))
+    module.addons_manifest = {}
+    module.load_addons_manifest()
     http.root = http.Root()
 
 def odoo_restart(delay):

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -32,7 +32,7 @@ from werkzeug.urls import url_encode, url_decode, iri_to_uri
 import odoo
 import odoo.modules.registry
 from odoo.api import call_kw, Environment
-from odoo.modules import get_module_path, get_resource_path, module
+from odoo.modules import get_resource_path, module
 from odoo.tools import image_process, html_escape, pycompat, ustr, apply_inheritance_specs, lazy_property, float_repr, osutil
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.translate import _
@@ -966,9 +966,9 @@ class WebClient(http.Controller):
 
         translations_per_module = {}
         for addon_name in mods:
-            manifest = http.addons_manifest.get(addon_name)
+            manifest = module.addons_manifest.get(addon_name)
             if manifest and manifest.get('bootstrap'):
-                addons_path = http.addons_manifest[addon_name]['addons_path']
+                addons_path = module.addons_manifest[addon_name]['addons_path']
                 f_name = os.path.join(addons_path, addon_name, "i18n", lang + ".po")
                 if not os.path.exists(f_name):
                     continue

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -16,7 +16,7 @@ from odoo.http import request
 from odoo import http, tools, _, SUPERUSER_ID
 from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.exceptions import UserError
-from odoo.modules.module import get_module_path, get_resource_path
+from odoo.modules import get_module_path, get_resource_path, module
 from odoo.tools.misc import file_open
 from odoo.tools.mimetypes import guess_mimetype
 
@@ -50,7 +50,7 @@ class Web_Editor(http.Controller):
         # Make sure we have at least size=1
         size = max(1, size)
         # Initialize font
-        addons_path = http.addons_manifest['web']['addons_path']
+        addons_path = module.addons_manifest['web']['addons_path']
         font_obj = ImageFont.truetype(addons_path + font, size)
 
         # if received character is not a number, keep old behaviour (icon is character)

--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -9,8 +9,7 @@ from werkzeug import urls
 
 import odoo
 from odoo.tools import misc
-from odoo import tools
-from odoo.modules import module
+from odoo import tools, modules
 from odoo.addons import __path__ as ADDONS_PATH
 from odoo import api, fields, http, models
 
@@ -206,7 +205,7 @@ class IrAsset(models.Model):
 
         # 2. Process all addons' manifests.
         for addon in self._topological_sort(tuple(addons)):
-            manifest = module.addons_manifest.get(addon)
+            manifest = modules.module.addons_manifest.get(addon)
             if not manifest:
                 continue
             manifest_assets = manifest.get('assets', {})
@@ -273,7 +272,7 @@ class IrAsset(models.Model):
         IrModule = self.env['ir.module.module']
 
         def mapper(addon):
-            manif = module.addons_manifest.get(addon, {})
+            manif = modules.module.addons_manifest.get(addon, {})
             from_terp = IrModule.get_values_from_terp(manif)
             from_terp['name'] = addon
             from_terp['depends'] = manif.get('depends', ['base'])
@@ -318,7 +317,7 @@ class IrAsset(models.Model):
         path_url = fs2web(path_def)
         path_parts = [part for part in path_url.split('/') if part]
         addon = path_parts[0]
-        addon_manifest = module.addons_manifest.get(addon)
+        addon_manifest = modules.module.addons_manifest.get(addon)
 
         safe_path = True
         if addon_manifest:

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -17,7 +17,7 @@ from odoo.addons import __path__ as ADDONS_PATH
 from odoo.addons.base.models.assetsbundle import AssetsBundle
 from odoo.addons.base.models.ir_asset import AssetPaths
 from odoo.addons.base.models.ir_attachment import IrAttachment
-from odoo.modules.module import get_resource_path, read_manifest
+from odoo.modules import module
 from odoo.tests import HttpCase, tagged
 from odoo.tests.common import TransactionCase
 from odoo.addons.base.models.qweb import QWebException
@@ -83,7 +83,7 @@ class AddonManifestPatched(TransactionCase):
 
     test_assetsbundle_manifest = None
     for path in ADDONS_PATH:
-        manifest = read_manifest(path, 'test_assetsbundle')
+        manifest = module.read_manifest(path, 'test_assetsbundle')
         if manifest:
             manifest['addons_path'] = path
             test_assetsbundle_manifest = manifest
@@ -92,15 +92,15 @@ class AddonManifestPatched(TransactionCase):
     def tearDown(self):
         super().tearDown()
         self.env.registry._init_modules = self.__genuine_registry_modules
-        http.addons_manifest = self.__genuine_addons_manifest
+        module.addons_manifest = self.__genuine_addons_manifest
 
     def setUp(self):
         super().setUp()
         self.__genuine_registry_modules = self.env.registry._init_modules
         self.env.registry._init_modules = func.lazy(lambda: set(self.installed_modules))
 
-        self.__genuine_addons_manifest = http.addons_manifest
-        http.addons_manifest = func.lazy(lambda: self.manifests)
+        self.__genuine_addons_manifest = module.addons_manifest
+        module.addons_manifest = func.lazy(lambda: self.manifests)
 
         self.installed_modules = ['base', 'test_assetsbundle']
         self.manifests = {
@@ -220,7 +220,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
         last_modified0 = bundle0.last_modified
         version0 = bundle0.version
 
-        path = get_resource_path('test_assetsbundle', 'static', 'src', 'js', 'test_jsfile1.js')
+        path = module.get_resource_path('test_assetsbundle', 'static', 'src', 'js', 'test_jsfile1.js')
         bundle1 = self._get_asset(self.jsbundle_name)
 
         with self._touch(path):
@@ -510,7 +510,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
 
         # Touch test_cssfile1.css
         # Note: No lang specific context given while calling _get_asset so it will load assets for en_US
-        path = get_resource_path('test_assetsbundle', 'static', 'src', 'css', 'test_cssfile1.css')
+        path = module.get_resource_path('test_assetsbundle', 'static', 'src', 'css', 'test_cssfile1.css')
         ltr_bundle1 = self._get_asset(self.cssbundle_name)
 
         with self._touch(path):
@@ -784,7 +784,7 @@ class TestAssetsBundleWithIRAMock(FileTouchable):
         self._bundle(self._get_asset(), False, False)
 
         # Touch the file and compile a third time
-        path = get_resource_path('test_assetsbundle', 'static', 'src', 'scss', 'test_file1.scss')
+        path = module.get_resource_path('test_assetsbundle', 'static', 'src', 'scss', 'test_file1.scss')
         t = time.time() + 5
         asset = self._get_asset()
         with self._touch(path, t):

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -12,12 +12,11 @@ import pathlib
 import lxml
 import base64
 
-from odoo import api, http
+from odoo import api, modules
 from odoo.addons import __path__ as ADDONS_PATH
 from odoo.addons.base.models.assetsbundle import AssetsBundle
 from odoo.addons.base.models.ir_asset import AssetPaths
 from odoo.addons.base.models.ir_attachment import IrAttachment
-from odoo.modules import module
 from odoo.tests import HttpCase, tagged
 from odoo.tests.common import TransactionCase
 from odoo.addons.base.models.qweb import QWebException
@@ -83,7 +82,7 @@ class AddonManifestPatched(TransactionCase):
 
     test_assetsbundle_manifest = None
     for path in ADDONS_PATH:
-        manifest = module.read_manifest(path, 'test_assetsbundle')
+        manifest = modules.module.read_manifest(path, 'test_assetsbundle')
         if manifest:
             manifest['addons_path'] = path
             test_assetsbundle_manifest = manifest
@@ -92,15 +91,15 @@ class AddonManifestPatched(TransactionCase):
     def tearDown(self):
         super().tearDown()
         self.env.registry._init_modules = self.__genuine_registry_modules
-        module.addons_manifest = self.__genuine_addons_manifest
+        modules.module.addons_manifest = self.__genuine_addons_manifest
 
     def setUp(self):
         super().setUp()
         self.__genuine_registry_modules = self.env.registry._init_modules
         self.env.registry._init_modules = func.lazy(lambda: set(self.installed_modules))
 
-        self.__genuine_addons_manifest = module.addons_manifest
-        module.addons_manifest = func.lazy(lambda: self.manifests)
+        self.__genuine_addons_manifest = modules.module.addons_manifest
+        modules.module.addons_manifest = func.lazy(lambda: self.manifests)
 
         self.installed_modules = ['base', 'test_assetsbundle']
         self.manifests = {
@@ -220,7 +219,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
         last_modified0 = bundle0.last_modified
         version0 = bundle0.version
 
-        path = module.get_resource_path('test_assetsbundle', 'static', 'src', 'js', 'test_jsfile1.js')
+        path = modules.module.get_resource_path('test_assetsbundle', 'static', 'src', 'js', 'test_jsfile1.js')
         bundle1 = self._get_asset(self.jsbundle_name)
 
         with self._touch(path):
@@ -510,7 +509,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
 
         # Touch test_cssfile1.css
         # Note: No lang specific context given while calling _get_asset so it will load assets for en_US
-        path = module.get_resource_path('test_assetsbundle', 'static', 'src', 'css', 'test_cssfile1.css')
+        path = modules.module.get_resource_path('test_assetsbundle', 'static', 'src', 'css', 'test_cssfile1.css')
         ltr_bundle1 = self._get_asset(self.cssbundle_name)
 
         with self._touch(path):
@@ -784,7 +783,7 @@ class TestAssetsBundleWithIRAMock(FileTouchable):
         self._bundle(self._get_asset(), False, False)
 
         # Touch the file and compile a third time
-        path = module.get_resource_path('test_assetsbundle', 'static', 'src', 'scss', 'test_file1.scss')
+        path = modules.module.get_resource_path('test_assetsbundle', 'static', 'src', 'scss', 'test_file1.scss')
         t = time.time() + 5
         asset = self._get_asset()
         with self._touch(path, t):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -173,14 +173,6 @@ class RecordCapturer:
 # Main classes
 # ------------------------------------------------------------
 class OdooSuite(unittest.suite.TestSuite):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        from odoo.http import root
-        if not root._loaded:
-            root.load_addons()
-            root._loaded = True
-
     if sys.version_info < (3, 8):
         # Partial backport of bpo-24412, merged in CPython 3.8
 


### PR DESCRIPTION
PDF reports like this one aren't properly printed (they lack the CSS/JS
assets) when printed via a cron.
`odoo.http.root.load_addons` that builds the `addons_manifest` cache
isn't called on cron workers or shells. Meaning they do not have the files
list for the assets, thus not being able to provide the assets for the
PDF reports.

opw-2555346