### PR TITLE
[IMP] payment_authorize: support ACH payments

### DIFF
--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -19,12 +19,14 @@ class AuthorizeController(http.Controller):
         """ Return public information on the acquirer.
 
         :param int acquirer_id: The acquirer handling the transaction, as a `payment.acquirer` id
-        :return: Information on the acquirer, namely: the state, login ID and public client key
+        :return: Information on the acquirer, namely: the state, payment method type, login ID, and
+                 public client key
         :rtype: dict
         """
         acquirer_sudo = request.env['payment.acquirer'].sudo().browse(acquirer_id).exists()
         return {
             'state': acquirer_sudo.state,
+            'payment_method_type': acquirer_sudo.authorize_payment_method_type,
             # The public API key solely used to identify the seller account with Authorize.Net
             'login_id': acquirer_sudo.authorize_login,
             # The public client key solely used to identify requests from the Accept.js suite

--- a/addons/payment_authorize/models/payment_token.py
+++ b/addons/payment_authorize/models/payment_token.py
@@ -17,6 +17,11 @@ class PaymentToken(models.Model):
     authorize_profile = fields.Char(
         string="Authorize.Net Profile ID",
         help="The unique reference for the partner/token combination in the Authorize.net backend.")
+    authorize_payment_method_type = fields.Selection(
+        string="Authorize.Net Payment Type",
+        help="The type of payment method this token is linked to.",
+        selection=[("credit_card", "Credit Card"), ("bank_account", "Bank Account (USA Only)")],
+    )
 
     def _handle_deactivation_request(self):
         """ Override of payment to request Authorize.Net to delete the token.

--- a/addons/payment_authorize/views/payment_authorize_templates.xml
+++ b/addons/payment_authorize/views/payment_authorize_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <template id="inline_form">
-        <div t-attf-id="o_authorize_form_{{acquirer_id}}" class="o_authorize_form">
+        <div t-if="acquirer.authorize_payment_method_type == 'credit_card'" t-attf-id="o_authorize_form_{{acquirer_id}}" class="o_authorize_form">
             <div class="form-group">
                 <label t-attf-for="o_authorize_card_{{acquirer_id}}" class="col-form-label">Card Number</label>
                 <input type="text" t-attf-id="o_authorize_card_{{acquirer_id}}" required="" maxlength="19" class="form-control"/>
@@ -19,6 +19,32 @@
                     <label t-attf-for="o_authorize_code_{{acquirer_id}}">Card Code</label>
                     <input type="number" t-attf-id="o_authorize_code_{{acquirer_id}}" max="999" class="form-control"/>
                 </div>
+            </div>
+        </div>
+        <div t-else="" t-attf-id="o_authorize_form_{{acquirer_id}}" class="o_authorize_form">
+            <div class="form-group">
+                <label t-attf-for="o_authorize_bank_name_{{acquirer_id}}" class="col-form-label">Bank Name</label>
+                <input type="text" t-attf-id="o_authorize_bank_name_{{acquirer_id}}" required="" class="form-control"/>
+            </div>
+            <div class="form-group">
+                <label t-attf-for="o_authorize_account_name_{{acquirer_id}}" class="col-form-label">Name On Account</label>
+                <input type="text" t-attf-id="o_authorize_account_name_{{acquirer_id}}" required="" class="form-control"/>
+            </div>
+            <div class="form-group">
+                <label t-attf-for="o_authorize_account_number_{{acquirer_id}}" class="col-form-label">Account Number</label>
+                <input type="text" t-attf-id="o_authorize_account_number_{{acquirer_id}}" required="" class="form-control"/>
+            </div>
+            <div class="form-group">
+                <label t-attf-for="o_authorize_aba_number_{{acquirer_id}}" class="col-form-label">ABA Routing Number</label>
+                <input type="text" t-attf-id="o_authorize_aba_number_{{acquirer_id}}" required="" class="form-control"/>
+            </div>
+            <div class="form-group">
+                <label t-attf-for="o_authorize_account_type_{{acquirer_id}}" class="col-form-label">Bank Account Type</label>
+                <select t-attf-id="o_authorize_account_type_{{acquirer_id}}" required="" class="form-control">
+                    <option value="checking">Personal Checking</option>
+                    <option value="savings">Personal Savings</option>
+                    <option value="businessChecking">Business Checking</option>
+                </select>
             </div>
         </div>
     </template>

--- a/addons/payment_authorize/views/payment_views.xml
+++ b/addons/payment_authorize/views/payment_views.xml
@@ -23,6 +23,10 @@
                     </a>
                 </group>
             </xpath>
+            <field name="display_as" position="before">
+                <field name="authorize_payment_method_type"
+                       attrs="{'invisible': [('provider', '!=', 'authorize')], 'required':[('provider', '=', 'authorize'), ('state', '!=', 'disabled')]}"/>
+            </field>
             <xpath expr="//field[@name='country_ids']" position="after">
                 <label for="authorize_currency_id" string="Currency" attrs="{'invisible': [('provider', '!=', 'authorize')]}"/>
                 <div attrs="{'invisible': [('provider', '!=', 'authorize')]}">
@@ -43,6 +47,7 @@
             <xpath expr='//field[@name="acquirer_ref"]' position='after'>
                 <field name="provider" invisible="1"/>
                 <field name="authorize_profile" attrs="{'invisible':[('provider', '!=', 'authorize')]}"/>
+                <field name="authorize_payment_method_type" attrs="{'invisible': [('provider', '!=', 'authorize')]}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before 660dc0ebaf it was possible to use Authorize to pay via your bank
account using the "Redirection to payment acquirer" option. Since the
refactor removed the redirect it was no longer possible. This
reintroduces that feature.

It does so by adding new form elements that accept bank account
information. Additionally it reintroduces the billTo and customer
parameters that Authorize requires when processing ACH payments.

task-2628318