### PR TITLE
[IMP] mass_mailing: use simplified form for mailing list quick creation

### DIFF
--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -105,6 +105,7 @@
     <record id="mailing_list_view_form_simplified" model="ir.ui.view">
         <field name="name">mailing.list.form.simplified</field>
         <field name="model">mailing.list</field>
+        <field name="priority" eval="25"/>
         <field name="arch" type="xml">
             <form string="Contact List">
                 <group>
@@ -120,11 +121,23 @@
                 <group>
                     <field name="is_public"/>
                 </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="mailing_list_view_form_simplified_footer" model="ir.ui.view">
+        <field name="name">mailing.list.form.simplified.footer</field>
+        <field name="model">mailing.list</field>
+        <field name="inherit_id" ref="mailing_list_view_form_simplified"/>
+        <field name="mode">primary</field>
+        <field name="priority" eval="30"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
                 <footer>
                     <button string="Create" name="close_dialog" type="object" class="btn-primary" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z"/>
                 </footer>
-            </form>
+            </xpath>
         </field>
     </record>
 
@@ -132,7 +145,7 @@
         <field name="name">Create a Mailing List</field>
         <field name="res_model">mailing.list</field>
         <field name="view_mode">form</field>
-        <field name="view_id" ref="mailing_list_view_form_simplified"/>
+        <field name="view_id" ref="mailing_list_view_form_simplified_footer"/>
         <field name="target">new</field>
     </record>
 

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -174,6 +174,7 @@
                                         <label for="contact_list_ids" string="Select mailing lists:" class="oe_edit_only"/>
                                         <field name="contact_list_ids" widget="many2many_tags"
                                             placeholder="Select mailing lists..." class="oe_inline"
+                                            context="{'form_view_ref': 'mass_mailing.mailing_list_view_form_simplified'}"
                                             attrs="{
                                                 'required':[('mailing_model_name','=','mailing.list')],
                                                 'readonly': [('state', 'in', ('sending', 'done'))]

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -127,7 +127,8 @@
 
             <xpath expr="//field[@name='contact_list_ids']" position="attributes">
                 <attribute name="context">
-                    {'mailing_sms' : context.get('mailing_sms')}
+                    {'mailing_sms' : context.get('mailing_sms'),
+                    'form_view_ref': 'mass_mailing.mailing_list_view_form_simplified'}
                 </attribute>
             </xpath>
             <!-- Option page tweaks -->


### PR DESCRIPTION
BEFORE THIS COMMIT

When creating a mailing.mailing from "Create a mailing", the form can contain
a mailing.list field. This is a m2m and one can create and edit lists from
there. However, when using create and edit, the default creation form contained
a few smart buttons that can make the user exit the view. This does not have
much sense for a mailing list being created, and we want the user to stay in
the mailing.mailing being created.

AFTER THIS COMMIT

The view mailing_list_view_form_simplified is used when using create and edit
from there instead of default form one. It does not include any misleading stat
buttons anymore.

The footer including discard and close buttons is removed and is added to a new
primary inheriting view mailing_list_view_form_simplified_footer, used instead
of the previous one in the mailing.list creation form in kanban view, keeping
the previous behaviour and clarifying structure.

Since the field is a many2many in this case, we want the user to be able to save
and create / save and new / discard. This was not the case before, removing the
footer will result in using the default one for m2m. That way, all these actions
will be available as well and work as expected.

--- Links ---
Task-Id - 2605436
COM PR - odoo/odoo#74772
