### PR TITLE
increase pager hitbox area

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -545,7 +545,7 @@
         <span class="btn-group" aria-atomic="true">
             <!-- accesskeys not wanted in X2Many widgets -->
             <button type="button"
-                class="fa fa-chevron-left btn btn-secondary o_pager_previous px-2 rounded-left"
+                class="fa fa-chevron-left btn btn-secondary o_pager_previous rounded-left"
                 t-att-disabled="state.disabled || singlePage"
                 t-att-accesskey="props.withAccessKey ? 'p' : false"
                 aria-label="Previous page"
@@ -554,7 +554,7 @@
                 t-on-click="_changeSelection(-1)"
             />
             <button type="button"
-                class="fa fa-chevron-right btn btn-secondary o_pager_next px-2 rounded-right"
+                class="fa fa-chevron-right btn btn-secondary o_pager_next rounded-right"
                 t-att-disabled="state.disabled || singlePage"
                 t-att-accesskey="props.withAccessKey ? 'n' : false"
                 aria-label="Next page"


### PR DESCRIPTION
PURPOSE
In the new design merged along the wowl framework, the pager buttons are smaller and harder to hit. The purpose of this task is to increase the size of the pager buttons to ease navigation.

SPEC
remove the px-2 class from the pager buttons

TASK 2610578



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
