### PR TITLE
[FIX] base, mail: _render_qweb_pdf should return a bytes-like object

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -429,7 +429,7 @@ class AccountBankStatement(models.Model):
                 self.env['ir.attachment'].create({
                     'name': statement.name and _("Bank Statement %s.pdf", statement.name) or _("Bank Statement.pdf"),
                     'type': 'binary',
-                    'raw': content.encode(),
+                    'raw': content,
                     'res_model': statement._name,
                     'res_id': statement.id
                 })

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -26,8 +26,8 @@ class TestMultiCompany(TestHrCommon):
         content, content_type = self.env.ref('hr.hr_employee_print_badge').with_user(self.res_users_hr_officer).with_context(
             allowed_company_ids=[self.company_1.id, self.company_2.id]
         )._render_qweb_pdf(res_ids=self.employees.ids)
-        self.assertIn('Bidule', content)
-        self.assertIn('Machin', content)
+        self.assertIn(b'Bidule', content)
+        self.assertIn(b'Machin', content)
 
     def test_single_company_report(self):
         with self.assertRaises(QWebException):  # CacheMiss followed by AccessError

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -214,7 +214,7 @@ class MailTemplate(models.Model):
                         result, format = res
 
                     # TODO in trunk, change return format to binary to match message_post expected format
-                    result = base64.b64encode(result.encode())
+                    result = base64.b64encode(result)
                     if not report_name:
                         report_name = 'report.' + report_service
                     ext = "." + format

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -54,10 +54,10 @@ class TestReports(TestReportsCommon):
             'company_id': self.env.company.id,
         })
         report = self.env.ref('stock.label_lot_template')
-        target = '\n\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C418]Mellohi^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta^FS\n^FO100,150^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta^FS\n^XZ\n\n\n'
+        target = b'\n\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C418]Mellohi^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta^FS\n^FO100,150^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta^FS\n^XZ\n\n\n'
 
         rendering, qweb_type = report._render_qweb_text(lot1.id)
-        self.assertEqual(target, rendering.replace(' ', ''), 'The rendering is not good')
+        self.assertEqual(target, rendering.replace(b' ', b''), 'The rendering is not good')
         self.assertEqual(qweb_type, 'text', 'the report type is not good')
 
     def test_report_quantity_1(self):

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -772,13 +772,6 @@ class IrActionsReport(models.Model):
         # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2083
         context['debug'] = False
 
-        # The test cursor prevents the use of another environment while the current
-        # transaction is not finished, leading to a deadlock when the report requests
-        # an asset bundle during the execution of test scenarios. In this case, return
-        # the html version.
-        if isinstance(self.env.cr, TestCursor):
-            return self_sudo.with_context(context)._render_qweb_html(res_ids, data=data)[0]
-
         save_in_attachment = OrderedDict()
         # Maps the streams in `save_in_attachment` back to the records they came from
         stream_record = dict()

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -595,7 +595,7 @@ class IrActionsReport(models.Model):
             website=website,
             web_base_url=self.env['ir.config_parameter'].sudo().get_param('web.base.url', default=''),
         )
-        return view_obj._render_template(template, values)
+        return view_obj._render_template(template, values).encode()
 
     def _post_pdf(self, save_in_attachment, pdf_content=None, res_ids=None):
         '''Merge the existing attachments by adding one by one the content of the attachments


### PR DESCRIPTION
`result` might be a Markup object (eg during tests) or a bytes-like object.

Step to reproduce: click on "Send by Mail" on a SO -> Traceback

Step to reproduce (2):
- Install website_sale
- Add something to the cart
- Go through checkout and click on Pay Now
- Crash, 500 error page, as this step is trying to generate the SO PDF to send
  by mail to the customer, which tries to encode a bytes-like object.

```
AttributeError: 'bytes' object has no attribute 'encode'
```

But if you do that flow during a test, eg
```
./odoo-bin -d mydb --test-tags=.test_02_admin_checkout
```
You have a Markup object, thus you had to encode it.

Now, even during test, we return a bytes-like object.

Related to #68299