### PR TITLE
[FIX] web: correctly put load_views rpc result in cache

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -186,13 +186,14 @@ function makeActionManager(env) {
             action.domain =
                 typeof domain === "string" ? evaluateExpr(domain, action.context) : domain;
         }
-        action = Object.assign({}, action); // manipulate a copy
+        action = { ...action }; // manipulate a copy to keep cached action unmodified
         action._originalAction = JSON.stringify(action);
         action.jsId = `action_${++id}`;
         if (action.type === "ir.actions.act_window" || action.type === "ir.actions.client") {
             action.target = action.target || "current";
         }
         if (action.type === "ir.actions.act_window") {
+            action.views = [...action.views]; // manipulate a copy to keep cached action unmodified
             action.controllers = {};
             const target = action.target;
             if (target !== "inline" && !(target === "new" && action.views[0][1] === "form")) {

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -2415,4 +2415,21 @@ QUnit.module("ActionManager", (hooks) => {
             "Validation Error"
         );
     });
+
+    QUnit.test("action and load_views rpcs are cached", async function (assert) {
+        const mockRPC = async (route, args) => {
+            assert.step(args.method || route);
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        assert.verifySteps(["/web/webclient/load_menus"]);
+
+        await doAction(webClient, 1);
+        assert.containsOnce(webClient, ".o_kanban_view");
+        assert.verifySteps(["/web/action/load", "load_views", "/web/dataset/search_read"]);
+
+        await doAction(webClient, 1);
+        assert.containsOnce(webClient, ".o_kanban_view");
+
+        assert.verifySteps(["/web/dataset/search_read"]);
+    });
 });


### PR DESCRIPTION
In the "view" service, there is a cache s.t. we don't do the
load_views rpc each time we enter an act_window action. However,
before this commit, we never did cache hits because we modified
(in place) the "views" key inside the action, which is used to
generate the cache key.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
