### PR TITLE
[FIX] project: fix parent company portal access rights

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -113,13 +113,16 @@
         <field name="name">Project/Task: portal users: (portal and following project) or (portal and following task)</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-        '|',
-            '&amp;',
-                ('project_id.privacy_visibility', '=', 'portal'),
-                ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-            '&amp;',
-                ('project_id.privacy_visibility', '=', 'portal'),
-                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+        '&amp;',
+            ('project_id.privacy_visibility', '=', 'portal'),
+            '|',
+                '|',
+                    ('project_id.message_partner_ids', 'child_of', [user.partner_id.id]),
+                    ('project_id.message_partner_ids', 'parent_of', [user.partner_id.id]),
+                '|',
+                    ('message_partner_ids', 'child_of', [user.partner_id.id]),
+                    ('message_partner_ids', 'parent_of', [user.partner_id.id]),
+
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>


### PR DESCRIPTION
- create 2 child contacts (A and B) with a common parent company
- grant them both portal access
- create a task in project with portal access level
- add one of the child contacts (A) as follower

The other child contact (B) will be able to see and access the task

opw-2574734

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
