### PR TITLE
[FIX] web: Allow no_quick_create option on M2O fields

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -127,7 +127,8 @@ var FieldMany2One = AbstractField.extend({
         this.can_write = 'can_write' in this.attrs ? JSON.parse(this.attrs.can_write) : true;
 
         this.nodeOptions = _.defaults(this.nodeOptions, {
-            quick_create: true,
+            quick_create: 'no_quick_create' in options ? !options.no_quick_create : true,
+            no_quick_create: 'no_quick_create' in options ? options.no_quick_create : false,
         });
         this.noOpen = 'noOpen' in options ? options.noOpen : this.nodeOptions.no_open;
         this.m2o_value = this._formatValue(this.value);


### PR DESCRIPTION
Issue:

  When creating a FieldWidget of type M2O with `no_quick_create: true`
  in options, the `Create` option is still displayed in input.

Cause:

  Option param `no_quick_create` not taken into account if in options.

Solution:

  Update `no_quick_create` and `quick_create` in this.nodeOptions based
  on options.

opw-2621062