### PR TITLE
[FIX] account: avoid crashing when using cash basis taxes with multivat setup

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -395,7 +395,7 @@ class AccountPartialReconcile(models.Model):
                     'line_ids': [],
                     'tax_cash_basis_rec_id': partial.id,
                     'tax_cash_basis_move_id': move.id,
-                    'fiscal_position_id': move.fiscal_position_id,
+                    'fiscal_position_id': move.fiscal_position_id.id,
                 }
 
                 # Tracking of lines grouped all together.


### PR DESCRIPTION
To reproduce:

1) Create a foreign VAT fiscal position fpos (so: assign it a different country than your fiscal country, and set a value to its foreign_vat field)

2) Create a cash basis tax in the same country as fpos

3) Make an invoice using this tax and fpos

4) Try registering a payment to your invoice. => Traceback

