### PR TITLE
Master groupby m2m boi

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -310,7 +310,7 @@ class MailActivityMixin(models.AbstractModel):
         )
         self.env.cr.execute(select_query, [tz] * 3 + where_params)
         fetched_data = self.env.cr.dictfetchall()
-        self._read_group_resolve_many2one_fields(fetched_data, annotated_groupbys)
+        self._read_group_resolve_many2x_fields(fetched_data, annotated_groupbys)
         data = [
             {key: self._read_group_prepare_data(key, val, groupby_dict)
              for key, val in row.items()}

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -213,6 +213,9 @@ class Base(models.AbstractModel):
                         group_by_value, format=DISPLAY_DATE_FORMATS[group_by_modifier],
                         locale=locale)
 
+            if field_type == 'many2many' and isinstance(group_by_value, list):
+                group_by_value = str(tuple(group_by_value)) or False
+
             record_values[group_by] = group_by_value
             record_values['__count'] = 1
 

--- a/addons/web/static/src/legacy/js/control_panel/groupby_menu.js
+++ b/addons/web/static/src/legacy/js/control_panel/groupby_menu.js
@@ -57,12 +57,14 @@ odoo.define('web.GroupByMenu', function (require) {
         //---------------------------------------------------------------------
 
         /**
+         * @see {@link odoo/fields.py} Field._description_sortable
+         * @see {@link odoo/fields.py} Many2Many.groupable
          * @private
          * @param {Object} field
          * @returns {boolean}
          */
         _validateField(field) {
-            return field.sortable &&
+            return (field.sortable || (field.type === "many2many" && field.store)) &&
                 field.name !== "id" &&
                 GROUPABLE_TYPES.includes(field.type);
         }

--- a/addons/web/static/src/legacy/js/control_panel/search_utils.js
+++ b/addons/web/static/src/legacy/js/control_panel/search_utils.js
@@ -151,6 +151,7 @@ odoo.define('web.searchUtils', function (require) {
         'datetime',
         'integer',
         'many2one',
+        'many2many',
         'selection',
     ];
     const DEFAULT_INTERVAL = 'month';

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
@@ -54,6 +54,7 @@ var KanbanColumn = Widget.extend({
         this.quickCreateView = options.quickCreateView;
         this.groupedBy = options.groupedBy;
         this.grouped_by_m2o = options.grouped_by_m2o;
+        this.grouped_by_m2m = options.grouped_by_m2m;
         this.editable = options.editable;
         this.deletable = options.deletable;
         this.archivable = options.archivable;
@@ -77,8 +78,8 @@ var KanbanColumn = Widget.extend({
 
         this.record_options = _.clone(recordOptions);
 
-        if (options.grouped_by_m2o || options.grouped_by_date ) {
-            // For many2one and datetime, a false value means that the field is not set.
+        if (options.grouped_by_m2o || options.grouped_by_date || options.grouped_by_m2m) {
+            // For many2x and datetime, a false value means that the field is not set.
             this.title = value ? value : _t('Undefined');
         } else {
             // False and 0 might be valid values for these fields.
@@ -250,6 +251,9 @@ var KanbanColumn = Widget.extend({
      * @return {Promise}
      */
     _addRecord: function (recordState, options) {
+        if (this.grouped_by_m2m) {
+            this.record_options.deletable = false;
+        }
         var record = new this.KanbanRecord(this, recordState, this.record_options);
         this.records.push(record);
         if (options && options.position === 'before') {

--- a/addons/web/static/src/legacy/js/views/list/list_model.js
+++ b/addons/web/static/src/legacy/js/views/list/list_model.js
@@ -73,12 +73,20 @@
                     context: context,
                 });
             }).then(function (results) {
-                results.forEach(function (data) {
-                    var record = _.findWhere(records, {res_id: data.id});
+                const updateLocalRecord = (id, data) => {
+                    const record = self.localData[id];
                     record.data = _.extend({}, record.data, data);
                     record._changes = {};
                     record._isDirty = false;
                     self._parseServerData(fieldNames, record, record.data);
+                };
+
+                results.forEach(function (data) {
+                    const record = _.findWhere(records, { res_id: data.id });
+                    updateLocalRecord(record.id, data);
+
+                    // Also update same resId records
+                    self._updateDuplicateRecords(record.id, (id) => updateLocalRecord(id, data));
                 });
             }).then(function () {
                 if (!list.groupedBy.length) {

--- a/addons/web/static/src/legacy/xml/kanban.xml
+++ b/addons/web/static/src/legacy/xml/kanban.xml
@@ -23,7 +23,7 @@
                             <a t-if="widget.editable and widget.id" role="menuitem" class="dropdown-item o_column_edit" href="#">Edit Stage</a>
                             <a t-if="widget.deletable and widget.id" role="menuitem" class="dropdown-item o_column_delete" href="#">Delete</a>
                         </t>
-                        <t t-if="widget.has_active_field and widget.archivable">
+                        <t t-if="widget.has_active_field and widget.archivable and !widget.grouped_by_m2m">
                             <a role="menuitem" href="#" class="dropdown-item o_column_archive_records">Archive All</a>
                             <a role="menuitem" href="#" class="dropdown-item o_column_unarchive_records">Unarchive All</a>
                         </t>

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -7119,7 +7119,7 @@ QUnit.module('Views', {
             "the kanban view should not be ungrouped");
 
         kanban.update({domain: []}); // 1st update on kanban view
-        kanban.update({groupBy: false}); // 2n update on kanban view
+        kanban.update({groupBy: []}); // 2n update on kanban view
         prom.resolve(); // simulate slow 1st update of kanban view
 
         await nextTick();

--- a/addons/web/tests/test_read_progress_bar.py
+++ b/addons/web/tests/test_read_progress_bar.py
@@ -11,6 +11,20 @@ class TestReadProgressBar(common.TransactionCase):
         super(TestReadProgressBar, self).setUp()
         self.Model = self.env['res.partner']
 
+    def test_read_progress_bar_m2m(self):
+        """ Test that read_progress_bar works with m2m field grouping """
+        progressbar = {
+            'field': 'type',
+            'colors': {
+                'contact': 'success', 'private': 'danger', 'other': 'muted',
+            }
+        }
+        result = self.env['res.partner'].read_progress_bar([], 'category_id', progressbar)
+        # check that it works when grouping by m2m field
+        self.assertTrue(result)
+        # check the null group
+        self.assertIn('False', result)
+
     def test_week_grouping(self):
         """The labels associated to each record in read_progress_bar should match
         the ones from read_group, even in edge cases like en_US locale on sundays

--- a/odoo/addons/test_read_group/tests/test_m2m_grouping.py
+++ b/odoo/addons/test_read_group/tests/test_m2m_grouping.py
@@ -43,19 +43,19 @@ class TestM2MGrouping(common.TransactionCase):
         )
         self.assertEqual(user_by_tasks, [
             {   # first task: both users
-                'task_ids': self.tasks[0].id,
+                'task_ids': (self.tasks[0].id, "Super Mario Bros."),
                 'task_ids_count': 2,
                 'name': ['Mario', 'Luigi'],
                 '__domain': [('task_ids', '=', self.tasks[0].id)],
             },
             {   # second task: Mario only
-                'task_ids': self.tasks[1].id,
+                'task_ids': (self.tasks[1].id, "Paper Mario"),
                 'task_ids_count': 1,
                 'name': ['Mario'],
                 '__domain': [('task_ids', '=', self.tasks[1].id)],
             },
             {   # third task: Luigi only
-                'task_ids': self.tasks[2].id,
+                'task_ids': (self.tasks[2].id, "Luigi's Mansion"),
                 'task_ids_count': 1,
                 'name': ['Luigi'],
                 '__domain': [('task_ids', '=', self.tasks[2].id)],
@@ -71,13 +71,13 @@ class TestM2MGrouping(common.TransactionCase):
         )
         self.assertEqual(task_by_users, [
             {   # task of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 1,
                 'name': ["Super Mario Bros."],
                 '__domain': ['&', ('user_ids', '=', self.users[0].id), ('id', '=', self.tasks[0].id)],
             },
             {   # task of Luigi
-                'user_ids': self.users[1].id,
+                'user_ids': (self.users[1].id, "Luigi"),
                 'user_ids_count': 1,
                 'name': ["Super Mario Bros."],
                 '__domain': ['&', ('user_ids', '=', self.users[1].id), ('id', '=', self.tasks[0].id)],
@@ -92,13 +92,13 @@ class TestM2MGrouping(common.TransactionCase):
         )
         self.assertEqual(task_by_users, [
             {   # tasks of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Paper Mario"]),
                 '__domain': [('user_ids', '=', self.users[0].id)],
             },
             {   # tasks of Luigi
-                'user_ids': self.users[1].id,
+                'user_ids': (self.users[1].id, "Luigi"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Luigi's Mansion"]),
                 '__domain': [('user_ids', '=', self.users[1].id)],
@@ -151,13 +151,13 @@ class TestM2MGrouping(common.TransactionCase):
             )
         self.assertEqual(as_admin, [
             {   # tasks of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Paper Mario"]),
                 '__domain': [('user_ids', '=', self.users[0].id)],
             },
             {   # tasks of Luigi
-                'user_ids': self.users[1].id,
+                'user_ids': (self.users[1].id, "Luigi"),
                 'user_ids_count': 2,
                 'name': unordered(["Super Mario Bros.", "Luigi's Mansion"]),
                 '__domain': [('user_ids', '=', self.users[1].id)],
@@ -203,7 +203,7 @@ class TestM2MGrouping(common.TransactionCase):
             )
         self.assertEqual(as_demo, [
             {   # tasks of Mario
-                'user_ids': self.users[0].id,
+                'user_ids': (self.users[0].id, "Mario"),
                 'user_ids_count': 2,
                 'name': unordered(['Super Mario Bros.', 'Paper Mario']),
                 '__domain': [('user_ids', '=', self.users[0].id)],

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2334,7 +2334,7 @@ class BaseModel(metaclass=MetaModel):
             # full domain for this groupby spec
             d = None
             if value:
-                if ftype == 'many2one':
+                if ftype in ['many2one', 'many2many']:
                     value = value[0]
                 elif ftype in ('date', 'datetime'):
                     locale = get_lang(self.env).code
@@ -2570,7 +2570,7 @@ class BaseModel(metaclass=MetaModel):
         if not groupby_fields:
             return fetched_data
 
-        self._read_group_resolve_many2one_fields(fetched_data, annotated_groupbys)
+        self._read_group_resolve_many2x_fields(fetched_data, annotated_groupbys)
 
         data = [{k: self._read_group_prepare_data(k, v, groupby_dict) for k, v in r.items()} for r in fetched_data]
 
@@ -2597,12 +2597,12 @@ class BaseModel(metaclass=MetaModel):
             )
         return result
 
-    def _read_group_resolve_many2one_fields(self, data, fields):
-        many2onefields = {field['field'] for field in fields if field['type'] == 'many2one'}
-        for field in many2onefields:
+    def _read_group_resolve_many2x_fields(self, data, fields):
+        many2xfields = {field['field'] for field in fields if field['type'] in ['many2one', 'many2many']}
+        for field in many2xfields:
             ids_set = {d[field] for d in data if d[field]}
-            m2o_records = self.env[self._fields[field].comodel_name].browse(ids_set)
-            data_dict = dict(lazy_name_get(m2o_records.sudo()))
+            m2x_records = self.env[self._fields[field].comodel_name].browse(ids_set)
+            data_dict = dict(lazy_name_get(m2x_records.sudo()))
             for d in data:
                 d[field] = (d[field], data_dict[d[field]]) if d[field] else False
 


### PR DESCRIPTION
PURPOSE
Allow to group records by many2many fields.
Use case: turn the user_id m2o field on project.task into a user_ids m2m field in order to assign multiple collaborators on a task

SPECIFICATION
Add many2many fields to the 'list of groupable fields'.
When grouping a set of records by a many2many, records linked to multiple records of the comodel will essentially be in multiple 'groups' (even though those are not really 'groups' anymore).
There will also be a "null" group, for records that have an empty value of the many2many, like "unassigned" records.

Example: grouping a project.task linked to 10 res.users by the user_ids many2many field, the project.task will be 'rendered/considered/displayed' 10 times, once per res.users.
Kind of like if we grouped the m2m relation table instead.

Additional view specific changes when grouping by a m2m field:

    listview
        editing an instance of a record also updates each other instance (if any)
            the same goes when scheduling an activity, etc.
        disable deletion
            the risk here is that the user might expected that this will 'unlike' the record from a specific record of the many2many field
    kanban
        disable drag&drop between groups
        disable deletion
    pivot/graph
        do nothing special for now (i.e. let the m2m grouping behave 'naturally', even if it means having incorrect aggregates)
        we are aware that grouping a reporting view (graph, pivot) will display erroneous/misleading aggregate
            we decided not to address this at this stage
                options:
                    disable aggregates or grouping entirely (restricting the feature)
                    adding some kind of 'warning'

     

TASK 2508608
ENTERPRISE PR odoo/enterprise#20192

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
