### PR TITLE
[FIX] mail: unlink attachment if not exist

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -401,6 +401,9 @@ class MailComposer(models.TransientModel):
         if values.get('body_html'):
             values['body'] = values.pop('body_html')
 
+        if not values.get("attachment_ids"):
+            values["attachment_ids"] = [(5, 0)]
+
         # This onchange should return command instead of ids for x2many field.
         values = self._convert_to_write(values)
 


### PR DESCRIPTION
Compose Email no setting `Optional report to print and attach` on the template, onchange template still show attachment file following video below
![Peek 2021-08-06 21-53](https://user-images.githubusercontent.com/24691983/128529877-5a7554ba-1e16-452c-a732-67b979582d1a.gif)

This pr is fix.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
