### PR TITLE
[ADD] core,web: allow the use of patterns for string fields

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -37,7 +37,13 @@ class AccountAccount(models.Model):
     name = fields.Char(string="Account Name", required=True, index='trigram', tracking=True)
     currency_id = fields.Many2one('res.currency', string='Account Currency', tracking=True,
         help="Forces all journal items in this account to have a specific currency (i.e. bank journals). If no currency is set, entries can use any currency.")
-    code = fields.Char(size=64, required=True, tracking=True)
+    code = fields.Char(
+        size=64,
+        required=True,
+        tracking=True,
+        pattern=ACCOUNT_CODE_REGEX.pattern,
+        help="The account code can only contain alphanumeric characters and dots."
+    )
     deprecated = fields.Boolean(default=False, tracking=True)
     used = fields.Boolean(compute='_compute_used', search='_search_used')
     account_type = fields.Selection(
@@ -285,14 +291,6 @@ class AccountAccount(models.Model):
                 journal_names=journals.mapped('display_name'),
                 journal_ids=journals.ids
             ))
-
-    @api.constrains('code')
-    def _check_account_code(self):
-        for account in self:
-            if not re.match(ACCOUNT_CODE_REGEX, account.code):
-                raise ValidationError(_(
-                    "The account code can only contain alphanumeric characters and dots."
-                ))
 
     @api.constrains('account_type')
     def _check_account_is_bank_journal_bank_account(self):

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -57,7 +57,11 @@ class AccountAccountTemplate(models.Model):
 
     name = fields.Char(required=True)
     currency_id = fields.Many2one('res.currency', string='Account Currency', help="Forces all moves for this account to have this secondary currency.")
