### PR TITLE
[FIX] project: fix burndown chart stage issue

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -71,6 +71,8 @@ WITH all_moves_stage_task AS (
       JOIN ir_model_fields imf ON mtv.field = imf.id
                               AND imf.model = 'project.task'
                               AND imf.name = 'stage_id'
+      JOIN project_task_type_rel pttr ON pttr.type_id = mtv.old_value_integer
+                              AND pttr.project_id = pt.project_id
      WHERE pt.active
 
     --We compute the last reached stage


### PR DESCRIPTION
before this commit:
When moving a task from project A to project B, the stages of project A are
displayed in the burndown chart of project B.

After this commit:
only the stages of project B will be displayed in the burndown chart of project B

Task-2616736

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
