### PR TITLE
[FIX] payment_fix_register_token: Fix invoice reconciliation using pa…

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -426,41 +426,29 @@ class AccountPaymentRegister(models.TransientModel):
             'destination_account_id': batch_result['lines'][0].account_id.id
         }
 
-    def _create_payments(self):
-        self.ensure_one()
-        batches = self._get_batches()
-        edit_mode = self.can_edit_wizard and (len(batches[0]['lines']) == 1 or self.group_payment)
+    def _init_payments(self, to_process, edit_mode=False):
+        """ Create the payments.
 
-        to_reconcile = []
-        if edit_mode:
-            payment_vals = self._create_payment_vals_from_wizard()
-            payment_vals_list = [payment_vals]
-            to_reconcile.append(batches[0]['lines'])
-        else:
-            # Don't group payments: Create one batch per move.
-            if not self.group_payment:
-                new_batches = []
-                for batch_result in batches:
-                    for line in batch_result['lines']:
-                        new_batches.append({
-                            **batch_result,
-                            'lines': line,
-                        })
-                batches = new_batches
+        :param to_process:  A list of python dictionary, one for each payment to create, containing:
+                            * create_vals:  The values used for the 'create' method.
+                            * to_reconcile: The journal items to perform the reconciliation.
+                            * batch:        A python dict containing everything you want about the source journal items
+                                            to which a payment will be created (see '_get_batches').
+        :param edit_mode:   Is the wizard in edition mode.
+        """
 
-            payment_vals_list = []
-            for batch_result in batches:
-                payment_vals_list.append(self._create_payment_vals_from_batch(batch_result))
-                to_reconcile.append(batch_result['lines'])
+        payments = self.env['account.payment'].create([x['create_vals'] for x in to_process])
 
-        payments = self.env['account.payment'].create(payment_vals_list)
+        for payment, vals in zip(payments, to_process):
+            vals['payment'] = payment
 
-        # If payments are made using a currency different than the source one, ensure the balance match exactly in
-        # order to fully paid the source journal items.
-        # For example, suppose a new currency B having a rate 100:1 regarding the company currency A.
-        # If you try to pay 12.15A using 0.12B, the computed balance will be 12.00A for the payment instead of 12.15A.
-        if edit_mode:
-            for payment, lines in zip(payments, to_reconcile):
+            # If payments are made using a currency different than the source one, ensure the balance match exactly in
+            # order to fully paid the source journal items.
+            # For example, suppose a new currency B having a rate 100:1 regarding the company currency A.
+            # If you try to pay 12.15A using 0.12B, the computed balance will be 12.00A for the payment instead of 12.15A.
+            if edit_mode:
+                lines = vals['to_reconcile']
+
                 # Batches are made using the same currency so making 'lines.currency_id' is ok.
                 if payment.currency_id != lines.currency_id:
                     liquidity_lines, counterpart_lines, writeoff_lines = payment._seek_for_lines()
@@ -491,23 +479,78 @@ class AccountPaymentRegister(models.TransientModel):
                         (1, debit_lines[0].id, {'debit': debit_lines[0].debit + delta_balance}),
                         (1, credit_lines[0].id, {'credit': credit_lines[0].credit + delta_balance}),
                     ]})
+        return payments
 
+    def _post_payments(self, to_process, edit_mode=False):
+        """ Post the newly created payments.
+
+        :param to_process:  A list of python dictionary, one for each payment to create, containing:
+                            * create_vals:  The values used for the 'create' method.
+                            * to_reconcile: The journal items to perform the reconciliation.
+                            * batch:        A python dict containing everything you want about the source journal items
+                                            to which a payment will be created (see '_get_batches').
+        :param edit_mode:   Is the wizard in edition mode.
+        """
+        payments = self.env['account.payment']
+        for vals in to_process:
+            payments |= vals['payment']
         payments.action_post()
 
+    def _reconcile_payments(self, to_process, edit_mode=False):
+        """ Reconcile the payments.
+
+        :param to_process:  A list of python dictionary, one for each payment to create, containing:
+                            * create_vals:  The values used for the 'create' method.
+                            * to_reconcile: The journal items to perform the reconciliation.
+                            * batch:        A python dict containing everything you want about the source journal items
+                                            to which a payment will be created (see '_get_batches').
+        :param edit_mode:   Is the wizard in edition mode.
+        """
         domain = [('account_internal_type', 'in', ('receivable', 'payable')), ('reconciled', '=', False)]
-        for payment, lines in zip(payments, to_reconcile):
+        for vals in to_process:
+            payment_lines = vals['payment'].line_ids.filtered_domain(domain)
+            lines = vals['to_reconcile']
 
-            # When using the payment tokens, the payment could not be posted at this point (e.g. the transaction failed)
-            # and then, we can't perform the reconciliation.
-            if payment.state != 'posted':
-                continue
-
-            payment_lines = payment.line_ids.filtered_domain(domain)
             for account in payment_lines.account_id:
                 (payment_lines + lines)\
                     .filtered_domain([('account_id', '=', account.id), ('reconciled', '=', False)])\
                     .reconcile()
 
