### PR TITLE
[FIX] lunch: Fixed e-mail sent at supplier's timezone

### DIFF
--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -46,7 +46,6 @@
                     </group>
                     <group>
                         <group string="Availability">
-                            <field name="tz" groups="base.group_no_one"/>
                             <field name="recurrency_monday"/>
                             <field name="recurrency_tuesday"/>
                             <field name="recurrency_wednesday"/>
@@ -62,6 +61,7 @@
                             <field name="send_by" widget="radio"/>
                             <label for="automatic_email_time" attrs="{'invisible': [('send_by', '!=', 'mail')]}"/>
                             <div class="o_row" attrs="{'invisible': [('send_by', '!=', 'mail')]}"><field name="automatic_email_time" widget="float_time"/> <field name="moment"/></div>
+                            <field name="tz" groups="base.group_no_one"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Steps:
- Set a supplier's 'Timezone' at a different timezone from user.
- Set 'Send Order By: Email' and set any 'Order Time'.

Result:
  E-mail will be sent at the set time, but in supplier's timezone.

Solution:
  E-mail is now sent in user's timezone.

opw-2541132

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
