### PR TITLE
[14.0] website: fix res.config settings

### DIFF
--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -168,6 +168,7 @@ class ResConfigSettings(models.TransientModel):
         }
 
     def action_open_robots(self):
+        self.website_id._force()
         return {
             'name': _("Robots.txt"),
             'view_mode': 'form',

--- a/addons/website/static/src/js/backend/res_config_settings.js
+++ b/addons/website/static/src/js/backend/res_config_settings.js
@@ -24,6 +24,9 @@ BaseSettingController.include({
      * Without this override, it is impossible to go to a website other than the
      * first because discarding will revert it back to the default value.
      *
+     * Without this override, it is impossible to edit robots.txt website other than the
+     * first because discarding will revert it back to the default value.
+     *
      * Without this override, it is impossible to install a theme on a website
      * other than the first because discarding will revert it back to the
      * default value.
@@ -32,6 +35,7 @@ BaseSettingController.include({
      */
     _onButtonClicked: function (ev) {
         if (ev.data.attrs.name === 'website_go_to'
+                || ev.data.attrs.name === 'action_open_robots'
                 || ev.data.attrs.name === 'install_theme_on_current_website') {
             FormController.prototype._onButtonClicked.apply(this, arguments);
         } else {

--- a/addons/website/static/src/js/backend/res_config_settings.js
+++ b/addons/website/static/src/js/backend/res_config_settings.js
@@ -27,6 +27,9 @@ BaseSettingController.include({
      * Without this override, it is impossible to edit robots.txt website other than the
      * first because discarding will revert it back to the default value.
      *
+     * Without this override, it is impossible to submit sitemap to google other than for the
+     * first website because discarding will revert it back to the default value.
+     *
      * Without this override, it is impossible to install a theme on a website
      * other than the first because discarding will revert it back to the
      * default value.
@@ -36,6 +39,7 @@ BaseSettingController.include({
     _onButtonClicked: function (ev) {
         if (ev.data.attrs.name === 'website_go_to'
                 || ev.data.attrs.name === 'action_open_robots'
+                || ev.data.attrs.name === 'action_ping_sitemap'
                 || ev.data.attrs.name === 'install_theme_on_current_website') {
             FormController.prototype._onButtonClicked.apply(this, arguments);
         } else {


### PR DESCRIPTION
[FIX] website: allow edit robots.txt to non-first website
Previous implementation always updated *current website*, which is not
always the same as the value from `res.config.settings`.

[FIX] website: allow submit sitemap to non-first website
