### PR TITLE
[FIX] stock: Fix forecast availability unit of measure mismatch

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -427,7 +427,8 @@ class StockMove(models.Model):
             if picking_type.code in self._consuming_picking_types() and is_unreserved:
                 outgoing_unreserved_moves_per_warehouse[warehouse_by_location[move.location_id]] |= move
             elif picking_type.code in self._consuming_picking_types():
-                move.forecast_availability = move.reserved_availability
+                move.forecast_availability = move.product_uom._compute_quantity(
+                    move.reserved_availability, move.product_id.uom_id, rounding_method='HALF-UP')
 
         for warehouse, moves in outgoing_unreserved_moves_per_warehouse.items():
             if not warehouse:  # No prediction possible if no warehouse.

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -4538,3 +4538,37 @@ class StockMove(SavepointCase):
         line1_result_package = picking.move_line_ids[0].result_package_id
         line2_result_package = picking.move_line_ids[1].result_package_id
         self.assertNotEqual(line1_result_package, line2_result_package, "Product and Product1 should be in a different package.")
+
+    def test_forecast_availability(self):
+        """ Make an outgoing picking in dozens for a product stored in units.
+        Check that reserved_availabity is expressed in move uom and forecast_availability is in product base uom
+        """
+        # create product
+        product = self.env['product.product'].create({
+            'name': 'Product In Units',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+        # make some stock
+        self.env['stock.quant']._update_available_quantity(product, self.stock_location, 36.0)
+        # create picking
+        picking_out = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id})
+        move = self.env['stock.move'].create({
+            'name': product.name,
+            'product_id': product.id,
+            'product_uom': self.uom_dozen.id,
+            'product_uom_qty': 2.0,
+            'picking_id': picking_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id})
+        # confirm
+        picking_out.action_confirm()
+        # check availability
+        picking_out.action_assign()
+        # check reserved_availabity expressed in move uom
+        self.assertEqual(move.reserved_availability, 2)
+        # check forecast_availability expressed in product base uom
+        self.assertEqual(move.forecast_availability, 24)


### PR DESCRIPTION
reserved_availability is expressed in move uom
forecast_availability must be in product base uom

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
