### PR TITLE
[IMP] microsoft_calendar: get videocall URL from a Outlook event

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz
+import re
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
@@ -23,6 +24,9 @@ ATTENDEE_CONVERTER_M2O = {
     'accepted': 'accepted',
     'organizer': 'accepted',
 }
+VIDEOCALL_URL_PATTERNS = (
+    r'https://teams.microsoft.com',
+)
 MAX_RECURRENT_EVENT = 720
 
 class Meeting(models.Model):
@@ -125,6 +129,16 @@ class Meeting(models.Model):
         if microsoft_event.is_recurrent() and not microsoft_event.is_recurrence():
             # Propagate the follow_recurrence according to the google result
             values['follow_recurrence'] = not microsoft_event.is_recurrence_outlier()
+
+        # if a videocall URL is provided with the Outlook event, use it
+        if microsoft_event.isOnlineMeeting and microsoft_event.onlineMeeting.get("joinUrl"):
+            values['videocall_location'] = microsoft_event.onlineMeeting["joinUrl"]
+        else:
+            # if a location is a URL matching a specific pattern (i.e a URL to access to a videocall),
+            # copy it in the 'videocall_location' instead
+            if values['location'] and any(re.match(p, values['location']) for p in VIDEOCALL_URL_PATTERNS):
+                values['videocall_location'] = values['location']
+                values['location'] = False
 
         values['microsoft_id'] = microsoft_event.id
         if microsoft_event.is_recurrent():


### PR DESCRIPTION
Basically, a Outlook event may contain a videocall URL in 2 different ways:

1) the event location may be a specific URL (such as `https://teams.microsoft.com/...`).  
In this case, we use it as `videocall_location` instead of classic `location`. We use a list of patterns to identify these specific URLs among classic locations.

2) the event may have an attribute `isOnlineMeeting` set to `True` and the attribute `onlineMeetingUrl` set with the URL. In this case, we use this `onlineMeetingUrl` as `videocall_location`.

opw-2601669


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
