### PR TITLE
[IMP] account_reports: Add two options 'Hide if Zero' and 'Hide If Em…

### DIFF
--- a/addons/account/models/account_tax_report.py
+++ b/addons/account/models/account_tax_report.py
@@ -102,7 +102,7 @@ class AccountTaxReportLine(models.Model):
     tag_ids = fields.Many2many(string="Tags", comodel_name='account.account.tag', relation='account_tax_report_line_tags_rel', help="Tax tags populating this line")
     report_action_id = fields.Many2one(string="Report Action", comodel_name='ir.actions.act_window', help="The optional action to call when clicking on this line in accounting reports.")
     children_line_ids = fields.One2many(string="Children Lines", comodel_name='account.tax.report.line', inverse_name='parent_id', help="Lines that should be rendered as children of this one")
-    parent_id = fields.Many2one(string="Parent Line", comodel_name='account.tax.report.line')
+    parent_id = fields.Many2one(string="Parent", comodel_name='account.tax.report.line')
     sequence = fields.Integer(string='Sequence', required=True,
         help="Sequence determining the order of the lines in the report (smaller ones come first). This order is applied locally per section (so, children of the same line are always rendered one after the other).")
     parent_path = fields.Char(index=True, unaccent=False)
@@ -114,7 +114,8 @@ class AccountTaxReportLine(models.Model):
     # fields used in specific localization reports, where a report line isn't simply the given by the sum of account.move.line with selected tags
     code = fields.Char(string="Code", help="Optional unique code to refer to this line in total formulas")
     formula = fields.Char(string="Formula", help="Python expression used to compute the value of a total line. This field is mutually exclusive with tag_name, setting it turns the line to a total line. Tax report line codes can be used as variables in this expression to refer to the balance of the corresponding lines in the report. A formula cannot refer to another line using a formula.")
-
+    hide_if_zero = fields.Boolean(default=False)
+    hide_if_empty = fields.Boolean(default=False)
     # fields used to carry over amounts between periods
 
     # The selection should be filled in localizations using the system

--- a/addons/account/views/account_tax_report_views.xml
+++ b/addons/account/views/account_tax_report_views.xml
@@ -99,15 +99,19 @@
                         <field name="name"/>
                     </group>
                     <group>
-                        <group>
+                        <group string="Main Info">
                             <field name="sequence" invisible="1"/>
                             <field name="tag_name"/>
                             <field name="code"/>
-                        </group>
-                        <group>
-                            <field name="report_id" invisible="1"/>
                             <field name="parent_id" readonly="1"/>
+                        </group>
+                        <group string="Computation">
+                            <field name="report_id" invisible="1"/>
                             <field name="formula"/>
+                        </group>
+                        <group string="Cosmetics" >
+                            <field name="hide_if_zero"/>
+                            <field name="hide_if_empty"/>
                         </group>
                     </group>
                     <group string="Carryover">


### PR DESCRIPTION
…pty' in Tax report

Add two options 'Hide if Zero' and 'Hide If Empty' in Tax report,
'Hide If Empty' only works based on 'Target id' same as like in 'Financial Report' 'Hide If Empty' only  works based on 'Domain name'

opw-2613012

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
