### PR TITLE
[FIX] mail: exception when sending an email with \n in the record_name

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2257,6 +2257,8 @@ class MailThread(models.AbstractModel):
             base_template = False
 
         mail_subject = message.subject or (message.record_name and 'Re: %s' % message.record_name) # in cache, no queries
+        # Replace new lines by spaces to conform to email headers requirements
+        mail_subject = ' '.join(mail_subject.splitlines())
         # prepare notification mail values
         base_mail_values = {
             'mail_message_id': message.id,

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -269,6 +269,16 @@ class TestMessagePost(BaseFunctionalTest, TestRecipients, MockEmails):
         self.assertEqual(new_msg.partner_ids, self.env['res.partner'])
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_post_email_with_multiline_subject(self):
+        _body, _body_alt, _subject = '<p>Test Body</p>', 'Test Body', '1st line\n2nd line'
+        msg = self.test_record.with_user(self.user_employee).message_post(
+            body=_body, subject=_subject,
+            message_type='comment', subtype='mt_comment',
+            partner_ids=[self.partner_1.id, self.partner_2.id]
+        )
+        self.assertEqual(msg.subject, '1st line 2nd line')
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_post_portal_ok(self):
         with patch.object(MailTestSimple, 'check_access_rights', return_value=True):
             self.test_record.message_subscribe((self.partner_1 | self.user_employee.partner_id).ids)


### PR DESCRIPTION
Step to follow:

- Create an Asset Models
- Set up the Fixed Asset Account:

Automate Asset -> Create in draft or Create and validate
Asset Model -> The one you have just created

- Create a Vendor bill

Account -> the Fixed Asset Account of the asset model created
Label -> insert a newline
Price -> (do not forget to set a price)

- Validate
- Go to the asset automatically created
- @ mention a user in the chatter

Cause of the issue:

The generated email subject comes from the record_name and it can
contain newlines
Email headers don't allow newlines and an exception is thrown here
https://github.com/python/cpython/blob/60b93d9e4922eeae25052bc15909d1f4152babde/Lib/email/policy.py#L143

Solution

Replace newlines by spaces in the email subject

opw-2522055