### PR TITLE
[ADD] website: new color palette for Orchid theme

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -1493,6 +1493,13 @@ $o-color-palettes: map-merge($o-color-palettes,
             'footer': 4,
             'copyright': 5,
         ),
+        'orchid-7': (
+            'o-color-1': #007564,
+            'o-color-2': #fcb752,
+            'o-color-3': #f8f8f8,
+            'o-color-4': #ffffff,
+            'o-color-5': #011a16,
+        ),
         'paptic-1': (
             'o-color-1': #6772E5,
             'o-color-2': #F5F9F9,


### PR DESCRIPTION
This commit adds a new color palette named 'orchid-7' to improve the theme Orchid.
This change is related to an update of the theme on [PR#481](https://github.com/odoo/design-themes/pull/481) in the Design-themes repo.

task-2619127