### PR TITLE
[IMP] stock: various optimizations when validating inventory.

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -565,16 +565,17 @@ class StockMoveLine(models.Model):
             # As the move's state is not computed over the move lines, we'll have to manually
             # recompute the moves which we adapted their lines.
             move_to_recompute_state = self.env['stock.move']
+            to_unlink_candidate_ids = set()
 
             rounding = self.product_uom_id.rounding
             for candidate in outdated_candidates:
                 if float_compare(candidate.product_qty, quantity, precision_rounding=rounding) <= 0:
                     quantity -= candidate.product_qty
-                    move_to_recompute_state |= candidate.move_id
                     if candidate.qty_done:
+                        move_to_recompute_state |= candidate.move_id
                         candidate.product_uom_qty = 0.0
                     else:
-                        candidate.unlink()
+                        to_unlink_candidate_ids.add(candidate.id)
                     if float_is_zero(quantity, precision_rounding=rounding):
                         break
                 else:
@@ -586,6 +587,7 @@ class StockMoveLine(models.Model):
                     candidate.product_uom_qty = self.product_id.uom_id._compute_quantity(quantity_split, candidate.product_uom_id, rounding_method='HALF-UP')
                     move_to_recompute_state |= candidate.move_id
                     break
+            self.env['stock.move.line'].browse(to_unlink_candidate_ids).unlink()
             move_to_recompute_state._recompute_state()
 
     def _should_bypass_reservation(self, location):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -5,6 +5,7 @@ from ast import literal_eval
 from datetime import date
 from itertools import groupby
 from operator import attrgetter, itemgetter
+from collections import defaultdict
 import time
 
 from odoo import api, fields, models, SUPERUSER_ID, _
@@ -417,17 +418,28 @@ class Picking(models.Model):
         - Done: if the picking is done.
         - Cancelled: if the picking is cancelled
         '''
+        picking_moves_state_map = defaultdict(dict)
+        picking_move_lines = defaultdict(set)
+        for move in self.env['stock.move'].search([('picking_id', 'in', self.ids)]):
+            picking_id = move.picking_id
+            move_state = move.state
+            picking_moves_state_map[picking_id.id].update({
+                'any_draft': picking_moves_state_map[picking_id.id].get('any_draft', False) or move_state == 'draft',
+                'all_cancel': picking_moves_state_map[picking_id.id].get('all_cancel', True) and move_state == 'cancel',
+                'all_cancel_done': picking_moves_state_map[picking_id.id].get('all_cancel_done', True) and move_state in ('cancel', 'done'),
+            })
+            picking_move_lines[picking_id.id].add(move.id)
         for picking in self:
-            if not picking.move_lines:
+            if not picking_moves_state_map[picking.id]:
                 picking.state = 'draft'
-            elif any(move.state == 'draft' for move in picking.move_lines):  # TDE FIXME: should be all ?
+            elif picking_moves_state_map[picking.id]['any_draft']:
                 picking.state = 'draft'
-            elif all(move.state == 'cancel' for move in picking.move_lines):
+            elif picking_moves_state_map[picking.id]['all_cancel']:
                 picking.state = 'cancel'
-            elif all(move.state in ['cancel', 'done'] for move in picking.move_lines):
+            elif picking_moves_state_map[picking.id]['all_cancel_done']:
                 picking.state = 'done'
             else:
-                relevant_move_state = picking.move_lines._get_relevant_state_among_moves()
+                relevant_move_state = self.env['stock.move'].browse(picking_move_lines[picking_id.id])._get_relevant_state_among_moves()
                 if picking.immediate_transfer and relevant_move_state not in ('draft', 'cancel', 'done'):
                     picking.state = 'assigned'
                 elif relevant_move_state == 'partially_available':


### PR DESCRIPTION
Backport of 14.0 PR odoo/odoo#73082 changing name to_unlink_candidates -> to_unlink_candidate_ids.

Backport of master PR odoo/odoo#62083

Improve `stock.picking._compute_state` by computing pickings new state conditions
beforehand. This avoids looping through picking.move_lines for each
condition for each picking. Add `picking.move_lines` to defaultdict beforehand
to avoid calling `picking.move_lines` in for loop.

#### Speedup

Validating a 171 lines inventory in a customer DB with 2M stock_moves and 22k stock_pickings. min, max and
avg time shown for each optimization.

Total time taken by `inventory.action_validate()`

| Before PR | Backport 14 only | Backport 14 + Backport master | Backport 14 + Backport master + _compute_state |
|:----------:|:--------------:|:-------------------------------:|:-------------------------------------------------:|
| +1h*| 17min | 13 min | 7min40s |

Avg, Min, Max time taken by `move_line._free_reservation`

| | Before PR | Backport 14 only | Backport 14 + Backport master | Backport 14 + Backport master + _compute_state |
|:--:|:----------:|:--------------:|:-------------------------------:|:-------------------------------------------------:|
| avg | 15s* | 5s | 4.71s | 2s |
| min | 0.001s | 0.001s | 0.001s | 0.001s |
| max | 11min* | 6min | 1min30s | 54s |


_\* validating the inventory 'Before PR' was stopped after 1h while still running. Thus the reported total, avg and max time 'Before PR' is probably underestimated._

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
