### PR TITLE
[FIX] hr_expense: fix the approval of multiple expense sheet

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1547,6 +1547,12 @@ msgid "The current user has no related employee. Please, create one."
 msgstr ""
 
 #. module: hr_expense
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
+msgid "The expense reports were successfully approved."
+msgstr ""
+
+#. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_template_register
 msgid ""
 "The first word of the email subject did not correspond to any product code. "
@@ -1566,6 +1572,12 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense_sheet__bank_journal_id
 msgid "The payment method used when the expense is paid by the company."
+msgstr ""
+
+#. module: hr_expense
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
+msgid "There are no expense reports to approve."
 msgstr ""
 
 #. module: hr_expense


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Expenses > Expense Reports to approve
- Select expense reports with different managers
- Click on the Action drop-down button > Approve report

Problem:
Traceback is triggered because we try to access `"self.user_id"` (manager) of expenses as a single element,
While we have several `”user_id”`

Solution:
- Filter the `"hr.expense.sheet"` which must be approved
- Approve each expense separately

opw-2622837


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
