### PR TITLE
[FIX] website_sale: missing image on ecommerce product metadata

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -112,7 +112,7 @@
                 </div>
                 <div class="oe_product_image">
                     <a itemprop="url" t-att-href="product_href">
-                        <span t-field="product.image" t-options="{'widget': 'image', 'resize': None if product_image_big else '300x300'}"/>
+                        <span t-field="product.image" t-options="{'widget': 'image', 'resize': None if product_image_big else '300x300', 'itemprop': 'image'}"/>
                     </a>
                 </div>
                 <t t-if="show_publish">


### PR DESCRIPTION
Before this commit:
No "image" metadata was available for products on the ecommerce main page (/shop). As such search engines SEO will be less effective.
In the case of the client, using "Google Search Console" would give the message: `Missing field 'image'` as a "Top Warning"

Note:
This issue was introduced by:
https://github.com/odoo/odoo/pull/30656
and was partially solved by:
https://github.com/odoo/odoo/pull/37870/commits/c66892e65d2ae0ca31a686f65d4b517a9d7ffd0b

OPW-2509546

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
