### PR TITLE
[FIX] point_of_sale: use correct location_id

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -149,15 +149,14 @@ class StockPicking(models.Model):
                             self.env['stock.move.line'].create(ml_vals)
 
                 else:
-                    if self.user_has_groups('stock.group_tracking_owner'):
-                        move._action_assign()
-                        for move_line in move.move_line_ids:
-                            move_line.qty_done = move_line.product_uom_qty
-                        if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
-                            remaining_qty = move.product_uom_qty - move.quantity_done
-                            ml_vals = move._prepare_move_line_vals()
-                            ml_vals.update({'qty_done':remaining_qty})
-                            self.env['stock.move.line'].create(ml_vals)
+                    move._action_assign()
+                    for move_line in move.move_line_ids:
+                        move_line.qty_done = move_line.product_uom_qty
+                    if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
+                        remaining_qty = move.product_uom_qty - move.quantity_done
+                        ml_vals = move._prepare_move_line_vals()
+                        ml_vals.update({'qty_done':remaining_qty})
+                        self.env['stock.move.line'].create(ml_vals)
                     move.quantity_done = move.product_uom_qty
 
     def _send_confirmation_email(self):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -406,15 +406,21 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.pos_config.current_session_id.action_pos_session_closing_control()
 
     def test_order_to_picking02(self):
-        """ This test is similar to test_order_to_picking except that this time, the product is tracked and its
-         location is a sublocation of the main warehouse
+        """ This test is similar to test_order_to_picking except that this time, there are two products:
+            - One tracked by lot
+            - One untracked
+            - Both are in a sublocation of the main warehouse
         """
-        product = self.env['product.product'].create({
-            'name': 'SuperProduct',
+        tracked_product, untracked_product = self.env['product.product'].create([{
+            'name': 'SuperProduct Tracked',
             'type': 'product',
             'tracking': 'lot',
             'available_in_pos': True,
-        })
+        }, {
+            'name': 'SuperProduct Untracked',
+            'type': 'product',
+            'available_in_pos': True,
+        }])
         wh_location = self.company_data['default_warehouse'].lot_stock_id
         shelf1_location = self.env['stock.location'].create({
             'name': 'shelf1',
@@ -423,16 +429,17 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         })
         lot = self.env['stock.production.lot'].create({
             'name': 'SuperLot',
-            'product_id': product.id,
+            'product_id': tracked_product.id,
             'company_id': self.env.company.id,
         })
         qty = 2
-        self.env['stock.quant']._update_available_quantity(product, shelf1_location, qty, lot_id=lot)
+        self.env['stock.quant']._update_available_quantity(tracked_product, shelf1_location, qty, lot_id=lot)
+        self.env['stock.quant']._update_available_quantity(untracked_product, shelf1_location, qty)
 
         self.pos_config.open_session_cb()
         self.pos_config.current_session_id.update_stock_at_closing = False
 
-        untax, atax = self.compute_tax(product, 1.15, 1)
+        untax, atax = self.compute_tax(tracked_product, 1.15, 1)
 
         for i in range(qty):
             pos_order = self.PosOrder.create({
@@ -442,17 +449,26 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 'partner_id': self.partner1.id,
                 'lines': [(0, 0, {
                     'name': "OL/0001",
-                    'product_id': product.id,
+                    'product_id': tracked_product.id,
                     'price_unit': untax + atax,
                     'discount': 0.0,
                     'qty': 1.0,
-                    'tax_ids': [(6, 0, product.taxes_id.ids)],
+                    'tax_ids': [(6, 0, tracked_product.taxes_id.ids)],
                     'price_subtotal': untax,
                     'price_subtotal_incl': untax + atax,
                     'pack_lot_ids': [[0, 0, {'lot_name': lot.name}]],
+                }), (0, 0, {
+                    'name': "OL/0002",
+                    'product_id': untracked_product.id,
+                    'price_unit': untax + atax,
+                    'discount': 0.0,
+                    'qty': 1.0,
+                    'tax_ids': [(6, 0, untracked_product.taxes_id.ids)],
+                    'price_subtotal': untax,
+                    'price_subtotal_incl': untax + atax,
                 })],
-                'amount_tax': atax,
-                'amount_total': untax + atax,
+                'amount_tax': 2 * atax,
+                'amount_total': 2 * (untax + atax),
                 'amount_paid': 0,
                 'amount_return': 0,
             })
@@ -462,14 +478,16 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 "active_id": pos_order.id,
             }
             pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
-                'amount': untax + atax,
+                'amount': 2 * (untax + atax),
             })
             context_payment = {'active_id': pos_order.id}
             pos_make_payment.with_context(context_payment).check()
 
             self.assertEqual(pos_order.state, 'paid')
-            self.assertEqual(pos_order.picking_ids[0].move_line_ids.lot_id, lot)
-            self.assertEqual(pos_order.picking_ids[0].move_line_ids.location_id, shelf1_location)
+            self.assertEqual(pos_order.picking_ids.move_line_ids[0].lot_id, lot)
+            self.assertFalse(pos_order.picking_ids.move_line_ids[1].lot_id)
+            self.assertEqual(pos_order.picking_ids.move_line_ids[0].location_id, shelf1_location)
+            self.assertEqual(pos_order.picking_ids.move_line_ids[1].location_id, shelf1_location)
 
         self.pos_config.current_session_id.action_pos_session_closing_control()
 


### PR DESCRIPTION
To reproduce the error:
1. In Settings, enable "Multi-Step Routes"
2. Create a storable product P
    - Available in POS
3. Update P's quantity:
    - Location: WH/Stock/Shelf 1
    - On Hand Quantity: 1
4. In a POS session, process an order with one P
5. Close the session
6. Consult P's moves

Error: The location used to sell P is Stock instead of Stock/Shelf 1

At some point, the step 5 triggers `_create_move_from_pos_order_lines`.
Because "Consignment" isn't checked in the settings, the if-blocked is
skipped and therefore the move isn't assigned:
https://github.com/odoo/odoo/blob/4bcc63cf49a8c3ab73812de3d171024aa8059b8f/addons/point_of_sale/models/stock_picking.py#L152-L161
Then, on L161, when setting `quantity_done`, it triggers the inverse
method `_quantity_done_set` which will create a SML (because there isn't
one yet):
https://github.com/odoo/odoo/blob/2841525a3a2f1273783874947884b57494def849/addons/stock/models/stock_move.py#L355-L359
but using the location of the move (i.e. Stock)


The if-condition was introduced with d59fc6c96b5b148ac8d2576a7017de90fb4af224 to fix another issue. In the 
meantime, another fix has been deployed for a second issue fe4323b59b88288a2e925165f9ea7a17d4662336 
However, this second commit also fixes the first issue, therefore the 
if-condition is no longer required. As a result, `_action_assign` will be 
called and a SML with the correct location will be created.

OPW-2607748