### PR TITLE
[IMP] mrp(_account), stock: improve MRP reporting + add byproduct cost share

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -458,8 +458,8 @@
             <field name="name">Drawer Black</field>
             <field name="categ_id" ref="product.product_category_5"/>
             <field name="tracking">lot</field>
-            <field name="standard_price">2000.0</field>
-            <field name="list_price">2250.0</field>
+            <field name="standard_price">20.0</field>
+            <field name="list_price">24.0</field>
             <field name="type">product</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
@@ -474,8 +474,8 @@
             <field name="name">Drawer Case Black</field>
             <field name="categ_id" ref="product.product_category_5"/>
             <field name="tracking">lot</field>
-            <field name="standard_price">800</field>
-            <field name="list_price">850</field>
+            <field name="standard_price">10</field>
+            <field name="list_price">20</field>
             <field name="type">product</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
@@ -568,35 +568,35 @@
 
         <!-- BoM -->
 
-        <record id="mrp_bom_laptop_cust" model="mrp.bom">
+        <record id="mrp_bom_drawer" model="mrp.bom">
             <field name="product_tmpl_id" ref="product.product_product_27_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
             <field name="code">PRIM-ASSEM</field>
         </record>
-        <record id="mrp_bom_laptop_cust_line_1" model="mrp.bom.line">
+        <record id="mrp_bom_drawer_line_1" model="mrp.bom.line">
             <field name="product_id" ref="product_product_drawer_drawer"/>
             <field name="product_qty">1</field>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_laptop_cust"/>
+            <field name="bom_id" ref="mrp_bom_drawer"/>
         </record>
-        <record id="mrp_bom_laptop_cust_line_2" model="mrp.bom.line">
+        <record id="mrp_bom_drawer_line_2" model="mrp.bom.line">
             <field name="product_id" ref="product_product_drawer_case"/>
             <field name="product_qty">1</field>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">2</field>
-            <field name="bom_id" ref="mrp_bom_laptop_cust"/>
+            <field name="bom_id" ref="mrp_bom_drawer"/>
         </record>
 
-        <record id="mrp_bom_laptop_cust_rout" model="mrp.bom">
+        <record id="mrp_bom_drawer_rout" model="mrp.bom">
             <field name="product_tmpl_id" ref="product.product_product_27_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">2</field>
             <field name="code">SEC-ASSEM</field>
         </record>
         <record id="mrp_routing_workcenter_1" model="mrp.routing.workcenter">
-            <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
+            <field name="bom_id" ref="mrp_bom_drawer_rout"/>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Long time assembly</field>
             <field name="time_cycle">180</field>
@@ -606,7 +606,7 @@
         </record>
 
         <record id="mrp_routing_workcenter_3" model="mrp.routing.workcenter">
-            <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
+            <field name="bom_id" ref="mrp_bom_drawer_rout"/>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Testing</field>
             <field name="time_cycle">60</field>
@@ -616,7 +616,7 @@
         </record>
 
         <record id="mrp_routing_workcenter_4" model="mrp.routing.workcenter">
-            <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
+            <field name="bom_id" ref="mrp_bom_drawer_rout"/>
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
             <field name="name">Packing</field>
             <field name="time_cycle">30</field>
@@ -624,37 +624,37 @@
             <field name="worksheet_type">pdf</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
-        <record id="mrp_bom_laptop_cust_rout_line_1" model="mrp.bom.line">
+        <record id="mrp_bom_drawer_rout_line_1" model="mrp.bom.line">
             <field name="product_id" ref="product_product_drawer_drawer"/>
             <field name="product_qty">1</field>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
+            <field name="bom_id" ref="mrp_bom_drawer_rout"/>
         </record>
-        <record id="mrp_bom_laptop_cust_rout_line_2" model="mrp.bom.line">
+        <record id="mrp_bom_drawer_rout_line_2" model="mrp.bom.line">
             <field name="product_id" ref="product_product_drawer_case"/>
             <field name="product_qty">1</field>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">2</field>
-            <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
+            <field name="bom_id" ref="mrp_bom_drawer_rout"/>
         </record>
 
         <record id="product.product_product_27" model="product.product">
             <field name="type">product</field>
         </record>
