### PR TITLE
[FIX] crm: allow regular salesman to convert and merge opportunities

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -136,7 +136,7 @@ class Lead2OpportunityPartner(models.TransientModel):
                     'user_id': self.user_id.id,
                     'team_id': self.team_id.id,
                 })
-        (to_merge - result_opportunity).unlink()
+        (to_merge - result_opportunity).sudo().unlink()
         return result_opportunity
 
     def _action_convert(self):


### PR DESCRIPTION
If an internal user does not belong to Sales / Administrator group, and wants
to convert a lead into an opportunity, he will face an access rights error if
another lead exists with the same email because we are trying to merge them.
We should allow him to convert and merge them without error.

Description of the issue/feature this PR addresses:
opw-2522568

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
