### PR TITLE
[FIX] account: always set the account move name

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -540,6 +540,10 @@ class AccountPayment(models.Model):
         if not self.move_id:
             self.name = False
 
+    @api.onchange('journal_id')
+    def _onchange_journal(self):
+        self.move_id._onchange_journal()
+
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS
     # -------------------------------------------------------------------------

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -707,3 +707,22 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'is_reconciled': True,
             'is_matched': True,
         }])
+
+    def test_payment_name(self):
+        AccountPayment = self.env['account.payment']
+        AccountPayment.search([]).unlink()
+
+        payment = AccountPayment.create({
+            'journal_id': self.company_data['default_journal_bank'].id,
+        })
+        self.assertRegex(payment.name, 'BNK1/\d{4}/\d{2}/0001')
+
+        with Form(AccountPayment.with_context(default_move_journal_types=('bank', 'cash'))) as payment_form:
+            self.assertEqual(payment_form._values['name'], '/')
+            payment_form.journal_id = self.company_data['default_journal_cash']
+            self.assertRegex(payment_form._values['name'], 'CSH1/\d{4}/\d{2}/0001')
+            payment_form.journal_id = self.company_data['default_journal_bank']
+        payment = payment_form.save()
+        self.assertEqual(payment.name, '/')
+        payment.action_post()
+        self.assertRegex(payment.name, 'BNK1/\d{4}/\d{2}/0002')


### PR DESCRIPTION
On payment creation, when changing twice the payment's journal, if the
first journal already has some lines and the second one doesn't have any
lines, the payment name will be incorrect.

To reproduce the error:
1. (If present, delete all payments)
2. Create and save a payment P01:
    - Journal: Bank
3. Create a second payment P02 (do not save it):
    - Journal: Bank
4. Change P02's payment: Cash
5. Change P02's payment: Bank
6. Save P02

Error: The name of P02 is "CSH1/2021/08/0001", which would be correct if
it was a Cash payment. This error has a consequence: suppose the user
creates a third payment (journal: Bank) and confirms it, its name will
be "CSH1/2021/08/0002" (again, name linked to the incorrect journal)

On step 4, when changing the journal to Cash, since the latter hasn't
any payment, the server returns a new name ("CSH1/2021/08/0001"). Then,
on step 5, when changing back the journal to "Bank", since the latter
already has a payment (P01) and since the current record already has a
name ("CSH1/2021/08/0001"), the server doesn't change it and the
`onchange` response doesn't contain anything. As a result, when saving
the payment from the client side, the wrong name is included in the data
("CSH1/2021/08/0001"). Regarding the consequence: later, when creating
and confirming a third payment, the server will take the name of the
previous one in the same journal and will increment it
("CSH1/2021/08/0002").

OPW-2601668