### PR TITLE
[14.0] [IMP] account: add hooks for account.analytic.default

### DIFF
--- a/addons/account/models/account_analytic_default.py
+++ b/addons/account/models/account_analytic_default.py
@@ -28,7 +28,7 @@ class AccountAnalyticDefault(models.Model):
             raise ValidationError(_('An analytic default requires at least an analytic account or an analytic tag.'))
 
     @api.model
-    def account_get(self, product_id=None, partner_id=None, account_id=None, user_id=None, date=None, company_id=None):
+    def _account_get_domain(self, product_id=None, partner_id=None, account_id=None, user_id=None, date=None, company_id=None):
         domain = []
         if product_id:
             domain += ['|', ('product_id', '=', product_id)]
@@ -48,18 +48,23 @@ class AccountAnalyticDefault(models.Model):
         if date:
             domain += ['|', ('date_start', '<=', date), ('date_start', '=', False)]
             domain += ['|', ('date_stop', '>=', date), ('date_stop', '=', False)]
-        best_index = -1
-        res = self.env['account.analytic.default']
-        for rec in self.search(domain):
-            index = 0
-            if rec.product_id: index += 1
-            if rec.partner_id: index += 1
-            if rec.account_id: index += 1
-            if rec.company_id: index += 1
-            if rec.user_id: index += 1
-            if rec.date_start: index += 1
-            if rec.date_stop: index += 1
-            if index > best_index:
-                res = rec
-                best_index = index
-        return res
+        return domain
+
+    def _compute_priority(self):
+        self.ensure_one()
+        priority = 0
+        if self.product_id: priority += 1
+        if self.partner_id: priority += 1
+        if self.account_id: priority += 1
+        if self.company_id: priority += 1
+        if self.user_id: priority += 1
+        if self.date_start: priority += 1
+        if self.date_stop: priority += 1
+        return priority
+
+    @api.model
+    def account_get(self, product_id=None, partner_id=None, account_id=None, user_id=None, date=None, company_id=None):
+        domain = self._account_get_domain(product_id=product_id, partner_id=partner_id, account_id=account_id, user_id=user_id, date=date, company_id=company_id)
+        records = self.search(domain)
+        # TODO in master: replace _compute_priority with a stored computed field and do this directly in search with limit=1
+        return fields.first(records.sorted(lambda r: (-r._compute_priority(), r.sequence)))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Add hooks for `account.analytic.default` matching

**Current behavior before PR:**
No way to extend this behaviour without fully overwriting the methods

**Desired behavior after PR is merged:**
Be able to cleanly extend this model



It's worth considering my comment: `TODO in master: replace _compute_priority with a stored computed field and do this directly in search with limit=1`

That should make the account matching slightly more performant

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
