### PR TITLE
Project Generic Improvements

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -12,6 +12,7 @@ from odoo.tools import date_utils, groupby as groupbyelem
 from odoo.osv.expression import AND, OR
 
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
+from odoo.addons.project.controllers.portal import ProjectCustomerPortal
 
 
 class TimesheetCustomerPortal(CustomerPortal):
@@ -172,3 +173,12 @@ class TimesheetCustomerPortal(CustomerPortal):
             'is_uom_day': request.env['account.analytic.line']._is_timesheet_encode_uom_day(),
         })
         return request.render("hr_timesheet.portal_my_timesheets", values)
+
+class TimesheetProjectCustomerPortal(ProjectCustomerPortal):
+
+    def _show_task_report(self, task_sudo, report_type, download):
+        domain = request.env['account.analytic.line']._timesheet_get_portal_domain()
+        task_domain = AND([domain, [('task_id', '=', task_sudo.id)]])
+        timesheets = request.env['account.analytic.line'].sudo().search(task_domain)
+        return self._show_report(model=timesheets,
+            report_type=report_type, report_ref='hr_timesheet.timesheet_report_task_timesheets', download=download)

--- a/addons/hr_timesheet/controllers/project.py
+++ b/addons/hr_timesheet/controllers/project.py
@@ -20,6 +20,7 @@ class ProjectCustomerPortal(CustomerPortal):
         timesheets_by_subtask = defaultdict(lambda: request.env['account.analytic.line'].sudo())
         for timesheet in subtasks_timesheets:
             timesheets_by_subtask[timesheet.task_id] |= timesheet
+        values['allow_timesheets'] = task.allow_timesheets
         values['timesheets'] = timesheets
         values['timesheets_by_subtask'] = timesheets_by_subtask
         values['is_uom_day'] = request.env['account.analytic.line']._is_timesheet_encode_uom_day()

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -269,3 +269,9 @@ class AccountAnalyticLine(models.Model):
     def _employee_timesheet_cost(self):
         self.ensure_one()
         return self.employee_id.timesheet_cost or 0.0
+
+    def _get_report_base_filename(self):
+        task_ids = self.task_id
+        if len(task_ids) == 1:
+            return _('Timesheets - %s', task_ids.name)
+        return _('Timesheets')

--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -59,6 +59,7 @@
             </div>
         </div>
     </template>
+
     <template id="report_timesheet">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
@@ -78,6 +79,36 @@
                             </h2>
                         </div>
                     </div>
+                    <t t-set='is_uom_day' t-value='docs._is_timesheet_encode_uom_day()'/>
+                    <t t-set='lines' t-value='docs'/>
+                    <t t-call="hr_timesheet.timesheet_table"/>
+                    <div class="oe_structure"/>
+                </div>
+            </t>
+        </t>
+    </template>
+
+    <!-- Project Task Timesheet Report for given timesheets -->
+    <template id="report_timesheet_task">
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <t t-set="company" t-value="docs.mapped('project_id')[0].company_id if len(docs.mapped('project_id')) == 1 else docs.env.company"/>
+                <t t-set="show_task" t-value="len(docs.mapped('task_id')) > 1"/>
+                <t t-set="show_project" t-value="False"/>
+                <div class="page">
+                    <div class="oe_structure"/>
+                    <div class="row" style="margin-top:10px;">
+                        <div class="col-lg-12">
+                            <h2>
+                                <span>Timesheet Entries
+                                    <t t-if="len(docs.mapped('task_id')) == 1">
+                                        for <t t-esc="docs.mapped('task_id')[0].name"/>
+                                    </t>
+                                </span>
+                            </h2>
+                        </div>
+                    </div>
+
                     <t t-set='is_uom_day' t-value='docs._is_timesheet_encode_uom_day()'/>
                     <t t-set='lines' t-value='docs'/>
                     <t t-call="hr_timesheet.timesheet_table"/>
@@ -179,6 +210,14 @@
         <field name="report_name">hr_timesheet.report_timesheet_project</field>
         <field name="report_file">report_timesheet_project</field>
         <field name="binding_model_id" ref="model_project_project"/>
+    </record>
+
+    <record id="timesheet_report_task_timesheets" model="ir.actions.report">
+        <field name="name">Timesheet Entries</field>
+        <field name="model">account.analytic.line</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">hr_timesheet.report_timesheet_task</field>
+        <field name="report_file">report_timesheet</field>
         <field name="binding_type">report</field>
     </record>
 </odoo>

--- a/addons/hr_timesheet/views/project_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_portal_templates.xml
@@ -2,10 +2,29 @@
 <odoo>
 
     <template id="portal_my_task" inherit_id="project.portal_my_task" name="Portal: My Task with Timesheets">
-        <xpath expr="//t[@t-set='card_body']" position="inside">
+        <xpath expr="//li[@id='task-nav']" position="before">
+            <li t-if="timesheets and allow_timesheets" class="list-group-item flex-grow-1" id='nav-report'>
+                <div class="o_download_pdf btn-toolbar flex-sm-nowrap">
+                    <div class="btn-group flex-grow-1 mr-1 mb-1">
+                        <a class="btn btn-secondary btn-block o_download_btn" t-att-href="task.get_portal_url(report_type='pdf', download=True)" title="Download"><i class="fa fa-download"/> Download</a>
+                    </div>
+                    <div class="btn-group flex-grow-1 mb-1">
+                        <a class="btn btn-secondary btn-block o_print_btn o_project_timesheet_print" t-att-href="task.get_portal_url(report_type='pdf')" href="#" title="Print" target="_blank"><i class="fa fa-print"/> Print</a>
+                    </div>
+                </div>
+            </li>
+        </xpath>
+        <xpath expr="//li[@id='nav-header']" position="after">
+            <li t-if="timesheets" class="nav-item">
+                <a class="nav-link pl-3" href="#task_timesheets">
+                    Timesheets
+                </a>
+            </li>
+        </xpath>
+        <xpath expr="//div[@id='card_body']" position="inside">
             <div class="container" t-if="timesheets">
                 <hr class="mt-4 mb-1"/>
