### PR TITLE
[FIX] account: prevent ValueError when applying reconciliation rule

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -346,8 +346,11 @@ class AccountReconcileModel(models.Model):
                 match = re.search(line.amount_string, st_line.payment_ref)
                 if match:
                     sign = 1 if residual_balance > 0.0 else -1
-                    extracted_balance = float(re.sub(r'\D' + self.decimal_separator, '', match.group(1)).replace(self.decimal_separator, '.'))
-                    balance = copysign(extracted_balance * sign, residual_balance)
+                    try:
+                        extracted_balance = float(re.sub(r'\D' + self.decimal_separator, '', match.group(1)).replace(self.decimal_separator, '.'))
+                        balance = copysign(extracted_balance * sign, residual_balance)
+                    except ValueError:
+                        balance = 0
                 else:
                     balance = 0
             else:


### PR DESCRIPTION
If we have a reconciliation model having a rule using a regex, we are extracting
the balance from the label, but we should not raise an error in case the regex
is matching an incorrect float value, and just set a zero balance instead.

Description of the issue/feature this PR addresses:
opw-2614726

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
