### PR TITLE
Fix for "Descriptive Stack Trace" in "Logo Upload" functionality in the "Partner Dashboard"

### DIFF
--- a/doc/cla/individual/Mrig26.md
+++ b/doc/cla/individual/Mrig26.md
@@ -1,0 +1,11 @@
+India, 2021-08-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mrigendra Soni mrigendrasoni26@gmail.com https://github.com/Mrig26

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -262,7 +262,7 @@ class ImageProcess():
         return self
 
 
-def image_process(base64_source, size=(0, 0), verify_resolution=False, quality=0, crop=None, colorize=False, output_format=''):
+def image_process(base64_source, size=(0, 0), verify_resolution=True, quality=0, crop=None, colorize=False, output_format=''):
     """Process the `base64_source` image by executing the given operations and
     return the result as a base64 encoded image.
     """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The pull request is regarding the Descriptive Stack Trace bug that was discovered earlier this month.

Current behavior before PR:
The "Upload Logo" functionality in the Partners Dashboard does not implements any check on the size of images uploaded.

Desired behavior after PR is merged:
The same functionality will now check for the size of images and prevent the upload of any oversized image.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
