### PR TITLE
[FIX] various: --test-file on Windows

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1220,7 +1220,7 @@ def load_test_file_py(registry, test_file):
     threading.currentThread().testing = True
     try:
         test_path, _ = os.path.splitext(os.path.abspath(test_file))
-        for mod in [m for m in get_modules() if '/%s/' % m in test_file]:
+        for mod in [m for m in get_modules() if '%s%s%s' % (os.path.sep, m, os.path.sep) in test_file]:
             for mod_mod in loader.get_test_modules(mod):
                 mod_path, _ = os.path.splitext(getattr(mod_mod, '__file__', ''))
                 if test_path == config._normalize(mod_path):

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import warnings
 import odoo
-from os.path import expandvars, expanduser, abspath, realpath
+from os.path import expandvars, expanduser, abspath, realpath, normcase
 from .. import release, conf, loglevels
 from . import appdirs
 
@@ -737,7 +737,7 @@ class configmanager(object):
     def _normalize(self, path):
         if not path:
             return ''
-        return realpath(abspath(expanduser(expandvars(path.strip()))))
+        return normcase(realpath(abspath(expanduser(expandvars(path.strip())))))
 
 
 config = configmanager()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The command line option `--test-file` doesn't work on Windows

Current behavior before PR:
The `--test-file` option is always normalized, and is compared against a unix-style path to see if the test module is within a valid Odoo module. Due to the difference in path separators, this check always fails, and the test won't run.

Desired behavior after PR is merged:
The unix-style path is changed to use the OS appropriate path separator from `os.path.sep`, so that it can match the normalized `--test-file` path, and the check works as intended. Additionally, path normalization includes the `os.path.normcase` function so that a casing difference doesn't cause a failure.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