-    code = fields.Char(size=64, required=True)
+    code = fields.Char(
+        size=64, required=True,
+        pattern=ACCOUNT_CODE_REGEX.pattern
+        help="The account code can only contain alphanumeric characters and dots.",
+    )
     account_type = fields.Selection(
         selection=[
             ("asset_receivable", "Receivable"),
@@ -103,14 +107,6 @@ class AccountAccountTemplate(models.Model):
                 name = record.code + ' ' + name
             res.append((record.id, name))
         return res
-
-    @api.constrains('code')
-    def _check_account_code(self):
-        for account in self:
-            if not re.match(ACCOUNT_CODE_REGEX, account.code):
-                raise ValidationError(_(
-                    "The account code can only contain alphanumeric characters and dots."
-                ))
 
 
 class AccountChartTemplate(models.Model):

--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import re
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
@@ -31,7 +30,8 @@ class AccountJournal(models.Model):
         string='Next Check Number',
         compute='_compute_check_next_number',
         inverse='_inverse_check_next_number',
-        help="Sequence number of the next printed check.",
+        pattern=r'^[0-9]+$',
+        help="Sequence number of the next printed check. Can only contain numbers",
     )
 
     @api.depends('check_manual_sequencing')
@@ -45,8 +45,6 @@ class AccountJournal(models.Model):
 
     def _inverse_check_next_number(self):
         for journal in self:
-            if journal.check_next_number and not re.match(r'^[0-9]+$', journal.check_next_number):
-                raise ValidationError(_('Next Check Number should only contains numbers.'))
             if int(journal.check_next_number) < journal.check_sequence_id.number_next_actual:
                 raise ValidationError(_(
                     "The last check number was %s. In order to avoid a check being rejected "

--- a/addons/account_check_printing/wizard/print_prenumbered_checks.py
+++ b/addons/account_check_printing/wizard/print_prenumbered_checks.py
@@ -1,22 +1,19 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import re
-from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
+from odoo import fields, models
 
 
 class PrintPreNumberedChecks(models.TransientModel):
     _name = 'print.prenumbered.checks'
     _description = 'Print Pre-numbered Checks'
 
-    next_check_number = fields.Char('Next Check Number', required=True)
-
-    @api.constrains('next_check_number')
-    def _check_next_check_number(self):
-        for check in self:
-            if check.next_check_number and not re.match(r'^[0-9]+$', check.next_check_number):
-                raise ValidationError(_('Next Check Number should only contains numbers.'))
+    next_check_number = fields.Char(
+        'Next Check Number',
+        required=True,
+        pattern=r'^[0-9]+$',
+        help="Sequence number of the next printed check. Can only contain numbers",
+    )
 
     def print_checks(self):
         check_number = int(self.next_check_number)

--- a/addons/l10n_us/models/res_partner_bank.py
+++ b/addons/l10n_us/models/res_partner_bank.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import re
-from odoo import fields, models, api, _
-from odoo.exceptions import ValidationError
+from odoo import fields, models
 
 
 class ResPartnerBank(models.Model):
     _inherit = 'res.partner.bank'
 
-    aba_routing = fields.Char(string="ABA/Routing", help="American Bankers Association Routing Number")
-
-    @api.constrains('aba_routing')
-    def _check_aba_routing(self):
-        for bank in self:
-            if bank.aba_routing and not re.match(r'^\d{1,9}$', bank.aba_routing):
-                raise ValidationError(_('ABA/Routing should only contains numbers (maximum 9 digits).'))
+    aba_routing = fields.Char(
+        string="ABA/Routing",
+        pattern=r'^\d{1,9}$',
+        help="American Bankers Association Routing Number. Maximum 9 digits.",
+    )

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -610,6 +610,21 @@ var FieldChar = InputField.extend(TranslatableFieldMixin, {
         }
         return this._super(value, options);
     },
+
+    isValid: function () {
+        if (this.value && this.field.pattern) {
+            // compatibility JS/Python
+            let pattern = this.field.pattern
+                .replace(/\\w/g, '\\p{L}')
+                .replace(/\\W/g, '\\P{L}')
+                .replace(/\\d/g, '\\p{N}')
+                .replace(/\\D/g, '\\P{N}');
+            if (!(new RegExp(pattern, 'u').test(this.value))) {
+                return false;
+            }
+        }
+        return this._super(...arguments);
+    },
 });
 
 var FieldDateRange = InputField.extend({

--- a/addons/web/static/src/views/fields/char/char_field.js
+++ b/addons/web/static/src/views/fields/char/char_field.js
@@ -65,6 +65,17 @@ export class CharField extends Component {
     }
 
     parse(value) {
+        if (value && this.props.pattern) {
+            // compatibility JS/Python
+            let pattern = this.props.pattern
+                .replace(/\\w/g, '\\p{L}')
+                .replace(/\\W/g, '\\P{L}')
+                .replace(/\\d/g, '\\p{N}')
+                .replace(/\\D/g, '\\P{N}');
+            if (!(new RegExp(pattern, 'u').test(value))) {
+                throw new Error("regex doesn't match")
+            }
+        }
         if (this.props.shouldTrim) {
             return value.trim();
         }
@@ -86,6 +97,7 @@ CharField.props = {
     shouldTrim: { type: Boolean, optional: true },
     maxLength: { type: Number, optional: true },
     isTranslatable: { type: Boolean, optional: true },
+    pattern: { type: String, optional: true },
 };
 
 CharField.displayName = _lt("Text");
@@ -95,6 +107,7 @@ CharField.extractProps = ({ attrs, field }) => {
     return {
         shouldTrim: field.trim && !archParseBoolean(attrs.password), // passwords shouldn't be trimmed
         maxLength: field.size,
+        pattern: field.pattern,
         isTranslatable: field.translate,
         dynamicPlaceholder: attrs.options.dynamic_placeholder,
         autocomplete: attrs.autocomplete,

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -1541,6 +1541,34 @@ QUnit.module('Legacy basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('char widget isValid method works with patterns', async function (assert) {
+        assert.expect(2);
+
+        this.data.partner.fields.foo.pattern = 'azerty';
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:'<form string="Partners">' +
+                        '<field name="foo"/>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        await testUtils.form.clickEdit(form);
+        await testUtils.fields.editInput(form.$('input[type="text"].o_field_widget'), 'this is wrong');
+        await testUtils.form.clickSave(form);
+        assert.hasClass(form.$('.o_field_widget'),'o_field_invalid',
+            "field should be displayed as invalid");
+
+        // Save should fail, editing to something right this time
+        await testUtils.fields.editInput(form.$('input[type="text"].o_field_widget'), 'this contains azerty');
+        await testUtils.form.clickSave(form);
+        assert.strictEqual(form.$('.o_field_widget').text(), 'this contains azerty',
+            'the new value should be displayed');
+        form.destroy();
+    });
+
     QUnit.test('char field in form view', async function (assert) {
         assert.expect(4);
 

--- a/addons/web/static/tests/views/fields/char_field_tests.js
+++ b/addons/web/static/tests/views/fields/char_field_tests.js
@@ -171,6 +171,34 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
+    QUnit.test('char widget isValid method works with patterns', async function (assert) {
+        serverData.models.partner.fields.foo.pattern = 'azerty';
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch:'<form string="Partners">' +
+                        '<field name="foo"/>' +
+                '</form>',
+        });
+
+        await editInput('.o_field_widget input[type="text"]', 'this is wrong');
+        await clickSave(target);
+        assert.hasClass('.o_field_widget','o_field_invalid',
+            "field should be displayed as invalid");
+
+        // Save should fail, editing to something right this time
+        await editInput('.o_field_widget input[type="text"]', 'this contains azerty');
+        await clickSave(target);
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input[type='text']").value,
+            'this contains azerty',
+            'the new value should be displayed',
+        );
+    });
+
     QUnit.test(
         "setting a char field to empty string is saved as a false value",
         async function (assert) {

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2697,7 +2697,7 @@ class Model(models.AbstractModel):
         return [
             'change_default', 'context', 'currency_field', 'definition_record', 'digits', 'domain', 'group_operator', 'groups',
             'help', 'name', 'readonly', 'related', 'relation', 'relation_field', 'required', 'searchable', 'selection', 'size',
-            'sortable', 'store', 'string', 'translate', 'trim', 'type',
+            'sortable', 'store', 'string', 'translate', 'trim', 'type', 'pattern',
         ]
 
     @api.model

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -228,7 +228,7 @@ class EmailMessage(models.Model):
 
     message = fields.Many2one('test_new_api.message', 'Message',
                               required=True, ondelete='cascade')
-    email_to = fields.Char('To')
+    email_to = fields.Char('To', pattern='@', help="You need a '@' in here")
 
 
 class DiscussionPartner(models.Model):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2640,6 +2640,17 @@ class TestFields(TransactionCaseWithUserDemo):
             records.mapped('harry')  # fetch all fields with prefetch='Harry Potter'
             records.mapped('rare_description')  # fetch that field only
 
+    def test_98_text_pattern(self):
+        with self.assertRaises(ValueError):
+            self.env['test_new_api.emailmessage'].create({
+                'message': 1,
+                'email_to': 'perfectly normal person',
+            })
+        self.env['test_new_api.emailmessage'].create({
+            'message': 1,
+            'email_to': 'perfectly.normal@person',
+        })
+
 
 class TestX2many(common.TransactionCase):
     def test_definition_many2many(self):


### PR DESCRIPTION
Having pattern validation can be useful for some char fields where the
format is known beforehand, instead of validating only server side with
an error.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
