### PR TITLE
[FIX] l10n_ch: Don't count foreign iban as qr_iban

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -271,7 +271,8 @@ class ResPartnerBank(models.Model):
         different.
         """
         self.ensure_one()
-        return self.acc_type == 'iban' \
+        return self.sanitized_acc_number.startswith('CH')\
+               and self.acc_type == 'iban'\
                and self._check_qr_iban_range(self.sanitized_acc_number)
 
     @api.model


### PR DESCRIPTION
When creating a bill when we specify a French account in the recipient's account we receive the following warning "Please fill in a correct ISR reference in the payment reference. The banks will refuse your payment file otherwise."

This PR adds a condition to limit the verification to Swiss accounts

opw-2581434