### PR TITLE
[FIX] web: Allow quick-create contact in document

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -488,12 +488,23 @@ var FieldMany2One = AbstractField.extend({
                 dialog.on('closed', self, createDone);
             };
             if (self.nodeOptions.quick_create) {
-                const prom = self.reinitialize({id: false, display_name: name});
+                const prom =  self._rpc({
+                    model: self.field.relation,
+                    method: 'name_create',
+                    args: [name],
+                    context: self.record.getContext(self.recordParams),
+                });
                 prom.guardedCatch(reason => {
                     reason.event.preventDefault();
                     slowCreate();
                 });
-                self.dp.add(prom).then(createDone).guardedCatch(reject);
+                self.dp.add(prom).then(function (result) {
+                    if (self.mode === "edit") {
+                        self.reinitialize({id: result[0], display_name: result[1]});
+                    }
+                    createDone();
+                }).guardedCatch(reject);
+
             } else {
                 slowCreate();
             }


### PR DESCRIPTION
Steps to reproduce:

  - Install Documents
  - Select any document
  - Change `Contact` to new one and click on create

Issue:

  Contact not created.

Cause:

  On click create, it does not call 'name_create'.

Solution:

  Do a name_create (Reverse to what is done in 13.0).

opw-2621062