-        <record id="mrp_production_laptop_cust" model="mrp.production">
+        <record id="mrp_production_drawer" model="mrp.production">
             <field name="product_id" ref="product.product_product_27"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="product_qty">5</field>
             <field name="location_src_id" ref="stock.stock_location_stock"/>
             <field name="location_dest_id" ref="stock.stock_location_stock"/>
-            <field name="bom_id" ref="mrp_bom_laptop_cust"/>
+            <field name="bom_id" ref="mrp_bom_drawer"/>
         </record>
 
         <function model="stock.move" name="create">
             <value model="stock.move" eval="
-                obj().env.ref('mrp.mrp_production_laptop_cust')._get_moves_raw_values() +
-                obj().env.ref('mrp.mrp_production_laptop_cust')._get_moves_finished_values()"/>
+                obj().env.ref('mrp.mrp_production_drawer')._get_moves_raw_values() +
+                obj().env.ref('mrp.mrp_production_drawer')._get_moves_finished_values()"/>
         </function>
 
         <!-- Run Scheduler -->
@@ -711,7 +711,7 @@
         <function model="mrp.production" name="action_confirm" eval="[[
             ref('mrp.mrp_production_3'),
             ref('mrp.mrp_production_4'),
-            ref('mrp.mrp_production_laptop_cust'),
+            ref('mrp.mrp_production_drawer'),
         ]]"/>
 
         <function model="mrp.production" name="button_plan">
@@ -719,25 +719,25 @@
         </function>
 
         <function model="mrp.production" name="write">
-            <value eval="[ref('mrp.mrp_production_laptop_cust')]"/>
+            <value eval="[ref('mrp.mrp_production_drawer')]"/>
             <value eval="{'qty_producing': 5, 'lot_producing_id': ref('mrp.lot_product_27_0')}"/>
         </function>
 
         <function model="mrp.production" name="action_assign">
-            <value eval="[ref('mrp.mrp_production_laptop_cust')]"/>
+            <value eval="[ref('mrp.mrp_production_drawer')]"/>
         </function>
 
         <function model="stock.move" name="write">
-            <value model="stock.move" eval="obj().env['stock.move'].search([('raw_material_production_id', '=', obj().env.ref('mrp.mrp_production_laptop_cust').id)]).ids"/>
+            <value model="stock.move" eval="obj().env['stock.move'].search([('raw_material_production_id', '=', obj().env.ref('mrp.mrp_production_drawer').id)]).ids"/>
             <value eval="{'quantity_done': 5}"/>
         </function>
 
         <function model="mrp.production" name="_post_inventory">
-            <value eval="[ref('mrp.mrp_production_laptop_cust')]"/>
+            <value eval="[ref('mrp.mrp_production_drawer')]"/>
         </function>
 
         <function model="mrp.production" name="button_mark_done">
-            <value eval="[ref('mrp.mrp_production_laptop_cust')]"/>
+            <value eval="[ref('mrp.mrp_production_drawer')]"/>
         </function>
 
         <!-- set 'create component' as True for the demo manufacturing picking type

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -135,6 +135,10 @@ class MrpWorkorder(models.Model):
         help="Technical field indicating whether the current user is working. ")
     working_user_ids = fields.One2many('res.users', string='Working user on this work order.', compute='_compute_working_users')
     last_working_user_id = fields.One2many('res.users', string='Last user that worked on this work order.', compute='_compute_working_users')
+    costs_hour = fields.Float(
+        string='Cost per hour',
+        help='Technical field to store the hourly cost of workcenter at time of work order completion (i.e. to keep a consistent cost).',
+        default=0.0, group_operator="avg")
 
     next_work_order_id = fields.Many2one('mrp.workorder', "Next Work Order", check_company=True)
     scrap_ids = fields.One2many('stock.scrap', 'workorder_id')
@@ -570,7 +574,8 @@ class MrpWorkorder(models.Model):
                 'qty_produced': workorder.qty_produced or workorder.qty_producing or workorder.qty_production,
                 'state': 'done',
                 'date_finished': end_date,
-                'date_planned_finished': end_date
+                'date_planned_finished': end_date,
+                'costs_hour': workorder.workcenter_id.costs_hour
             }
             if not workorder.date_start:
                 vals['date_start'] = end_date
@@ -648,6 +653,7 @@ class MrpWorkorder(models.Model):
             'state': 'done',
             'date_finished': end_date,
             'date_planned_finished': end_date,
