### PR TITLE
[FIX] web: list error handlers on error handle

### DIFF
--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -75,8 +75,6 @@ async function completeUncaughtError(env, uncaughtError, originalError) {
 
 export const errorService = {
     start(env) {
-        const handlers = registry.category("error_handlers").getAll();
-
         function handleError(error, originalError, retry = true) {
             const services = env.services;
             if (!services.dialog || !services.notification || !services.rpc) {
@@ -90,7 +88,7 @@ export const errorService = {
                 }
                 return;
             }
-            for (let handler of handlers) {
+            for (let handler of registry.category("error_handlers").getAll()) {
                 if (handler(env, error, originalError)) {
                     break;
                 }

--- a/addons/web/static/tests/core/errors/error_service_tests.js
+++ b/addons/web/static/tests/core/errors/error_service_tests.js
@@ -265,3 +265,18 @@ QUnit.test("check retry", async (assert) => {
     await def.resolve();
     assert.verifySteps(["dispatched"]);
 });
+
+QUnit.test("lazy loaded handlers", async (assert) => {
+    await makeTestEnv();
+    const errorEvent = new PromiseRejectionEvent("error", { reason: new Error(), promise: null });
+
+    await unhandledRejectionCb(errorEvent);
+    assert.verifySteps([]);
+
+    errorHandlerRegistry.add("__test_handler__", () => {
+        assert.step("in handler");
+    });
+
+    await unhandledRejectionCb(errorEvent);
+    assert.verifySteps(["in handler"]);
+});


### PR DESCRIPTION
Before this commit, error handlers were listed at the start
of  the service and some handlers couldn't be found if they
are not in the registry when the service is started.
Now, they are listed when errors are handled.
