### PR TITLE
[FIX] website_sale*: correctly show continue selling setting

### DIFF
--- a/addons/website_sale_comparison_wishlist/static/src/js/wishlist.js
+++ b/addons/website_sale_comparison_wishlist/static/src/js/wishlist.js
@@ -1,24 +1,23 @@
 /** @odoo-module **/
 
-import publicWidget from "web.public.widget";
-import "website_sale_comparison.comparison";
+import publicWidget from 'web.public.widget';
+import 'website_sale_comparison.comparison';
 
 publicWidget.registry.ProductComparison.include({
-  events: _.extend(
-    {},
-    publicWidget.registry.ProductComparison.prototype.events,
-    {
-      "click .wishlist-section .o_add_to_compare": "_onClickCompare",
-    }
-  ),
-  /**
-   * @private
-   * @param {Event} ev
-   */
-  _onClickCompare: function (ev) {
-    const $el = $(ev.currentTarget);
-    let productID = $el.data('product-id');
-    productID = parseInt(productID, 10);
-    this.productComparison._addNewProducts(productID);
-  },
+    events: _.extend({}, publicWidget.registry.ProductComparison.prototype.events, {
+        'click .wishlist-section .o_add_to_compare': '_onClickCompare',
+    }),
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onClickCompare: function (ev) {
+        const productID = parseInt(ev.currentTarget.dataset.productId, 10);
+        this.productComparison._addNewProducts(productID);
+    },
 });

--- a/addons/website_sale_stock/models/res_config_settings.py
+++ b/addons/website_sale_stock/models/res_config_settings.py
@@ -25,9 +25,10 @@ class ResConfigSettings(models.TransientModel):
     def get_values(self):
         res = super(ResConfigSettings, self).get_values()
         IrDefault = self.env['ir.default'].sudo()
+        allow_out_of_stock_order = IrDefault.get('product.template', 'allow_out_of_stock_order')
 
         res.update(
-            allow_out_of_stock_order=IrDefault.get('product.template', 'allow_out_of_stock_order') or True,
+            allow_out_of_stock_order=allow_out_of_stock_order if allow_out_of_stock_order is not None else True,
             available_threshold=IrDefault.get('product.template', 'available_threshold') or 5.0,
             show_availability=IrDefault.get('product.template', 'show_availability') or False
         )

--- a/addons/website_sale_stock_wishlist/static/src/js/website_sale.js
+++ b/addons/website_sale_stock_wishlist/static/src/js/website_sale.js
@@ -6,30 +6,28 @@ import ajax from "web.ajax";
 import { qweb as QWeb } from "web.core";
 
 const loadXml = async () => {
-  return ajax.loadXML(
-    "/website_sale_stock_wishlist/static/src/xml/product_availability.xml",
-    QWeb
-  );
+    return ajax.loadXML('/website_sale_stock_wishlist/static/src/xml/product_availability.xml', QWeb);
 };
 
 publicWidget.registry.WebsiteSale.include({
-  /**
-   * It will display additional info messages regarding the select product's stock and the wishlist.
-   * @override
-   */
-  _onChangeCombination: function (ev, $parent, combination) {
-    this._super.apply(this, arguments);
-    loadXml().then(function () {
-      if ($('.o_add_wishlist_dyn').length) {
-        var $message = $(
-          QWeb.render(
-            "website_sale_stock_wishlist.product_availability",
-            combination
-          )
-        );
-        $message.appendTo($("div.availability_messages"));
-      }
-    });
-  },
-});
 
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Displays additional info messages regarding the product's
+     * stock and the wishlist.
+     *
+     * @override
+     */
+    _onChangeCombination: async function (ev, $parent, combination) {
+        this._super(...arguments);
+        loadXml().then(() => {
+            if (this.el.querySelector('.o_add_wishlist_dyn')) {
+                const messageEl = this.el.querySelector('div.availability_messages');
+                messageEl.insertAdjacentHTML('beforeend', QWeb.render('website_sale_stock_wishlist.product_availability', combination));
+            }
+        });
+    },
+});

--- a/addons/website_sale_stock_wishlist/static/src/js/wishlist.js
+++ b/addons/website_sale_stock_wishlist/static/src/js/wishlist.js
@@ -1,43 +1,47 @@
 /** @odoo-module **/
 
-import publicWidget from "web.public.widget";
-import "website_sale_wishlist.wishlist";
+import publicWidget from 'web.public.widget';
+import 'website_sale_wishlist.wishlist';
 
 publicWidget.registry.ProductWishlist.include({
-  events: _.extend(
-    {},
-    publicWidget.registry.ProductWishlist.prototype.events,
-    {
-      "click .wishlist-section .o_notify_stock": "_onClickNotifyStock",
-    }
-  ),
-  /**
-   * It will remove wishlist indication when adding a product to the wishlist.
-   * @override
-   */
-  _addNewProducts: function () {
-    this._super.apply(this, arguments);
-    this.$("#stock_wishlist_message").addClass("d-none");
-  },
-  /**
-   * @private
-   * @param {Event} ev
-   */
-  _onClickNotifyStock: function (ev) {
-    const tr = $(ev.currentTarget).parents("tr");
-    const wish = tr.data("wish-id");
-    const icon = $(ev.currentTarget).find("i");
-    const currentNotify = ev.currentTarget.dataset.notify === 'True';
-    this._rpc({
-      route: "/shop/wishlist/notify/" + wish,
-      params: {
-        notify: !currentNotify,
-      }
-    }).then((notify) => {
-      ev.currentTarget.dataset.notify = notify ? 'True' : 'False';
-      icon.toggleClass("fa-check-square-o", notify);
-      icon.toggleClass("fa-square-o", !notify);
-    });
-  },
-});
+    events: _.extend({}, publicWidget.registry.ProductWishlist.prototype.events, {
+        'click .wishlist-section .o_notify_stock': '_onClickNotifyStock',
+    }),
 
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Removes wishlist indication when adding a product to the wishlist.
+     *
+     * @override
+     */
+    _addNewProducts: function () {
+        this._super(...arguments);
+        const wishlistMessageEl = this.el.querySelector('#stock_wishlist_message');
+        if (wishlistMessageEl) {
+            wishlistMessageEl.classList.add('d-none');
+        }
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onClickNotifyStock: function (ev) {
+        const targetEl = ev.currentTarget;
+        const wishID = targetEl.closest('tr').dataset.wishId;
+        const iconEl = targetEl.querySelector('i');
+        const currentNotify = targetEl.dataset.notify === 'True';
+        this._rpc({
+            route: `/shop/wishlist/notify/${wishID}`,
+            params: {
+                notify: !currentNotify,
+            }
+        }).then((notify) => {
+            targetEl.dataset.notify = notify ? 'True' : 'False';
+            iconEl.classList.toggle('fa-check-square-o', notify);
+            iconEl.classList.toggle('fa-square-o', !notify);
+        });
+    },
+});


### PR DESCRIPTION
*: website_sale_comparison_wishlist, website_sale_stock_wishlist

The config setting to continue selling even with no stock was always
shown as true, even if it was false.

Also, this reindents wrongly indented js files.

task-2458165


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
