### PR TITLE
[FIX] base: drop milliseconds in default trigger

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -416,7 +416,7 @@ class ir_cron(models.Model):
             of as soon as possible.
         """
         if at is None:
-            at_list = [datetime.utcnow()]
+            at_list = [fields.Datetime.now()]
         elif isinstance(at, datetime):
             at_list = [at]
         else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
