### PR TITLE
[FIX] web_editor: use hint whitelist rather than blacklist

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -151,7 +151,7 @@ export class OdooEditor extends EventTarget {
                         return closestElement(selection.anchorNode, 'P, DIV');
                     }
                 },
-                isHintBlacklisted: () => false,
+                isHintWhitelisted: () => true,
                 _t: string => string,
             },
             options,
@@ -1839,7 +1839,7 @@ export class OdooEditor extends EventTarget {
 
         for (const [selector, text] of Object.entries(selectors)) {
             for (const el of this.editable.querySelectorAll(selector)) {
-                if (!this.options.isHintBlacklisted(el)) {
+                if (this.options.isHintWhitelisted(el)) {
                     this._makeHint(el, text);
                 }
             }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -88,9 +88,10 @@ const Wysiwyg = Widget.extend({
                     return !(node && node.hasAttribute && node.hasAttribute('data-oe-model')) && node;
                 }
             },
-            isHintBlacklisted: node => {
-                return node.hasAttribute &&
-                    (node.hasAttribute('data-target') || node.hasAttribute('data-oe-model'));
+            isHintWhitelisted: node => {
+                const attributeNames = node.getAttributeNames();
+                const isNodeNaked = !attributeNames.length || (attributeNames.includes('class') && !node.className.trim());
+                return isNodeNaked;
             },
             noScrollSelector: 'body, .note-editable, .o_content, #wrapwrap',
             commands: commands,


### PR DESCRIPTION
The hints were showing at unpredictable location.
With this commit, only allow hints when the node does
not contain any tag in order to avoid seeing them on wrong a node.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
