### PR TITLE
[FIX] mail: access mail.activity.type

### DIFF
--- a/addons/calendar/tests/test_mail_activity_mixin.py
+++ b/addons/calendar/tests/test_mail_activity_mixin.py
@@ -22,7 +22,7 @@ class TestMailActivityMixin(MailCommon):
         cls.activity_type_1 = cls.env['mail.activity.type'].create({
             'name': 'Calendar Activity Test Default',
             'summary': 'default activity',
-            'res_model_id': cls.env['ir.model']._get('base.res_partner').id,
+            'res_model': 'res.partner',
         })
         cls.env['ir.model.data'].create({
             'name': cls.activity_type_1.name.lower().replace(' ', '_'),

--- a/addons/crm/data/mail_activity_demo.xml
+++ b/addons/crm/data/mail_activity_demo.xml
@@ -3,26 +3,26 @@
     <record id="mail_activity_demo_followup_quote" model="mail.activity.type">
         <field name="name">Follow-up Quote</field>
         <field name="icon">fa-file-text-o</field>
-        <field name="res_model_id" ref="crm.model_crm_lead"/>
+        <field name="res_model">crm.lead</field>
         <field name="delay_count">30</field>
     </record>
     <record id="mail_activity_demo_make_quote" model="mail.activity.type">
         <field name="name">Make Quote</field>
         <field name="icon">fa-file-text-o</field>
-        <field name="res_model_id" ref="crm.model_crm_lead"/>
+        <field name="res_model">crm.lead</field>
         <field name="delay_count">15</field>
     </record>
     <record id="mail_activity_demo_call_demo" model="mail.activity.type">
         <field name="name">Call for Demo</field>
         <field name="icon">fa-phone</field>
-        <field name="res_model_id" ref="crm.model_crm_lead"/>
+        <field name="res_model">crm.lead</field>
         <field name="delay_count">10</field>
     </record>
 
     <record id="mail_activity_type_demo_email_with_template" model="mail.activity.type">
         <field name="name">Email: Welcome Demo</field>
         <field name="icon">fa-envelope</field>
-        <field name="res_model_id" ref="crm.model_crm_lead"/>
+        <field name="res_model">crm.lead</field>
         <field name="mail_template_ids" eval="[(4, ref('crm.mail_template_demo_crm_lead'))]"/>
     </record>
 </odoo>

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -216,7 +216,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.activity_type_1 = cls.env['mail.activity.type'].create({
             'name': 'Lead Test Activity 1',
             'summary': 'ACT 1 : Presentation, barbecue, ... ',
-            'res_model_id': cls.env['ir.model']._get('crm.crm_lead').id,
+            'res_model': 'crm.lead',
             'category': 'meeting',
             'delay_count': 5,
         })

--- a/addons/crm/tests/test_crm_activity.py
+++ b/addons/crm/tests/test_crm_activity.py
@@ -17,13 +17,13 @@ class TestCrmMailActivity(TestCrmCommon):
             'name': 'Initial Contact',
             'delay_count': 5,
             'summary': 'ACT 1 : Presentation, barbecue, ... ',
-            'res_model_id': cls.env['ir.model']._get('crm.lead').id,
+            'res_model': 'crm.lead',
         })
         cls.activity_type_2 = cls.env['mail.activity.type'].create({
             'name': 'Call for Demo',
             'delay_count': 6,
             'summary': 'ACT 2 : I want to show you my ERP !',
-            'res_model_id': cls.env['ir.model']._get('crm.lead').id,
+            'res_model': 'crm.lead',
         })
         for activity_type in cls.activity_type_1 + cls.activity_type_2:
             cls.env['ir.model.data'].create({

--- a/addons/crm/views/mail_activity_views.xml
+++ b/addons/crm/views/mail_activity_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="sales_team.mail_activity_type_action_config_sales" model="ir.actions.act_window">
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', 'in', ['crm.lead', 'res.partner'])]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', 'in', ['crm.lead', 'res.partner'])]</field>
         <field name="context">{'default_res_model': 'crm.lead'}</field>
     </record>
 </odoo>

--- a/addons/fleet/data/mail_data.xml
+++ b/addons/fleet/data/mail_data.xml
@@ -4,7 +4,7 @@
         <record id="mail_act_fleet_contract_to_renew" model="mail.activity.type">
             <field name="name">Contract to Renew</field>
             <field name="icon">fa-car</field>
