### PR TITLE
[REV] account: fix fiscal position with delivery address

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -167,10 +167,11 @@ class AccountFiscalPosition(models.Model):
         # This can be easily overridden to apply more complex fiscal rules
         PartnerObj = self.env['res.partner']
         partner = PartnerObj.browse(partner_id)
-        delivery = PartnerObj.browse(delivery_id)
 
-        # If partner and delivery have the same vat prefix, use invoicing
-        if not delivery or (delivery.vat and partner.vat and delivery.vat[:2] == partner.vat[:2]):
+        # if no delivery use invoicing
+        if delivery_id:
+            delivery = PartnerObj.browse(delivery_id)
+        else:
             delivery = partner
 
         # partner manually set fiscal position always win

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -149,15 +149,3 @@ class TestFiscalPosition(common.TransactionCase):
         mapped_taxes = self.fp2m.map_tax(self.src_tax)
 
         self.assertEqual(mapped_taxes, self.dst1_tax | self.dst2_tax)
-
-    def test_30_fp_country_delivery(self):
-        """
-            Customer is in Belgium
-            Delivery is in France
-            Check if fiscal position is France
-        """
-        self.george.vat = False
-        self.assertEqual(
-            self.fp.get_fiscal_position(self.ben.id, self.george.id),
-            self.fr_b2c.id,
-            "FR B2C should be set")


### PR DESCRIPTION
This reverts the following commits:
- 164409b00106a5f91d8b84ac698f4cf2aebedb91
- f11c807217cccd96fa18fe24c0cbb436bb1830d1
- c92ebc91e261827dfafa602eae5408de2a072609

The fix we initially made did not cover every possible scenario,
and applied to every fiscal position, which was not required.

It requires a more in depth rework that is under way
and will come in a future PR.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
