### PR TITLE
[FIX] web: get remaining days on a date field

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1018,8 +1018,8 @@ const RemainingDays = AbstractField.extend({
         // timezone), to get a meaningful delta for the user
         const nowUTC = moment().utc();
         const nowUserTZ = nowUTC.clone().add(session.getTZOffset(nowUTC), 'minutes');
-        const valueUserTZ = this.value.clone().add(session.getTZOffset(this.value), 'minutes');
-        const diffDays = valueUserTZ.startOf('day').diff(nowUserTZ.startOf('day'), 'days');
+        const fieldValue = this.field.type == "datetime" ? this.value.clone().add(session.getTZOffset(this.value), 'minutes') : this.value;
+        const diffDays = fieldValue.startOf('day').diff(nowUserTZ.startOf('day'), 'days');
         let text;
         if (Math.abs(diffDays) > 99) {
             text = this._formatValue(this.value, 'date');

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4743,6 +4743,40 @@ QUnit.module('basic_fields', {
         unpatchDate();
     });
 
+    QUnit.test('remaining_days widget on a date field in list view in UTC-6', async function (assert) {
+        assert.expect(6);
+
+        const unpatchDate = patchDate(2017, 9, 8, 15, 35, 11); // October 8 2017, 15:35:11
+        this.data.partner.records = [
+            { id: 1, date: '2017-10-08' }, // today
+            { id: 2, date: '2017-10-09' }, // tomorrow
+            { id: 3, date: '2017-10-07' }, // yesterday
+            { id: 4, date: '2017-10-10' }, // + 2 days
+            { id: 5, date: '2017-10-05' }, // - 3 days
+        ];
+
+        const list = await createView({
+            View: ListView,
+            model: 'partner',
+            data: this.data,
+            arch: '<tree><field name="date" widget="remaining_days"/></tree>',
+            session: {
+                getTZOffset: () => -360,
+            },
+        });
+
+        assert.strictEqual(list.$('.o_data_cell:nth(0)').text(), 'Today');
+        assert.strictEqual(list.$('.o_data_cell:nth(1)').text(), 'Tomorrow');
+        assert.strictEqual(list.$('.o_data_cell:nth(2)').text(), 'Yesterday');
+        assert.strictEqual(list.$('.o_data_cell:nth(3)').text(), 'In 2 days');
+        assert.strictEqual(list.$('.o_data_cell:nth(4)').text(), '3 days ago');
+
+        assert.strictEqual(list.$('.o_data_cell:nth(0) .o_field_widget').attr('title'), '10/08/2017');
+
+        list.destroy();
+        unpatchDate();
+    });
+
     QUnit.test('remaining_days widget on a datetime field in list view in UTC-8', async function (assert) {
         assert.expect(5);
 


### PR DESCRIPTION
When getting the remaining days before the deadline of an activity, the
module applies the TZ offset on the deadline date. This leads to
incorrect data.

To reproduce the error:
(Need crm)
1. Configure your computer:
    - TZ: America/Anchorage (UTC-8)
2. Log in DB
3. Ensure user's profile has the correct TZ
4. Create a lead
5. Schedule an activity A:
    - To Do
    - Due Date: tomorrow
6. CRM > Sales > My Activities

Error: The deadline of A is "Today" instead of "Tomorrow"

To get the days difference, the module computes the current date in
user's TZ. Then, it takes the deadline value and applies the offset
between UTC and user's TZ to this deadline value. Eventually, it
compares the two dates.

Here is the problem: the deadline is a date, not a datetime. As a
result, when applying the offset, if the user's TZ is a "negative" one
(UTC-...), it will change the date to the previous day.

For instance, suppose current date is 2021/08/06. In above use case, the
deadline is 2021/08/07. When comparing the dates, the deadline
(2021/08/07 00:00:00) becomes 2021/08/06 16:00:00 (because we are
UTC-8), thus the module will display "Today".

We shouldn't add any offset on a date field.

OPW-2448835