### PR TITLE
[FIX] l10n_ch_qr_iban: do not create new module category

### DIFF
--- a/addons/l10n_ch_qriban/__manifest__.py
+++ b/addons/l10n_ch_qriban/__manifest__.py
@@ -12,7 +12,7 @@ This should help for reconciliation on the bank statements where the old IBAN co
     """,
     'version': '1.0',
     'author': 'Odoo S.A',
-    'category': 'Localization',
+    'category': 'Hidden',
     'depends': ['l10n_ch'],
     'data': [
         'views/res_bank_views.xml',


### PR DESCRIPTION
We do not need to see this bugfix module in the list of modules, and
certainly not with a new category that shows up in the controlpanel.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