-            <field name="res_model_id" ref="fleet.model_fleet_vehicle_log_contract"/>
+            <field name="res_model">fleet.vehicle.log.contract</field>
         </record>
 
         <record id="mt_fleet_driver_updated" model="mail.message.subtype">

--- a/addons/fleet/views/mail_activity_views.xml
+++ b/addons/fleet/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'fleet.vehicle.log.contract')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'fleet.vehicle.log.contract')]</field>
         <field name="context">{'default_res_model': 'fleet.vehicle.log.contract'}</field>
     </record>
     <menuitem id="fleet_menu_config_activity_type"

--- a/addons/hr/models/hr_plan.py
+++ b/addons/hr/models/hr_plan.py
@@ -20,7 +20,7 @@ class HrPlanActivityType(models.Model):
     activity_type_id = fields.Many2one(
         'mail.activity.type', 'Activity Type',
         default=lambda self: self.env.ref('mail.mail_activity_data_todo'),
-        domain=lambda self: ['|', ('res_model_id', '=', False), ('res_model_id', '=', self.env['ir.model']._get('hr.employee').id)],
+        domain=lambda self: ['|', ('res_model', '=', False), ('res_model', '=', 'hr.employee')],
         ondelete='restrict'
     )
     summary = fields.Char('Summary', compute="_compute_default_summary", store=True, readonly=False)

--- a/addons/hr_expense/data/mail_data.xml
+++ b/addons/hr_expense/data/mail_data.xml
@@ -5,7 +5,7 @@
         <record id="mail_act_expense_approval" model="mail.activity.type">
             <field name="name">Expense Approval</field>
             <field name="icon">fa-dollar</field>
-            <field name="res_model_id" ref="hr_expense.model_hr_expense_sheet"/>
+            <field name="res_model">hr.expense.sheet</field>
         </record>
 
         <!-- default alias for expenses -->

--- a/addons/hr_expense/views/mail_activity_views.xml
+++ b/addons/hr_expense/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'hr.expense.sheet')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'hr.expense.sheet')]</field>
         <field name="context">{'default_res_model': 'hr.expense.sheet'}</field>
     </record>
     <menuitem id="hr_expense_menu_config_activity_type"

--- a/addons/hr_holidays/data/mail_data.xml
+++ b/addons/hr_holidays/data/mail_data.xml
@@ -5,24 +5,24 @@
         <record id="mail_act_leave_approval" model="mail.activity.type">
             <field name="name">Time Off Approval</field>
             <field name="icon">fa-sun-o</field>
-            <field name="res_model_id" ref="hr_holidays.model_hr_leave"/>
+            <field name="res_model">hr.leave</field>
         </record>
         <record id="mail_act_leave_second_approval" model="mail.activity.type">
             <field name="name">Time Off Second Approve</field>
             <field name="icon">fa-sun-o</field>
-            <field name="res_model_id" ref="hr_holidays.model_hr_leave"/>
+            <field name="res_model">hr.leave</field>
         </record>
 
         <!-- Leave specific activities -->
         <record id="mail_act_leave_allocation_approval" model="mail.activity.type">
             <field name="name">Allocation Approval</field>
             <field name="icon">fa-sun-o</field>
-            <field name="res_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
+            <field name="res_model">hr.leave.allocation</field>
         </record>
         <record id="mail_act_leave_allocation_second_approval" model="mail.activity.type">
             <field name="name">Allocation Second Approve</field>
             <field name="icon">fa-sun-o</field>
-            <field name="res_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
+            <field name="res_model">hr.leave.allocation</field>
         </record>
 
         <!-- Holidays-related subtypes for messaging / Chatter -->

--- a/addons/hr_holidays/views/mail_activity_views.xml
+++ b/addons/hr_holidays/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', 'in', ['hr.leave', 'hr.leave.allocation'])]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', 'in', ['hr.leave', 'hr.leave.allocation'])]</field>
         <field name="context">{'default_res_model': 'hr.leave'}</field>
     </record>
 </odoo>

--- a/addons/hr_recruitment/views/mail_activity_views.xml
+++ b/addons/hr_recruitment/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'hr.applicant')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'hr.applicant')]</field>
         <field name="context">{'default_res_model': 'hr.applicant'}</field>
     </record>
     <menuitem id="hr_recruitment_menu_config_activity_type"

