### PR TITLE
[FIX] website_sale: sign up pt-BR translation

### DIFF
--- a/addons/website_sale/i18n/pt_BR.po
+++ b/addons/website_sale/i18n/pt_BR.po
@@ -2833,7 +2833,7 @@ msgstr "Exibir opções"
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.confirmation
 msgid "Sign Up"
-msgstr "Registe-se"
+msgstr "Registre-se"
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.snippet_options


### PR DESCRIPTION
replace "Registe-se" by "Registre-se"

Current behavior before PR: 

Wrong translation "Registe-se"  for "Sign up"

Desired behavior after PR is merged:

Right translation "Registre-se" for "Sign up"


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

https://github.com/odoo/odoo/pull/75409