-                <h5 class="mt-2 mb-2">Timesheets</h5>
+                <h5 id="task_timesheets" class="mt-2 mb-2" data-anchor="true">Timesheets</h5>
                 <t t-call="hr_timesheet.portal_timesheet_table"/>
             </div>
         </xpath>

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -4,10 +4,10 @@
         <record id="act_hr_timesheet_line_by_project" model="ir.actions.act_window">
             <field name="name">Timesheets</field>
             <field name="res_model">account.analytic.line</field>
-            <field name="view_mode">tree,form</field>
+            <field name="view_mode">tree,kanban,pivot,graph,form</field>
             <field name="view_id" ref="timesheet_view_tree_user"/>
-            <field name="domain">[('project_id', '!=', False)]</field>
-            <field name="context">{"default_project_id": active_id, "search_default_project_id": [active_id]}</field>
+            <field name="domain">[('project_id', '=', active_id)]</field>
+            <field name="context">{"default_project_id": active_id}</field>
             <field name="search_view_id" ref="hr_timesheet_line_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -16,6 +16,41 @@
                 Track your working hours by projects every day and invoice this time to your customers.
               </p>
             </field>
+        </record>
+
+        <record id="act_hr_timesheet_line_by_project_view_tree" model="ir.actions.act_window.view">
+            <field name="view_mode">tree</field>
+            <field name="sequence" eval="1"/>
+            <field name="view_id" ref="timesheet_view_tree_user"/>
+            <field name="act_window_id" ref="act_hr_timesheet_line_by_project"/>
+        </record>
+
+        <record id="act_hr_timesheet_line_by_project_view_kanban" model="ir.actions.act_window.view">
+            <field name="view_mode">kanban</field>
+            <field name="sequence" eval="2"/>
+            <field name="view_id" ref="view_kanban_account_analytic_line"/>
+            <field name="act_window_id" ref="act_hr_timesheet_line_by_project"/>
+        </record>
+
+        <record id="act_hr_timesheet_line_by_project_view_pivot" model="ir.actions.act_window.view">
+            <field name="view_mode">pivot</field>
+            <field name="sequence" eval="3"/>
+            <field name="view_id" ref="view_hr_timesheet_line_pivot"/>
+            <field name="act_window_id" ref="act_hr_timesheet_line_by_project"/>
+        </record>
+
+        <record id="act_hr_timesheet_line_by_project_view_graph" model="ir.actions.act_window.view">
+            <field name="view_mode">graph</field>
+            <field name="sequence" eval="4"/>
+            <field name="view_id" ref="view_hr_timesheet_line_graph_all"/>
+            <field name="act_window_id" ref="act_hr_timesheet_line_by_project"/>
+        </record>
+
+        <record id="act_hr_timesheet_line_by_project_view_form" model="ir.actions.act_window.view">
+            <field name="view_mode">form</field>
+            <field name="sequence" eval="10"/>
+            <field name="view_id" ref="hr_timesheet_line_form"/>
+            <field name="act_window_id" ref="act_hr_timesheet_line_by_project"/>
         </record>
 
         <record id="project_project_view_form_simplified_inherit_timesheet" model="ir.ui.view">

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -415,10 +415,12 @@ class CustomerPortal(Controller):
             raise UserError(_("%s is not the reference of a report", report_ref))
 
         if hasattr(model, 'company_id'):
+            if len(model.company_id) > 1:
+                raise UserError(_('Multi company reports are not supported.'))
             report_sudo = report_sudo.with_company(model.company_id)
 
         method_name = '_render_qweb_%s' % (report_type)
-        report = getattr(report_sudo, method_name)([model.id], data={'report_type': report_type})[0]
+        report = getattr(report_sudo, method_name)(list(model.ids), data={'report_type': report_type})[0]
         reporthttpheaders = [
             ('Content-Type', 'application/pdf' if report_type == 'pdf' else 'text/html'),
             ('Content-Length', len(report)),

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -419,12 +419,20 @@ class ProjectCustomerPortal(CustomerPortal):
         })
         return request.render("project.portal_my_tasks", values)
 
+    def _show_task_report(self, task_sudo, report_type, download):
+        # This method is to be overriden to report timesheets if the module is installed.
+        # The route should not be called if at least hr_timesheet is not installed
+        raise MissingError(_('There is nothing to report.'))
+
     @http.route(['/my/task/<int:task_id>'], type='http', auth="public", website=True)
-    def portal_my_task(self, task_id, access_token=None, **kw):
+    def portal_my_task(self, task_id, report_type=None, access_token=None, **kw):
         try:
             task_sudo = self._document_check_access('project.task', task_id, access_token)
         except (AccessError, MissingError):
             return request.redirect('/my')
+
+        if report_type in ('pdf', 'html', 'text'):
+            return self._show_task_report(task_sudo, report_type, download=kw.get('download'))
 
         # ensure attachment are accessible with access token inside template
         for attachment in task_sudo.attachment_ids:

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -15,6 +15,8 @@ STATUS_COLOR = {
     'off_track': 23,  # red / danger
     'on_hold': 4,  # light blue
     False: 0,  # default grey -- for studio
+    # Only used in project.task
+    'to_define': 0,
 }
 
 class ProjectUpdate(models.Model):
@@ -34,7 +36,9 @@ class ProjectUpdate(models.Model):
             if 'description' in fields and not result.get('description'):
                 result['description'] = self._build_description(project)
             if 'status' in fields and not result.get('status'):
-                result['status'] = project.last_update_status
+                # `to_define` is not an option for self.status, here we actually want to default to `on_track`
+                # the goal of `to_define` is for a project to start without an actual status.
+                result['status'] = project.last_update_status if project.last_update_status != 'to_define' else 'on_track'
         return result
 
     name = fields.Char("Title", required=True, tracking=True)

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -34,7 +34,7 @@ access_project_update_project_user,project.update.project.user,model_project_upd
 access_project_update_project_manager,project.update.project.manager,model_project_update,project.group_project_manager,1,1,1,1
 access_project_milestone_user,project.milestone.user,model_project_milestone,base.group_user,1,0,0,0
 access_project_milestone_portal,project.milestone.portal,model_project_milestone,base.group_portal,1,0,0,0
