### PR TITLE
fix qweb v2 chm

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -395,7 +395,7 @@ class IrActionsReport(models.Model):
                 res_ids.append(None)
 
         if not bodies:
-            body = b''.join(lxml.html.tostring(c, encoding='utf-8') for c in body_parent.getchildren())
+            body = ''.join(lxml.html.tostring(c, encoding='unicode') for c in body_parent.getchildren())
             bodies.append(body)
 
         # Get paperformat arguments set in the root html tag. They are prioritized over
@@ -452,13 +452,13 @@ class IrActionsReport(models.Model):
         if header:
             head_file_fd, head_file_path = tempfile.mkstemp(suffix='.html', prefix='report.header.tmp.')
             with closing(os.fdopen(head_file_fd, 'wb')) as head_file:
-                head_file.write(header)
+                head_file.write(header.encode())
             temporary_files.append(head_file_path)
             files_command_args.extend(['--header-html', head_file_path])
         if footer:
             foot_file_fd, foot_file_path = tempfile.mkstemp(suffix='.html', prefix='report.footer.tmp.')
             with closing(os.fdopen(foot_file_fd, 'wb')) as foot_file:
-                foot_file.write(footer)
+                foot_file.write(footer.encode())
             temporary_files.append(foot_file_path)
             files_command_args.extend(['--footer-html', foot_file_path])
 
@@ -467,7 +467,7 @@ class IrActionsReport(models.Model):
             prefix = '%s%d.' % ('report.body.tmp.', i)
             body_file_fd, body_file_path = tempfile.mkstemp(suffix='.html', prefix=prefix)
             with closing(os.fdopen(body_file_fd, 'wb')) as body_file:
-                body_file.write(body)
+                body_file.write(body.encode())
             paths.append(body_file_path)
             temporary_files.append(body_file_path)
 

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -1105,13 +1105,7 @@ class QWeb(object):
         else:
             code.append(self._indent("force_display = None", indent))
 
-            if ttype == 't-esc':
-                # deprecated use.
-                code.append(self._indent(dedent("""
-                    if content is not None and content is not False:
-                        content = str(content)
-                """), indent))
-            elif ttype == 't-raw':
+            if ttype == 't-raw':
                 # deprecated use.
                 code.append(self._indent(dedent("""
                     if content is not None and content is not False:
@@ -1125,9 +1119,7 @@ class QWeb(object):
         # deprecated use.
         if options.get('dev_mode'):
             _logger.warning(
-                "Found deprecated directive @t-esc=%r in template %r. Replace by "
-                "@t-out, and explicitely wrap content in `str` if "
-                "necessary (which likely is not the case)",
+                "Found deprecated directive @t-esc=%r in template %r. Replace by @t-out",
                 el.get('t-esc'),
                 options.get('ref', '<unknown>'),
             )

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -989,6 +989,43 @@ class TestQWebBasic(TransactionCase):
         self.assertEqual(html, """<root><span data-oe-type="text" data-oe-expression="text">a<br>
         b &lt;b&gt;c&lt;/b&gt;</span></root>""")
 
+    def test_out_markup(self):
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="esc-markup">
+                <t t-set="content"><span>toto</span></t>
+                <div t-out="content"/>
+            </t>'''
+        })
+        result = """
+                <div><span>toto</span></div>
+        """
+        rendered = self.env['ir.qweb']._render(t.id, {})
+        self.assertEqual(rendered.strip(), result.strip())
+
+    def test_esc_markup(self):
+        # t-esc is equal to t-out
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="esc-markup">
+                <t t-set="content"><span>toto</span></t>
+                <div t-esc="content"/>
+            </t>'''
+        })
+        ref = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="esc-markup">
+                <t t-set="content"><span>toto</span></t>
+                <div t-out="content"/>
+            </t>'''
+        })
+        rendered = self.env['ir.qweb']._render(t.id, {})
+        result = self.env['ir.qweb']._render(ref.id, {})
+        self.assertEqual(rendered.strip(), result.strip())
+
     def test_if_from_body(self):
         t = self.env['ir.ui.view'].create({
             'name': 'test',


### PR DESCRIPTION
[FIX] base: t-esc does not escape Markdown content and is equal to t-out

This is the same behavior as javascript. Which had been changed during
the refactoring of qweb. t-esc asked for escaping whatever the content.
However, a lot of templates still use t-esc. It is easier to go back to
the previous functionality.

[FIX] all: add missing encoding for the templates