### PR TITLE
[FIX] repair: do not allow to delete invoiced repair

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -202,10 +202,10 @@ class Repair(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_confirmed(self):
         for order in self:
+            if order.invoice_id and order.invoice_id.posted_before:
+                raise UserError(_('You can not delete a repair order which is linked to an invoice which has been posted once.'))
             if order.state not in ('draft', 'cancel'):
                 raise UserError(_('You can not delete a repair order once it has been confirmed. You must first cancel it.'))
-            if order.state == 'cancel' and order.invoice_id and order.invoice_id.posted_before:
-                raise UserError(_('You can not delete a repair order which is linked to an invoice which has been posted once.'))
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
Before this commit, User was allowed to delete repair order which
is linked to posted invoice by moving it to Draft.

With this commit, user is not allowed to delete repair order linked to
a posted Invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
