### PR TITLE
[FIX] web, web_editor: avoid freezing browser when scrolling to undefined

### DIFF
--- a/addons/web/static/src/js/core/dom.js
+++ b/addons/web/static/src/js/core/dom.js
@@ -157,10 +157,10 @@ var dom = {
         }
     },
     /**
-     * @return {HTMLElement}
+     * @return {HTMLElement|null}
      */
     closestScrollable(el) {
-        return $(el).closestScrollable()[0];
+        return $(el).closestScrollable()[0] || null;
     },
     /**
      * @param {HTMLElement} el
@@ -548,6 +548,9 @@ var dom = {
      * @return {Promise}
      */
     scrollTo(el, options = {}) {
+        if (!el) {
+            throw new Error("The scrollTo function was called without any given element");
+        }
         const $el = $(el);
         const $scrollable = $el.parent().closestScrollable();
         const $topLevelScrollable = $().getScrollingElement();

--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -128,6 +128,10 @@ $.fn.extend({
     closestScrollable() {
         let $el = this;
         while ($el[0] !== document.scrollingElement) {
+            // Avoid infinite loop.
+            if (!$el.length) {
+                return $();
+            }
             if ($el.isScrollable()) {
                 return $el;
             }

--- a/addons/website/static/src/scss/website.editor.ui.scss
+++ b/addons/website/static/src/scss/website.editor.ui.scss
@@ -116,6 +116,9 @@ $o-we-switch-inactive-color: #F7F7F7 !default;
     max-width: $popover-max-width * 1.2;
     // Prevent UI glitch after fetching page preview (size might change)
     width: $popover-max-width * 1.2;
+    // Prevent the edited link from being deselected when clicking between
+    // buttons in the popover
+    user-select: none;
 
     .o_we_url_link {
         word-break: break-all;


### PR DESCRIPTION
Before this commit the browser did freeze if scrollTo(undefined) was
called.
This happened because jQuery's closestScrollable entered an infinite
recursive exploration of .parent() elements starting from $(undefined).
avoid losing link focus when clicking on popover
This was detected because clicking between the buttons of the link popover
widget did deselect the link. When this happened, if edit was clicked,
the edited link was the one within the popover widget instead of the one
one the page.

After this commit such wrong calls to scrollTo() will not freeze the
browser anymore, it will just have no effect.
Clicking on the panel between the buttons has no effect anymore.

task-2630257

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
