### PR TITLE
[FIX] sale_crm: create a new customer when a wrong match is found and…

### DIFF
--- a/addons/sale_crm/tests/test_crm_lead_convert_quotation.py
+++ b/addons/sale_crm/tests/test_crm_lead_convert_quotation.py
@@ -77,6 +77,26 @@ class TestLeadConvertToTicket(crm_common.TestCrmCommon):
         self.assertEqual(action['context']['default_partner_id'], self.contact_2.id)
 
     @users('user_sales_salesman')
+    def test_lead_convert_to_quotation_false_match_create(self):
+        lead = self.lead_1.with_user(self.env.user)
+
+        # invoke wizard and apply it
+        convert = self.env['crm.quotation.partner'].with_context({
+            'active_model': 'crm.lead',
+            'active_id': lead.id,
+        }).create({'action': 'create'})
+
+        convert.write({'partner_id': self.contact_2.id})
+
+        self.assertEqual(convert.action, 'create')
+
+        # ignore matching partner and create a new one
+        convert.action_apply()
+
+        self.assertTrue(bool(lead.partner_id.id))
+        self.assertNotEqual(lead.partner_id, self.contact_2)
+
+    @users('user_sales_salesman')
     def test_lead_convert_to_quotation_nothing(self):
         """ Test doing nothing about customer while converting """
         lead = self.lead_1.with_user(self.env.user)

--- a/addons/sale_crm/wizard/crm_opportunity_to_quotation.py
+++ b/addons/sale_crm/wizard/crm_opportunity_to_quotation.py
@@ -45,6 +45,8 @@ class Opportunity2Quotation(models.TransientModel):
             the freshly created opportunity view.
         """
         self.ensure_one()
-        if self.action != 'nothing':
-            self.lead_id.handle_partner_assignment(force_partner_id=self.partner_id.id, create_missing=(self.action == 'create'))
+        if self.action == 'create':
+            self.lead_id.handle_partner_assignment(create_missing=True)
+        elif self.action == 'exist':
+            self.lead_id.handle_partner_assignment(force_partner_id=self.partner_id.id, create_missing=False)
         return self.lead_id.action_new_quotation()


### PR DESCRIPTION
… create is selected

When clicking on the 'New quotation' action, if no current customer is linked to the lead, a popup opens with the following options:
- Create a new customer
- Link to an existing customer
- Do not link to a customer

If odoo found a potential matching customer but we decide it is the
wrong one and select the first option, a new one should always be
created

opw-2545065
Task-2622793