### PR TITLE
[FIX] web: Allow array value for many2many search filter

### DIFF
--- a/addons/web/static/src/js/control_panel/control_panel_model_extension.js
+++ b/addons/web/static/src/js/control_panel/control_panel_model_extension.js
@@ -857,7 +857,7 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
                 child.attrs.isDefault = true;
                 let value = this.searchDefaults[child.attrs.name];
                 if (child.tag === 'field') {
-                    child.attrs.defaultValue = Array.isArray(value) ? value[0] : value;
+                    child.attrs.defaultValue = this.fields[child.attrs.name].type === 'many2one' && Array.isArray(value) ? value[0] : value;
                 } else if (child.tag === 'groupBy') {
                     child.attrs.defaultRank = typeof value === 'number' ? value : 100;
                 }

--- a/addons/web/static/tests/control_panel/control_panel_model_extension_tests.js
+++ b/addons/web/static/tests/control_panel/control_panel_model_extension_tests.js
@@ -369,5 +369,52 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
 
         });
 
+        QUnit.test('search defaults on X2M fields', async function (assert) {
+            assert.expect(1);
+
+            const context = {
+                search_default_otom: [1, 2],
+                search_default_mtom: [1, 2]
+            };
+            const fields = this.fields;
+            fields.otom = { string: "O2M", type: "one2many", relation: 'partner' };
+            fields.mtom = { string: "M2M", type: "many2many", relation: 'partner' };
+            const arch = `
+                <search>
+                    <field name="otom"/>
+                    <field name="mtom"/>
+                </search>`;
+            const model = createModel({ arch, fields, context });
+            assert.deepEqual(sanitizeFilters(model), [
+                {
+                    "defaultAutocompleteValue": {
+                      "label": [1, 2],
+                      "operator": "ilike",
+                      "value": [1, 2]
+                    },
+                    "defaultRank": -10,
+                    "description": "O2M",
+                    "fieldName": "otom",
+                    "fieldType": "one2many",
+                    "isDefault": true,
+                    "type": "field"
+                },
+                {
+                    "defaultAutocompleteValue": {
+                      "label": [1, 2],
+                      "operator": "ilike",
+                      "value": [1, 2]
+                    },
+                    "defaultRank": -10,
+                    "description": "M2M",
+                    "fieldName": "mtom",
+                    "fieldType": "many2many",
+                    "isDefault": true,
+                    "type": "field"
+                }
+            ]);
+
+        });
+
     });
 });


### PR DESCRIPTION
Issue:

  In an action, if we add to the context a key `search_default_x_ids`
  (who is a many2many field) with an array of ids as value, it will
  display/use only the first value in the search bar.

Cause:

  If filter-type is 'field' and it's an array, it will take the first
  value.

Solution:

  Take first value of array only if field-type is a `many2one`.

Inspired by Odoo v13.0

opw-2596345