### PR TITLE
[FIX] mail: markallasread doesn't care of domain

### DIFF
--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -320,7 +320,8 @@ const DiscussWidget = AbstractAction.extend({
      * @private
      */
     _onClickMarkAllAsRead() {
-        this.env.models['mail.message'].markAllAsRead(this.domain);
+        const domain = this.discuss.stringifiedDomain ? JSON.parse(this.discuss.stringifiedDomain) : undefined;
+        this.env.models['mail.message'].markAllAsRead(domain);
     },
     /**
      * @private


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- log with admin, set handle email by odoo on your profile
- with demo account open a sale order and add admin on follower and send a two messages ('test' and 'truc')
- With admin user Go to discuss
- add a search in searchbar, search 'truc'
- click on Mark All Read
--> Issue all messages are mark all read. The domain is not care.

In V12 it works, the issue come from : https://github.com/odoo/odoo/commit/3fea5b2136627c1d7e83b2a5e111952fe3eb10a1

@tde-banana-odoo 



https://user-images.githubusercontent.com/16716992/130430716-d610b4bc-281f-4869-8db0-b61a906a98be.mov



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
