### PR TITLE
[FIX] web: parse and format dates of mock server

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -775,7 +775,7 @@ export class MockServer {
                 if (aggregateFunction === "day") {
                     return date.toFormat("yyyy-MM-dd");
                 } else if (aggregateFunction === "week") {
-                    return `W${date.toFormat("WW yyyy")}`;
+                    return `W${date.toFormat("WW kkkk")}`;
                 } else if (aggregateFunction === "quarter") {
                     return `Q${date.toFormat("q yyyy")}`;
                 } else if (aggregateFunction === "year") {
@@ -837,6 +837,9 @@ export class MockServer {
                     } else if (aggregateFunction === "year") {
                         startDate = parseDate(val, { format: "y" });
                         endDate = startDate.plus({ years: 1 });
+                    } else if (aggregateFunction === "quarter") {
+                        startDate = parseDate(val, { format: "q yyyy" });
+                        endDate = startDate.plus({ quarters: 1 });
                     } else {
                         startDate = parseDate(val, { format: "MMMM yyyy" });
                         endDate = startDate.plus({ months: 1 });

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -27,6 +27,25 @@ QUnit.module("Mock Server", {
                         { id: 2, name: "Raoul", email: "raoul@example.com", active: false },
                     ],
                 },
+                bar: {
+                    fields: {
+                        foo: {
+                            string: "Foo",
+                            type: "integer",
+                            searchable: true,
+                            group_operator: "sum",
+                        },
+                        date: { string: "Date", type: "date", store: true, sortable: true },
+                    },
+                    records: [
+                        { id: 1, foo: 12, date: "2016-12-14" },
+                        { id: 2, foo: 1, date: "2016-10-26" },
+                        { id: 3, foo: 17, date: "2016-12-15" },
+                        { id: 4, foo: 2, date: "2016-04-11" },
+                        { id: 5, foo: 22, date: "2016-12-15" },
+                        { id: 6, foo: 42, date: "2019-12-30" },
+                    ],
+                },
             },
         };
     },
@@ -93,4 +112,103 @@ QUnit.test("performRPC: search_read with active_test=true", async function (asse
         },
     });
     assert.deepEqual(result, [{ id: 1, name: "Jean-Michel" }]);
+});
+
+QUnit.test("performRPC: read_group, group by date", async function (assert) {
+    assert.expect(10);
+    const server = new MockServer(this.data, {});
+    let result = await server.performRPC("", {
+        model: "bar",
+        method: "read_group",
+        args: [[]],
+        kwargs: {
+            fields: ["foo"],
+            domain: [],
+            groupby: ["date"], //Month by default
+        },
+    });
+    assert.deepEqual(
+        result.map((x) => x.date),
+        ["December 2016", "October 2016", "April 2016", "December 2019"]
+    );
+    assert.deepEqual(
+        result.map((x) => x.date_count),
+        [3, 1, 1, 1]
+    );
+
+    result = await server.performRPC("", {
+        model: "bar",
+        method: "read_group",
+        args: [[]],
+        kwargs: {
+            fields: ["foo"],
+            domain: [],
+            groupby: ["date:day"],
+        },
+    });
+    assert.deepEqual(
+        result.map((x) => x["date:day"]),
+        ["2016-12-14", "2016-10-26", "2016-12-15", "2016-04-11", "2019-12-30"]
+    );
+    assert.deepEqual(
+        result.map((x) => x.date_count),
+        [1, 1, 2, 1, 1]
+    );
+
+    result = await server.performRPC("", {
+        model: "bar",
+        method: "read_group",
+        args: [[]],
+        kwargs: {
+            fields: ["foo"],
+            domain: [],
+            groupby: ["date:week"],
+        },
+    });
+    assert.deepEqual(
+        result.map((x) => x["date:week"]),
+        ["W50 2016", "W43 2016", "W15 2016", "W01 2020"]
+    );
+    assert.deepEqual(
+        result.map((x) => x.date_count),
+        [3, 1, 1, 1]
+    );
+
+    result = await server.performRPC("", {
+        model: "bar",
+        method: "read_group",
+        args: [[]],
+        kwargs: {
+            fields: ["foo"],
+            domain: [],
+            groupby: ["date:quarter"],
+        },
+    });
+    assert.deepEqual(
+        result.map((x) => x["date:quarter"]),
+        ["Q4 2016", "Q2 2016", "Q4 2019"]
+    );
+    assert.deepEqual(
+        result.map((x) => x.date_count),
+        [4, 1, 1]
+    );
+
+    result = await server.performRPC("", {
+        model: "bar",
+        method: "read_group",
+        args: [[]],
+        kwargs: {
+            fields: ["foo"],
+            domain: [],
+            groupby: ["date:year"],
+        },
+    });
+    assert.deepEqual(
+        result.map((x) => x["date:year"]),
+        ["2016", "2019"]
+    );
+    assert.deepEqual(
+        result.map((x) => x.date_count),
+        [5, 1]
+    );
 });


### PR DESCRIPTION
On 00e3cb74c44565b2106dba6befac2b6f8512eede the migration of the code to
parse and formate dates on the mock server from moment to luxon was
done. Two issues were introduced on that commit: Parsing a date
displayed on quarter wasn't possible; And the ISO week year wasn't used
to format the date, but it was used to parse the date, for symmetry's
sake, now the ISO week year is used on both.