### PR TITLE
[FIX] web: widget pie_chart supports timeRanges

### DIFF
--- a/addons/web/static/src/js/widgets/pie_chart.js
+++ b/addons/web/static/src/js/widgets/pie_chart.js
@@ -52,7 +52,7 @@ var PieChart = Widget.extend({
             context: pieChartContext,
             domain: domain,
             groupBy: [],
-            timeRanges: {},
+            timeRanges: record.timeRanges || {},
         };
 
         this.viewInfo = {


### PR DESCRIPTION
During the refactor of the comparison feature, the pie_chart widget was forgotten
Before this commit, the pie_chart widget did not support timeRanges any longer

After this commit it does again.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
