### PR TITLE
[FIX] website_event: fix flag url in dynamic snippet

### DIFF
--- a/addons/website_event/views/event_templates_widgets.xml
+++ b/addons/website_event/views/event_templates_widgets.xml
@@ -25,7 +25,7 @@
             <h6 class="o_wevent_sidebar_title">
                 <t t-if="country">
                     <i class="fa fa-flag mr-2"/>Events: <span t-esc="country.name"/>
-                    <img class="img-fluid" t-att-src="website.image_url(country, 'image')" alt=""/>
+                    <img class="img-fluid" t-att-src="country.image_url" alt=""/>
                 </t>
                 <t t-else="">
                     <i class="fa fa-globe mr-2"/>Upcoming Events


### PR DESCRIPTION
Since Odoo 14.0 flag image is not a binary field anymore [1] and field name is
changed to `image_url`.
So, fix it by using the url directly.

STEPS:
* Flag image is used when user country_code is provided and there are events for
that country. The user country_code is computed by IP. If you run Odoo locally
you can temporarly update `get_country_events` to force some country code
* In a website page add a header-title block first, then add the dynamic snippet
"Events"

BEFORE: dummy image "no photo yet"
AFTER: flag image

---

[1] https://github.com/odoo/odoo/commit/710705b64c0134a5b568d998d0a3eb0df0f541c0
opw-2625695

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
