### PR TITLE
[FIX] hr_recruitment: fix access error in get_suggested_recipients

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -402,7 +402,7 @@ class Applicant(models.Model):
         recipients = super(Applicant, self)._message_get_suggested_recipients()
         for applicant in self:
             if applicant.partner_id:
-                applicant._message_add_suggested_recipient(recipients, partner=applicant.partner_id, reason=_('Contact'))
+                applicant._message_add_suggested_recipient(recipients, partner=applicant.partner_id.sudo(), reason=_('Contact'))
             elif applicant.email_from:
                 email_from = applicant.email_from
                 if applicant.partner_name:


### PR DESCRIPTION
Since a partner of the type private is created when
the partner is created at message post (see _message_post_after_hook),
most of the hr.applicant are linked to a partner_id of type private

And recruitment officer may not have the access to private address,
those user can get an access error while opening a form view of an
hr.applicant due to get_suggested_recipients called.

They are already able to see the email address and the name of the
applicant directly on the applicant form we can consider they should
be able to call get_suggested_recipients

Solution: read the partner with sudo






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
