### PR TITLE
[FIX] web_editor: add missing style entries

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1417,9 +1417,13 @@ export class OdooEditor extends EventTarget {
         const block = closestBlock(sel.anchorNode);
         for (const [style, tag, isList] of [
             ['paragraph', 'P', false],
+            ['pre', 'PRE', false],
             ['heading1', 'H1', false],
             ['heading2', 'H2', false],
             ['heading3', 'H3', false],
+            ['heading4', 'H4', false],
+            ['heading5', 'H5', false],
+            ['heading6', 'H6', false],
             ['blockquote', 'BLOCKQUOTE', false],
             ['unordered', 'UL', true],
             ['ordered', 'OL', true],


### PR DESCRIPTION
When the user selects text, the editor compares its closest block type
with a pre-made list of text types (eg. p, h1...).
In case of a match, the 'active' class is applied on the relative
toolbar component.

This commit will extend the comparison list adding text styles that were
initially missing (= the code, h4, h5 and h6 tags were never marked as
active).

Related to task-2496339
