### PR TITLE
[FIX] crm: prevent the display of closed opportunities

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -823,7 +823,7 @@
                     <filter string="Won" name="won" domain="['&amp;', ('active', '=', True), ('stage_id.is_won', '=', True)]"/>
                     <filter string="Lost" name="lost" domain="['&amp;', ('active', '=', False), ('probability', '=', 0)]"/>
                     <separator/>
-                    <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
+                    <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="['&amp;', ('date_closed', '=', False), ('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"
                         domain="[('activity_ids.date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
                         help="Show all opportunities for which the next action date is before today"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to CRM and create a team.
- Create 2 Opportunities and assign them to the created team
- Put a date in the past for 'Expected Closing'
- Mark one of the Opportunities as Won
- Go to CRM > Sales > Teams
- You will see that the number of overdue opportunities is 1 but when clicking on it, it shows 2

Problem:
As an opportunity is in a stage with "is_one = True" so it was won (Probability 100%).
It should not be displayed with the overdue opportunities

Lost opportunities should not be displayed also.

Solution:
Opportunities won or lost have a closing date, so we can use this field to filter them:
https://github.com/odoo/odoo/blob/14.0/addons/crm/models/crm_lead.py#L590-L591

opw-2590471


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
