### PR TITLE
[FIX] calendar : Creator of meeting with quick_create was never found

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -474,10 +474,10 @@ class Meeting(models.Model):
             if op in (2, 3):  # Remove partner
                 removed_partner_ids += [command[1]]
             elif op == 6:  # Replace all
-                removed_partner_ids += set(self.partner_ids.ids) - set(command[2])  # Don't recreate attendee if partner already attend the event
-                added_partner_ids += set(command[2]) - set(self.partner_ids.ids)
+                removed_partner_ids += set(self.attendee_ids.mapped('partner_id').ids) - set(command[2])  # Don't recreate attendee if partner already attend the event
+                added_partner_ids += set(command[2]) - set(self.attendee_ids.mapped('partner_id').ids)
             elif op == 4:
-                added_partner_ids += [command[1]] if command[1] not in self.partner_ids.ids else []
+                added_partner_ids += [command[1]] if command[1] not in self.attendee_ids.mapped('partner_id').ids else []
             # commands 0 and 1 not supported
 
         attendees_to_unlink = self.env['calendar.attendee'].search([

--- a/addons/calendar/static/src/js/calendar_renderer.js
+++ b/addons/calendar/static/src/js/calendar_renderer.js
@@ -59,6 +59,16 @@ const AttendeeCalendarPopover = CalendarPopover.extend({
     isEventEditable() {
         return this._isEventPrivate() ? this.isCurrentPartnerAttendee() : this._super();
     },
+     /**
+     * @return {boolean}
+     */
+    displayAttendeeAnswerChoice() {
+        // check if we are a partner and if we are the only attendee.
+        // This avoid to display attendee anwser dropdown for single user attendees
+        const isCurrentpartner = (currentValue) => currentValue === session.partner_id;
+        const onlyAttendee = this.event.extendedProps.record.partner_ids.every(isCurrentpartner);
+        return this.isCurrentPartnerAttendee() && ! onlyAttendee;
+    },
 
     //--------------------------------------------------------------------------
     // Private

--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -42,7 +42,7 @@
 
     <t t-name="Calendar.attendee.status.popover" t-extend="CalendarView.event.popover">
         <t t-jquery=".o_cw_popover_delete" t-operation="after">
-            <div t-if="widget.isCurrentPartnerAttendee()" class="btn-group o-calendar-attendee-status ml-2">
+            <div t-if="widget.displayAttendeeAnswerChoice()" class="btn-group o-calendar-attendee-status ml-2">
                 <a href="#" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <i t-attf-class="fa fa-circle o-calendar-attendee-status-icon #{widget.selectedStatusInfo.color}"/> <span class="o-calendar-attendee-status-text" t-esc="widget.selectedStatusInfo.text"></span>
                 </a>


### PR DESCRIPTION
Issue: When creating a Meeting with quick_create (click and slide), the creator was not invited but is attending, since he was not invited, he cannot change his status to Accept, Decline, or Uncertain

Steps to reproduce :

 1) Go to Calendar (On the main view : Calendar view)
 2) Click to create a meeting, enter a Summary and press create
 3) Click on the meeting you just created
  3a) Optional: Edit the meeting and go to Invitations tab, you are not invited.
 4) Click on "Needs Action" to change your attendee state to Accept
 5) Refresh the page
 6) Click on the same meeting
  6a) Optional: Edit the meeting and go to Invitations tab, you are still not invited.
 7) Bug, your attendee state is still "Needs Action"

Why is that a bug:
With quick_create, there is no partner_ids given to the vals_list of create(), therefore _default_partners the default is triggered on the creation of the event that adds self.env.user.partner_id to the partner_ids.
However, for attendee_ids, there was no default, so if the key attendee_ids isn't present, nothing is done, which is what happens on quick_create since no attendee is added since we add them via the partner_ids (line 714) that isn't present
Not an attendee means no attendee_status

Side Note: The business flow was already that way, since the self.env.user.partner_id was added by the default of partner_ids in quick_create or in normal create. The problem was that the attendees_id of val_list on line 714 was taken from the partner_ids before the default of partner_ids was triggered.
On the normal create, it wasn't a problem since the meeting creator partner_id is filled when loading the normal create view, but on quick_create that view is never loaded up, so the default of partner_ids is created on line 721 when the event is created, adding the current user in the partner_ids of the event, but without modifying the attendee_ids

opw-2538295