+            'costs_hour': self.workcenter_id.costs_hour
         })
 
     def button_scrap(self):

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -25,7 +25,7 @@ class ProductTemplate(models.Model):
 
     def _compute_bom_count(self):
         for product in self:
-            product.bom_count = self.env['mrp.bom'].search_count([('product_tmpl_id', '=', product.id)])
+            product.bom_count = self.env['mrp.bom'].search_count(['|', ('product_tmpl_id', '=', product.id), ('byproduct_ids.product_id.product_tmpl_id', '=', product.id)])
 
     def _compute_used_in_bom_count(self):
         for template in self:
@@ -73,7 +73,7 @@ class ProductProduct(models.Model):
 
     def _compute_bom_count(self):
         for product in self:
-            product.bom_count = self.env['mrp.bom'].search_count(['|', ('product_id', '=', product.id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product.product_tmpl_id.id)])
+            product.bom_count = self.env['mrp.bom'].search_count(['|', '|', ('byproduct_ids.product_id', '=', product.id), ('product_id', '=', product.id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product.product_tmpl_id.id)])
 
     def _compute_used_in_bom_count(self):
         for product in self:
@@ -181,12 +181,12 @@ class ProductProduct(models.Model):
     def action_view_bom(self):
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.product_open_bom")
         template_ids = self.mapped('product_tmpl_id').ids
-        # bom specific to this variant or global to template
+        # bom specific to this variant or global to template or that contains the product as a byproduct
         action['context'] = {
             'default_product_tmpl_id': template_ids[0],
             'default_product_id': self.ids[0],
         }
-        action['domain'] = ['|', ('product_id', 'in', self.ids), '&', ('product_id', '=', False), ('product_tmpl_id', 'in', template_ids)]
+        action['domain'] = ['|', '|', ('byproduct_ids.product_id', 'in', self.ids), ('product_id', 'in', self.ids), '&', ('product_id', '=', False), ('product_tmpl_id', 'in', template_ids)]
         return action
 
     def action_view_mos(self):

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="report_mrp_bom">
         <div class="container o_mrp_bom_report_page">
-            <t t-if="data.get('components') or data.get('lines')">
+            <t t-if="data.get('components') or data.get('lines') or data.get('operations')">
                 <div class="row">
                     <div class="col-lg-12">
                         <h1 style="display:inline;">BoM Structure </h1>
@@ -46,7 +46,7 @@
                                             <span><t t-esc="data['price']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
                                         </td>
                                         <td t-if="data['report_structure'] != 'bom_structure'" class="o_mrp_bom_cost text-right">
-                                            <span><t t-esc="data['total']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
+                                            <span><t t-esc="data['bom_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
                                         </td>
                                         <td t-if="data['report_type'] == 'html'">
                                             <span>
@@ -60,18 +60,36 @@
                                     <t t-if="data['report_type'] == 'pdf'" t-call="mrp.report_mrp_bom_pdf_line"/>
                                 </tbody>
                                 <tfoot>
-                                    <tr>
+                                    <tr t-if="data['report_structure'] != 'bom_structure'" class="o_mrp_prod_cost">
                                         <td></td>
-                                        <td name="td_mrp_bom_f"></td>
-                                        <td t-if="data['report_structure'] != 'bom_structure'" class="text-right o_mrp_prod_cost"><span><strong>Unit Cost</strong></span></td>
-                                        <td groups="uom.group_uom"></td>
-                                        <td t-if="data['report_structure'] != 'bom_structure'" class="o_mrp_prod_cost text-right">
+                                        <td name="td_mrp_bom_f" class="text-right">
+                                            <span><t t-if="data['byproducts']" t-esc="data['bom_prod_name']"/></span>
+                                        </td>
+                                        <td class="text-right"><span><strong>Unit Cost</strong></span></td>
+                                        <td groups="uom.group_uom"><span><t t-esc="data['bom'].product_uom_id.name"/></span></td>
+                                        <td class="text-right">
                                             <span><t t-esc="data['price']/data['bom_qty']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
                                         </td>
-                                        <td t-if="data['report_structure'] != 'bom_structure'" class="o_mrp_bom_cost text-right">
-                                            <span><t t-esc="data['total']/data['bom_qty']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
+                                        <td class="text-right">
+                                            <span><t t-esc="data['cost_share'] * data['total'] / data['bom_qty']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
                                         </td>
                                     </tr>
