### PR TITLE
[FIX] l10n_it_edi: hide Italian EDI fields from invoice view if the i…

### DIFF
--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -168,7 +168,7 @@
             <xpath expr="//page[@name='other_info']" position="after">
                 <page string="Electronic Invoicing"
                     name="electronic_invoicing"
-                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}">
+                    attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), ('country_code', '!=', 'IT')]}">
                     <group>
                         <group>
                             <field name="l10n_it_stamp_duty"/>


### PR DESCRIPTION
…nvoice is not Italian

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
