### PR TITLE
[IMP] mail_plugin: add translations

### DIFF
--- a/addons/mail_plugin/static/src/to_translate/translations_outlook.xml
+++ b/addons/mail_plugin/static/src/to_translate/translations_outlook.xml
@@ -3,6 +3,7 @@
     Only named string params e.g: %(param)s are supported by the plugins,
     unnamed params like %s are not supported.-->
 <resources>
+    <string>Login</string>
     <string>Logout</string>
     <string>Company created</string>
     <string>Company Insights</string>
@@ -34,7 +35,7 @@
     <string>You don't have enough credit to enrich.</string>
     <string>Something bad happened. Please, try again later.</string>
     <string>Could not autocomplete the company. Internal error. Try again later...</string>
-    <string>There was a problem contacting the service, please try again later.</string>
+    <string>Could not connect to your database. Please try again.</string>
     <string>An error has occurred when trying to fetch translations.</string>
     <string>This company has no email address and could not be enriched.</string>
     <string>No extra information found</string>


### PR DESCRIPTION
Purpose
=======
Currently the application will display a 404 error message, if the mail
plugin module is not installed or if the user made an error in the URL
of his Odoo database, which is confusing for end users.

So, we show an error message during the authentication process if the
database is not reachable and we should add the translations related to
those changes.

Task-2577531
See odoo/mail-client-extensions/pull/17