### PR TITLE
[FIX] mass_mailing: fix mailing count in stats button in campaign

### DIFF
--- a/addons/mass_mailing/models/utm.py
+++ b/addons/mass_mailing/models/utm.py
@@ -22,7 +22,7 @@ class UtmCampaign(models.Model):
     def _compute_mailing_mail_count(self):
         if self.ids:
             mailing_data = self.env['mailing.mailing'].read_group(
-                [('campaign_id', 'in', self.ids)],
+                [('campaign_id', 'in', self.ids), ('mailing_type', '=', 'mail')],
                 ['campaign_id'],
                 ['campaign_id']
             )


### PR DESCRIPTION
PURPOSE
To fix the stat button count of mailing.mailing in campaign.

SPECIFICATION
Currently we are getting all records of mailing.mailing instead of
getting only records with mailing_type=mail.

To bE:
Only show count of records which have mailing_type = mail.

TASK ID: 2417993

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
