### PR TITLE
[FIX] point_of_sale: 2nd order is not sync when loading demo products

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -343,7 +343,10 @@ odoo.define('point_of_sale.Chrome', function(require) {
                 await this.rpc({
                     'route': '/pos/load_onboarding_data',
                 });
-                this.env.pos.load_server_data();
+                await this.env.pos.load_server_data((model) => {
+                    return ['pos.category', 'product.product'].includes(model.model);
+                });
+                this.render();
             }
         }
 

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -628,7 +628,9 @@ exports.PosModel = Backbone.Model.extend({
     ],
 
     // loads all the needed data on the sever. returns a promise indicating when all the data has loaded.
-    load_server_data: function(){
+    // loaderSelector should be undefined or a method that takes one item of the `models` field and returns
+    // a boolean.
+    load_server_data: function(loaderSelector){
         var self = this;
         var progress = 0;
         var progress_step = 1.0 / self.models.length;
@@ -640,6 +642,10 @@ exports.PosModel = Backbone.Model.extend({
                     resolve();
                 } else {
                     var model = self.models[index];
+                    if (loaderSelector && !loaderSelector(model)) {
+                        load_model(index+1);
+                        return;
+                    }
                     self.setLoadingMessage(_t('Loading')+' '+(model.label || model.model || ''), progress);
 
                     var cond = typeof model.condition === 'function'  ? model.condition(self,tmp) : true;


### PR DESCRIPTION
To reproduce:
1. Start odoo instance with `point_of_sale` module **without** demo
2. (Install localization if not yet installed.)
3. Start pos session.
4. Agree to load demo products after pos gui loaded.

Bugs:
1. https://drive.google.com/file/d/1hfYEzFXrL5EEQ-n2UwMtBgp5mYUwBN4H/view
2. https://www.youtube.com/watch?v=mlloK89O_QQ

When loading the demo data, `load_server_data` is called, which calls again
the following:
1. `self.pos_session = pos_sessions[0];` from `pos.session` loader
    -> reason of Bug 1
2. `self.db.set_uuid(self.config.uuid);` from `pos.config` loader
    -> reason of Bug 2

This fix is about only calling the specific loading methods for the data
being loaded. Since there are 2 models being loaded (pos.category and
product.product, see point_of_sale_onboarding.xml), it's more appropriate
to do it this this way, than calling every loading methods.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
