### PR TITLE
[ADD] ir_actions.py: logger log in server action in context

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -408,15 +408,16 @@ class IrActionsServer(models.Model):
     _order = 'sequence,name'
 
     DEFAULT_PYTHON_CODE = """# Available variables:
-#  - env: Odoo Environment on which the action is triggered
-#  - model: Odoo Model of the record on which the action is triggered; is a void recordset
+#  - env: environment on which the action is triggered
+#  - model: model of the record on which the action is triggered; is a void recordset
 #  - record: record on which the action is triggered; may be void
 #  - records: recordset of all records on which the action is triggered in multi-mode; may be void
 #  - time, datetime, dateutil, timezone: useful Python libraries
-#  - float_compare: Odoo function to compare floats based on specific precisions
+#  - float_compare: utility function to compare floats based on specific precision
 #  - log: log(message, level='info'): logging function to record debug information in ir.logging table
-#  - UserError: Warning Exception to use with raise
-#  - Command: x2Many commands namespace
+#  - _logger: _logger.info(message): logger to emit messages in server logs
+#  - UserError: exception class for raising user-facing warning messages
+#  - Command: x2many commands namespace
 # To return an action, assign: action = {...}\n\n\n\n"""
 
     type = fields.Char(default='ir.actions.server')

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -17,6 +17,32 @@ import logging
 from pytz import timezone
 
 _logger = logging.getLogger(__name__)
+_server_action_logger = _logger.getChild("server_action_safe_eval")
+
+
+class LoggerProxy:
+    """ Proxy of the `_logger` element in order to be used in server actions.
+    We purposefully restrict its method as it will be executed in `safe_eval`.
+    """
+    @staticmethod
+    def log(level, message, *args, stack_info=False, exc_info=False):
+        _server_action_logger.log(level, message, *args, stack_info=stack_info, exc_info=exc_info)
+
+    @staticmethod
+    def info(message, *args, stack_info=False, exc_info=False):
+        _server_action_logger.info(message, *args, stack_info=stack_info, exc_info=exc_info)
+
+    @staticmethod
+    def warning(message, *args, stack_info=False, exc_info=False):
+        _server_action_logger.warning(message, *args, stack_info=stack_info, exc_info=exc_info)
+
+    @staticmethod
+    def error(message, *args, stack_info=False, exc_info=False):
+        _server_action_logger.error(message, *args, stack_info=stack_info, exc_info=exc_info)
+
+    @staticmethod
+    def exception(message, *args, stack_info=False, exc_info=True):
+        _server_action_logger.exception(message, *args, stack_info=stack_info, exc_info=exc_info)
 
 
 class IrActions(models.Model):
@@ -610,6 +636,7 @@ class IrActionsServer(models.Model):
             'records': records,
             # helpers
             'log': log,
+            '_logger': LoggerProxy,
         })
         return eval_context
 

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -331,13 +331,16 @@
                                     <h3>Help with Python expressions</h3>
                                     <p>Various fields may use Python code or Python expressions. The following variables can be used:</p>
                                     <ul>
-                                        <li><code>env</code>: Odoo Environment on which the action is triggered</li>
-                                        <li><code>model</code>: Odoo Model of the record on which the action is triggered; is a void recordset</li>
+                                        <li><code>env</code>: environment on which the action is triggered</li>
+                                        <li><code>model</code>: model of the record on which the action is triggered; is a void recordset</li>
                                         <li><code>record</code>: record on which the action is triggered; may be be void</li>
                                         <li><code>records</code>: recordset of all records on which the action is triggered in multi mode; may be void</li>
                                         <li><code>time</code>, <code>datetime</code>, <code>dateutil</code>, <code>timezone</code>: useful Python libraries</li>
-                                        <li><code>log(message, level='info')</code>:logging function to record debug information in <code>ir.logging</code> table</li>
-                                        <li><code>UserError</code>: Warning Exception to use with <code>raise</code></li>
+                                        <li><code>float_compare()</code>: utility function to compare floats based on a specific precision</li>
+                                        <li><code>log(message, level='info')</code>: logging function to record debug information in <code>ir.logging</code> table</li>
+                                        <li><code>_logger.info(message)</code>: logger to emit messages in server logs</li>
+                                        <li><code>UserError</code>: exception class for raising user-facing warning messages</li>
+                                        <li><code>Command</code>: x2many commands namespace</li>
                                         <li>To return an action, assign: <code>action = {...}</code></li>
                                     </ul>
                                     <div attrs="{'invisible': [('state', '!=', 'code')]}">


### PR DESCRIPTION
This PR is mainly meant for the support.

Note that the `stack_info` is purposefully accessible to add some stack trace in the logs.

Example of support tickets where it can be useful:
A certain field of a particular model change it's value with no particular pattern and way to reproduce.
With this commit, we can now create an automated actions on the model update trigger to dump the current stack that will lead us on the action that did trigger it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
