### PR TITLE
[FIX] hr: prevent traceback when loading calendar views.

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -504,6 +504,9 @@ class HrEmployeePrivate(models.Model):
     def _get_unusual_days(self, date_from, date_to=None):
         # Checking the calendar directly allows to not grey out the leaves taken
         # by the employee
+        # Prevents a traceback when loading calendar views and no employee is linked to the user.
+        if not self:
+            return {}
         self.ensure_one()
         calendar = self.resource_calendar_id
         if not calendar:


### PR DESCRIPTION
When loading calendar views, the client tries to load 'unusual' days,
linked to the employee of the current user. But it does not check that
the current user is linked to an employee for that company.

Task ID: 2628736
