### PR TITLE
[FIX] payment_fix_register_token: link invoice

### DIFF
--- a/addons/payment_fix_register_token/models/account_payment_register.py
+++ b/addons/payment_fix_register_token/models/account_payment_register.py
@@ -69,3 +69,12 @@ class AccountPaymentRegister(models.TransientModel):
         payment_vals = super()._create_payment_vals_from_wizard()
         payment_vals['payment_token_id'] = self.payment_token_id.id
         return payment_vals
+
+    def _create_payments(self):
+        payments = super()._create_payments()
+        batches = self._get_batches()
+        # On register payment wizard, it only allow selecting payment token
+        # if processing single invoice and grouping invoices
+        if self.group_payment or len(batches[0]["lines"]) == 1:
+            payments.payment_transaction_id.write({"invoice_ids": [(6, 0, batches[0]["lines"].move_id.ids)]})
+        return payments


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Setup Payment Acquirer, I use Stripe in this case
- Configure Electronic method for incoming payment on Stripe journal
- Create a saved payment token for a partner A
- Create Sale Order for partner A > Create Invoice + Post > Register Payment
- On the Register Payment wizard, choose Stripe journal and select Electronic for the method
- Select the payment token saved for that partner
- Register the Payment

Current behavior before PR:
- Invoice isn't linked with the Transaction done by the payment acquirer `transaction_ids`

Desired behavior after PR is merged:
- Invoice is linked with traction done by the payment acquirer

Note:

I want to make this change in `payment` but not sure if that's a good place

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
