### PR TITLE
[FIX] web_editor: prevent merging of unbreakable node

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -12,6 +12,7 @@ import {
     isFontAwesome,
     isMediaElement,
     getDeepRange,
+    isUnbreakable,
 } from './utils.js';
 
 const NOT_A_NUMBER = /[^\d]/g;
@@ -93,7 +94,7 @@ class Sanitize {
         }
 
         // Merge identical elements together
-        while (areSimilarElements(node, node.previousSibling)) {
+        while (areSimilarElements(node, node.previousSibling) && !isUnbreakable(node)) {
             getDeepRange(this.root, { select: true });
             const restoreCursor = preserveCursor(this.root.ownerDocument);
             const nodeP = node.previousSibling;


### PR DESCRIPTION
Current behavior before PR:
Trying to edit a document with two side to side divs with content was not possible, because the editor would try to merge the divs which the editor itself does not allow.

Desired behavior after PR is merged:
A document with two similar unbreakable elements next to each other can now be edited without problem.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
