### PR TITLE
[FIX] base: avoid recursion depth errors during uninstall

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2164,7 +2164,6 @@ class IrModelData(models.Model):
                     records.unlink()
             except Exception:
                 if len(records) <= 1:
-                    _logger.info('Unable to delete %s', records, exc_info=True)
                     undeletable_ids.extend(ref_data._ids)
                 else:
                     # divide the batch in two, and recursively delete them
@@ -2200,6 +2199,9 @@ class IrModelData(models.Model):
 
         # remove models
         delete(self.env['ir.model'].browse(unique(model_ids)))
+
+        # log undeletable ids
+        _logger.info("ir.model.data could not be deleted (%s)", undeletable_ids)
 
         # sort out which undeletable model data may have become deletable again because
         # of records being cascade-deleted or tables being dropped just above


### PR DESCRIPTION
For some reason _logger.info with exc_info=True inside a recursive
function generates RecursionErrors, presumably because the logger uses
recursion itself to generate the stack trace that is logged.

A simple solution would be to remove exc_info=True, but I've decided to
move the log out of the delete function and simply call it once per
uninstall process with all undeletable IDs, so it's kind of a fix +
optimization.

Example before this patch: https://runbot.odoo.com/runbot/build/9554306 (see full logs and grep RecursionError)
Example after this patch: https://runbot.odoo.com/runbot/build/9204177 (no error)

NB: The runbot kills individual sub builds after they reach a certain amount of time, however it's normal for a full enterprise install to take longer than 10-11min if one uninstalls a core module (which means uninstalling a lot of other modules that depend on it)