### PR TITLE
Master sms provider feedback thc

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -292,7 +292,7 @@ class MassMailing(models.Model):
                 m.id as mailing_id,
                 COUNT(s.id) AS expected,
                 COUNT(s.sent_datetime) AS sent,
-                COUNT(s.trace_status) FILTER (WHERE s.trace_status = 'outgoing') AS scheduled,
+                COUNT(s.trace_status) FILTER (WHERE s.trace_status in ('outgoing', 'processing')) AS scheduled,
                 COUNT(s.trace_status) FILTER (WHERE s.trace_status = 'cancel') AS canceled,
                 COUNT(s.trace_status) FILTER (WHERE s.trace_status in ('sent', 'open', 'reply')) AS delivered,
                 COUNT(s.trace_status) FILTER (WHERE s.trace_status in ('open', 'reply')) AS opened,

--- a/addons/mass_mailing_sms/controllers/main.py
+++ b/addons/mass_mailing_sms/controllers/main.py
@@ -2,11 +2,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http, _
-from odoo.addons.phone_validation.tools import phone_validation
 from odoo.http import request
 
+from odoo.addons.phone_validation.tools import phone_validation
+from odoo.addons.sms.controller.main import SmsController
 
-class MailingSMSController(http.Controller):
+
+class MailingSMSController(SmsController):
 
     def _check_trace(self, mailing_id, trace_code):
         try:
@@ -99,3 +101,11 @@ class MailingSMSController(http.Controller):
             mailing_trace_id=trace_id
         )
         return request.redirect(request.env['link.tracker'].get_url_from_code(code), code=301, local=False)
+
+    @http.route('/sms/status', type='json', auth='public', csrf=False)
+    def update_sms_status(self, message_statuses):
+        for message_status in message_statuses:
+            request.env['mailing.trace'].sudo().search([
+                ('sms_uuid', 'in', message_status['uuids']),
+            ]).update_status(message_status['sms_status'])
+        return super().update_sms_status(message_statuses)

--- a/addons/mass_mailing_sms/models/sms_sms.py
+++ b/addons/mass_mailing_sms/models/sms_sms.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+from itertools import groupby
 
 from odoo import fields, models, tools
 
@@ -28,19 +29,20 @@ class SmsSms(models.Model):
             res[sms.id] = body
         return res
 
-    def _postprocess_iap_sent_sms(self, iap_results, failure_reason=None, unlink_failed=False, unlink_sent=True):
-        all_sms_ids = [item['res_id'] for item in iap_results]
-        if any(sms.mailing_id for sms in self.env['sms.sms'].sudo().browse(all_sms_ids)):
-            for state in self.IAP_TO_SMS_STATE.keys():
-                sms_ids = [item['res_id'] for item in iap_results if item['state'] == state]
-                traces = self.env['mailing.trace'].sudo().search([
-                    ('sms_sms_id_int', 'in', sms_ids)
-                ])
-                if traces and state == 'success':
-                    traces.set_sent()
-                elif traces:
-                    traces.set_failed(failure_type=self.IAP_TO_SMS_STATE[state])
+    def _postprocess_iap_sent_sms(self, iap_results, failure_reason=None, unlink_failed=False):
+        key = lambda result: result['state']
+        for state, results in groupby(sorted(iap_results, key=key), key=key):
+            uuids = tuple(result['uuid'] for result in results)
+            traces = self.env['mailing.trace'].sudo().search([
+                ('sms_uuid', 'in', uuids),
+            ])
+            if traces and state == 'success':
+                traces.write({
+                    'trace_status': 'processing',
+                })
+            elif traces:
+                traces.set_failed(failure_type=self.IAP_TO_SMS_STATE[state])
         return super(SmsSms, self)._postprocess_iap_sent_sms(
             iap_results, failure_reason=failure_reason,
-            unlink_failed=unlink_failed, unlink_sent=unlink_sent
+            unlink_failed=unlink_failed
         )

