### PR TITLE
[IMP] mail: allow user to delete their messages

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1882,7 +1882,15 @@ class MailThread(models.AbstractModel):
         """ Hook to add custom behavior after having posted the message. Both
         message and computed value are given, to try to lessen query count by
         using already-computed values instead of having to rebrowse things. """
-        pass
+
+    def _message_update_content_after_hook(self, message):
+        """ Hook to add custom behavior after having updated the message content. """
+
+    def _check_can_update_message_content(self, message):
+        """" Checks that the current user can update the content of the message. """
+        note_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
+        if not message.subtype_id.id == note_id:
+            raise exceptions.UserError(_("Only logged notes can have their content updated on model '%s'", self._name))
 
     # ------------------------------------------------------
     # MESSAGE POST TOOLS

--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -208,8 +208,13 @@ export class Composer extends Component {
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickCaptureGlobal(ev) {
+    async _onClickCaptureGlobal(ev) {
         if (this.contains(ev.target)) {
+            return;
+        }
+        // Let event be handled by bubbling handlers first
+        await new Promise(this.env.browser.setTimeout);
+        if (isEventHandled(ev, 'MessageActionList.replyTo')) {
             return;
         }
         if (!this.composer) {

--- a/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.js
+++ b/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.js
@@ -1,0 +1,39 @@
+/** @odoo-module **/
+
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
+
+import Dialog from 'web.OwlDialog';
+
+const { Component } = owl;
+const { useRef } = owl.hooks;
+
+export class DeleteMessageConfirmDialog extends Component {
+
+    /**
+     * @override
+     */
+    setup() {
+        super.setup();
+        this.title = this.env._t("Confirmation");
+        this.dialogRef = useRef('dialog');
+    }
+
+    /**
+     * @returns {mail.message}
+     */
+    get actionList() {
+        return this.messaging && this.messaging.models['mail.message_action_list'].get(this.props.actionListLocalId);
+    }
+}
+
+Object.assign(DeleteMessageConfirmDialog, {
+    components: {
+        Dialog,
+    },
+    props: {
+        actionListLocalId: String,
+    },
+    template: 'mail.DeleteMessageConfirmDialog',
+});
+
+registerMessagingComponent(DeleteMessageConfirmDialog);

--- a/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.scss
+++ b/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.scss
@@ -1,0 +1,3 @@
+.o_DeleteMessageConfirmDialog_blockquote {
+    font-style: normal;
+}

--- a/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.xml
+++ b/addons/mail/static/src/components/delete_message_confirm_dialog/delete_message_confirm_dialog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.DeleteMessageConfirmDialog" owl="1">
+        <Dialog contentClass="'o_DeleteMessageConfirmDialog'" title="title" t-on-dialog-closed="actionList.onDeleteConfirmDialogClosed" t-ref="dialog">
+            <p>Are you sure you want to delete this message?</p>
+            <blockquote class="o_DeleteMessageConfirmDialog_blockquote">
+                <Message messageLocalId="actionList.message.localId" showActions="false"/>
+            </blockquote>
+            <small t-if="!actionList.message.originThread or actionList.message.originThread.model !== 'mail.channel'">Pay attention: The followers of this document who were notified by email will still be able to read the content of this message and reply to it.</small>
+            <t t-set-slot="buttons">
+                <button class="btn btn-primary" t-on-click="actionList.onClickConfirmDelete">Delete</button>
+                <button class="btn btn-secondary" t-on-click="dialogRef.comp._close()">Cancel</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
@@ -74,8 +74,9 @@ QUnit.test('reply: discard on pressing escape', async function (assert) {
         '.o_Message',
         "should display a single message"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.containsOnce(
         document.body,
@@ -192,9 +193,10 @@ QUnit.test('reply: discard on discard button click', async function (assert) {
         '.o_Message',
         "should display a single message"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
 
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.containsOnce(
         document.body,
@@ -252,18 +254,18 @@ QUnit.test('reply: discard on reply button toggle', async function (assert) {
         '.o_Message',
         "should display a single message"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
 
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.containsOnce(
         document.body,
         '.o_Composer',
         "should have composer after clicking on reply to message"
     );
-
     await afterNextRender(() =>
-        document.querySelector(`.o_Message_commandReply`).click()
+        document.querySelector(`.o_MessageActionList_actionReply`).click()
     );
     assert.containsNone(
         document.body,
@@ -307,9 +309,10 @@ QUnit.test('reply: discard on click away', async function (assert) {
         '.o_Message',
         "should display a single message"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
 
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.containsOnce(
         document.body,
@@ -410,9 +413,10 @@ QUnit.test('"reply to" composer should log note if message replied to is a note'
         '.o_Message',
         "should display a single message"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
 
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.strictEqual(
         document.querySelector('.o_Composer_buttonSend').textContent.trim(),
@@ -481,9 +485,10 @@ QUnit.test('"reply to" composer should send message if message replied to is not
         '.o_Message',
         "should display a single message"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
 
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.strictEqual(
         document.querySelector('.o_Composer_buttonSend').textContent.trim(),

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -1243,20 +1243,23 @@ QUnit.test('basic rendering of message', async function (assert) {
         1,
         "should have date in header of message"
     );
-    assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_header .o_Message_commands`).length,
-        1,
-        "should have commands in header of message"
+    await afterNextRender(() => 
+        document.querySelector('.o_Message').click()
     );
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_header .o_Message_command`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList`).length,
         1,
-        "should have a single command in header of message"
+        "should action list in message"
     );
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_commandStar`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList_action`).length,
         1,
-        "should have command to star message"
+        "should have a single action in action list of message"
+    );
+    assert.strictEqual(
+        message.querySelectorAll(`:scope .o_MessageActionList_actionStar`).length,
+        1,
+        "should have action to star message"
     );
     assert.strictEqual(
         message.querySelectorAll(`:scope .o_Message_content`).length,
@@ -1345,20 +1348,23 @@ QUnit.test('basic rendering of squashed message', async function (assert) {
         message2.querySelector(`:scope .o_Message_sidebar`).classList.contains('o-message-squashed'),
         "message 2 should have squashed sidebar"
     );
+    await afterNextRender(() => 
+        document.querySelector('.o_Message.o-squashed').click()
+    );
     assert.strictEqual(
         message2.querySelectorAll(`:scope .o_Message_sidebar .o_Message_date`).length,
         1,
         "message 2 should have date in sidebar"
     );
     assert.strictEqual(
-        message2.querySelectorAll(`:scope .o_Message_sidebar .o_Message_commands`).length,
+        message2.querySelectorAll(`:scope .o_MessageActionList`).length,
         1,
-        "message 2 should have some commands in sidebar"
+        "message 2 should have some actions"
     );
     assert.strictEqual(
-        message2.querySelectorAll(`:scope .o_Message_sidebar .o_Message_commandStar`).length,
+        message2.querySelectorAll(`:scope .o_MessageActionList_actionStar`).length,
         1,
-        "message 2 should have star command in sidebar"
+        "message 2 should have star action in action list"
     );
     assert.strictEqual(
         message2.querySelectorAll(`:scope .o_Message_core`).length,
@@ -2489,13 +2495,14 @@ QUnit.test('toggle_star message', async function (assert) {
         message.classList.contains('o-starred'),
         "message should not be starred"
     );
+    await afterNextRender(() => message.click());
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_commandStar`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList_actionStar`).length,
         1,
-        "message should have star command"
+        "message should have star action"
     );
 
-    await afterNextRender(() => message.querySelector(`:scope .o_Message_commandStar`).click());
+    await afterNextRender(() => message.querySelector(`:scope .o_MessageActionList_actionStar`).click());
     assert.verifySteps(['rpc:toggle_message_starred']);
     assert.strictEqual(
         document.querySelector(`
@@ -2518,7 +2525,7 @@ QUnit.test('toggle_star message', async function (assert) {
         "message should be starred"
     );
 
-    await afterNextRender(() => message.querySelector(`:scope .o_Message_commandStar`).click());
+    await afterNextRender(() => message.querySelector(`:scope .o_MessageActionList_actionStar`).click());
     assert.verifySteps(['rpc:toggle_message_starred']);
     assert.strictEqual(
         document.querySelectorAll(`
@@ -2915,25 +2922,26 @@ QUnit.test('rendering of inbox message', async function (assert) {
         " on Refactoring",
         "should display origin thread name"
     );
+    await afterNextRender(() => message.click());
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_command`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList_action`).length,
         3,
-        "should display 3 commands"
+        "should display 3 actions"
     );
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_commandStar`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList_actionStar`).length,
         1,
-        "should display star command"
+        "should display star action"
     );
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_commandReply`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList_actionReply`).length,
         1,
-        "should display reply command"
+        "should display reply action"
     );
     assert.strictEqual(
-        message.querySelectorAll(`:scope .o_Message_commandMarkAsRead`).length,
+        message.querySelectorAll(`:scope .o_MessageActionList_actionMarkRead`).length,
         1,
-        "should display mark as read command"
+        "should display mark as read action"
     );
 });
 
@@ -3209,9 +3217,10 @@ QUnit.test('reply to message from inbox (message linked to document)', async fun
         " on Refactoring",
         "should display message originates from record 'Refactoring'"
     );
+    await afterNextRender(() => document.querySelector('.o_Message').click());
 
     await afterNextRender(() =>
-        document.querySelector('.o_Message_commandReply').click()
+        document.querySelector('.o_MessageActionList_actionReply').click()
     );
     assert.ok(
         document.querySelector('.o_Message').classList.contains('o-selected'),
@@ -3456,12 +3465,19 @@ QUnit.test('mark a single message as read should only move this message to "Hist
         2,
         "inbox mailbox should have 2 messages"
     );
+    await afterNextRender(() =>
+        document.querySelector(`
+            .o_Message[data-message-local-id="${
+                this.messaging.models['mail.message'].findFromIdentifyingData({ id: 1 }).localId
+            }"]
+        `).click()
+    );
 
     await afterNextRender(() =>
         document.querySelector(`
             .o_Message[data-message-local-id="${
                 this.messaging.models['mail.message'].findFromIdentifyingData({ id: 1 }).localId
-            }"] .o_Message_commandMarkAsRead
+            }"] .o_MessageActionList_actionMarkRead
         `).click()
     );
     assert.containsOnce(

--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -27,17 +27,8 @@
     margin-inline-end: map-get($spacers, 2);
 }
 
-.o_Message_commandStar {
-    font-size: 1.3em;
-}
-
 .o_Message_Composer {
     flex: 1 1 auto;
-}
-
-.o_Message_commands {
-    display: flex;
-    align-items: center;
 }
 
 .o_Message_content {
@@ -77,29 +68,6 @@
     display: flex;
     flex-flow: row wrap;
     align-items: baseline;
-}
-
-.o_Message_headerCommands {
-    margin-inline-end: map-get($spacers, 2);
-    align-self: center;
-
-    .o_Message_headerCommand {
-        padding-left: map-get($spacers, 2);
-        padding-right: map-get($spacers, 2);
-
-        &.o-mobile {
-            padding-left: map-get($spacers, 3);
-            padding-right: map-get($spacers, 3);
-
-            &:first-child {
-                padding-left: map-get($spacers, 2);
-            }
-
-            &:last-child {
-                padding-right: map-get($spacers, 2);
-            }
-        }
-    }
 }
 
 .o_Message_headerDate {
@@ -143,21 +111,12 @@
     max-width: $o-mail-message-sidebar-width;
     display: flex;
     margin-top: map-get($spacers, 2);
-    margin-inline-end: map-get($spacers, 2);
     justify-content: center;
-
-    &.o-message-squashed {
-        align-items: flex-start;
-    }
 }
 
 .o_Message_sidebarItem {
     margin-left: map-get($spacers, 1);
     margin-right: map-get($spacers, 1);
-
-    &.o-message-squashed {
-        display: flex;
-    }
 }
 
 .o_Message_trackingValues {
@@ -180,21 +139,6 @@
 
 .o_Message {
     background-color: $white;
-
-    &:hover, &.o-clicked {
-
-        .o_Message_commands {
-            opacity: 1;
-        }
-
-        .o_Message_sidebarItem.o-message-squashed {
-            display: flex;
-        }
-
-        .o_Message_seenIndicator.o-message-squashed {
-            display: none;
-        }
-    }
 
     .o_Message_partnerImStatusIcon {
         color: $white;
@@ -220,17 +164,6 @@
         }
     }
 
-    &.o-starred {
-
-        .o_Message_commandStar {
-            display: flex;
-        }
-
-        .o_Message_commands {
-            display: flex;
-        }
-    }
-
     &.o-has-message-selection:not(.o-selected) {
         opacity: 0.5;
     }
@@ -246,40 +179,6 @@
 
 .o_Message_authorRedirect {
     cursor: pointer;
-}
-
-.o_Message_command {
-    cursor: pointer;
-    color: gray('400');
-
-    &:not(.o-mobile) {
-        &:hover {
-            filter: brightness(0.8);
-        }
-    }
-
-    &.o-mobile {
-        filter: brightness(0.8);
-
-        &:hover {
-            filter: brightness(0.75);
-        }
-    }
-
-    &.o-message-selected {
-        color: gray('500');
-    }
-}
-
-.o_Message_commandStar {
-
-    &.o-message-starred {
-        color: gold;
-
-        &:hover {
-            filter: brightness(0.9);
-        }
-    }
 }
 
 .o_Message_content .o_mention {
@@ -299,8 +198,14 @@
     }
 }
 
-.o_Message_headerCommands:not(.o-mobile) {
-    opacity: 0;
+.o_Message_contentWrapper {
+    // transparent border to avoid layout moving around when it becomes active
+    border: $border-width solid transparent;
+    border-radius: $o-mail-rounded-rectangle-border-radius-sm;
+
+    &.o_Message_contentWrapper_active {
+        border: $border-width solid $border-color;
+    }
 }
 
 .o_Message_highlightIndicator.o-active {
@@ -331,14 +236,6 @@
     &.o-error {
         color: o-text-color('danger');
     }
-}
-
-.o_Message_sidebarCommands {
-    display: none;
-}
-
-.o_Message_sidebarItem.o-message-squashed {
-    display: none;
 }
 
 .o_Message_subject {

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -14,11 +14,11 @@
                 'o-selected': isSelected,
                 'o-squashed': props.isSquashed,
                 'o-starred': message and message.isStarred,
-            }" t-on-click="_onClick" t-att-data-message-local-id="message and message.localId"
+            }" t-on-click="_onClick" t-on-mouseenter="state.isHovered = true" t-on-mouseleave="state.isHovered = false" t-att-data-message-local-id="message and message.localId"
         >
             <t t-if="message" name="rootCondition">
                 <div class="o_Message_highlightIndicator" t-att-class="{ 'o-active': message.isHighlighted }"/>
-                <div class="o_Message_sidebar" t-att-class="{ 'o-message-squashed': props.isSquashed }">
+                <div class="o_Message_sidebar" t-att-class="{ 'o-message-squashed align-items-start': props.isSquashed }">
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_authorAvatarContainer o_Message_sidebarItem">
                             <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="avatar" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" alt="Avatar"/>
@@ -36,32 +36,19 @@
                         </div>
                     </t>
                     <t t-else="">
-                        <t t-if="message.date">
-                            <div class="o_Message_date o_Message_sidebarItem o-message-squashed" t-att-class="{ 'o-message-selected': isSelected }">
+                        <t t-if="isActive and message.date">
+                            <div class="o_Message_date o_Message_sidebarItem d-flex" t-att-class="{ 'o-message-selected': isSelected }">
                                 <t t-esc="shortTime"/>
                             </div>
                         </t>
-                        <div class="o_Message_commands o_Message_sidebarCommands o_Message_sidebarItem o-message-squashed" t-att-class="{ 'o-message-selected': isSelected, 'o-mobile': messaging.device.isMobile }">
-                            <t t-if="message.message_type !== 'notification'">
-                                <div class="o_Message_command o_Message_commandStar fa"
-                                    t-att-class="{
-                                        'fa-star': message.isStarred,
-                                        'fa-star-o': !message.isStarred,
-                                        'o-message-selected': isSelected,
-                                        'o-message-starred': message.isStarred,
-                                        'o-mobile': messaging.device.isMobile,
-                                    }" t-on-click="_onClickStar"
-                                />
-                            </t>
-                        </div>
-                        <t t-if="message.isCurrentPartnerAuthor and threadView and threadView.thread and threadView.thread.hasSeenIndicators">
-                            <MessageSeenIndicator class="o_Message_seenIndicator o-message-squashed" messageLocalId="message.localId" threadLocalId="threadView.thread.localId"/>
+                        <t t-if="!isActive and message.isCurrentUserOrGuestAuthor and threadView and threadView.thread and threadView.thread.hasSeenIndicators">
+                            <MessageSeenIndicator class="o_Message_seenIndicator" messageLocalId="message.localId" threadLocalId="threadView.thread.localId"/>
                         </t>
                     </t>
                 </div>
-                <div class="o_Message_core">
+                <div class="o_Message_core flex-grow-1">
                     <t t-if="!props.isSquashed">
-                        <div class="o_Message_header">
+                        <div class="o_Message_header ml-2">
                             <t t-if="message.author">
                                 <div class="o_Message_authorName o_Message_authorRedirect o_redirect text-truncate" t-on-click="_onClickAuthorName" title="Open profile">
                                     <t t-esc="message.author.nameOrDisplayName"/>
@@ -87,7 +74,7 @@
                                     - <t t-esc="message.dateFromNow"/>
                                 </div>
                             </t>
-                            <t t-if="message.isCurrentPartnerAuthor and threadView and threadView.thread and threadView.thread.hasSeenIndicators">
+                            <t t-if="message.isCurrentUserOrGuestAuthor and threadView and threadView.thread and threadView.thread.hasSeenIndicators">
                                 <MessageSeenIndicator class="o_Message_seenIndicator" messageLocalId="message.localId" threadLocalId="threadView.thread.localId"/>
                             </t>
                             <t t-if="threadView and message.originThread and message.originThread !== threadView.thread">
@@ -119,75 +106,54 @@
                                     </Popover>
                                 </t>
                             </t>
-                            <div class="o_Message_commands o_Message_headerCommands" t-att-class="{ 'o-mobile': messaging.device.isMobile }">
-                                <t t-if="!message.isTemporary and ((message.message_type !== 'notification' and message.originThread and message.originThread.model === 'mail.channel') or !message.isTransient)">
-                                    <span class="o_Message_command o_Message_commandStar o_Message_headerCommand fa"
-                                        t-att-class="{
-                                            'fa-star': message.isStarred,
-                                            'fa-star-o': !message.isStarred,
-                                            'o-message-selected': isSelected,
-                                            'o-message-starred': message.isStarred,
-                                            'o-mobile': messaging.device.isMobile,
-                                        }" t-on-click="_onClickStar" title="Mark as Todo"
-                                    />
-                                </t>
-                                <t t-if="props.hasReplyIcon">
-                                    <span class="o_Message_command o_Message_commandReply o_Message_headerCommand fa fa-reply"
-                                        t-att-class="{
-                                            'o-message-selected': isSelected,
-                                            'o-mobile': messaging.device.isMobile,
-                                        }" t-on-click="_onClickReply" title="Reply"
-                                    />
-                                </t>
-                                <t t-if="props.hasMarkAsReadIcon">
-                                    <span class="o_Message_command o_Message_commandMarkAsRead o_Message_headerCommand fa fa-check"
-                                        t-att-class="{
-                                            'o-message-selected': isSelected,
-                                            'o-mobile': messaging.device.isMobile,
-                                        }" t-on-click="_onClickMarkAsRead" title="Mark as Read"
-                                    />
-                                </t>
-                            </div>
                         </div>
                     </t>
-                    <div class="o_Message_content" t-ref="content">
-                        <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- message.prettyBody is inserted here from _update() -->
-                        <t t-if="message.subtype_description and !message.isBodyEqualSubtypeDescription">
-                            <p t-esc="message.subtype_description"/>
+                    <div class="o_Message_contentWrapper position-relative" t-att-class="{ 'o_Message_contentWrapper_active': isActive and props.showActions }">
+                        <MessageActionList
+                            t-if="(isActive or message.actionList.showDeleteConfirm) and props.showActions"
+                            actionListLocalId="message.actionList.localId"
+                            hasReplyIcon="props.hasReplyIcon"
+                            hasMarkAsReadIcon="props.hasMarkAsReadIcon"
+                        />
+                        <div class="o_Message_content m-2" t-ref="content">
+                            <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- message.prettyBody is inserted here from _update() -->
+                            <t t-if="message.subtype_description and !message.isBodyEqualSubtypeDescription">
+                                <p t-esc="message.subtype_description"/>
+                            </t>
+                            <t t-if="trackingValues.length > 0">
+                                <ul class="o_Message_trackingValues">
+                                    <t t-foreach="trackingValues" t-as="value" t-key="value.id">
+                                        <li>
+                                            <div class="o_Message_trackingValue">
+                                                <div class="o_Message_trackingValueFieldName o_Message_trackingValueItem" t-esc="value.changed_field"/>
+                                                <t t-if="value.old_value">
+                                                    <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>
+                                                </t>
+                                                <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img"/>
+                                                <t t-if="value.new_value">
+                                                    <div class="o_Message_trackingValueNewValue o_Message_trackingValueItem" t-esc="value.new_value"/>
+                                                </t>
+                                            </div>
+                                        </li>
+                                    </t>
+                                </ul>
+                            </t>
+                        </div>
+                        <t t-if="message.subject and !message.isSubjectSimilarToOriginThreadName">
+                            <p class="o_Message_subject m-2 mt-0">Subject: <t t-esc="message.subject"/></p>
                         </t>
-                        <t t-if="trackingValues.length > 0">
-                            <ul class="o_Message_trackingValues">
-                                <t t-foreach="trackingValues" t-as="value" t-key="value.id">
-                                    <li>
-                                        <div class="o_Message_trackingValue">
-                                            <div class="o_Message_trackingValueFieldName o_Message_trackingValueItem" t-esc="value.changed_field"/>
-                                            <t t-if="value.old_value">
-                                                <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>
-                                            </t>
-                                            <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img"/>
-                                            <t t-if="value.new_value">
-                                                <div class="o_Message_trackingValueNewValue o_Message_trackingValueItem" t-esc="value.new_value"/>
-                                            </t>
-                                        </div>
-                                    </li>
-                                </t>
-                            </ul>
+                        <t t-if="message.attachments and message.attachments.length > 0">
+                            <div class="o_Message_footer">
+                                <AttachmentList
+                                    class="o_Message_attachmentList"
+                                    areAttachmentsDownloadable="true"
+                                    areAttachmentsEditable="message.author === messaging.currentPartner"
+                                    attachmentLocalIds="message.attachments.map(attachment => attachment.localId)"
+                                    attachmentsDetailsMode="props.attachmentsDetailsMode"
+                                />
+                            </div>
                         </t>
                     </div>
-                    <t t-if="message.subject and !message.isSubjectSimilarToOriginThreadName">
-                        <p class="o_Message_subject mb-0">Subject: <t t-esc="message.subject"/></p>
-                    </t>
-                    <t t-if="message.attachments and message.attachments.length > 0">
-                        <div class="o_Message_footer">
-                            <AttachmentList
-                                class="o_Message_attachmentList"
-                                areAttachmentsDownloadable="true"
-                                areAttachmentsEditable="message.author === messaging.currentPartner"
-                                attachmentLocalIds="message.attachments.map(attachment => attachment.localId)"
-                                attachmentsDetailsMode="props.attachmentsDetailsMode"
-                            />
-                        </div>
-                    </t>
                 </div>
             </t>
         </div>

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -103,10 +103,11 @@ QUnit.test('basic rendering', async function (assert) {
         1,
         "message should display date"
     );
+    await afterNextRender(() => messageEl.click());
     assert.strictEqual(
-        messageEl.querySelectorAll(`:scope .o_Message_commands`).length,
+        messageEl.querySelectorAll(`:scope .o_MessageActionList`).length,
         1,
-        "message should display list of commands"
+        "message should display list of actions"
     );
     assert.strictEqual(
         messageEl.querySelectorAll(`:scope .o_Message_content`).length,

--- a/addons/mail/static/src/components/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.js
@@ -1,0 +1,26 @@
+/** @odoo-module */
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
+
+const { Component } = owl;
+
+export class MessageActionList extends Component {
+
+    /**
+     * @returns {mail.message}
+     */
+    get actionList() {
+        return this.messaging && this.messaging.models['mail.message_action_list'].get(this.props.actionListLocalId);
+    }
+
+}
+
+Object.assign(MessageActionList, {
+    props: {
+        actionListLocalId: String,
+        hasMarkAsReadIcon: Boolean,
+        hasReplyIcon: Boolean,
+    },
+    template: "mail.MessageActionList",
+});
+
+registerMessagingComponent(MessageActionList);

--- a/addons/mail/static/src/components/message_action_list/message_action_list.scss
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.scss
@@ -1,0 +1,22 @@
+.o_MessageActionList {
+    @include o-position-absolute($top: - map-get($spacers, 3), $right: map-get($spacers, 2));
+    background-color: $white;
+    border: $border-width solid $border-color;
+    border-radius: $o-mail-rounded-rectangle-border-radius-sm;
+
+    &:hover {
+        box-shadow: 0 4px .5rem -.5rem black;
+    }
+}
+
+.o_MessageActionList_action {
+    cursor: pointer;
+
+    &:hover {
+        background-color: mix($border-color, $white);
+    }
+}
+
+.o_MessageActionList_actionStar.o_MessageActionList_actionStar_active {
+    color: gold;
+}

--- a/addons/mail/static/src/components/message_action_list/message_action_list.xml
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="mail.MessageActionList" owl="1">
+        <div class="o_MessageActionList" t-on-click="actionList.onClick">
+            <span t-if="actionList.message.canStarBeToggled" class="o_MessageActionList_action o_MessageActionList_actionStar p-2" t-att-class="{
+                    'o_MessageActionList_actionStar_active': actionList.message.isStarred,
+                    'fa fa-lg fa-star': actionList.message.isStarred,
+                    'fa fa-lg fa-star-o': !actionList.message.isStarred,
+                }" title="Mark as Todo" t-on-click="actionList.onClickToggleStar"/>
+            <span t-if="props.hasReplyIcon" class="o_MessageActionList_action o_MessageActionList_actionReply p-2 fa fa-lg fa-reply" title="Reply" t-on-click="actionList.onClickReplyTo"/>
+            <span t-if="props.hasMarkAsReadIcon" class="o_MessageActionList_action o_MessageActionList_actionMarkRead p-2 fa fa-lg fa-check" title="Mark as Read" t-on-click="actionList.onClickMarkAsRead"/>
+            <span t-if="actionList.message.canBeDeleted" class="o_MessageActionList_action o_MessageActionList_actionDelete p-2 fa fa-lg fa-trash" title="Delete" t-on-click="actionList.onClickDelete"/>
+            <DeleteMessageConfirmDialog t-if="actionList.showDeleteConfirm" actionListLocalId="actionList.localId"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/js/tours/mail.js
+++ b/addons/mail/static/src/js/tours/mail.js
@@ -41,7 +41,11 @@ tour.register('mail_tour', {
     content: _t("Post your message on the thread"),
     position: "top",
 }, {
-    trigger: '.o_Discuss_thread .o_Message_commandStar',
+    trigger: '.o_Discuss_thread .o_Message',
+    content: _t("Click on your message"),
+    position: "top",
+}, {
+    trigger: '.o_Discuss_thread .o_MessageActionList_actionStar',
     content: Markup(_t("Messages can be <b>starred</b> to remind you to check back later.")),
     position: "bottom",
 }, {

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -205,6 +205,11 @@ function factory(dependencies) {
          * @param {mail.message} message
          */
         replyToMessage(message) {
+            // When already replying to this message, just stop replying to it.
+            if (this.replyingToMessage === message) {
+                this.clearReplyingToMessage();
+                return;
+            }
             this.update({ replyingToMessage: link(message) });
             // avoid to reply to a note by a message and vice-versa.
             // subject to change later by allowing subtype choice.

--- a/addons/mail/static/src/models/message_action_list/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list/message_action_list.js
@@ -1,0 +1,108 @@
+/** @odoo-module **/
+
+import { registerNewModel } from '@mail/model/model_core';
+import { attr, one2one } from '@mail/model/model_field';
+import { markEventHandled } from '@mail/utils/utils';
+
+function factory(dependencies) {
+
+    class MessageActionList extends dependencies['mail.model'] {
+
+        /**
+         * @override
+         */
+        _created() {
+            // bind handlers so they can be used in templates
+            this.onClick = this.onClick.bind(this);
+            this.onClickReplyTo = this.onClickReplyTo.bind(this);
+            this.onClickConfirmDelete = this.onClickConfirmDelete.bind(this);
+            this.onClickDelete = this.onClickDelete.bind(this);
+            this.onClickMarkAsRead = this.onClickMarkAsRead.bind(this);
+            this.onClickToggleStar = this.onClickToggleStar.bind(this);
+            this.onDeleteConfirmDialogClosed = this.onDeleteConfirmDialogClosed.bind(this);
+        }
+
+        //----------------------------------------------------------------------
+        // Private
+        //----------------------------------------------------------------------
+
+        /**
+         * @private
+         * @param {MouseEvent} ev
+         */
+        onClick(ev) {
+            markEventHandled(ev, 'MessageActionList.Click');
+        }
+
+        /**
+         * @private
+         * @param {MouseEvent} ev
+         */
+        onClickConfirmDelete(ev) {
+            this.message.updateContent({ body: '' });
+        }
+
+        /**
+         * @private
+         * @param {MouseEvent} ev
+         */
+        onClickDelete(ev) {
+            this.update({ showDeleteConfirm: true });
+        }
+
+        /**
+         * @private
+         * @param {MouseEvent} ev
+         */
+        onClickMarkAsRead(ev) {
+            this.message.markAsRead();
+        }
+
+        /**
+         * Opens the reply composer for this message (or closes it if it was
+         * already opened).
+         *
+         * @private
+         * @param {MouseEvent} ev
+         */
+        onClickReplyTo(ev) {
+            markEventHandled(ev, 'MessageActionList.replyTo');
+            this.message.replyTo();
+        }
+
+        /**
+         * @private
+         * @param {MouseEvent} ev
+         */
+        onClickToggleStar(ev) {
+            this.message.toggleStar();
+        }
+
+        /**
+         * @private
+         * @param {CustomEvent} ev
+         */
+        onDeleteConfirmDialogClosed(ev) {
+            this.update({ showDeleteConfirm: false })
+        }
+
+    }
+
+    MessageActionList.fields = {
+        message: one2one('mail.message', {
+            inverse: 'actionList'
+        }),
+        /**
+         * Whether to show the message delete-confirm dialog
+         */
+        showDeleteConfirm: attr({
+            default: false,
+        }),
+    };
+
+    MessageActionList.modelName = 'mail.message_action_list';
+
+    return MessageActionList;
+}
+
+registerNewModel('mail.message_action_list', factory);

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -89,6 +89,8 @@ function factory(dependencies) {
                             return this._handleNotificationChannelRenamed(message.payload);
                         case 'mail.channel_update':
                             return this._handleNotificationChannelUpdate(message.payload);
+                        case 'mail.message_update':
+                            return this.messaging.models['mail.message'].insert(message.payload);
                         case 'res.users_settings_changed':
                             return this._handleNotificationResUsersSettings(message.payload);
                     }


### PR DESCRIPTION
This commit allows users to "delete" their messages in discuss, as well
as their notes on other records. Admins can delete anyone discuss
messages or notes. Tracking messages such as a change in stage or other
cannot be deleted.

This "delete" is a "soft-delete" in that it only empties the message's
content, so that it is no longer displayed in the UI, but remains in the
database so that people who got notified by email can still reply to the
message, among other things.

task-2365646