### PR TITLE
[IMP] payment_adyen: migrate to the latest API

### DIFF
--- a/addons/payment_adyen/__manifest__.py
+++ b/addons/payment_adyen/__manifest__.py
@@ -17,9 +17,10 @@
     'uninstall_hook': 'uninstall_hook',
     'assets': {
         'web.assets_frontend': [
-            'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.9.4/adyen.css',
-            'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.9.4/adyen.js',
+            'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.css',
+            'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.js',
             'payment_adyen/static/src/js/payment_form.js',
+            'payment_adyen/static/src/scss/dropin.scss',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/payment_adyen/const.py
+++ b/addons/payment_adyen/const.py
@@ -1,15 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 # Endpoints of the API.
-# See https://docs.adyen.com/api-explorer/#/CheckoutService/v53/overview for Checkout API
+# See https://docs.adyen.com/api-explorer/#/CheckoutService/v67/overview for Checkout API
 # See https://docs.adyen.com/api-explorer/#/Recurring/v49/overview for Recurring API
 API_ENDPOINT_VERSIONS = {
     '/disable': 49,                 # Recurring API
-    '/originKeys': 53,              # Checkout API
-    '/payments': 53,                # Checkout API
-    '/payments/details': 53,        # Checkout API
+    '/payments': 67,                # Checkout API
+    '/payments/details': 67,        # Checkout API
     '/payments/{}/refunds': 67,     # Checkout API
-    '/paymentMethods': 53,          # Checkout API
+    '/paymentMethods': 67,          # Checkout API
 }
 
 # Adyen-specific mapping of currency codes in ISO 4217 format to the number of decimals.

--- a/addons/payment_adyen/models/payment_acquirer.py
+++ b/addons/payment_adyen/models/payment_acquirer.py
@@ -23,8 +23,11 @@ class PaymentAcquirer(models.Model):
         help="The code of the merchant account to use with this acquirer",
         required_if_provider='adyen', groups='base.group_system')
     adyen_api_key = fields.Char(
-        string="API Key", help="The API key of the user account", required_if_provider='adyen',
+        string="API Key", help="The API key of the webservice user", required_if_provider='adyen',
         groups='base.group_system')
+    adyen_client_key = fields.Char(
+        string="Client Key", help="The client key of the webservice user",
+        required_if_provider='adyen')
     adyen_hmac_key = fields.Char(
         string="HMAC Key", help="The HMAC key of the webhook", required_if_provider='adyen',
         groups='base.group_system')
@@ -107,8 +110,10 @@ class PaymentAcquirer(models.Model):
         except requests.exceptions.ConnectionError:
             _logger.exception("unable to reach endpoint at %s", url)
             raise ValidationError("Adyen: " + _("Could not establish the connection to the API."))
-        except requests.exceptions.HTTPError:
-            _logger.exception("invalid API request at %s with data %s", url, payload)
+        except requests.exceptions.HTTPError as error:
+            _logger.exception(
+                "invalid API request at %s with data %s: %s", url, payload, error.response.text
+            )
             raise ValidationError("Adyen: " + _("The communication with the API failed."))
         return response.json()
 

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -15,11 +15,6 @@ _logger = logging.getLogger(__name__)
 class PaymentTransaction(models.Model):
     _inherit = 'payment.transaction'
 
-    adyen_payment_data = fields.Char(
-        string="Saved Payment Data",
-        help="Data that must be passed back to Adyen when returning from redirect", readonly=True,
-        groups='base.group_system')
-
     #=== BUSINESS METHODS ===#
 
     def _get_specific_processing_values(self, processing_values):
@@ -74,9 +69,8 @@ class PaymentTransaction(models.Model):
             },
             'reference': self.reference,
             'paymentMethod': {
-                'recurringDetailReference': self.token_id.acquirer_ref
-            },  # Required by Adyen although it is also provided with 'storedPaymentMethodId'
-            'storedPaymentMethodId': self.token_id.acquirer_ref,
+                'recurringDetailReference': self.token_id.acquirer_ref,
+            },
             'shopperReference': self.token_id.adyen_shopper_reference,
             'recurringProcessingModel': 'Subscription',
             'shopperIP': payment_utils.get_customer_ip_address(),
@@ -237,7 +231,7 @@ class PaymentTransaction(models.Model):
             _logger.warning("An error occurred on transaction with reference %s (reason: %s)",
                             self.reference, refusal_reason)
             self._set_error(
-                _("An error occured during processing of your payment. Please try again.")
+                _("An error occurred during the processing of your payment. Please try again.")
             )
         elif payment_state in RESULT_CODES_MAPPING['refused']:
             _logger.warning("The transaction with reference %s was refused (reason: %s)",

--- a/addons/payment_adyen/static/src/scss/dropin.scss
+++ b/addons/payment_adyen/static/src/scss/dropin.scss
@@ -1,0 +1,6 @@
+.o_adyen_dropin {
+    [aria-hidden="true"], [aria-hidden="1"]
+    {
+        display: block !important;
+    }
+}

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -11,6 +11,7 @@ class AdyenCommon(PaymentCommon):
         cls.adyen = cls._prepare_acquirer('adyen', update_values={
             'adyen_merchant_account': 'dummy',
             'adyen_api_key': 'dummy',
+            'adyen_client_key': 'dummy',
             'adyen_hmac_key': 'dummy',
             'adyen_checkout_api_url': 'https://this.is.an.url',
             'adyen_recurring_api_url': 'https://this.is.an.url',

--- a/addons/payment_adyen/views/payment_adyen_templates.xml
+++ b/addons/payment_adyen/views/payment_adyen_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <template id="inline_form">
-        <div t-attf-id="o_adyen_dropin_container_{{acquirer_id}}"/>
+        <div t-attf-id="o_adyen_dropin_container_{{acquirer_id}}" class="o_adyen_dropin"/>
     </template>
 
 </odoo>

--- a/addons/payment_adyen/views/payment_views.xml
+++ b/addons/payment_adyen/views/payment_views.xml
@@ -10,6 +10,7 @@
                 <group attrs="{'invisible': [('provider', '!=', 'adyen')]}">
                     <field name="adyen_merchant_account" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_api_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                    <field name="adyen_client_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_hmac_key" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_checkout_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
                     <field name="adyen_recurring_api_url" attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>


### PR DESCRIPTION
Checkout API v67
Web Drop-in v4.7.3

originKey is deprecated and often cause issues (e.g. when the stored
'base_url' system parameter is different from the currently visited URL,
the drop-in widget won't instantiate).

clientKey allows:
- the usage of a single key for all allowed origins in an environment;
- to add or remove origins without having to generate a new client key;
- to identify the environment in the blink of an eye by reading the
  human-readable prefix, test or live.

/!\ Users will now have to set origins themselves in Adyen backend.

task-2590477