--- a/addons/mass_mailing_sms/tests/common.py
+++ b/addons/mass_mailing_sms/tests/common.py
@@ -57,6 +57,7 @@ class MassSMSCase(SMSCase, MockLinkTracker):
         # map trace state to sms state
         state_mapping = {
             'sent': 'sent',
+            'processing': 'processing',
             'outgoing': 'outgoing',
             'error': 'error',
             'cancel': 'canceled',
@@ -90,11 +91,8 @@ class MassSMSCase(SMSCase, MockLinkTracker):
             self.assertTrue(bool(trace.sms_sms_id_int))
 
             if check_sms:
-                if status == 'sent':
-                    if sent_unlink:
-                        self.assertSMSIapSent([number], content=content)
-                    else:
-                        self.assertSMS(partner, number, 'sent', content=content)
+                if status == 'processing':
+                    self.assertSMS(partner, number, 'processing', content=content)
                 elif status in state_mapping:
                     sms_state = state_mapping[status]
                     failure_type = recipient_info['failure_type'] if status in ('error', 'cancel', 'bounce') else None

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -35,6 +35,9 @@
                     confirm="This will send SMS to all recipients now. Do you still want to proceed ?"/>
             </xpath>
             <!-- Headers / Warnings -->
+            <xpath expr="//div[hasclass('alert-info')]" position="attributes">
+                <attribute name="attrs">{'invisible': ['&amp;','&amp;','&amp;','&amp;','&amp;','&amp;',('state', '!=', 'in_queue'),('sent', '=', 0),('processing', '=', 0),('canceled', '=', 0),('scheduled', '=', 0),('failed', '=', 0),('warning_message', '=', False)]}</attribute>
+            </xpath>
             <xpath expr="//header" position="after">
                 <field name="sms_has_insufficient_credit" invisible="1"/>
                 <div class="alert alert-warning text-center o-hidden-ios" attrs="{'invisible': [('sms_has_insufficient_credit', '=', False)]}" role="alert">
@@ -67,7 +70,20 @@
                 <attribute name="attrs">{'invisible': [('mailing_type', '!=', 'mail')]}</attribute>
             </xpath>
             <xpath expr="//span[@name='scheduled_text']" position="after">
-                <span name="scheduled_text_sms" attrs="{'invisible': [('mailing_type', '!=', 'sms')]}">SMS Text Message are in queue and will be sent soon.</span>
+                <span name="scheduled_text_sms" attrs="{'invisible': [('mailing_type', '!=', 'sms')]}">SMS are in queue and will be sent soon.</span>
+            </xpath>
+            <xpath expr="//div[hasclass('alert-info')]/div[hasclass('o_mails_scheduled')]" position="after">
+                <div attrs="{'invisible': [('processing', '=', 0)]}">
+                    <button class="btn-link py-0"
+                            name="action_view_traces_processing"
+                            type="object">
+                        <strong>
+                            <field name="processing" class="oe_inline me-2"/>
+                            <span name="processing">SMS Text Message are beeing processed by IAP.</span>
+                        </strong>
+                    </button>
+                </div>
+                <span name="processing_text_sms" attrs="{'invisible': [('mailing_type', '!=', 'sms')]}"></span>
             </xpath>
             <xpath expr="//span[@name='sent']" position="attributes">
                 <attribute name="attrs">{'invisible': [('mailing_type', '!=', 'mail')]}</attribute>

--- a/addons/mass_mailing_sms/views/mailing_trace_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_trace_views.xml
@@ -5,11 +5,14 @@
         <field name="model">mailing.trace</field>
         <field name="inherit_id" ref="mass_mailing.mailing_trace_view_search"/>
         <field name="arch" type="xml">
-           <xpath expr="//field[@name='email']" position="after">
+            <xpath expr="//field[@name='email']" position="after">
                 <field name="sms_sms_id_int"/>
                 <field name="sms_sms_id"/>
                 <field name="sms_number"/>
-           </xpath>
+            </xpath>
+            <xpath expr="//filter[@name='filter_canceled']" position="after">
+                <filter string="Processing" name="filter_processing" domain="[('trace_status', '=', 'processing')]"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/sms/controller/__init__.py
+++ b/addons/sms/controller/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import wizard
-from . import controller
+from . import main

--- a/addons/sms/controller/main.py
+++ b/addons/sms/controller/main.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+
+
+class SmsController(http.Controller):
+
+    @http.route('/sms/status', type='json', auth='public', csrf=False)
+    def update_sms_status(self, message_statuses):
+        """
+        Receive a batch of delivery reports from IAP
+
+        :param message_statuses:
+        [
+            {
+                'sms_status': status0,
+                'uuids': [uuid00, uuid01, ...],
+            },
+            {
+                'sms_status': status1,
+                'uuids': [uuid10, uuid11, ...],
+            },
+            ...
+        ]
+        """
+        for message_status in message_statuses:
+            request.env['sms.sms'].sudo().search([
+                ('uuid', 'in', message_status['uuids']),
+            ]).update_status(message_status['sms_status'])
+        return 'OK'

--- a/addons/sms/models/mail_notification.py
+++ b/addons/sms/models/mail_notification.py
@@ -17,5 +17,12 @@ class MailNotification(models.Model):
         ('sms_number_format', 'Wrong Number Format'),
         ('sms_credit', 'Insufficient Credit'),
         ('sms_server', 'Server Error'),
-        ('sms_acc', 'Unregistered Account')
+        ('sms_acc', 'Unregistered Account'),
+        # delivery report errors (DLR)
+        ('sms_delivered', 'Delivered'),
+        ('sms_not_delivered', 'Not Delivered'),
+        ('sms_not_allowed', 'Not Allowed'),
+        ('sms_invalid_destination', 'Invalid Destination'),
+        ('sms_rejected', 'Rejected'),
+        ('sms_expired', 'Expired'),
     ])

