### PR TITLE
[IMP] hr: remove personal documents tab

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -202,12 +202,6 @@
                                     <group name="application_group"/>
                                 </group>
                             </page>
-                            <page string="Personal Documents" name="personal_documents" groups="hr.group_hr_manager">
-                                <group>
-                                    <field name="id_card"/>
-                                    <field name="driving_license"/>
-                                </group>
-                            </page>
                         </notebook>
 
                     </sheet>


### PR DESCRIPTION
The personal documents tab on the employee form view is removed in favor
of the chatter + documents app to hold and manage documents.
The fields are kept because the salary configurator needs fields to bind
to be able to still request documents. This might change in the future.

Task ID: 2628750