--- a/addons/mail/models/ir_actions.py
+++ b/addons/mail/models/ir_actions.py
@@ -28,7 +28,7 @@ class ServerActions(models.Model):
     # Next Activity
     activity_type_id = fields.Many2one(
         'mail.activity.type', string='Activity',
-        domain="['|', ('res_model_id', '=', False), ('res_model_id', '=', model_id)]",
+        domain="['|', ('res_model', '=', False), ('res_model', '=', model_name)]",
         ondelete='restrict')
     activity_summary = fields.Char('Summary')
     activity_note = fields.Html('Note')

--- a/addons/mail/models/ir_model.py
+++ b/addons/mail/models/ir_model.py
@@ -26,6 +26,9 @@ class IrModel(models.Model):
         # Delete followers, messages and attachments for models that will be unlinked.
         models = tuple(self.mapped('model'))
 
+        query = "DELETE FROM mail_activity_type WHERE res_model IN %s"
+        self.env.cr.execute(query, [models])
+
         query = "DELETE FROM mail_followers WHERE res_model IN %s"
         self.env.cr.execute(query, [models])
 

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -20,19 +20,19 @@ class MailActivityType(models.Model):
     """ Activity Types are used to categorize activities. Each type is a different
     kind of activity e.g. call, mail, meeting. An activity can be generic i.e.
     available for all models using activities; or specific to a model in which
-    case res_model_id field should be used. """
+    case res_model field should be used. """
     _name = 'mail.activity.type'
     _description = 'Activity Type'
     _rec_name = 'name'
     _order = 'sequence, id'
 
-    @api.model
-    def default_get(self, fields):
-        if not self.env.context.get('default_res_model_id') and self.env.context.get('default_res_model'):
-            self = self.with_context(
-                default_res_model_id=self.env['ir.model']._get(self.env.context.get('default_res_model'))
-            )
-        return super(MailActivityType, self).default_get(fields)
+    def _get_model_selection(self):
+        return [
+            (model.model, model.name)
+            for model in self.env['ir.model'].sudo().search(
+                ['&', ('is_mail_thread', '=', True), ('transient', '=', False)])
+        ]
+
 
     name = fields.Char('Name', required=True, translate=True)
     summary = fields.Char('Default Summary', translate=True)
@@ -55,27 +55,25 @@ class MailActivityType(models.Model):
         ('warning', 'Alert'),
         ('danger', 'Error')], string="Decoration Type",
         help="Change the background color of the related activities of this type.")
-    res_model_id = fields.Many2one(
-        'ir.model', 'Model', index=True,
-        domain=['&', ('is_mail_thread', '=', True), ('transient', '=', False)],
+    res_model = fields.Selection(selection=_get_model_selection, string="Model",
         help='Specify a model if the activity should be specific to a model'
              ' and not available when managing activities for other models.')
     triggered_next_type_id = fields.Many2one(
         'mail.activity.type', string='Trigger', compute='_compute_triggered_next_type_id',
         inverse='_inverse_triggered_next_type_id', store=True, readonly=False,
-        domain="['|', ('res_model_id', '=', False), ('res_model_id', '=', res_model_id)]", ondelete='restrict',
+        domain="['|', ('res_model', '=', False), ('res_model', '=', res_model)]", ondelete='restrict',
         help="Automatically schedule this activity once the current one is marked as done.")
     chaining_type = fields.Selection([
         ('suggest', 'Suggest Next Activity'), ('trigger', 'Trigger Next Activity')
     ], string="Chaining Type", required=True, default="suggest")
     suggested_next_type_ids = fields.Many2many(
         'mail.activity.type', 'mail_activity_rel', 'activity_id', 'recommended_id', string='Suggest',
-        domain="['|', ('res_model_id', '=', False), ('res_model_id', '=', res_model_id)]",
+        domain="['|', ('res_model', '=', False), ('res_model', '=', res_model)]",
         compute='_compute_suggested_next_type_ids', inverse='_inverse_suggested_next_type_ids', store=True, readonly=False,
         help="Suggest these activities once the current one is marked as done.")
     previous_type_ids = fields.Many2many(
         'mail.activity.type', 'mail_activity_rel', 'recommended_id', 'activity_id',
-        domain="['|', ('res_model_id', '=', False), ('res_model_id', '=', res_model_id)]",
+        domain="['|', ('res_model', '=', False), ('res_model', '=', res_model)]",
         string='Preceding Activities')
     category = fields.Selection([
         ('default', 'None'), ('upload_file', 'Upload Document')
@@ -86,18 +84,18 @@ class MailActivityType(models.Model):
     default_note = fields.Html(string="Default Note", translate=True)
 
     #Fields for display purpose only
-    initial_res_model_id = fields.Many2one('ir.model', 'Initial model', compute="_compute_initial_res_model_id", store=False,
+    initial_res_model = fields.Selection(selection=_get_model_selection, string='Initial model', compute="_compute_initial_res_model", store=False,
             help='Technical field to keep track of the model at the start of editing to support UX related behaviour')
     res_model_change = fields.Boolean(string="Model has change", help="Technical field for UX related behaviour", default=False, store=False)
 
-    @api.onchange('res_model_id')
-    def _onchange_res_model_id(self):
-        self.mail_template_ids = self.mail_template_ids.filtered(lambda template: template.model_id == self.res_model_id)
-        self.res_model_change = self.initial_res_model_id and self.initial_res_model_id != self.res_model_id
+    @api.onchange('res_model')
+    def _onchange_res_model(self):
+        self.mail_template_ids = self.sudo().mail_template_ids.filtered(lambda template: template.model_id.model == self.res_model)
+        self.res_model_change = self.initial_res_model and self.initial_res_model != self.res_model
 
-    def _compute_initial_res_model_id(self):
+    def _compute_initial_res_model(self):
         for activity_type in self:
-            activity_type.initial_res_model_id = activity_type.res_model_id
+            activity_type.initial_res_model = activity_type.res_model
 
     @api.depends('delay_unit', 'delay_count')
     def _compute_delay_label(self):
@@ -160,12 +158,14 @@ class MailActivity(models.Model):
         if not default_vals.get('res_model_id'):
             return ActivityType
         current_model_id = default_vals['res_model_id']
-        if activity_type_todo and activity_type_todo.active and (activity_type_todo.res_model_id.id == current_model_id or not activity_type_todo.res_model_id):
+        current_model = self.env["ir.model"].sudo().browse(current_model_id)
+        if activity_type_todo and activity_type_todo.active and \
+                (activity_type_todo.res_model == current_model.model or not activity_type_todo.res_model):
             return activity_type_todo
-        activity_type_model = ActivityType.search([('res_model_id', '=', current_model_id)], limit=1)
+        activity_type_model = ActivityType.search([('res_model', '=', current_model.model)], limit=1)
         if activity_type_model:
             return activity_type_model
-        activity_type_generic = ActivityType.search([('res_model_id','=', False)], limit=1)
+        activity_type_generic = ActivityType.search([('res_model', '=', False)], limit=1)
         return activity_type_generic
 
     # owner
@@ -182,7 +182,7 @@ class MailActivity(models.Model):
     # activity
     activity_type_id = fields.Many2one(
         'mail.activity.type', string='Activity Type',
-        domain="['|', ('res_model_id', '=', False), ('res_model_id', '=', res_model_id)]", ondelete='restrict',
+        domain="['|', ('res_model', '=', False), ('res_model', '=', res_model)]", ondelete='restrict',
         default=_default_activity_type_id)
     activity_category = fields.Selection(related='activity_type_id.category', readonly=True)
     activity_decoration = fields.Selection(related='activity_type_id.decoration_type', readonly=True)
@@ -740,8 +740,8 @@ class MailActivity(models.Model):
                 'o_closest_deadline': group['date_deadline'],
             }
         activity_type_infos = []
-        activity_type_ids = self.env['mail.activity.type'].sudo().search(
-            ['|', ('res_model_id.model', '=', res_model), ('res_model_id', '=', False)])
+        activity_type_ids = self.env['mail.activity.type'].search(
+            ['|', ('res_model', '=', res_model), ('res_model', '=', False)])
         for elem in sorted(activity_type_ids, key=lambda item: item.sequence):
             mail_template_info = []
             for mail_template_id in elem.mail_template_ids:
@@ -790,7 +790,7 @@ class MailActivityMixin(models.AbstractModel):
         """
         return self.env.ref('mail.mail_activity_data_todo', raise_if_not_found=False) \
             or self.env['mail.activity.type'].search([('res_model', '=', self._name)], limit=1) \
