### PR TITLE
[FIX] project_timesheet_holidays: prevent multi-company issue in time

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -66,7 +66,8 @@ class Holidays(models.Model):
         for holiday in self.filtered(
                 lambda request: request.holiday_type == 'employee' and
                                 request.holiday_status_id.timesheet_project_id and
-                                request.holiday_status_id.timesheet_task_id):
+                                request.holiday_status_id.timesheet_task_id and
+                                request.holiday_status_id.timesheet_project_id.sudo().company_id == (request.holiday_status_id.company_id or self.env.company)):
             holiday._timesheet_create_lines()
 
         return super(Holidays, self)._validate_leave_request()


### PR DESCRIPTION
off.

When validating a time off with a company-less time off type, if the
time off type is configured to create timesheet entries in a project, a
multi-company security rule could be triggered by accessing the project.
We now check that the company of the task is valid in the current
context (it would make no sense to have an employee work on a task from
another company anyway) before creating the timesheets.

Task ID: 2628148
