### PR TITLE
[FIX] web: legacy dropdown position

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -67,7 +67,6 @@
 
   &_menu {
     @extend .dropdown-menu;
-    position: relative;
 
     &.o_dropdown_menu_right {
       // FIXME: does commenting this break anything?


### PR DESCRIPTION
Before this commit: the legacy dropdown menus are not placed properly

Issue introduced with commit odoo/odoo@0bb93b2

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
