### PR TITLE
[IMP] website: add logged in param for conditional visibility

### DIFF
--- a/addons/website/static/src/js/content/inject_dom.js
+++ b/addons/website/static/src/js/content/inject_dom.js
@@ -24,6 +24,8 @@ document.addEventListener('DOMContentLoaded', () => {
         htmlEl.dataset.country = country;
     }
 
+    htmlEl.dataset.logged = !session.is_website_user;
+
     // Create CSS rules in a dedicated style tag according to the snippet
     // visibility option's computed ones (saved as data attributes).
     const styleEl = document.createElement('style');

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1186,6 +1186,16 @@
                 <t t-set="model">utm.source</t>
                 <t t-set="call_with">display_name</t>
             </t>
+            <we-select string="⌙ Users"
+                data-dependencies="visibility_conditional"
+                data-attribute-name="data-logged"
+                data-save-attribute="visibilityValueLogged"
+                data-no-preview="true"
+                data-attribute-default-value="">
+                <we-button data-select-value="true">Visible for Logged In</we-button>
+                <we-button data-select-value="false">Visible for Logged Out</we-button>
+                <we-button data-select-value="">Visible for Everyone</we-button>
+            </we-select>
         </we-collapse>
     </div>
 


### PR DESCRIPTION
This commits adds to the existing conditional visibility option
introduced in [1], the option to display or hide blocs to a user,
depending on if he's logged in or not.

A select widget was added as an alternative to the many2one widgets that
were currently used, as we don't need to connect to the database to
display logged in/logged out option.

[1]: 1c44278

task-2618946




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