--- a/addons/sms/models/sms_api.py
+++ b/addons/sms/models/sms_api.py
@@ -35,27 +35,59 @@ class SmsApi(models.AbstractModel):
         return self._contact_iap('/iap/message_send', params)
 
     @api.model
-    def _send_sms_batch(self, messages):
+    def _send_sms_batch(self, messages, dlr=False):
         """ Send SMS using IAP in batch mode
 
-        :param messages: list of SMS to send, structured as dict [{
-            'res_id':  integer: ID of sms.sms,
-            'number':  string: E164 formatted phone number,
-            'content': string: content to send
-        }]
+        :param list messages: list of SMS (grouped by content) to send:
+            [
+                {
+                    'content' : str,
+                    'numbers' : [
+                        {
+                            'uuid' : str,
+                            'number' : str,
+                        },
+                        {
+                            'uuid' : str,
+                            'number' : str,
+                        },
+                        ...
+                    ]
+                },
+                {
+                    'content' : str,
+                    'numbers' : [{...}, {...}, ...]
+                },
+                ...
+            ]
+        :param bool dlr: whether to receive delivery reports or not
 
         :return: return of /iap/sms/1/send controller which is a list of dict [{
-            'res_id': integer: ID of sms.sms,
-            'state':  string: 'insufficient_credit' or 'wrong_number_format' or 'success',
-            'credit': integer: number of credits spent to send this SMS,
+            'uuid': string: UUID of sms.sms,
+            'state': string: One of the following: {
+                'success', 'server_error', 'unregistered', 'insufficient_credit',
+                'wrong_number_format', 'duplicate_message', 'no_compatible_provider',
+            }
+            'credit': integer: number of credits spent to send this SMS (is only
+                returned if the definitive amount is known),
         }]
+
+        NOTE: IAP returning 'success' simply means that:
+            - the request to send the message has been received by IAP
+            - enough credits are available to send the message
+            - the given number has the correct format (no guarantee that the number exists)
+            - the country the number is registered in is supported by IAP
+            - the content is non-empty and conforms to rules applied by IAP's providers
+            - the message has NOT YET been sent
+            - the message can still be blocked by anti-spam mechanisms
 
         :raises: normally none
         """
         params = {
-            'messages': messages
+            'messages': messages,
+            'webhook_url': dlr and (self.get_base_url() + '/sms/status')
         }
