### PR TITLE
[FIX] purchase_stock : prevent wrong destination in PO

### DIFF
--- a/addons/purchase_stock/i18n/purchase_stock.pot
+++ b/addons/purchase_stock/i18n/purchase_stock.pot
@@ -261,6 +261,15 @@ msgid "Exception(s):"
 msgstr ""
 
 #. module: purchase_stock
+#: code:addons/purchase_stock/models/purchase.py:0
+#, python-format
+msgid ""
+"For the product %s, the warehouse of the operation type (%s) is inconsistent"
+" with the location (%s) of the reordering rule (%s). Change the operation "
+"type or cancel the request for quotation."
+msgstr ""
+
+#. module: purchase_stock
 #. openerp-web
 #: code:addons/purchase_stock/static/src/js/tours/purchase_stock.js:0
 #, python-format

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -272,7 +272,7 @@ class PurchaseOrderLine(models.Model):
     qty_received_method = fields.Selection(selection_add=[('stock_moves', 'Stock Moves')])
 
     move_ids = fields.One2many('stock.move', 'purchase_line_id', string='Reservation', readonly=True, copy=False)
-    orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Orderpoint')
+    orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Orderpoint', copy=False)
     move_dest_ids = fields.One2many('stock.move', 'created_purchase_line_id', 'Downstream Moves')
     product_description_variants = fields.Char('Custom Description')
     propagate_cancel = fields.Boolean('Propagate cancellation', default=True)
@@ -442,8 +442,15 @@ class PurchaseOrderLine(models.Model):
             res.append(extra_move_vals)
         return res
 
+    def _check_orderpoint_picking_type(self):
+        warehouse_loc = self.order_id.picking_type_id.warehouse_id.view_location_id
+        if self.orderpoint_id and not warehouse_loc.parent_path in self.orderpoint_id.location_id.parent_path:
+            raise UserError(_('For the product %s, the warehouse of the operation type (%s) is inconsistent with the location (%s) of the reordering rule (%s). Change the operation type or cancel the request for quotation.',
+                              self.product_id.display_name, self.order_id.picking_type_id.display_name, self.orderpoint_id.location_id.display_name, self.orderpoint_id.display_name))
+    
     def _prepare_stock_move_vals(self, picking, price_unit, product_uom_qty, product_uom):
         self.ensure_one()
+        self._check_orderpoint_picking_type()
         product = self.product_id.with_context(lang=self.order_id.dest_address_id.lang or self.env.user.lang)
         description_picking = product._get_description(self.order_id.picking_type_id)
         if self.product_description_variants:


### PR DESCRIPTION
Steps to reproduce the bug:
- create 2 warehouses A & B
- create a new product and add a seller
- Create an Automated replenishment order of the created product for warehouse A
- click on “Automate orders”
- open PO
- in “other information” tab > change the picking type to the “warehouse B” picking type
- confirm order
- click on the receipt

Problem:
The destination location is “Warehouse A” instead of “Warehouse B”
The problem also appears after the duplication.

Solution:
Use the parent_path to check if the location that the user wants to use is below the original warehouse.

opw-2588082




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
