### PR TITLE
[FIX] web: legacy: FieldRadio: unequivocally display the selected val…

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -3423,14 +3423,20 @@ var FieldRadio = FieldSelection.extend({
         this.$el.empty();
         this.$el.attr('role', 'radiogroup')
             .attr('aria-label', this.string);
+
         _.each(this.values, function (value, index) {
+            const isChecked = value[0] === currentValue;
+            // On disabled buttons, it is not clear whether they are checked or not
+            // But we want the selected value to be visible even in readonly
+            const isDisabled = self.hasReadonlyModifier && !isChecked;
+
             self.$el.append(qweb.render('FieldRadio.button', {
-                checked: value[0] === currentValue,
+                checked: isChecked,
                 id: self.unique_id + '_' + value[0],
                 index: index,
                 name: self.unique_id,
                 value: value,
-                disabled: self.hasReadonlyModifier,
+                disabled: isDisabled,
             }));
         });
     },

--- a/addons/web/static/tests/legacy/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields_tests.js
@@ -2360,6 +2360,36 @@ QUnit.module('relational_fields', {
         form.destroy();
     });
 
+    QUnit.test('fieldradio widget shows selected value clearly in readonly', async function (assert) {
+        assert.expect(8);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form>' +
+                    '<group>' +
+                        '<field name="color" widget="radio" readonly="1"/>' +
+                    '</group>' +
+                '</form>',
+        });
+
+        assert.containsOnce(form, ".o_field_radio");
+        const radio = form.el.querySelector(".o_field_radio");
+        assert.containsN(radio, ".o_radio_item", 2);
+
+        const radioItems = radio.querySelectorAll(".o_radio_input");
+        assert.strictEqual(radioItems[0].dataset.value, "red");
+        assert.strictEqual(radioItems[0].getAttribute("checked"), "true");
+        assert.strictEqual(radioItems[0].getAttribute("disabled"), null); // not disabled
+
+        assert.strictEqual(radioItems[1].dataset.value, "black");
+        assert.strictEqual(radioItems[1].getAttribute("checked"), null); // not checked
+        assert.strictEqual(radioItems[1].getAttribute("disabled"), "true");
+
+        form.destroy();
+    });
+
     QUnit.test('fieldradio widget with numerical keys encoded as strings', async function (assert) {
         assert.expect(7);
 


### PR DESCRIPTION
…ue in readonly

Have a FieldRadio in a form view.
Apply the readonly modifier on that widget.

Before this commit, all inputs of the fieldRadio were disabled to not be able to click on them.
This disabled attribute prevented the value of the field to be clearly visible (all the values were greyed).

After this commit, the checked value is not disabled. That way, we can clearly see it, and clicking on it has not effect anyway.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
