### PR TITLE
[FIX] website: remove useless lang attr in configurator template

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2426,9 +2426,6 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 </template>
 
 <template id="website_configurator" name="Website Configurator" inherit_id="web.frontend_layout" primary="True">
-    <xpath expr="//html" position="attributes">
-        <attribute name="lang"><t t-esc='lang'/></attribute>
-    </xpath>
     <xpath expr="//head/t[@t-call-assets][last()]" position="after">
         <t t-call-assets="website.website_configurator_assets_js" lazy_load="True"/>
     </xpath>


### PR DESCRIPTION
The attribute lang was set in the template website.website_configurator.
This is not needed. This commit therefore remove this code.

task-2602521

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
