### PR TITLE
[FIX] mrp: set backorder name with custom sequence name

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1408,7 +1408,7 @@ class MrpProduction(models.Model):
             return name
         seq_back = "-" + "0" * (SIZE_BACK_ORDER_NUMERING - 1 - int(math.log10(sequence))) + str(sequence)
         regex = re.compile(r"-\d+$")
-        if regex.search(name):
+        if regex.search(name) and sequence > 1:
             return regex.sub(seq_back, name)
         return name + seq_back
 
@@ -1431,6 +1431,7 @@ class MrpProduction(models.Model):
         for production in self:
             if production.backorder_sequence == 0:  # Activate backorder naming
                 production.backorder_sequence = 1
+            production.name = self._get_name_backorder(production.name, production.backorder_sequence)
             backorder_mo = production.copy(default=production._get_backorder_mo_vals())
             if close_mo:
                 production.move_raw_ids.filtered(lambda m: m.state not in ('done', 'cancel')).write({
@@ -1463,8 +1464,6 @@ class MrpProduction(models.Model):
                     wo.qty_producing = wo.qty_remaining
                 if wo.qty_producing == 0:
                     wo.action_cancel()
-
-            production.name = self._get_name_backorder(production.name, production.backorder_sequence)
 
             # We need to adapt `duration_expected` on both the original workorders and their
             # backordered workorders. To do that, we use the original `duration_expected` and the


### PR DESCRIPTION
If the prefix of the production sequence contains some dashes, it can
lead to undesirable behaviors

To reproduce the error:
(Enable debug mode)
1. Settings > Technical > Sequences & Identifiers > Sequences, edit "San
Francisco Sequence production":
    - Prefix: "WH-MO-"
2. Create a MO
    - Quantity: 2
3. Confirm, Edit:
    - Quantity: 1/2
4. (Keep MO's name in mind and) Validate + Create backorder

Error: Backorder's name is "WH-MO-002" instead of "WH-MO-0000X-002".
Going back to the initial MO, its name became "WH-MO-001" (was
"WH-MO-0000X")

Note: This commit does not fully fix the issue. For instance, on step
1, if the user updates the prefix with "WH-MO-" and set the sequence
size equals to `SIZE_BACK_ORDER_NUMERING`, the same issue will occur
again.

OPW-2618971