### PR TITLE
[FIX] account: tax details: correct taxes computation when using taxes affecting base with repetition

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -185,7 +185,6 @@ class AccountMoveLine(models.Model):
                     AND (
                         -- keeping only the rows from affecting_base_tax_lines that end with the same taxes applied (see comment in affecting_base_tax_ids)
                         NOT tax.include_base_amount
-                        OR tax_line_tax_ids.tax_ids IS NULL
                         OR base_line_tax_ids.tax_ids[ARRAY_LENGTH(base_line_tax_ids.tax_ids, 1) - COALESCE(ARRAY_LENGTH(tax_line_tax_ids.tax_ids, 1), 0):ARRAY_LENGTH(base_line_tax_ids.tax_ids, 1)]
                             = ARRAY[account_move_line.tax_line_id] || COALESCE(tax_line_tax_ids.tax_ids, ARRAY[]::INTEGER[])
                     )


### PR DESCRIPTION
[FIX] account: tax details: fix incorrect test 


[FIX] account: tax details: correct taxes computation when using taxes affecting base with repetition

1) Let's consider then following taxes

- tax 1, 42%, affecting the base
- tax 2, 10%

2) Create an invoice with the following lines, and post it:
- price=100, taxes=tax1
- price=100, taxes=tax2
- price=100, taxes=tax1+tax2

=> The tax details should compute the following amounts:

- base amount of tax 1: 200
- tax amount for tax 1: 84
- base amount of tax 2: 242
- tax amount for tax 2: 24.2

Before this fix, the base amount for tax 1 wasn't computed properly, and gave 300 instead of 200. This was because the same tax line (the one from tax1 with no tax_ids) was matching two different base lines: the one with tax1 and tax2, and the one with only tax1.