### PR TITLE
[FIX] mrp, sale_mrp: sell decimal qty of kit

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -407,9 +407,8 @@ class StockMove(models.Model):
                 return 0.0
         if qty_ratios:
             # Now that we have every ratio by components, we keep the lowest one to know how many kits we can produce
-            # with the quantities delivered of each component. We use the floor division here because a 'partial kit'
-            # doesn't make sense.
-            return min(qty_ratios) // 1
+            # with the quantities delivered of each component.
+            return min(qty_ratios)
         else:
             return 0.0
 

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -275,9 +275,8 @@ class TestSaleMrpFlow(TransactionCase):
         backorder_1 = po.picking_ids - picking_original
         self.assertEqual(backorder_1.backorder_id.id, picking_original.id)
 
-        # Even if some components are received completely,
-        # no KitParent should be received
-        self.assertEqual(order_line.qty_received, 0)
+        # Check that a partial qty of the kit is received
+        self.assertEqual(order_line.qty_received, 0.58)
 
         # Process just enough components to make 1 kit_parent
         qty_to_process = {
@@ -397,8 +396,7 @@ class TestSaleMrpFlow(TransactionCase):
         wiz = Form(self.env[wiz_act['res_model']].with_context(wiz_act['context'])).save()
         wiz.process()
 
-        # As one of each component is missing, only 6 kit_parents should be received
-        self.assertEqual(order_line.qty_received, 6)
+        self.assertEqual(order_line.qty_received, 6.5)
 
         # Check that the 4th backorder is created.
         self.assertEqual(len(po.picking_ids), 7)


### PR DESCRIPTION
When selling a decimal quantity of a kit, the delivered quantity will be
rounded.

To reproduce the error:
- Create a kit K
- Create a sale order SO with 5.55 K
- Confirm the SO and the associated delivery

Error: on the SO, the delivered quantity is 5 even though, on the
delivery order, the done quantity is 5.55

OPW-2608563