### PR TITLE
[FIX] mrp, stock: fix UoM behavior for done MOs/pickings

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -267,7 +267,7 @@
                                         decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"
                                         decoration-warning="not is_done and (quantity_done - should_consume_qty &gt; 0.0001)"
                                         attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('show_details_visible', '=', True)]}"/>
-                                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
+                                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('id', '!=', False)]}" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
                                     <field name="show_details_visible" invisible="1"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         groups="stock.group_production_lot" optional="hide"


### PR DESCRIPTION
This PR fixes 2 things:

1. Preventing a validation error when adding more component moves to a Done MO while UoM setting is active.
~2. Preventing changing of UoMs for done moves in MOs and pickings (this causes quant inconsistencies)~

opw: 2514262

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
