### PR TITLE
[FIX] website_event: fix the direction of event sub-menus

### DIFF
--- a/addons/website/static/src/js/menu/customize.js
+++ b/addons/website/static/src/js/menu/customize.js
@@ -14,7 +14,7 @@ var CustomizeMenu = Widget.extend({
     xmlDependencies: ['/website/static/src/xml/website.editor.xml'],
     events: {
         'show.bs.dropdown': '_onDropdownShow',
-        'click .dropdown-item[data-view-key]': '_onCustomizeOptionClick',
+        'change .dropdown-item[data-view-key]': '_onCustomizeOptionChange',
     },
 
     /**
@@ -95,10 +95,10 @@ var CustomizeMenu = Widget.extend({
                     currentGroup = item.inherit_id[1];
                     $menu.append('<li class="dropdown-header">' + currentGroup + '</li>');
                 }
-                var $a = $('<a/>', {href: '#', class: 'dropdown-item', 'data-view-key': item.key, role: 'menuitem'})
-                            .append(qweb.render('website.components.switch', {id: 'switch-' + item.id, label: item.name}));
-                $a.find('input').prop('checked', !!item.active);
-                $menu.append($a);
+                var $label = $(qweb.render('website.components.switch', {id: 'switch-' + item.id, label: item.name}));
+                $label.attr("data-view-key", item.key);
+                $label.find('input').prop('checked', !!item.active);
+                $menu.append($label);
             });
         });
     },
@@ -114,7 +114,7 @@ var CustomizeMenu = Widget.extend({
      * @private
      * @param {Event} ev
      */
-    _onCustomizeOptionClick: function (ev) {
+    _onCustomizeOptionChange: function (ev) {
         ev.preventDefault();
         var viewKey = $(ev.currentTarget).data('viewKey');
         this._doCustomize(viewKey);

--- a/addons/website/static/src/xml/track_page.xml
+++ b/addons/website/static/src/xml/track_page.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
 
-	<t t-name="website.track_page">
-		<div role="separator" class="dropdown-divider"/>
-		<a href="#" name="switch-track-page" class="dropdown-item" role="menuitem">
-			<label class="o_switch" for="switch-track-page">
-				<input id="switch-track-page" type="checkbox"/>
-				<span/>
-				Track Visitor
-			</label>
-		</a>
-	</t>
+    <t t-name="website.track_page">
+        <div role="separator" class="dropdown-divider"/>
+        <label class="o_switch dropdown-item m-0" for="switch-track-page">
+            <input id="switch-track-page" type="checkbox"/>
+            <span/>
+            Track Visitor
+        </label>
+    </t>
 
 </templates>
+
+

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -7,7 +7,7 @@
 
     <!-- Custom checkbox (material-design-like toggle) -->
     <t t-name="website.components.switch">
-        <label class="o_switch" t-att-for="id">
+        <label class="o_switch dropdown-item m-0" t-att-for="id">
             <input type="checkbox" t-att-id="id" t-att-checked="checked ? 'checked' : undefined"/>
             <span/>
             <div t-if="label"><t t-esc="label"/></div>

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -301,7 +301,9 @@ class Event(models.Model):
         :param menus_update_by_field: see ``_get_menus_update_by_field``"""
         for event in self:
             if event.menu_id and not event.website_menu:
-                event.menu_id.sudo().unlink()
+                # do not rely on cascade, as it is done in SQL -> not calling override and
+                # letting some ir.ui.views in DB
+                (event.menu_id + event.menu_id.child_id).sudo().unlink()
             elif event.website_menu and not event.menu_id:
                 root_menu = self.env['website.menu'].sudo().create({'name': event.name, 'website_id': event.website_id.id})
                 event.menu_id = root_menu

--- a/addons/website_event/static/src/xml/customize_options.xml
+++ b/addons/website_event/static/src/xml/customize_options.xml
@@ -3,13 +3,11 @@
 
     <t t-name="website_event.customize_options" id="event_options">
         <li class="dropdown-header">Event Specific</li>
-        <a href="#" name="display-website-menu" class="dropdown-item" role="menuitem">
-            <label class="o_switch" for="display-website-menu">
-                <input id="display-website-menu" type="checkbox"/>
-                <span/>
-                Event Sub-menu
-            </label>
-        </a>
+        <label class="o_switch dropdown-item m-0" name="display-website-menu" for="display-website-menu">
+            <input id="display-website-menu" type="checkbox"/>
+            <span/>
+            Event Sub-menu
+        </label>
     </t>
 
 </templates>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -38,11 +38,11 @@
                 <nav class="navbar navbar-light border-top shadow-sm navbar-expand-md">
                     <div class="container align-items-baseline">
                         <a t-att-href="event.website_url" t-field="event.name" class="navbar-brand h4 my-0 mr-0"/>
-                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#o_wevent_event_submenu" aria-controls="o_wevent_event_submenu" aria-expanded="false" aria-label="Toggle navigation">
+                        <button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#o_wevent_event_submenu" aria-controls="o_wevent_event_submenu" aria-expanded="false" aria-label="Toggle navigation">
                             <span class="navbar-toggler-icon"></span>
                         </button>
                         <div id="o_wevent_event_submenu" class="collapse navbar-collapse">
-                            <ul class="navbar-nav w-100 d-flex flex-row flex-wrap" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
+                            <ul class="navbar-nav w-100 flex-md-wrap" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
                                 <t t-foreach="event.menu_id.child_id" t-as="submenu">
                                     <t t-call="website.submenu">
                                         <t t-set="item_class" t-value="'nav-item'"/>

--- a/addons/website_event_meet/static/src/xml/customize_options.xml
+++ b/addons/website_event_meet/static/src/xml/customize_options.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-extend="website_event.customize_options">
-        <t t-jquery="a[name='display-website-menu']" t-operation="after">
-            <a t-if="window.document.location.pathname.endsWith('/community')" class="dropdown-item" href="#" name="allow-room-creation" role="menuitem">
-                <label class="o_switch" for="allow-room-creation">
-                    <input id="allow-room-creation" type="checkbox"/>
-                    <span/>
-                    Allow Room Creation
-                </label>
-            </a>
+        <t t-jquery="label[name='display-website-menu']" t-operation="after">
+            <label t-if="window.document.location.pathname.endsWith('/community')" class="o_switch dropdown-item m-0" for="allow-room-creation">
+                <input id="allow-room-creation" type="checkbox"/>
+                <span/>
+                Allow Room Creation
+            </label>
         </t>
     </t>
 </templates>

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -329,7 +329,7 @@ odoo.define('website_sale_tour.tour', function (require) {
     },
     {
         content: "Enable Extra step",
-        trigger: 'a.dropdown-item label:contains("Extra Step Option")',
+        trigger: 'label.dropdown-item:contains("Extra Step Option")',
     },
     {
         content: "Open Dropdown for logout",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -15,7 +15,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
             },
             {
                 content: "click on 'Attributes & Variants filters'",
-                trigger: "#customize-menu a:contains(Attributes & Variants filters)",
+                trigger: "#customize-menu label:contains(Attributes & Variants filters)",
             },
             {
                 content: "select product attribute Steel",
@@ -39,7 +39,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
             },
             {
                 content: "check page loaded after enable  variant group",
-                trigger: '#customize-menu a:contains(List View of Variants)',
+                trigger: '#customize-menu label:contains(List View of Variants)',
                 run: function () {}, // it's a check
             },
             {
@@ -49,7 +49,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
             },
             {
                 content: "click on 'List View of Variants'",
-                trigger: "#customize-menu a:contains(List View of Variants)",
+                trigger: "#customize-menu label:contains(List View of Variants)",
             },
             {
                 content: "check page loaded after list of variant customization enabled",
@@ -81,7 +81,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
             },
             {
                 content: "remove 'List View of Variants'",
-                trigger: "#customize-menu a:contains(List View of Variants):has(input:checked)",
+                trigger: "#customize-menu label:contains(List View of Variants):has(input:checked)",
             },
             {
                 content: "check page loaded after list of variant customization disabled",
@@ -133,7 +133,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
             },
             {
                 content: "remove 'Attributes & Variants filters'",
-                trigger: "#customize-menu a:contains(Attributes & Variants filters):has(input:checked)",
+                trigger: "#customize-menu label:contains(Attributes & Variants filters):has(input:checked)",
             },
             {
                 content: "finish",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -31,7 +31,7 @@ tour.register('shop_list_view_b2c', {
         },
         {
             content: "click on 'List View of Variants'",
-            trigger: '#customize-menu a:contains(List View of Variants)',
+            trigger: '#customize-menu label:contains(List View of Variants)',
         },
         {
             content: "check page loaded after list of variant customization enabled",

--- a/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
+++ b/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
@@ -18,10 +18,10 @@ tour.register('shop_sale_coupon', {
         },
         {
             content: "enable 'Show # found' if needed",
-            trigger: "#customize-menu a:contains(Show # found)",
+            trigger: "#customize-menu label:contains(Show # found)",
             run: function () {
-                if (!$('#customize-menu a:contains(Show # found) input').prop('checked')) {
-                    $('#customize-menu a:contains(Show # found)').click();
+                if (!$('#customize-menu label:contains(Show # found) input').prop('checked')) {
+                    $('#customize-menu label:contains(Show # found)').click();
                 }
             }
         },
@@ -48,10 +48,10 @@ tour.register('shop_sale_coupon', {
         },
         {
             content: "enable 'Promo Code' if needed",
-            trigger: "#customize-menu a:contains(Promo Code)",
+            trigger: "#customize-menu label:contains(Promo Code)",
             run: function () {
-                if (!$('#customize-menu a:contains(Promo Code) input').prop('checked')) {
-                    $('#customize-menu a:contains(Promo Code)').click();
+                if (!$('#customize-menu label:contains(Promo Code) input').prop('checked')) {
+                    $('#customize-menu label:contains(Promo Code)').click();
                 }
             }
         },


### PR DESCRIPTION
PURPOSE

The event sub-menus should be showing vertically.
The purpose of this commit is to showing sub-menus
vertically in the mobile view

SPECIFICATIONS

Currently, In the mobile view, all the event sub-menus are showing
horizontally which looks ugly and hard for selection.

This improves the layout of the event sub-menus in mobile view

This is the goal of this commit.

LINKS

PR #74912
TaskID-2616588

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
