### PR TITLE
[IMP] mrp: improve bom filter line by variant feature

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -461,7 +461,7 @@ class MrpProduction(models.Model):
             relevant_move_state = production.move_raw_ids._get_relevant_state_among_moves()
             # Compute reservation state according to its component's moves.
             if relevant_move_state == 'partially_available':
-                if production.bom_id.operation_ids and production.bom_id.ready_to_produce == 'asap':
+                if production.workorder_ids.operation_id and production.bom_id.ready_to_produce == 'asap':
                     production.reservation_state = production._get_ready_to_produce_state()
                 else:
                     production.reservation_state = 'confirmed'
@@ -602,7 +602,7 @@ class MrpProduction(models.Model):
         # we need to avoid keeping incorrect lines, so clearing is necessary too.
         if self.product_id != self._origin.product_id:
             self.move_raw_ids = [(5,)]
-        if self.bom_id and self.product_qty > 0:
+        if self.bom_id and self.product_id and self.product_qty > 0:
             # keep manual entries
             list_move_raw = [(4, move.id) for move in self.move_raw_ids.filtered(lambda m: not m.bom_line_id)]
             moves_raw_values = self._get_moves_raw_values()
@@ -671,9 +671,9 @@ class MrpProduction(models.Model):
             if message:
                 return {'warning': {'title': _('Warning'), 'message': message}}
 
-    @api.onchange('bom_id')
+    @api.onchange('bom_id', 'product_id')
     def _onchange_workorder_ids(self):
-        if self.bom_id:
+        if self.bom_id and self.product_id:
             self._create_workorder()
         else:
             self.workorder_ids = False
@@ -719,7 +719,7 @@ class MrpProduction(models.Model):
                 if 'qty_producing' in vals:
                     finished_move_lines.write({'qty_done': vals.get('qty_producing')})
 
-            if not production.bom_id.operation_ids and vals.get('date_planned_start') and not vals.get('date_planned_finished'):
+            if not production.workorder_ids.operation_id and vals.get('date_planned_start') and not vals.get('date_planned_finished'):
                 new_date_planned_start = fields.Datetime.to_datetime(vals.get('date_planned_start'))
                 if not production.date_planned_finished or new_date_planned_start >= production.date_planned_finished:
                     production.date_planned_finished = new_date_planned_start + datetime.timedelta(hours=1)
@@ -793,7 +793,7 @@ class MrpProduction(models.Model):
 
     def _create_workorder(self):
         for production in self:
-            if not production.bom_id:
+            if not production.bom_id or not production.product_id:
                 continue
             workorders_values = []
 
@@ -805,6 +805,8 @@ class MrpProduction(models.Model):
                 if not (bom.operation_ids and (not bom_data['parent_line'] or bom_data['parent_line'].bom_id.operation_ids != bom.operation_ids)):
                     continue
                 for operation in bom.operation_ids:
