### PR TITLE
[FIX] survey: fix survey form view "conditional" question icon

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -218,7 +218,7 @@
                 <field name="survey_id"/>
                 <field name="question_type"/>
                 <field name="triggering_question_id" invisible="1"/>
-                <button icon="fa-code-fork" attrs="{'invisible': [('triggering_question_id', '=', False)]}"
+                <button disabled="disabled" icon="fa-code-fork" attrs="{'invisible': [('triggering_question_id', '=', False)]}"
                     title="This question depends on another question's answer." class="icon_rotates"/>
             </tree>
         </field>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -71,7 +71,7 @@
                                     <field name="survey_id" invisible="1"/>
                                     <field name="triggering_question_id" invisible="1"/>
                                     <field name="random_questions_count" attrs="{'column_invisible': [('parent.questions_selection', '=', 'all')], 'invisible': [('is_page', '=', False)]}" />
-                                    <button icon="fa-code-fork" attrs="{'invisible': [('triggering_question_id', '=', False)]}"
+                                    <button disabled="disabled" icon="fa-code-fork" attrs="{'invisible': [('triggering_question_id', '=', False)]}"
                                         title="This question depends on another question's answer." class="icon_rotates"/>
                                     <control>
                                         <create name="add_question_control" string="Add a question"/>


### PR DESCRIPTION
Since the latest OWL refactoring, "button" DOM element in tree views cannot
be defined without an associated action (it will crash on click).

In the survey module, we use a "fake" button to mark a question as conditional
(based on the answer of another question). The button functions as a simple
icon and has no attached action.

To fix the issue, we now mark the button as "disabled" so the click action will
not trigger anything.

Task-2618108
