### PR TITLE
[FIX] l10n_de_skr04 : add missing tag to taxes

### DIFF
--- a/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
@@ -287,6 +287,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'plus_report_line_ids': [ref('l10n_de.tax_report_de_tag_41')],
+                    'tag_ids': [ref('l10n_de.tag_de_intracom_community_delivery')],
                 }),
 
                 (0,0, {
@@ -300,6 +301,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'minus_report_line_ids': [ref('l10n_de.tax_report_de_tag_41')],
+                    'tag_ids': [ref('l10n_de.tag_de_intracom_community_delivery')],
                 }),
 
                 (0,0, {
@@ -326,6 +328,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'plus_report_line_ids': [ref('l10n_de.tax_report_de_tag_43')],
+                    'tag_ids': [ref('l10n_de.tag_de_intracom_community_delivery')],
                 }),
 
                 (0,0, {
@@ -339,6 +342,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'minus_report_line_ids': [ref('l10n_de.tax_report_de_tag_43')],
+                    'tag_ids': [ref('l10n_de.tag_de_intracom_community_delivery')],
                 }),
 
                 (0,0, {


### PR DESCRIPTION
Steps to reproduce

- On a DB with german localization and SKR04 chart
- Accounting > Configuration > taxes
- Select Steuerfreie Ausfuhr (§4 Nr. 1a UStG) or
  Steuerfreie innergem. Lieferung (§4 Abs. 1b UStG)

Issue

The tag l10n_de.tag_de_intracom_community_delivery doesn't appear

opw-2545462

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
