### PR TITLE
[FIX] purchase_stock: add the partner_id to the price difference lines

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -153,6 +153,7 @@ class AccountMove(models.Model):
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
                         'exclude_from_invoice_tab': True,
                         'is_anglo_saxon_line': True,
+                        'partner_id': line.partner_id.id,
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)
@@ -172,6 +173,7 @@ class AccountMove(models.Model):
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
                         'exclude_from_invoice_tab': True,
                         'is_anglo_saxon_line': True,
+                        'partner_id': line.partner_id.id,
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product, e.g:”Product A”, with a AVCO + Automated category
- Make sure to assign an account in the price difference account field
- Create an RFQ with the “Product A”
- Confirm RFQ and receive the product
- Create the vendor bill and edit to change the unit cost from 55 to 56
- Post the bill
- Check journal items

Problem:
Price difference accounts have no partner_id
![Screenshot from 2021-08-12 16-05-53](https://user-images.githubusercontent.com/78867936/129211729-34eeeab7-5027-41f9-9cfc-5c2971f25885.png)


opw-2616388



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
