### PR TITLE
[FIX] account: issue with currency rounding in vendor bills

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -434,6 +434,7 @@ class AccountMove(models.Model):
     @api.onchange('line_ids', 'invoice_payment_term_id', 'invoice_date_due', 'invoice_cash_rounding_id', 'invoice_vendor_bill_id')
     def _onchange_recompute_dynamic_lines(self):
         self._recompute_dynamic_lines()
+        self._onchange_currency()
 
     @api.model
     def _get_tax_grouping_key_from_tax_line(self, tax_line):


### PR DESCRIPTION
Step to follow

- Create a rate of 0.273747605000 for the EUR currency
- Create a purchase tax of 18%
- Create a vendor bill
- Select EUR as Currency
- Add a line with 155.32 as price and 18% of taxes
- Journal items prices are off by a few cents until you select EUR again

Solution

- Call _onchange_currency() when lines are changed

opw-2569668