-        return self._contact_iap('/iap/sms/2/send', params)
+        return self._contact_iap('/iap/sms/3/send', params)
 
     @api.model
     def _get_sms_api_error_messages(self):
@@ -73,4 +105,7 @@ class SmsApi(models.AbstractModel):
             'unregistered': _("You don't have an eligible IAP account."),
             'insufficient_credit': ' '.join([_('You don\'t have enough credits on your IAP account.'), buy_credits]),
             'wrong_number_format': _("The number you're trying to reach is not correctly formatted."),
+            'duplicate_message': _('A SMS has bee removed since it was duplicated.'),
+            'country_not_supported': _('The destination country is not supported.'),
+            'incompatible_content': _('The content of the message violates rules applied by our providers.')
         }

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -3,6 +3,9 @@
 
 import logging
 import threading
+from uuid import uuid4
+from itertools import groupby
+from collections import defaultdict
 
 from odoo import api, fields, models, tools, _
 
@@ -20,7 +23,12 @@ class SmsSms(models.Model):
         'insufficient_credit': 'sms_credit',
         'wrong_number_format': 'sms_number_format',
         'server_error': 'sms_server',
-        'unregistered': 'sms_acc'
+        'unregistered': 'sms_acc',
+        # delivery report errors (DLR)
+        'not_allowed': 'sms_not_allowed',
+        'invalid_destination': 'sms_invalid_destination',
+        'rejected': 'sms_rejected',
+        'expired': 'sms_expired',
     }
 
     number = fields.Char('Number')
@@ -29,6 +37,7 @@ class SmsSms(models.Model):
     mail_message_id = fields.Many2one('mail.message', index=True)
     state = fields.Selection([
         ('outgoing', 'In Queue'),
+        ('processing', 'Processing'),
         ('sent', 'Sent'),
         ('error', 'Error'),
         ('canceled', 'Canceled')
@@ -43,7 +52,19 @@ class SmsSms(models.Model):
         ('sms_blacklist', 'Blacklisted'),
         ('sms_duplicate', 'Duplicate'),
         ('sms_optout', 'Opted Out'),
+        # delivery report errors (DLR)
+        ('sms_not_allowed', 'Not Allowed'),
+        ('sms_invalid_destination', 'Invalid Destination'),
+        ('sms_rejected', 'Rejected'),
+        ('sms_expired', 'Expired'),
     ], copy=False)
+    uuid = fields.Char(
+        'UUID', help="UUID used by sms service",
+        required=True, copy=False, readonly=True, index=True, default=lambda r: uuid4().hex)
+
+    _sql_constraints = [
+        ('uuid_unique', 'unique(uuid)', 'UUID should be unique'),
+    ]
 
     def action_set_canceled(self):
         self.state = 'canceled'
@@ -85,16 +106,22 @@ class SmsSms(models.Model):
             if not self._context.get('sms_skip_msg_notification', False):
                 notifications.mail_message_id._notify_message_notification_update()
 
-    def send(self, unlink_failed=False, unlink_sent=True, auto_commit=False, raise_exception=False):
+    def update_status(self, sms_status):
+        self.state = 'sent'
+        if sms_status in {'delivered', 'sent', 'not_delivered'}:
+            self.unlink()
+        else:
+            self.action_set_error(self.IAP_TO_SMS_STATE.get(sms_status))
+
+    def send(self, unlink_failed=False, auto_commit=False, raise_exception=False):
         """ Main API method to send SMS.
 
           :param unlink_failed: unlink failed SMS after IAP feedback;
-          :param unlink_sent: unlink sent SMS after IAP feedback;
           :param auto_commit: commit after each batch of SMS;
           :param raise_exception: raise if there is an issue contacting IAP;
         """
         for batch_ids in self._split_batch():
-            self.browse(batch_ids)._send(unlink_failed=unlink_failed, unlink_sent=unlink_sent, raise_exception=raise_exception)
+            self.browse(batch_ids)._send(unlink_failed=unlink_failed, raise_exception=raise_exception)
             # auto-commit if asked except in testing mode
             if auto_commit is True and not getattr(threading.current_thread(), 'testing', False):
                 self._cr.commit()
