### PR TITLE
[IMP] website: avoid colors mitigation for configurator logo

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -171,7 +171,7 @@ class BaseDocumentLayout(models.TransientModel):
                 wizard.secondary_color = wizard.logo_secondary_color
 
     @api.model
-    def extract_image_primary_secondary_colors(self, logo, white_threshold=225):
+    def extract_image_primary_secondary_colors(self, logo, white_threshold=225, mitigate=175):
         """
         Identifies dominant colors
 
@@ -181,6 +181,7 @@ class BaseDocumentLayout(models.TransientModel):
 
         :param logo: logo to process
         :param white_threshold: arbitrary value defining the maximum value a color can reach
+        :param mitigate: arbitrary value defining the maximum value a band can reach
 
         :return colors: hex values of primary and secondary colors
         """
@@ -211,9 +212,8 @@ class BaseDocumentLayout(models.TransientModel):
 
         if not colors:  # May happen when the whole image is white
             return False, False
-        primary, remaining = tools.average_dominant_color(colors)
-        secondary = tools.average_dominant_color(
-            remaining)[0] if len(remaining) > 0 else primary
+        primary, remaining = tools.average_dominant_color(colors, mitigate=mitigate)
+        secondary = tools.average_dominant_color(remaining, mitigate=mitigate)[0] if remaining else primary
 
         # Lightness and saturation are calculated here.
         # - If both colors have a similar lightness, the most colorful becomes primary

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -216,7 +216,8 @@ class PaletteSelectionScreen extends Component {
         const [color1, color2] = await rpc.query({
             model: 'base.document.layout',
             method: 'extract_image_primary_secondary_colors',
-            args: [img]
+            args: [img],
+            kwargs: {mitigate: 255},
         });
         this.dispatch('setRecommendedPalette', color1, color2);
     }


### PR DESCRIPTION
The algorithm extracting primary and secondary colors from
an image automatically mitigates too bright colors. A color
component is considered as too bright if its value is above
an arbitrary value. We re-use this algorithm in the website
configurator to extract colors from logo and to generate a
palette. In this particular case we don't want the mitigation
to be applied. We therefore added the mitigation threshold as
a parameter of 'extract_image_primary_secondary_colors' and
avoided any mitigation by setting it to 255 in our case.

task-2602521

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
