### PR TITLE
[FIX] web: Hide "View Bookmark" button on PDF.js

### DIFF
--- a/addons/web/static/src/js/libs/pdfjs.js
+++ b/addons/web/static/src/js/libs/pdfjs.js
@@ -6,8 +6,9 @@ import config from 'web.config';
  * Until we have our own implementation of the /web/static/lib/pdfjs/web/viewer.{html,js,css}
  * (currently based on Firefox), this method allows us to hide the buttons that we do not want:
  * * "Open File"
- * * "Print" (Hidden on mobile)
- * * "Download"
+ * * "View Bookmark"
+ * * "Print" (Hidden on mobile device like Android, iOS, ...)
+ * * "Download" (Hidden on mobile device like Android, iOS, ...)
  *
  * @link https://mozilla.github.io/pdf.js/getting_started/
  *
@@ -16,7 +17,8 @@ import config from 'web.config';
 export function hidePDFJSButtons(rootElement) {
     const cssStyle = document.createElement("style");
     cssStyle.rel = "stylesheet";
-    cssStyle.innerHTML = `button#secondaryOpenFile.secondaryToolbarButton, button#openFile.toolbarButton {
+    cssStyle.innerHTML = `button#secondaryOpenFile.secondaryToolbarButton, button#openFile.toolbarButton,
+a#secondaryViewBookmark.secondaryToolbarButton, a#viewBookmark.toolbarButton {
 display: none !important;
 }`;
     if (config.device.isMobileDevice) {


### PR DESCRIPTION
The "View Bookmark" button is used to set URL parameter to be able
to jump to bookmark by copy pasting the generated link.

As there is no way to copy this, this feature is useless in our case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