@@ -146,7 +173,7 @@ class SmsSms(models.Model):
         try:
             # auto-commit except in testing mode
             auto_commit = not getattr(threading.current_thread(), 'testing', False)
-            res = self.browse(ids).send(unlink_failed=False, unlink_sent=True, auto_commit=auto_commit, raise_exception=False)
+            res = self.browse(ids).send(unlink_failed=False, auto_commit=auto_commit, raise_exception=False)
         except Exception:
             _logger.exception("Failed processing SMS queue")
         return res
@@ -156,60 +183,63 @@ class SmsSms(models.Model):
         for sms_batch in tools.split_every(batch_size, self.ids):
             yield sms_batch
 
-    def _send(self, unlink_failed=False, unlink_sent=True, raise_exception=False):
+    def _send(self, unlink_failed=False, raise_exception=False):
         """ This method tries to send SMS after checking the number (presence and
         formatting). """
-        iap_data = [{
-            'res_id': record.id,
-            'number': record.number,
-            'content': record.body,
-        } for record in self]
-
+        messages = defaultdict(list)
+        for record in self:
+            messages[record.body].append({
+                'number': record.number,
+                'uuid': record.uuid,
+            })
         try:
-            iap_results = self.env['sms.api']._send_sms_batch(iap_data)
+            iap_results = self.env['sms.api']._send_sms_batch([{
+                'content': content,
+                'numbers': numbers,
+            } for content, numbers in messages.items()], dlr=True)
         except Exception as e:
             _logger.info('Sent batch %s SMS: %s: failed with exception %s', len(self.ids), self.ids, e)
             if raise_exception:
                 raise
             self._postprocess_iap_sent_sms(
-                [{'res_id': sms.id, 'state': 'server_error'} for sms in self],
-                unlink_failed=unlink_failed, unlink_sent=unlink_sent)
+                [{'uuid': sms.uuid, 'state': 'server_error'} for sms in self],
+                unlink_failed=unlink_failed)
         else:
             _logger.info('Send batch %s SMS: %s: gave %s', len(self.ids), self.ids, iap_results)
-            self._postprocess_iap_sent_sms(iap_results, unlink_failed=unlink_failed, unlink_sent=unlink_sent)
+            self._postprocess_iap_sent_sms(iap_results, unlink_failed=unlink_failed)
 
-    def _postprocess_iap_sent_sms(self, iap_results, failure_reason=None, unlink_failed=False, unlink_sent=True):
-        todelete_sms_ids = []
+    def _postprocess_iap_sent_sms(self, iap_results, failure_reason=None, unlink_failed=False):
+        todelete_sms_uuids = []
         if unlink_failed:
-            todelete_sms_ids += [item['res_id'] for item in iap_results if item['state'] != 'success']
-        if unlink_sent:
-            todelete_sms_ids += [item['res_id'] for item in iap_results if item['state'] == 'success']
+            todelete_sms_uuids += [item['uuid'] for item in iap_results if item['state'] != 'success']
 