+                                    <t t-if="data['report_structure'] != 'bom_structure'" t-foreach="data['byproducts']" t-as="byproduct">
+                                        <tr class="o_mrp_bom_cost">
+                                            <td/>
+                                            <td name="td_mrp_bom_byproducts_f" class="text-right">
+                                                <span><t t-esc="byproduct['product_name']"/></span>
+                                            </td>
+                                            <td class="text-right"><span><strong>Unit Cost</strong></span></td>
+                                            <td groups="uom.group_uom"><span><t t-esc="byproduct['product_uom']"/></span></td>
+                                            <td class="text-right">
+                                                <span><t t-esc="byproduct['product_cost'] / byproduct['product_qty']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
+                                            </td>
+                                            <td class="text-right">
+                                                <span><t t-esc="byproduct['cost_share'] * data['total'] / byproduct['product_qty']" t-options='{"widget": "monetary", "display_currency": currency}'/></span>
+                                            </td>
+                                        </tr>
+                                    </t>
                                 </tfoot>
                             </table>
                         </div>
@@ -137,12 +155,30 @@
                     <span t-esc="data['operations_time']" t-options='{"widget": "float_time"}'/>
                 </td>
                 <td groups="uom.group_uom"><span>Minutes</span></td>
-                <td class="o_mrp_prod_cost">
-                </td>
+                <td/>
                 <td class="o_mrp_bom_cost text-right">
                     <span t-esc="data['operations_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>
                 </td>
                 <td/>
+            </tr>
+        </t>
+        <t t-if="data['byproducts']">
+            <t t-set="space_td" t-value="'margin-left: '+ str(data['level'] * 20) + 'px;'"/>
+            <tr class="o_mrp_bom_report_line o_mrp_bom_cost" t-att-data-id="'byproduct-' + str(data['bom'].id)" t-att-data-bom-id="data['bom'].id" t-att-parent_id="data['bom'].id" t-att-data-qty="data['bom_qty']" t-att-data-level="data['level']" t-att-data-total="data['total']">
+                <td name="td_byproducts">
+                    <span t-att-style="space_td"/>
+                    <span class="o_mrp_bom_unfoldable fa fa-fw fa-caret-right" t-att-data-function="'get_byproducts'" role="img" aria-label="Unfold" title="Unfold"/>
+                    By-Products
+                </td>
+                <td/>
+                <td class="text-right">
+                    <span t-esc="data['byproducts_total']"/>
+                </td>
+                <td groups="uom.group_uom"/>
+                <td/>
+                <td class="text-right">
+                    <span t-esc="data['byproducts_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>
+                </td>
             </tr>
         </t>
     </template>
@@ -161,13 +197,38 @@
                   <span t-esc="op['duration_expected']" t-options='{"widget": "float_time"}'/>
               </td>
               <td groups="uom.group_uom"><span>Minutes</span></td>
-              <td class="o_mrp_prod_cost"></td>
+              <td/>
               <td class="o_mrp_bom_cost text-right">
                   <span t-esc="op['total']" t-options='{"widget": "monetary", "display_currency": currency}'/>
               </td>
               <td/>
           </tr>
       </t>
+    </template>
+
+    <template id="report_mrp_byproduct_line">
+        <t t-set="currency" t-value="data['currency']"/>
+        <t t-foreach="data['byproducts']" t-as="byproduct">
+            <t t-set="space_td" t-value="'margin-left: '+ str(byproduct['level'] * 20) + 'px;'"/>
+            <tr class="o_mrp_bom_report_line o_mrp_bom_cost"  t-att-parent_id="'byproduct-' + str(data['bom_id'])">
+                <td name="td_byproduct_line">
+                    <span t-att-style="space_td"/>
+                    <a href="#" t-att-data-res-id="byproduct['product_id'].id" t-att-data-model="byproduct['product_id']._name" class="o_mrp_bom_action"><t t-esc="byproduct['product_name']"/></a>
+                </td>
+                <td/>
+                <td class="text-right">
+                    <span t-esc="byproduct['product_qty']"/>
+                </td>
+                <td groups="uom.group_uom"><span t-esc="byproduct['product_uom']"/></td>
+                <td class="text-right">
+                    <span t-esc="byproduct['product_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>
+                </td>
+                <td class="text-right">
+                    <span t-esc="byproduct['bom_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>
+                </td>
+                <td/>
+            </tr>
+        </t>
     </template>
 
     <template id="report_mrp_bom_pdf">