+                    if operation._skip_operation_line(bom_data['product']):
+                        continue
                     workorders_values += [{
                         'name': operation.name,
                         'production_id': production.id,
@@ -854,6 +856,8 @@ class MrpProduction(models.Model):
                 raise UserError(_("You cannot have %s  as the finished product and in the Byproducts", self.product_id.name))
             moves.append(production._get_move_finished_values(production.product_id.id, production.product_qty, production.product_uom_id.id))
             for byproduct in production.bom_id.byproduct_ids:
+                if byproduct._skip_byproduct_line(production.product_id):
+                    continue
                 product_uom_factor = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
                 qty = byproduct.product_qty * (product_uom_factor / production.bom_id.product_qty)
                 moves.append(production._get_move_finished_values(
@@ -969,10 +973,11 @@ class MrpProduction(models.Model):
         the first operation of the bom. If not returns 'waiting'
         """
         self.ensure_one()
-        first_operation = self.bom_id.operation_ids[0]
-        if len(self.bom_id.operation_ids) == 1:
+        operations = self.workorder_ids.operation_id
+        if len(operations) == 1:
             moves_in_first_operation = self.move_raw_ids
         else:
+            first_operation = operations[0]
             moves_in_first_operation = self.move_raw_ids.filtered(lambda move: move.operation_id == first_operation)
         moves_in_first_operation = moves_in_first_operation.filtered(
             lambda move: move.bom_line_id and

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -208,6 +208,8 @@ class MrpUnbuild(models.Model):
                 factor = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id) / unbuild.bom_id.product_qty
                 moves += unbuild._generate_move_from_bom_line(self.product_id, self.product_uom_id, unbuild.product_qty)
                 for byproduct in unbuild.bom_id.byproduct_ids:
+                    if byproduct._skip_byproduct_line(unbuild.product_id):
+                        continue
                     quantity = byproduct.product_qty * factor
                     moves += unbuild._generate_move_from_bom_line(byproduct.product_id, byproduct.product_uom_id, quantity, byproduct_id=byproduct.id)
         return moves

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -126,7 +126,7 @@
         </t>
         <t t-if="data['operations']">
             <t t-set="space_td" t-value="'margin-left: '+ str(data['level'] * 20) + 'px;'"/>
-            <tr class="o_mrp_bom_report_line o_mrp_bom_cost" t-att-data-id="'operation-' + str(data['bom'].id)" t-att-data-bom-id="data['bom'].id" t-att-parent_id="data['bom'].id" t-att-data-qty="data['bom_qty']" t-att-data-level="data['level']">
+            <tr class="o_mrp_bom_report_line o_mrp_bom_cost" t-att-data-product_id="data['product'].id" t-att-data-id="'operation-' + str(data['bom'].id)" t-att-data-bom-id="data['bom'].id" t-att-parent_id="data['bom'].id" t-att-data-qty="data['bom_qty']" t-att-data-level="data['level']">
                 <td name="td_opr">
                     <span t-att-style="space_td"/>
                     <span class="o_mrp_bom_unfoldable fa fa-fw fa-caret-right" t-att-data-function="'get_operations'" role="img" aria-label="Unfold" title="Unfold"/>

--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -86,11 +86,13 @@ var MrpBomReport = stock_report_generic.extend({
       var $parent = $(event.currentTarget).closest('tr');
       var activeID = $parent.data('bom-id');
       var qty = $parent.data('qty');
+      var productId = $parent.data('product_id');
       var level = $parent.data('level') || 0;
       return this._rpc({
               model: 'report.mrp.report_bom_structure',
               method: 'get_operations',
               args: [
+                  productId,
                   activeID,
                   parseFloat(qty),
                   level + 1

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -24,6 +24,8 @@
                             <field name="product_uom_id" groups="uom.group_uom"/>
                         </div>
                         <field name="operation_id" groups="mrp.group_mrp_routings" options="{'no_quick_create':True,'no_create_edit':True}"/>
+                        <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
+                        <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
                     </group>
                 </form>
             </field>
@@ -89,8 +91,8 @@
                                     <field name="product_qty"/>
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <field name="parent_product_tmpl_id" invisible="1" />
-                                    <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
                                     <field name="product_uom_id" options="{'no_open':True,'no_create':True}" groups="uom.group_uom"/>
+                                    <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
                                     <field name="bom_product_template_attribute_value_ids" optional="hide" widget="many2many_tags" options="{'no_create': True}" attrs="{'column_invisible': [('parent.product_id', '!=', False)]}" groups="product.group_product_variant"/>
                                     <field name="allowed_operation_ids" invisible="1"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" optional="hidden" attrs="{'column_invisible': [('parent.type','not in', ('normal', 'phantom'))]}" options="{'no_quick_create':True,'no_create_edit':True}"/>
@@ -119,6 +121,8 @@
                                     <field name="product_uom_id" groups="uom.group_uom"/>
                                     <field name="allowed_operation_ids" invisible="1"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" options="{'no_quick_create':True,'no_create_edit':True}"/>
+                                    <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
+                                    <field name="bom_product_template_attribute_value_ids" optional="hide" widget="many2many_tags" options="{'no_create': True}" attrs="{'column_invisible': [('parent.product_id', '!=', False)]}" groups="product.group_product_variant"/>
                                 </tree>
                            </field>
                        </page>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -14,6 +14,8 @@
                     <field name="time_computed_on" optional="hide"/>
                     <field name="time_cycle" widget="float_time" string="Duration (minutes)" width="1.5"/>
                     <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                    <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
+                    <field name="bom_product_template_attribute_value_ids" optional="hide" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
                 </tree>
             </field>
         </record>
@@ -31,6 +33,9 @@
                 <xpath expr="//field[@name='bom_id']" position="replace"/>
                 <xpath expr="//field[@name='time_cycle']" position="attributes">
                     <attribute name="sum">Total Duration</attribute>
+                </xpath>
+                <xpath expr="//field[@name='bom_product_template_attribute_value_ids']" position="attributes">
+                    <attribute name="attrs">{'column_invisible': [('parent.product_id', '!=', False)]}</attribute>
                 </xpath>
             </field>
         </record>
@@ -65,6 +70,8 @@
                                 <field name="workcenter_id" context="{'default_company_id': company_id}"/>
                                 <field name="sequence" groups="base.group_no_one"/>
                                 <field name="bom_id" invisible="context.get('bom_id_invisible', False)"/>
+                                <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
+                                <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
                             </group><group name="workorder">
                                 <field name="workorder_count" invisible="1"/>
                                 <field name="time_mode" widget="radio"/>

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -69,11 +69,15 @@ class ProductProduct(models.Model):
             boms_to_recompute = []
         total = 0
         for opt in bom.operation_ids:
+            if opt._skip_operation_line(self):
+                continue
+
             duration_expected = (
                 opt.workcenter_id.time_start +
                 opt.workcenter_id.time_stop +
                 opt.time_cycle)
             total += (duration_expected / 60) * opt.workcenter_id.costs_hour
+
         for line in bom.bom_line_ids:
             if line._skip_bom_line(self):
                 continue


### PR DESCRIPTION
On BoM, a component line can be filter out depending
of the product variant to manufacture
(with "Apply on Variant" field).

Extend this feature to operation and byproduct line.

task-2614126