-access_project_milestone_project_user,project.milestone.project.user,model_project_milestone,project.group_project_user,1,0,0,0
+access_project_milestone_project_user,project.milestone.project.user,model_project_milestone,project.group_project_user,1,1,1,1
 access_project_milestone_project_manager,project.milestone.project.manager,model_project_milestone,project.group_project_manager,1,1,1,1
 access_project_collaborator_manager,project.collaborator.manager,model_project_collaborator,project.group_project_manager,1,1,1,1
 access_project_collaborator_portal,project.collaborator.portal,model_project_collaborator,base.group_portal,1,0,0,0

--- a/addons/project/static/src/js/widgets/project_state_select.js
+++ b/addons/project/static/src/js/widgets/project_state_select.js
@@ -1,0 +1,81 @@
+/** @odoo-module **/
+
+import {qweb} from 'web.core';
+import fieldRegistry from 'web.field_registry';
+import {StateSelectionWidget} from 'web.basic_fields';
+
+
+/**
+ * List of colors according to the selection value, see `project_update.py`
+ */
+const STATUS_COLORS = {
+    'on_track': 10,
+    'at_risk': 2,
+    'off_track': 1,
+    'on_hold': 4,
+};
+
+export const ProjectStateSelectionWidget = StateSelectionWidget.extend({
+
+    /**
+     * @override
+     */
+    init() {
+        this._super.apply(this, arguments);
+        // The dropdown never disappears without `edit` mode on.
+        this.mode = 'edit';
+    },
+
+    /**
+     * @override
+     * @private
+     */
+    _prepareDropdownValues() {
+        const self = this;
+        const _data = [];
+        const current_state_id = self.recordData.last_update_status;
+        _.map(this.field.selection || [], function(selection_item) {
+            // Exclude `to_define` from the dropdown list
+            if (selection_item[0] === 'to_define' && current_state_id !== 'to_define') {
+                return;
+            }
+            const value = {
+                'name': selection_item[0],
+                'tooltip': selection_item[1],
+            };
+            value.state_class = 'o_status_bubble mx-0 o_color_bubble_' + STATUS_COLORS[selection_item[0]];
+            value.state_name = selection_item[1];
+            _data.push(value);
+        });
+        return _data;
+    },
+
+    /**
+     * @override
+     * @private
+     */
+    _render() {
+        // Complete override since most of `StateSelectionWidget` is hardcoded.
+        // See `_render` from `StateSelectionWidget`
+        const states = this._prepareDropdownValues();
+        const currentState = _.findWhere(states, {name: this.value}) || states[0];
+        this.$('.o_status')
+            .removeClass('o_status_bubble mx-0 o_color_bubble_10 o_color_bubble_2 o_color_bubble_1 o_color_bubble_4')
+            .addClass(currentState.state_class)
+            .prop('special_click', true)
+            .parent().attr('title', currentState.state_name)
+            .attr('aria-label', this.string + ": " + currentState.state_name);
+
+        const $items = $(qweb.render('FormSelection.items', {
+            states: _.without(states, currentState)
+        }));
+        const $dropdown = this.$('.dropdown-menu');
+        $dropdown.children().remove();
+        $items.appendTo($dropdown);
+
+        const isReadonly = this.record.evalModifiers(this.attrs.modifiers).readonly;
+        this.$('a[data-toggle=dropdown]').toggleClass('disabled', isReadonly || false);
+    }
+});
+
+fieldRegistry.add('project_state_selection', ProjectStateSelectionWidget);

--- a/addons/project/static/src/project_control_panel/project_control_panel.xml
+++ b/addons/project/static/src/project_control_panel/project_control_panel.xml
@@ -4,7 +4,7 @@
     <t t-name="project.ProjectControlPanelContentBadge" owl="1">
         <t t-tag="isProjectUser ? 'button' : 'span'" class="badge border d-flex p-2 ml-2 bg-white">
             <span t-attf-class="o_status_bubble o_color_bubble_{{data.color}}"/>
-            <span class="font-weight-normal ml-1" t-esc="data.status"/>
+            <span t-att-class="'font-weight-normal ml-1' + (data.color === 0 ? ' text-muted' : '')" t-esc="data.status"/>
         </t>
     </t>
 

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -118,7 +118,7 @@ class TestProjectSharing(TestProjectSharingCommon):
                 Command.create({'partner_id': self.user_portal.partner_id.id}),
             ],
         })
-        with self.get_project_sharing_form_view(self.env['project.task'].with_context({'tracking_disable': True, 'default_project_id': self.project_portal.id}), self.user_portal) as form:
+        with self.get_project_sharing_form_view(self.env['project.task'].with_context({'tracking_disable': True, 'default_project_id': self.project_portal.id, 'default_user_ids': [(4, self.user_portal.id)]}), self.user_portal) as form:
             form.name = 'Test'
             task = form.save()
             self.assertEqual(task.name, 'Test')

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -175,117 +175,137 @@
         </t>
     </template>
 
-    <template id="portal_my_task" name="My Task">
-        <t t-call="portal.portal_layout">
+    <template id="portal_my_task" name="My Task" inherit_id="portal.portal_sidebar" primary="True">
+        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <t t-set="o_portal_fullwidth_alert" groups="project.group_project_user">
                 <t t-call="portal.portal_back_in_edit_mode">
                     <t t-set="backend_url" t-value="'/web#model=project.task&amp;id=%s&amp;view_type=form' % (task.id)"/>
                 </t>
             </t>
 
