### PR TITLE
[FIX] l10n_latam_invoice_document : Allow change of the inv n°

### DIFF
--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -20,6 +20,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="l10n_latam_invoice_document.view_move_form"/>
         <field name="arch" type="xml">
+            <field name="l10n_latam_manual_document_number" position="attributes">
+                <attribute name="attrs">{'invisible': [('posted_before', '=', True)]}</attribute>
+            </field>
             <field name="l10n_latam_document_number" position="attributes">
                 <attribute name="attrs">{
                     'invisible': [

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
         compute='_compute_l10n_latam_document_number', inverse='_inverse_l10n_latam_document_number',
         string='Document Number', readonly=True, states={'draft': [('readonly', False)]})
     l10n_latam_use_documents = fields.Boolean(related='journal_id.l10n_latam_use_documents')
-    l10n_latam_manual_document_number = fields.Boolean(compute='_compute_l10n_latam_manual_document_number', string='Manual Number')
+    l10n_latam_manual_document_number = fields.Boolean(compute='_compute_l10n_latam_manual_document_number', readonly=False, string='Manual Number')
 
     @api.depends('l10n_latam_document_type_id')
     def _compute_name(self):

--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -44,6 +44,7 @@
                 <field name="l10n_latam_document_type_id"
                     attrs="{'invisible': [('l10n_latam_use_documents', '=', False)], 'required': [('l10n_latam_use_documents', '=', True)], 'readonly': [('posted_before', '=', True)]}"
                     domain="[('id', 'in', l10n_latam_available_document_type_ids)]" options="{'no_open': True, 'no_create': True}"/>
+                <field name="l10n_latam_manual_document_number"/>
                 <field name="l10n_latam_document_number"
                     attrs="{'invisible': ['|', ('l10n_latam_use_documents', '=', False), ('l10n_latam_manual_document_number', '=', False), '|', '|', ('l10n_latam_use_documents', '=', False), ('highest_name', '!=', False), ('state', '!=', 'draft')], 'required': ['|', ('l10n_latam_manual_document_number', '=', True), ('highest_name', '=', False)], 'readonly': [('posted_before', '=', True), ('state', '!=', 'draft')]}"/>
             </xpath>


### PR DESCRIPTION
Steps to reproduce :

- On a db with chilian localization
- Create a new customer invoice and select a document type
- Save it and create a new one with the same document type

Issue :

We're not able to change the invoice number on the second invoice,
this is a problem when uploading multiple invoices from the past, in
this case, we want to be able to set the invoice number manually.

Solution :

Added a field to the view, in order to compute the field
l10n_latam_manual_document_number, and display the field
l10n_latam_document_number.

opw-2582641

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
