### PR TITLE
[IMP] core: formalize short-circuit operators 💡

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -306,7 +306,7 @@ class Partner(models.Model):
             Partner = self.with_context(active_test=False).sudo()
             domain = [
                 ('vat', '=', partner.vat),
-                ('company_id', 'in', [False, partner.company_id.id]),
+                ('company_id', '?=', partner.company_id.id),
             ]
             if partner_id:
                 domain += [('id', '!=', partner_id), '!', ('id', 'child_of', partner_id)]

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5455,6 +5455,7 @@ Fields:
 
     def filtered_domain(self, domain):
         if not domain: return self
+        domain = expression.normalize_term_operators(domain)
         result = []
         for d in reversed(domain):
             if d == '|':
@@ -5520,7 +5521,7 @@ Fields:
                         ok = any(map(lambda x: x is not None and x <= value, data))
                     elif comparator == '>=':
                         ok = any(map(lambda x: x is not None and x >= value, data))
-                    elif comparator in ('!=', '<>'):
+                    elif comparator == '!=':
                         ok = value not in data
                     elif comparator == 'not in':
                         ok = all(map(lambda x: x not in data, value))
@@ -5536,8 +5537,6 @@ Fields:
                     elif comparator == 'like':
                         data = [(x or "") for x in data]
                         ok = bool(fnmatch.filter(data, value and '*'+value_esc+'*'))
-                    elif comparator == '=?':
-                        ok = (value in data) or not value
                     elif comparator in ('=like'):
                         data = [(x or "") for x in data]
                         ok = bool(fnmatch.filter(data, value_esc))


### PR DESCRIPTION
Previous to this PR, [we had only 1 short-circuit operator: `=?`](https://github.com/odoo/odoo/blob/44029495bc4f85c9f99b16dbab0a49c6ba0f19f9/odoo/osv/expression.py#L1028-L1035).

This PR formalizes the concept and applies it to all existing operators, also introducing a left short-circuit equivalent (`?=`).

```
    Short-circuit operators are:

    <term_operator>?     right is false or left <term_operator> right
    ?<term_operator>     left is false or left <term_operator> right

    Some examples of short-circuit operators:

    =?          right = false or left = right
    !=?         right = false or left != right
    >?          right = false or left > right
    <?          right = false or left < right
    >=?         right = false or left >= right
    <=?         right = false or left <= right
    in?         right = false or left in right
    not in?     right = false or left not in right

    ?=          left = false or left = right
    ?!=         left = false or left != right
    ?>          left = false or left > right
    ?<          left = false or left < right
    ?>=         left = false or left >= right
    ?<=         left = false or left <= right
    ?in         left = false or left in right
    ?not in     left = false or left not in right
```

Using short-circuit operators enables the simplification of some domains like, for example, probably the most common one in Odoo:

`[('|', ('company_id', '=', False), ('company_id', 'in', company_ids)]`

With short-circuit operators:
`[('company_id', '?in', company_ids)]`

Here's another example with a datetime field:

`['|', ('deadline', '=', False), ('deadline', '<=', fields.Datetime.now())]` 

`[('deadline', '?<=', fields.Datetime.now())]`



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
