### PR TITLE
[FIX] account: parse sequence with date before year 2000

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -21,8 +21,8 @@ class SequenceMixin(models.AbstractModel):
     _sequence_field = "name"
     _sequence_date_field = "date"
     _sequence_index = False
-    _sequence_monthly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((20|21)\d{2}|(\d{2}(?=\D))))(?P<prefix2>\D*?)(?P<month>(0[1-9]|1[0-2]))(?P<prefix3>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'
-    _sequence_yearly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((20|21)?\d{2}))(?P<prefix2>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'
+    _sequence_monthly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((19|20|21)\d{2}|(\d{2}(?=\D))))(?P<prefix2>\D*?)(?P<month>(0[1-9]|1[0-2]))(?P<prefix3>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'
+    _sequence_yearly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((19|20|21)?\d{2}))(?P<prefix2>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'
     _sequence_fixed_regex = r'^(?P<prefix1>.*?)(?P<seq>\d{0,9})(?P<suffix>\D*?)$'
 
     sequence_prefix = fields.Char(compute='_compute_split_sequence', store=True)


### PR DESCRIPTION
Steps to repodruce:

  - Install 'Accounting' module
  - Set user language to French
  - Create journal entry
  - Set a date before 2000. Example : 01/01/1999
  - Insert some journal items
  - Save the journal entry

Issue:

  Error message is raised :
  ```The journal entry cannot be saved : "The Date (01/01/1999) doesn't match the Numéro (OPD/1999/01/0001).```

Cause:

  Incomplete regex: parsing only years who begin with 20 or 21.
  https://github.com/odoo/odoo/commit/26a43f23ec2b2490aec0731e25568703729581f0#diff-67b6f8b23970c1b18fc5e7f82b7585ad82e7bace885cdd78274837a4876a6a9fL24-R25

Solution:

  Add 19 to regex to allow years like '19XX'.

opw-2616575