### PR TITLE
[IMP] odoo: models: add field name in field descr

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3079,6 +3079,7 @@ class BaseModel(metaclass=MetaModel):
                 continue
 
             description = field.get_description(self.env)
+            description['name'] = fname
             if readonly:
                 description['readonly'] = True
                 description['states'] = {}


### PR DESCRIPTION
The fields dict maps field names to their description. Before this
commit, the field name wasn't specified in the description, meaning
that we could never manipulate the field description without its
key, which would often be convenient.