### PR TITLE
[FIX] product_images: correctly throw an UserError

### DIFF
--- a/addons/product_images/wizard/product_fetch_image_wizard.py
+++ b/addons/product_images/wizard/product_fetch_image_wizard.py
@@ -47,7 +47,7 @@ class ProductFetchImageWizard(models.TransientModel):
         google_pse_id_is_set = bool(ICP.get_param('google.pse.id'))
         google_custom_search_key_is_set = bool(ICP.get_param('google.custom_search.key'))
         if not (google_pse_id_is_set and google_custom_search_key_is_set):
-            raise google_pse_id_is_set(_(
+            raise UserError(_(
                 "The API Key and Search Engine ID must be set in the General Settings."
             ))
 


### PR DESCRIPTION
The UserError was inadvertently removed and replaced by 
`google_pse_id_is_set` variable, which is a boolean.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
