### PR TITLE
[FIX]account,account_debit_note: not show only purchasable product

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -103,10 +103,13 @@ class AccountMoveReversal(models.TransientModel):
             action.update({
                 'view_mode': 'form',
                 'res_id': moves_to_redirect.id,
+                'context':{'default_type':  moves_to_redirect.type},
             })
         else:
             action.update({
                 'view_mode': 'tree,form',
                 'domain': [('id', 'in', moves_to_redirect.ids)],
             })
+            if len(set(moves_to_redirect.mapped('type'))) == 1:
+                action['context'] = {'default_type':  moves_to_redirect.mapped('type').pop()}
         return action

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -76,6 +76,7 @@ class AccountDebitNote(models.TransientModel):
             'name': _('Debit Notes'),
             'type': 'ir.actions.act_window',
             'res_model': 'account.move',
+            'context': {'default_type': default_values['type']},
             }
         if len(new_moves) == 1:
             action.update({


### PR DESCRIPTION
Only purchaseable products are not searchable in the lines of debit notes
and credit notes if this account moves are created from their tree view with
the CREATE button. This changes make that this behavieour were also if we
create this account moves from the buttons in the invoices "ADD CREDIT NOTE"
and "ADD DEBIT NOTE".

TASK: https://www.odoo.com/my/task/2543493

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
