### PR TITLE
[FIX] hr: use correct default date

### DIFF
--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -14,7 +14,7 @@ class HrDepartureWizard(models.TransientModel):
         ('retired', 'Retired')
     ], string="Departure Reason", default="fired")
     departure_description = fields.Text(string="Additional Information")
-    departure_date = fields.Date(string="Departure Date", required=True, default=fields.Date.today)
+    departure_date = fields.Date(string="Departure Date", required=True, default=fields.Date.context_today)
     employee_id = fields.Many2one(
         'hr.employee', string='Employee', required=True,
         default=lambda self: self.env.context.get('active_id', None),


### PR DESCRIPTION
`fields.Date.today` doesn't give date based on TZ which might be wrong
in some cases as it doesn't respect TZ.

With this commit, we are using `fields.Date.context_today` as default date.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
