### PR TITLE
[IMP] mrp UI improvement

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -21,13 +21,18 @@
                     <field name="production_real_duration" attrs="{'invisible': [('production_real_duration', '=', 0)]}" widget="float_time" sum="Total real duration"/>
                     <field name="lot_producing_id" optional="hide"/>
                     <field name="bom_id" readonly="1" optional="hide"/>
+                    <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="origin" optional="show"/>
                     <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
                     <field name="reservation_state" optional="show" decoration-danger="reservation_state == 'confirmed'" decoration-success="reservation_state == 'assigned'"/>
                     <field name="product_qty" sum="Total Qty" string="Quantity" readonly="1" optional="show"/>
                     <field name="product_uom_id" string="UoM" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" optional="show"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
-                    <field name="state" optional="show" widget='badge' decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')"/>
+                    <field name="state" 
+                           decoration-success="state in ('done', 'to_close')"
+                           decoration-warning="state == 'draft'"
+                           decoration-info="state in ('confirmed', 'progress')"
+                           optional="show" widget="badge"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                     <field name="delay_alert_date" invisible="1"/>
                     <field string=" " name="json_popover" widget="stock_rescheduling_popover" attrs="{'invisible': [('delay_alert_date', '=', False)]}"/>
@@ -235,7 +240,7 @@
                                 attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" editable="bottom">
                                     <field name="product_id" force_save="1" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '|', ('move_lines_count', '&gt;', 0), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
-                                    <field name="location_id" string="From" readonly="1" groups="stock.group_stock_multi_locations"/>
+                                    <field name="location_id" string="From" readonly="1" groups="stock.group_stock_multi_locations" optional="show"/>
                                     <field name="move_line_ids" invisible="1">
                                         <tree>
                                             <field name="lot_id" invisible="1"/>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -34,13 +34,13 @@
             <field name="arch" type="xml">
                 <tree string="Work Center" multi_edit="1">
                     <field name="sequence" widget="handle"/>
-                    <field name="name"/>
-                    <field name="code"/>
+                    <field name="name" optional="show"/>
+                    <field name="code" optional="show"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'no_create': True, 'color_field': 'color'}" optional="show"/>
                     <field name="alternative_workcenter_ids" widget="many2many_tags" optional="show"/>
                     <field name="productive_time" optional="hide"/>
-                    <field name="costs_hour"/>
-                    <field name="capacity"/>
+                    <field name="costs_hour" optional="show"/>
+                    <field name="capacity" optional="show"/>
                     <field name="time_efficiency" optional="show"/>
                     <field name="oee_target" optional="show"/>
                     <field name="time_start" optional="hide"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Add some "optional=show" in MO and WO
Change the color of the state in MO list (we need to have the state draft in another color than grey)

Current behavior before PR:
The state in MO list have the state draft in grey and grey is for cancelled state only.
There is some column for which we can give the possibility to hide them.
Don't know the next activities in the MO list view

Desired behavior after PR is merged:

Change the color for the state draft
Give the possibility to hide some column
Add a column "next activities" in the MO list

Task related: 2615395

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
