### PR TITLE
[FIX] website_slides_survey: fix certificate preview

### DIFF
--- a/addons/website_slides_survey/views/website_slides_templates_course.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_course.xml
@@ -31,6 +31,9 @@
             <xpath expr="//a[@name='o_wslides_list_slide_add_quizz']" position="attributes">
                 <attribute name="t-if">channel.can_upload and not slide.question_ids and slide.slide_type != 'certification'</attribute>
             </xpath>
+            <xpath expr="//a[@t-if='channel.can_upload']" position="attributes">
+                <attribute name="t-attf-class">#{'d-none' if slide.slide_type == 'certification' else ''}</attribute>
+            </xpath>
         </template>
 
         <template id="course_slides_list_inherit_survey" inherit_id="website_slides.course_slides_list">


### PR DESCRIPTION
Current behavior before PR:
it was raising an error while trying to preview the certificate

Desired behavior after PR is merged:
prevent the preview of the certificate, as it is not possible to
set the preview of the certificate

Task: https://www.odoo.com/web#id=2623276&action=4043&model=project.task&view_type=form&cids=2&menu_id=4720

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