-            or self.env['mail.activity.type'].search([('res_model_id', '=', False)], limit=1)
+            or self.env['mail.activity.type'].search([('res_model', '=', False)], limit=1)
 
     activity_ids = fields.One2many(
         'mail.activity', 'res_id', 'Activities',

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -16,24 +16,24 @@
                             <field name="active" invisible="1"/>
                             <field name="category"/>
                             <field name="default_user_id" options="{'no_create': True, 'no_edit': True}" domain="[('share', '=', False)]"/>
-                            <field name="res_model_id" groups="base.group_no_one"/>
+                            <field name="res_model" groups="base.group_no_one"/>
                             <field name="res_model_change" invisible="1"/>
-                            <field name="initial_res_model_id" invisible="1"/>
+                            <field name="initial_res_model" invisible="1"/>
                             <field name="summary"/>
                             <field name="icon" groups="base.group_no_one"/>
                             <field name="decoration_type" groups="base.group_no_one"/>
                         </group>
                         <group name="activity_planning" string="Next Activity">
                             <field name="chaining_type" attrs="{'invisible': [('category', '=', 'upload_file')]}"/>
-                            <field name="triggered_next_type_id" options="{'no_open': True}" context="{'default_res_model_id': res_model_id}"
+                            <field name="triggered_next_type_id" options="{'no_open': True}" context="{'default_res_model': res_model}"
                                 attrs="{'required': ['&amp;', ('chaining_type', '=', 'trigger'), ('category', '!=', 'upload_file')],
                                 'invisible': ['&amp;', ('chaining_type', '=', 'suggest'), ('category', '!=', 'upload_file')]}"/>
