### PR TITLE
[IMP] mrp_subcontracting: take produce_delay in account

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 from odoo import api, fields, models
 from odoo.tools.float_utils import float_compare
+from dateutil.relativedelta import relativedelta
 
 
 class StockPicking(models.Model):
@@ -112,7 +113,7 @@ class StockPicking(models.Model):
             'location_dest_id': subcontract_move.picking_id.partner_id.with_company(subcontract_move.company_id).property_stock_subcontractor.id,
             'product_qty': subcontract_move.product_uom_qty,
             'picking_type_id': warehouse.subcontracting_type_id.id,
-            'date_planned_start': subcontract_move.date
+            'date_planned_start': subcontract_move.date - relativedelta(days=product.produce_delay)
         }
         return vals
 


### PR DESCRIPTION
In subcontracting, there wasn't a way to make
the subcontracting resupply delivery plan before
the subcontracting receipt.

Now the hidden subcontracted MO, take in account
(in his planning) the `produce_delay` (in days) of
the product which is automatically plan the
subcontracting resupply delivery correctly.

task-2486811