### PR TITLE
[FIX] hr: make image zoomable again

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -31,6 +31,7 @@
             <field name="model">hr.employee.public</field>
             <field name="arch" type="xml">
                 <form string="Employee" create="0" write="0" js_class="hr_employee_form">
+                    <field name="image_128" invisible="1" />
                     <header/>
                     <sheet>
                         <field name="user_id" invisible="1"/>
@@ -119,6 +120,7 @@
                     <field name="user_partner_id"/>
                     <field name="last_activity"/>
                     <field name="hr_icon_display"/>
+                    <field name="image_128" />
                     <templates>
                         <t t-name="kanban-box">
                         <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">
@@ -168,7 +170,7 @@
                                     <li t-if="record.work_email.raw_value"><field name="work_email" /></li>
                                     <li t-if="record.work_phone.raw_value" class="o_force_ltr"><field name="work_phone" /></li>
                                 </ul>
-                                <div class="oe_kanban_content">
+                                <div class="oe_kanban_content position-absolute fixed-bottom mr-2">
                                     <div class="o_kanban_record_bottom">
                                         <div class="oe_kanban_bottom_left"/>
                                         <div class="oe_kanban_bottom_right">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -42,6 +42,7 @@
                     <field name="active" invisible="1"/>
                     <field name="user_partner_id" invisible="1"/>
                     <field name="hr_presence_state" invisible="1"/>
+                    <field name="image_128" invisible="1" />
                     <header>
                         <button name="%(plan_wizard_action)d" string="Launch Plan" type="action" groups="hr.group_hr_manager"/>
                     </header>
@@ -245,6 +246,7 @@
                    <field name="user_id"/>
                    <field name="user_partner_id"/>
                    <field name="hr_icon_display"/>
+                   <field name="image_128" />
                    <templates>
                        <t t-name="kanban-box">
                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">


### PR DESCRIPTION
The zoom feature of Image Widget expects a field `image_` being present
in the view to check if a zoomable image is available or not.

Since #69819 the image field was replaced by an avatar one thus breaking
the zoom.

TaskID: 2622671

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
