### PR TITLE
[FIX] hr: employee view for non hr groups

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -185,8 +185,8 @@
                                         <label for="barcode"/>
                                         <div class="o_row">
                                             <field name="barcode"/>
-                                            <button string="Generate" class="btn btn-link" type="object" name="generate_random_barcode" attrs="{'invisible': [('barcode', '!=', False)]}"/>
-                                            <button name="%(hr_employee_print_badge)d" string="Print Badge" class="btn btn-link" type="action" attrs="{'invisible': [('barcode', '=', False)]}"/>
+                                            <button string="Generate" class="btn btn-link" type="object" name="generate_random_barcode" attrs="{'invisible': [('barcode', '!=', False)]}" groups="hr.group_hr_user"/>
+                                            <button name="%(hr_employee_print_badge)d" string="Print Badge" class="btn btn-link" type="action" attrs="{'invisible': [('barcode', '=', False)]}" groups="hr.group_hr_user"/>
                                         </div>
                                     </group>
                                 </group>


### PR DESCRIPTION
Restrict barcode buttons access to hr.group_hr_user group.

Description of the issue/feature this PR addresses: Fixes https://github.com/odoo/odoo/issues/75008




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
