### PR TITLE
[FIX] web_editor: Non editable parts saved if there were no modification

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -496,6 +496,11 @@ export class OdooEditor extends EventTarget {
                 if (!attributeCache.get(record.target)[record.attributeName]) {
                     continue;
                 }
+                // Skip the attributes changes based on the dropzones
+                // Dropzones sould not make the dom element Dirty
+                if (record.oldValue && record.oldValue.includes('oe_drop_zone')) {
+                    continue;
+                }
             }
             filteredRecords.push(record);
         }


### PR DESCRIPTION
**PURPOSE**
Currently, when you do not have made any changes in the dom element
still, the editable parts are getting dirty somehow. Even you just started
dragging the snippet but not put yet at any dropzones makes all the editable
parts of the view as dirty and it will create extra views or worst duplicate
views for the website.

**SPECIFICATION**

the system is currently catching all the DOM mutations and making the editable
parts as dirty even if you have made any small changes in any of the single
editable part of your website.

The solution to this issue is to just filter out the exact mutation change among
all the mutations change and make the specific editable part dirty.

With this commit, we are filtering out the dropzone based mutation changes
and making dirty only the part where we have dropped the snippet.

task-2567752

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr