### PR TITLE
[fix] google_calendar: add consistency check to avoid exception during synchronization

### DIFF
--- a/addons/google_calendar/models/google_calendar.py
+++ b/addons/google_calendar/models/google_calendar.py
@@ -84,7 +84,7 @@ class SyncEvent(object):
                                  'The event has been deleted from one side, we delete on other side !')
             #If event is not deleted !
             elif self.OE.status and (self.GG.status or not is_owner):
-                if self.OE.update.split('.')[0] != self.GG.update.split('.')[0]:
+                if self.GG.update and self.OE.update.split('.')[0] != self.GG.update.split('.')[0]:
                     if self.OE.update < self.GG.update:
                         tmpSrc = 'GG'
                     elif self.OE.update > self.GG.update:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
performing a google calendar synchronization was observed that self.OE.update attribute is not always available in the event causing an **AttributeError** exception. this PR is to add consistency check in **compute_OP** method in order to avoid **AttributeError** exception

Current behavior before PR:
Traceback (most recent call last):
  File "/path/odoo/lib/python2.7/site-packages/odoo/http.py", line 642, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/path/odoo/lib/python2.7/site-packages/odoo/http.py", line 684, in dispatch
    result = self._call_function(**self.params)
  File "/path/odoo/lib/python2.7/site-packages/odoo/http.py", line 334, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/path/odoo/lib/python2.7/site-packages/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/path/odoo/lib/python2.7/site-packages/odoo/http.py", line 327, in checked_call
    result = self.endpoint(*a, **kw)
  File "/path/odoo/lib/python2.7/site-packages/odoo/http.py", line 942, in __call__
    return self.method(*args, **kw)
  File "/path/odoo/lib/python2.7/site-packages/odoo/http.py", line 507, in response_wrap
    response = f(*args, **kw)
  File "/path/odoo/lib/python2.7/site-packages/odoo/addons/google_calendar/controllers/main.py", line 43, in sync_data
    return GoogleCal.with_context(context).synchronize_events()
  File "/path/odoo/lib/python2.7/site-packages/odoo/addons/google_calendar/models/google_calendar.py", line 593, in synchronize_events
    res = recs.update_events(lastSync)
  File "/path/odoo/lib/python2.7/site-packages/odoo/addons/google_calendar/models/google_calendar.py", line 786, in update_events
    event_to_synchronize[base_event][current_event].compute_OP(modeFull=not lastSync)
  File "/path/odoo/lib/python2.7/site-packages/odoo/addons/google_calendar/models/google_calendar.py", line 87, in compute_OP
    if self.OE.update.split('.')[0] != self.GG.update.split('.')[0]:
AttributeError: 'NoneType' object has no attribute 'split'

Desired behavior after PR is merged:
avoid the **AttributeError** exception.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
