### PR TITLE
[IMP] stock: removal in closest location

### DIFF
--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -9,6 +9,10 @@
             <field name="name">Last In First Out (LIFO)</field>
             <field name="method">lifo</field>
         </record>
+        <record id="removal_closest" model="product.removal">
+            <field name="name">Closest Location</field>
+            <field name="method">closest</field>
+        </record>
     </data>
     <data noupdate="1">
         <!-- Resource: stock.location -->

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -443,6 +443,8 @@ class StockQuant(models.Model):
             return 'in_date ASC, id'
         elif removal_strategy == 'lifo':
             return 'in_date DESC, id DESC'
+        elif removal_strategy == 'closest':
+            return 'location_id ASC, id DESC'
         raise UserError(_('Removal strategy %s not implemented.') % (removal_strategy,))
 
     def _gather(self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False):


### PR DESCRIPTION
Assuming that the only thing cared about when removing items from stock
is the accessibility of the product. Then it would be better to take
products stored on the floor instead of on higher levels of my racks.
In this case current solutions in Odoo are not the most efficient.
Closest location picks items in the 'smallest' location (in alphabetical
order)

Task-2568735

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
