### PR TITLE
[FIX] base_gengo: Gengo callback tracebacks

### DIFF
--- a/addons/base_gengo/controller/main.py
+++ b/addons/base_gengo/controller/main.py
@@ -12,9 +12,9 @@ class website_gengo(Controller):
     def gengo_callback(self, **post):
         IrTranslationSudo = request.env['ir.translation'].sudo()
         if post and post.get('job') and post.get('pgk'):
-            if post.get('pgk') != request.env['base.gengo.translation'].sudo().get_gengo_key():
+            if post.get('pgk') != request.env['base.gengo.translations'].sudo().get_gengo_key():
                 return Response("Bad authentication", status=104)
-            job = json.loads(post['job'], 'utf-8')
+            job = json.loads(post['job'])
             tid = job.get('custom_data', False)
             if (job.get('status') == 'approved') and tid:
                 term = IrTranslationSudo.browse(int(tid))
@@ -33,10 +33,10 @@ class website_gengo(Controller):
                     #('order_id', "=", term.order_id),
                 ]
 
-                all_ir_tanslations = IrTranslationSudo.search(domain)
+                all_ir_translations = IrTranslationSudo.search(domain)
 
-                if all_ir_tanslations:
-                    all_ir_tanslations.write({
+                if all_ir_translations:
+                    all_ir_translations.write({
                         'state': 'translated',
                         'value': job.get('body_tgt')
                     })


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

There's two ways Odoo can get job responses from Gengo: the first is
this callback, initiated by Gengo. The second is a cronjob ran by Odoo
which retrieves translated terms. The callback resulted in a traceback
in the logs, because there was a typo in 'base.gengo.translations' (it
was missing an -s at the end). `json.loads` was also being called with
an unexpected extra parameter ('utf-8'), resulting in another traceback.

This PR fixes both of those and I was able to confirm the callback was
able to update translations in Odoo as a result.


Current behavior before PR:
Translations only get updated by Odoo's cronjob, not by Gengo's callback. Which means machine translations will update more slowly. There will also be traceback spam in Odoo's logs.

Desired behavior after PR is merged:
The Gengo callback is able to update translations and no more tracebacks occur.