### PR TITLE
[IMP] hr_timesheet, portal, {sale_}project: few improvements for portal

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -35,7 +35,7 @@ class TimesheetCustomerPortal(CustomerPortal):
 
     def _task_get_searchbar_sortings(self):
         values = super()._task_get_searchbar_sortings()
-        values['progress'] = {'label': _('Progress'), 'order': 'progress asc'}
+        values['progress'] = {'label': _('Progress'), 'order': 'progress asc', 'sequence': 9}
         return values
 
     def _get_searchbar_groupby(self):

--- a/addons/hr_timesheet/views/project_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_portal_templates.xml
@@ -24,6 +24,34 @@
         <t t-if="not is_uom_day and task.planned_hours > 0" t-call="project.portal_my_task_planned_hours_template"></t>
     </template>
 
+    <template id="portal_tasks_list_inherit" inherit_id="project.portal_tasks_list" name="Portal: My Tasks with Timesheets">
+        <xpath expr="//t[@t-call='portal.portal_table']" position="inside">
+            <t t-set="timesheet_ids" t-value="task.sudo().timesheet_ids"/>
+            <t t-set="is_uom_day" t-value="timesheet_ids._is_timesheet_encode_uom_day()"/>
+        </xpath>
+        <xpath expr="//thead/tr/th[@name='project_portal_assignees']" position="after">
+            <th t-if="is_uom_day">Days Spent</th>
+            <th t-else="">Hours Spent</th>
+        </xpath>
+        <xpath expr="//tbody/t/tr/td[@name='project_portal_assignees']" position="after">
+            <td>
+                <t t-if="is_uom_day">
+                    <t t-out="timesheet_ids._convert_hours_to_days(task.effective_hours)"/>
+                    <span t-if="task.planned_hours > 0"> / <t t-out="timesheet_ids._convert_hours_to_days(task.planned_hours)"/></span>
+                    <span> day(s)</span>
+                </t>
+                <t t-else="">
+                    <span t-field="task.effective_hours" t-options='{"widget": "float_time"}'/>
+                    <t t-if="task.planned_hours > 0">
+                        /
+                        <span t-field="task.planned_hours" t-options='{"widget": "float_time"}'/>
+                    </t>
+                    <span> hour(s)</span>
+                </t>
+            </td>
+        </xpath>
+    </template>
+
     <template id="portal_timesheet_table" name="Portal Timesheet Table">
         <table class="table table-sm">
             <thead>

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -121,7 +121,7 @@ class CustomerPortal(Controller):
     MANDATORY_BILLING_FIELDS = ["name", "phone", "email", "street", "city", "country_id"]
     OPTIONAL_BILLING_FIELDS = ["zipcode", "state_id", "vat", "company_name"]
 
