### PR TITLE
[IMP] website_slides_survey: add context to survey_id

### DIFF
--- a/addons/website_slides_survey/views/slide_slide_views.xml
+++ b/addons/website_slides_survey/views/slide_slide_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//field[@name='slide_type']" position="after">
                 <field name="survey_id"
                     attrs="{'invisible': [('slide_type', '!=', 'certification')], 'required': [('slide_type', '=', 'certification')]}"
-                    domain="[('certification', '=', True)]"/>
+                    domain="[('certification', '=', True)]" context="{'default_certification': True, 'default_scoring_type': 'scoring_without_answers'}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
PURPOSE
Make sure that when users "quick create" a certification, the survey we create is set as a certification.
Otherwise it is afterward excluded from the domain and not possible to find in eLearning.

SPECIFICATION:
Current
When user quick create a certification, then it will create record in survey but not with certification
equals to True. Due to which it will be excluded from domain and we will not able to find it in survey_id in elearning.

To Be:
Pass certification equals to true and scoring_type
equals to scoring_without_answers in context of survey_id. So now,
it will be not excluded in domain('certificate', '=', True) in elearning.

Task Id: 2621296

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
