### PR TITLE
[FIX] google_calendar: prevent weird behavior when partner email and …

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -149,8 +149,9 @@ class Meeting(models.Model):
                 if attendee[2].get('displayName') and not partner.name:
                     partner.name = attendee[2].get('displayName')
         for odoo_attendee in attendees_by_emails.values():
-            # Remove old attendees
-            if tools.email_normalize(odoo_attendee.email) not in emails:
+            # Remove old attendees but only if it does not correspond to the current user.
+            email = tools.email_normalize(odoo_attendee.email)
+            if email not in emails and email != self.env.user.email:
                 attendee_commands += [(2, odoo_attendee.id)]
                 partner_commands += [(3, odoo_attendee.partner_id.id)]
         return attendee_commands, partner_commands


### PR DESCRIPTION
…user email differs.

This commit allows using different mail on the user and the partner without experiencing weird behaviors.
    
Before this commit, sometimes when user would set a different email on his user_id and his main partner, the sync event would not be visible as long as the event was not accepted in Google.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
