### PR TITLE
[FIX] point_of_sale: call the configureGui before calling start

### DIFF
--- a/addons/point_of_sale/static/src/js/main.js
+++ b/addons/point_of_sale/static/src/js/main.js
@@ -38,8 +38,8 @@ odoo.define('web.web_client', function (require) {
         webClient.isStarted = true;
         const chrome = new (Registries.Component.get(Chrome))(null, { webClient });
         await chrome.mount(document.querySelector('.o_action_manager'));
-        await chrome.start();
         configureGui({ component: chrome });
+        await chrome.start();
     }
 
     AbstractService.prototype.deployServices(env);


### PR DESCRIPTION
The chrome.start() call also involves iot device loading
which is dependent on Gui to show error when there is any.
In this fix, we call configureGui when the Chrome instance is
available and before calling start.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