-    _items_per_page = 20
+    _items_per_page = 80
 
     def _prepare_portal_layout_values(self):
         """Values for /my/* templates rendering.

--- a/addons/project/static/src/scss/portal_rating.scss
+++ b/addons/project/static/src/scss/portal_rating.scss
@@ -32,3 +32,26 @@
         opacity: 0.4
     }
 }
+
+.o_priority_star {
+   display: inline-block;
+
+   &.fa-star-o {
+       color: $o-main-color-muted;
+   }
+   &.fa-star {
+       color: $o-main-favorite-color;
+   }
+}
+
+.o_status {
+    display: block;
+    background-color: gray('200');
+    height: 12px;
+    width: 12px;
+    box-shadow: inset 0 0 0 1px rgba($black, .2);
+
+    .dropdown-item > & {
+        transform: translateX(-50%);
+    }
+}

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -22,6 +22,14 @@
         </xpath>
     </template>
 
+    <template id="portal_my_tasks_priority_widget_template" name="Priority Widget Template">
+        <span t-attf-class="o_priority_star fa fa-star#{'' if task.priority == '1' else '-o'}"/>
+    </template>
+
+    <template id="portal_my_tasks_state_widget_template" name="Status Widget Template">
+        <span t-att-title="task.kanban_state_label" t-attf-class="o_status rounded-circle #{'bg-success' if task.kanban_state == 'done' else 'bg-danger' if task.kanban_state == 'blocked' else ''}"/>
+    </template>
+
     <template id="portal_my_home" name="Show Projects / Tasks" customize_show="True" inherit_id="portal.portal_my_home" priority="40">
         <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
             <t t-call="portal.portal_docs_entry">
@@ -56,10 +64,8 @@
                             <a t-attf-href="/my/project/#{project.id}?{{ keep_query() }}"><span t-field="project.name"/></a>
                         </td>
                         <td class="text-right">
-                            <a t-attf-href="/my/tasks?{{keep_query(filterby=project.id)}}">
-                                <t t-esc="project.task_count_with_subtasks" />
-                                <t t-esc="project.label_tasks" />
-                            </a>
+                            <t t-out="project.task_count_with_subtasks" />
+                            <t t-out="project.label_tasks" />
                         </td>
                     </tr>
                 </tbody>
@@ -95,6 +101,7 @@
                     <thead>
                         <tr t-attf-class="{{'thead-light' if not groupby == 'none' else ''}}">
                             <th class="text-left">Ref</th>
+                            <th t-if="groupby != 'priority'">Priority</th>
                             <th t-if="groupby == 'none'">Name</th>
                             <th t-if="groupby == 'project'">
                                 <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for project:</em>
@@ -102,14 +109,19 @@
                             <th t-if="groupby == 'stage'">
                                 <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in stage:</em>
                                 <span class="text-truncate" t-field="tasks[0].sudo().stage_id.name"/></th>
-                            <th t-if="groupby == 'user'">
-                                <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().user_ids"><span t-field="tasks[0].sudo().project_id.label_tasks"/> assigned to:</em>
-                                <span class="text-truncate" t-esc="', '.join(tasks[0].sudo().mapped('user_ids.name'))"/></th>
+                            <th t-if="groupby == 'priority'">
+                                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in priority:</em>
+                                <span class="text-truncate" t-field="tasks[0].sudo().priority"/></th>
+                            <th t-if="groupby == 'status'">
+                                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> in status:</em>
+                                <span class="text-truncate" t-field="tasks[0].sudo().kanban_state"/></th>
                             <th t-if="groupby == 'customer'">
                                 <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().partner_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for customer:</em>
                                 <span class="text-truncate" t-field="tasks[0].sudo().partner_id.name"/></th>
-                            <th t-if="groupby != 'project'" class="text-center" name="portal_my_tasks_project_th">Project</th>
-                            <th t-if="groupby != 'stage'" class="text-center">Stage</th>
+                            <th name="project_portal_assignees">Assignees</th>
+                            <th t-if="groupby != 'status'">Status</th>
+                            <th t-if="groupby != 'project'">Project</th>
+                            <th t-if="groupby != 'stage'">Stage</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -118,13 +130,25 @@
                                 <td class="text-left">
                                     #<span t-esc="task.id"/>
                                 </td>
+                                <td t-if="groupby != 'priority'">
+                                    <t t-call="project.portal_my_tasks_priority_widget_template"/>
+                                </td>
                                 <td>
-                                    <a t-attf-href="/my/task/#{task.id}?{{ keep_query() }}"><span t-field="task.name"/></a>
+                                    <a t-attf-href="/my/#{task_url}/#{task.id}?{{ keep_query() }}"><span t-field="task.name"/></a>
                                 </td>
-                                <td t-if="groupby != 'project'" class="text-center">
-                                    <span class="badge badge-pill badge-info" title="Current project of the task" t-esc="task.project_id.name" />
+                                <td name="project_portal_assignees">
+                                    <t t-set="assignees" t-value="task.sudo().user_ids"/>
+                                    <span t-if="assignees" t-out="'%s%s' % (assignees[:1].name, ' + %s others' % len(assignees[1:]) if len(assignees.user_ids) > 1 else '')" t-att-title="'\n'.join(assignees[1:].mapped('name'))"/>
                                 </td>
-                                <td t-if="groupby != 'stage'" class="text-center">
+                                <td t-if="groupby != 'status'">
+                                    <t t-call="project.portal_my_tasks_state_widget_template">
+                                        <t t-set="path" t-value="'tasks'"/>
+                                    </t>
+                                </td>
+                                <td t-if="groupby != 'project'">
+                                    <span class="badge badge-pill badge-info mw-100 text-truncate" title="Current project of the task" t-esc="task.project_id.name" />
+                                </td>
+                                <td t-if="groupby != 'stage'">
                                     <span class="badge badge-pill badge-info" title="Current stage of the task" t-esc="task.stage_id.name" />
                                 </td>
                             </tr>
@@ -165,6 +189,7 @@
                         <div class="col-12">
                             <h5 class="d-flex mb-1 mb-md-0 row">
                                 <div class="col-9">
+                                    <t t-call="project.portal_my_tasks_priority_widget_template"/>
                                     <span t-field="task.name" class="text-truncate"/>
                                     <small class="text-muted d-none d-md-inline"> (#<span t-field="task.id"/>)</small>
                                 </div>
@@ -177,7 +202,12 @@
                     </div>
                 </t>
                 <t t-set="card_body">
-                    <div class="row" t-if="task.user_ids or task.partner_id">
+                    <div class="float-right">
+                        <t t-call="project.portal_my_tasks_state_widget_template">
+                            <t t-set="path" t-value="'task'"/>
+                        </t>
+                    </div>
+                    <div class="row mt-3" t-if="task.user_ids or task.partner_id">
                         <div class="col-12 col-md-6 pb-2" t-if="task.user_ids">
                             <strong>Assigned to</strong>
                             <div class="row">
@@ -193,7 +223,7 @@
                                 </t>
                             </div>
                         </div>
-                        <div class="coll-12 col-md-6 pb-2" t-if="task.partner_id">
+                        <div class="col-12 col-md-6 pb-2" t-if="task.partner_id">
                             <strong>Customer</strong>
                             <div class="row">
                                 <div class="col d-flex align-items-center flex-grow-0 pr-3">

--- a/addons/sale_project/__manifest__.py
+++ b/addons/sale_project/__manifest__.py
@@ -17,6 +17,7 @@ This module allows to generate a project/task from sales orders.
         'views/product_views.xml',
         'views/project_task_views.xml',
         'views/sale_order_views.xml',
+        'views/sale_project_portal_templates.xml',
         'views/project_sharing_views.xml',
     ],
     'auto_install': True,

--- a/addons/sale_project/controllers/portal.py
+++ b/addons/sale_project/controllers/portal.py
@@ -16,8 +16,8 @@ class SaleProjectCustomerPortal(ProjectCustomerPortal):
 
     def _task_get_searchbar_groupby(self):
         values = super()._task_get_searchbar_groupby()
-        values['sale_order'] = {'input': 'sale_order', 'label': _('Sales Order'), 'order': 4}
-        values['sale_line'] = {'input': 'sale_line', 'label': _('Sales Order Item'), 'order': 5}
+        values['sale_order'] = {'input': 'sale_order', 'label': _('Sales Order'), 'order': 7}
+        values['sale_line'] = {'input': 'sale_line', 'label': _('Sales Order Item'), 'order': 8}
         return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
 
     def _task_get_groupby_mapping(self):
@@ -27,9 +27,9 @@ class SaleProjectCustomerPortal(ProjectCustomerPortal):
 
     def _task_get_searchbar_inputs(self):
         values = super()._task_get_searchbar_inputs()
-        values['sale_order'] = {'input': 'sale_order', 'label': _('Search in Sales Order'), 'order': 4}
-        values['sale_line'] = {'input': 'sale_line', 'label': _('Search in Sales Order Item'), 'order': 5}
-        values['invoice'] = {'input': 'invoice', 'label': _('Search in Invoice'), 'order': 6}
+        values['sale_order'] = {'input': 'sale_order', 'label': _('Search in Sales Order'), 'order': 7}
+        values['sale_line'] = {'input': 'sale_line', 'label': _('Search in Sales Order Item'), 'order': 8}
+        values['invoice'] = {'input': 'invoice', 'label': _('Search in Invoice'), 'order': 9}
         return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
 
     def _task_get_search_domain(self, search_in, search):

--- a/addons/sale_project/views/sale_project_portal_templates.xml
+++ b/addons/sale_project/views/sale_project_portal_templates.xml
@@ -2,13 +2,17 @@
 <odoo>
 
     <template id="portal_tasks_list_inherit" inherit_id="project.portal_tasks_list">
-        <xpath expr="//t[@t-call='portal.portal_table']//thead/tr/th[@name='portal_my_tasks_project_th']" position="before">
+        <xpath expr="//t[@t-call='portal.portal_table']//thead/tr/th[@name='project_portal_assignees']" position="before">
             <th t-if="groupby == 'sale_order'">
-                <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().sale_order_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order:</em>
-                <span class="text-truncate" t-field="tasks[0].sudo().sale_order_id"/></th>
+                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order:</em>
+                <span t-if="tasks[0].sudo().sale_order_id" class="text-truncate" t-field="tasks[0].sudo().sale_order_id"/>
+                <span t-else="">None</span>
+            </th>
             <th t-if="groupby == 'sale_line'">
-                <em class="font-weight-normal text-muted" t-if="tasks[0].sudo().sale_line_id"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order item:</em>
-                <span class="text-truncate" t-field="tasks[0].sudo().sale_line_id"/></th>
+                <em class="font-weight-normal text-muted"><span t-field="tasks[0].sudo().project_id.label_tasks"/> for sale order item:</em>
+                <span t-if="tasks[0].sudo().sale_line_id" class="text-truncate" t-field="tasks[0].sudo().sale_line_id"/>
+                <span t-else="">None</span>
+            </th>
         </xpath>
     </template>
 


### PR DESCRIPTION
PURPOSE

Generic UX improvements for the portal

SPECIFICATIONS

For projects list view,

- clicking on the project should open the list view of tasks with groupby stage
- the number of tasks should not be clickable

For tasks list view,

- display the fa-star of the priority field on the left of the name of the task
- add the following fields on the right of the name:
  user_id, time spent, kanban_state
- for the kanban_state,
  only display the colored dot and indicate the name of the state on hover
- for the time spent:
  indicate the nb of hours recorded / nb of planned hours(or days(as per unit))
  (if the nb of planned hours = 0, only display the nb of hours recorded)

For tasks search view,

- add a group by priority and status and reorder accordingly
- add a quick search on status and priority and reorder accordingly
- add a sort by priority, assigned to and status and reorder accordingly

For task form view,

- display the fa-star icon of the priority field on the left of the name of task
- add the kanban state in the top right corner

the kanban_state field should be editable by portal users
increase nb of items displayed in the list view to 80 items per page(generic)

Task-2613330

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
