### PR TITLE
[FIX] base: fix ir_attachment read_group

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -378,11 +378,11 @@ class IrAttachment(models.Model):
         """Override read_group to add res_field=False in domain if not present."""
         if not fields:
             raise AccessError(_("Sorry, you must provide fields to read on attachments"))
+        groupby = [groupby] if isinstance(groupby, str) else groupby
         if any('(' in field for field in fields + groupby):
             raise AccessError(_("Sorry, the syntax 'name:agg(field)' is not available for attachments"))
         if not any(item[0] in ('id', 'res_field') for item in domain):
             domain.insert(0, ('res_field', '=', False))
-        groupby = [groupby] if isinstance(groupby, str) else groupby
         allowed_fields = self._read_group_allowed_fields()
         fields_set = set(field.split(':')[0] for field in fields + groupby)
         if not self.env.user._is_system() and (not fields or fields_set.difference(allowed_fields)):


### PR DESCRIPTION
When called with a `srt` as readgroup parameter we get a traceback.
Example:
`read_group([('partner_id', 'in', self.ids)], 'partner_id', 'partner_id')`
TB:
```
 Traceback (most recent call last):
   File "/home/odoo/src/odoo/14.0/odoo/tools/safe_eval.py", line 330, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
   File "", line 2, in <module>
   File "/home/odoo/src/odoo/14.0/odoo/addons/base/models/ir_attachment.py", line 420, in read_group
    if any('(' in field for field in fields + groupby):
 TypeError: can only concatenate list (not "str") to list
 ```

 Observed on the upgrade request 22627.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
