### PR TITLE
[FIX] base: skip unneeded update_list call

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -636,6 +636,8 @@ class Module(models.Model):
 
     @assert_log_admin_access
     def button_upgrade(self):
+        if not self:
+            return
         Dependency = self.env['ir.module.module.dependency']
         self.update_list()
 


### PR DESCRIPTION
`update_list` is an expensive operation and could be avoided when no modules are
updated. Particually, it speeds up initial theme installation on website, which
has following code:

```
    themes.filtered(lambda m: m.state == 'installed').button_upgrade()
```

Benchmark for Odoo 15: `/website/configurator_apply` was spent 36% for unneeded
`update_list` call.