### PR TITLE
[FIX] website_slide: Prevent downloadable content to use the CDN.

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -124,7 +124,7 @@
                                         <a id="last" href="#" onclick="return false;"
                                            class="text-decoration-none mx-1 mx-sm-2" title="Last slide"
                                            aria-label="Last slide" role="button"> <i class="fa fa-step-forward"/> </a>
-                                        <a t-if="slide.slide_resource_downloadable" id="download" t-attf-href="/web/content/slide.slide/#{slide.id}/datas?download=true"
+                                        <a data-no-post-process="1" t-if="slide.slide_resource_downloadable" id="download" t-attf-href="/web/content/slide.slide/#{slide.id}/datas?download=true"
                                            class="text-decoration-none ml-1 ml-sm-2" title="Download Content" role="img" aria-label="Download">
                                             <i class="fa fa-download" />
                                         </a>


### PR DESCRIPTION
If a CDN is enabled on the website, QWeb will replace the URLs of
a template if permitted via the `cdn_filters` of the website.

In the case where we try to fetch a `datas` field on a `slide.slide`
that is not public, the CDN would inevitably fail to fetch the resource.

TaskID #2540717
