### PR TITLE
[FIX] account_edi: don't open the form view when clicking on a row of…

### DIFF
--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -43,7 +43,7 @@
                 </xpath>
                 <xpath expr="//page[@id='other_tab']" position="after">
                     <page id="edi_documents" string="EDI Documents" groups="base.group_no_one" attrs="{'invisible': [('edi_document_ids', '=', [])]}">
-                        <field name="edi_document_ids">
+                        <field name="edi_document_ids" style="pointer-events:none;">
                             <tree create="false" delete="false" edit="false" decoration-danger="error">
                                 <field name="name"/>
                                 <field name="edi_format_name"/>

--- a/addons/account_edi/views/account_payment_views.xml
+++ b/addons/account_edi/views/account_payment_views.xml
@@ -35,7 +35,7 @@
                 </xpath>
                 <xpath expr="//group[@name='group3']" position="after">
                     <group groups="base.group_no_one">
-                        <field name="edi_document_ids" string="EDI Documents" attrs="{'invisible': [('edi_document_ids', '=', [])]}">
+                        <field name="edi_document_ids" string="EDI Documents" attrs="{'invisible': [('edi_document_ids', '=', [])]}"  style="pointer-events:none;">
                             <tree create="false" delete="false" edit="false" decoration-danger="error">
                                 <field name="name"/>
                                 <field name="edi_format_name"/>


### PR DESCRIPTION
… the tree view

On debug mode, a tree view is displayed on account.move and account.payment with the account.edi.document related to this record. Clicking on it opens the form view for account.edi.document and, in edit mode, even allows to edit documents, which should not be allowed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
