### PR TITLE
[FIX] sale_mrp: Issue in delivered quantity for sales order with kit items

### DIFF
--- a/addons/sale_mrp/models/sale_mrp.py
+++ b/addons/sale_mrp/models/sale_mrp.py
@@ -53,7 +53,8 @@ class SaleOrderLine(models.Model):
                         'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
                     }
                     order_qty = order_line.product_uom._compute_quantity(order_line.product_uom_qty, relevant_bom.product_uom_id)
-                    order_line.qty_delivered = moves._compute_kit_quantities(order_line.product_id, order_qty, relevant_bom, filters)
+                    qty_delivered = moves._compute_kit_quantities(order_line.product_id, order_qty, relevant_bom, filters)
+                    order_line.qty_delivered = relevant_bom.product_uom_id._compute_quantity(qty_delivered, order_line.product_uom)
 
                 # If no relevant BOM is found, fall back on the all-or-nothing policy. This happens
                 # when the product sold is made only of kits. In this case, the BOM of the stock moves


### PR DESCRIPTION
Step to follow

Create a sale order for a kit with a quantity of one and Dozens as a unit of
measure
Confirm and validate the delivery
The delivered quantity will be 12 instead of 1

Cause of the issue

The delivered quantity wasn't recomputed in relation to the sales order
quantity

opw-2535193