### PR TITLE
[IMP] core,mail: speed up _get_tracked_fields

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -547,7 +547,6 @@ class MailThread(models.AbstractModel):
         # we have to flush() again in case we triggered some recomputations
         self.flush()
 
-    @tools.ormcache('self.env.uid', 'self.env.su')
     def _get_tracked_fields(self):
         """ Return the set of tracked fields names for the current model. """
         fields = {
@@ -556,7 +555,10 @@ class MailThread(models.AbstractModel):
             if getattr(field, 'tracking', None) or getattr(field, 'track_visibility', None)
         }
 
-        return fields and set(self.fields_get(fields))
+        # attributes should be not empty to skip reading translatable
+        # attributes like `string` and `help`, so pass `type` which is always
+        # returned anyway
+        return fields and set(self.fields_get(fields, attributes=['type']))
 
     def _message_track_post_template(self, changes):
         if not changes:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -735,10 +735,12 @@ class Field(MetaField('DummyField', (object,), {})):
     # Field description
     #
 
-    def get_description(self, env):
+    def get_description(self, env, attributes=None):
         """ Return a dictionary that describes the field ``self``. """
         desc = {'type': self.type}
         for attr, prop in self.description_attrs:
+            if attributes and attr not in attributes:
+                continue
             value = getattr(self, prop)
             if callable(value):
                 value = value(env)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3078,15 +3078,11 @@ class BaseModel(metaclass=MetaModel):
             if field.groups and not self.env.su and not self.user_has_groups(field.groups):
                 continue
 
-            description = field.get_description(self.env)
+            description = field.get_description(self.env, attributes)
             description['name'] = fname
             if readonly:
                 description['readonly'] = True
                 description['states'] = {}
-            if attributes:
-                description = {key: val
-                               for key, val in description.items()
-                               if key in attributes}
             res[fname] = description
 
         return res


### PR DESCRIPTION
The method returns a dictionary of fields with some attributes, but in fact it
is used just to get list of field names. Before this commit it read translatable
field `help` and `string`, which are not used.

After this optimization, `ormcache` is not needed anymore since the method
doesn't query DB and takes less than 10ms. Before it was 30-50ms on the
following steps:
* restart odoo
* open user avatar: /web/image?model=res.users&field=avatar_128&id=2
