### PR TITLE
[FIX] tests: error when running unit tests on port is   not 8069

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -82,6 +82,11 @@ def get_db_name():
     # the command-line, this will break when installing another
     # database from XML-RPC).
     if not db and hasattr(threading.current_thread(), 'dbname'):
+        # Force POST value that is set as 8069 by dynamic value
+        # to avoid dead test of Odoo
+        global PORT
+        PORT = odoo.tools.config['http_port']
+
         return threading.current_thread().dbname
     return db
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Error when running unit tests on port is not 8069

Desired behavior after PR is merged:
No error when running unit tests on port is not 8069



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
