### PR TITLE
[FIX] product: vendor pricelist ignore variants

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -626,6 +626,8 @@ class ProductProduct(models.Model):
                 continue
             if not res or res.name == seller.name:
                 res |= seller
+        if res.product_id:
+            res = res.filtered(lambda s: s.product_id)
         return res.sorted('price')[:1]
 
     def price_compute(self, price_type, uom=False, currency=False, company=None):


### PR DESCRIPTION
Step to follow

- Create a product P with variants V1 and V2
- Create a pricelist for vendor V with product P, no variant and 10 as the unit price
- Create a pricelist for vendor V with product P, variant V1 and 20 as the unit price
- Create a RFQ with vendor V, product P and variant V1

Cause of the issue

The unit price will be 10 even though we selected the V1.
When selecting product.supplierinfo, both will be selected
and then the cheapest one will be returned.

Solution

If we found sellers with a product_id (meaning with a price for our
variant), remove the others

opw-2530352