### PR TITLE
[FIX] hr_holidays: fix time off allocation access right

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -69,6 +69,12 @@
         <field name="domain_force">['|', ('holiday_status_id.company_id', '=', False), ('holiday_status_id.company_id', 'in', [user.company_id.id])]</field>
     </record>
 
+    <record id="hr_leave_allocation_rule_multicompany" model="ir.rule">
+        <field name="name">Leave Allocations: multi company global rule</field>
+        <field name="model_id" ref="model_hr_leave_allocation"/>
+        <field name="domain_force">['|', ('holiday_status_id.company_id', '=', False), ('holiday_status_id.company_id', 'in', [user.company_id.id])]</field>
+    </record>
+
     <record id="hr_leave_allocation_rule_employee" model="ir.rule">
         <field name="name">Allocations: employee: read own</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>


### PR DESCRIPTION
Steps to reproduce the problem:
- Connect as admin
- Create a new employee, e.g: “Employee1” for company “My Company (San Francisco)”
- Create a new time off request for this employee, and select a time off type linked to the company "San Francisco"
- create a user and do not give him access to the company “San Francisco”, e.g: “user1”
- Log in as “user1”
- Go to time off > Managers > Allocations > remove default filter

Problem:
user1 is able to see the time off allocation of “Employee1”, even though he does not have access to My Company San Francisco.

Solution:
Add multi-company rules  for the “hr.leave_allocation” model to display only the time off allocations to which the current user has access

A rule has already been added for "hr.leave" model:
https://github.com/odoo/odoo/blob/0f3281e3b1dc943b81d79d2a8f82fca7b95b8186/addons/hr_holidays/security/hr_holidays_security.xml#L65-L70

opw-2535709




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
