### PR TITLE
[FIX] web: mock active_test for search and search_read

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -464,6 +464,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/webclient/**/helpers.js',
             'web/static/tests/qunit.js',
             'web/static/tests/main.js',
+            'web/static/tests/mock_server_tests.js',
             'web/static/tests/setup.js',
 
             # These 2 lines below are taken from web.assets_frontend

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -942,7 +942,9 @@ export class MockServer {
             fieldNames = Object.keys(model.fields);
         }
         fieldNames = [...new Set(fieldNames.concat(["id"]))];
-        let records = this.getRecords(params.model, params.domain || []);
+        const { context } = params;
+        const active_test = context && "active_test" in context ? context.active_test : true;
+        let records = this.getRecords(params.model, params.domain || [], { active_test });
         if (params.sort) {
             // warning: only consider first level of sort
             params.sort = params.sort.split(",")[0];

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -1,0 +1,96 @@
+/** @odoo-module **/
+
+import { MockServer } from "./helpers/mock_server";
+
+QUnit.module("Mock Server", {
+    beforeEach() {
+        this.data = {
+            models: {
+                "res.partner": {
+                    fields: {
+                        name: {
+                            string: "Name",
+                            type: "string",
+                        },
+                        email: {
+                            string: "Email",
+                            type: "string",
+                        },
+                        active: {
+                            string: "Active",
+                            type: "bool",
+                            default: true,
+                        },
+                    },
+                    records: [
+                        { id: 1, name: "Jean-Michel", email: "jean.michel@example.com" },
+                        { id: 2, name: "Raoul", email: "raoul@example.com", active: false },
+                    ],
+                },
+            },
+        };
+    },
+});
+
+QUnit.test("performRPC: search with active_test=false", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "search",
+        args: [[]],
+        kwargs: {
+            context: { active_test: false },
+        },
+    });
+    const ids = result.map((record) => record.id);
+    assert.deepEqual(ids, [1, 2]);
+});
+
+QUnit.test("performRPC: search with active_test=true", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "search",
+        args: [[]],
+        kwargs: {
+            context: { active_test: true },
+        },
+    });
+    const ids = result.map((record) => record.id);
+    assert.deepEqual(ids, [1]);
+});
+
+QUnit.test("performRPC: search_read with active_test=false", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "search_read",
+        args: [[]],
+        kwargs: {
+            fields: ["name"],
+            context: { active_test: false },
+        },
+    });
+    assert.deepEqual(result, [
+        { id: 1, name: "Jean-Michel" },
+        { id: 2, name: "Raoul" },
+    ]);
+});
+
+QUnit.test("performRPC: search_read with active_test=true", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "search_read",
+        args: [[]],
+        kwargs: {
+            fields: ["name"],
+            context: { active_test: true },
+        },
+    });
+    assert.deepEqual(result, [{ id: 1, name: "Jean-Michel" }]);
+});


### PR DESCRIPTION
The support for "active_test" context key was ignored in "search" and
"search_read" methods. See https://github.com/odoo/odoo/commit/bf0e3403098a9a36cb7c818388ccca1ea87682bd





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