-        for state in self.IAP_TO_SMS_STATE.keys():
-            sms_ids = [item['res_id'] for item in iap_results if item['state'] == state]
-            if sms_ids:
-                if state != 'success' and not unlink_failed:
-                    self.env['sms.sms'].sudo().browse(sms_ids).write({
-                        'state': 'error',
-                        'failure_type': self.IAP_TO_SMS_STATE[state],
-                    })
-                if state == 'success' and not unlink_sent:
-                    self.env['sms.sms'].sudo().browse(sms_ids).write({
-                        'state': 'sent',
-                        'failure_type': False,
-                    })
-                notifications = self.env['mail.notification'].sudo().search([
-                    ('notification_type', '=', 'sms'),
-                    ('sms_id', 'in', sms_ids),
-                    ('notification_status', 'not in', ('sent', 'canceled')),
-                ])
-                if notifications:
-                    notifications.write({
-                        'notification_status': 'sent' if state == 'success' else 'exception',
-                        'failure_type': self.IAP_TO_SMS_STATE[state] if state != 'success' else False,
-                        'failure_reason': failure_reason if failure_reason else False,
-                    })
+        key = lambda result: result['state']
+        for state, results in groupby(sorted(iap_results, key=key), key=key):
+            uuids = tuple(result['uuid'] for result in results)
+            sms = self.env['sms.sms'].sudo().search(
+                [('uuid', 'in', uuids)])
+            if state != 'success' and not unlink_failed:
+                sms.write({
+                    'state': 'error',
+                    'failure_type': self.IAP_TO_SMS_STATE[state],
+                })
+            if state == 'success':
+                sms.write({
+                    'state': 'processing',
+                    'failure_type': False,
+                })
+            notifications = self.env['mail.notification'].sudo().search([
+                ('notification_type', '=', 'sms'),
+                ('sms_id', 'in', sms.ids),
+                ('notification_status', 'not in', ('sent', 'canceled')),
+            ])
+            if notifications:
+                notifications.write({
+                    'notification_status': 'sent' if state == 'success' else 'exception',
+                    'failure_type': self.IAP_TO_SMS_STATE[state] if state != 'success' else False,
+                    'failure_reason': failure_reason if failure_reason else False,
+                })
         self.mail_message_id._notify_message_notification_update()
 
-        if todelete_sms_ids:
-            self.browse(todelete_sms_ids).sudo().unlink()
+        if todelete_sms_uuids:
+            self.env['sms.sms'].sudo().search([('uuid', 'in', todelete_sms_uuids)]).unlink()

--- a/addons/sms/views/sms_sms_views.xml
+++ b/addons/sms/views/sms_sms_views.xml
@@ -23,7 +23,8 @@
                         </group>
                     </group>
                     <group>
-                        <field name="body" widget="sms_widget" string="Message" required="1"/>
+                        <field name="body" widget="sms_widget" string="Message" required="1" 
+                        attrs="{'readonly': [('state', 'in', ('processing', 'sent'))]}"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
+from uuid import uuid4
 
 from odoo import api, fields, models, _
 from odoo.addons.phone_validation.tools import phone_validation
@@ -198,10 +199,12 @@ class SendSMS(models.TransientModel):
 
     def _action_send_sms_numbers(self):
         self.env['sms.api']._send_sms_batch([{
-            'res_id': 0,
-            'number': number,
             'content': self.body,
-        } for number in self.sanitized_numbers.split(',')])
+            'numbers': [{
+                'uuid': uuid4().hex,
+                'number': number,
+            } for number in self.sanitized_numbers.split(',')]
+        }])
         return True
 
     def _action_send_sms_comment_single(self, records=None):

--- a/addons/test_mail_sms/tests/test_sms_composer.py
+++ b/addons/test_mail_sms/tests/test_sms_composer.py
@@ -224,7 +224,6 @@ class TestSMSComposerBatch(TestSMSCommon):
             ).create({
                 'body': self._test_body,
             })
-
             with self.mockSMSGateway():
                 messages = composer._action_send_sms()
 

--- a/addons/test_mail_sms/tests/test_sms_management.py
+++ b/addons/test_mail_sms/tests/test_sms_management.py
@@ -133,8 +133,8 @@ class TestSMSWizards(TestSMSActionsCommon):
                 wizard.action_resend()
 
         self.assertSMSNotification([
-            {'partner': self.partner_1, 'state': 'sent'},
-            {'partner': self.partner_2, 'state': 'sent'}
+            {'partner': self.partner_1, 'state': 'processing'},
+            {'partner': self.partner_2, 'state': 'processing'}
         ], 'TEST BODY', self.msg, check_sms=True)
         self.assertMessageBusNotifications(self.msg)
 
