### PR TITLE
[IMP] account: remove search when opening journal entries of a bank statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -468,7 +468,6 @@ class AccountBankStatement(models.Model):
             'type': 'ir.actions.act_window',
             'domain': [('move_id', 'in', self.line_ids.move_id.ids)],
             'context': {
-                'search_default_account_id': self.journal_id.default_account_id.id,
                 'journal_id': self.journal_id.id,
                 'group_by': 'move_id',
                 'expand': True


### PR DESCRIPTION
Remove an unnecessary default search when opening the journal entries
of a bank statement.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
