### PR TITLE
[FIX] web : select optional products with checkbox in SOL

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1976,10 +1976,6 @@ var FieldOne2Many = FieldX2Many.extend({
                     allowWarning: data.allowWarning
                 }).then(function () {
                     self.creatingRecord = false;
-                }).then(function (){
-                    if (data.onSuccess){
-                        data.onSuccess();
-                    }
                 }).guardedCatch(function() {
                     self.creatingRecord = false;
                 })


### PR DESCRIPTION
Steps to reproduce :

- Configure a product P with optional product OP
- Go to Sales > Create a Sale Order
- Toggle Studio and add a checkbox to SOL list view
- Add product P to SOL and add OP, confirm

Got a traceback "TypeError : cannot read property 'focusableElement'
of null"

As the method 'onSuccess' called 'unselectRow()' in
product_configurator_widget.js:107, the method getFocusableElement() in
field_wrapper.js:107 didn't trigger the fields when confirming the
optional products.

opw-2616662

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
