### PR TITLE
[FIX] website_crm_partner_assign: fix multi datepickers on portal

### DIFF
--- a/addons/website_crm_partner_assign/static/src/js/crm_partner_assign.js
+++ b/addons/website_crm_partner_assign/static/src/js/crm_partner_assign.js
@@ -15,7 +15,7 @@ publicWidget.registry.crmPartnerAssign = publicWidget.Widget.extend({
         'click .new_opp_confirm': '_onNewOppConfirm',
         'click .edit_opp_confirm': '_onEditOppConfirm',
         'change .edit_opp_form .next_activity': '_onChangeNextActivity',
-        'click div.input-group span.fa-calendar': '_onCalendarIconClick',
+        'click div.input-group.date[data-target-input="nearest"]': '_onCalendarInputGroupClick',
     },
 
     //--------------------------------------------------------------------------
@@ -227,9 +227,7 @@ publicWidget.registry.crmPartnerAssign = publicWidget.Widget.extend({
     _onEditOppConfirm: function (ev) {
         ev.preventDefault();
         ev.stopPropagation();
-        if ($(".edit_opp_form")[0].checkValidity()) {
-            this._buttonExec($(ev.currentTarget), this._editOpportunity);
-        }
+        this._buttonExec($(ev.currentTarget), this._editOpportunity);
     },
     /**
      * @private
@@ -250,8 +248,9 @@ publicWidget.registry.crmPartnerAssign = publicWidget.Widget.extend({
      * @private
      * @param {Event} ev
      */
-    _onCalendarIconClick: function (ev) {
-        $(ev.currentTarget).closest('div.date').datetimepicker({
+    _onCalendarInputGroupClick: function (ev) {
+        const $calendarInputGroup = $(ev.currentTarget);
+        const calendarOptions = {
             format : time.getLangDateFormat(),
             icons: {
                 time: 'fa fa-clock-o',
@@ -259,13 +258,20 @@ publicWidget.registry.crmPartnerAssign = publicWidget.Widget.extend({
                 up: 'fa fa-chevron-up',
                 down: 'fa fa-chevron-down',
             },
-        });
+        };
+        // in some screen sizes, the automatic position opens the picker below input,
+        // but because #next_activity_div is the last element, we always open the
+        // picker on top the input to prevent extra scroll
+        if ($calendarInputGroup.is('#next_activity_div')) {
+            calendarOptions.widgetPositioning = {vertical: 'top'};
+        }
+        $calendarInputGroup.datetimepicker(calendarOptions);
     },
 
     _parse_date: function (value) {
         console.log(value);
-        var date = moment(value, "YYYY-MM-DD", true);
-        if (date.isValid()) {
+        var date = moment(value, time.getLangDateFormat(), true);
+        if (date.isValid() && date.year() >= 1900) {
             return time.date_to_str(date.toDate());
         }
         else {

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -654,7 +654,7 @@
                                             </div>
                                             <div class="form-group">
                                                 <div class="row">
-                                                    <div class="col-md-6">
+                                                    <div class="col-md-5">
                                                         <label>Priority:</label>
                                                         <div class="input-group">
                                                             <label class="radio-inline">
@@ -678,11 +678,11 @@
                                                             </label>
                                                         </div>
                                                     </div>
-                                                    <div class="col-md-6">
+                                                    <div class="col-md-7">
                                                         <label>Expected Closing:</label>
                                                         <div class="input-group date" id="exp_closing_div" data-target-input="nearest">
                                                             <t t-set='date_formatted'><t t-options='{"widget": "date"}' t-esc="opportunity.date_deadline"/></t>
-                                                            <input type="date" min="1900-01-01" name="date_deadline" t-att-value="date_formatted" class="datetimepicker-input form-control date_deadline" data-date-format="YYYY-MM-DD" t-att-name="prefix" placeholder="YYYY-MM-DD"/>
+                                                            <input type="text" name="date_deadline" data-target="#exp_closing_div" t-att-value="date_formatted" class="datetimepicker-input form-control date_deadline" t-att-name="prefix"/>
                                                             <div class="input-group-append" data-target="#exp_closing_div" data-toggle="datetimepicker">
                                                                 <span class="input-group-text">
                                                                     <span class="fa fa-calendar" role="img" aria-label="Calendar"></span>
@@ -708,7 +708,7 @@
                                                 <label class="col-form-label" for="activity_date_deadline">Next Activity Date</label>
                                                 <div class="input-group date" id="next_activity_div" data-target-input="nearest">
                                                     <t t-set='date_formatted'><t t-options='{"widget": "date"}' t-esc="user_activity.date_deadline"/></t>
-                                                    <input type="date" min="1900-01-01" name="activity_date_deadline" t-att-value="date_formatted" class="form-control activity_date_deadline datetimepicker-input" data-date-format="YYYY-MM-DD" t-att-name="prefix" placeholder="YYYY-MM-DD"/>
+                                                    <input type="text" name="activity_date_deadline" data-target="#next_activity_div" t-att-value="date_formatted" class="form-control activity_date_deadline datetimepicker-input" t-att-name="prefix"/>
                                                     <div class="input-group-append" data-target="#next_activity_div" data-toggle="datetimepicker">
                                                         <span class="input-group-text">
                                                             <span class="fa fa-calendar" role="img" aria-label="Calendar" title="Calendar"></span>


### PR DESCRIPTION
PURPOSE

The date inputs should be having only one calendar button.
The purpose of this commit is to remove the additional calendar
buttons on the edit portal opportunities pop-up.

SPECIFICATIONS

Currently, while editing opportunities by a portal user, the popup is appearing.
In that popup, 'Expected Closing' and 'Next Activity Date' input fields having 
date type so a calendar icon is added to the input. Thus, an additional calendar 
icon is added after the input, which looks ugly and it is not working properly.

This removes the additional calendar buttons on edit portal opportunities.

This is the goal of this commit.

PR #75453
TaskID-2624728


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
