### PR TITLE
[IMP] hr_timesheet,sale_timesheet: improve setting in the timesheet m…

### DIFF
--- a/addons/hr_timesheet/data/hr_timesheet_data.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_data.xml
@@ -15,17 +15,6 @@
         name="_init_data_analytic_account"
         eval="[]"/>
 
-    <data noupdate="1">
-        <record id="ir_config_parameter_timesheet_rounding" model="ir.config_parameter">
-            <field name="key">hr_timesheet.timesheet_rounding</field>
-            <field name="value">15</field>
-        </record>
-        <record id="ir_config_parameter_timesheet_min_duration" model="ir.config_parameter">
-            <field name="key">hr_timesheet.timesheet_min_duration</field>
-            <field name="value">15</field>
-        </record>
-    </data>
-
     <record id="internal_project_default_stage" model="project.task.type">
         <field name="sequence">1</field>
         <field name="name">Internal</field>

--- a/addons/hr_timesheet/models/res_config_settings.py
+++ b/addons/hr_timesheet/models/res_config_settings.py
@@ -9,8 +9,10 @@ class ResConfigSettings(models.TransientModel):
 
     module_project_timesheet_synchro = fields.Boolean("Awesome Timesheet",
         compute="_compute_timesheet_modules", store=True, readonly=False)
