### PR TITLE
[FIX] mass_mailing: fix the issue with the action helper overflow

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -189,25 +189,27 @@
                         </group>
                         <notebook>
                             <page string="Mail Body" name="mail_body">
-                                <div class="mt-n2">
-                                    <field name="body_html" class="o_mail_body oe_read_only" widget="html"
-                                        options="{'cssReadonly': 'mass_mailing.iframe_css_assets_readonly'}"/>
-                                    <field name="body_arch" class="o_mail_body oe_edit_only" widget="mass_mailing_html"
-                                        options="{
-                                            'snippets': 'mass_mailing.email_designer_snippets',
-                                            'cssEdit': 'mass_mailing.iframe_css_assets_edit',
-                                            'inline-field': 'body_html'
-                                    }" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
-                                </div>
-                                <field name="is_body_empty" invisible="1"/>
-                                <div class="o_view_nocontent oe_read_only" attrs="{'invisible': ['|', ('is_body_empty', '=', False), ('state', 'in', ('sending', 'done'))]}">
-                                    <div class="o_nocontent_help">
-                                        <p class="o_view_nocontent_smiling_face">
-                                            No template picked yet.
-                                        </p>
-                                        <p>
-                                            Start editing your mailing to design something awesome.
-                                        </p>
+                                <div class="position-relative">
+                                    <div class="mt-n2">
+                                        <field name="body_html" class="o_mail_body oe_read_only" widget="html"
+                                            options="{'cssReadonly': 'mass_mailing.iframe_css_assets_readonly'}"/>
+                                        <field name="body_arch" class="o_mail_body oe_edit_only" widget="mass_mailing_html"
+                                            options="{
+                                                'snippets': 'mass_mailing.email_designer_snippets',
+                                                'cssEdit': 'mass_mailing.iframe_css_assets_edit',
+                                                'inline-field': 'body_html'
+                                        }" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                    </div>
+                                    <field name="is_body_empty" invisible="1"/>
+                                    <div class="o_view_nocontent oe_read_only" attrs="{'invisible': ['|', ('is_body_empty', '=', False), ('state', 'in', ('sending', 'done'))]}">
+                                        <div class="o_nocontent_help">
+                                            <p class="o_view_nocontent_smiling_face">
+                                                No template picked yet.
+                                            </p>
+                                            <p>
+                                                Start editing your mailing to design something awesome.
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             </page>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the user creates a new marketing compaign, the action helper of the notebook (page "Mail Body") can be placed off the parent container.

Current behavior before PR:
The action helper is placed relatively to the form sheet container.

Desired behavior after PR is merged:
The action helper is placed relatively to the notebook page content.

task-2614456
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
