### PR TITLE
[FIX] hr_timesheet: fix traceback in portal view

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -220,6 +220,7 @@ class AccountAnalyticLine(models.Model):
         company_uom = self.env.company.timesheet_encode_uom_id
         return company_uom == self.env.ref('uom.product_uom_day')
 
+    @api.model
     def _convert_hours_to_days(self, time):
         uom_hour = self.env.ref('uom.product_uom_hour')
         uom_day = self.env.ref('uom.product_uom_day')

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -285,6 +285,7 @@ class Task(models.Model):
                 warning_msg, self.env.ref('hr_timesheet.timesheet_action_task').id,
                 _('See timesheet entries'), {'active_ids': tasks_with_timesheets.ids})
 
+    @api.model
     def _convert_hours_to_days(self, time):
         uom_hour = self.env.ref('uom.product_uom_hour')
         uom_day = self.env.ref('uom.product_uom_day')

--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -45,7 +45,7 @@
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
                                         <t t-if="is_uom_day">
-                                            Total: <span class="text-muted" t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                                            Total: <span class="text-muted" t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                                         </t>
                                         <t t-else="">
                                             Total: <span class="text-muted" t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
@@ -59,7 +59,7 @@
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
                                         <t t-if="is_uom_day">
-                                            Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                                            Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                                         </t>
                                         <t t-else="">
                                             Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
@@ -73,7 +73,7 @@
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
                                         <t t-if="is_uom_day">
-                                            Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                                            Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                                         </t>
                                         <t t-else="">
                                             Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
@@ -87,7 +87,7 @@
                                     </th>
                                     <th colspan="1" class="text-right text-muted">
                                         <t t-if="is_uom_day">
-                                            Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                                            Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                                         </t>
                                         <t t-else="">
                                             Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
@@ -98,7 +98,7 @@
                             <tr t-else="">
                                 <div style="text-align: right;" class="mr-2 mb-1 text-muted">
                                     <t t-if="is_uom_day">
-                                        Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                                        Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                                     </t>
                                     <t t-else="">
                                         Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>

--- a/addons/hr_timesheet/views/project_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_portal_templates.xml
@@ -18,8 +18,8 @@
     </template>
 
     <template id="portal_my_task_planned_hours_template">
-        <t t-if="is_uom_day and timesheets[0]._convert_hours_to_days(task.planned_hours) > 0">
-            <strong>Planned Days:</strong> <span t-esc="timesheets[0]._convert_hours_to_days(task.planned_hours)" t-options='{"widget": "timesheet_uom"}'/>
+        <t t-if="is_uom_day and timesheets._convert_hours_to_days(task.planned_hours) > 0">
+            <strong>Planned Days:</strong> <span t-esc="timesheets._convert_hours_to_days(task.planned_hours)" t-options='{"widget": "timesheet_uom"}'/>
         </t>
         <t t-if="not is_uom_day and task.planned_hours > 0" t-call="project.portal_my_task_planned_hours_template"></t>
     </template>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -35,7 +35,7 @@
                 </th>
                 <th colspan="1" class="text-right text-muted font-weight-normal">
                     <t t-if="is_uom_day">
-                        Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                        Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                     </t>
                     <t t-else="">
                         Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
@@ -52,7 +52,7 @@
                 </th>
                 <th colspan="1" class="text-right text-muted">
                     <t t-if="is_uom_day">
-                        Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                        Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                     </t>
                     <t t-else="">
                         Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
@@ -60,7 +60,7 @@
                 </th>
             </t>
             <t t-elif="groupby == 'invoice'">
-                <t t-set="invoice" t-value="timesheets[0].timesheet_invoice_id"/>
+                <t t-set="invoice" t-value="timesheets.timesheet_invoice_id"/>
                 <th colspan="6">
                     <t t-if="invoice">
                         <em class="font-weight-normal text-muted">Timesheets for Invoice:</em>
@@ -69,7 +69,7 @@
                 </th>
                 <th colspan="1" class="text-right text-muted">
                     <t t-if="is_uom_day">
-                        Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                        Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                     </t>
                     <t t-else="">
                         Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>


### PR DESCRIPTION
Opening the task portal view while having the timesheet encoding in days
and having no timesheets linked to the viewed task would cause a
traceback.

This was caused by an index out of range exception.
The function called has been changed to a `api.model` function instead
and all calls have been changed to be compliant with that change.

Task ID: 2630244