### PR TITLE
[IMP] hr_timesheet: improve generic usage

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -179,7 +179,7 @@ class AccountAnalyticLine(models.Model):
     def _default_user(self):
         return self.env.context.get('user_id', self.env.user.id)
 
-    name = fields.Char('Description', required=True)
+    name = fields.Char('Description', required=True, translate=True)
     date = fields.Date('Date', required=True, index=True, default=fields.Date.context_today)
     amount = fields.Monetary('Amount', required=True, default=0.0)
     unit_amount = fields.Float('Quantity', default=0.0)

--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -61,7 +61,7 @@ class ResCompany(models.Model):
         for company in self:
             company = company.with_company(company)
             results += [{
-                'name': _('Internal'),
+                'name': _('Internal - %s', company.name),
                 'allow_timesheets': True,
                 'company_id': company.id,
                 'type_ids': type_ids,

--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -6,13 +6,13 @@
                     <thead>
                         <tr>
                             <th class="align-middle"><span>Date</span></th>
-                            <th class="align-middle"><span>Responsible</span></th>
-                            <th class="align-middle"><span>Description</span></th>
+                            <th class="align-middle"><span>Employee</span></th>
                             <th class="align-middle" t-if="show_project"><span>Project</span></th>
                             <th class="align-middle" t-if="show_task"><span>Task</span></th>
+                            <th class="align-middle"><span>Description</span></th>
                             <th class="text-right">
-                                <span t-if="is_uom_day">Time Spent (Days)</span>
-                                <span t-else="">Time Spent (Hours)</span>
+                                <span t-if="is_uom_day">Days Spent</span>
+                                <span t-else="">Hours Spent</span>
                             </th>
                         </tr>
                    </thead>
@@ -25,14 +25,14 @@
                                <span t-field="line.user_id.partner_id.name"/>
                                <span t-if="not line.user_id.partner_id.name" t-field="line.employee_id"/>
                             </td>
-                            <td >
-                                <span t-field="line.name" t-options="{'widget': 'text'}"/>
-                            </td>
                             <td t-if="show_project">
                                 <span t-field="line.project_id.sudo().name"/>
                             </td>
                             <td t-if="show_task">
                                 <t t-if="line.task_id"><span t-field="line.task_id.sudo().name"/></t>
+                            </td>
+                            <td >
+                                <span t-field="line.name" t-options="{'widget': 'text'}"/>
                             </td>
                             <td class="text-right">
                                 <span t-if="is_uom_day" t-esc="line._get_timesheet_time_day()" t-options="{'widget': 'timesheet_uom'}"/>


### PR DESCRIPTION
Purpose of this commit to improve ux for
timesheet app.

So, In this commit done following changes:

- make name field of account.analytic.line model
  translatable by user.
- changes in report of timesheet:
  - make generic table templete for timesheet.
  - changes label for employee_id field column
    'responsible' into 'employee' and unit_
    amount field column 'time spent (hours)'
    into 'hours spent' and 'time spent (days)'
    into 'days spent'.
  - move name(description) field column right of
    the task column.
  - add timesheet entry report for project.
- change internal project name when user has
  access to multiple companies.

Task Id: 2604773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
