### PR TITLE
[FIX] l10n_cl: update VAT only if it is changed

### DIFF
--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -54,12 +54,13 @@ class ResPartner(models.Model):
         return super().create(values)
 
     def write(self, values):
-        for record in self:
-            vat_values = {
-                'vat': values.get('vat', record.vat),
-                'l10n_latam_identification_type_id': values.get(
-                    'l10n_latam_identification_type_id', record.l10n_latam_identification_type_id.id),
-                'country_id': values.get('country_id', record.country_id.id)
-            }
-            values['vat'] = self._format_vat_cl(vat_values)
+        if 'vat' in values or 'l10n_latam_identification_type_id' in values:      
+            for record in self:
+                vat_values = {
+                    'vat': values.get('vat', record.vat),
+                    'l10n_latam_identification_type_id': values.get(
+                        'l10n_latam_identification_type_id', record.l10n_latam_identification_type_id.id),
+                    'country_id': values.get('country_id', record.country_id.id)
+                }
+                values['vat'] = self._format_vat_cl(vat_values)
         return super().write(values)


### PR DESCRIPTION
Steps to reproduce the bug:
- install l10n_cl
- Create two contacts and for only one of the two fill in the "Identification Number" field
- Go to contact app > select both contacts to edit some of their fields at the same time
- For example, edit “City” > save

Problem:
The "Identification Number" of contact 1 is copied to the second contact,
while normally only the "city" field of the two contacts needs to be changed.
This is due to the fact that we do not check in the write function if the vat or identification_type are in values before changing the vat.

Solution:
check that `vat` or  `l10n_latam_identification_type_id` are in values before changing the vat

opw-2587994

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
