### PR TITLE
[FIX] mrp : workorder_id already set when duplicating planned WO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -536,6 +536,15 @@ class MrpProduction(models.Model):
             production._onchange_move_raw()
         return production
 
+    def copy(self, default=None):
+        """
+        When there is a kit in the child bom of that production, we should not copy the workorder
+        """
+        res = super().copy(default)
+        if any(bom.type == 'phantom' for bom in self.bom_id.bom_line_ids.child_bom_id):
+            res.move_raw_ids.workorder_id = False
+        return res
+
     def unlink(self):
         if any(production.state == 'done' for production in self):
             raise UserError(_('Cannot delete a manufacturing order in done state.'))


### PR DESCRIPTION
Issue: When duplicating a planned WO, there are no components shown in
the work order

Steps to reproduce :
 1) Create a MO for an object with at least 1 component that is a kit
 2) Plan it
 3) Duplicate
 4) Plan the duplicate
 5) Go to the WO, the kit component is not there

opw-2531877

Backporting of 6aaf337558e59474efcef937f0175ee531b4b477