### PR TITLE
[FIX] pos: fix arabic receipt

### DIFF
--- a/addons/point_of_sale/static/lib/html2canvas.js
+++ b/addons/point_of_sale/static/lib/html2canvas.js
@@ -1211,7 +1211,7 @@
           textNode.nodeValue = textTransform(textNode.nodeValue, getCSS(el, "textTransform"));
           textAlign = textAlign.replace(["-webkit-auto"],["auto"]);
     
-          textList = (!options.letterRendering && /^(left|right|justify|auto)$/.test(textAlign) && noLetterSpacing(getCSS(el, "letterSpacing"))) ?
+          textList = (!options.letterRendering && /^(left|right|justify|auto|center)$/.test(textAlign) && noLetterSpacing(getCSS(el, "letterSpacing"))) ?
           textNode.nodeValue.split(/(\b| )/)
           : textNode.nodeValue.split("");
     

--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -57,7 +57,6 @@ var PrinterMixin = {
                     $('.pos-receipt-print').empty();
                     resolve(self.process_canvas(canvas));
                 },
-                letterRendering: true,
             })
         });
         return promise;


### PR DESCRIPTION
This fix should solve the separated characters in the Arabic printed receipt

Current behavior before PR:
- The Arabic characters are separated in the printed receipt

Desired behavior after PR is merged:
- The Arabic characters should be connected in the printed receipt


opw-2613534
opw-2620606
opw-2627466
