### PR TITLE
[FIX][13.0] payment_paypal: cannot charge extra fees to customers for paying with Paypal

### DIFF
--- a/addons/payment_paypal/models/payment.py
+++ b/addons/payment_paypal/models/payment.py
@@ -91,7 +91,7 @@ class AcquirerPaypal(models.Model):
             'business': self.paypal_email_account,
             'item_name': '%s: %s' % (self.company_id.name, values['reference']),
             'item_number': values['reference'],
-            'amount': values['amount'],
+            'amount': values['amount'] + values['fees'],
             'currency_code': values['currency'] and values['currency'].name or '',
             'address1': values.get('partner_address'),
             'city': values.get('partner_city'),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Cannot charge extra fees to customers for paying with Paypal

Desired behavior after PR is merged:
Can charge extra fees to customers for paying with Paypal




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
