### PR TITLE
[FIX] mail: message_notify use the model and res_id arguments

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2025,8 +2025,8 @@ class MailThread(models.AbstractModel):
         MailThread = self.env['mail.thread']
         values = {
             'parent_id': parent_id,
-            'model': self._name if self else False,
-            'res_id': self.id if self else False,
+            'model': self._name if self else model,
+            'res_id': self.id if self else res_id,
             'message_type': 'user_notification',
             'subject': subject,
             'body': body,


### PR DESCRIPTION
Bug
===
The arguments model and res_id were declared on the method but never
used. This method was supposed to be callable from the model and not
from the records with those 2 parameters.

Make this possible.

Task-2599676