### PR TITLE
[FIX] survey: No crash when getting stats of answers of a survey

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -438,7 +438,8 @@ class SurveyQuestion(models.Model):
 
         count_data = dict.fromkeys(suggested_answers, 0)
         for line in user_input_lines:
-            if line.suggested_answer_id or (line.value_char_box and self.comment_count_as_answer):
+            if line.suggested_answer_id in count_data\
+               or (line.value_char_box and self.comment_count_as_answer):
                 count_data[line.suggested_answer_id] += 1
 
         table_data = [{


### PR DESCRIPTION
If for any reason the initial linked question of one possible answer was
changed and if one existing survey has already been answered using that
possibility, we currently got an Internal Server Error while we should
simply just ignore these answers when getting the statistics of that
survey.

Description of the issue/feature this PR addresses:
opw-2627264

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
