### PR TITLE
[FIX] web: pdf.js courier font ok with chrome 92


### DIFF
--- a/addons/web/static/lib/pdfjs/src/core/evaluator.js
+++ b/addons/web/static/lib/pdfjs/src/core/evaluator.js
@@ -1491,7 +1491,8 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
 
     getBaseFontMetrics: function PartialEvaluator_getBaseFontMetrics(name) {
       var defaultWidth = 0;
-      var widths = [];
+      // Odoo: backport mozilla/pdf.js@8805614a03c for courier font bug with chrome 92
+      var widths = Object.create(null);
       var monospace = false;
       var lookupName = (stdFontMap[name] || name);
 


### PR DESCRIPTION

In new version of chrome (92) or firefox when some fonts (eg. courier)
were used they woudl sometimes not be shown on the rendering canvas.

This was solved in pdf.js whith this commit:

https://github.com/mozilla/pdf.js/commit/8805614a03

And this PR is backporting that commit in 14.0 version.

opw-2621405 opw-2613412 opw-2620186 opw-2618225 opw-2616690 opw-2615502
opw-2616249 opw-2615144 opw-2613969 opw-2613793 opw-2618129 opw-2617736
opw-2622506 opw-2614508 opw-2620883 opw-2622105 opw-2620863 opw-2615326
opw-2622842 opw-2620220 opw-2622842 opw-2620220 opw-2615346 opw-2615026
opw-2618389 opw-2619382 opw-2613286 opw-2621730 opw-2613412 opw-2622029
opw-2620625 opw-2622311
