### PR TITLE
[CLA] adds sebalix to camptocamp's CLA

### DIFF
--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -39,3 +39,4 @@ Frédéric Junod frederic.junod@camptocamp.com https://github.com/fredj
 Thomas Nowicki thomas.nowicki@camptocamp.com https://github.com/Tonow-c2c
 Stéphane Mangin stephane.mangin@camptocamp.com https://github.com/StephaneMangin
 Anna Janiszewska anna.janiszewska@camptocamp.com https://github.com/ajaniszewska-dev
+Sébastien Alix sebastien.alix@camptocamp.com https://github.com/sebalix


### PR DESCRIPTION
CLA was already included on `13.0` branch: https://github.com/odoo/odoo/commit/642f9d00648695e9e4a7b9d7f4f4e6d5b6abfe3d

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
