### PR TITLE
[FIX] web: export fail when list passed to write function

### DIFF
--- a/addons/test_xlsx_export/ir.model.access.csv
+++ b/addons/test_xlsx_export/ir.model.access.csv
@@ -2,3 +2,4 @@
 access_export_group_operator,access_export_group_operator,model_export_group_operator,,1,1,1,1
 access_export_group_operator_one2many,access_export_group_operator_one2many,model_export_group_operator_one2many,,1,1,1,1
 access_export_integer,access_export_integer,model_export_integer,,1,1,1,1
+access_export_computed_binary,access_export_computed_binary,model_export_computed_binary,,1,1,1,1

--- a/addons/test_xlsx_export/models.py
+++ b/addons/test_xlsx_export/models.py
@@ -34,3 +34,14 @@ class GroupOperatorO2M(models.Model):
 
     parent_id = fields.Many2one('export.group_operator')
     value = fields.Integer()
+
+class ComputedBinary(models.Model):
+    _name = 'export.computed.binary'
+    _description = 'Export computed binary'
+
+    binary_field = fields.Binary(compute='_compute_binary_field')
+
+    def _compute_binary_field(self):
+        # This kind of computed binary field is obviously a bad idea,
+        # but since the ORM supports it, the export also needs to handle it.
+        self.binary_field = ["computed value"]

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -824,6 +824,8 @@ class ExportXlsxWriter:
             cell_style = self.datetime_style
         elif isinstance(cell_value, datetime.date):
             cell_style = self.date_style
+        elif isinstance(cell_value, (list, tuple)):
+            cell_value = pycompat.to_text(cell_value)
         self.write(row, column, cell_value, cell_style)
 
 class GroupExportXlsxWriter(ExportXlsxWriter):


### PR DESCRIPTION
when trying to export the field `Tax amount by group` in invoices it fails with a traceback as the `write` function only expects a string while the `write_cell` function passes a list of tuples.

To reproduce it: go to invoices list view -> group by some field -> select some invoices and export the field Tax amount by group

opw-2591239
