### PR TITLE
[FIX] sale_timesheet: display all tasks on overview

### DIFF
--- a/addons/sale_timesheet/views/hr_timesheet_templates.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_templates.xml
@@ -132,6 +132,7 @@
                                                             data-model="project.task"
                                                             data-views='[[false, "list"], [false, "form"]]'
                                                             t-att-data-domain="json.dumps([['project_id', 'in', projects.ids], ['sale_line_id', '=', False]])"
+                                                            t-att-data-context="json.dumps({'active_test': False})"
                                                         >
                                                             <span class="btn-link"
                                                                   style="font-weight:normal;"


### PR DESCRIPTION
Steps to reproduce:
- Open Project Overview
- Click on Non Billable Tasks Button

Bug:
- Hours recorded is different than total Tasks displayed on Non Billable Tasks Button

Fix:
This is happening as Archived tasks were not displayed in list.
Now we are passing `active_test': False` in context to show all tasks.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
