### PR TITLE
[FIX] web: FieldDomain and DomainSelector in debug

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3357,16 +3357,11 @@ var JournalDashboardGraph = AbstractField.extend({
  * not allow to).
  */
 var FieldDomain = AbstractField.extend({
-    /**
-     * Fetches the number of records which are matched by the domain (if the
-     * domain is not server-valid, the value is false) and the model the
-     * field must work with.
-     */
-    specialData: "_fetchSpecialDomain",
-
+    resetOnAnyFieldChange: true,
     events: _.extend({}, AbstractField.prototype.events, {
         "click .o_domain_show_selection_button": "_onShowSelectionButtonClick",
         "click .o_field_domain_dialog_button": "_onDialogEditButtonClick",
+        "click .o_refresh_count": "_onRefreshCountClick",
     }),
     custom_events: _.extend({}, AbstractField.prototype.custom_events, {
         domain_changed: "_onDomainSelectorValueChange",
@@ -3392,6 +3387,11 @@ var FieldDomain = AbstractField.extend({
         }
 
         this._setState();
+
+        this._isValidForModel = true;
+        this.nbRecords = null;
+        this.lastCountFetchKey = null; // used to prevent from unnecessary fetching the count
+        this.debugEdition = false; // true iff the domain was edited with the textarea (in debug only)
     },
     /**
      * We use the on_attach_callback hook here when widget is attached to the DOM, so that
@@ -3408,6 +3408,19 @@ var FieldDomain = AbstractField.extend({
     // Public
     //--------------------------------------------------------------------------
 
+    /**
+     * The record is about to be saved, we need to ensure that the current
+     * domain is valid, if we manually edited it with the textarea. To do so,
+     * we perform a search_count with that domain.
+     *
+     * @override
+     * @returns {Promise|undefined}
+     */
+    commitChanges() {
+        if (this.debugEdition) {
+            return this._fetchCount();
+        }
+    },
     /**
      * A domain field is always set since the false value is considered to be
      * equal to "[]" (match all records).
@@ -3438,11 +3451,56 @@ var FieldDomain = AbstractField.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Fetches the number of records matching the current domain.
+     *
+     * @private
+     * @param {boolean} [force=false] if true, performs the rpc, even if the
+     *   domain is the same as before
+     * @returns {Promise}
+     */
+    _fetchCount(force = false) {
+        if (!this._domainModel) {
+            this._isValidForModel = true;
+            this.nbRecords = 0;
+            return Promise.resolve();
+        }
+
+        // do not re-fetch the count if nothing has changed
+        const value = this.value || "[]"; // false stands for the empty domain
+        const key = `${this._domainModel}/${value}`;
+        if (!force && this.lastCountFetchKey === key) {
+            return this.lastCountFetchProm;
+        }
+        this.lastCountFetchKey = key;
+
+        this.nbRecords = null;
+
+        const context = this.record.getContext({ fieldName: this.name });
+        this.lastCountFetchProm = new Promise((resolve) => {
+            this._rpc({
+                model: this._domainModel,
+                method: 'search_count',
+                args: [Domain.prototype.stringToArray(value, this.record.evalContext)],
+                context: context
+            }, { shadow: true }).then(async (nbRecords) => {
+                this._isValidForModel = true;
+                this.nbRecords = nbRecords;
+                resolve();
+            }).guardedCatch((reason) => {
+                reason.event.preventDefault(); // prevent traceback (the search_count might be intended to break)
+                this._isValidForModel = false;
+                this.nbRecords = 0;
+                resolve();
+            });
+        });
+        return this.lastCountFetchProm;
+    },
+    /**
      * @private
      * @override _render from AbstractField
      * @returns {Promise}
      */
-    _render: function () {
+    _render: async function () {
         // If there is no model, only change the non-domain-selector content
         if (!this._domainModel) {
             this._replaceContent();
@@ -3461,11 +3519,24 @@ var FieldDomain = AbstractField.extend({
                 debugMode: config.isDebug(),
             });
             def = this.domainSelector.prependTo(this.$el);
-        } else {
+        } else if (!this.debugEdition) {
+            // do not update the domainSelector if we edited the domain with the textarea
+            // as we don't want it to format what we just wrote
             def = this.domainSelector.setDomain(value);
         }
+
         // ... then replace the other content (matched records, etc)
-        return def.then(this._replaceContent.bind(this));
+        await Promise.resolve(def);
+        this._replaceContent();
+
+        // Finally, fetch the number of records matching the domain, but do not
+        // wait for it to render the field widget (simply update the number of
+        // records when we know it)
+        if (!this.debugEdition) {
+            // do not automatically recompute the count if we're editing the
+            // domain with the textarea
+            this._fetchCount().then(() => this._replaceContent());
+        }
     },
     /**
      * Render the field DOM except for the domain selector part. The full field
@@ -3481,8 +3552,10 @@ var FieldDomain = AbstractField.extend({
         this._$content = $(qweb.render("FieldDomain.content", {
             hasModel: !!this._domainModel,
             isValid: !!this._isValidForModel,
-            nbRecords: this.record.specialData[this.name].nbRecords || 0,
-            inDialogEdit: this.inDialog && this.mode === "edit",
+            nbRecords: this.nbRecords,
+            inDialog: this.inDialog,
+            editMode: this.mode === "edit",
+            isDebug: config.isDebug(),
         }));
         this._$content.appendTo(this.$el);
     },
@@ -3492,7 +3565,7 @@ var FieldDomain = AbstractField.extend({
      *
      * @private
      */
-    _reset: function () {
+    _reset: function (record, ev) {
         this._super.apply(this, arguments);
         var oldDomainModel = this._domainModel;
         this._setState();
@@ -3500,6 +3573,9 @@ var FieldDomain = AbstractField.extend({
             // If the model has changed, destroy the current domain selector
             this.domainSelector.destroy();
             this.domainSelector = null;
+        }
+        if (ev.target !== this) {
+            this.debugEdition = false;
         }
     },
     /**
@@ -3510,15 +3586,31 @@ var FieldDomain = AbstractField.extend({
      * @private
      */
     _setState: function () {
-        var specialData = this.record.specialData[this.name];
-        this._domainModel = specialData.model;
-        this._isValidForModel = (specialData.nbRecords !== false);
+        let domainModel = this.nodeOptions.model;
+        if (Object.prototype.hasOwnProperty.call(this.record.data, domainModel)) {
+            domainModel = this.record.data[domainModel];
+        }
+        this._domainModel = domainModel;
     },
 
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
+    /**
+     * Recompute the number of records matching the domain when the user clicks
+     * on the refresh button. Useful after manually editing the domain through
+     * the textarea in debug mode, as in this case, the count isn't automatically
+     * recomputed.
+     *
+     * @param {MouseEvent} ev
+     */
+    async _onRefreshCountClick(ev) {
+        ev.stopPropagation();
+        ev.currentTarget.setAttribute("disabled", "disabled");
+        await this._fetchCount(true);
+        this._replaceContent();
+    },
     /**
      * Called when the "Show selection" button is clicked
      * -> Open a modal to see the matched records
@@ -3552,15 +3644,17 @@ var FieldDomain = AbstractField.extend({
         }).open();
     },
     /**
-     * Called when the domain selector value is changed (do nothing if it is the
-     * one which is in a dialog (@see _onDomainSelectorDialogValueChange))
+     * Called when the domain selector value is changed
      * -> Adapt the internal value state
      *
      * @param {OdooEvent} e
+     * @param {Domain} e.data.domain
      */
     _onDomainSelectorValueChange: function (e) {
-        if (this.inDialog) return;
-        this._setValue(Domain.prototype.arrayToString(this.domainSelector.getDomain()));
+        // we don't want to recompute the count if the domain has been edited
+        // from the debug textarea (for performance reasons, as it might be costly)
+        this.debugEdition = !!e.data.debug;
+        this._setValue(Domain.prototype.arrayToString(e.data.domain));
     },
     /**
      * Called when the in-dialog domain selector value is confirmed
@@ -3579,6 +3673,19 @@ var FieldDomain = AbstractField.extend({
      */
     _onOpenRecord: function (event) {
         event.stopPropagation();
+    },
+    /**
+     * Stops the enter navigation in a DomainSelector's textarea.
+     *
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onKeydown: function (ev) {
+        if (ev.which === $.ui.keyCode.ENTER && ev.target.tagName === "TEXTAREA") {
+            ev.stopPropagation();
+            return;
+        }
+        this._super.apply(this, arguments);
     },
 });
 

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -3014,68 +3014,6 @@ var BasicModel = AbstractModel.extend({
         });
     },
     /**
-     * Fetches the number of records associated to the domain the value of the
-     * given field represents.
-     *
-     * @param {Object} record - an element from the localData
-     * @param {Object} fieldName - the name of the field
-     * @param {Object} fieldInfo
-     * @returns {Promise<any>}
-     *          The promise is resolved with the fetched special data. If this
-     *          data is the same as the previously fetched one (for the given
-     *          parameters), no RPC is done and the promise is resolved with
-     *          the undefined value.
-     */
-    _fetchSpecialDomain: function (record, fieldName, fieldInfo) {
-        var self = this;
-        var context = record.getContext({fieldName: fieldName});
-
-        var domainModel = fieldInfo.options.model;
-        if (record.data.hasOwnProperty(domainModel)) {
-            domainModel = record._changes && record._changes[domainModel] || record.data[domainModel];
-        }
-        var domainValue = record._changes && record._changes[fieldName] || record.data[fieldName] || [];
-
-        // avoid rpc if not necessary
-        var hasChanged = this._saveSpecialDataCache(record, fieldName, {
-            context: context,
-            domainModel: domainModel,
-            domainValue: domainValue,
-        });
-        if (!hasChanged) {
-            return Promise.resolve();
-        } else if (!domainModel) {
-            return Promise.resolve({
-                model: domainModel,
-                nbRecords: 0,
-            });
-        }
-
-        return new Promise(function (resolve) {
-            var evalContext = self._getEvalContext(record);
-            self._rpc({
-                model: domainModel,
-                method: 'search_count',
-                args: [Domain.prototype.stringToArray(domainValue, evalContext)],
-                context: context
-            })
-            .then(function (nbRecords) {
-                resolve({
-                    model: domainModel,
-                    nbRecords: nbRecords,
-                });
-            })
-            .guardedCatch(function (reason) {
-                var e = reason.event;
-                e.preventDefault(); // prevent traceback (the search_count might be intended to break)
-                resolve({
-                    model: domainModel,
-                    nbRecords: 0,
-                });
-            });
-        });
-    },
-    /**
      * Fetch all data in a ungrouped list
      *
      * @param {Object} list a valid resource object

--- a/addons/web/static/src/js/widgets/domain_selector.js
+++ b/addons/web/static/src/js/widgets/domain_selector.js
@@ -3,8 +3,9 @@ odoo.define("web.DomainSelector", function (require) {
 
 var core = require("web.core");
 var datepicker = require("web.datepicker");
+var dom = require('web.dom');
 var Domain = require("web.Domain");
-var field_utils = require ("web.field_utils");
+var field_utils = require("web.field_utils");
 var ModelFieldSelector = require("web.ModelFieldSelector");
 var Widget = require("web.Widget");
 
@@ -541,6 +542,7 @@ var DomainSelector = DomainTree.extend({
         this.$debugInput = this.$(".o_domain_debug_input");
         if (this.$debugInput.length) {
             this.$debugInput.val(Domain.prototype.arrayToString(this.getDomain()));
+            dom.autoresize(this.$debugInput);
         }
 
         // Warn the user if the domain is not valid after rendering
@@ -577,25 +579,24 @@ var DomainSelector = DomainTree.extend({
         this._addChild(this.options.default || [["id", "=", 1]]);
     },
     /**
-     * Called when the debug input value is changed -> constructs the tree
-     * representation if valid or warn the user if invalid.
+     * Called when the debug input value is changed -> notifies the change if
+     * valid or warn the user if invalid.
      *
      * @param {Event} e
      */
-    _onDebugInputChange: function (e) {
+    _onDebugInputChange: async function (e) {
         // When the debug input changes, the string prefix domain is read. If it
-        // is syntax-valid the widget is re-rendered and notifies the parents.
-        // If not, a warning is shown to the user and the input is ignored.
+        // is syntax-valid a "domain_changed" event is triggered to notify the
+        // parent, but the widget isn't redrawn.
+        // If the domain is not valid, a warning is shown to the user.
         var domain;
         try {
-            domain = Domain.prototype.stringToArray($(e.currentTarget).val());
+            domain = Domain.prototype.stringToArray(e.currentTarget.value);
         } catch (err) { // If there is a syntax error, just ignore the change
             this.displayNotification({ title: _t("Syntax error"), message: _t("Domain not properly formed"), type: 'danger' });
             return;
         }
-        this._redraw(domain).then((function () {
-            this.trigger_up("domain_changed", {child: this, alreadyRedrawn: true});
-        }).bind(this));
+        this.trigger_up("domain_changed", { child: this, noRedraw: true, domain, debug: true });
     },
     /**
      * Called when a (child's) domain has changed -> redraw the entire tree
@@ -604,9 +605,11 @@ var DomainSelector = DomainTree.extend({
      * @param {OdooEvent} e
      */
     _onDomainChange: function (e) {
+        // Add the current domain to the payload if not already there
+        e.data.domain = e.data.domain || this.getDomain();
         // If a subdomain notifies that it underwent some modifications, the
         // DomainSelector catches the message and performs a full re-rendering.
-        if (!e.data.alreadyRedrawn) {
+        if (!e.data.noRedraw) {
             this._redraw();
         }
     },

--- a/addons/web/static/src/js/widgets/domain_selector_dialog.js
+++ b/addons/web/static/src/js/widgets/domain_selector_dialog.js
@@ -11,8 +11,12 @@ var _t = core._t;
  * @class DomainSelectorDialog
  */
 return Dialog.extend({
+    custom_events: _.extend({}, Dialog.prototype.custom_events, {
+        domain_changed: "_onDomainChange",
+    }),
     init: function (parent, model, domain, options) {
         this.model = model;
+        this.newDomain = null;
         this.options = _.extend({
             readonly: true,
             debugMode: false,
@@ -26,7 +30,9 @@ return Dialog.extend({
         } else {
             buttons = [
                 {text: _t("Save"), classes: "btn-primary", close: true, click: function () {
-                    this.trigger_up("domain_selected", {domain: this.domainSelector.getDomain()});
+                    this.trigger_up("domain_selected", {
+                        domain: this.newDomain !== null ? this.newDomain : this.domainSelector.getDomain(),
+                    });
                 }},
                 {text: _t("Discard"), close: true},
             ];
@@ -49,6 +55,15 @@ return Dialog.extend({
             this._super.apply(this, arguments),
             this.domainSelector.appendTo(this.$el)
         ]);
+    },
+    /**
+     * Called when the domain selector value is changed.
+     *
+     * @param {OdooEvent} ev
+     */
+    _onDomainChange: function (ev) {
+        ev.stopPropagation();
+        this.newDomain = ev.data.domain;
     },
 });
 });

--- a/addons/web/static/src/scss/domain_selector.scss
+++ b/addons/web/static/src/scss/domain_selector.scss
@@ -79,7 +79,7 @@
                 font-family: monospace;
                 font-weight: normal;
 
-                > input {
+                > textarea {
                     border: none;
                     padding-top: 8px;
                     background: transparent;

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1028,14 +1028,19 @@
 </t>
 <t t-name="FieldDomain.content">
     <div t-if="hasModel" class="o_field_domain_panel">
-        <i class="fa fa-arrow-right" role="img" aria-label="Domain" title="Domain"/>
+        <t t-if="nbRecords !== null">
+            <i class="fa fa-arrow-right" role="img" aria-label="Domain" title="Domain"/>
+            <button t-if="isValid" class="btn btn-sm btn-secondary o_domain_show_selection_button" type="button">
+                <t t-esc="nbRecords"/> record(s)
+            </button>
+            <span t-else="" class="text-warning" role="alert"><i class="fa fa-exclamation-triangle" role="img" aria-label="Warning" title="Warning"/> Invalid domain</span>
+            <button t-if="isDebug and editMode" class="btn btn-sm btn-icon fa fa-refresh o_refresh_count" role="img" aria-label="Refresh" title="Refresh"/>
+        </t>
+        <t t-else="">
+            <i class="fa fa-circle-o-notch fa-spin" role="img" aria-label="Loading" title="Loading"/>
+        </t>
 
-        <button t-if="isValid" class="btn btn-sm btn-secondary o_domain_show_selection_button" type="button">
-            <t t-esc="nbRecords"/> record(s)
-        </button>
-        <span t-else="" class="text-warning" role="alert"><i class="fa fa-exclamation-triangle" role="img" aria-label="Warning" title="Warning"/> Invalid domain</span>
-
-        <button t-if="inDialogEdit" class="btn btn-sm btn-primary o_field_domain_dialog_button">Edit Domain</button>
+        <button t-if="inDialog and editMode" class="btn btn-sm btn-primary o_field_domain_dialog_button">Edit Domain</button>
     </div>
     <div t-else="">Select a model to add a filter.</div>
 </t>
@@ -1084,7 +1089,7 @@
     </t>
     <label t-if="widget.debug &amp;&amp; !widget.readonly" class="o_domain_debug_container">
         <span class="small"># Code editor</span>
-        <input type="text" class="o_domain_debug_input"/>
+        <textarea type="text" class="o_domain_debug_input"/>
     </label>
 </div>
 <div t-name="DomainTree" class="o_domain_node o_domain_tree">

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -7452,7 +7452,7 @@ QUnit.module('basic_fields', {
     });
 
     QUnit.test('domain field: handle false domain as []', async function (assert) {
-        assert.expect(3);
+        assert.expect(4);
 
         this.data.partner.records[0].foo = false;
         this.data.partner.fields.bar.type = "char";
@@ -7557,6 +7557,194 @@ QUnit.module('basic_fields', {
 
         assert.strictEqual($('.modal .o_data_row').text(), '1214',
             "should have picked the correct list view");
+
+        form.destroy();
+    });
+
+    QUnit.test('domain field: manually edit domain with textarea', async function (assert) {
+        assert.expect(9);
+
+        const originalDebug = odoo.debug;
+        odoo.debug = true;
+
+        this.data.partner.records[0].foo = false;
+        this.data.partner.fields.bar.type = "char";
+        this.data.partner.records[0].bar = "product";
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                </form>`,
+            mockRPC(route, args) {
+                if (args.method === 'search_count') {
+                    assert.step(JSON.stringify(args.args[0]));
+                }
+                return this._super.apply(this, arguments);
+            },
+            viewOptions: {
+                mode: 'edit',
+            },
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
+        assert.verifySteps(["[]"]);
+
+        await testUtils.fields.editAndTrigger(form.$('.o_domain_debug_input'), "[['id', '<', 40]]", ["change"]);
+        // the count should not be re-computed when editing with the textarea
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
+        assert.verifySteps([]);
+
+        await testUtils.form.clickSave(form);
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "1 record(s)");
+        assert.verifySteps([
+            "[[\"id\",\"<\",40]]", // to validate the domain, before saving
+            "[[\"id\",\"<\",40]]", // to render in readonly once it has been saved
+        ]);
+
+        form.destroy();
+        odoo.debug = originalDebug;
+    });
+
+    QUnit.test('domain field: manually set an invalid domain with textarea', async function (assert) {
+        assert.expect(9);
+
+        const originalDebug = odoo.debug;
+        odoo.debug = true;
+
+        this.data.partner.records[0].foo = false;
+        this.data.partner.fields.bar.type = "char";
+        this.data.partner.records[0].bar = "product";
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                </form>`,
+            mockRPC(route, args) {
+                if (args.method === 'search_count') {
+                    assert.step(JSON.stringify(args.args[0]));
+                }
+                if (args.method === "write") {
+                    throw new Error("should not save");
+                }
+                return this._super.apply(this, arguments);
+            },
+            viewOptions: {
+                mode: 'edit',
+            },
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
+        assert.verifySteps(["[]"]);
+
+        await testUtils.fields.editAndTrigger(form.$('.o_domain_debug_input'), "[['abc']]", ["change"]);
+        // the count should not be re-computed when editing with the textarea
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
+        assert.verifySteps([]);
+
+        await testUtils.form.clickSave(form);
+        assert.hasClass(form.$(".o_field_domain"), "o_field_invalid", "the field is marked as invalid");
+        assert.hasClass(form.$(".o_form_view"), "o_form_editable", "the view is still in edit mode");
+        assert.verifySteps(["[[\"abc\"]]"]);
+
+        form.destroy();
+        odoo.debug = originalDebug;
+    });
+
+    QUnit.test('domain field: reload count by clicking on the refresh button', async function (assert) {
+        assert.expect(7);
+
+        const originalDebug = odoo.debug;
+        odoo.debug = true;
+
+        this.data.partner.records[0].foo = "[]";
+        this.data.partner.fields.bar.type = "char";
+        this.data.partner.records[0].bar = "product";
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                </form>`,
+            async mockRPC(route, args) {
+                if (args.method === 'search_count') {
+                    assert.step(JSON.stringify(args.args[0]));
+                }
+                return this._super.apply(this, arguments);
+            },
+            viewOptions: {
+                mode: 'edit',
+            },
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
+
+        await testUtils.fields.editAndTrigger(form.$('.o_domain_debug_input'), "[['id', '<', 40]]", ["change"]);
+        // the count should not be re-computed when editing with the textarea
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
+        assert.verifySteps(["[]"]);
+
+        // click on the refresh button
+        await testUtils.dom.click(form.$(".o_refresh_count"));
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "1 record(s)");
+        assert.verifySteps(["[[\"id\",\"<\",40]]"]);
+
+        form.destroy();
+        odoo.debug = originalDebug;
+    });
+
+    QUnit.test('domain field: does not wait for the count to render', async function (assert) {
+        assert.expect(5);
+
+        this.data.partner.records[0].foo = "[]";
+        this.data.partner.fields.bar.type = "char";
+        this.data.partner.records[0].bar = "product";
+
+        const def = testUtils.makeTestPromise();
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
+                </form>`,
+            async mockRPC(route, args) {
+                const result = this._super.apply(this, arguments);
+                if (args.method === 'search_count') {
+                    await def;
+                }
+                return result;
+            },
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, ".o_field_domain_panel .fa-circle-o-notch.fa-spin");
+        assert.containsNone(form, ".o_field_domain_panel .o_domain_show_selection_button");
+
+        def.resolve();
+        await testUtils.nextTick();
+
+        assert.containsNone(form, ".o_field_domain_panel .fa-circle-o-notch .fa-spin");
+        assert.containsOnce(form, ".o_field_domain_panel .o_domain_show_selection_button");
+        assert.strictEqual(form.$(".o_domain_show_selection_button").text().trim(), "2 record(s)");
 
         form.destroy();
     });

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -3,9 +3,9 @@ odoo.define('web.field_one_to_many_tests', function (require) {
 
 var AbstractField = require('web.AbstractField');
 var AbstractStorageService = require('web.AbstractStorageService');
+const BasicModel = require('web.BasicModel');
 const ControlPanel = require('web.ControlPanel');
 const fieldRegistry = require('web.field_registry');
-var FormController = require('web.FormController');
 var FormView = require('web.FormView');
 var KanbanRecord = require('web.KanbanRecord');
 var ListRenderer = require('web.ListRenderer');
@@ -4927,15 +4927,20 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
-        QUnit.test('one2many kanban with edit type action and domain widget (widget using SpecialData)', async function (assert) {
-            assert.expect(1);
+        QUnit.test('one2many kanban with edit type action and widget with specialData', async function (assert) {
+            assert.expect(3);
 
-            this.data.turtle.fields.model_name = { string: "Domain Condition Model", type: "char" };
-            this.data.turtle.fields.condition = { string: "Domain Condition", type: "char" };
-            _.each(this.data.turtle.records, function (record) {
-                record.model_name = 'partner';
-                record.condition = '[]';
+            testUtils.mock.patch(BasicModel, {
+                _fetchSpecialDataForMyWidget() {
+                    assert.step("_fetchSpecialDataForMyWidget");
+                    return Promise.resolve();
+                },
             });
+            const MyWidget = AbstractField.extend({
+                specialData: "_fetchSpecialDataForMyWidget",
+                className: "my_widget",
+            });
+            fieldRegistry.add('specialWidget', MyWidget);
 
             var form = await createView({
                 View: FormView,
@@ -4950,16 +4955,15 @@ QUnit.module('fields', {}, function () {
                     '<div><field name="display_name"/></div>' +
                     '<div><field name="turtle_foo"/></div>' +
                     // field without Widget in the list
-                    '<div><field name="condition"/></div>' +
+                    '<div><field name="turtle_int"/></div>' +
                     '<div> <a type="edit"> Edit </a> </div>' +
                     '</t>' +
                     '</templates>' +
                     '</kanban>' +
                     '<form>' +
                     '<field name="product_id" widget="statusbar"/>' +
-                    '<field name="model_name"/>' +
                     // field with Widget requiring specialData in the form
-                    '<field name="condition" widget="domain" options="{\'model\': \'model_name\'}"/>' +
+                    '<field name="turtle_int" widget="specialWidget"/>' +
                     '</form>' +
                     '</field>' +
                     '</group>' +
@@ -4968,19 +4972,26 @@ QUnit.module('fields', {}, function () {
             });
 
             await testUtils.dom.click(form.$('.oe_kanban_action:eq(0)'));
-            assert.strictEqual($('.o_domain_selector').length, 1, "should add domain selector widget");
+            assert.containsOnce(document.body, ".modal .my_widget", "should add our custom widget");
+            assert.verifySteps(["_fetchSpecialDataForMyWidget"]);
             form.destroy();
         });
 
         QUnit.test('one2many list with onchange and domain widget (widget using SpecialData)', async function (assert) {
-            assert.expect(3);
+            assert.expect(4);
 
-            this.data.turtle.fields.model_name = { string: "Domain Condition Model", type: "char" };
-            this.data.turtle.fields.condition = { string: "Domain Condition", type: "char" };
-            _.each(this.data.turtle.records, function (record) {
-                record.model_name = 'partner';
-                record.condition = '[]';
+            testUtils.mock.patch(BasicModel, {
+                _fetchSpecialDataForMyWidget() {
+                    assert.step("_fetchSpecialDataForMyWidget");
+                    return Promise.resolve();
+                },
             });
+            const MyWidget = AbstractField.extend({
+                specialData: "_fetchSpecialDataForMyWidget",
+                className: "my_widget",
+            });
+            fieldRegistry.add('specialWidget', MyWidget);
+
             this.data.partner.onchanges = {
                 turtles: function (obj) {
                     var virtualID = obj.turtles[1][1];
@@ -4995,13 +5006,10 @@ QUnit.module('fields', {}, function () {
                             turtle_qux: 9.8,
                             partner_ids: [],
                             turtle_ref: 'product,37',
-                            model_name: 'partner',
-                            condition: '[]',
                         }],
                     ];
                 },
             };
-            var nbFetchSpecialDomain = 0;
             var form = await createView({
                 View: FormView,
                 model: 'partner',
@@ -5013,12 +5021,11 @@ QUnit.module('fields', {}, function () {
                     '<field name="display_name"/>' +
                     '<field name="turtle_foo"/>' +
                     // field without Widget in the list
-                    '<field name="condition"/>' +
+                    '<field name="turtle_int"/>' +
                     '</tree>' +
                     '<form>' +
-                    '<field name="model_name"/>' +
                     // field with Widget requiring specialData in the form
-                    '<field name="condition" widget="domain" options="{\'model\': \'model_name\'}"/>' +
+                    '<field name="turtle_int" widget="specialWidget"/>' +
                     '</form>' +
                     '</field>' +
                     '</group>' +
@@ -5027,27 +5034,20 @@ QUnit.module('fields', {}, function () {
                 viewOptions: {
                     mode: 'edit',
                 },
-                mockRPC: function (route) {
-                    if (route === '/web/dataset/call_kw/partner/search_count') {
-                        nbFetchSpecialDomain++;
-                    }
-                    return this._super.apply(this, arguments);
-                }
             });
 
             await testUtils.dom.click(form.$('.o_field_one2many .o_field_x2many_list_row_add a'));
             assert.strictEqual($('.modal').length, 1, "form view dialog should be opened");
-            await testUtils.fields.editInput($('.modal-body input[name="model_name"]'), 'partner');
             await testUtils.dom.click($('.modal-footer button:first'));
 
-            assert.strictEqual(form.$('.o_field_one2many tbody tr:first').text(), "coucouhas changed[]",
+            assert.strictEqual(form.$('.o_field_one2many tbody tr:first').text(), "coucouhas changed42",
                 "the onchange should create one new record and remove the existing");
 
             await testUtils.dom.click(form.$('.o_field_one2many .o_list_view tbody tr:eq(0) td:first'));
 
             await testUtils.form.clickSave(form);
-            assert.strictEqual(nbFetchSpecialDomain, 1,
-                "should only fetch special domain once");
+            assert.verifySteps(["_fetchSpecialDataForMyWidget"], "should only fetch special data once");
+
             form.destroy();
         });
 

--- a/addons/web/static/tests/widgets/domain_selector_tests.js
+++ b/addons/web/static/tests/widgets/domain_selector_tests.js
@@ -2,6 +2,7 @@ odoo.define('web.domain_selector_tests', function (require) {
 "use strict";
 
 var DomainSelector = require("web.DomainSelector");
+var Widget = require("web.Widget");
 var testUtils = require("web.test_utils");
 
 QUnit.module('widgets', {}, function () {
@@ -51,7 +52,7 @@ QUnit.module('DomainSelector', {
 }, function () {
 
     QUnit.test("creating a domain from scratch", async function (assert) {
-        assert.expect(13);
+        assert.expect(12);
 
         var $target = $("#qunit-fixture");
 
@@ -97,8 +98,9 @@ QUnit.module('DomainSelector', {
             "field selector popover should contain the 'Bar' field");
 
         // Clicking the "Bar" field should change the internal domain and this
-        // should be displayed in the debug input
+        // should be displayed in the debug textarea
         await testUtils.dom.click($barLi);
+        assert.containsOnce(domainSelector, "textarea.o_domain_debug_input");
         assert.strictEqual(
             domainSelector.$(".o_domain_debug_input").val(),
             '[["bar","=",True]]',
@@ -127,16 +129,6 @@ QUnit.module('DomainSelector', {
             "the domain input should contain a domain with 'bar', 'id' and a subgroup"
         );
 
-        // Changing the domain input to update the subgroup to use the "foo"
-        // field instead of "id" should rerender the widget and adapt the
-        // widget suggestions
-        domainSelector.$(".o_domain_debug_input").val('["&","&",["bar","=",True],"|",["foo","=","hello"],["id","=",1],["id","=",1]]').change();
-        await testUtils.nextTick();
-        assert.strictEqual(domainSelector.$(".o_field_selector").eq(1).find("input.o_field_selector_debug").val(), "foo",
-            "the second field selector should now contain the 'foo' value");
-        assert.ok(domainSelector.$(".o_domain_leaf_operator_select").eq(1).html().indexOf("contains") >= 0,
-            "the second operator selector should now contain the 'contains' operator");
-
         // There should be five "-" buttons to remove domain part; clicking on
         // the two last ones, should leave a domain with only the "bar" and
         // "foo" fields, with the initial "&" operator
@@ -146,8 +138,8 @@ QUnit.module('DomainSelector', {
         await testUtils.dom.click(domainSelector.$(".o_domain_delete_node_button").last());
         assert.strictEqual(
             domainSelector.$(".o_domain_debug_input").val(),
-            '["&",["bar","=",True],["foo","=","hello"]]',
-            "the domain input should contain a domain with 'bar' and 'foo'"
+            '["&",["bar","=",True],["id","=",1]]',
+            "the domain input should contain a domain with 'bar' and 'id'"
         );
         domainSelector.destroy();
     });
@@ -272,6 +264,45 @@ QUnit.module('DomainSelector', {
         assert.strictEqual(document.querySelector('div[name="foo"]').closest('.modal-body').style.overflow,
             'visible', "modal should have visible overflow if there is inline domain field widget");
         actionManager.destroy();
+    });
+
+    QUnit.test("edit a domain with the debug textarea", async function (assert) {
+        assert.expect(5);
+
+        const $target = $("#qunit-fixture");
+
+        // Create the domain selector and its mock environment
+        const Parent = Widget.extend({
+            custom_events: {
+                domain_changed: (e) => {
+                    assert.deepEqual(e.data.domain, [
+                        ["product_id", "ilike", 1],
+                        ["id", "=", 0]
+                    ]);
+                    assert.ok(e.data.debug);
+                },
+            },
+        });
+        const parent = new Parent(null);
+        const domainSelector = new DomainSelector(parent, "partner", [["product_id", "ilike", 1]], {
+            debugMode: true,
+            readonly: false,
+        });
+        await testUtils.mock.addMockEnvironment(domainSelector, {data: this.data});
+        await domainSelector.appendTo($target);
+
+        assert.containsOnce(domainSelector, ".o_domain_node", "should have a single domain node");
+        const newValue = `
+[
+    ['product_id', 'ilike', 1],
+    ['id', '=', 0]
+]`;
+        await testUtils.fields.editAndTrigger(domainSelector.$('.o_domain_debug_input'), newValue, ["change"]);
+        assert.strictEqual(domainSelector.$('.o_domain_debug_input').val(), newValue,
+            "the domain should not have been formatted");
+        assert.containsOnce(domainSelector, ".o_domain_node", "should still have a single domain node");
+
+        domainSelector.destroy();
     });
 });
 });


### PR DESCRIPTION
Before this commit, the FieldDomain (using the DomainSelector)
didn't work well for manual edition of large domains (i.e. via the
"code editor"). For instance:
 - the editor was an input, so limitated to 1 line
 - the user friendly representation of the domain was redrawn each
   time the input was blured (could thus freeze the interface, or
   at least make it flicker)
 - the count (search_count rpc) was recomputed at blur as well
   (could also freeze the interface)

This commit fixes those issues as follows:
 - use a (automatically resizable) textarea instead of the input
 - do not format the content of the textarea when it is blured
 - do not update the user friendly part of the widget when the
   textarea is blured
 - do not recompute the count when the textarea is blured
 - add a button to allow to manually re-compute the count

For both debug and non-debug mode, we also no longer wait for the
count to be fetched to render the widget. We display a spinner
until the rpc is done.

Task 2619505

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
