### PR TITLE
[FIX] pos_adyen: no retry on another order after failure


### DIFF
--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -112,15 +112,15 @@ var PaymentAdyen = PaymentInterface.extend({
 
     _adyen_pay: function () {
         var self = this;
+        var order = this.pos.get_order();
 
-        if (this.pos.get_order().selected_paymentline.amount < 0) {
+        if (order.selected_paymentline.amount < 0) {
             this._show_error(_t('Cannot process transactions with negative amount.'));
             return Promise.resolve();
         }
 
-
-        if (this.poll_response_error)   {
-            this.poll_response_error = false;
+        if (order === this.poll_error_order) {
+            delete this.poll_error_order;
             return self._adyen_handle_response({});
         }
 
@@ -191,7 +191,7 @@ var PaymentAdyen = PaymentInterface.extend({
             shadow: true,
         }).catch(function (data) {
             reject();
-            self.poll_response_error = true;
+            self.poll_error_order = self.pos.get_order();
             return self._handle_odoo_connection_failure(data);
         }).then(function (status) {
             var notification = status.latest_response;


### PR DESCRIPTION

When there is a connection failure (eg. server restart) while we are
polling adyen for payment status during the payment process, we would
show a connection error and when clicking on retry, we would do a new
payment even if the first one was successful causing a double payment.

After dcb1e2b48, the retry after failure should just continue the
polling as if there was no connection failure, so for example:

- order 1: pay with adyen => connection failure during payment
- order 1: retry => payment successful

But in this particular case:

- order 1: pay with adyen => connection failure during payment
- order 1: close adyen payment line and pay with another payment method
- order 2: pay with adyen => we will receive the response from order 1

With this changeset, we only continue the polling for adyen status if we
are retrying to pay the same order.

opw-2587625
