### PR TITLE
[FIX] l10n_in: quantity in tax and base grouping key create an issue

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -59,7 +59,6 @@ class AccountMove(models.Model):
         if tax_line.move_id.journal_id.company_id.country_id.code == 'IN':
             res['product_id'] = tax_line.product_id.id
             res['product_uom_id'] = tax_line.product_uom_id
-            res['quantity'] = tax_line.quantity
         return res
 
     @api.model
@@ -69,8 +68,6 @@ class AccountMove(models.Model):
         if base_line.move_id.journal_id.company_id.country_id.code == 'IN':
             res['product_id'] = base_line.product_id.id
             res['product_uom_id'] = base_line.product_uom_id
-            res['quantity'] = base_line.quantity
-            res['id'] = base_line.id
         return res
 
     @api.model
@@ -81,8 +78,6 @@ class AccountMove(models.Model):
         tax_key += [
             line.product_id.id,
             line.product_uom_id,
-            line.quantity,
-            line.id,
         ]
         return tax_key
 


### PR DESCRIPTION
We need quantity in tax line and we added from this PR https://github.com/odoo/odoo/pull/73402
but after it creates a problem in tax amount
because in tax line, the unit price is set base on quantity and by default is 1 but after PR 73402 it's the same as invoice line so rounding issue is there and this rounded amount is multiplay by quantity so this creates a big difference

before PR 73402:

```
 Name      | unit price | quantity | taxable amount |
=====================================================
 Product A | 5.55       | 8000     | 44400          | (invoice line)
 Tax 5.0%  | 1          | 8000     | 2220           |

```

After PR 73402:

```
 Name      | unit price | quantity | taxable amount |
=====================================================
 Product A | 5.55       | 8000     | 44400          | (invoice line)
 Tax 5.0%  | 0.27       | 8000     | 2160           |

```
So in this PR, we remove quantity from grouping key




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
