### PR TITLE
[FIX] web_editor: Blacklist `o_not_editable` elements from hints

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -90,7 +90,8 @@ const Wysiwyg = Widget.extend({
             },
             isHintBlacklisted: node => {
                 return node.hasAttribute &&
-                    (node.hasAttribute('data-target') || node.hasAttribute('data-oe-model'));
+                    (node.hasAttribute('data-target') || node.hasAttribute('data-oe-model'))
+                    || !!(node.closest('.o_not_editable'));
             },
             noScrollSelector: 'body, .note-editable, .o_content, #wrapwrap',
             commands: commands,


### PR DESCRIPTION
`_makeHint` should not be able to alter elements that have ancestors
with the class `.o_not_editable`
