### PR TITLE
[FIX] mrp: fix the display of a duration greater than 24 hours

### DIFF
--- a/addons/mrp/static/src/js/mrp.js
+++ b/addons/mrp/static/src/js/mrp.js
@@ -122,7 +122,15 @@ var TimeCounter = AbstractField.extend({
         } else {
             clearTimeout(this.timer);
         }
-        this.$el.html($('<span>' + moment.utc(this.duration).format("HH:mm:ss") + '</span>'));
+
+        const duration = moment.duration(this.duration, 'milliseconds');
+        const hours = Math.floor(duration.asHours());
+        const minutes = duration.minutes();
+        const seconds = duration.seconds();
+        //display the variables in two-character format, e.g: 09 intead of 9
+        const text = _.str.sprintf("%02d:%02d:%02d", hours, minutes, seconds);
+        const $mrpTimeText = $('<span>', { text });
+        this.$el.empty().append($mrpTimeText);
     },
 });
 


### PR DESCRIPTION
In the "Time Tracking" tab in a work order, The `"mrp_time_counter"` widget
does not display the duration correctly if it is greater than 24 hours.

For example, if we have a start_date at "05/08/2021 16:00:00" and end_date at "06/08/2021 16:00:01"
the difference between the two is equivalent to "86401000" milliseconds(1 day and 1 second).
So the widget should display "24:00:01" but it displays "00:00:01".

Because as we convert the milliseconds into "moment.UTC" we have "02/01/1970 00:00:01"
and therefore when we format, we do not take into account the date.

opw-2615044




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
