### PR TITLE
[FIX] website_slides: Translation issue

### DIFF
--- a/addons/website_slides/i18n/website_slides.pot
+++ b/addons/website_slides/i18n/website_slides.pot
@@ -524,6 +524,7 @@ msgstr ""
 #. module: website_slides
 #. openerp-web
 #: code:addons/website_slides/static/src/js/slides_course_fullscreen_player.js:0
+#: code:addons/website_slides/static/src/js/slides_share.js:0
 #, python-format
 msgid "<strong>Thank you!</strong> Mail has been sent."
 msgstr ""

--- a/addons/website_slides/static/src/js/slides_share.js
+++ b/addons/website_slides/static/src/js/slides_share.js
@@ -3,6 +3,8 @@ odoo.define('website_slides.slides_share', function (require) {
 
 var publicWidget = require('web.public.widget');
 require('website_slides.slides');
+var core = require('web.core');
+var _t = core._t;
 
 var ShareMail = publicWidget.Widget.extend({
     events: {
@@ -29,7 +31,7 @@ var ShareMail = publicWidget.Widget.extend({
                     email: input.val(),
                 },
             }).then(function () {
-                self.$el.html($('<div class="alert alert-info" role="alert"><strong>Thank you!</strong> Mail has been sent.</div>'));
+                self.$el.html($('<div class="alert alert-info" role="alert">' + _t('<strong>Thank you!</strong> Mail has been sent.') + '</div>'));
             });
         } else {
             this.$el.addClass('o_has_error').find('.form-control, .custom-select').addClass('is-invalid');


### PR DESCRIPTION
Steps to reproduce the bug:

- Website in another language than English
- Go to Courses (elarning) and share a title by email
- The "Thank you" message is in English no matter what the language of the website is

opw:2574385