### PR TITLE
[12.0] [13.0] [14.0] account, pos_adyen: remove missing QWeb files from manifest

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -83,7 +83,6 @@ You could use this simplified accounting in case you work with an (external) acc
     'qweb': [
         "static/src/xml/account_payment.xml",
         'static/src/xml/account_resequence.xml',
-        "static/src/xml/account_report_backend.xml",
         "static/src/xml/bills_tree_upload_views.xml",
         'static/src/xml/account_journal_activity.xml',
         'static/src/xml/grouped_view_widget.xml',

--- a/addons/pos_adyen/__manifest__.py
+++ b/addons/pos_adyen/__manifest__.py
@@ -16,7 +16,6 @@
         'views/res_config_settings_views.xml',
     ],
     'depends': ['adyen_platforms', 'point_of_sale'],
-    'qweb': ['static/src/xml/pos.xml'],
     'installable': True,
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Removes nonexistent QWeb files listed in `account` and `pos_adyen` addon manifests. 

- `account`
    - `14.0`: [manifest](https://github.com/odoo/odoo/blob/60d8ca7c91a349fa4c4f28a4f2308f333f9c6b7b/addons/account/__manifest__.py#L86), [`static/src/xml` directory](https://github.com/odoo/odoo/tree/14.0/addons/account/static/src/xml).
    - `13.0`: [manifest](https://github.com/odoo/odoo/blob/21d02671fce48ef0a7ac1c70602613852819b50c/addons/account/__manifest__.py#L73), [`static/src/xml` directory](https://github.com/odoo/odoo/tree/13.0/addons/account/static/src/xml).
    - `12.0`: [manifest](https://github.com/odoo/odoo/blob/257fc29601470a9f79de2144da0d441142a9e913/addons/account/__manifest__.py#L72), [`static/src/xml` directory](https://github.com/odoo/odoo/tree/12.0/addons/account/static/src/xml).
- `pos_adyen`
    - `14.0`: [manifest](https://github.com/odoo/odoo/blob/60d8ca7c91a349fa4c4f28a4f2308f333f9c6b7b/addons/pos_adyen/__manifest__.py#L19), [has no `static/src/xml` directory](https://github.com/odoo/odoo/tree/14.0/addons/pos_adyen/static/src).
    - `13.0`: [manifest](https://github.com/odoo/odoo/blob/21d02671fce48ef0a7ac1c70602613852819b50c/addons/pos_adyen/__manifest__.py#L16), [has no `static/src/xml` directory](https://github.com/odoo/odoo/tree/13.0/addons/pos_adyen/static/src).
    - `12.0`: not affected (addon does not exist).

Current behavior before PR:

- Nonexistent QWeb files are listed in the manifest.

Desired behavior after PR is merged:

- Nonexistent QWeb files are not listed in the manifest.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
