### PR TITLE
Fixes read access error due to missing sudo in computation of anglo saxon price unit

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -617,7 +617,7 @@ class ProductProduct(models.Model):
             return 0.0
 
         returned_quantities = defaultdict(float)
-        for move in stock_moves:
+        for move in stock_moves.sudo():
             if move.origin_returned_move_id:
                 returned_quantities[move.origin_returned_move_id.id] += abs(sum(move.stock_valuation_layer_ids.mapped('quantity')))
         candidates = stock_moves\


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When an accountant validates a refund which is linked to some returned stock moves with products enabled for valuation an Access Error is raised due to an missing sudo.

The error was introduced in commit 4d3147a0b123ab591c1ca03a2ee86479992424d / PR #69923
Current behavior before PR:
Access Error is raised

Desired behavior after PR is merged:
No Access Error is raised