### PR TITLE
[FIX] stock: do not copy move on duplicating scrap

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -44,7 +44,7 @@ class StockScrap(models.Model):
         'stock.quant.package', 'Package',
         states={'done': [('readonly', True)]}, check_company=True)
     owner_id = fields.Many2one('res.partner', 'Owner', states={'done': [('readonly', True)]}, check_company=True)
-    move_id = fields.Many2one('stock.move', 'Scrap Move', readonly=True, check_company=True)
+    move_id = fields.Many2one('stock.move', 'Scrap Move', readonly=True, check_company=True, copy=False)
     picking_id = fields.Many2one('stock.picking', 'Picking', states={'done': [('readonly', True)]}, check_company=True)
     location_id = fields.Many2one(
         'stock.location', 'Source Location', domain="[('usage', '=', 'internal'), ('company_id', 'in', [company_id, False])]",


### PR DESCRIPTION
Before this commit, Scrap move was copied to new record on
duplicating Scrap order.

With this commit, Scrap move is not copied.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
