### PR TITLE
[FIX] stock_account : wrong account when PO in anglo-saxon accounting

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -225,7 +225,7 @@ class AccountMoveLine(models.Model):
             and self.move_id.is_purchase_document():
             fiscal_position = self.move_id.fiscal_position_id
             accounts = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fiscal_position)
-            if accounts['stock_input']:
+            if accounts['stock_input'] and len(accounts) == 1:
                 return accounts['stock_input']
         return super(AccountMoveLine, self)._get_computed_account()
 


### PR DESCRIPTION
Issue: When creating a bill from a purchase order in anglo-saxon
accounting, the account_id of the invoice_line_ids was **always**
set to stock_input instead of the specified account in the product
category

Steps to reproduce :
 1) Install Purchase, Inventory, Accounting
 2) Ensures anglo-saxon accounting is enabled
 3) Create a Product Category with income account and expense account
 4) Create a Product with that product category
 5) Create a Purchase Order (rfq) for that product
 6) Confirm, Receive products, validate
 7) Go back to the Purchase Order, create bill
 Bug -> The Account is Stock Interim (Received) instead of the account
 of the product category

Why is that a bug:
 It feels like an unexpected behaviour, when some accounts are set in
 the product category, they should be used instead of forcing them to
 be stock_input. Also in the comment it says to use
 "stock input account by default", but the behaviour was more "use
 stock input account if it is present" which is not the same

Side Note :
 I'm not sure of the intended business flow, from what I got from the
 code it looks like it should be that account when no other account can
 be found, but maybe the business flow is different ? I haven't been
 able to find use cases where `accounts['stock_input']` was falsly, also
 maybe we should use `'stock_input' in accounts and ...` instead of the
 current condition ?

opw-2615301