### PR TITLE
[FIX] web_editor: use proper text color for dropdown items in cc envs

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -720,7 +720,11 @@ blockquote {
                 &:active {
                     &, h6 { // Quick fix: sometimes we use h6 in dropdowns
                         @include gradient-bg($-btn-primary-color);
-                        color: color-yiq($-btn-primary-color);
+                        color: color-yiq($-btn-primary-color) !important;
+
+                        @include hover-focus {
+                            color: color-yiq($-btn-primary-color) !important;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When inside a specific color preset, active dropdown items' background
color is set to that preset's primary color. However, their text color
was not properly computed mainly because of [1] which forced other rules
as important.

[1]: https://github.com/odoo/odoo/commit/2172295cefa1d8780332709bf0c97cfa23def3a5
