### PR TITLE
[IMP] core: always log console.error during HttpCase

### DIFF
--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -9,21 +9,27 @@ from unittest.mock import patch
 class TestHttpCase(HttpCase):
 
     def test_console_error_string(self):
-        with self.assertRaises(AssertionError) as error_catcher:
-            code = "console.error('test error','message')"
-            with patch('odoo.tests.common.ChromeBrowser.take_screenshot', return_value=None):
-                self.browser_js(url_path='about:blank', code=code)
-        # second line must contains error message
-        self.assertEqual(error_catcher.exception.args[0].splitlines()[1], "test error message")
+        with self.assertLogs(level='ERROR') as log_catcher:
+            with self.assertRaises(AssertionError) as error_catcher:
+                code = "console.error('test error','message')"
+                with patch('odoo.tests.common.ChromeBrowser.take_screenshot', return_value=None):
+                    self.browser_js(url_path='about:blank', code=code)
+            # second line must contains error message
+            self.assertEqual(error_catcher.exception.args[0].splitlines()[1], "test error message")
+        self.assertEqual(len(log_catcher.output), 1)
+        self.assertIn('test error message', log_catcher.output[0])
 
     def test_console_error_object(self):
-        with self.assertRaises(AssertionError) as error_catcher:
-            code = "console.error(TypeError('test error message'))"
-            with patch('odoo.tests.common.ChromeBrowser.take_screenshot', return_value=None):
-                self.browser_js(url_path='about:blank', code=code)
-        # second line must contains error message
-        self.assertEqual(error_catcher.exception.args[0].splitlines()[1:3],
-        ['TypeError: test error message', '    at <anonymous>:1:15'])
+        with self.assertLogs(level='ERROR') as log_catcher:
+            with self.assertRaises(AssertionError) as error_catcher:
+                code = "console.error(TypeError('test error message'))"
+                with patch('odoo.tests.common.ChromeBrowser.take_screenshot', return_value=None):
+                    self.browser_js(url_path='about:blank', code=code)
+            # second line must contains error message
+            self.assertEqual(error_catcher.exception.args[0].splitlines()[1:3],
+            ['TypeError: test error message', '    at <anonymous>:1:15'])
+        self.assertEqual(len(log_catcher.output), 1)
+        self.assertIn('TypeError: test error message\n    at <anonymous>:1:15', log_catcher.output[0])
 
     def test_console_log_object(self):
         logger = logging.getLogger('odoo')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1147,6 +1147,11 @@ class ChromeBrowser:
             message += '\n' + stack
 
         log_type = type
+        self._logger.getChild('browser').log(
+            self._TO_LEVEL.get(log_type, logging.INFO),
+            "%s", message # might still have %<x> characters
+        )
+
         if log_type == 'error':
             self.take_screenshot()
             self._save_screencast()
@@ -1159,13 +1164,8 @@ class ChromeBrowser:
                     "Trying to set result to failed (%s) but found the future settled (%s)",
                     message, self._result
                 )
-        else:
-            self._logger.getChild('browser').log(
-                self._TO_LEVEL.get(log_type, logging.INFO),
-                "%s", message # might still have %<x> characters
-            )
-            if 'test successful' in message:
-                self._result.set_result(True)
+        elif 'test successful' in message:
+            self._result.set_result(True)
 
     def _handle_exception(self, exceptionDetails, timestamp):
         message = exceptionDetails['text']


### PR DESCRIPTION
When running test tours, logging a message to `console.error` causes the test tour to fail. Only one such message can cause the tour to fail, if other message are written on the console they are simply logged in the odoo logs. The offending message, however, is only shown at the end of run, as part of the failing test logs. Arguably, it is better to include it in the browser logs as well.