### PR TITLE
[FIX] hr_timesheet: fix setting display

### DIFF
--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -73,10 +73,10 @@
                             <div class="o_setting_right_pane">
                                 <strong>Round Timesheets</strong>
                                 <div class="o_row w-30">
-                                    <span class="o_light_label"><label for="timesheet_min_duration"/><field name="timesheet_min_duration" class="col-lg-2"/> minutes</span>
+                                    <span class="o_light_label"><label for="timesheet_min_duration"/><field name="timesheet_min_duration" class="col-lg-2 text-center"/> minutes</span>
                                 </div>
                                 <div class="o_row">
-                                    <span class="o_light_label"><label for="timesheet_rounding"/><field name="timesheet_rounding" class="col-lg-2"/> minutes</span>
+                                    <span class="o_light_label"><label for="timesheet_rounding"/><field name="timesheet_rounding" class="col-lg-2 text-center"/> minutes</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Purpose of this commit is to display the value of
timesheet_min_duration and timesheet_rounding
fields center in the setting of the timesheet app.

So, In this commit add a text-center class for that
fields in XML of the setting in the timesheet app.

Task ID: 2616165

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