-            <t t-call="portal.portal_record_layout">
-                <t t-set="card_header">
-                    <div class="row no-gutters">
-                        <div class="col-12">
-                            <h5 class="d-flex mb-1 mb-md-0 row">
-                                <div class="col-9">
-                                    <t t-call="project.portal_my_tasks_priority_widget_template"/>
-                                    <span t-field="task.name" class="text-truncate"/>
-                                    <small class="text-muted d-none d-md-inline"> (#<span t-field="task.id"/>)</small>
+            <div class="row mt16 o_project_portal_sidebar">
+                <t t-call="portal.portal_record_sidebar">
+                    <t t-set="classes" t-value="'col-lg-auto d-print-none'"/>
+
+                    <t t-set="entries">
+                        <ul class="list-group list-group-flush flex-wrap flex-row flex-lg-column">
+                            <li id="task-nav" class="list-group-item pl-0 flex-grow-1" t-ignore="true" role="complementary">
+                                <ul class="nav flex-column">
+                                    <li class="nav-item" id="nav-header">
+                                        <a class="nav-link pl-3" href="#card_header" style="max-width: 200px;">
+                                            Task
+                                        </a>
+                                    </li>
+                                    <li class="nav-item" id="nav-chat">
+                                        <a class="nav-link pl-3" href="#task_chat">
+                                            History
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+
+                            <li t-if="task.user_ids or task.partner_id" class="list-group-item flex-grow-1 pl-0">
+                                <div class="col-12 col-md-12 pb-2" t-if="task.user_ids">
+                                    <strong>Assignees</strong>
+                                    <t t-foreach="task.user_ids" t-as="user">
+                                        <div class="row pl-3 flex-nowrap">
+                                            <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(user.avatar_1024)" alt="Contact"/>
+                                            <div class="ml-2">
+                                                <div t-esc="user" t-options='{"widget": "contact", "fields": ["name"]}'/>
+                                                <a t-attf-href="tel:{{user.phone}}" t-if="user.phone"><div t-esc="user" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
+                                            </div>
+                                        </div>
+                                    </t>
                                 </div>
-                                <div class="col-3 text-right">
-                                    <small class="text-right">Stage:</small>
-                                    <span t-field="task.stage_id.name" class=" badge badge-pill badge-info" title="Current stage of this task"/>
+                                <div class="col-12 col-md-12 pb-2" t-if="task.partner_id">
+                                    <strong>Customer</strong>
+                                    <div class="row pl-3 flex-nowrap">
+                                        <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(task.partner_id.avatar_1024)" alt="Contact"/>
+                                        <div class="ml-2">
+                                            <div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["name"]}'/>
+                                            <a t-attf-href="tel:{{task.partner_id.phone}}" t-if="task.partner_id.phone"><div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
+                                        </div>
+                                    </div>
                                 </div>
-                            </h5>
-                        </div>
-                    </div>
+                            </li>
+                        </ul>
+                    </t>
                 </t>
-                <t t-set="card_body">
-                    <div class="float-right">
-                        <t t-call="project.portal_my_tasks_state_widget_template">
-                            <t t-set="path" t-value="'task'"/>
-                        </t>
-                    </div>
-                    <div class="row mt-3" t-if="task.user_ids or task.partner_id">
-                        <div class="col-12 col-md-6 pb-2" t-if="task.user_ids">
-                            <strong>Assignees</strong>
-                            <div class="row">
-                                <t t-foreach="task.user_ids" t-as="user">
-                                    <div class="col d-flex align-items-center flex-grow-0 pr-3">
-                                        <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(user.avatar_1024)" alt="Contact"/>
-                                    </div>
-                                    <div class="col pl-md-0">
-                                        <div t-esc="user" t-options='{"widget": "contact", "fields": ["name"]}'/>
-                                        <a t-attf-href="mailto:{{user.email}}" t-if="user.email"><div t-esc="user" t-options='{"widget": "contact", "fields": ["email"]}'/></a>
-                                        <a t-attf-href="tel:{{user.phone}}" t-if="user.phone"><div t-esc="user" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
-                                    </div>
+                <div id="task_content" class="col-12 col-lg justify-content-end">
+                    <div id="card" class="card">
+                        <div id="card_header" class="card-header bg-white" data-anchor="true">
+                            <div class="row no-gutters">
+                                <div class="col-12">
+                                    <h5 class="d-flex mb-1 mb-md-0 row">
+                                        <div class="col-9">
+                                            <t t-call="project.portal_my_tasks_priority_widget_template"/>
+                                            <span t-field="task.name" class="text-truncate"/>
+                                            <small class="text-muted d-none d-md-inline"> (#<span t-field="task.id"/>)</small>
+                                        </div>
+                                        <div class="col-3 text-right">
+                                            <small class="text-right">Stage:</small>
+                                            <span t-field="task.stage_id.name" class=" badge badge-pill badge-info" title="Current stage of this task"/>
+                                        </div>
+                                    </h5>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="card_body" class="card-body">
+                            <div class="float-right">
+                                <t t-call="project.portal_my_tasks_state_widget_template">
+                                    <t t-set="path" t-value="'task'"/>
                                 </t>
                             </div>
-                        </div>
-                        <div class="col-12 col-md-6 pb-2" t-if="task.partner_id">
-                            <strong>Customer</strong>
-                            <div class="row">
-                                <div class="col d-flex align-items-center flex-grow-0 pr-3">
-                                    <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(task.partner_id.avatar_1024)" alt="Contact"/>
+                            <div class="row mb-4">
+                                <div class="col-12 col-md-6">
+                                    <div t-if="project_accessible"><strong>Project:</strong> <a t-attf-href="/my/project/#{task.project_id.id}" t-field="task.project_id"/></div>
+                                    <div t-else=""><strong>Project:</strong> <a t-field="task.project_id"/></div>
+                                    <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "date"}'/></div>
+                                    <div name="portal_my_task_planned_hours">
+                                        <t t-call="project.portal_my_task_planned_hours_template"/>
+                                    </div>
                                 </div>
