### PR TITLE
[FIX] website_slides: fix the scrolling while creating a section

### DIFF
--- a/addons/website_slides/i18n/website_slides.pot
+++ b/addons/website_slides/i18n/website_slides.pot
@@ -731,6 +731,15 @@ msgstr ""
 #: code:addons/website_slides/static/src/js/tours/slides_tour.js:0
 #, python-format
 msgid ""
+"A good course has a structure. Pick a name for your first section and click "
+"<b>Save</b> to create it."
+msgstr ""
+
+#. module: website_slides
+#. openerp-web
+#: code:addons/website_slides/static/src/js/tours/slides_tour.js:0
+#, python-format
+msgid ""
 "A good course has structure and a table of content. Your first section will "
 "be the <b>Introduction</b>."
 msgstr ""
@@ -5343,6 +5352,13 @@ msgstr ""
 msgid ""
 "e.g. In this video, we'll give you the keys on how Odoo can help you to grow"
 " your business. At the end, we'll propose you a quiz to test your knowledge."
+msgstr ""
+
+#. module: website_slides
+#. openerp-web
+#: code:addons/website_slides/static/src/xml/slide_management.xml:0
+#, python-format
+msgid "e.g. Introduction"
 msgstr ""
 
 #. module: website_slides

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -37,12 +37,8 @@ tour.register('slides_tour', {
     content: _t("Congratulations, your course has been created, but there isn't any content yet. First, let's add a <b>Section</b> to give your course a structure."),
     position: 'bottom',
 }, {
-    trigger: 'input[name="name"]',
-    content: _t("A good course has structure and a table of content. Your first section will be the <b>Introduction</b>."),
-    position: 'bottom',
-}, {
     trigger: 'button.btn-primary',
-    content: _t("Click on <b>Save</b> to apply changes."),
+    content: _t("A good course has a structure. Pick a name for your first section and click <b>Save</b> to create it."),
     position: 'bottom',
     width: 260,
 }, {

--- a/addons/website_slides/static/src/xml/slide_management.xml
+++ b/addons/website_slides/static/src/xml/slide_management.xml
@@ -15,7 +15,7 @@
                 <div class="form-group row">
                     <label for="section_name" class="col-sm-3 col-form-label">Section name</label>
                     <div class="col-sm-9">
-                        <input type="text" class="form-control" name="name" id="section_name" required="required"/>
+                        <input type="text" class="form-control" name="name" id="section_name" required="required" placeholder="e.g. Introduction"/>
                     </div>
                 </div>
             </form>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -13,7 +13,7 @@
         Slide Type Selection template
     -->
     <t t-name="website.slide.upload.modal.select">
-        <div class="row p-1 mt-4">
+        <div class="row p-1 mt-4 mb-2">
             <div t-foreach="widget.slide_type_data" t-as="slide_type" class="col-6 col-md-3">
                 <t t-set="type_data" t-value="widget.slide_type_data[slide_type]"/>
 


### PR DESCRIPTION
PURPOSE

The scrollbar is showing the ugly while adding a section and uploading 
new content in the course.
The purpose of this commit is to remove the vertical scrollbar, add 
the placeholder on the input field and remove the tour, and also 
reword the message for the save button.

SPECIFICATIONS

Currently, during the slide tour, while adding 'Section' from the
website, the modal is opened, and the tour/bubble for this step is
added at the bottom of the input which introduces a vertical scrollbar
to this simple modal which looks ugly.
This also happens while uploading new 'Content' from the website.

After this commit, this step will be removed (and thus bubble for input),
input field has a placeholder, the message will be improved for 
the save button. This commit also adds a little bottom margin for the anchor
(so that there's enough space for tour bubble).

This is the goal of this commit.


LINKS

PR #74816
Task-2616529

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
