### PR TITLE
[FIX] web_editor: command bar hints styling issues

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -295,5 +295,9 @@ i.oe-commandbar-commandImg {
     top: 0;
     left: 0;
     display: block;
-    color: rgba(55, 53, 47, 0.4);
+    color: inherit;
+    opacity: 0.4;
+    pointer-events: none;
+    text-align: inherit;
+    width: 100%;
 }


### PR DESCRIPTION
The command bar hints were not properly text-aligned, and the color was sometime not visible depending on the background.

task-2607335
task-2607337




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
