### PR TITLE
[FIX] website_crm_partner_assign: fix a traceback when null probability

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -218,7 +218,7 @@ class CrmLead(models.Model):
         for lead in self:
             lead_values = {
                 'planned_revenue': values['planned_revenue'],
-                'probability': values['probability'],
+                'probability': values['probability'] or False,
                 'priority': values['priority'],
                 'date_deadline': values['date_deadline'] or False,
             }


### PR DESCRIPTION
Bug
===
1. Login as "Portal"
2. Go to "/my/opportunity"
3. Create an opportunity
4. Edit this opportunity from the frontend and set the probability empty
=> Save, an error is raised

Technical
=========
The probability is set to "None" and not to "False", therefor the
verification "probability >= 100" in the write method of the lead will
raise an error.

By using False instead of None, this verification will work.

Task-2613208