### PR TITLE
[FIX] purchase_stock: warehouse resupply with multi-step reception

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -171,7 +171,9 @@ class Orderpoint(models.Model):
             ('state','in',('draft','sent','to approve')),
             '|',
                 ('orderpoint_id','in',self.ids),
-                ('move_dest_ids.product_id', 'in', self.mapped('product_id.id'))
+                '&',
+                  ('move_dest_ids.product_id', 'in', self.mapped('product_id.id')),
+                  ('move_dest_ids.location_id', 'in', self.mapped('location_id.id')),
         ])
         for poline in purchase_lines_in_progress:
             orderpoints = self.filtered(lambda x: x.product_id == poline.product_id)


### PR DESCRIPTION
- Main WH configured as 2 steps receptions.
- Configure an orderpoint for productA on WH.
- Create a WH2 and configure a resupply of WH2 from WH.
- Configure an orderpoint for same product on WH2.
- Create a delivery order for productA
- Run scheduler.

The second orderpoint will not trigger anymore a PO line as it will see
the first one for the same product with a move dest id.

The mentioned use case was broken following
https://github.com/odoo/odoo/commit/006ab22aae0e6d8e9bd88d827282d6755f808cf0
Tuning the fix to only fetch PO belonging to the same WH

opw-2531488

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
