### PR TITLE
[FIX] stock_picking_batch: remove empty pickings

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -191,14 +191,24 @@ class StockPickingBatch(models.Model):
         if any(picking.state not in ('assigned', 'confirmed') for picking in pickings):
             raise UserError(_('Some transfers are still waiting for goods. Please check or force their availability before setting this batch to done.'))
 
+        empty_pickings = set()
         for picking in pickings:
+            if all(float_is_zero(line.qty_done, precision_rounding=line.product_uom_id.rounding) for line in picking.move_line_ids if line.state not in ('done', 'cancel')):
+                empty_pickings.add(picking.id)
             picking.message_post(
                 body="<b>%s:</b> %s <a href=#id=%s&view_type=form&model=stock.picking.batch>%s</a>" % (
                     _("Transferred by"),
                     _("Batch Transfer"),
                     picking.batch_id.id,
                     picking.batch_id.name))
-        return pickings.button_validate()
+
+        if len(empty_pickings) == len(pickings):
+            return pickings.button_validate()
+        else:
+            res = pickings.with_context(skip_immediate=True).button_validate()
+            self.env['stock.picking'].browse(empty_pickings).batch_id = False
+            return res
+
 
     def action_assign(self):
         self.ensure_one()


### PR DESCRIPTION
If a picking is totally empty (no move line with quantity recorded) in a
batch at validation. This one will be ignored by the immediate transfer
mechanism as well as the backorder creation. It is simply remove from
the batch.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
