### PR TITLE
do not display extenal button when no_open is true

### DIFF
--- a/addons/sale/static/src/js/product_configurator_widget.js
+++ b/addons/sale/static/src/js/product_configurator_widget.js
@@ -42,7 +42,8 @@ var ProductConfiguratorWidget = relationalFields.FieldMany2One.extend({
      * Add button linking to product_id/product_template_id form.
      */
     _addProductLinkButton: function () {
-        if (this.$('.o_external_button').length === 0) {
+        const hasExternalButton = !this.noOpen && !this.floating && this.isSet();
+        if (hasExternalButton && this.$('.o_external_button').length === 0) {
             var $productLinkButton = $('<button>', {
                 type: 'button',
                 class: 'fa fa-external-link btn btn-secondary o_external_button',

--- a/addons/sale/static/tests/product_configurator_tests.js
+++ b/addons/sale/static/tests/product_configurator_tests.js
@@ -96,5 +96,28 @@ odoo.define('sale.product_configurator_tests', function (require) {
 
             form.destroy();
         });
+
+        QUnit.test('product_configurator many2one with no_open option', async function (assert) {
+            assert.expect(1);
+
+            const form = await createView({
+                View: FormView,
+                model: 'line',
+                data: this.data,
+                arch: `
+                    <form>
+                        <field name="product_id" widget="product_configurator" options="{'no_open': True}"/>
+                    </form>`,
+                res_id: 1,
+                viewOptions: {
+                    mode: 'edit',
+                },
+            });
+
+            assert.containsNone(form, '.o_external_button',
+                "should not have extenal button in form");
+
+            form.destroy();
+        });
     });
 });


### PR DESCRIPTION
PURPOSE
When product_configurator widget is applied on field and no_open option is True then it should not display external button beside input element.

SPEC
Do not display external button when no_open option is True.

TASK 2608073



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