@@ -149,8 +149,8 @@ class TestSMSWizards(TestSMSActionsCommon):
                 wizard.action_resend()
 
         self.assertSMSNotification([
-            {'partner': self.partner_1, 'state': 'sent', 'number': self.random_numbers_san[0]},
-            {'partner': self.partner_2, 'state': 'sent', 'number': self.random_numbers_san[1]}
+            {'partner': self.partner_1, 'state': 'processing', 'number': self.random_numbers_san[0]},
+            {'partner': self.partner_2, 'state': 'processing', 'number': self.random_numbers_san[1]}
         ], 'TEST BODY', self.msg, check_sms=True)
         self.assertMessageBusNotifications(self.msg)
 
@@ -194,6 +194,6 @@ class TestSMSWizards(TestSMSActionsCommon):
             with self.mockSMSGateway():
                 wizard.action_resend()
 
-        self.assertSMSNotification([{'partner': self.partner_1, 'state': 'sent'}], 'TEST BODY', self.msg, check_sms=True)
+        self.assertSMSNotification([{'partner': self.partner_1, 'state': 'processing'}], 'TEST BODY', self.msg, check_sms=True)
         self.assertSMSNotification([{'partner': self.partner_2, 'state': 'canceled', 'number': self.notif_p2.sms_number, 'failure_type': 'sms_credit'}], 'TEST BODY', self.msg, check_sms=False)
         self.assertMessageBusNotifications(self.msg)

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -42,7 +42,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
             )
 
         self.assertEqual(record.message_ids[0].body, '<p>Performance Test</p>')
-        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages, sent_unlink=True)
+        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages)
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
     @users('employee')
@@ -57,7 +57,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
             )
 
         self.assertEqual(record.message_ids[0].body, '<p>Performance Test</p>')
-        self.assertSMSNotification([{'partner': partner} for partner in self.partners], 'Performance Test', messages, sent_unlink=True)
+        self.assertSMSNotification([{'partner': partner} for partner in self.partners], 'Performance Test', messages)
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
     @users('employee')
@@ -70,7 +70,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
             )
 
         self.assertEqual(record.message_ids[0].body, '<p>Performance Test</p>')
-        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages, sent_unlink=True)
+        self.assertSMSNotification([{'partner': self.customer}], 'Performance Test', messages)
 
 
 @tagged('mail_performance')

--- a/addons/test_mail_sms/tests/test_sms_post.py
+++ b/addons/test_mail_sms/tests/test_sms_post.py
@@ -333,9 +333,9 @@ class TestSMSPostException(TestSMSCommon, TestSMSRecipients):
             messages = test_record._message_sms(self._test_body, partner_ids=(self.partner_1 | self.partner_2 | self.partner_3).ids)
 
         self.assertSMSNotification([
-            {'partner': self.partner_1, 'state': 'sent'},
+            {'partner': self.partner_1, 'state': 'processing'},
             {'partner': self.partner_2, 'state': 'exception', 'failure_type': 'sms_credit'},
-            {'partner': self.partner_3, 'state': 'sent'},
+            {'partner': self.partner_3, 'state': 'processing'},
         ], self._test_body, messages)
 
     def test_message_sms_crash_server_crash(self):
@@ -365,9 +365,9 @@ class TestSMSPostException(TestSMSCommon, TestSMSRecipients):
             messages = test_record._message_sms(self._test_body, partner_ids=(self.partner_1 | self.partner_2 | self.partner_3).ids)
 
         self.assertSMSNotification([
-            {'partner': self.partner_1, 'state': 'sent'},
+            {'partner': self.partner_1, 'state': 'processing'},
             {'partner': self.partner_2, 'state': 'exception', 'failure_type': 'sms_acc'},
-            {'partner': self.partner_3, 'state': 'sent'},
+            {'partner': self.partner_3, 'state': 'processing'},
         ], self._test_body, messages)
 
     def test_message_sms_crash_wrong_number(self):
