### PR TITLE
[FIX] account: Allow user to change tax with many lines

### DIFF
--- a/addons/account/static/src/js/tax_group.js
+++ b/addons/account/static/src/js/tax_group.js
@@ -28,43 +28,63 @@ odoo.define('account.tax_group', function (require) {
          * @param {Id} taxGroupId
          * @param {Float} deltaAmount
          */
-        _changeTaxValueByTaxGroup: function (taxGroupId, deltaAmount) {
-            var self = this;
-            // Search for the first tax line with the same tax group and modify its value
-            var line_id = self.record.data.line_ids.data.find(elem => elem.data.tax_group_id && elem.data.tax_group_id.data.id === taxGroupId);
+         _changeTaxValueByTaxGroup: function (taxGroupId, deltaAmount) {
+            const self = this;
 
-            var debitAmount = 0;
-            var creditAmount = 0;
-            var amount_currency = 0;
-            if (line_id.data.currency_id) { // If multi currency enable
-                if (this.record.data.type === "in_invoice") {
-                    amount_currency = line_id.data.amount_currency - deltaAmount;
+            // Search for the first tax line with the same tax group and modify its value
+            function applyChange(line_id){
+                let debitAmount = 0;
+                let creditAmount = 0;
+                let amount_currency = 0;
+                if (line_id.data.currency_id) { // If multi currency enable
+                    if (self.record.data.move_type === "in_invoice") {
+                        amount_currency = line_id.data.amount_currency - deltaAmount;
+                    } else {
+                        amount_currency = line_id.data.amount_currency + deltaAmount;
+                    }
                 } else {
-                    amount_currency = line_id.data.amount_currency + deltaAmount;
-                }
-            } else {
-                var balance = line_id.data.price_subtotal;
-                balance -= deltaAmount;
-                if (this.record.data.type === "in_invoice") { // For vendor bill
-                    if (balance > 0) {
-                        debitAmount = balance;
-                    } else if (balance < 0) {
-                        creditAmount = -balance;
-                    }
-                } else { // For refund
-                    if (balance > 0) {
-                        creditAmount = balance;
-                    } else if (balance < 0) {
-                        debitAmount = -balance;
+                    let balance = line_id.data.price_subtotal;
+                    balance -= deltaAmount;
+                    if (self.record.data.move_type === "in_invoice") { // For vendor bill
+                        if (balance > 0) {
+                            debitAmount = balance;
+                        } else if (balance < 0) {
+                            creditAmount = -balance;
+                        }
+                    } else { // For refund
+                        if (balance > 0) {
+                            creditAmount = balance;
+                        } else if (balance < 0) {
+                            debitAmount = -balance;
+                        }
                     }
                 }
+
+                // Trigger ORM
+                self.trigger_up('field_changed', {
+                    dataPointID: self.record.id,
+                    changes: { line_ids: { operation: "UPDATE", id: line_id.id, data: { amount_currency: amount_currency, debit: debitAmount, credit: creditAmount } } }, // account.move change
+                    initialEvent: { dataPointID: line_id.id, changes: { amount_currency: amount_currency, debit: debitAmount, credit: creditAmount }, }, // account.move.line change
+                });
             }
-            // Trigger ORM
-            self.trigger_up('field_changed', {
-                dataPointID: self.record.id,
-                changes: { line_ids: { operation: "UPDATE", id: line_id.id, data: { amount_currency: amount_currency, debit: debitAmount, credit: creditAmount } } }, // account.move change
-                initialEvent: { dataPointID: line_id.id, changes: { amount_currency: amount_currency, debit: debitAmount, credit: creditAmount }, }, // account.move.line change
-            });
+
+            let line_id = self.record.data.line_ids.data.find(elem => elem.data.tax_group_id && elem.data.tax_group_id.data.id === taxGroupId);
+
+            if (line_id){
+                applyChange(line_id);
+            } else {
+                const {limit, id, count} = self.record.data.line_ids;
+                let offset = count - limit;
+                self.trigger_up('load', {
+                    id,
+                    limit,
+                    offset,
+                    on_success: value => {
+                        line_id = value.data.find(elem => elem.data.tax_group_id && elem.data.tax_group_id.data.id === taxGroupId);
+                        applyChange(line_id);
+                    },
+                });
+            }
         },
 
         /**


### PR DESCRIPTION
The current code uses cached data to retrieve the tax_line which is usually near the end of lines (often the second to last line).
This only works if there are fewer lines than the limit, but otherwise the line is not found and a traceback appears.

In case there are 50 invoice_line_ids for example, there will be 52 line_ids (invoice_line_ids + 2 lines including one containing the tax),
the base limit of the list subview is 40, the tax_line will not be in the cached data.

The following fix automatically loads the last page to always access the tax line.

The last page is loaded only if the tax_line is not already in the cache

opw-2566580