-                            <field name="suggested_next_type_ids" widget="many2many_tags" context="{'default_res_model_id': res_model_id}"
+                            <field name="suggested_next_type_ids" widget="many2many_tags" context="{'default_res_model': res_model}"
                                 attrs="{'invisible': ['|', ('chaining_type', '=', 'trigger'), ('category', '=', 'upload_file')]}"/>
                             <field name="mail_template_ids" widget="many2many_tags"
-                                domain="[('model_id', '=', res_model_id)]"
-                                attrs="{'invisible': [('res_model_id', '=', False)]}"
-                                context="{'default_model_id': res_model_id}"/>
+                                domain="[('model_id.model', '=', res_model)]"
+                                attrs="{'invisible': [('res_model', '=', False)]}"
+                                context="{'default_model': res_model}"/>
                             <label for="delay_count"/>
                             <div>
                                 <div class="o_row">
@@ -73,7 +73,7 @@
                 <field name="summary"/>
                 <field name="delay_label" string="Planned in" class="text-right"/>
                 <field name="delay_from" string="Type"/>
-                <field name="res_model_id" groups="base.group_no_one"/>
+                <field name="res_model" groups="base.group_no_one"/>
                 <field name="icon" groups="base.group_no_one"/>
             </tree>
         </field>
@@ -168,7 +168,7 @@
         <field name="model">mail.activity</field>
         <field name="arch" type="xml">
             <search string="Activity">
-                <field name="res_model_id"/>
+                <field name="res_model"/>
                 <field name="summary"/>
                 <field name="activity_type_id"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/maintenance/data/mail_data.xml
+++ b/addons/maintenance/data/mail_data.xml
@@ -5,7 +5,7 @@
     <record id="mail_act_maintenance_request" model="mail.activity.type">
         <field name="name">Maintenance Request</field>
         <field name="icon">fa-wrench</field>
-        <field name="res_model_id" ref="maintenance.model_maintenance_request"/>
+        <field name="res_model">maintenance.request</field>
     </record>
 
     <!-- email alias for maintenance requests -->

--- a/addons/maintenance/views/mail_activity_views.xml
+++ b/addons/maintenance/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'maintenance.request')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'maintenance.request')]</field>
         <field name="context">{'default_res_model': 'maintenance.request'}</field>
     </record>
     <menuitem id="maintenance_menu_config_activity_type"

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -220,7 +220,7 @@
         <field name="name">Session open over 7 days</field>
         <field name="summary">note</field>
         <field name="category">default</field>
-        <field name="res_model_id" ref="model_pos_session"/>
+        <field name="res_model">pos.session</field>
         <field name="icon">fa-tasks</field>
         <field name="delay_count">0</field>
     </record>

--- a/addons/product_expiry/data/product_expiry_data.xml
+++ b/addons/product_expiry/data/product_expiry_data.xml
@@ -7,7 +7,7 @@
         <record id="mail_activity_type_alert_date_reached" model="mail.activity.type">
             <field name="name">Alert Date Reached</field>
             <field name="category">default</field>
