### PR TITLE
[FIX] l10n_ar, l10n_ch: multicurrency tests

### DIFF
--- a/addons/l10n_ar/demo/account_customer_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_invoice_demo.xml
@@ -131,6 +131,10 @@
     </record>
 
     <!-- Invoice to ADHOC in USD and vat 21 -->
+    <record id="base.USD" model="res.currency">
+        <field name="active" eval="True"/>
+    </record>
+
     <record id="demo_invoice_10" model="account.move">
         <field name="partner_id" ref="l10n_ar.res_partner_adhoc"/>
         <field name="invoice_user_id" ref="base.user_demo"/>

--- a/addons/l10n_ch/tests/test_l10n_ch_isr_print.py
+++ b/addons/l10n_ch/tests/test_l10n_ch_isr_print.py
@@ -59,7 +59,7 @@ class ISRTest(AccountTestInvoicingCommon):
         })
         invoice_chf.action_post()
         self.assertTrue(self.print_isr(invoice_chf))
-
+        self.env.ref('base.EUR').active = True
         invoice_eur = self.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': self.partner_a.id,


### PR DESCRIPTION
since odoo/odoo@4402949 all currencies are inactive by default - activate currencies required for l10n tests