### PR TITLE
[IMP] mail: move attachment handler to the models

### DIFF
--- a/addons/mail/static/src/components/attachment/attachment.js
+++ b/addons/mail/static/src/components/attachment/attachment.js
@@ -1,8 +1,9 @@
 /** @odoo-module **/
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
+import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
 
-const { Component, useState } = owl;
+const { Component } = owl;
 
 export class Attachment extends Component {
 
@@ -11,9 +12,7 @@ export class Attachment extends Component {
      */
     constructor(...args) {
         super(...args);
-        this.state = useState({
-            hasDeleteConfirmDialog: false,
-        });
+        useComponentToModel({ fieldName: 'component', modelName: 'mail.attachment', propNameAsRecordLocalId: 'attachmentLocalId' });
     }
 
     //--------------------------------------------------------------------------
@@ -94,16 +93,6 @@ export class Attachment extends Component {
     // Handlers
     //--------------------------------------------------------------------------
 
-    /**
-     * Download the attachment when clicking on donwload icon.
-     *
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickDownload(ev) {
-        ev.stopPropagation();
-        this.env.services.navigate(`/web/content/ir.attachment/${this.attachment.id}/datas`, { download: true });
-    }
 
     /**
      * Open the attachment viewer when clicking on viewable attachment.
@@ -123,29 +112,6 @@ export class Attachment extends Component {
         });
     }
 
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickUnlink(ev) {
-        ev.stopPropagation();
-        if (!this.attachment) {
-            return;
-        }
-        if (this.attachment.isLinkedToComposer) {
-            this.attachment.remove();
-            this.trigger('o-attachment-removed', { attachmentLocalId: this.props.attachmentLocalId });
-        } else {
-            this.state.hasDeleteConfirmDialog = true;
-        }
-    }
-
-   /**
-    * @private
-    */
-    _onDeleteConfirmDialogClosed() {
-        this.state.hasDeleteConfirmDialog = false;
-    }
 }
 
 Object.assign(Attachment, {

--- a/addons/mail/static/src/components/attachment/attachment.xml
+++ b/addons/mail/static/src/components/attachment/attachment.xml
@@ -43,14 +43,14 @@
                                     <div class="o_Attachment_action o_Attachment_actionUnlink"
                                         t-att-class="{
                                             'o-pretty': attachment.isLinkedToComposer,
-                                        }" t-on-click="_onClickUnlink" title="Remove"
+                                        }" t-on-click="attachment.onClickUnlink" title="Remove"
                                     >
                                         <i class="fa fa-times"/>
                                     </div>
                                 </t>
                                 <!-- Download button -->
                                 <t t-if="props.isDownloadable and !attachment.isUploading" t-key="'download'">
-                                    <div class="o_Attachment_action o_Attachment_actionDownload" t-on-click="_onClickDownload" title="Download">
+                                    <div class="o_Attachment_action o_Attachment_actionDownload" t-on-click="attachment.onClickDownload" title="Download">
                                         <i class="fa fa-download"/>
                                     </div>
                                 </t>
@@ -90,22 +90,22 @@
                         </t>
                         <!-- Remove button -->
                         <t t-if="props.isEditable">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" t-on-click="_onClickUnlink" title="Remove">
+                            <div class="o_Attachment_asideItem o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" t-on-click="attachment.onClickUnlink" title="Remove">
                                 <i class="fa fa-times"/>
                             </div>
                         </t>
                         <!-- Download button -->
                         <t t-if="props.isDownloadable and !attachment.isUploading">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemDownload" t-on-click="_onClickDownload" title="Download">
+                            <div class="o_Attachment_asideItem o_Attachment_asideItemDownload" t-on-click="attachment.onClickDownload" title="Download">
                                 <i class="fa fa-download"/>
                             </div>
                         </t>
                     </div>
                 </t>
-                <t t-if="state.hasDeleteConfirmDialog">
+                <t t-if="attachment.hasDeleteConfirmDialog">
                     <AttachmentDeleteConfirmDialog
                         attachmentLocalId="props.attachmentLocalId"
-                        t-on-dialog-closed="_onDeleteConfirmDialogClosed"
+                        t-on-dialog-closed="attachment.onDeleteConfirmDialogClosed"
                     />
                 </t>
             </t>

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
@@ -3,9 +3,10 @@
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 import Dialog from 'web.OwlDialog';
+import { useRefToModel } from '@mail/component_hooks/use_ref_to_model/use_ref_to_model';
+import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
 
 const { Component } = owl;
-const { useRef } = owl.hooks;
 
 export class AttachmentDeleteConfirmDialog extends Component {
 
@@ -14,8 +15,8 @@ export class AttachmentDeleteConfirmDialog extends Component {
      */
     constructor(...args) {
         super(...args);
-        // to manually trigger the dialog close event
-        this._dialogRef = useRef('dialog');
+        useComponentToModel({ fieldName: 'componentAttachmentDeleteConfirmDialog', modelName: 'mail.attachment', propNameAsRecordLocalId: 'attachmentLocalId' });
+        useRefToModel({ fieldName: 'dialogRef', modelName: 'mail.attachment', propNameAsRecordLocalId: 'attachmentLocalId', refName: 'dialog' });
     }
 
     //--------------------------------------------------------------------------
@@ -44,26 +45,6 @@ export class AttachmentDeleteConfirmDialog extends Component {
      */
     getTitle() {
         return this.env._t("Confirmation");
-    }
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _onClickCancel() {
-        this._dialogRef.comp._close();
-    }
-
-    /**
-     * @private
-     */
-    async _onClickOk() {
-        await this.attachment.remove();
-        this._dialogRef.comp._close();
-        this.trigger('o-attachment-removed', { attachmentLocalId: this.props.attachmentLocalId });
     }
 
 }

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.xml
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.xml
@@ -4,8 +4,8 @@
         <Dialog contentClass="'o_AttachmentDeleteConfirmDialog'" title="getTitle()" size="'medium'" t-ref="dialog">
             <p class="o_AttachmentDeleteConfirmDialog_mainText" t-esc="getBody()"/>
             <t t-set-slot="buttons">
-                <button class="o_AttachmentDeleteConfirmDialog_confirmButton btn btn-primary" t-on-click="_onClickOk">Ok</button>
-                <button class="o_AttachmentDeleteConfirmDialog_cancelButton btn btn-secondary" t-on-click="_onClickCancel">Cancel</button>
+                <button class="o_AttachmentDeleteConfirmDialog_confirmButton btn btn-primary" t-on-click="attachment.onClickAttachmentDeleteConfirmDialogOk">Ok</button>
+                <button class="o_AttachmentDeleteConfirmDialog_cancelButton btn btn-secondary" t-on-click="attachment.onClickAttachmentDeleteConfirmDialogCancel">Cancel</button>
             </t>
         </Dialog>
     </t>

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
@@ -25,9 +25,9 @@
                         <span class="o_AttachmentViewer_nameText text-truncate" t-esc="attachmentViewer.attachment.displayName"/>
                     </div>
                     <div class="o-autogrow"/>
-                    <div class="o_AttachmentViewer_buttonDownload o_AttachmentViewer_headerItem o_AttachmentViewer_headerItemButton" t-on-click="_onClickDownload" role="button" title="Download">
-                        <i class="o_AttachmentViewer_headerItemButtonIcon fa fa-download fa-fw" t-att-class="{ 'o-hasLabel': messaging.device.sizeClass > env.device.SIZES.MD }" role="img"/>
-                        <t t-if="messaging.device.sizeClass > env.device.SIZES.MD">
+                    <div class="o_AttachmentViewer_buttonDownload o_AttachmentViewer_headerItem o_AttachmentViewer_headerItemButton" t-on-click="attachmentViewer.attachment.onClickDownload" role="button" title="Download">
+                        <i class="o_AttachmentViewer_headerItemButtonIcon fa fa-download fa-fw" t-att-class="{ 'o-hasLabel': attachmentViewer.messaging.device.sizeClass > env.device.SIZES.MD }" role="img"/>
+                        <t t-if="attachmentViewer.messaging.device.sizeClass > env.device.SIZES.MD">
                             <span>Download</span>
                         </t>
                     </div>
@@ -47,7 +47,7 @@
                         </div>
                     </t>
                     <t t-if="attachmentViewer.attachment.fileType === 'application/pdf'">
-                        <iframe class="o_AttachmentViewer_view o_AttachmentViewer_viewIframe o_AttachmentViewer_viewPdf" t-ref="iframeViewerPdf" t-att-class="{ 'o-isMobile': messaging.device.isMobile }" t-att-src="attachmentViewer.attachment.defaultSource"/>
+                        <iframe class="o_AttachmentViewer_view o_AttachmentViewer_viewIframe o_AttachmentViewer_viewPdf" t-ref="iframeViewerPdf" t-att-class="{ 'o-isMobile': attachmentViewer.messaging.device.isMobile }" t-att-src="attachmentViewer.attachment.defaultSource"/>
                     </t>
                     <t t-if="attachmentViewer.attachment.isTextFile">
                         <iframe class="o_AttachmentViewer_view o_AttachmentViewer_viewIframe o_text" t-att-src="attachmentViewer.attachment.defaultSource"/>
@@ -56,9 +56,16 @@
                         <iframe allow="autoplay; encrypted-media" class="o_AttachmentViewer_view o_AttachmentViewer_viewIframe o_AttachmentViewer_youtube" t-att-src="attachmentViewer.attachment.defaultSource" height="315" width="560"/>
                     </t>
                     <t t-if="attachmentViewer.attachment.fileType === 'video'">
-                        <video class="o_AttachmentViewer_view o_AttachmentViewer_viewVideo" t-att-class="{ 'o-isMobile': messaging.device.isMobile }" t-on-click="_onClickVideo" controls="controls">
+                        <video class="o_AttachmentViewer_view o_AttachmentViewer_viewVideo" t-att-class="{ 'o-isMobile': attachmentViewer.messaging.device.isMobile }" t-on-click="_onClickVideo" controls="controls">
                             <source t-att-data-type="attachmentViewer.attachment.mimetype" t-att-src="attachmentViewer.attachment.defaultSource"/>
                         </video>
+                    </t>
+                </div>
+                <div class="o-autogrow"/>
+                <div class="o_AttachmentViewer_buttonDownload o_AttachmentViewer_headerItem o_AttachmentViewer_headerItemButton" t-on-click="attachmentViewer.attachment.onClickDownload" role="button" title="Download">
+                    <i class="o_AttachmentViewer_headerItemButtonIcon fa fa-download fa-fw" t-att-class="{ 'o-hasLabel': attachmentViewer.messaging.device.sizeClass > env.device.SIZES.MD }" role="img"/>
+                    <t t-if="attachmentViewer.messaging.device.sizeClass > env.device.SIZES.MD">
+                        <span>Download</span>
                     </t>
                 </div>
                 <t t-if="attachmentViewer.attachment.fileType === 'image'">
@@ -78,16 +85,24 @@
                         <div class="o_AttachmentViewer_toolbarButton" t-on-click="_onClickPrint" title="Print" role="button">
                             <i class="fa fa-fw fa-print" role="img"/>
                         </div>
-                        <div class="o_AttachmentViewer_buttonDownload o_AttachmentViewer_toolbarButton" t-on-click="_onClickDownload" title="Download" role="button">
+                        <div class="o_AttachmentViewer_buttonDownload o_AttachmentViewer_toolbarButton" t-on-click="attachmentViewer.attachment.onClickDownload" title="Download" role="button">
                             <i class="fa fa-download fa-fw" role="img"/>
                         </div>
                     </div>
+                    <div class="o_AttachmentViewer_zoomer" t-ref="zoomer">
+                        <t t-if="attachmentViewer.isImageLoading">
+                            <div class="o_AttachmentViewer_loading">
+                                <i class="fa fa-3x fa-circle-o-notch fa-fw fa-spin" role="img" title="Loading"/>
+                            </div>
+                        </t>
+                        <img class="o_AttachmentViewer_view o_AttachmentViewer_viewImage" t-on-click="_onClickImage" t-on-mousedown="_onMousedownImage" t-on-wheel="_onWheelImage" t-on-load="attachmentViewer.onLoadImage()" t-att-src="attachmentViewer.attachment.defaultSource" t-att-style="imageStyle" draggable="false" alt="Viewer" t-key="'image_' + attachmentViewer.attachment.id" t-ref="image_{{ attachmentViewer.attachment.id }}"/>
+                    </div>
                 </t>
                 <t t-if="attachmentViewer.attachments.length > 1">
-                    <div class="o_AttachmentViewer_buttonNavigation o_AttachmentViewer_buttonNavigationPrevious" t-on-click="_onClickPrevious" title="Previous (Left-Arrow)" role="button">
+                    <div class="o_AttachmentViewer_buttonNavigation o_AttachmentViewer_buttonNavigationPrevious" t-on-click="attachmentViewer.onClickPrevious" title="Previous (Left-Arrow)" role="button">
                         <span class="fa fa-chevron-left" role="img"/>
                     </div>
-                    <div class="o_AttachmentViewer_buttonNavigation o_AttachmentViewer_buttonNavigationNext" t-on-click="_onClickNext" title="Next (Right-Arrow)" role="button">
+                    <div class="o_AttachmentViewer_buttonNavigation o_AttachmentViewer_buttonNavigationNext" t-on-click="attachmentViewer.onClickNext" title="Next (Right-Arrow)" role="button">
                         <span class="fa fa-chevron-right" role="img"/>
                     </div>
                 </t>


### PR DESCRIPTION
This commit move the handlers for attachment, attachment_delete_confirm_dialog and
attachment_viewer component.

Part of task-2579306