### PR TITLE
[FIX] payment: suitable payment token and acquirer fix

### DIFF
--- a/addons/payment/models/account_payment.py
+++ b/addons/payment/models/account_payment.py
@@ -40,7 +40,7 @@ class AccountPayment(models.Model):
                     ('company_id', '=', payment.company_id.id),
                     ('acquirer_id.capture_manually', '=', False),
                     ('partner_id', 'in', related_partner_ids.ids),
-                    ('acquirer_id.journal_id', '=', payment.journal_id.id),
+                    ('acquirer_id', '=', payment.payment_method_line_id.payment_acquirer_id.id),
                 ])
             else:
                 payment.suitable_payment_token_ids = [Command.clear()]
@@ -70,7 +70,7 @@ class AccountPayment(models.Model):
             ('company_id', '=', self.company_id.id),
             ('partner_id', 'in', related_partner_ids.ids),
             ('acquirer_id.capture_manually', '=', False),
-            ('acquirer_id.journal_id', '=', self.journal_id.id),
+            ('acquirer_id', '=', self.payment_method_line_id.payment_acquirer_id.id),
          ], limit=1)
 
     def _get_payment_chatter_link(self):

--- a/addons/payment/wizards/account_payment_register.py
+++ b/addons/payment/wizards/account_payment_register.py
@@ -46,7 +46,7 @@ class AccountPaymentRegister(models.TransientModel):
                     ('company_id', '=', wizard.company_id.id),
                     ('acquirer_id.capture_manually', '=', False),
                     ('partner_id', 'in', related_partner_ids.ids),
-                    ('acquirer_id.journal_id', '=', wizard.journal_id.id),
+                    ('acquirer_id', '=', wizard.payment_method_line_id.payment_acquirer_id.id),
                 ])
             else:
                 wizard.suitable_payment_token_ids = [Command.clear()]
@@ -77,7 +77,7 @@ class AccountPaymentRegister(models.TransientModel):
                     ('company_id', '=', wizard.company_id.id),
                     ('partner_id', 'in', related_partner_ids.ids),
                     ('acquirer_id.capture_manually', '=', False),
-                    ('acquirer_id.journal_id', '=', wizard.journal_id.id),
+                    ('acquirer_id', '=', wizard.payment_method_line_id.payment_acquirer_id.id),
                  ], limit=1)
             else:
                 wizard.payment_token_id = False


### PR DESCRIPTION
Fix two issues:

The search of suitable payment tokens was searching on the journal_id
field of the payment acquirer that is no longer stored.
Change it to now search on the acquirer_id directly, since we have
this information.

The _inverse_journal_id method on payment acquirers would create
new payment line with the manual payment method when no provider
are given to an acquirer, or no payment method is existing for
a given provider. This would cause issues with the creation of
multiple lines with the same name on a same journal, which would
trigger the constrains blocking that.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
