### PR TITLE
[FIX] hr_expense: convert base amount if different currency

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -412,6 +412,7 @@ class HrExpense(models.Model):
                 if tax['tax_repartition_line_id']:
                     rep_ln = self.env['account.tax.repartition.line'].browse(tax['tax_repartition_line_id'])
                     base_amount = self.env['account.move']._get_base_amount_to_display(tax['base'], rep_ln)
+                    base_amount = expense.currency_id._convert(base_amount, company_currency, expense.company_id, account_date) if different_currency else base_amount
                 else:
                     base_amount = None
 

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -134,6 +134,7 @@ class TestAccountEntry(TestExpenseCommon):
                     self.assertEquals(len(line.analytic_line_ids), 1, "The debit move line should have 1 analytic lines")
                     self.assertEquals(line.product_id, self.product_expense, "Product of debit move line should be the one from the expense")
                 else:
+                    self.assertEqual(line.tax_base_amount, 318.18)
                     self.assertAlmostEquals(line.debit, 31.82)
                     self.assertAlmostEquals(line.amount_currency, 63.64)
                     self.assertEquals(len(line.analytic_line_ids), 0, "The tax move line should not have analytic lines")


### PR DESCRIPTION
In a multi-currencies environment, if the user creates an expense with a
different currency than the company's, one of the associated account
move lines will have an incorrect base amount.

To reproduce the issue:
(Need account_accountant. Let USD be the company's currency)
1. In Settings, enable "Multi-Currencies"
2. Edit the currency rates:
    - EUR: 2
    - USD: 1
3. Create an expense:
    - Currency: EUR
    - Unit Price: 700
    - tax: 15%
4. Create Report, Submit, Approve, Post Journal Entries
5. Accounting > Reporting > Tax Report, This Financial Year
6. Audit of "Tax 15.00%"

Error: Base amount of the expense is $700, which is incorrect. It should
be either 700€ or $350

OPW-2613547