### PR TITLE
[FIX] purchase: show confirmation date in locked PO

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -164,8 +164,8 @@
                             <field name="currency_id" groups="base.group_multi_currency" force_save="1"/>
                         </group>
                         <group>
-                            <field name="date_order" attrs="{'invisible': [('state','=','purchase')]}"/>
-                            <field name="date_approve" attrs="{'invisible': [('state','!=','purchase')]}"/>
+                            <field name="date_order" attrs="{'invisible': [('state','in',('purchase','done'))]}"/>
+                            <field name="date_approve" attrs="{'invisible': [('state','not in',('purchase','done'))]}"/>
                             <field name="origin" attrs="{'invisible': [('origin','=',False)]}"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                         </group>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to purchase app > create a request for quotation
- click on confirm > Lock

Problem:
Date confirmation becomes invisible, and date order becomes visible

Solution:
As we have already confirmed the purchase order and the lock button only appears when the PO is confirmed,
it makes sense to leave the confirmation date visible

https://github.com/odoo/odoo/blob/13.0/addons/purchase/views/purchase_views.xml#L138-L139

opw-2612608




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
