### PR TITLE
[13.0][FIX] mrp_subcontracting: Consume after producing

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -47,17 +47,6 @@ class StockMove(models.Model):
         default['location_id'] = self.picking_id.location_id.id
         return super(StockMove, self).copy(default=default)
 
-    def write(self, values):
-        """ If the initial demand is updated then also update the linked
-        subcontract order to the new quantity.
-        """
-        if 'product_uom_qty' in values:
-            if self.env.context.get('cancel_backorder') is False:
-                return super(StockMove, self).write(values)
-            self.filtered(lambda m: m.is_subcontract and
-            m.state not in ['draft', 'cancel', 'done'])._update_subcontract_order_qty(values['product_uom_qty'])
-        return super(StockMove, self).write(values)
-
     def action_show_details(self):
         """ Open the produce wizard in order to register tracked components for
         subcontracted product. Otherwise use standard behavior.
@@ -206,4 +195,3 @@ operations.""") % ('\n'.join(overprocessed_moves.mapped('product_id.display_name
                     'mo_id': production.id,
                     'product_qty': production.product_uom_qty + quantity_change
                 }).change_prod_qty()
-


### PR DESCRIPTION
With previous code, the call to super is done before doing all the producing stuff, so the consumption takes place before the stock is available. This is not a problem if you don't have any kind of negative stock levels control, as first a negative quant is created, and when the production is done, the negative quant is neutralized.

But if you start using the OCA module `stock_no_negative`, then the negative stock exception raises, and you are not able to finish the subcontracting reception.

Swapping the super call order, means another thing: the backorder is created after the producing code, so we need to filter out the lines that are not being received.
    
A new test has been included for checking the partial reception flow.

@Tecnativa TT31389