### PR TITLE
[FIX] purchase : Missing access right for User in Purchase group

### DIFF
--- a/addons/account/wizard/pos_box.py
+++ b/addons/account/wizard/pos_box.py
@@ -34,7 +34,7 @@ class CashBox(models.TransientModel):
                 raise UserError(_("You cannot put/take money in/out for a bank statement which is closed."))
             values = box._calculate_values_for_statement_line(record)
             account = record.journal_id.company_id.transfer_account_id
-            self.env['account.bank.statement.line'].with_context(counterpart_account_id=account.id).create(values)
+            self.env['account.bank.statement.line'].with_context(counterpart_account_id=account.id).sudo().create(values)
 
 
 class CashBoxOut(CashBox):


### PR DESCRIPTION
Issue: When closing a PoS session, the user can Cash In/Out of the register but it requires Accounting/Billing group or Purchase/User group. However with Purchase/User group, there was an access right error (not allowed to create account.move.line

Steps to reproduce :
 1) Install PoS Module
 2) PoS > Your Shop > Settings and enable Advanced Cash Control
 3) As administrator and in debug mode go to Settings > Users & Companies > Users
 4) Remove Accounting, Inventory and Purchase group of [User A]
 5) Log in with [User A], open a PoS Session, close it, and in Cash Control form, click Cash In/Out
 6) Remove or add money
 -> Access right error, you need to be Accounting/Billing or Purchase/User
 7) As administrator, add the User group to Purchase for [User A]
 8) As [User A], click Cash In/Out, removed or add money
 -> Still access right error

Why is that a bug:
 The first warning asks us to give the Purchase/User group to the user if we want to Cash In/Out but even when doing that, the access rights are still not enough to allow the creation of the entry

opw-2611298