@@ -180,7 +241,7 @@
       <t t-set="currency" t-value="data['currency']"/>
       <t t-foreach="data['lines']" t-as="l">
           <t t-set="space_td" t-value="'margin-left: '+ str(l['level'] * 20) + 'px;'"/>
-          <tr t-if="data['report_structure'] != 'bom_structure' or l['type'] != 'operation'">
+          <tr t-if="data['report_structure'] != 'bom_structure' or l['type'] not in ['operation', 'byproduct']">
               <td>
                   <div t-att-style="space_td">
                     <div><t t-esc="l['name']"/></div>
@@ -192,7 +253,7 @@
               <td class="text-right">
                   <span>
                       <t t-if="l['type'] == 'operation'" t-esc="l['quantity']" t-options='{"widget": "float_time"}'/>
-                      <t t-if="l['type'] == 'bom'" t-esc="l['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
+                      <t t-if="l['type'] in ['bom', 'byproduct']" t-esc="l['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit of Measure"}'/>
                   </span>
               </td>
               <td groups="uom.group_uom"><span><t t-esc="l['uom']"/></span></td>

--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -101,6 +101,27 @@ var MrpBomReport = stock_report_generic.extend({
               self.render_html(event, $parent, result);
           });
     },
+    get_byproducts: function(event) {
+        var self = this;
+        var $parent = $(event.currentTarget).closest('tr');
+        var activeID = $parent.data('bom-id');
+        var qty = $parent.data('qty');
+        var level = $parent.data('level') || 0;
+        var total = $parent.data('total') || 0;
+        return this._rpc({
+                model: 'report.mrp.report_bom_structure',
+                method: 'get_byproducts',
+                args: [
+                    activeID,
+                    parseFloat(qty),
+                    level + 1,
+                    parseFloat(total)
+                ]
+            })
+            .then(function (result) {
+                self.render_html(event, $parent, result);
+            });
+      },
     update_cp: function () {
         var status = {
             cp_content: {

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -120,6 +120,7 @@
                                     <field name="product_id" context="{'default_type': 'product'}"/>
                                     <field name="product_qty"/>
                                     <field name="product_uom_id" groups="uom.group_uom"/>
+                                    <field name="cost_share" optional="hide"/>
                                     <field name="allowed_operation_ids" invisible="1"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" options="{'no_quick_create':True,'no_create_edit':True}"/>
                                     <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
@@ -268,13 +269,14 @@
         </record>
 
         <record id="template_open_bom" model="ir.actions.act_window">
-            <field name="context">{'default_product_tmpl_id': active_id, 'search_default_product_tmpl_id': active_id}</field>
+            <field name="context">{'default_product_tmpl_id': active_id}</field>
             <field name="name">Bill of Materials</field>
             <field name="res_model">mrp.bom</field>
+            <field name="domain">['|', ('product_tmpl_id', '=', active_id), ('byproduct_ids.product_id.product_tmpl_id', '=', active_id)]</field>
         </record>
 
         <record id="product_open_bom" model="ir.actions.act_window">
-            <field name="context">{'default_product_id': active_id, 'search_default_product_id': active_id}</field>
+            <field name="context">{'default_product_id': active_id}</field>
             <field name="name">Bill of Materials</field>
             <field name="res_model">mrp.bom</field>
             <field name="domain">[]</field> <!-- Force empty -->

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -468,7 +468,10 @@
             <field name="arch" type="xml">
                 <graph string="Manufacturing Orders" type="bar" stacked="False" sample="1">
                     <field name="date_planned_finished"/>
-                    <field name="product_uom_qty" type="measure" />                    
+                    <field name="product_uom_qty" type="measure"/>
+                    <field name="backorder_sequence" invisible="1"/>
+                    <field name="qty_producing" string="Quantity Produced"/>
+                    <field name="product_uom_qty" string= "Product Quantity"/>
                 </graph>
             </field>
         </record>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -578,7 +578,13 @@
             <field name="res_model">mrp.production</field>
             <field name="view_mode">graph,pivot,form</field>
             <field name="target">current</field>
-            <field name="context">{'search_default_scheduled_date': 1, 'search_default_product': 2, 'default_company_id': allowed_company_ids[0]}</field>
+            <field name="context">{
+                'search_default_product': 1,
+                'search_default_scheduled_date': 2,
+                'search_default_filter_confirmed': True,
+                'search_default_filter_planned': True,
+                'default_company_id': allowed_company_ids[0]
+            }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data yet!
@@ -605,7 +611,7 @@
             parent="menu_mrp_reporting"
             action="mrp_workorder_report"
             groups="group_mrp_routings"
-            sequence="11"/>
+            sequence="10"/>
 
         <record id="action_mrp_production_form" model="ir.actions.act_window">
             <field name="name">Manufacturing Orders</field>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -357,6 +357,7 @@
                                     <field name="is_quantity_done_editable" invisible="1"/>
                                     <field name="quantity_done" string="Produced" attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('is_quantity_done_editable', '=', False)]}"/>
                                     <field name="product_uom" groups="uom.group_uom"/>
+                                    <field name="cost_share" optional="hide"/>
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         groups="stock.group_production_lot"

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -134,7 +134,11 @@
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">mrp.workorder</field>
             <field name="domain">[]</field>
-            <field name="context">{'search_default_workcenter': 1, 'search_default_product': 2}</field>
+            <field name="context">{'search_default_workcenter': 1,
+                                   'search_default_ready': True,
+                                   'search_default_waiting': True,
+                                   'search_default_pending': True,
+                                   'search_default_progress': True,}</field>
             <field name="view_mode">graph,pivot,tree,form,gantt</field>
             <field name="search_view_id" ref="view_mrp_production_work_order_search"/>
             <field name="help" type="html">
@@ -316,7 +320,12 @@
                                     <span class="o_stat_text">Lost</span>
                                 </div>
                             </button>
-                            <button name="%(action_mrp_workcenter_load_report_graph)d" type="action" class="oe_stat_button" icon="fa-bar-chart" context="{'search_default_workcenter_id': id}">
+                            <button name="%(action_mrp_workcenter_load_report_graph)d" type="action" class="oe_stat_button" icon="fa-bar-chart"
+                                context="{'search_default_workcenter_id': id,
+                                          'search_default_ready': True,
+                                          'search_default_waiting': True,
+                                          'search_default_pending': True,
+                                          'search_default_progress': True}">
                                 <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value"><field name="workcenter_load" widget="statinfo" nolabel="1"/> Minutes</span>
                                     <span class="o_stat_text">Load</span>

