### PR TITLE
[REV] crm: remove unnecessary sudo

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -136,7 +136,7 @@ class Lead2OpportunityPartner(models.TransientModel):
                     'user_id': self.user_id.id,
                     'team_id': self.team_id.id,
                 })
-        (to_merge - result_opportunity).sudo().unlink()
+        (to_merge - result_opportunity).unlink()
         return result_opportunity
 
     def _action_convert(self):


### PR DESCRIPTION
Revert "[FIX] crm: allow regular salesman to convert and merge opportunities"
This reverts commit 24db93c0e6b88f89fdf03d63afee05fc858ed977.

Indeed adding a sudo at the end of merge process is a strange way to fix
an unexplained issue about "similar emails". CRM code has been cleaned
since v14+ and flows should not gain random sudo trying to solve an
undefined problem.
