### PR TITLE
[FIX] sale_stock: fix effective picking date

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -41,7 +41,7 @@ class SaleOrder(models.Model):
         for order in self:
             pickings = order.picking_ids.filtered(lambda x: x.state == 'done' and x.location_dest_id.usage == 'customer')
             dates_list = [date for date in pickings.mapped('date_done') if date]
-            order.effective_date = dates_list and min(dates_list).date()
+            order.effective_date = dates_list and fields.Date.context_today(order, min(dates_list))
 
     @api.depends('picking_policy')
     def _compute_expected_date(self):


### PR DESCRIPTION
- Create a sale order that generates picking and confirm it.
- Validate the picking  when the local DATE and the GMT DATE
are different (i.e. GMT-4, between local 20:00:00 and 23:59:59)

Effective Date will be different in the SO and the picking

opw-2559308

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
