### PR TITLE
[FIX] website_event_track: no cookie lifetime service worker error


### DIFF
--- a/addons/website_event_track/static/src/js/website_event_pwa_widget.js
+++ b/addons/website_event_track/static/src/js/website_event_pwa_widget.js
@@ -121,6 +121,8 @@ odoo.define("website_event_track.website_event_pwa_widget", function (require) {
                     action: "prefetch-assets",
                     urls: assetsUrls,
                 });
+            }).catch(function (error) {
+                console.error("Service worker ready failed, error:", error);
             });
             var currentPageUrl = window.location.href;
             var childrenPagesUrls = Array.from(document.querySelectorAll('a[href^="' + this._getScope() + '/"]')).map(function (el) {
@@ -131,6 +133,8 @@ odoo.define("website_event_track.website_event_pwa_widget", function (require) {
                     action: "prefetch-pages",
                     urls: childrenPagesUrls.concat(currentPageUrl),
                 });
+            }).catch(function (error) {
+                console.error("Service worker ready failed, error:", error);
             });
         },
 


### PR DESCRIPTION

If you use firefox and have set cookie to be deleted when you close
firefox, server worker are nuked which cause an error to be shown in
website_event_track:

https://bugzilla.mozilla.org/show_bug.cgi?id=1429714

With this fix, the error is handler and shown in the console instead of
as a traceback to the user.

opw-2556734
