### PR TITLE
[FIX] web : pdf report : address overlapping with body of report

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -203,7 +203,9 @@
         </div>
 
         <div t-attf-class="article o_report_layout_boxed o_company_#{company.id}_layout" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
-            <t t-call="web.address_layout"/>
+            <div class="pt-5">
+                <t t-call="web.address_layout"/>
+            </div>
             <t t-raw="0"/>
         </div>
 
@@ -292,7 +294,9 @@
         </div>
 
         <div t-attf-class="article o_report_layout_standard o_company_#{company.id}_layout"  t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
-            <t t-call="web.address_layout"/>
+            <div class="pt-5">
+                <t t-call="web.address_layout"/>
+            </div>
             <t t-raw="0"/>
         </div>
 


### PR DESCRIPTION
Issue: When generating a pdf report with the address on the header,
if there were too many lines, the text below was erased by the header

Steps to reproduce :
 1) Set a street 2 field to your company address
 2) Print > Preview External Report
 3) Look at the PDF, you can't clearly see This is a sample of an
 external report.

Side-Note: Backporting from d4eb8099eba25ea44c493188056b3efbdb9f1f29

opw-2574842