### PR TITLE
[FIX] hr_holidays: Fix accrual dates based on creation date

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -180,7 +180,12 @@ class HolidaysAllocation(models.Model):
             if holiday.interval_unit == 'years':
                 delta = relativedelta(years=holiday.interval_number)
 
-            values['nextcall'] = (holiday.nextcall if holiday.nextcall else today) + delta
+            if holiday.nextcall:
+                values['nextcall'] = holiday.nextcall + delta
+            else:
+                values['nextcall'] = holiday.date_from
+                while values['nextcall'] <= datetime.combine(today, time(0, 0, 0)):
+                    values['nextcall'] += delta
 
             period_start = datetime.combine(today, time(0, 0, 0)) - delta
             period_end = datetime.combine(today, time(0, 0, 0))


### PR DESCRIPTION
Steps:
1. Create new time off allocation
2. Set type to accrual and set start date other than present day
3. Set the accrual to add every month
4. Validate and run the scheduled action for Accrual Time Off
5. Check the field 'nextcall' with Studio or editing form view
Result:
Nextcall date is set to 1 month after the date of creation of allocation record instead of start date.

Solution:
Nextcall is now based on start date.

opw-2558480

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
