### PR TITLE
[FIX] account: update default value in alias on journal type change

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -850,7 +850,7 @@ class AccountJournal(models.Model):
                     bank_account = self.env['res.partner.bank'].browse(vals['bank_account_id'])
                     if bank_account.partner_id != company.partner_id:
                         raise UserError(_("The partners of the journal's company and the related bank account mismatch."))
-            if 'alias_name' in vals:
+            if 'alias_name' in vals  or 'type' in vals and self.alias_id:
                 journal._update_mail_alias(vals)
         result = super(AccountJournal, self).write(vals)
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to settings and enable “External Email Servers” option
- Go to accounting > Configuration > journals
- Create a new journal, Choose "purchase" type
- save
- Go to advanced settings tab > click on email alias
- Note that default value = `in_invoice`
- Create another journal, choose "Miscellaneous" type > save
- Change the type to "purchase"

Problem:
the default value = "out_invoice", because it is not updated in the write function after changing the journal type
In the case of type == 'purchase', the default value should be 'in_invoice', and in any other case, it should be 'out_invoice'.

opw-2618357

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
