### PR TITLE
[FIX] calendar: correctly assign user on activity

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -832,7 +832,7 @@ class Meeting(models.Model):
                         deadline = deadline.astimezone(pytz.timezone(user_tz))
                     activity_values['date_deadline'] = deadline.date()
                 if 'user_id' in fields:
-                    activity_values['user_id'] = event.user_id.id
+                    activity_values['user_id'] = event.user_id.id or self.env.user.id
                 if activity_values.keys():
                     event.activity_ids.write(activity_values)
 


### PR DESCRIPTION
Steps to Reproduce Bug:
- Go to CRM --> Pipeline (or any other record where we can link calendar event)
- Click on Meeting Smart Button
- Create Meeting and remove Default Responsible
- Save

Bug:
- Mandatory field user_id is not set on activity.
- `Model: Activity (mail.activity), Field: Assigned to (user_id)`

With this Commit, we are using logged in user as default assignee on
activity if Responsible is not set.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
