### PR TITLE
[FIX] repair: display correct default location

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -191,8 +191,9 @@ class Repair(models.Model):
     @api.onchange('company_id')
     def _onchange_company_id(self):
         if self.company_id:
-            warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.company_id.id)], limit=1)
-            self.location_id = warehouse.lot_stock_id
+            if self.location_id.company_id != self.company_id:
+                warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.company_id.id)], limit=1)
+                self.location_id = warehouse.lot_stock_id
         else:
             self.location_id = False
 


### PR DESCRIPTION
How to reproduce the problem:
- Install the repair App
- Repairs -> Create (a Repair Order) (and activate the debug mode)
- Change the Location Field to something else (than the usual default WH/Stock)
- Open Developer Tools -> Set Defaults
- For Defaults, choose "Location = [the changed Location]", "All Users" -> Save Default
- Create a new Repair Order: the Location is not set to the default we set earlier through the Developer Tools

Cause of the problem : an Onchange method was overriding the default Location

Solution : it will now check, in the onchange, if the change is necessary, before overriding the default.

opw-2545876