### PR TITLE
[IMP] website: update the bewise-1 palette

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -599,15 +599,13 @@ $o-color-palettes: map-merge($o-color-palettes,
         ),
         'bewise-1': (
             'o-color-1': #162238,
-            'o-color-2': #fda301,
+            'o-color-2': #b4904f,
             'o-color-3': #f0f4f4,
             'o-color-4': #ffffff,
             'o-color-5': #222222,
 
-            'o-cc4-bg': #b4904f,
-
             'body': 'o-color-3',
-            'menu': 4,
+            'menu': 3,
             'footer': 1,
             'copyright': 1,
         ),


### PR DESCRIPTION
This commit updates the bewise-1 palette. It replaces the o-color-2 by the extra color of the o_cc4 and improves the compatibility with the others palettes when we switch between them.

This change is related to an update of the theme Be Wise on [PR#477](https://github.com/odoo/design-themes/pull/477) in the Design-theme repo.

task-2573302