### PR TITLE
[FIX] profiling: manage long c-call

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -23,7 +23,7 @@ except ImportError:
 from odoo import SUPERUSER_ID
 from odoo.http import request
 from odoo.modules.module import get_resource_path
-from odoo.tools import func, misc, transpile_javascript, is_odoo_module, SourceMapGenerator
+from odoo.tools import func, misc, transpile_javascript, is_odoo_module, SourceMapGenerator, profiler
 from odoo.tools.misc import html_escape as escape
 from odoo.tools.pycompat import to_text
 
@@ -1018,6 +1018,7 @@ class ScssStylesheetAsset(PreprocessedCSS):
             return super(ScssStylesheetAsset, self).compile(source)
 
         try:
+            profiler.force_hook()
             return libsass.compile(
                 string=source,
                 include_paths=[

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -166,9 +166,21 @@ class PeriodicCollector(Collector):
 
     def run(self):
         self.active = True
+        last_time = time.time()
         while self.active:  # maybe add a check on parent_thread state?
+            duration = time.time() - last_time
+            if duration > self.frame_interval * 10 and self.last_frame:
+                # The profiler has unexpectedly slept for more than 10 frame intervals. This may
+                # happen when calling a C library without releasing the GIL. In that case, the
+                # last frame was taken before the call, and the next frame is after the call, and
+                # the call itself does not appear in any of those frames: the duration of the call
+                # is incorrectly attributed to the last frame.
+                self._entries[-1]['stack'].append(('profiling', 0, '⚠ Profiler freezed for %s s' % duration, ''))
+                self.last_frame = None  # skip duplicate detection for the next frame.
             self.add()
+            last_time = time.time()
             time.sleep(self.frame_interval)
+
         self._entries.append({'stack': [], 'start': time.time()})  # add final end frame
 
     def start(self):

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -59,6 +59,18 @@ def make_session(name=''):
     return f'{datetime.datetime.now():%Y-%m-%d %H:%M:%S} {name}'
 
 
+def force_hook():
+    """
+    Force periodic profiling collectors to generate some stack trace.  This is
+    useful before long calls that do not release the GIL, so that the time
+    spent in those calls is attributed to a specific stack trace, instead of
+    some arbitrary former frame.
+    """
+    thread = threading.current_thread()
+    for func in getattr(thread, 'profile_hooks', ()):
+        func()
+
+
 class Collector:
     """
     Base class for objects that collect profiling data.
@@ -187,11 +199,18 @@ class PeriodicCollector(Collector):
         interval = self.profiler.params.get('traces_async_interval')
         if interval:
             self.frame_interval = min(max(float(interval), 0.001), 1)
+
+        init_thread = self.profiler.init_thread
+        if not hasattr(init_thread, 'profile_hooks'):
+            init_thread.profile_hooks = []
+        init_thread.profile_hooks.append(self.add)
+
         self.thread.start()
 
     def stop(self):
         self.active = False
         self.thread.join()
+        self.profiler.init_thread.profile_hooks.remove(self.add)
 
     def add(self, entry=None, frame=None):
         """ Add an entry (dict) to this collector. """


### PR DESCRIPTION
 In some cases the gil won't be release for a long time,  creating longs frames giving incorrect informations.
    
This pr will add information on the frame when this one last for too long.

This pr also proposes a mechanism to manually add a frame before a blocking c-call and triggers it before calling libsaas.compile.
