### PR TITLE
[FIX] website: make robust IDs for visibility conditions on snippets

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3041,11 +3041,11 @@ options.registry.ConditionalVisibility = options.Class.extend({
      *
      * @private
      */
-     _updateCSSSelectors() {
+    _updateCSSSelectors() {
         // There are 2 data attributes per option:
         // - One that stores the current records selected
         // - Another that stores the value of the rule "Hide for / Visible for"
-        let visibilityId = '';
+        const visibilityIDParts = [];
         const onlyAttributes = [];
         const hideAttributes = [];
         const target = this.$target[0];
@@ -3068,11 +3068,12 @@ options.registry.ConditionalVisibility = options.Class.extend({
                 }
                 // Create a visibilityId based on the options name and their
                 // values. eg : hide for en_US(id:1) -> lang1h
-                visibilityId += attribute.attributeName.replace('data-', '')
-                + records.reduce((acc, record) => acc += record.id, '')
-                + (hideFor ? 'h' : 'o');
+                const type = attribute.attributeName.replace('data-', '');
+                const valueIDs = records.map(record => record.id).sort();
+                visibilityIDParts.push(`${type}_${hideFor ? 'h' : 'o'}_${valueIDs.join('_')}`);
             }
         }
+        const visibilityId = visibilityIDParts.join('_');
         // Creates CSS selectors based on those attributes, the reducers
         // combine the attributes' values.
         let selectors = '';


### PR DESCRIPTION
As nicely pointed by kig-odoo at [1], the new feature of snippet
visibility conditions introduced in [2] has some issues. This fixes
the fact that condition identifiers were built by combining IDs without
a separator. A condition targeting a lang with ID:4 and another one with
ID:5 could thus produce the same condition identifier as another
condition targeting a lang with ID:45 (as 4 and 5 side-by-side makes
45...). Now, all parts of the identifiers are separated with '_'.

[1]: https://github.com/odoo/odoo/pull/67140#issuecomment-902531321
[2]: https://github.com/odoo/odoo/commit/1c442782f887a8c16bae05a43fae13a310ac05df