-    module_project_timesheet_holidays = fields.Boolean("Record Time Off",
+    module_project_timesheet_holidays = fields.Boolean("Time Off",
         compute="_compute_timesheet_modules", store=True, readonly=False)
+    reminder_user_allow = fields.Boolean(string="Employee Reminder", help="If checked, send an email to all users who have not recorded their timesheet")
+    reminder_manager_allow = fields.Boolean(string="Manager Reminder", help="If checked, send an email to all manager")
     project_time_mode_id = fields.Many2one(
         'uom.uom', related='company_id.project_time_mode_id', string='Project Time Unit', readonly=False,
         help="This will set the unit of measure used in projects and tasks.\n"
@@ -20,8 +22,6 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.timesheet_encode_uom_id', readonly=False,
         help="""This will set the unit of measure used to encode timesheet. This will simply provide tools
         and widgets to help the encoding. All reporting will still be expressed in hours (default value).""")
-    timesheet_min_duration = fields.Integer('Minimal duration', default=15, config_parameter='hr_timesheet.timesheet_min_duration')
-    timesheet_rounding = fields.Integer('Rounding up', default=15, config_parameter='hr_timesheet.timesheet_rounding')
     is_encode_uom_days = fields.Boolean(compute='_compute_is_encode_uom_days')
 
     @api.depends('timesheet_encode_uom_id')

--- a/addons/hr_timesheet/static/src/js/timesheet_config_form_view.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_config_form_view.js
@@ -3,10 +3,35 @@ odoo.define('hr_timesheet.res.config.form', function (require) {
 
     const core = require('web.core');
     const config = require('web.config');
+    const Dialog = require('web.Dialog');
     const viewRegistry = require('web.view_registry');
     const BaseSetting = require('base.settings');
+    const QWeb = core.qweb;
     
     const _t = core._t;
+
+    const TimesheetConfigQRCodeDialog = Dialog.extend({
+        /**
+         * @override
+         */
+        init: function (parent, url) {
+            this.url = _.str.sprintf("/report/barcode/?type=QR&value=%s&width=256&height=256&humanreadable=1", url);
+            this._super(parent, {
+                title: _t('Download our App'),
+                buttons: [{
+                    text: _t('View App'),
+                    classes: 'btn-primary',
+                    click: function() {
+                        window.open(url, '_blank');
+                    }
+                }, {
+                    text: _t('Discard'),
+                    close: true
+                }],
+                $content: QWeb.render('hr_timesheet_qr_code', {widget: this})
+            });
+        },
+    });
 
     const TimesheetConfigQRCodeMixin = {
         async _renderView() {
@@ -14,16 +39,10 @@ odoo.define('hr_timesheet.res.config.form', function (require) {
             await this._super(...arguments);
             const google_url = "https://play.google.com/store/apps/details?id=com.odoo.OdooTimesheets";
             const apple_url = "https://apps.apple.com/be/app/awesome-timesheet/id1078657549";
-            const action_desktop = {
-                name: _t('Download our App'),
-                type: 'ir.actions.client',
-                tag: 'timesheet_qr_code_modal',
-                target: 'new',
-            };
             this.$el.find('img.o_config_app_store').on('click', function(event) {
                 event.preventDefault();
                 if (!config.device.isMobile) {
-                    self.do_action(_.extend(action_desktop, {params: {'url': apple_url}}));
+                    new TimesheetConfigQRCodeDialog(this, apple_url).open();
                 } else {
                     self.do_action({type: 'ir.actions.act_url', url: apple_url});
                 }
@@ -31,7 +50,7 @@ odoo.define('hr_timesheet.res.config.form', function (require) {
             this.$el.find('img.o_config_play_store').on('click', function(event) {
                 event.preventDefault();
                 if (!config.device.isMobile) {
-                    self.do_action(_.extend(action_desktop, {params: {'url': google_url}}));
+                    new TimesheetConfigQRCodeDialog(this, google_url).open();
                 } else {
                     self.do_action({type: 'ir.actions.act_url', url: google_url});
                 }
@@ -50,6 +69,6 @@ odoo.define('hr_timesheet.res.config.form', function (require) {
 
     viewRegistry.add('hr_timesheet_config_form', TimesheetConfigFormView);
 
-    return {TimesheetConfigQRCodeMixin, TimesheetConfigFormRenderer, TimesheetConfigFormView};
+    return {TimesheetConfigQRCodeDialog, TimesheetConfigQRCodeMixin, TimesheetConfigFormRenderer, TimesheetConfigFormView};
 
 });

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -37,7 +37,7 @@
                                 </div>
                                 <div class="content-group">
                                     <div class="mt16">
-                                        <field name="timesheet_encode_uom_id" options="{'no_create': True, 'no_open': True}" required="1" class="col-lg-5"/>
+                                        <field name="timesheet_encode_uom_id" options="{'no_create': True, 'no_open': True}" required="1" class="col-lg-5 pl-0"/>
                                         <field name="is_encode_uom_days" invisible="1"/>
                                     </div>
                                 </div>
@@ -69,21 +69,30 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('module_project_timesheet_synchro', '=', False), ('is_encode_uom_days', '=', True)]}">
-                            <div class="o_setting_right_pane">
-                                <strong>Time Rounding</strong>
+                    </div>
+                    <h2>Timesheets Control</h2>
+                    <div class="row mt16 o_settings_container">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="reminder_user_allow" widget="upgrade_boolean"/>
+                            </div>
+                            <div class="o_setting_right_pane" id="reminder_user_allow">
+                                <label for="reminder_user_allow"/>
+                                <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
-                                    Minimal duration and rounding applied when using the timer
+                                    Send a periodical email reminder to timesheets users
                                 </div>
-                                <div class="content-group">
-                                    <div class="mt16">
-                                        <div class="o_row w-30">
-                                            <span class="o_light_label"><label for="timesheet_min_duration"/><field name="timesheet_min_duration" class="col-lg-2 text-center"/> minutes</span>
-                                        </div>
-                                        <div class="o_row">
-                                            <span class="o_light_label"><label for="timesheet_rounding"/><field name="timesheet_rounding" class="col-lg-2 text-center"/> minutes</span>
-                                        </div>
-                                    </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="reminder_manager_allow" widget="upgrade_boolean"/>
+                            </div>
+                            <div class="o_setting_right_pane" id="reminder_manager_allow">
+                                <label for="reminder_manager_allow"/>
+                                <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
+                                <div class="text-muted">
+                                    Send a periodical email reminder to timesheets managers
                                 </div>
                             </div>
                         </div>
@@ -99,7 +108,7 @@
                                     <label for="module_project_timesheet_holidays"/>
                                     <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
                                     <div class="text-muted">
-                                        Create timesheets upon time off validation
+                                        Generate timesheets upon time off validation
                                     </div>
                                     <div class="content-group">
                                         <div id="module_project_timesheet_holidays"/>

--- a/addons/project_timesheet_holidays/views/res_config_settings_views.xml
+++ b/addons/project_timesheet_holidays/views/res_config_settings_views.xml
@@ -10,12 +10,12 @@
                 <div attrs="{'invisible': [('module_project_timesheet_holidays','=',False)]}">
                     <div class="row mt16">
                         <div class="w-100">
-                            <label string="Project" for="internal_project_id" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="internal_project_id" context="{'active_test': False}" class="oe_inline"/>
+                            <label string="Project" for="internal_project_id" class="col-2 col-lg-3"/>
+                            <field name="internal_project_id" context="{'active_test': False}" class="oe_inline ml16"/>
                         </div>
                         <div class="w-100">
-                            <label string="Task" for="leave_timesheet_task_id" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="leave_timesheet_task_id" context="{'active_test': False, 'default_project_id': internal_project_id}" class="oe_inline"/>
+                            <label string="Task" for="leave_timesheet_task_id" class="col-2 col-lg-3"/>
+                            <field name="leave_timesheet_task_id" context="{'active_test': False, 'default_project_id': internal_project_id}" class="oe_inline ml16"/>
                         </div>
                     </div>
                 </div>

--- a/addons/sale_timesheet/models/__init__.py
+++ b/addons/sale_timesheet/models/__init__.py
@@ -8,4 +8,5 @@ from . import project
 from . import project_overview
 from . import project_update
 from . import sale_order
+from . import res_config_settings
 from . import project_sale_line_employee_map

--- a/addons/sale_timesheet/models/res_config_settings.py
+++ b/addons/sale_timesheet/models/res_config_settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    invoice_policy = fields.Boolean(string="Invoice Policy", help="Timesheets taken when invoicing time spent")

--- a/addons/sale_timesheet/views/product_views.xml
+++ b/addons/sale_timesheet/views/product_views.xml
@@ -33,7 +33,7 @@
     </record>
 
     <record id="product_template_action_default_services" model="ir.actions.act_window">
-        <field name="name">Products</field>
+        <field name="name">Services</field>
         <field name="res_model">product.template</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="sale_timesheet.product_template_view_search_sale_timesheet"/>

--- a/addons/sale_timesheet/views/res_config_settings_views.xml
+++ b/addons/sale_timesheet/views/res_config_settings_views.xml
@@ -25,6 +25,17 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box" name="invoice_policy">
+                        <div class="o_setting_left_pane">
+                            <field name="invoice_policy" widget="upgrade_boolean"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="invoice_policy"/>
+                            <div class="text-muted">
+                                Timesheets taken into account when invoicing your time
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
…odule

The purpose of this task is to improve the setting of the timesheet module.

In this commit, we improve the following:
 - Rename the label, description and align the field with the name and
   description of the feature
 - Add an 'OK' button in the 'download our app' modal
 - Render the frequency field properly in the employee/manager reminders
   setting on mobile view
 - In configure your services link: change the name of the action to "Services"
 - Display the following options in the community, with the usual 'Enterprise'
   tag:  Round Timesheet, Employee/Manager reminder, Invoicing Policy

Task-Id: 2531338
PR: #74967

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
