### PR TITLE
[FIX] project, hr_recruitment: give read access on ir.model

### DIFF
--- a/addons/hr_recruitment/security/ir.model.access.csv
+++ b/addons/hr_recruitment/security/ir.model.access.csv
@@ -12,3 +12,4 @@ access_hr_applicant_category,hr.applicant_category,model_hr_applicant_category,,
 access_hr_applicant_category_manager,hr.applicant_category,model_hr_applicant_category,group_hr_recruitment_user,1,1,1,1
 access_calendar_event_type_hr_officer,calendar.event.type.officer,calendar.model_calendar_event_type,group_hr_recruitment_user,1,1,1,0
 access_applicant_get_refuse_reason,access.applicant.get.refuse.reason,model_applicant_get_refuse_reason,hr_recruitment.group_hr_recruitment_user,1,1,1,0
+access_ir_model,access_ir_model,base.model_ir_model,hr_recruitment.group_hr_recruitment_user,1,0,0,0

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -19,6 +19,7 @@ access_project_tags_all,project.project_tags_all,model_project_tags,,1,0,0,0
 access_project_tags_manager,project.project_tags_manager,model_project_tags,project.group_project_manager,1,1,1,1
 access_project_tags_portal,project_tags_portal,project.model_project_tags,base.group_portal,1,0,0,0
 access_mail_activity_type_project_manager,mail.activity.type.project.manager,mail.model_mail_activity_type,project.group_project_manager,1,1,1,1
+access_ir_model,access_ir_model,base.model_ir_model,project.group_project_user,1,0,0,0
 access_account_analytic_account_user,account.analytic.account,analytic.model_account_analytic_account,project.group_project_user,1,0,0,0
 access_account_analytic_account_manager,account.analytic.account,analytic.model_account_analytic_account,project.group_project_manager,1,1,1,1
 access_account_analytic_line_project,account.analytic.line project,analytic.model_account_analytic_line,project.group_project_manager,1,1,1,1


### PR DESCRIPTION
Many2one to ir.model on mail.activity.type leads to an access error when
a project user or a recruitment officer open the Configuration > Activity
Types menu.

since #69120