### PR TITLE
[IMP] web: split js and css assets generation in perfs test

### DIFF
--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -25,13 +25,16 @@ class TestAssetsGenerateTimeCommon(odoo.tests.TransactionCase):
                     bundles |= set(assets.keys())
 
         for bundle in bundles:
-            start_t = time.time()
             with mute_logger('odoo.addons.base.models.assetsbundle'):
-                try:
-                    self.env['ir.qweb']._generate_asset_nodes(bundle, options={})
-                    yield (bundle, time.time() - start_t)
-                except ValueError:
-                    _logger.info('Error detected while generating bundle %r', bundle)
+                for assets_type in 'css', 'js':
+                    try:
+                        start_t = time.time()
+                        css = assets_type == 'css'
+                        js = assets_type == 'js'
+                        self.env['ir.qweb']._generate_asset_nodes(bundle, options={}, css=css, js=js)
+                        yield (f'{bundle}.{assets_type}', time.time() - start_t)
+                    except ValueError:
+                        _logger.info('Error detected while generating bundle %r %s', bundle, assets_type)
 
 
 @odoo.tests.tagged('post_install', '-at_install')


### PR DESCRIPTION
The given time are currently quite high (arround 5 seconds for some
bundles) but it is difficult to know what kind of assets are taking so
much time. This commit will split js and css in order to track the
generation time separatelly.

