### PR TITLE
[FIX] web_editor: keep "Outline + Rounded" style when editing link

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -146,7 +146,17 @@ var LinkDialog = Dialog.extend({
         if (this.data.iniClassName) {
             this.$('input[name="link_style_color"], select[name="link_style_size"] > option, select[name="link_style_shape"] > option').each(function () {
                 var $option = $(this);
-                if ($option.val() && self.data.iniClassName.match(new RegExp('(^|btn-| |btn-outline-)' + $option.val()))) {
+                var value = $option.val();
+                if (!value) {
+                    return;
+                }
+                var subValues = value.split(',');
+                var active = true;
+                for (var i = 0; i < subValues.length; i++) {
+                    var classPrefix = new RegExp('(^|btn-| |btn-outline-)' + subValues[i]);
+                    active = active && classPrefix.test(self.data.iniClassName);
+                }
+                if (active) {
                     if ($option.is("input")) {
                         $option.prop("checked", true);
                     } else {


### PR DESCRIPTION
Before this commit editing a link that was saved with the style "Outline & Rounded" did reset the style to as different value.

After this commit "Outline + Rounded" is not lost when re-editing the
link.

task-2629461

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