+    def _create_payments(self):
+        self.ensure_one()
+        batches = self._get_batches()
+        edit_mode = self.can_edit_wizard and (len(batches[0]['lines']) == 1 or self.group_payment)
+        to_process = []
+
+        if edit_mode:
+            payment_vals = self._create_payment_vals_from_wizard()
+            to_process.append({
+                'create_vals': payment_vals,
+                'to_reconcile': batches[0]['lines'],
+                'batch': batches[0],
+            })
+        else:
+            # Don't group payments: Create one batch per move.
+            if not self.group_payment:
+                new_batches = []
+                for batch_result in batches:
+                    for line in batch_result['lines']:
+                        new_batches.append({
+                            **batch_result,
+                            'lines': line,
+                        })
+                batches = new_batches
+
+            for batch_result in batches:
+                to_process.append({
+                    'create_vals': self._create_payment_vals_from_batch(batch_result),
+                    'to_reconcile': batch_result['lines'],
+                    'batch': batch_result,
+                })
+
+        payments = self._init_payments(to_process, edit_mode=edit_mode)
+        self._post_payments(to_process, edit_mode=edit_mode)
+        self._reconcile_payments(to_process, edit_mode=edit_mode)
         return payments
 
     def action_create_payments(self):

--- a/addons/payment/models/account_payment.py
+++ b/addons/payment/models/account_payment.py
@@ -106,18 +106,26 @@ class AccountPayment(models.Model):
         # | Cancelled|<-----------------| cancel() |<-----
         # |__________|                  |__________|
 
+        # Create the missing payment transactions.
         payments_need_trans = self.filtered(lambda pay: pay.payment_token_id and not pay.payment_transaction_id)
-        transactions = payments_need_trans._create_payment_transaction()
+        payments_need_trans._create_payment_transaction()
 
-        res = super(AccountPayment, self - payments_need_trans).action_post()
-
+        # Process payment transactions directly.
+        payments_with_trans = self.filtered('payment_transaction_id')
+        transactions = payments_with_trans.payment_transaction_id
         transactions.s2s_do_transaction()
 
-        # Post payments for issued transactions.
+        # Post payments.
+        payments_to_post = self.filtered(lambda pay: not pay.payment_transaction_id
+                                                     or pay.payment_transaction_id.state == 'done')
+        res = super(AccountPayment, payments_to_post).action_post()
+
+        # Post process transactions.
+        transactions = payments_need_trans.payment_transaction_id.filtered(lambda x: x.state == 'done')
         transactions._post_process_after_done()
-        payments_trans_done = payments_need_trans.filtered(lambda pay: pay.payment_transaction_id.state == 'done')
-        super(AccountPayment, payments_trans_done).action_post()
-        payments_trans_not_done = payments_need_trans.filtered(lambda pay: pay.payment_transaction_id.state != 'done')
-        payments_trans_not_done.action_cancel()
+
+        # Cancel payments if the payment transactions failed.
+        payments_to_cancel = payments_need_trans.payment_transaction_id.filtered(lambda x: x.state != 'done').payment_id
+        payments_to_cancel.action_cancel()
 
         return res

--- a/addons/payment_fix_register_token/tests/__init__.py
+++ b/addons/payment_fix_register_token/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_account_payment_register

--- a/addons/payment_fix_register_token/tests/test_account_payment_register.py
+++ b/addons/payment_fix_register_token/tests/test_account_payment_register.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import patch
+
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install')
+class TestAccountPaymentRegister(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.pay_method_electronic = cls.env.ref('payment.account_payment_method_electronic_in')
+
+        cls.partner_a.country_id = cls.env.ref('base.us')
+
+        cls.pay_acquirer = cls.env['payment.acquirer'].create({
+            'name': "Dummy acquirer",
+            'provider': 'manual',
+            'company_id': cls.env.company.id,
+        })
+
+        cls.pay_token = cls.env['payment.token'].create({
+            'name': "Dummy Token",
+            'partner_id': cls.partner_a.id,
+            'acquirer_id': cls.pay_acquirer.id,
+            'acquirer_ref': "TEST",
+        })
+
+    def test_register_payment_electronic(self):
+
+        def _s2s_do_transaction_mock(_self, **_kwargs):
+            _self.state = 'done'
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 1000.0})],
+        })
+        invoice.action_post()
+        self.assertRecordValues(invoice, [{'amount_residual': 1000.0}])
+
+        with patch(
+            'odoo.addons.payment.models.payment_acquirer.PaymentTransaction.s2s_do_transaction',
+            new=_s2s_do_transaction_mock,
+        ):
+            payments = self.env['account.payment.register']\
+                .with_context(active_model='account.move', active_ids=invoice.ids)\
+                .create({
+                    'payment_method_id': self.pay_method_electronic.id,
+                    'payment_token_id': self.pay_token.id,
+                })\
+                ._create_payments()
+
+        self.assertRecordValues(payments.payment_transaction_id, [{'invoice_ids': invoice.ids}])
+        self.assertRecordValues(invoice, [{'amount_residual': 0.0}])


### PR DESCRIPTION
…yment token

Register a payment for an invoice using a payment token.
=> The payment transaction is not correctly linked to the invoice.

This is because the reconciliation is not yet done when processing the payment transactions.

Issue started with https://github.com/odoo/odoo/pull/74838

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
