### PR TITLE
[IMP] website: add 'no result' message for industry selection

### DIFF
--- a/addons/website/static/src/components/configurator/configurator.xml
+++ b/addons/website/static/src/components/configurator/configurator.xml
@@ -56,7 +56,7 @@
                 </div>
                 <div t-attf-class="o_configurator_typing_text d-inline d-md-flex align-items-center o_configurator_industry mb-md-2 mb-lg-4 {{!state.selectedType ? 'o_configurator_hide' : 'o_configurator_show'}}">
                     <label class="o_configurator_industry_wrapper mr-2">
-                        <input t-on-blur="blurIndustrySelection" t-on-input="inputIndustrySelection" t-ref="industrySelection"/>
+                        <input t-on-blur="_blurIndustrySelection" t-ref="industrySelection"/>
                     </label>
                     <span> business</span>
                     <span t-att-class="!state.selectedIndustry ? 'o_configurator_hide' : 'o_configurator_show'">,</span>

--- a/addons/website/static/src/scss/configurator.scss
+++ b/addons/website/static/src/scss/configurator.scss
@@ -171,6 +171,15 @@
                         font-family: $font-family-base;
                         text-decoration: none;
                         line-height: 1.2;
+
+                        &.o_no_result, &.o_no_result:hover {
+                            background-color: transparent !important;
+                            color: gray('600') !important;
+                            cursor: default;
+                            padding: $dropdown-item-padding-y*4 $dropdown-item-padding-x;
+                            font-style: italic;
+                            font-size: .5em;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When the user search for an industry in the industry autocomplete
input, an information message is now displayed if no industry match
the user's search.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
