### PR TITLE
[FIX] website_forum: add missing ID which lead to broken JS

### DIFF
--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -561,7 +561,7 @@
             </span>
             <a t-else="" class="nav-link rounded-pill text-reset" t-attf-href="/forum/#{slug(forum)}/flagged_queue">
                 <i class="fa fa-flag fa-fw"/> Flagged
-                <span t-attf-class="badge pull-right #{forum.count_flagged_posts > 0 and 'badge-danger' or 'badge-light'}" t-esc="forum.count_flagged_posts"/>
+                <span id="count_flagged_posts" t-attf-class="badge pull-right #{forum.count_flagged_posts > 0 and 'badge-danger' or 'badge-light'}" t-esc="forum.count_flagged_posts"/>
             </a>
         </t>
     </nav>


### PR DESCRIPTION
That ID was removed with c8c8eb3d5652e98, but the JS code is expecting to find
this ID inside the DOM to increment the flag counter.

Courtesy of @dwa-odoo
Spotted while working on task-2167561
