### PR TITLE
[FIX] web_editor: fix invisible document links when sent via email

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -417,7 +417,7 @@ FieldHtml.include({
      */
     _toInline: function () {
         var $editable = this.wysiwyg.getEditable();
-        var html = this.wysiwyg.getValue();
+        var html = this.wysiwyg.getValue({'style-inline': true});
         $editable.html(html);
 
         attachmentThumbnailToLinkImg($editable);

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -108,7 +108,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         }
         var _super = this._super.bind(this);
         return this.wysiwyg.saveCroppedImages(this.$content).then(function () {
-            return self.wysiwyg.save().then(function (result) {
+            return self.wysiwyg.save(self.nodeOptions).then(function (result) {
                 self._isDirty = result.isDirty;
                 _super();
             });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -130,7 +130,9 @@ var Wysiwyg = Widget.extend({
         $editable.find('[title=""]').removeAttr('title');
         $editable.find('[alt=""]').removeAttr('alt');
         $editable.find('[data-original-title=""]').removeAttr('data-original-title');
-        $editable.find('a.o_image, span.fa, i.fa').html('');
+        if (!options || !options['style-inline']) {
+            $editable.find('a.o_image, span.fa, i.fa').html('');
+        }
         $editable.find('[aria-describedby]').removeAttr('aria-describedby').removeAttr('data-original-title');
         return $editable.html();
     },
@@ -142,9 +144,9 @@ var Wysiwyg = Widget.extend({
      * @returns {Promise}
      *      - resolve with true if the content was dirty
      */
-    save: function () {
+    save: function (options) {
         var isDirty = this.isDirty();
-        var html = this.getValue();
+        var html = this.getValue(options);
         if (this.$target.is('textarea')) {
             this.$target.val(html);
         } else {


### PR DESCRIPTION
- Go to any record with a chatter (i.e. a SO)
- Use full composer to send a message
- In editor, use "File/Image" option to upload a document to the body of the message
- Upload any document (i.e. a PDF file)
- PDF icon will appear in the message
- Send the message
In the chatter, PDF icon appear in the message, allowing to download the file.
But in the sent email, the link is present but it is not visible. There is no icon.

Such link is a <a> element with "o_image" class. When converting to inline, an <img>
element is added with an icon depending on file mime-type.
However, when getting its value, a cleaning is executed, removing this added <img>.

It should not be cleaned when converting to inline.

opw-2558602


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
