### PR TITLE
[FIX] stock: Don't set DO to ready if nothing could be reserved

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -629,8 +629,10 @@ class StockMove(models.Model):
             'confirmed': 1,
         }
         moves_todo = self\
-            .filtered(lambda move: move.state not in ['cancel', 'done'])\
+            .filtered(lambda move: move.state not in ['cancel', 'done'] and not (move.state == 'assigned' and not move.product_uom_qty))\
             .sorted(key=lambda move: (sort_map.get(move.state, 0), move.product_uom_qty))
+        if not moves_todo:
+            return 'assigned'
         # The picking should be the same for all moves.
         if moves_todo[0].picking_id.move_type == 'one':
             most_important_move = moves_todo[0]

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -709,3 +709,34 @@ class TestPacking(TransactionCase):
                 {"qty_done": 0, "result_package_id": new_package.id},
             ],
         )
+
+    def test_picking_state_with_null_qty(self):
+        receipt_form = Form(self.env['stock.picking'].with_context(default_immediate_transfer=False))
+        picking_type_id = self.warehouse.out_type_id
+        receipt_form.picking_type_id = picking_type_id
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.productA
+            move_line.product_uom_qty = 10
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.productB
+            move_line.product_uom_qty = 10
+        receipt = receipt_form.save()
+        receipt.action_confirm()
+        self.assertEqual(receipt.state, 'confirmed')
+        receipt.move_ids_without_package[1].product_uom_qty = 0
+        self.assertEqual(receipt.state, 'confirmed')
+
+        receipt_form = Form(self.env['stock.picking'].with_context(default_immediate_transfer=True))
+        picking_type_id = self.warehouse.out_type_id
+        receipt_form.picking_type_id = picking_type_id
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.productA
+            move_line.quantity_done = 10
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.productB
+            move_line.quantity_done = 10
+        receipt = receipt_form.save()
+        receipt.action_confirm()
+        self.assertEqual(receipt.state, 'assigned')
+        receipt.move_ids_without_package[1].product_uom_qty = 0
+        self.assertEqual(receipt.state, 'assigned')


### PR DESCRIPTION
When changing a delivery order to 0 quantity demand, after clicking Unlock and Edit, and shipping policy is "as soon as possible," the status changes to Ready even though there is 0 reserved and 0 demand. Cannot remove the line entirely unless delivery order is cancelled.

opw-2611018