### PR TITLE
show product code in the POS receipt 

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1939,6 +1939,7 @@ exports.Orderline = Backbone.Model.extend({
             unit_name:          this.get_unit().name,
             is_in_unit:         this.get_unit().id == this.pos.uom_unit_id,
             price:              this.get_unit_display_price(),
+            default_code:       this.get_product().default_code,
             discount:           this.get_discount(),
             default_code:       this.get_product().default_code,
             product_name:       this.get_product().display_name,

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1939,7 +1939,6 @@ exports.Orderline = Backbone.Model.extend({
             unit_name:          this.get_unit().name,
             is_in_unit:         this.get_unit().id == this.pos.uom_unit_id,
             price:              this.get_unit_display_price(),
-            default_code:       this.get_product().default_code,
             discount:           this.get_discount(),
             default_code:       this.get_product().default_code,
             product_name:       this.get_product().display_name,

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1940,6 +1940,7 @@ exports.Orderline = Backbone.Model.extend({
             is_in_unit:         this.get_unit().id == this.pos.uom_unit_id,
             price:              this.get_unit_display_price(),
             discount:           this.get_discount(),
+            default_code:       this.get_product().default_code,
             product_name:       this.get_product().display_name,
             product_name_wrapped: this.generate_wrapped_product_name(),
             price_lst:          this.get_lst_price(),


### PR DESCRIPTION
show product code in printing receipt POS

Description of the issue/feature this PR addresses:
the product code can't be displayed in the  POS receipt 
so i have to add the product code in it

Current behavior before PR:
can't display the code of product 

Desired behavior after PR is merged:
show the product code in the pos receipt 





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