@@ -386,9 +386,9 @@ class TestSMSPostException(TestSMSCommon, TestSMSRecipients):
             messages = test_record._message_sms(self._test_body, partner_ids=(self.partner_1 | self.partner_2 | self.partner_3).ids)
 
         self.assertSMSNotification([
-            {'partner': self.partner_1, 'state': 'sent'},
+            {'partner': self.partner_1, 'state': 'processing'},
             {'partner': self.partner_2, 'state': 'exception', 'failure_type': 'sms_number_format'},
-            {'partner': self.partner_3, 'state': 'sent'},
+            {'partner': self.partner_3, 'state': 'processing'},
         ], self._test_body, messages)
 
 

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -238,7 +238,7 @@ class TestMassSMS(TestMassSMSCommon):
         self.assertSMSTraces(
             [{'partner': record.customer_id,
               'number': self.records_numbers[i],
-              'trace_status': 'sent',
+              'trace_status': 'processing',
               'content': 'Dear %s this is a mass SMS with two links' % record.display_name
              } for i, record in enumerate(self.records)],
             mailing, self.records,
@@ -273,7 +273,7 @@ class TestMassSMS(TestMassSMSCommon):
         self.assertSMSTraces(
             [{'partner': record.customer_id,
               'number': record.customer_id.phone_sanitized,
-              'trace_status': 'sent',
+              'trace_status': 'processing',
               'content': 'Dear %s this is a mass SMS with two links' % record.display_name
              } for record in records],
             mailing, records,
@@ -298,7 +298,7 @@ class TestMassSMS(TestMassSMSCommon):
         self.assertSMSTraces(
             [{'partner': new_record.customer_id,
               'number': new_record.customer_id.phone_sanitized,
-              'trace_status': 'sent',
+              'trace_status': 'processing',
               'content': 'Dear %s this is a mass SMS with two links' % new_record.display_name
              }],
             mailing, new_record,
@@ -353,8 +353,8 @@ class TestMassSMS(TestMassSMSCommon):
         self.assertSMSTraces(
             [{'number': '+32456000000', 'trace_status': 'cancel', 'failure_type': 'sms_optout'},
              {'number': '+32456000101', 'trace_status': 'cancel', 'failure_type': 'sms_optout'},
-             {'number': '+32456000202', 'trace_status': 'sent'},
-             {'number': '+32456000303', 'trace_status': 'sent'},
+             {'number': '+32456000202', 'trace_status': 'processing'},
+             {'number': '+32456000303', 'trace_status': 'processing'},
              {'number': '+32456000404', 'trace_status': 'cancel', 'failure_type': 'sms_blacklist'}],
             mailing, recipients
         )

--- a/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
@@ -42,10 +42,10 @@ class TestMailingStatistics(TestMassSMSCommon):
 
         # check mailing statistics
         self.assertEqual(mailing.clicked, 3)
-        self.assertEqual(mailing.delivered, 10)
+        self.assertEqual(mailing.delivered, 3)
         self.assertEqual(mailing.opened, 3)
         self.assertEqual(mailing.opened_ratio, 30)
-        self.assertEqual(mailing.sent, 10)
+        self.assertEqual(mailing.processing, 7)
 
         with self.mock_mail_gateway(mail_unlink_sent=True):
             mailing._action_send_statistics()
@@ -62,8 +62,8 @@ class TestMailingStatistics(TestMassSMSCommon):
         body_html = html.fromstring(mail.body_html)
         kpi_values = body_html.xpath('//div[@data-field="sms"]//*[hasclass("kpi_value")]/text()')
         self.assertEqual(
-            [t.strip().strip('%') for t in kpi_values],
-            ['100', str(mailing.opened_ratio), str(mailing.replied_ratio)]
+            [t.strip().strip('%') for t in kpi_values], #received, clicked, bounced
+            ['30', str(mailing.opened_ratio), str(mailing.replied_ratio)]
         )
         # test body content: clicks (a bit hackish but hey we are in stable)
         kpi_click_values = body_html.xpath('//div[hasclass("global_layout")]/table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

-Users doesn't know the real state of the sms sent. Only if there was no errors on iap-service, but that doesn't mean they where all sent to the contacts without problem.

Current behavior before PR:

-The only feedback is from iap-services as a return of the client request.

Desired behavior after PR is merged:

-Now there is a feedback coming from the provider to iap-services that we send back to client with a specific route.

Task: 2630217

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
