### PR TITLE
[FIX] web: Force email refresh on member save

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -802,13 +802,15 @@ var FieldMany2One = AbstractField.extend({
                     readonly: !self.can_write,
                     on_saved: function (record, changed) {
                         if (changed) {
-                            const _setValue = self._setValue.bind(self, self.value.data, {
-                                forceChange: true,
-                            });
-                            self.trigger_up('reload', {
-                                db_id: self.value.id,
-                                onSuccess: _setValue,
-                                onFailure: _setValue,
+                            new Promise(function (resolve, reject) {
+                                self.trigger_up('reload_model', {
+                                    db_id: self.value.id,
+                                    onSuccess: resolve,
+                                });
+                            }).then(() => {
+                                self._setValue(self.value.data, { forceChange: true }).then(function () {
+                                    self.trigger_up('reload', { db_id: self.value.id, 'no_reload': true });
+                                });
                             });
                         }
                     },


### PR DESCRIPTION
Currently,
If we create User from Member Tab without Mail id and after User created, add
mail id on user then mail id is not reflate in the Member Tab because of email
become visible after a page load.

After this commit,
If we create User from Member Tab without Mail id and after User created, add
mail id on user then mail id is reflated instantly in the Member tab. no need to
refresh explicitly.

ID - 2277539

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
