### PR TITLE
[FIX] base: manifest cache is empty using cron

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -140,6 +140,10 @@ class IrAsset(models.Model):
         if bundle in seen:
             raise Exception("Circular assets bundle declaration: %s" % " > ".join(seen + [bundle]))
 
+        from odoo.http import root
+        if not root._loaded:
+            root.load_addons()
+            root._loaded = True
         manifest_cache = http.addons_manifest
         exts = []
         if js:


### PR DESCRIPTION
When generating some sale order/invoices pdf automatically (via cron for example), the format of the
invoice is not correct (missing style, background image, etc). The html used to generate these pdf's
misses the asset lines (link to css and js files).

The asset lines are not generated because the manifest cache (http.addons_manifest) is empty if we
render a pdf from a cron.

This commit will generate http.addons_manifest if it's not yet done before.

opw-2581621
opw-2597990
opw-2542242
