### PR TITLE
[IMP] product: Improve product `name_get` performance

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -108,6 +108,7 @@ class ProductProduct(models.Model):
         'Barcode', copy=False,
         help="International Article Number used for product identification.")
     product_template_attribute_value_ids = fields.Many2many('product.template.attribute.value', relation='product_variant_combination', string="Attribute Values", ondelete='restrict')
+    product_template_variant_value_ids = fields.Many2many('product.template.attribute.value', relation='product_variant_combination', domain=[('attribute_line_id.value_count', '>', 1)], ondelete='restrict')
     combination_indices = fields.Char(compute='_compute_combination_indices', store=True, index=True)
     is_product_variant = fields.Boolean(compute='_compute_is_product_variant')
 
@@ -473,7 +474,7 @@ class ProductProduct(models.Model):
 
         # Prefetch the fields used by the `name_get`, so `browse` doesn't fetch other fields
         # Use `load=False` to not call `name_get` for the `product_tmpl_id`
-        self.sudo().read(['name', 'default_code', 'product_tmpl_id'], load=False)
+        self.sudo().read(['name', 'default_code', 'product_tmpl_id', 'product_template_variant_value_ids'], load=False)
 
         product_template_ids = self.sudo().mapped('product_tmpl_id').ids
 
@@ -489,7 +490,7 @@ class ProductProduct(models.Model):
             for r in supplier_info:
                 supplier_info_by_template.setdefault(r.product_tmpl_id, []).append(r)
         for product in self.sudo():
-            variant = product.product_template_attribute_value_ids._get_combination_name()
+            variant = ", ".join(product.product_template_variant_value_ids.mapped('name'))
 
             name = variant and "%s (%s)" % (product.name, variant) or product.name
             sellers = []

--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -172,7 +172,13 @@ class ProductTemplateAttributeLine(models.Model):
     attribute_id = fields.Many2one('product.attribute', string="Attribute", ondelete='restrict', required=True, index=True)
     value_ids = fields.Many2many('product.attribute.value', string="Values", domain="[('attribute_id', '=', attribute_id)]",
         relation='product_attribute_value_product_template_attribute_line_rel', ondelete='restrict')
+    value_count = fields.Integer(compute='_compute_value_count', store=True)
     product_template_value_ids = fields.One2many('product.template.attribute.value', 'attribute_line_id', string="Product Attribute Values")
+
+    @api.depends('value_ids')
+    def _compute_value_count(self):
+        for record in self:
+            record.value_count = len(record.value_ids)
 
     @api.onchange('attribute_id')
     def _onchange_attribute_id(self):

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -309,7 +309,7 @@
                     <field name="default_code" optional="show" readonly="1"/>
                     <field name="barcode" optional="hide" readonly="1"/>
                     <field name="name" readonly="1"/>
-                    <field name="product_template_attribute_value_ids" widget="many2many_tags" groups="product.group_product_variant" readonly="1"/>
+                    <field name="product_template_variant_value_ids" widget="many2many_tags" groups="product.group_product_variant" readonly="1"/>
                     <field name="company_id" groups="base.group_multi_company" optional="hide" readonly="1"/>
                     <field name="lst_price" optional="show" string="Sales Price"/>
                     <field name="standard_price" optional="show"/>
@@ -355,7 +355,7 @@
                     <field name="product_tmpl_id" class="oe_inline" readonly="1" invisible="1" attrs="{'required': [('id', '!=', False)]}"/>
                 </field>
                 <xpath expr="//div[hasclass('oe_title')]" position="inside">
-                    <field name="product_template_attribute_value_ids" widget="many2many_tags" readonly="1"
+                    <field name="product_template_variant_value_ids" widget="many2many_tags" readonly="1"
                         groups="product.group_product_variant"/>
                 </xpath>
             </field>

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3648,7 +3648,8 @@ class Many2many(_RelationalMulti):
             )
         if self.store:
             if not (self.relation and self.column1 and self.column2):
-                self._explicit = False
+                if not self.relation:
+                    self._explicit = False
                 # table name is based on the stable alphabetical order of tables
                 comodel = model.env[self.comodel_name]
                 if not self.relation:


### PR DESCRIPTION
A separate many2many field is added to product containing all variant-like attribute values (the specification-like values are left out by adding a domain on the field). Using these in the `name_get` method instead of `_filter_single_value_lines` improves performance.
    
This PR is based on github.com/odoo/odoo/pull/67648, except for the addition of a computed field containing the number of attribute values in an attribute line. This extra field allows for the specifications to be kept the same (attribute lines with only one value are not considered to be variant-like).