### PR TITLE
render buttons after list selection box

### DIFF
--- a/addons/web/static/src/legacy/js/views/list/list_controller.js
+++ b/addons/web/static/src/legacy/js/views/list/list_controller.js
@@ -659,6 +659,7 @@ var ListController = BasicController.extend({
      * @private
      */
     _updateSelectionBox() {
+        this._renderHeaderButtons();
         if (this.$selectionBox) {
             this.$selectionBox.remove();
             this.$selectionBox = null;
@@ -674,7 +675,6 @@ var ListController = BasicController.extend({
             }));
             this.$selectionBox.appendTo(this.$buttons);
         }
-        this._renderHeaderButtons();
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -557,7 +557,7 @@ QUnit.module('Views', {
         assert.hasClass(cpButtons[0].querySelector('button[name="x"]'), 'btn btn-secondary');
         assert.containsOnce(cpButtons[0], '.o_list_selection_box');
         assert.strictEqual(
-            cpButtons[0].querySelector('button[name="x"]').previousElementSibling,
+            cpButtons[0].querySelector('button[name="x"]').nextElementSibling,
             cpButtons[0].querySelector('.o_list_selection_box')
         );
         assert.containsNone(cpButtons[0], 'button[name="y"]');
@@ -2230,6 +2230,38 @@ QUnit.module('Views', {
         await testUtils.dom.click(list.$('.o_list_selection_box .o_list_select_domain'));
         assert.containsOnce(list.$('.o_cp_buttons'), '.o_list_selection_box');
         assert.strictEqual(list.$('.o_list_selection_box').text().trim(), 'All 4 selected');
+
+        list.destroy();
+    });
+
+    QUnit.test('selection box is displayed after header buttons', async function (assert) {
+        assert.expect(5);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch:
+                `<tree>
+                    <header>
+                         <button name="x" type="object" class="plaf" string="plaf"/>
+                         <button name="y" type="object" class="plouf" string="plouf"/>
+                    </header>
+                    <field name="foo"/>
+                    <field name="bar"/>
+                </tree>`,
+        });
+
+        assert.containsN(list, '.o_data_row', 4);
+        assert.containsNone(list.$('.o_cp_buttons'), '.o_list_selection_box');
+
+        // select a record
+        await testUtils.dom.click(list.$('.o_data_row:first .o_list_record_selector input'));
+        assert.containsOnce(list.$('.o_cp_buttons'), '.o_list_selection_box');
+        const lastElement = list.$('.o_cp_buttons .o_list_buttons').children(":last")[0];
+        assert.strictEqual(lastElement, list.$('.o_cp_buttons .o_list_selection_box')[0],
+            "last element should selection box");
+        assert.strictEqual(list.$('.o_list_selection_box').text().trim(), '1 selected');
 
         list.destroy();
     });


### PR DESCRIPTION
PURPOSE
Show list selection box after all list header buttons.

SPEC
List selection box should displayed after all list header buttons.

TASK 2628038


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
