### PR TITLE
[FIX] l10n_pos_cert: Fixed unlink empty cash register who blocked closing session 

### DIFF
--- a/addons/l10n_fr_pos_cert/models/account_bank_statement.py
+++ b/addons/l10n_fr_pos_cert/models/account_bank_statement.py
@@ -9,8 +9,11 @@ class AccountBankStatement(models.Model):
     _inherit = 'account.bank.statement'
 
     def unlink(self):
-        for statement in self.filtered(lambda s: s.company_id._is_accounting_unalterable() and s.journal_id.pos_payment_method_ids):
-            raise UserError(_('You cannot modify anything on a bank statement (name: %s) that was created by point of sale operations.') % (statement.name,))
+        for statement in self:
+            if not statement.company_id._is_accounting_unalterable() or not statement.s.journal_id.pos_payment_method_ids:
+                continue
+            if statement.state != 'open':
+                raise UserError(_('You cannot modify anything on a bank statement (name: %s) that was created by point of sale operations.') % (statement.name))
         return super(AccountBankStatement, self).unlink()
 
 


### PR DESCRIPTION
Actually it's Impossible to open and just after close pos session without orders.
In standard Odoo unlink this empty cash register (if not difference in cash register) and the  l10n_pos_cert module raise it
if the company is accounting unalterable.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
