### PR TITLE
[FIX] pos_adyen: Connection failure during Adyen payment

### DIFF
--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -118,6 +118,12 @@ var PaymentAdyen = PaymentInterface.extend({
             return Promise.resolve();
         }
 
+
+        if (this.poll_response_error)   {
+            this.poll_response_error = false;
+            return self._adyen_handle_response({});
+        }
+
         var data = this._adyen_pay_data();
 
         return this._call_adyen(data).then(function (data) {
@@ -185,6 +191,7 @@ var PaymentAdyen = PaymentInterface.extend({
             shadow: true,
         }).catch(function (data) {
             reject();
+            self.poll_response_error = true;
             return self._handle_odoo_connection_failure(data);
         }).then(function (status) {
             var notification = status.latest_response;


### PR DESCRIPTION
Steps to reproduce the bug:

When making a payment intent from Adyen terminal with the POS, the payment intent was validated by Adyen
but Odoo stopped polling because a connection failure happened  and then on retry it made second payment
even if the first one was successful.

Fix:

Now after a failure, it will try to poll again the last transaction (with get_latest_adyen_status)
and set the payment as successful or cancelled based on the last response.

opw:2587625

Co-authored-by:  nle-odoo <nle@odoo.com>