### PR TITLE
[FIX] web_editor: fix overlay missing after animation

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -118,7 +118,10 @@ var SnippetEditor = Widget.extend({
         }
 
         var _animationsCount = 0;
-        var postAnimationCover = _.throttle(() => this.cover(), 100);
+        var postAnimationCover = _.throttle(() => {
+            this.toggleOverlayVisibility(true);
+            this.cover();
+        }, 100);
         this.$target.on('transitionstart.snippet_editor, animationstart.snippet_editor', () => {
             // We cannot rely on the fact each transition/animation start will
             // trigger a transition/animation end as the element may be removed


### PR DESCRIPTION
Before this commit, with some animations (e.g. Bounce In-Left) the
overlay of the animated element no longer reappeared after the
animation.

This is because at the start of the animation the element is outside
the viewport and therefore its overlay is hidden but never redisplayed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
