### PR TITLE
[IMP] stock: clean up commit calls and add logs

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -542,6 +542,7 @@ class StockWarehouseOrderpoint(models.Model):
             if use_new_cursor:
                 cr.commit()
                 cr.close()
+                _logger.info("A batch of 1000 orderpoints is processed and commited")
 
         return {}
 

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -518,8 +518,6 @@ class ProcurementGroup(models.Model):
         # recomputed
         orderpoints.sudo()._compute_qty_to_order()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
-        if use_new_cursor:
-            self._cr.commit()
 
         # Search all confirmed stock_moves and try to assign them
         domain = self._get_moves_to_assign_domain(company_id)
@@ -529,12 +527,14 @@ class ProcurementGroup(models.Model):
             self.env['stock.move'].browse(moves_chunk).sudo()._action_assign()
             if use_new_cursor:
                 self._cr.commit()
+                _logger.info("A batch of 100 moves are assigned and commited")
 
         # Merge duplicated quants
         self.env['stock.quant']._quant_tasks()
 
         if use_new_cursor:
             self._cr.commit()
+            _logger.info("_run_scheduler_tasks is finished and commited")
 
     @api.model
     def run_scheduler(self, use_new_cursor=False, company_id=False):


### PR DESCRIPTION
the deleted commit is not needed since it's already called in
`_procure_orderpoint_confirm`

The logs are usefull to check whether we have progress on repeating the
scheduler that gives timeout error.