### PR TITLE
[FIX] l10n_latam_invoice_document : Allow change of the inv n°

### DIFF
--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -46,7 +46,7 @@
                     attrs="{'invisible': [('l10n_latam_use_documents', '=', False)], 'required': [('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"
                     domain="[('id', 'in', l10n_latam_available_document_type_ids)]" options="{'no_open': True, 'no_create': True}"/>
                 <field name="l10n_latam_document_number"
-                    attrs="{'invisible': ['|', ('l10n_latam_sequence_id', '!=', False), ('l10n_latam_use_documents', '=', False)], 'required': [('l10n_latam_sequence_id', '=', False), ('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
+                    attrs="{'invisible': [('l10n_latam_use_documents', '=', False)], 'required': [('l10n_latam_sequence_id', '=', False), ('l10n_latam_use_documents', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce :

On a db with chilian localization
Create a new customer invoice and select a document type
Save it and create a new one with the same document type
Issue :

We're not able to change the invoice number on the second invoice,
this is a problem when uploading multiple invoices from the past, in
this case, we want to be able to set the invoice number manually.

Solution :

Changed the visibility of the field l10n_latam_document_number.

opw-2582641

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
