### PR TITLE
[12.0][FIX] registry: check if index exists before logging

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1002,7 +1002,7 @@ class Field(MetaField('DummyField', (object,), {})):
                 sql.create_index(model._cr, indexname, model._table, ['"%s"' % self.name])
             except psycopg2.OperationalError:
                 _schema.error("Unable to add index for %s", self)
-        else:
+        elif sql.index_exists(model._cr, indexname):
             _schema.info("Keep unexpected index %s on table %s", indexname, model._table)
 
     def update_db_related(self, model):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Too much logs "Keep unexpected index" are spammed when updating modules.
Indeed, this log is triggered even if the field has actually no index in the database, thus the log is false (no index is kept).

## Current behavior before PR:

The `update_db_index` method is called even if the field has no index
(the check on `index` field attribute is here on purpose).

Before 13f02a60c870 was applied, the call of `sql.drop_index` was taking
care of the index existence with a `IF EXISTS` SQL statement, so even if
the field had no index it wasn't causing any issue.

With 13f02a60c870 applied, the log 'Keep unexpected index' is spam even if
the field has actually no index at all in the database.

These logs can also prevent some CI to work properly because it generates too much output (Travis).

## Desired behavior after PR is merged:

This commit ensures to check the existence of the index before logging.

ping @nseinlet @yelizariev @rco-odoo 

Fix on 13.0 here: https://github.com/odoo/odoo/pull/75388

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
