### PR TITLE
[FIX] web_editor: change link shortcut to ctrl+M

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -893,8 +893,8 @@ const Wysiwyg = Widget.extend({
      * Handle custom keyboard shortcuts.
      */
     _handleShortcuts: function (e) {
-        // Open the link modal / tool when CTRL+K is pressed.
-        if (e && e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+        // Open the link modal / tool when CTRL+M is pressed.
+        if (e && e.key === 'm' && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             this.toggleLinkTools();
         }


### PR DESCRIPTION
Old shortcut (ctrl+K) was conflicting with the new command palette feature, so we change it to CTRL+M.

task-2593213


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
