### PR TITLE
[FIX] account: copy the invoice_date_due when duplicating an invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1927,7 +1927,13 @@ class AccountMove(models.Model):
             default['date'] = self.company_id._get_user_fiscal_lock_date() + timedelta(days=1)
         if self.move_type == 'entry':
             default['partner_id'] = False
-        return super(AccountMove, self).copy(default)
+        invoice = super().copy(default)
+
+        # Make sure to recompute payment terms. This could be necessary if the date is different for example.
+        # Also, this is necessary when creating a credit note because the current invoice is copied.
+        invoice._recompute_payment_terms_lines()
+
+        return invoice
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Accounting
- Create an invoice:
    - select a `invoice_payment_term_id`
    - Add product on “account.move.live”
- Save and duplicate it.

Problem:
The `invoice_payment_term_id` field will be duplicated on the second invoice, but not the `invoice_date_due` field

Solution:
The `invoice_date_due` field is set in the `_recompute_payment_terms_lines()` function when adding an `account.move.line`.
As in the duplicate invoice, we also have an `account.move.line` we can therefore call this function so that the field is set
https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L1043

opw- 2628333


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
