### PR TITLE
[FIX] stock: use docids as product_id in report

### DIFF
--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -11,6 +11,10 @@ class ReportStockRule(models.AbstractModel):
 
     @api.model
     def _get_report_values(self, docids, data=None):
+        # Overriding data values here since used also in _get_routes.
+        data['product_id'] = data.get('product_id', docids)
+        data['warehouse_ids'] = data.get('warehouse_ids', [])
+
         product = self.env['product.product'].browse(data['product_id'])
         warehouses = self.env['stock.warehouse'].browse(data['warehouse_ids'])
 


### PR DESCRIPTION
Steps to reproduce:

  - Install Inventory and Studio modules
  - Go to Inventory -> Products -> Products
  - Open Studio
  - Click on Reports tab
  - Select `Product Routes Report`

Issue:

  Traceback is raised.

Cause:

  No 'product_id' provided in data while getting report values.

Solution:

  If no `product_id` key or value in data, set `docids` (or an empty
  recordset if no docids) as product_id and set 'warehouse_ids'
  to an empty recordset.

opw-2619142