-                                <div class="col pl-md-0">
-                                    <div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["name"]}'/>
-                                    <a t-attf-href="mailto:{{task.partner_id.email}}" t-if="task.partner_id.email"><div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["email"]}'/></a>
-                                    <a t-attf-href="tel:{{task.partner_id.phone}}" t-if="task.partner_id.phone"><div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["phone"]}'/></a>
+                                <div class="col-12 col-md-6" name="portal_my_task_second_column"></div>
+                            </div>
+
+                            <div class="row" t-if="task.description or task.attachment_ids">
+                                <div t-if="task.description" t-attf-class="col-12 col-lg-7 mb-4 mb-md-0 {{'col-lg-7' if task.attachment_ids else 'col-lg-12'}}">
+                                    <hr class="mb-1"/>
+                                    <div class="d-flex my-2">
+                                        <strong>Description</strong>
+                                    </div>
+                                    <div class="py-1 px-2 bg-100 small" t-field="task.description"/>
+                                </div>
+                                <div t-if="task.attachment_ids" t-attf-class="col-12 col-lg-5 o_project_portal_attachments {{'col-lg-5' if task.description else 'col-lg-12'}}">
+                                    <hr class="mb-1 d-none d-lg-block"/>
+                                    <strong class="d-block mb-2">Attachments</strong>
+                                    <div class="row">
+                                        <div t-attf-class="col {{'col-lg-6' if not task.description else 'col-lg-12'}}">
+                                            <ul class="list-group">
+                                                <a class="list-group-item list-group-item-action d-flex align-items-center oe_attachments py-1 px-2" t-foreach='task.attachment_ids' t-as='attachment' t-attf-href="/web/content/#{attachment.id}?download=true&amp;access_token=#{attachment.access_token}" target="_blank" data-no-post-process="">
+                                                    <div class='oe_attachment_embedded o_image o_image_small mr-2 mr-lg-3' t-att-title="attachment.name" t-att-data-mimetype="attachment.mimetype" t-attf-data-src="/web/image/#{attachment.id}/50x40?access_token=#{attachment.access_token}"/>
+                                                    <div class='oe_attachment_name text-truncate'><t t-esc='attachment.name'/></div>
+                                                </a>
+                                            </ul>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
 
-                    <div class="row mb-4">
-                        <div class="col-12 col-md-6">
-                            <div t-if="project_accessible"><strong>Project:</strong> <a t-attf-href="/my/project/#{task.project_id.id}" t-field="task.project_id"/></div>
-                            <div t-else=""><strong>Project:</strong> <a t-field="task.project_id"/></div>
-                            <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "date"}'/></div>
-                            <div name="portal_my_task_planned_hours">
-                                <t t-call="project.portal_my_task_planned_hours_template"/>
-                            </div>
-                        </div>
-                        <div class="col-12 col-md-6" name="portal_my_task_second_column"></div>
+                    <div class="mt32" id="task_chat" data-anchor="true">
+                        <h4><strong>Message and communication history</strong></h4>
+                        <t t-call="portal.message_thread">
+                            <t t-set="object" t-value="task"/>
+                            <t t-set="token" t-value="task.access_token"/>
+                            <t t-set="pid" t-value="pid"/>
+                            <t t-set="hash" t-value="hash"/>
+                        </t>
                     </div>
-
-                    <div class="row" t-if="task.description or task.attachment_ids">
-                        <div t-if="task.description" t-attf-class="col-12 col-lg-7 mb-4 mb-md-0 {{'col-lg-7' if task.attachment_ids else 'col-lg-12'}}">
-                            <hr class="mb-1"/>
-                            <div class="d-flex my-2">
-                                <strong>Description</strong>
-                            </div>
-                            <div class="py-1 px-2 bg-100 small" t-field="task.description"/>
-                        </div>
-                        <div t-if="task.attachment_ids" t-attf-class="col-12 col-lg-5 o_project_portal_attachments {{'col-lg-5' if task.description else 'col-lg-12'}}">
-                            <hr class="mb-1 d-none d-lg-block"/>
-                            <strong class="d-block mb-2">Attachments</strong>
-                            <div class="row">
-                                <div t-attf-class="col {{'col-lg-6' if not task.description else 'col-lg-12'}}">
-                                    <ul class="list-group">
-                                        <a class="list-group-item list-group-item-action d-flex align-items-center oe_attachments py-1 px-2" t-foreach='task.attachment_ids' t-as='attachment' t-attf-href="/web/content/#{attachment.id}?download=true&amp;access_token=#{attachment.access_token}" target="_blank" data-no-post-process="">
-                                            <div class='oe_attachment_embedded o_image o_image_small mr-2 mr-lg-3' t-att-title="attachment.name" t-att-data-mimetype="attachment.mimetype" t-attf-data-src="/web/image/#{attachment.id}/50x40?access_token=#{attachment.access_token}"/>
-                                            <div class='oe_attachment_name text-truncate'><t t-esc='attachment.name'/></div>
-                                        </a>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </t>
-            </t>
-
-            <div class="mt32">
-                <h4><strong>Message and communication history</strong></h4>
-                <t t-call="portal.message_thread">
-                    <t t-set="object" t-value="task"/>
-                    <t t-set="token" t-value="task.access_token"/>
-                    <t t-set="pid" t-value="pid"/>
-                    <t t-set="hash" t-value="hash"/>
-                </t>
+                </div>
             </div>
-        </t>
+        </xpath>
     </template>
 
     <template id="portal_my_task_planned_hours_template">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -197,6 +197,7 @@
                     <field name="name"/>
                     <field name="fold"/>
                     <field name="description"/>
+                    <field name="sequence" widget="handle"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="oe_kanban_global_click">
@@ -288,14 +289,36 @@
                                 </span>
                             </div>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '=', -1)]}" class="oe_stat_button oe_read_only" icon="fa-smile-o" groups="project.group_project_rating">
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button oe_read_only text-success" icon="fa-smile-o" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
                                     %
                                 </span>
