### PR TITLE
[FIX] project: focus on task name

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -436,7 +436,7 @@
                     <div class="oe_title pr-0">
                         <h1 class="d-flex flex-row justify-content-between">
                             <field name="priority" widget="priority" class="mr-3"/>
-                            <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
+                            <field name="name" class="o_task_name text-truncate" placeholder="Task Title..." default_focus="1" />
                             <field name="kanban_state" widget="state_selection" class="ml-auto"/>
                         </h1>
                     </div>


### PR DESCRIPTION
When creating a new task the name field was not automatically focused.

TaskID: 2585999

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
