### PR TITLE
[master] [IMP] sale, pos_sale: facilitate inheritance on sale report

### DIFF
--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -58,9 +58,9 @@ class SaleReport(models.Model):
 
     order_id = fields.Many2one('sale.order', 'Order #', readonly=True)
 
-    def _query(self, with_clause='', fields={}, groupby='', from_clause=''):
-        with_ = ("WITH %s" % with_clause) if with_clause else ""
-
+    def _select_sale(self, fields=None):
+        if not fields:
+            fields = {}
         select_ = """
             coalesce(min(l.id), -s.id) as id,
             l.product_id as product_id,
@@ -101,7 +101,9 @@ class SaleReport(models.Model):
 
         for field in fields.values():
             select_ += field
+        return select_
 
+    def _from_sale(self, from_clause=''):
         from_ = """
                 sale_order_line l
                       right outer join sale_order s on (s.id=l.order_id)
@@ -113,7 +115,9 @@ class SaleReport(models.Model):
                     left join product_pricelist pp on (s.pricelist_id = pp.id)
                 %s
         """ % from_clause
+        return from_
 
+    def _group_by_sale(self, groupby=''):
         groupby_ = """
             l.product_id,
             l.order_id,
@@ -138,8 +142,14 @@ class SaleReport(models.Model):
             l.discount,
             s.id %s
         """ % (groupby)
+        return groupby_
 
-        return '%s (SELECT %s FROM %s GROUP BY %s)' % (with_, select_, from_, groupby_)
+    def _query(self, with_clause='', fields=None, groupby='', from_clause=''):
+        if not fields:
+            fields = {}
+        with_ = ("WITH %s" % with_clause) if with_clause else ""
+        return '%s (SELECT %s FROM %s GROUP BY %s)' % \
+               (with_, self._select_sale(fields), self._from_sale(from_clause), self._group_by_sale(groupby))
 
     def init(self):
         # self._table = sale_report


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
modules installed: `sale, pos_sale, module1`(depends of `sale`), `module 2`(depends of `point_of_sale `and `pos_sale`)
Currently is imposible add custom field to `pos.order `or `pos.order.line` and reflect field value into `sale.report`.
If custom field is added on `sale.order` or` sale.order.line` can inherit function `_query`, [example here](https://github.com/odoo/odoo/blob/master/addons/sale_margin/report/sale_report.py#L13) and add field to report easily. But if add same field to model `pos.order` **field value always is `NULL`** [for this function](https://github.com/odoo/odoo/blob/13.0/addons/pos_sale/report/sale_report.py#L70)

**Current behavior before PR:**
Add a field(new_field_id ) to `sale.order `and `pos.order` into two modules

`MODULE 1`(depends sale) working fine
```
class SaleOrder(models.Model):
    _inherit = 'sale.order'

    new_field_id = fields.Many2one('any.model')


class SaleReport(models.Model):
    _inherit = 'sale.report'

    new_field_id = fields.Many2one('any.model')

    def _query(self, with_clause='', fields={}, groupby='', from_clause=''):
        fields['new_field_id '] = ", s.new_field_id"
        groupby += " , s.new_field_id"
        return super(SaleReport, self)._query(with_clause, fields, groupby, from_clause)
```


`MODULE 2`(depends `point_of_sale`, `pos_sale`, optional can add dependency for `module1 `but is not solution)

```
class PosOrder(models.Model):
    _inherit = 'pos.order'

    new_field_id = fields.Many2one('any.model')

```

For inherit sale.report i try this:
replace NULL(generate by https://github.com/odoo/odoo/blob/13.0/addons/pos_sale/report/sale_report.py#L70) after call super:

```
class SaleReport(models.Model):
    _inherit = 'sale.report'

    new_field_id = fields.Many2one('any.model')

    def _query(self, with_clause='', fields={}, groupby='', from_clause=''):
        res =super(SaleReport, self)._query(with_clause, fields, groupby, from_clause)
        res = res .replace(", NULL AS new_field_id ", ", pos.new_field_id ")
        return res 
```

This raise error: `Field must appear in the GROUP BY clause or be used in an aggregate function`  So is imposibble add field to `GROUP BY` sentence and show value for field  new_field_id to sale.report


**Desired behavior after PR is merged:**

Can inherit easy and add field to `GROUP BY` as:

```
class SaleReport(models.Model):
    _inherit = "sale.report"

   new_field_id = fields.Many2one('any.model')

    def _select_pos(self, fields={}):
        select_ = super(SaleReport, self)._select_pos(fields=fields)
        select_ = select_ .replace(", NULL AS new_field_id ", ", pos.new_field_id ")
        return select_

    def _group_by_pos(self, groupby=''):
        groupby_ = super(SaleReport, self)._group_by_pos(groupby=groupby)
        groupby_ += ", pos.new_field_id"
        return groupby_
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