-                                <span class="o_stat_text">
-                                    Customer Satisfaction
+                                <span class="o_stat_text text-secondary">
+                                    Satisfaction
+                                </span>
+                            </div>
+                        </button>
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_active', '=', False), ('rating_percentage_satisfaction', '>=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button oe_read_only text-warning" icon="fa-meh-o" groups="project.group_project_rating">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_value">
+                                    <field name="rating_percentage_satisfaction" nolabel="1"/>
+                                    %
+                                </span>
+                                <span class="o_stat_text text-secondary">
+                                    Satisfaction
+                                </span>
+                            </div>
+                        </button>
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_active', '=', False), '|', ('rating_percentage_satisfaction', '>=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button oe_read_only text-danger" icon="fa-frown-o" groups="project.group_project_rating">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_value">
+                                    <field name="rating_percentage_satisfaction" nolabel="1"/>
+                                    %
+                                </span>
+                                <span class="o_stat_text text-secondary">
+                                    Satisfaction
                                 </span>
                             </div>
                         </button>
@@ -310,6 +333,18 @@
                                     <field name="analytic_account_balance"/>
                                 </span>
                                 <span class="o_stat_text">Gross Margin</span>
+                            </div>
+                        </button>
+                        <button class="oe_stat_button" name="%(project.project_update_all_action)d" type="action" groups="project.group_project_manager">
+                            <div class="pl-4">
+                                <field name="last_update_color" invisible="1"/>
+                                <field name="last_update_status" readonly="1" widget="status_with_color" options="{'color_field': 'last_update_color'}"/>
+                            </div>
+                        </button>
+                        <button class="oe_stat_button o_project_not_clickable" disabled="disabled" groups="!project.group_project_manager">
+                            <div class="pl-4">
+                                <field name="last_update_color" invisible="1"/>
+                                <field name="last_update_status" readonly="1" widget="status_with_color" options="{'color_field': 'last_update_color', 'no_quick_edit': 1}"/>
                             </div>
                         </button>
                         <button class="oe_stat_button" name="%(project.project_collaborator_action)d" type="action" icon="fa-users" groups="project.group_project_manager">
@@ -615,6 +650,7 @@
                     <field name="last_update_status"/>
                     <field name="tag_ids"/>
                     <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info"}'/>
+                    <field name="sequence" widget="handle"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card">
@@ -653,9 +689,6 @@
                                                 </div>
                                                 <div role="menuitem">
                                                     <a name="action_view_tasks" type="object">Tasks</a>
-                                                </div>
-                                                <div role="menuitem" t-if="record.doc_count.raw_value">
-                                                    <a name="attachment_tree_view" type="object">Documents</a>
                                                 </div>
                                             </div>
                                             <div class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting" groups="project.group_project_manager">
@@ -701,7 +734,8 @@
                                         <field name="activity_ids" widget="kanban_activity"/>
                                     </div>
                                     <div class="oe_kanban_bottom_right">
-                                        <span t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
+                                        <field t-if="record.last_update_status.value &amp;&amp; widget.editable" name="last_update_status" widget="project_state_selection"/>
+                                        <span t-if="record.last_update_status.value &amp;&amp; !widget.editable" t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
                                         <field name="user_id" widget="many2one_avatar_user"/>
                                     </div>
                                 </div>
@@ -783,6 +817,8 @@
                     <field name="repeat_show_month" invisible="1" />
                     <field name="recurrence_id" invisible="1" />
                     <field name="allow_task_dependencies" invisible="1" />
+                    <field name="rating_last_value" invisible="1"/>
+                    <field name="rating_count" invisible="1"/>
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
                             attrs="{'invisible' : [('user_ids', '!=', [])]}" data-hotkey="q"/>
@@ -794,10 +830,32 @@
                     </div>
                     <sheet string="Task">
                     <div class="oe_button_box" name="button_box">
-                        <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" string="Parent Task" attrs="{'invisible': [('parent_id', '=', False)]}"/>
-                        <button name="%(rating_rating_action_task)d" type="action" attrs="{'invisible': [('rating_count', '=', 0)]}" class="oe_stat_button" icon="fa-smile-o" groups="project.group_project_rating">
-                            <field name="rating_count" string="Rating" widget="statinfo"/>
+                        <!-- Dummy tag for organizing buttons, using position='replace' when inheriting -->
+                        <span id="button_products" invisible="1"/>
+                        <span id="button_worksheet" invisible="1"/>
+                        <!-- Dummy tag used to organize buttons, englobing the 3 buttons modifies the width of the button -->
+                        <span id="start_rating_buttons" invisible="1"/>
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '&lt;', 66.6)]}" class="oe_stat_button text-success" icon="fa-smile-o" groups="project.group_project_rating">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
+                                <span class="o_stat_text text-secondary">Satisfaction</span>
+                            </div>
                         </button>
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '>=', 66.6), ('rating_percentage_satisfaction', '&lt;', 33.3)]}" class="oe_stat_button text-warning" icon="fa-meh-o" groups="project.group_project_rating">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
+                                <span class="o_stat_text text-secondary">Satisfaction</span>
+                            </div>
+                        </button>
+                        <button name="action_open_ratings" type="object" attrs="{'invisible': ['|', '|', ('rating_count', '=', 0), ('rating_percentage_satisfaction', '>=', 33.3),  ('rating_percentage_satisfaction', '&lt;', 0)]}" class="oe_stat_button text-danger" icon="fa-frown-o" groups="project.group_project_rating">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_value"><field name="rating_percentage_satisfaction" widget="integer"/>%</span>
+                                <span class="o_stat_text text-secondary">Satisfaction</span>
+                            </div>
+                        </button>
+                        <!-- Dummy tag used to organize buttons -->
+                        <span id="end_rating_buttons" invisible="1"/>
+                        <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" string="Parent Task" attrs="{'invisible': [('parent_id', '=', False)]}"/>
                         <button name="action_recurring_tasks" type="object" attrs="{'invisible': [('recurrence_id', '=', False)]}" class="oe_stat_button" icon="fa-repeat" groups="project.group_project_recurring_tasks">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
