### PR TITLE
[FIX] stock: fix stock_picking compute state

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -439,7 +439,7 @@ class Picking(models.Model):
             elif picking_moves_state_map[picking.id]['all_cancel_done']:
                 picking.state = 'done'
             else:
-                relevant_move_state = self.env['stock.move'].browse(picking_move_lines[picking_id.id])._get_relevant_state_among_moves()
+                relevant_move_state = self.env['stock.move'].browse(picking_move_lines[picking.id])._get_relevant_state_among_moves()
                 if picking.immediate_transfer and relevant_move_state not in ('draft', 'cancel', 'done'):
                     picking.state = 'assigned'
                 elif relevant_move_state == 'partially_available':


### PR DESCRIPTION
Fix error when retrieving _get_relevant_state_among_moves()
for each picking in stock_picking._compute_state.

Fix a small error introduced in odoo/odoo#74808


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
