### PR TITLE
[FIX][mail]: Fix issue for email compose wizard

### DIFF
--- a/addons/mail/tests/test_mail_full_composer.py
+++ b/addons/mail/tests/test_mail_full_composer.py
@@ -22,4 +22,13 @@ class TestMailFullComposer(HttpCase):
             'login': 'testuser',
             'password': 'testuser',
         })
+        if self.env['ir.module.module'].search([('name', '=', 'base_automation')], limit=1).state == 'installed':
+            automated_action = self.env['base.automation'].create({
+                'name': 'Test',
+                'active': True,
+                'trigger': 'on_change',
+                'on_change_field_ids': (4, self.ref('mail.field_mail_compose_message__template_id'),),
+                'state': 'code',
+                'model_id': self.env.ref('mail.model_mail_compose_message').id,
+            })
         self.start_tour("/web#id=%d&model=res.partner" % testuser.partner_id, 'mail/static/tests/tours/mail_full_composer_test_tour.js', login='testuser')

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -78,6 +78,7 @@ class MailComposer(models.TransientModel):
             result.update(self.get_record_data(result))
 
         filtered_result = dict((fname, result[fname]) for fname in result if fname in fields)
+        filtered_result['create_uid'] = self.env.user.id
         return filtered_result
 
     # content


### PR DESCRIPTION
- Create_uid is not on mail.compose.message model so because of 'Mail Compose Message Rule' record rule getting error
- By this commit, create_uid set on mail.compose.message model
- Added test case

Steps to reproduce this warning:
 1. Create automated action for the 'mail.compose.message' model
 2. Try to open 'Email compose Wizard'

Warning:

"Due to security restrictions, you are not allowed to modify 'Email composition wizard' (mail.compose.message) records.

Records: mail.compose.message,NewId_0x7f8e99762310 (id=NewId_0x7f8e99762310)
User: USERNAME (id=2)

This restriction is due to the following rules:

Contact your administrator to request access if necessary."

opw- 2628005