### PR TITLE
[FIX] stock_account: pick same cogs when generating a refund

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -133,7 +133,10 @@ class AccountMove(models.Model):
 
                 # Compute accounting fields.
                 sign = -1 if move.type == 'out_refund' else 1
-                price_unit = line._stock_account_get_anglo_saxon_price_unit()
+                if move.type == 'out_refund' and move.reversed_entry_id:
+                    price_unit = move.reversed_entry_id.line_ids.filtered(lambda ml: ml.product_id == line.product_id and ml.account_id == debit_interim_account).price_unit
+                else:
+                    price_unit = line._stock_account_get_anglo_saxon_price_unit()
                 balance = sign * line.quantity * price_unit
 
                 # Add interim account line.


### PR DESCRIPTION
- Start from a product in FIFO category (empty inventory)
- Purchase 1 product @200$, 1 product @300$
- Sell 2 units of the product for 500, validate transfer for 1 unit,
create backorder, partial invoice, validate the second unit, create a
second invoice.
- Now go to the 1st invoice, the COGS entry is for 200$, add a credit
note. The behavior of the system will depends on the following choice

1) Partial Refund -> invoice will be created in draft, when posting the
COGS entry will be processed from scratch, resulting in 300$

2) Full Refund -> will directly create a posted entry, COGS entry is
200$ (as it just revert the old one)

3) Full Refund and new draft invoice -> mix of the previous 2, posted
entry with 200$ COGS, the draft invoice once posted has a 300$ entry

The behavior of the system should be coherent

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
