### PR TITLE
[IMP] mail: make ctivity view header sticky

### DIFF
--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -5,6 +5,11 @@
         thead > tr > th:first-of-type {
             min-width: 300px;
         }
+        thead > tr > th {
+            @include o-position-sticky($top: -1px);
+            background-color: white;
+            z-index: 1;
+        }
         tbody > tr > td, tfoot > tr > td {
             cursor: pointer;
         }

--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -6,9 +6,24 @@
             min-width: 300px;
         }
         thead > tr > th {
-            @include o-position-sticky($top: -1px);
+            @include o-position-sticky($top: 0px);
             background-color: white;
             z-index: 1;
+            &:after,
+            &:before {
+                content: '';
+                position: absolute;
+                left: 0;
+                width: 100%;
+            }
+            &:before {
+                top: -1px;
+                border-top: 2px solid #E0E2E6;
+            }
+            &:after {
+                bottom: -2px;
+                border-bottom: 2px solid #E0E2E6;
+            }
         }
         tbody > tr > td, tfoot > tr > td {
             cursor: pointer;

--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -2,6 +2,8 @@
     height: 100%;
     > table {
         background-color: white;
+        border-collapse: separate; /* Don't collapse */
+        border-spacing: 0;
         thead > tr > th:first-of-type {
             min-width: 300px;
         }
@@ -17,7 +19,7 @@
                 width: 100%;
             }
             &:before {
-                top: -1px;
+                top: -2px;
                 border-top: 2px solid #E0E2E6;
             }
             &:after {


### PR DESCRIPTION
PURPOSE
Freeze the headers of a grouped kanban to keep the activity types visible when scrolling down.

SPECIFICATION
Freeze the header of the activity view when scrolling down (i.e. <tr> tag)

TASK 2615324


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