-            <field name="res_model_id" ref="stock.model_stock_production_lot"/>
+            <field name="res_model">stock.production.lot</field>
             <field name="icon">fa-tasks</field>
             <field name="delay_count">0</field>
         </record>

--- a/addons/project/views/mail_activity_views.xml
+++ b/addons/project/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'project.task')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'project.task')]</field>
         <field name="context">{'default_res_model': 'project.task'}</field>
     </record>
     <menuitem id="project_menu_config_activity_type"

--- a/addons/sale/data/mail_data_various.xml
+++ b/addons/sale/data/mail_data_various.xml
@@ -5,7 +5,7 @@
         <record id="mail_act_sale_upsell" model="mail.activity.type">
             <field name="name">Order Upsell</field>
             <field name="icon">fa-line-chart</field>
-            <field name="res_model_id" ref="sale.model_sale_order"/>
+            <field name="res_model">sale.order</field>
         </record>
 
         <!-- Sale-related subtypes for messaging / Chatter -->

--- a/addons/sale/views/crm_team_views.xml
+++ b/addons/sale/views/crm_team_views.xml
@@ -130,7 +130,7 @@
     </record>
 
     <record id="sales_team.mail_activity_type_action_config_sales" model="ir.actions.act_window">
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', 'in', ['sale.order', 'res.partner', 'product.template', 'product.product'])]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', 'in', ['sale.order', 'res.partner', 'product.template', 'product.product'])]</field>
     </record>
 
 </odoo>

--- a/addons/sale/views/mail_activity_views.xml
+++ b/addons/sale/views/mail_activity_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'sale.order')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'sale.order')]</field>
         <field name="context">{'default_res_model': 'sale.order'}</field>
     </record>
     <menuitem id="sale_menu_config_activity_type"

--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -36,7 +36,7 @@
         </record>
 
         <record id="sales_team.mail_activity_type_action_config_sales" model="ir.actions.act_window">
-            <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', 'in', ['crm.lead', 'sale.order', 'res.partner', 'product.template', 'product.product'])]</field>
+            <field name="domain">['|', ('res_model', '=', False), ('res_model', 'in', ['crm.lead', 'sale.order', 'res.partner', 'product.template', 'product.product'])]</field>
         </record>
 
 </odoo>

--- a/addons/sales_team/views/mail_activity_views.xml
+++ b/addons/sales_team/views/mail_activity_views.xml
@@ -4,7 +4,7 @@
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'res.partner')]</field>
+        <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'res.partner')]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create an Activity Type

--- a/addons/test_mail/data/data.xml
+++ b/addons/test_mail/data/data.xml
@@ -5,19 +5,19 @@
         <field name="name">Do Stuff</field>
         <field name="summary">Really?! Wow! A superpowers drug you can just rub onto your skin?</field>
         <field name="category">default</field>
-        <field name="res_model_id" ref="test_mail.model_mail_test_activity"/>
+        <field name="res_model">mail.test.activity</field>
     </record>
     <record id="mail_act_test_meeting" model="mail.activity.type">
         <field name="name">Meet People</field>
         <field name="summary">You'd think it would be something you'd have to freebase. Noooooo!</field>
         <field name="category">default</field>
-        <field name="res_model_id" ref="test_mail.model_mail_test_activity"/>
+        <field name="res_model">mail.test.activity</field>
     </record>
     <record id="mail_act_test_call" model="mail.activity.type">
         <field name="name">Call People</field>
         <field name="summary">Then throw her in the laundry room, which will hereafter be referred to as "the brig".</field>
         <field name="category">default</field>
-        <field name="res_model_id" ref="test_mail.model_mail_test_activity"/>
+        <field name="res_model">mail.test.activity</field>
     </record>
 
 </odoo>

--- a/addons/website_slides/data/mail_data.xml
+++ b/addons/website_slides/data/mail_data.xml
@@ -12,6 +12,6 @@
         <field name="name">Access Request</field>
         <field name="icon">fa-check-circle</field>
         <field name="sequence">50</field>
-        <field name="res_model_id" ref="website_slides.model_slide_channel"/>
+        <field name="res_model">slide.channel</field>
     </record>
 </data></odoo>


### PR DESCRIPTION
Change `mail.activity.type` model to use selection fields instead of many2one to `ir.model`

Project users need to access `mail.activity.type` configuration which was not possible without admin rights, cf bug at #74954