### PR TITLE
[FIX] web_editor: ensure a node exists

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -85,7 +85,7 @@ const Wysiwyg = Widget.extend({
                 const selection = document.getSelection();
                 if (selection.isCollapsed && selection.rangeCount) {
                     const node = closestElement(selection.anchorNode, 'P, DIV');
-                    return !(node.hasAttribute && node.hasAttribute('data-oe-model')) && node;
+                    return !(node && node.hasAttribute && node.hasAttribute('data-oe-model')) && node;
                 }
             },
             isHintBlacklisted: node => {


### PR DESCRIPTION
Whenever using the `getPowerboxElement`, it is possible to have a
null node.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