@@ -816,6 +874,8 @@
                                 </span>
                             </div>
                         </button>
+                        <!-- Dummy tag used to organize buttons -->
+                        <span id="end_button_box" invisible="1"/>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title pr-0">
@@ -1248,7 +1308,7 @@
             <field name="name">My Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
-            <field name="context">{'search_default_my_tasks': 1, 'search_default_personal_stage': 1, 'all_task': 0}</field>
+            <field name="context">{'search_default_my_tasks': 1, 'search_default_personal_stage': 1, 'all_task': 0, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form_extended"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -39,6 +39,12 @@
             <field name="rated_partner_id" position="attributes">
                 <attribute name="string">Assigned to</attribute>
             </field>
+            <field name="create_date" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </field>
+            <field name="feedback" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </field>
             <div name="rating_image_container" position="replace">
                 <field name="rating_text" string="Rating"/>
             </div>
@@ -92,7 +98,7 @@
     </record>
 
     <record id="rating_rating_action_view_project_rating" model="ir.actions.act_window">
-        <field name="name">Rating</field>
+        <field name="name">Ratings</field>
         <field name="res_model">rating.rating</field>
         <field name="view_mode">kanban,tree,graph,pivot,form</field>
         <field name="domain">[('consumed','=',True), ('parent_res_model','=','project.project')]</field>
@@ -102,6 +108,13 @@
                 There are no ratings for this project at the moment
             </p>
         </field>
+    </record>
+
+    <record id="rating_rating_action_view_project_rating_kanban" model="ir.actions.act_window.view">
+        <field name="sequence" eval="5"/>
+        <field name="view_mode">kanban</field>
+        <field name="act_window_id" ref="rating_rating_action_view_project_rating"/>
+        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_view_project_rating_tree" model="ir.actions.act_window.view">
@@ -133,7 +146,7 @@
     </record>
 
     <record id="rating_rating_action_task" model="ir.actions.act_window">
-        <field name="name">Customer Ratings on Task</field>
+        <field name="name">Ratings</field>
         <field name="res_model">rating.rating</field>
         <field name="view_mode">kanban,tree,pivot,graph,form</field>
         <field name="domain">[('res_model', '=', 'project.task'), ('res_id', '=', active_id), ('consumed', '=', True)]</field>
@@ -145,6 +158,13 @@
                 Let's wait for your customers to manifest themselves.
             </p>
         </field>
+    </record>
+
+    <record id="rating_rating_action_task_kanban" model="ir.actions.act_window.view">
+        <field name="sequence" eval="5"/>
+        <field name="view_mode">kanban</field>
+        <field name="act_window_id" ref="rating_rating_action_task"/>
+        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_task_tree" model="ir.actions.act_window.view">

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -69,7 +69,7 @@
                                 <div class="o_setting_right_pane">
                                     <label for="module_project_forecast"/>
                                     <div class="text-muted" name="project_forecast_msg">
-                                        Plan resource allocation across projets and tasks, and estimate deadlines more accurately
+                                        Plan resource allocation across projects and tasks, and estimate deadlines more accurately
                                     </div>
                                 </div>
                             </div>

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -98,7 +98,8 @@ class RatingMixin(models.AbstractModel):
                 grades_per_record[record_id]['bad'] += group['__count']
         for record in self:
             grade_repartition = grades_per_record.get(record.id, default_grades)
-            record.rating_percentage_satisfaction = grade_repartition['great'] * 100 / sum(grade_repartition.values()) if sum(grade_repartition.values()) else -1
+            grade_count = sum(grade_repartition.values())
+            record.rating_percentage_satisfaction = grade_repartition['great'] * 100 / grade_count if grade_count else -1
 
     def write(self, values):
         """ If the rated ressource name is modified, we should update the rating res_name too.

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -34,11 +34,10 @@
             </xpath>
             <xpath expr="//button[@name='%(project.act_project_project_2_project_task_all)d']" position="before">
                 <button class="d-none d-md-inline oe_stat_button"
-                        type="object" name="action_view_so" icon="fa-dollar"
-                        attrs="{'invisible': [('sale_order_id', '=', False)]}"
-                        string="Sales Order"
+                        type="object" name="action_view_sos" icon="fa-dollar"
+                        attrs="{'invisible': [('sale_order_count', '=', 0)]}"
                         groups="sales_team.group_sale_salesman_all_leads">
-                    <field name="sale_order_id" attrs="{'invisible': True}"/> 
+                    <field name="sale_order_count" widget="statinfo" string="Sales Orders"/>
                 </button>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
@@ -53,7 +52,7 @@
         <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
         <field name="inherit_id" ref="project.view_task_form2"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_recurring_tasks']" position="before">
+            <xpath expr="//span[@id='start_rating_buttons']" position="before">
                 <button class="d-none d-md-inline oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': [('sale_order_id', '=', False)]}"

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -174,6 +174,13 @@ class Project(models.Model):
             ], limit=1)
             project.sale_line_id = sol or project.sale_line_employee_ids.sale_line_id[:1]  # get the first SOL containing in the employee mappings if no sol found in the search
 
+    def _get_all_sales_orders(self):
+        return super()._get_all_sales_orders() | self.sale_line_employee_ids.sale_line_id.order_id
+
+    @api.depends('sale_line_employee_ids.sale_line_id')
+    def _compute_sale_order_count(self):
+        super()._compute_sale_order_count()
+
     @api.constrains('sale_line_id')
     def _check_sale_line_type(self):
         for project in self.filtered(lambda project: project.sale_line_id):
@@ -279,19 +286,6 @@ class Project(models.Model):
             ],
         })
         return action
-
-    def action_view_all_rating(self):
-        return {
-            'name': _('Rating'),
-            'type': 'ir.actions.act_window',
-            'res_model': 'rating.rating',
-            'view_mode': 'kanban,list,graph,pivot,form',
-            'view_type': 'ir.actions.act_window',
-            'context': {
-                'search_default_rating_last_30_days': True,
-            },
-            'domain': [('consumed', '=', True), ('parent_res_model', '=', 'project.project'), ('parent_res_id', '=', self.id)],
-        }
 
     # ----------------------------
     #  Project Updates

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -10,7 +10,7 @@ class ProjectProductEmployeeMap(models.Model):
 
     project_id = fields.Many2one('project.project', "Project", required=True)
     employee_id = fields.Many2one('hr.employee', "Employee", required=True)
-    sale_line_id = fields.Many2one('sale.order.line', "Sale Order Item", compute="_compute_sale_line_id", store=True, readonly=False,
+    sale_line_id = fields.Many2one('sale.order.line', "Sales Order Item", compute="_compute_sale_line_id", store=True, readonly=False,
         domain="""[
             ('is_service', '=', True),
             ('is_expense', '=', False),

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -6,8 +6,14 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="hr_timesheet.project_invoice_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_view_so']" position="attributes">
+            <xpath expr="//button[@name='action_view_sos']" position="attributes">
                 <attribute name="attrs">{'invisible': ['|', ('allow_billable', '=', False), ('sale_order_id', '=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//button[@name='%(project.action_project_task_burndown_chart_report)d']" position="after">
+                <button string="Costs / Revenues" class="oe_stat_button" type="object" name="action_view_timesheet" icon="fa-puzzle-piece" attrs="{'invisible': [('allow_billable', '=', False)]}" groups="project.group_project_manager"/>
+            </xpath>
+            <xpath expr="//button[@name='action_view_sos']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('allow_billable', '=', False), ('sale_order_count', '=', 0)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='%(project.action_project_task_burndown_chart_report)d']" position="after">
                 <button name="action_billable_time_button" type="object" class="oe_stat_button" icon="fa-clock-o" attrs="{'invisible': ['|', ('allow_timesheets', '=', False), ('analytic_account_id', '=', False)]}" groups="hr_timesheet.group_hr_timesheet_approver">
@@ -114,7 +120,7 @@
                 <div t-if="record.allow_billable.raw_value and record.sale_order_id.raw_value and record.pricing_type.raw_value != 'task_rate'"
                     role="menuitem"
                     groups="sales_team.group_sale_salesman_all_leads">
-                    <a name="action_view_so" type="object">Sales Order</a>
+                    <a name="action_view_sos" type="object">Sales Orders</a>
                 </div>
             </xpath>
         </field>

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -969,6 +969,7 @@ tour.stepUtils.mobileModifier(tour.stepUtils.autoExpandMoreButtons('.o_control_p
 ...tour.stepUtils.goBackBreadcrumbsMobile(
         _t('Back to the sale order'),
         undefined,
+        ".breadcrumb-item.active:contains('Timesheets')",
         ".breadcrumb-item.active:contains('the_flow.project')",
         ".breadcrumb-item.active:contains('the_flow.service')"
     ),


### PR DESCRIPTION
Adds multi record support to `_show_report`.
Limited to records within the same company to stay as close as possible
to the default behaviour.

Adds the satisfaction percentage as an optional compute to
`rating.mixin`.

Smaller changes:
 - Projects created on the fly (through `name_create`) will now come with a
   default `new` stage in order for them to not be empty.
 - Removed task auto assign upon creation besides in FSM's 'My tasks' menu.
 - Allow the reordering of projects without needing to group by
   anything.
 - Make `project.task`.`description` and `project.tags`.`name`
   translatable.
 - Disable the creation of records in the view when clicking on `Tasks
   in recurrence` stat button.
 - Track the planned date of the task in the chatter
 - Disable the creation of records in the view when clicking on
   'invoices' stat button and add the kanban view to that action.
 - Make milestones completely available to regular project users.
 - Remove the 'Documents' button in the project's kanban settings menu.
 - Add kanban, pivot and graph views to the 'Hours Recorded' stat button
   on projects
 - Add the calendar view on the 'Hours Forecast' stat button on projects
 - The 'Sales Orders' stat button on the `project.project`'s form view
   will now display the amount of sales order linked to the whole
   project. So the one linked to the project itself if it exists + all
   the tasks. It will also open them, form view if 1 else list view.
 - Fix a typo in the settings 'projets' => 'projects'
 - The analytic account  of the project will now be assigned to the
   sales order when a task is created through the 'Create a task in an
   existing project' option.

Changed the portal task view to include a sidebar similar to sales
orders, with a simple menu leading to different parts of the screen.

Changed the `project.task` 'rating' stat button:
 - The icon will now represent the latest review.
 - The action will directly lead to the record's form view if there is
   only 1 rating.
 - Make some fields readonly in the form view.
 - Display the % of satisfaction instead of the number of ratings.

Reorder all stat buttons on the `project.task` form view in this order:
 - Products, Worksheet, Sales Order(s), Invoices, Ratings, Hours
   Forecast, Parent Task, Tasks in recurrence, Tickets, Quotations and
   lastly Customer Preview

Make the status of the project editable directly through the kanban
view. A new widget has been added to handle that properly. When editing
the status through that means, a `project.update` will be created with
the current date and the appropriate status. In addition to that a new
status has been added (only on `project.task`, not `project.status`)
namely `to_define` in order to differentiate new and running projects.
Projects now start with the `to_define` status.

The `project.project`'s  rating stat button has been changed in the
following ways:
 - The icon will now change in function of the satisfaction percentage,
   smile above 66%, meh between 33% and 66% and frown below 33%.
 - The color will also change depending on the rate, smile is green, meh
   is orange and frown is red.
 - The ratings will now be in function of the last 30 days instead of
   all time and the action will also filter on those 30 days.
 - Change the action name from 'Rating' to 'Ratings'.

`project.project` ticket stat button:
 - Will now open the form view when there is only one record.
 - Added the activity view.
 - Disable the creation of new records.
 - Rename the action to 'Tickets'.

Task ID: 2611006
