### PR TITLE
[FIX] l10n_it_edi_sdicoop: do no copy transaction ID and attachment I…

### DIFF
--- a/addons/l10n_it_edi_sdicoop/models/account_invoice.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_invoice.py
@@ -13,8 +13,8 @@ DEFAULT_FACTUR_ITALIAN_DATE_FORMAT = '%Y-%m-%d'
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_it_edi_transaction = fields.Char()
-    l10n_it_edi_attachment_id = fields.Many2one('ir.attachment')
+    l10n_it_edi_transaction = fields.Char(copy=False)
+    l10n_it_edi_attachment_id = fields.Many2one('ir.attachment', copy=False)
 
     def send_pec_mail(self):
         self.ensure_one()


### PR DESCRIPTION
…D when duplicating invoice

When duplicating an invoice, a new edi should be generated, therefore l10n_it_edi_transaction and l10n_it_edi_attachment_id should by copy=False.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
