### PR TITLE
[FIX] web: correctly position popover

### DIFF
--- a/addons/web/static/src/core/popover/popover.scss
+++ b/addons/web/static/src/core/popover/popover.scss
@@ -62,7 +62,7 @@
   &.o-popper-position {
     &--tm {
       animation: $animation-time slide-top;
-      margin-top: -$arrow-size;
+      margin-top: $arrow-size;
 
       &::before,
       &::after {
@@ -84,7 +84,7 @@
 
     &--rm {
       animation: $animation-time slide-right;
-      margin-left: $arrow-size;
+      margin-left: -$arrow-size;
 
       &::before,
       &::after {
@@ -106,7 +106,7 @@
 
     &--bm {
       animation: $animation-time slide-bottom;
-      margin-top: $arrow-size;
+      margin-top: -$arrow-size;
 
       &::before,
       &::after {
@@ -128,7 +128,7 @@
 
     &--lm {
       animation: $animation-time slide-left;
-      margin-left: -$arrow-size;
+      margin-left: $arrow-size;
 
       &::before,
       &::after {


### PR DESCRIPTION
Before this commit, the popover was a bit far from its target. We
use a margin to compensate the arrow size (8px), but we used it the
wrong way, meaning that instead of applying, e.g. a margin of -8px,
we applied a margin of 8px. As a consequence, popover were always
positionned at 16px from their target.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
