### PR TITLE
[ADD] l10n_ae_pos

### DIFF
--- a/addons/l10n_ae_pos/__manifest__.py
+++ b/addons/l10n_ae_pos/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'U.A.E. - Point of Sale',
+    'author': 'Odoo PS',
+    'category': 'Accounting/Localizations/Point of Sale',
+    'description': """
+United Arab Emirates POS Localization
+=======================================================
+    """,
+    'depends': ['l10n_ae', 'point_of_sale'],
+    'qweb': ['static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml'],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ae_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/l10n_ae_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="OrderReceiptVAT" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[contains(text(), 'Total Taxes')]" position="replace">
+            <div>
+                <t t-if="env.pos.company.country.code == 'AE'">VAT</t>
+                <t t-else="">Total Taxes</t>
+                <span t-esc="env.pos.format_currency(receipt.total_tax)" class="pos-receipt-right-align"/>
+            </div>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Replace `Total Taxes` string on pos receipt with `VAT` as per government regulations in UAE when the company is based in UAE.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
