### PR TITLE
[FIX] web_editor: fix bold that bolds too many nodes

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -1,3 +1,4 @@
+import { applyInlineStyle } from '../../src/commands/commands.js';
 import { OdooEditor } from '../../src/OdooEditor.js';
 import { getTraversedNodes } from '../../src/utils/utils.js';
 import {
@@ -2694,6 +2695,16 @@ X[]
             });
         });
     });
+
+    describe('applyInlineStyle', () => {
+        it('should apply style to selection only', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a<span>[b<span>c]d</span>e</span>f</p>',
+                stepFunction: editor => applyInlineStyle(editor, (el) => el.style.color = 'tomato'),
+                contentAfter: '<p>a<span><span style="color: tomato;">[b</span><span><span style="color: tomato;">c]</span>d</span>e</span>f</p>',
+            });
+        });
+    })
 
     describe('setTagName', () => {
         describe('to paragraph', () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/fontSize.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/fontSize.test.js
@@ -19,7 +19,7 @@ describe('FontSize', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<h1>[ab</h1><p>]cd</p>',
                 stepFunction: setFontSize('36px'),
-                contentAfter: '<h1><span style="font-size: 36px;">[ab</span></h1><p>]cd</p>',
+                contentAfter: '<h1><span style="font-size: 36px;">[ab]</span></h1><p>cd</p>',
             });
         });
     });


### PR DESCRIPTION
The bold command used `assignInlineStyle`, which misidentified when a text node needed
to be wrapped in an inline element in some situations, eg:
`<p>aaa<span style="font-weight: normal;">[bbb<span>c]cccc</span>bb</span>dddddd</p>`

task-2613476


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
