### PR TITLE
[FIX][12.0] Mail wizard uses template's reply-to field

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -285,7 +285,8 @@ class MailComposer(models.TransientModel):
         reply_to_value = dict.fromkeys(res_ids, None)
         if mass_mail_mode and not self.no_auto_thread:
             records = self.env[self.model].browse(res_ids)
-            reply_to_value = self.env['mail.thread']._notify_get_reply_to_on_records(default=self.email_from, records=records)
+            default_reply_to = rendered_values.get('reply-to') or rendered_values.get('email-from') or self.email_from
+            reply_to_value = self.env['mail.thread']._notify_get_reply_to_on_records(default=default_reply_to, records=records)
 
         blacklisted_rec_ids = []
         if mass_mail_mode and hasattr(self.env[self.model], "_primary_email"):

--- a/doc/cla/individual/aleuffre.md
+++ b/doc/cla/individual/aleuffre.md
@@ -1,0 +1,11 @@
+Italy, 2021-08-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alessandro Uffreduzzi alessandrouffreduzzi@protonmail.com https://github.com/aleuffre


### PR DESCRIPTION
**_Description of the issue/feature this PR addresses:_**
Currently, in mass_mail_mode, the wizard always gets the reply-to address wrong. This issue is often hidden because the reply-to address may be overwritten later by the catchall domain in ir.config.parameter, if it exists.


**_Current behavior before PR:_**
The reply-to address is set to the **unrendered** value of the "email_from" field. So for example, if the "email_from" value of the template is `${user.email}`, reply-to is set to `${user.email}`, and not to `myemail@example.com`.
Secondly, the default to use should be the reply_to field, and not email_from field.

**_Desired behavior after PR is merged_**:
The wizard uses the **rendered** "reply_to" field of the template as its default, if it exists. Otherwise it falls back to the **rendered** "email_from" if that exists. Finally, it falls back on the **unrendered** email_from as it is now.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
