### PR TITLE
[FIX] web_editor: make the background image positioning usable again

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1996,7 +1996,7 @@ body.editor_enable.editor_has_snippets {
         // Background position overlay
         &.o_we_background_position_overlay {
             background-color: rgba(0,0,0,.7);
-            z-index: auto;
+            pointer-events: auto;
 
             .o_we_overlay_content {
                 cursor: grab;


### PR DESCRIPTION
Before this commit the controls for the background image positioning
were not accepting events anymore and were below margin handles.
Also if the buttons were drawn outside of the visible area the user was
unable to access them.

After this commit the controls for the background image positioning can
be used again.

task-2627710

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
