### PR TITLE
do not show Add Custom Field in modal

### DIFF
--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -28,8 +28,6 @@ FormRenderer.include({
          * This is set when arch contains `div.oe_chatter`.
          */
         this._chatterContainerTarget = undefined;
-        // Do not load chatter in form view dialogs
-        this._isFromFormViewDialog = params.isFromFormViewDialog;
     },
     /**
      * @override

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1093,6 +1093,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
         this.isReadonly = this.mode === 'readonly';
         this.view = this.attrs.views[this.attrs.mode];
         this.isMany2Many = this.field.type === 'many2many' || this.attrs.widget === 'many2many';
+        this.isInDialog = options.isInDialog;
         this.activeActions = {};
         this.recordParams = {fieldName: this.name, viewType: this.viewType};
         // The limit is fixed so it cannot be changed by adding/removing lines in
@@ -1464,6 +1465,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
                 no_open: (this.isReadonly && !this.hasReadonlyModifier) &&
                     (this._canQuickEdit || toBoolElse(arch.attrs.no_open || '', false)),
                 columnInvisibleFields: this.currentColInvisibleFields,
+                isInDialog: this.isInDialog,
             });
         }
 

--- a/addons/web/static/src/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/js/views/basic/basic_renderer.js
@@ -738,6 +738,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
             hasReadonlyModifier: modifiers.readonly,
             mode: modifiers.readonly ? 'readonly' : mode,
             viewType: this.viewType,
+            isInDialog: options.isInDialog,
         };
         let widget;
         if (legacy) {

--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -51,6 +51,8 @@ var FormRenderer = BasicRenderer.extend({
         // display them (e.g. in Studio, in "show invisible" mode). This flag
         // allows to disable this optimization.
         this.renderInvisible = false;
+        // whether form is rendered in dialogs, some widgets are not rendered in dialog e.g. Chatter
+        this._isFromFormViewDialog = params.isFromFormViewDialog;
     },
     /**
      * @override
@@ -707,7 +709,7 @@ var FormRenderer = BasicRenderer.extend({
      * @returns {jQueryElement}
      */
     _renderInnerGroupField: function (node) {
-        var $el = this._renderFieldWidget(node, this.state);
+        var $el = this._renderFieldWidget(node, this.state, { isInDialog: this._isFromFormViewDialog });
         var $tds = $('<td/>').append($el);
 
         if (node.attrs.nolabel !== '1') {
@@ -870,7 +872,7 @@ var FormRenderer = BasicRenderer.extend({
      * @returns {jQueryElement}
      */
     _renderTagField: function (node) {
-        return this._renderFieldWidget(node, this.state);
+        return this._renderFieldWidget(node, this.state, { isInDialog: this._isFromFormViewDialog });
     },
     /**
      * @private

--- a/addons/web/static/src/js/views/form/form_view.js
+++ b/addons/web/static/src/js/views/form/form_view.js
@@ -47,7 +47,7 @@ var FormView = BasicView.extend({
         this.controllerParams.mode = mode;
 
         this.rendererParams.mode = mode;
-        this.rendererParams.isFromFormViewDialog = params.isFromFormViewDialog;
+        this.rendererParams.isFromFormViewDialog = params.isFromFormViewDialog || params.isInDialog;
         this.rendererParams.fieldIdsToNames = this.fieldsView.fieldIdsToNames;
     },
 
@@ -79,6 +79,7 @@ var FormView = BasicView.extend({
         params.hasSearchView = inDialog ? false : params.hasSearchView;
         params.hasActionMenus = !inDialog && !inline;
         params.searchMenuTypes = inDialog ? [] : params.searchMenuTypes;
+        params.isInDialog = inDialog;
         if (inDialog || inline || fullscreen) {
             params.mode = 'edit';
         } else if (action.context && action.context.form_view_initial_mode) {

--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -78,6 +78,7 @@ var ListRenderer = BasicRenderer.extend({
         this.isGrouped = this.state.groupedBy.length > 0;
         this.groupbys = params.groupbys;
         this.no_open = params.no_open;
+        this.isInDialog = params.isInDialog;
     },
     /**
      * Compute columns visilibity. This can't be done earlier as we need the

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -76,6 +76,7 @@ var ListView = BasicView.extend({
         this.rendererParams.addCreateLine = false;
         this.rendererParams.addCreateLineInGroups = editable && this.controllerParams.activeActions.create;
         this.rendererParams.isMultiEditable = this.arch.attrs.multi_edit && !!JSON.parse(this.arch.attrs.multi_edit);
+        this.rendererParams.isInDialog = params.isInDialog;
 
         this.modelParams.groupbys = this.groupbys;
 

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -363,6 +363,7 @@ var SelectCreateDialog = ViewDialog.extend({
             _.extend(viewOptions, {
                 hasSelectors: !this.options.disable_multiple_selection,
                 readonly: true,
+                isInDialog: true,
 
             }, this.options.list_view_options);
             selectCreateController = select_create_controllers_registry.SelectCreateListController;


### PR DESCRIPTION
PURPOSE
Since saas14.3, a new 'Add custom field' option has been appended to each optional fields dropdown.
This item is next to optional fields and redirects to the user to studio, inviting him to add custom fields.
Just like studio is not accessible on modals, the 'add custom field' link should not be available either.

SPECIFICATION
Hide the 'add custom field' link if the listview is in a modal

TASK 2523116


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
