### PR TITLE
center o_cp_action_menus div

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -31,6 +31,7 @@
 
     .o_cp_bottom_left {
         display: flex;
+        justify-content: space-between;
 
         > .o_cp_action_menus {
             padding-right: 10px;


### PR DESCRIPTION
PURPOSE
Since commit a1f286916de099560e0f344def3b2d7ffa9fec38 o_cp_action_menus is not centered anymore as justify-content: space-between; was removed from scss.

SPEC
Make o_cp_action_menus centered.

TASK 2628050


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
