### PR TITLE
[FIX] mrp: correctly copy cancelled MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -808,7 +808,10 @@ class MrpProduction(models.Model):
         # covers at least 2 cases: backorders generation (follow default logic for moves copying)
         # and copying a done MO via the form (i.e. copy only the non-cancelled moves since no backorder = cancelled finished moves)
         if not default or 'move_finished_ids' not in default:
-            default['move_finished_ids'] = [(0, 0, move.copy_data()[0]) for move in self.move_finished_ids.filtered(lambda m: m.state != 'cancel' and m.product_qty != 0.0)]
+            move_finished_ids = self.move_finished_ids
+            if self.state != 'cancel':
+                move_finished_ids = self.move_finished_ids.filtered(lambda m: m.state != 'cancel' and m.product_qty != 0.0)
+            default['move_finished_ids'] = [(0, 0, move.copy_data()[0]) for move in move_finished_ids]
         if not default or 'move_raw_ids' not in default:
             default['move_raw_ids'] = [(0, 0, move.copy_data()[0]) for move in self.move_raw_ids.filtered(lambda m: m.product_qty != 0.0)]
         return super(MrpProduction, self).copy_data(default=default)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -114,6 +114,15 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(len(mo_copy.move_finished_ids), 1, "Incorrect number of moves for products to produce [i.e. cancelled moves should not be copied")
         self.assertEqual(mo_copy.move_finished_ids.product_uom_qty, 2, "Incorrect qty of products to produce")
 
+        # check that a cancelled MO is copied correctly
+        mo_copy.action_cancel()
+        self.assertEqual(mo_copy.state, 'cancel')
+        mo_copy_2 = mo_copy.copy()
+        self.assertEqual(mo_copy_2.state, 'draft', "Copied production order should be draft.")
+        self.assertEqual(len(mo_copy_2.move_raw_ids), 2, "Incorrect number of component moves.")
+        self.assertEqual(len(mo_copy_2.move_finished_ids), 1, "Incorrect number of moves for products to produce [i.e. copying a cancelled MO should copy its cancelled moves]")
+        self.assertEqual(mo_copy_2.move_finished_ids.product_uom_qty, 2, "Incorrect qty of products to produce")
+
     def test_production_avialability(self):
         """ Checks the availability of a production order through mutliple calls to `action_assign`.
         """


### PR DESCRIPTION
Missed the case of copying a cancelled MO needing its cancelled
move_finished_ids to still be copied during commit:
79efbd0e4707892041ee7c58c81c1d7edd033edd

Steps to reproduce:
Step 1: make a MO and cancel it
Step 2: duplicate the MO and try to mark as done

Expected result: qty is produced
Actual result: Validation Error about quantity to produce must be
               positive (due to no move_finished_ids)

Follow up to task: 2618962

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
