### PR TITLE
[FIX] base,l10n_ch: Display all QR codes in QR bill 

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -184,7 +184,7 @@
                     <div id="qrcode" t-if="(o.company_id.qr_code) and (o.currency_id.name == 'EUR') and (o.partner_bank_id.acc_number != False)">
                         <p t-if="(o.partner_bank_id.qr_code_valid)">
                             <strong class="text-center">Scan me with your banking app.</strong><br /><br />
-                            <img class="border border-dark rounded" t-att-src="o.partner_bank_id.build_qr_code_url(o.residual,(o.reference) if (o.reference) else o.number)"/>
+                            <img class="border border-dark rounded" t-att-src="o.partner_bank_id.build_qr_code_base64(o.residual,(o.reference) if (o.reference) else o.number)"/>
                         </p>
                         <p t-if="(o.partner_bank_id.qr_code_valid == False)">
                             <strong class="text-center">The SEPA QR Code informations are not set correctly.</strong><br />

--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -21,8 +21,6 @@
 
         <template id="l10n_ch_swissqr_template">
             <t t-call="web.external_layout">
-                <!-- add class to body tag -->
-                <script>document.body.className += " l10n_ch_qr";</script>
                 <!-- add default margin for header (matching A4 European margin) -->
                 <t t-set="report_header_style">padding-top:6.2mm; padding-left:8.2mm; padding-right:8.2mm;</t>
 
@@ -78,7 +76,7 @@
                             <span class="swissqr_text title title_zone">Payment part</span><br/>
                         </div>
 
-                        <img class="swissqr" t-att-src="o.partner_bank_id.build_swiss_code_url(o.residual, o.currency_id.name, None, o.partner_id, None, o.reference, o.name or o.number)"/>
+                        <img class="swissqr" t-att-src="o.partner_bank_id.build_swiss_code_base64(o.residual, o.currency_id.name, None, o.partner_id, None, o.reference, o.name or o.number)"/>
                         <img class="ch_cross" src="/l10n_ch/static/src/img/CH-Cross_7mm.png"/>
 
                         <div id="indications_zone" class="swissqr_column_right indication_zone">

--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -1,5 +1,5 @@
-body.l10n_ch_qr {
-    padding:0;
+body {
+    padding: 0!important;
 
     /* Disable custom bakground */
     .o_report_layout_background {
@@ -10,7 +10,7 @@ body.l10n_ch_qr {
     .swissqr_title {
         position: absolute;
         padding: 15px;
-        padding-top: 150px;
+        padding-top: 200px;
     }
 
     .swissqr_content {
@@ -19,7 +19,7 @@ body.l10n_ch_qr {
 
     .swissqr_receipt {
         position: absolute;
-        background_color: white;
+        background-color: white;
         border-color:black;
         border-width: 1pt 1pt 1pt 1pt;
         border-style: solid;

--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -106,7 +106,7 @@
                                 <div t-if="(tx.acquirer_id.qr_code == True) and (tx.currency_id.name == 'EUR')">
                                     <div t-if="tx.acquirer_id.journal_id.bank_account_id.qr_code_valid">
                                         <h3>Or scan me with your banking app.</h3>
-                                        <img class="border border-dark rounded" t-att-src="tx.acquirer_id.journal_id.bank_account_id.build_qr_code_url(tx.amount,tx.reference)"/>
+                                        <img class="border border-dark rounded" t-att-src="tx.acquirer_id.journal_id.bank_account_id.build_qr_code_base64(tx.amount,tx.reference)"/>
                                     </div>
                                     <div t-if="(tx.acquirer_id.journal_id.bank_account_id.qr_code_valid == False)">
                                         <h3>The SEPA QR Code informations are not set correctly.</h3>
@@ -145,7 +145,7 @@
             <div t-if="(payment_tx_id.acquirer_id.qr_code == True) and (payment_tx_id.currency_id.name == 'EUR')">
                 <div t-if="payment_tx_id.acquirer_id.journal_id.bank_account_id.qr_code_valid">
                     <h3>Or scan me with your banking app.</h3>
-                    <img class="border border-dark rounded" t-att-src="payment_tx_id.acquirer_id.journal_id.bank_account_id.build_qr_code_url(payment_tx_id.amount,payment_tx_id.reference)"/>
+                    <img class="border border-dark rounded" t-att-src="payment_tx_id.acquirer_id.journal_id.bank_account_id.build_qr_code_base64(payment_tx_id.amount,payment_tx_id.reference)"/>
                 </div>
                 <div t-if="(payment_tx_id.acquirer_id.journal_id.bank_account_id.qr_code_valid == False)">
                     <h3>The SEPA QR Code informations are not set correctly.</h3>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1632,7 +1632,7 @@
                 <div t-if="(payment_tx_id.acquirer_id.qr_code == True) and (payment_tx_id.acquirer_id.provider == 'transfer') and (payment_tx_id.currency_id.name == 'EUR')">
                     <div class="card-body" t-if="payment_tx_id.acquirer_id.journal_id.bank_account_id.qr_code_valid">
                         <h3>Or scan me with your banking app.</h3>
-                        <img class="border border-dark rounded" t-att-src="payment_tx_id.acquirer_id.journal_id.bank_account_id.build_qr_code_url(order.amount_total,payment_tx_id.reference)"/>
+                        <img class="border border-dark rounded" t-att-src="payment_tx_id.acquirer_id.journal_id.bank_account_id.build_qr_code_base64(order.amount_total,payment_tx_id.reference)"/>
                     </div>
                     <div class="card-body" t-if="payment_tx_id.acquirer_id.journal_id.bank_account_id.qr_code_valid == False">
                         <h3>The SEPA QR Code informations are not set correctly.</h3>


### PR DESCRIPTION
Issue:

  When trying to print a Swiss QR bill, if multiple images are presents
  in document, and they have an URL as src, some pictures will not be
  displayed.
  (Same issue may occur with simple QR code)

Cause:

  It's a known issue with wkhtmltopdf: odoo@2949138
  Also, adding CSS class to body by JS break wkhtmltopdf.

Solution:

  Replace link by base64 image value (use a function to retrieve base64
  image instead of image_url).
  Remove class 'l10n_ch_qr' added by js (no need since CSS file dedicated
  to this report).

  Extra: Alter some CSS for better rendering.

opw-2620082