### PR TITLE
[13.0][FIX] hr_holidays: Set domain correctly according to company_ids from Leave Allocations: multi company global rule

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -139,7 +139,7 @@
     <record id="hr_leave_allocation_rule_multicompany" model="ir.rule">
         <field name="name">Leave Allocations: multi company global rule</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>
-        <field name="domain_force">['|', ('holiday_status_id.company_id', '=', False), ('holiday_status_id.company_id', 'in', [user.company_id.id])]</field>
+        <field name="domain_force">['|', ('holiday_status_id.company_id', '=', False), ('holiday_status_id.company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="hr_leave_allocation_rule_employee" model="ir.rule">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
With this change the allocation request records are correctly displayed according to the selected companies.

Related to: https://github.com/odoo/odoo/commit/a6f951845d5de869b2e138403aecfd4c653bf8b3

**Impacted versions**:
- 13.0
- 14.0

cc @Tecnativa TT31458

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