--- a/addons/mrp/views/stock_scrap_views.xml
+++ b/addons/mrp/views/stock_scrap_views.xml
@@ -22,4 +22,15 @@
             </field>
         </field>
     </record>
+
+    <record id="stock_scrap_search_view_inherit_mrp" model="ir.ui.view">
+        <field name="name">stock.scrap.search.inherit.mrp</field>
+        <field name="model">stock.scrap</field>
+        <field name="inherit_id" ref="stock.stock_scrap_search_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='transfer']" position="after">
+                <filter string="Manufacturing Order" name="production_id" domain="[]" context="{'group_by':'production_id'}"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/mrp_account/__manifest__.py
+++ b/addons/mrp_account/__manifest__.py
@@ -19,12 +19,13 @@ If the automated inventory valuation is active, the necessary accounting entries
 """,
     'website': 'https://www.odoo.com/app/manufacturing',
     'depends': ['mrp', 'stock_account'],
-    "init_xml" : [],
-    "demo_xml" : [],
     "data": [
         'security/ir.model.access.csv',
         "views/product_views.xml",
         "views/mrp_production_views.xml",
+    ],
+    'demo': [
+        'data/mrp_account_demo.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/mrp_account/data/mrp_account_demo.xml
+++ b/addons/mrp_account/data/mrp_account_demo.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Create extra MOs that will have stock.valuation.layers + can be used to populate reports -->
+    <record id="mrp_production_drawer_2" model="mrp.production">
+        <field name="product_id" ref="product.product_product_27"/>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="product_qty">5</field>
+        <field name="location_src_id" ref="stock.stock_location_stock"/>
+        <field name="location_dest_id" ref="stock.stock_location_stock"/>
+        <field name="bom_id" ref="mrp.mrp_bom_drawer"/>
+        <field name="create_date" eval="(datetime.now() - relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M:%S')"/>
+        <field name="date_planned_start" eval="(datetime.now() - relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
+
+    <record id="mrp_production_drawer_3" model="mrp.production">
+        <field name="product_id" ref="product.product_product_27"/>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="product_qty">3</field>
+        <field name="location_src_id" ref="stock.stock_location_stock"/>
+        <field name="location_dest_id" ref="stock.stock_location_stock"/>
+        <field name="bom_id" ref="mrp.mrp_bom_drawer"/>
+        <field name="create_date" eval="(datetime.now() - relativedelta(weeks=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
+        <field name="date_planned_start" eval="(datetime.now() - relativedelta(weeks=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
+
+    <function model="stock.move" name="create">
+        <value model="stock.move" eval="
+            obj().env.ref('mrp_account.mrp_production_drawer_2')._get_moves_raw_values() +
+            obj().env.ref('mrp_account.mrp_production_drawer_2')._get_moves_finished_values() +
+            obj().env.ref('mrp_account.mrp_production_drawer_3')._get_moves_raw_values() +
+            obj().env.ref('mrp_account.mrp_production_drawer_3')._get_moves_finished_values()"/>
+    </function>
+
+    <function model="mrp.production" name="action_confirm" eval="[[
+        ref('mrp_account.mrp_production_drawer_2'),
+        ref('mrp_account.mrp_production_drawer_3'),
+    ]]"/>
+
+    <function model="mrp.production" name="write">
+        <value eval="[ref('mrp_account.mrp_production_drawer_2')]"/>
+        <value eval="{'qty_producing': 5, 'lot_producing_id': ref('mrp.lot_product_27_0')}"/>
+    </function>
+    <function model="mrp.production" name="write">
+        <value eval="[ref('mrp_account.mrp_production_drawer_3')]"/>
+        <value eval="{'qty_producing': 3, 'lot_producing_id': ref('mrp.lot_product_27_0')}"/>
+    </function>
+
+    <function model="mrp.production" name="action_assign">
+        <value eval="[ref('mrp_account.mrp_production_drawer_2'),
+                        ref('mrp_account.mrp_production_drawer_3')]"/>
+    </function>
+
+    <function model="stock.move" name="write">
+        <value model="stock.move" eval="obj().env['stock.move'].search([('raw_material_production_id', '=', obj().env.ref('mrp_account.mrp_production_drawer_2').id)]).ids"/>
+        <value eval="{'quantity_done': 5}"/>
+    </function>
+    <function model="stock.move" name="write">
+        <value model="stock.move" eval="obj().env['stock.move'].search([('raw_material_production_id', '=', obj().env.ref('mrp_account.mrp_production_drawer_3').id)]).ids"/>
+        <value eval="{'quantity_done': 4}"/>
+    </function>
+
+    <function model="mrp.production" name="_post_inventory">
+        <value eval="[ref('mrp_account.mrp_production_drawer_2'),
+                        ref('mrp_account.mrp_production_drawer_3')]"/>
+    </function>
+
+    <function model="mrp.production" name="button_mark_done">
+        <value eval="[ref('mrp_account.mrp_production_drawer_2'),
+                        ref('mrp_account.mrp_production_drawer_3')]"/>
+    </function>
+
+    <!-- Rewrite history so they finished in the past so it looks more interesting in graphs -->
+    <function model="mrp.production" name="write">
+        <value eval="[ref('mrp_account.mrp_production_drawer_2')]"/>
+        <value eval="{'date_finished': (datetime.now() - relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M:%S')}"/>
+    </function>
+    <function model="mrp.production" name="write">
+        <value eval="[ref('mrp_account.mrp_production_drawer_3')]"/>
+        <value eval="{'date_finished': (datetime.now() - relativedelta(weeks=1)).strftime('%Y-%m-%d %H:%M:%S')}"/>
+    </function>
+</odoo>

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, _
-from odoo.exceptions import UserError
+from odoo import models
+from odoo.tools import float_round
 
 
 class ProductTemplate(models.Model):
@@ -39,6 +39,12 @@ class ProductProduct(models.Model):
         bom = self.env['mrp.bom']._bom_find(self)[self]
         if bom:
             self.standard_price = self._compute_bom_price(bom, boms_to_recompute=boms_to_recompute)
+        else:
+            bom = self.env['mrp.bom'].search([('byproduct_ids.product_id', '=', self.id)], order='sequence, product_id, id', limit=1)
+            if bom:
+                price = self._compute_bom_price(bom, boms_to_recompute=boms_to_recompute, byproduct_bom=True)
+                if price:
+                    self.standard_price = price
 
     def _compute_average_price(self, qty_invoiced, qty_to_invoice, stock_moves):
         self.ensure_one()
@@ -61,7 +67,7 @@ class ProductProduct(models.Model):
             value += line_qty * move.product_id._compute_average_price(qty_invoiced * line_qty, qty_to_invoice * line_qty, move)
         return value
 
-    def _compute_bom_price(self, bom, boms_to_recompute=False):
+    def _compute_bom_price(self, bom, boms_to_recompute=False, byproduct_bom=False):
         self.ensure_one()
         if not bom:
             return 0
@@ -88,4 +94,16 @@ class ProductProduct(models.Model):
                 total += line.product_id.uom_id._compute_price(child_total, line.product_uom_id) * line.product_qty
             else:
                 total += line.product_id.uom_id._compute_price(line.product_id.standard_price, line.product_uom_id) * line.product_qty
-        return bom.product_uom_id._compute_price(total / bom.product_qty, self.uom_id)
+        if byproduct_bom:
+            byproduct_lines = bom.byproduct_ids.filtered(lambda b: b.product_id == self and b.cost_share != 0)
+            product_uom_qty = 0
+            for line in byproduct_lines:
+                product_uom_qty += line.product_uom_id._compute_quantity(line.product_qty, self.uom_id, round=False)
+            byproduct_cost_share = sum(byproduct_lines.mapped('cost_share'))
+            if byproduct_cost_share and product_uom_qty:
+                return total * byproduct_cost_share / 100 / product_uom_qty
+        else:
+            byproduct_cost_share = sum(bom.byproduct_ids.mapped('cost_share'))
+            if byproduct_cost_share:
+                total *= float_round(1 - byproduct_cost_share / 100, precision_rounding=0.0001)
+            return bom.product_uom_id._compute_price(total / bom.product_qty, self.uom_id)

--- a/addons/mrp_account/views/mrp_production_views.xml
+++ b/addons/mrp_account/views/mrp_production_views.xml
@@ -16,4 +16,15 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_production_graph_inherit_mrp_account" model="ir.ui.view">
+        <field name="name">mrp.production.graph.inherited.mrp.account</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.view_production_graph"/>
+        <field name="arch" type="xml">
+            <xpath expr="//graph" position="inside">
+                <field name="extra_cost" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -15,6 +15,7 @@
                         <filter string="Product" name="product" domain="[]" context="{'group_by':'product_id'}"/>
                         <filter string="Location" name="location" domain="[]" context="{'group_by':'location_id'}"/>
                         <filter string="Scrap Location" name="scrap_location" domain="[]" context="{'group_by':'scrap_location_id'}"/>
+                        <filter string="Transfer" name="transfer" domain="[]" context="{'group_by':'picking_id'}"/>
                     </group>
                 </search>
             </field>
@@ -136,7 +137,7 @@
             <field name="name">Scrap Orders</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">stock.scrap</field>
-            <field name="view_mode">tree,form,kanban</field>
+            <field name="view_mode">tree,form,kanban,pivot,graph</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Scrap products


### PR DESCRIPTION
This PR does multiple things:

1. Improve overall MRP reporting by:
- customizing the measures for "Reporting > MO" to hide not useful measures + give them better names
- storing a WO's `costs_hour` at time of completion so cost reporting stays consistent even when corresponding Work Center's `costs_hour` changes
- adds pivot/graph view for scrap orders

2. Allow by-products to have a "cost share" for a MO (i.e. split up total MO cost between product to produce and its by-products), which includes:
- Including cost share in stock valuation 
- Updating corresponding BoM cost structure report
- Allowing cost of a by-product (on its product page) be updated from a BoM it is a by-product of

Task: 2440068
ENT PR: odoo/enterprise#20169
Upgrade PR: odoo/upgrade#2727

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
