### PR TITLE
[FIX] account: Manual reconcile use the currency

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -4364,6 +4364,18 @@ msgid "Either pass both debit and credit or none."
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "Amount in currency must be provide with the currency."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "The currency must be the same of the computed write-off currency."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__is_email
 msgid "Email"
 msgstr ""

--- a/addons/account/models/reconciliation_widget.py
+++ b/addons/account/models/reconciliation_widget.py
@@ -480,7 +480,6 @@ class AccountReconciliation(models.AbstractModel):
         """
 
         Partner = self.env['res.partner']
-        Account = self.env['account.account']
 
         for datum in data:
             if len(datum['mv_line_ids']) >= 1 or len(datum['mv_line_ids']) + len(datum['new_mv_line_dicts']) >= 2:
@@ -860,16 +859,7 @@ class AccountReconciliation(models.AbstractModel):
 
         # Create writeoff move lines
         if len(new_mv_line_dicts) > 0:
-            company_currency = account_move_line[0].account_id.company_id.currency_id
-            same_currency = False
-            currencies = list(set([aml.currency_id or company_currency for aml in account_move_line]))
-            if len(currencies) == 1 and currencies[0] != company_currency:
-                same_currency = True
-            # We don't have to convert debit/credit to currency as all values in the reconciliation widget are displayed in company currency
-            # If all the lines are in the same currency, create writeoff entry with same currency also
             for mv_line_dict in new_mv_line_dicts:
-                if not same_currency:
-                    mv_line_dict['amount_currency'] = False
                 writeoff_lines += account_move_line._create_writeoff([mv_line_dict])
 
             (account_move_line + writeoff_lines).reconcile()

--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -1413,11 +1413,16 @@ var StatementModel = BasicModel.extend({
 
         var result = {
             name : prop.label,
-            debit : amount > 0 ? amount : 0,
-            credit : amount < 0 ? -amount : 0,
             tax_exigible: prop.tax_exigible,
             analytic_tag_ids: [[6, null, _.pluck(prop.analytic_tag_ids, 'id')]]
         };
+        if (line.currency_id) {
+            result.amount_currency = amount;
+            result.currency_id = line.currency_id;
+        } else {
+            result.debit = amount > 0 ? amount : 0;
+            result.credit = amount < 0 ? -amount : 0;
+        }
         if (!isNaN(prop.id)) {
             result.counterpart_aml_id = prop.id;
         } else {

--- a/addons/account/static/src/xml/account_reconciliation.xml
+++ b/addons/account/static/src/xml/account_reconciliation.xml
@@ -101,7 +101,15 @@
                 <tr>
                     <td class="cell_account_code"><t t-esc="state.st_line.account_code"/></td>
                     <td class="cell_due_date"><t t-esc="state.st_line.date"/></td>
-                    <td class="cell_label"><t t-if="state.st_line.name" t-esc="state.st_line.name"/> <t t-if="state.st_line.amount_currency_str"> (<t t-esc="state.st_line.amount_currency_str"/>)</t></td>
+                    <td class="cell_label">
+                        <t t-if="state.st_line.name" t-esc="state.st_line.name"/>
+                        <t t-if="state.st_line.amount_currency_str">
+                            (<span t-if="state.st_line.amount_currency_str"
+                                t-attf-class="o_multi_currency o_multi_currency_color_#{state.st_line.currency_id%8} line_info_button fa fa-money"
+                                t-att-data-content="state.st_line.amount_str"/>
+                            <t t-esc="state.st_line.amount_currency_str"/>)
+                        </t>
+                    </td>
                     <td class="cell_left"><t t-if="state.st_line.amount &gt; 0"><t t-raw="state.st_line.amount_str"/></t></td>
                     <td class="cell_right"><t t-if="state.st_line.amount &lt; 0"><t t-raw="state.st_line.amount_str"/></t></td>
                     <td class="cell_info_popover"></td>

--- a/addons/account/static/tests/reconciliation_tests.js
+++ b/addons/account/static/tests/reconciliation_tests.js
@@ -38,6 +38,7 @@ var db = {
             {id: 4, display_name: "partner 4", image: 'DDD'},
             {id: 8, display_name: "Agrolait", image: 'EEE'},
             {id: 12, display_name: "Camptocamp", image: 'FFF', property_account_receivable_id: 287, property_account_payable_id: 287},
+            {id: 13, display_name: "partner currency", image: 'GGG'},
             // add more to have 'Search More' option
             {id: 98, display_name: "partner 98", image: 'YYY'},
             {id: 99, display_name: "partner 99", image: 'ZZZ'},
@@ -63,6 +64,7 @@ var db = {
             {id: 287, code: 101200, name: "101200 Account Receivable", company_id: 1},
             {id: 288, code: 101300, name: "101300 Tax Paid", company_id: 1},
             {id: 308, code: 101401, name: "101401 Bank", company_id: 1},
+            {id: 309, code: 101402, name: "101402 Bank €", company_id: 1},
             {id: 499, code: 499001, name: "499001 Suspense Account", company_id: 1},
             {id: 500, code: 500, name: "500 Account", company_id: 1},
             {id: 501, code: 501, name: "501 Account", company_id: 1},
@@ -168,7 +170,8 @@ var db = {
             company_id: {string: "Company", type: 'many2one', relation: 'res.company'},
         },
         records: [
-            {id: 8, display_name: "company 1 journal", type:'general', company_id: 1}
+            {id: 8, display_name: "company 1 journal", type:'general', company_id: 1},
+            {id: 9, display_name: "company 1 journal €", type:'general', company_id: 1},
         ]
     },
     'account.analytic.account': {
@@ -470,6 +473,55 @@ var data_widget = [
         },
         'reconciliation_proposition': []
     },
+    {
+        'st_line': {
+            'currency_id': 3,
+            'communication_partner_name': false,
+            'open_balance_account_id': 285,
+            'name': "First",
+            'partner_name': "partner currency",
+            'partner_id': 13,
+            'has_no_partner': false,
+            'journal_id': 8,
+            'account_name': "Bank",
+            'note': "",
+            'amount': 50.0,
+            'amount_str': "$ 50.00",
+            'amount_currency_str': "",
+            'date': "2017-01-01",
+            'account_code': "101401",
+            'ref': "",
+            'id': 9,
+            'statement_id': 2,
+            'company_id': 1,
+        },
+        'reconciliation_proposition': []
+    },
+    {
+        'st_line': {
+            'currency_id': 7,
+            'communication_partner_name': false,
+            'open_balance_account_id': 285,
+            'name': "Second",
+            'partner_name': "partner currency",
+            'partner_id': 13,
+            'has_no_partner': false,
+            'journal_id': 8,
+            'account_name': "Bank",
+            'note': "",
+            'amount': 50.0,
+            'amount_currency': 70.0,
+            'amount_str': "£ 50.00",
+            'amount_currency_str': "$ 70.00",
+            'date': "2017-01-01",
+            'account_code': "101401",
+            'ref': "",
+            'id': 10,
+            'statement_id': 2,
+            'company_id': 1,
+        },
+        'reconciliation_proposition': []
+    },
 ];
 
 var mv_lines = {
@@ -511,6 +563,14 @@ var mv_lines = {
         {'account_type': "receivable", 'amount_currency_str': "", 'currency_id': false, 'date_maturity': "2017-02-22", 'date': "2017-01-23", 'total_amount_str': "$ 525.00", 'partner_id': 8, 'account_name': "101200 Account Receivable", 'name': "INV/2017/0004", 'partner_name': "Agrolait", 'total_amount_currency_str': "", 'id': 399, 'credit': 0.0, 'journal_id': [1, "Customer Invoices"], 'amount_str': "$ 525.00", 'debit': 525.0, 'account_code': "101200", 'ref': "", 'already_paid': false},
     ],
     '[8,"",0]': [],
+    '[9,"",0]': [
+        {'account_type': "liquidity", 'amount_currency_str': "", 'currency_id': false, 'date_maturity': "2017-01-23", 'date': "2017-01-23", 'total_amount_str': "$ 100.00", 'partner_id': 13, 'account_name': "Bank", 'name': "BNK1/2017/0003: CUST.IN/2017/0001", 'partner_name': "partner currency", 'total_amount_currency_str': "", 'id': 394, 'credit': 0.0, 'journal_id': [8, "company 1 journal"], 'amount_str': "$ 100.00", 'debit': 100.0, 'account_code': "101401", 'ref': "", 'already_paid': true},
+        {'account_type': "liquidity", 'amount_currency_str': "€ 100.00", 'currency_id': 5, 'date_maturity': "2017-01-23", 'date': "2017-01-23", 'total_amount_str': "$ 130.00", 'partner_id': 13, 'account_name': "Bank €", 'name': "BNK1/2017/0004: CUST.IN/2017/0002", 'partner_name': "partner currency", 'total_amount_currency_str': "€ 100.00", 'id': 396, 'credit': 0.0, 'journal_id': [9, "company 1 journal €"], 'amount_str': "$ 130.00", 'debit': 130.0, 'account_code': "101402", 'ref': "INV/2017/0003", 'already_paid': true},
+    ],
+    '[10,"",0]': [
+        {'account_type': "liquidity", 'amount_currency_str': "$ 100.00", 'currency_id': 3, 'date_maturity': "2017-01-23", 'date': "2017-01-23", 'total_amount_str': "£ 120.00", 'partner_id': 13, 'account_name': "Bank", 'name': "BNK1/2017/0003: CUST.IN/2017/0001", 'partner_name': "partner currency", 'total_amount_currency_str': "$ 100.00", 'id': 394, 'credit': 0.0, 'journal_id': [8, "company 1 journal"], 'amount_str': "£ 120.00", 'debit': 120.0, 'account_code': "101401", 'ref': "", 'already_paid': true},
+        {'account_type': "liquidity", 'amount_currency_str': "€ 100.00", 'currency_id': 5, 'date_maturity': "2017-01-23", 'date': "2017-01-23", 'total_amount_str': "£ 140.00", 'partner_id': 13, 'account_name': "Bank €", 'name': "BNK1/2017/0004: CUST.IN/2017/0002", 'partner_name': "partner currency", 'total_amount_currency_str': "€ 100.00", 'id': 396, 'credit': 0.0, 'journal_id': [9, "company 1 journal €"], 'amount_str': "£ 140.00", 'debit': 140.0, 'account_code': "101402", 'ref': "INV/2017/0003", 'already_paid': true},
+    ],
 };
 
 var auto_reconciliation = {
@@ -529,7 +589,7 @@ var auto_reconciliation = {
 };
 
 var data_for_manual_reconciliation_widget = {
-    '[null,[282,283,284,285,286,287,288,308,499,500,501,502,503,504]]': {
+    '[null,[282,283,284,285,286,287,288,308,309,499,500,501,502,503,504]]': {
         'customers': [
             {'account_id': 287, 'partner_name': "Agrolait", 'reconciliation_proposition': [], 'currency_id': 3, 'max_date': "2017-02-14 12:30:31", 'last_time_entries_checked': null, 'account_code': "101200", 'partner_id': 8, 'account_name': "101200 Account Receivable", 'mode': "customers"},
             {'account_id': 7, 'partner_name': "Camptocamp", 'reconciliation_proposition': [], 'currency_id': 3, 'max_date': "2017-02-13 14:24:55", 'last_time_entries_checked': null, 'account_code': "101200", 'partner_id': 12, 'account_name': "101200 Account Receivable", 'mode': "customers"}
@@ -948,10 +1008,8 @@ QUnit.module('account', {
         testUtils.mock.addMockEnvironment(clientAction, {
             data: this.params.data,
             mockRPC: function (route, args) {
-                console.log(args.method);
                 if (args.method === 'process_bank_statement_line') {
                     var lines = args.args['1'];
-                    console.log(args.arsg);
                     assert.deepEqual(args.args, [
                         [6],
                         [{
@@ -1050,6 +1108,293 @@ QUnit.module('account', {
 
         assert.strictEqual(clientAction.$('.accounting_view tbody').text().replace(/[\n\r\s]+/g, ' ').replace(/[\u200B]/g, ''),
             " 101200 2017-02-07 INV/2017/0012 $ 650.00 ", "should display the created reconciliation line with the currency");
+
+        clientAction.destroy();
+    });
+
+    QUnit.test('Reconciliation currencies: create write-off', async function (assert) {
+        assert.expect(21);
+
+        var clientAction = new ReconciliationClientAction.StatementAction(null, this.params.options);
+
+        this.params.data_preprocess = {
+            value_min: 0,
+            value_max: 4,
+            notifications: [],
+            num_already_reconciled_lines: 0,
+            st_lines_ids: [9, 10],
+            statement_name: 'BNK/2014/001',
+        };
+
+        testUtils.mock.addMockEnvironment(clientAction, {
+            data: this.params.data,
+            session: {
+                currencies: Object.assign({
+                    5: {
+                        digits: [69, 2],
+                        position: "before",
+                        symbol: "€",
+                    },
+                    7: {
+                        digits: [69, 2],
+                        position: "before",
+                        symbol: "£",
+                    },
+                }, this.params.session.currencies),
+            },
+            translateParameters: {
+                date_format: "%m/%d/%Y",
+                direction:"ltr",
+                name:"English",
+                thousands_sep: ",",
+                time_format: "%H:%M:%S",
+                decimal_point: ".",
+                id:1,
+                grouping: [3,0],
+            },
+            archs: {
+                'account.bank.statement.line,false,search': '<search string="Statement Line"><field name="display_name"/></search>',
+            },
+            mockRPC: function (route, args) {
+                if (args.method === 'process_bank_statement_line') {
+                    assert.deepEqual(args.args[0], [10], "Should have the selected proposition");
+                    assert.deepEqual(args.args[1][0].new_aml_dicts, [{
+                        "name": "test",
+                        "debit": 90,
+                        "credit": 0,
+                        "analytic_tag_ids": [[6, null, []]],
+                        "account_id": 287,
+                    }], "Should call process_bank_statement_line with write-off");
+                    assert.deepEqual(args.args[1][0].partner_id, 13, "Should call process_bank_statement_line with write-off partner");
+                    assert.deepEqual(args.args[1][0].payment_aml_ids, [396], "Should call process_bank_statement_line with write-off aml");
+                }
+                return this._super(route, args);
+            },
+        });
+        await clientAction.appendTo($('#qunit-fixture'));
+        await testUtils.nextTick();
+
+        const line0 = clientAction.widgets[0];
+        const line1 = clientAction.widgets[1];
+
+        // first
+
+        assert.strictEqual(line0.$('.o_multi_currency').data("content"), "€ 100.00", "should display icon money for multi-currency in propositions");
+        assert.strictEqual(line0.$('.mv_line .cell_right').text().replace(/[\n\r\s]+/g, ' '), " $ 100.00 $ 130.00 ", "should display the different amounts with the currency in propositions");
+        assert.strictEqual(line0.$('.accounting_view tfoot .cell_right').text(), "$\u00a050.00", "should display the total in currency");
+
+        await testUtils.dom.click(line0.$('.match td:last'));
+
+        assert.strictEqual(line0.$('.accounting_view tbody .o_multi_currency').data("content"), "€ 100.00", "should display icon money for multi-currency in selection");
+        assert.strictEqual(line0.$('.accounting_view tbody .cell_right').text().replace(/[\n\r\s]+/g, ' '), " $ 130.00 ", "should display the different amounts with the currency in selection");
+        assert.strictEqual(line0.$('.accounting_view tfoot .cell_left').text(), "$\u00a080.00", "should display the total in currency");
+
+        // check and open the second line (in £).
+
+        assert.strictEqual(line1.$('.accounting_view .cell_label:first').text().replace(/[\n\r\s]+/g, ' '), " Second ( $ 70.00) ", "should display the original value currency in head");
+        assert.strictEqual(line1.$('.accounting_view thead .o_multi_currency').data("content"), "£ 50.00", "should display icon money for multi-currency on head");
+        assert.strictEqual(line1.$('.accounting_view tfoot .cell_right').text(), "£\u00a050.00", "should display the total in currency");
+        assert.strictEqual(line1.$('.accounting_view thead .cell_left').text(), "£ 50.00", "should display the value in journal currency in propositions");
+
+        await testUtils.dom.click(line1.$('tfoot td:first'));
+
+        assert.strictEqual(line1.$('.mv_line .o_multi_currency:first').data("content"), "$ 100.00", "should display icon money for multi-currency in propositions");
+        assert.strictEqual(line1.$('.mv_line .o_multi_currency:last').data("content"), "€ 100.00", "should display icon money for multi-currency in propositions");
+        assert.strictEqual(line1.$('.mv_line .cell_right').text().replace(/[\n\r\s]+/g, ' '), " £ 120.00 £ 140.00 ", "should display the different amounts with the currency");
+
+        // add a matched line
+
+        await testUtils.dom.click(line1.$('.match td:last'));
+
+        assert.strictEqual(line1.$('.accounting_view tbody .o_multi_currency').data("content"), "€ 100.00", "should display icon money for multi-currency in selection");
+        assert.strictEqual(line1.$('.accounting_view tbody .cell_right').text().replace(/[\n\r\s]+/g, ' '), " £ 140.00 ", "should display the different amounts with the currency in selection");
+        assert.strictEqual(line1.$('.accounting_view tfoot .cell_left').text(), "£\u00a090.00", "should display the total in currency");
+
+        // open create write-off tab
+
+        await testUtils.dom.click(line1.$('li[data-original-title="Create a counterpart"] a'));
+
+        // select an account with the many2one (drop down)
+        await testUtils.dom.click(line1.$('.create .create_account_id input'));
+        $('.ui-autocomplete .ui-menu-item a:contains(101200)').trigger('mouseenter').trigger('click');
+        await testUtils.nextTick();
+        // insert label
+        await testUtils.fields.editInput(line1.$('.create .create_label input'), 'test');
+        await testUtils.nextTick();
+
+        assert.strictEqual(line1.$('.accounting_view tbody tr:eq(1)').text().replace(/[\n\r\s]+/g, ' '), " 101200​ New test £ 90.00 ", "should add the write-off");
+
+        // reconcile
+
+        await testUtils.dom.click(line1.$('.o_reconcile.btn-primary'));
+
+        clientAction.destroy();
+    });
+
+    QUnit.test('Manual Reconciliation currencies: create write-off', async function (assert) {
+        // see python test: test_02_admin_reconcile_multi_currency_writeoff
+        assert.expect(3);
+
+        var clientAction = new ReconciliationClientAction.ManualAction(null, this.params.options);
+
+        // tweak the data to fit our needs
+        this.params.data_for_manual_reconciliation_widget = {};
+        this.params.data_for_manual_reconciliation_widget["[null,[282,283,284,285,286,287,288,308,309,499,500,501,502,503,504]]"] = {
+            customers: [],
+            suppliers: [],
+            accounts: [
+                {
+                    "partner_id": 13,
+                    "partner_name": "ooo",
+                    "last_time_entries_checked": null,
+                    "account_id": 309,
+                    "account_name": "101402 Bank €",
+                    "account_code": "101402",
+                    "max_date": "2021-08-23 11:12:22",
+                    "currency_id": 5,
+                    "reconciliation_proposition": [],
+                    "mode": "customers",
+                    "company_id": 1
+                },
+            ],
+        };
+        this.params.move_lines_for_manual_reconciliation['[309,13,"",0]'] = [
+            {
+                "id": 320,
+                "name": "BNK1/2021/0001: Customer Payment",
+                "ref": "",
+                "account_id": [309, "101402 Bank €"],
+                "already_paid": false,
+                "account_code": "101402",
+                "account_name": "101402 Bank €",
+                "account_type": "receivable",
+                "date_maturity": "08/23/2021",
+                "date": "08/23/2021",
+                "journal_id": [9, "company 1 journal €"],
+                "partner_id": 13,
+                "partner_name": "partner currency",
+                "currency_id": 5,
+                "recs_count": 2,
+                "debit": 0,
+                "credit": 50,
+                "amount_currency": "",
+                "amount_str": "€ 50.00",
+                "total_amount_str": "€ 50.00",
+                "amount_currency_str": "",
+                "total_amount_currency_str": ""
+            },
+            {
+                "id": 318,
+                "name": "INV/2021/0001",
+                "ref": "",
+                "account_id": [309, "101402 Bank €"],
+                "already_paid": false,
+                "account_code": "101402",
+                "account_name": "101402 Bank €",
+                "account_type": "receivable",
+                "date_maturity": "08/23/2021",
+                "date": "08/23/2021",
+                "journal_id": [9, "company 1 journal €"],
+                "partner_id": 13,
+                "partner_name": "partner currency",
+                "currency_id": 5,
+                "recs_count": 2,
+                "debit": 100,
+                "credit": 0,
+                "amount_currency": "",
+                "amount_str": "€ 100.00",
+                "total_amount_str": "€ 100.00",
+                "amount_currency_str": "",
+                "total_amount_currency_str": ""
+            },
+        ];
+
+        this.params.data_preprocess = {
+            value_min: 0,
+            value_max: 4,
+            notifications: [],
+            num_already_reconciled_lines: 0,
+            st_lines_ids: [9, 10],
+            statement_name: 'BNK/2014/001',
+        };
+
+        testUtils.mock.addMockEnvironment(clientAction, {
+            data: this.params.data,
+            session: {
+                currencies: Object.assign({
+                    5: {
+                        digits: [69, 2],
+                        position: "before",
+                        symbol: "€",
+                    },
+                    7: {
+                        digits: [69, 2],
+                        position: "before",
+                        symbol: "£",
+                    },
+                }, this.params.session.currencies),
+            },
+            archs: {
+                'account.bank.statement.line,false,search': '<search string="Statement Line"><field name="display_name"/></search>',
+            },
+            mockRPC: function (route, args) {
+                if (args.method === 'process_move_lines') {
+                    assert.deepEqual(args.args,
+                        [
+                            [
+                              {
+                                "id": null,
+                                "type": null,
+                                "mv_line_ids": [318, 320],
+                                "new_mv_line_dicts": [
+                                  {
+                                    "account_id": 287,
+                                    "amount_currency": -50,
+                                    "analytic_tag_ids": [[6, null, []]],
+                                    "currency_id": 5,
+                                    "date": args.args[0][0].new_mv_line_dicts[0].date,
+                                    "journal_id": 9,
+                                    "name": "test"
+                                  }
+                                ],
+                              }
+                            ]
+                        ], "should call process_move_lines with the write-off data");
+                }
+
+                return this._super(route, args);
+            },
+        });
+
+        await clientAction.appendTo($('#qunit-fixture'));
+        await testUtils.nextTick();
+
+        // The first reconciliation "line" is where it happens
+        var line0 = clientAction.widgets[0];
+
+        // Add invoice prop & add payment prop
+        await testUtils.dom.click(line0.$('.match:first .cell_account_code:last'));
+        await testUtils.dom.click(line0.$('.match:first .cell_account_code:last'));
+
+        assert.strictEqual(line0.$('.accounting_view tfoot .cell_right').text(), "€\u00a050.00", "should display the total");
+
+        // select an account with the many2one (drop down)
+        await testUtils.dom.click(line0.$('.create .create_account_id input'));
+        $('.ui-autocomplete .ui-menu-item a:contains(101200)').trigger('mouseenter').trigger('click');
+        await testUtils.nextTick();
+        // insert label
+        await testUtils.fields.editInput(line0.$('.create .create_label input'), 'test');
+        await testUtils.nextTick();
+        // select an account with the many2one (drop down)
+        await testUtils.dom.click(line0.$('.create .create_journal_id input'));
+        $('.ui-autocomplete .ui-menu-item a:contains(€)').trigger('mouseenter').trigger('click');
+        await testUtils.nextTick();
+
+        assert.strictEqual(line0.$('.accounting_view tbody tr:last').text().replace(/[\n\r\s]+/g, ' '), " 101200​ New test € 50.00 ", "should add the write-off");
+
+        // reconcile
+
+        await testUtils.dom.click(line0.$('.o_reconcile.btn-primary'));
 
         clientAction.destroy();
     });
@@ -1788,7 +2133,7 @@ QUnit.module('account', {
         assert.expect(5);
 
         // tweak the data to fit our needs
-        this.params.data_for_manual_reconciliation_widget['[283, null, "", 0, 6]'] = _.extend({}, this.params.data_for_manual_reconciliation_widget['[null,[282,283,284,285,286,287,288,308,499,500,501,502,503,504]]']);
+        this.params.data_for_manual_reconciliation_widget['[283, null, "", 0, 6]'] = _.extend({}, this.params.data_for_manual_reconciliation_widget['[null,[282,283,284,285,286,287,288,308,309,499,500,501,502,503,504]]']);
         this.params.data_for_manual_reconciliation_widget['[283, null, "", 0, 6]'].accounts[0].reconciliation_proposition = [
             {account_id: 283, account_type: "other", amount_currency_str: "", currency_id: false, date_maturity: "2017-03-18", date: "2017-02-16",
              total_amount_str: "$ 500.00", partner_id: 8, account_name: "101000 Current Assets", name: "INV/2017/0987", partner_name: "Agrolait",
@@ -1906,7 +2251,7 @@ QUnit.module('account', {
     QUnit.test('Tax on account receivable', async function(assert){
         assert.expect(21);
 
-        this.params.data_for_manual_reconciliation_widget['[null,[282,283,284,285,286,287,288,308,499,500,501,502,503,504]]'].accounts = [];
+        this.params.data_for_manual_reconciliation_widget['[null,[282,283,284,285,286,287,288,308,309,499,500,501,502,503,504]]'].accounts = [];
         var clientAction = new ReconciliationClientAction.ManualAction(null, this.params.options);
         testUtils.mock.addMockEnvironment(clientAction, {
             data: this.params.data,
@@ -1947,16 +2292,33 @@ QUnit.module('account', {
 
                     // Index aiming at the correct object in the list
                     var idx = _.has(args.args[0][0].new_mv_line_dicts[0], 'journal_id') ? 0 : 1;
-                    assert.deepEqual(
-                        _.pick(args.args[0][0].new_mv_line_dicts[idx],
-                               'account_id', 'name', 'credit', 'debit', 'journal_id'),
-                        {account_id: 287, name: "dummy text", credit: 0, debit: 180, journal_id: 8},
+                    assert.deepEqual(args.args[0][0].new_mv_line_dicts[idx], {
+                            "account_id": 287,
+                            "amount_currency": 180,
+                            "analytic_tag_ids": [[6, null, []]],
+                            "currency_id": 3,
+                            "date": args.args[0][0].new_mv_line_dicts[0].date,
+                            "journal_id": 8,
+                            "name": "dummy text",
+                            "tag_ids": [[6, null, [1]]],
+                            "tax_ids": [[6, null, [6]]],
+                        },
                         "Reconciliation rpc payload, new_mv_line_dicts.gift is correct"
                     );
                     assert.deepEqual(
-                        _.pick(args.args[0][0].new_mv_line_dicts[1 - idx],
-                               'account_id', 'name', 'credit', 'debit', 'tax_repartition_line_id'),
-                        {account_id: 287, name: "dummy text Tax 20.00%", credit: 0, debit: 36, tax_repartition_line_id: 2},
+                        args.args[0][0].new_mv_line_dicts[1 - idx], {
+                            "account_id": 287,
+                            "amount_currency": 36,
+                            "analytic_tag_ids": [[6, null, []]],
+                            "currency_id": 3,
+                            "date": args.args[0][0].new_mv_line_dicts[1 - idx].date,
+                            "journal_id": 8,
+                            "name": "dummy text Tax 20.00%",
+                            "tag_ids": [[6, null, [2]]],
+                            "tax_base_amount": -180,
+                            "tax_ids": [[6, null, [6]]],
+                            "tax_repartition_line_id": 2
+                        },
                         "Reconciliation rpc payload, new_mv_line_dicts.tax is correct"
                     );
                 }
@@ -1994,7 +2356,7 @@ QUnit.module('account', {
         assert.verifySteps(["Tax"], "Tax rpc done");
 
         await testUtils.dom.click($reconcileForm.find('.create_journal_id input'),{allowInvisible:true});
-        $('.ui-autocomplete .ui-menu-item a:contains(company 1 journal)').trigger('mouseover').trigger('click');
+        $('.ui-autocomplete .ui-menu-item a:contains(company 1 journal):first').trigger('mouseover').trigger('click');
         await testUtils.nextTick();
         await testUtils.fields.editAndTrigger($reconcileForm.find('.create_label input'),'dummy text','input');
         await testUtils.dom.click($reconcileForm.find('.create_label input'));

--- a/addons/account/static/tests/tours/reconciliation.js
+++ b/addons/account/static/tests/tours/reconciliation.js
@@ -115,4 +115,66 @@ Tour.register('bank_statement_reconciliation', {
     ]
 );
 
+Tour.register('payment_reconciliation', {
+        test: true,
+        // Go to the payments
+    }, [
+        {
+            content: "wait form view",
+            trigger: '.o_list_view .o_data_row td.o_data_cell:contains(test)',
+        },
+
+        {
+            content: "open reconciliation view",
+            trigger: 'button[name="open_payment_matching_screen"]',
+        },
+
+        {
+            content: "add the invoice line",
+            trigger: '.match .cell_account_code:first'
+        },
+        {
+            content: "add the payment line",
+            extra_trigger: '.accounting_view tbody tr .cell_right .line_amount',
+            trigger: '.match .cell_account_code:first'
+        },
+        {
+            content: "create write-off: add label",
+            trigger: '.create .create_label input',
+            run: 'text label test'
+        },
+        {
+            content: "create write-off: open account selection",
+            trigger: '.create .create_account_id input',
+            run: 'text bank test'
+        },
+        {
+            content: "create write-off: select account",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains(bank test)',
+        },
+        {
+            content: "create write-off: open journal selection",
+            trigger: '.create .create_journal_id input',
+            run: 'text journal test',
+        },
+        {
+            content: "create write-off: select journal",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains(journal test)',
+        },
+
+        {
+            content: "click on reconcile",
+            extra_trigger: '.accounting_view tbody tr:last:contains(label test)',
+            trigger: '.o_reconcile.btn-primary'
+        },
+
+        // Be done
+        {
+            content: "check the number off validate lines",
+            trigger: '.o_control_panel .progress-reconciliation:contains(1 / 1)'
+        },
+    ]
+);
+
+
 });

--- a/addons/account/tests/test_reconciliation_widget.py
+++ b/addons/account/tests/test_reconciliation_widget.py
@@ -39,6 +39,270 @@ class TestUi(odoo.tests.HttpCase):
 
 
 @odoo.tests.tagged('post_install', '-at_install')
+@odoo.tests.common.at_install(False)
+@odoo.tests.common.post_install(True)
+class TestUiMultiCurrency(odoo.tests.HttpCase):
+    def setUp(self):
+        super(TestUiMultiCurrency, self).setUp()
+
+        self.swiss_currency = self.env.ref("base.CHF")
+        self.base_currency = self.env.ref("base.USD")
+        self.base_company = self.env.ref('base.main_company')
+
+        self.account_exchange = self.env.ref('l10n_generic_coa.income_currency_exchange')
+
+        # create accounts and journal with swiss currency
+        self.swiss_account_receivable = self.env['account.account'].create({
+            'code': 'test 1000',
+            'name': 'receivable swiss',
+            'reconcile': True,
+            'user_type_id': self.env.ref("account.data_account_type_receivable").id,
+            'currency_id': self.swiss_currency.id,
+        })
+        self.swiss_account_payable = self.env['account.account'].create({
+            'code': 'test 1001',
+            'name': 'payable swiss',
+            'reconcile': True,
+            'user_type_id': self.env.ref("account.data_account_type_payable").id,
+            'currency_id': self.swiss_currency.id,
+        })
+        self.swiss_account_bank = self.env['account.account'].create({
+            'code': 'test 1002',
+            'name': 'bank swiss',
+            'reconcile': True,
+            'user_type_id': self.env.ref("account.data_account_type_liquidity").id,
+            'currency_id': self.swiss_currency.id,
+        })
+        self.swiss_account_income = self.env['account.account'].create({
+            'code': 'test 1003',
+            'name': 'income swiss',
+            'reconcile': True,
+            'user_type_id': self.env.ref("account.data_account_type_direct_costs").id,
+            'currency_id': self.swiss_currency.id,
+        })
+        self.swiss_journal = self.env['account.journal'].create({
+            'name': 'journal swiss',
+            'type': 'sale',
+            'code': 'INV_test',
+            'currency_id': self.swiss_currency.id,
+            'default_credit_account_id': self.swiss_account_bank.id,
+            'default_debit_account_id': self.swiss_account_bank.id,
+        })
+
+        # create partner with swiss accounts
+        self.swiss_partner = self.env['res.partner'].create({
+            'name': 'test',
+            'property_account_receivable_id': self.swiss_account_receivable.id,
+            'property_account_payable_id': self.swiss_account_payable.id,
+        })
+
+    def test_01_admin_reconcile_multi_currency_writeoff_swiss_invoice_swiss_payment(self):
+        # create an invoice in swiss currency
+        invoice = self.env['account.move'].with_context(default_type='out_invoice').create({
+            'type': 'out_invoice',
+            'partner_id': self.swiss_partner.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'product that cost %s' % 100,
+                'quantity': 1,
+                'price_unit': 100,
+                'account_id': self.swiss_account_income.id,
+            })],
+            'currency_id': self.swiss_currency.id,
+            'journal_id': self.swiss_journal.id,
+        })
+        invoice.post()
+
+        self.assertEqual(invoice.amount_total, 100.00)
+
+        # create payment in swiss currency
+        payment = self.env['account.payment'].create({
+            'payment_date': time.strftime('%Y-%m-%d'),
+            'payment_type': 'inbound',
+            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+            'partner_type': 'customer',
+            'partner_id': self.swiss_partner.id,
+            'amount': 50,
+            'journal_id': self.swiss_journal.id,
+            'currency_id': self.swiss_currency.id,
+        })
+        payment.post()
+
+        # To be able to test reconciliation, admin user must have access to accounting features, so we give him the right group for that
+        self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('account.group_account_user').id)]})
+
+        self.swiss_journal.write({'name': 'journal test', 'type': 'general'}) # should be used by the tour
+        self.swiss_account_bank.write({'name': 'bank test'}) # should be used by the tour
+
+        last_line_id = self.env['account.move.line'].search([], order="id desc", limit=1).id
+
+        # called by reconciliation js widget and add the write-off (see js test: "Manual Reconciliation currencies: create write-off")
+        self.start_tour('/web#action=account.action_account_payments', 'payment_reconciliation', login="admin")
+
+        # check move lines
+
+        amount = self.swiss_currency._convert(50.0, self.base_currency, self.base_company, payment.payment_date)
+        write_off_move_lines = self.env['account.move.line'].search([('id', '>=', last_line_id)])
+
+        self.assertRecordValues(
+            write_off_move_lines,
+            [
+                {
+                    'account_id': self.swiss_account_bank.id,
+                    'name': 'label test',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': 50.0,
+                    'debit': amount,
+                    'credit': 0.0,
+                },
+                {
+                    'account_id': self.swiss_account_receivable.id,
+                    'name': 'Write-Off',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': -50.0,
+                    'debit': 0.0,
+                    'credit': amount,
+                },
+                {
+                    'account_id': self.swiss_account_bank.id,
+                    'name': f'CUST.IN/{time.strftime("%Y")}/0001',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': 50.0,
+                    'debit': amount,
+                    'credit': 0.0,
+                },
+                {
+                    'account_id': self.swiss_account_receivable.id,
+                    'name': 'Currency exchange rate difference',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': 0.0,
+                    'debit': 0.01,
+                    'credit': 0.0,
+                },
+                {
+                    'account_id': self.account_exchange.id,
+                    'name': 'Currency exchange rate difference',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': 0.0,
+                    'debit': 0.0,
+                    'credit': 0.01,
+                },
+            ],
+        )
+
+    def test_02_admin_reconcile_multi_currency_writeoff_swiss_invoice_dollar_payment(self):
+        # create partner, account and journal without currency
+        partner = self.env['res.partner'].create({
+            'name': 'test',
+        })
+        account_receivable = self.env.ref('l10n_generic_coa.receivable').id
+        account_bank = self.env['account.account'].create({
+            'code': 'test 1102',
+            'name': 'bank test', # should be used by the tour
+            'reconcile': True,
+            'user_type_id': self.env.ref("account.data_account_type_liquidity").id,
+        })
+        journal = self.env['account.journal'].create({
+            'name': 'journal test', # should be used by the tour
+            'code': 'Bank Test',
+            'type': 'general',
+            'default_debit_account_id': account_bank.id,
+            'default_credit_account_id': account_bank.id,
+        })
+
+        # create an invoice in swiss currency
+        invoice = self.env['account.move'].with_context(default_type='out_invoice').create({
+            'type': 'out_invoice',
+            'partner_id': partner.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'product that cost %s' % 100,
+                'quantity': 1,
+                'price_unit': 100,
+                'account_id': account_bank.id,
+            })],
+            'currency_id': self.swiss_currency.id,
+            'journal_id': self.swiss_journal.id,
+        })
+        invoice.post()
+
+        self.assertEqual(invoice.amount_total, 100.00)
+        self.assertEqual(invoice.currency_id.id, self.swiss_currency.id)
+
+        # create payment in dollar currency
+        payment = self.env['account.payment'].create({
+            'payment_date': time.strftime('%Y-%m-%d'),
+            'payment_type': 'inbound',
+            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+            'partner_type': 'customer',
+            'partner_id': partner.id,
+            'amount': 50.0,
+            'journal_id': journal.id,
+            'currency_id': self.base_currency.id,
+        })
+
+        payment.post()
+
+        # To be able to test reconciliation, admin user must have access to accounting features, so we give him the right group for that
+        self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('account.group_account_user').id)]})
+
+        last_line_id = self.env['account.move.line'].search([], order="id desc", limit=1).id
+
+        # called by reconciliation js widget and add the write-off (see js test: "Manual Reconciliation currencies: create write-off")
+        self.start_tour('/web#action=account.action_account_payments', 'payment_reconciliation', login="admin")
+
+        # check move lines
+
+        invoice_base_amount = self.swiss_currency._convert(100.0, self.base_currency, self.base_company, payment.payment_date)
+        amount = invoice_base_amount - 50.0
+        write_off_move_lines = self.env['account.move.line'].search([('id', '>=', last_line_id)])
+
+        self.assertRecordValues(
+            write_off_move_lines,
+            [
+                {
+                    'account_id': account_receivable,
+                    'name': 'Currency exchange rate difference',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': -0.01,
+                    'debit': 0.0,
+                    'credit': 0.0,
+                },
+                {
+                    'account_id': self.account_exchange.id,
+                    'name': 'Currency exchange rate difference',
+                    'currency_id': self.swiss_currency.id,
+                    'amount_currency': 0.01,
+                    'debit': 0.0,
+                    'credit': 0.0,
+                },
+                {
+                    'account_id': account_bank.id,
+                    'name': 'label test',
+                    'currency_id': False,
+                    'amount_currency': 0.0,
+                    'debit': amount,
+                    'credit': 0.0,
+                },
+                {
+                    'account_id': account_receivable,
+                    'name': 'Write-Off',
+                    'currency_id': False,
+                    'amount_currency': 0.0,
+                    'debit': 0.0,
+                    'credit': amount,
+                },
+                {
+                    'account_id': journal.default_credit_account_id.id,
+                    'name': f'CUST.IN/{time.strftime("%Y")}/0001',
+                    'currency_id': False,
+                    'amount_currency': 0.0,
+                    'debit': 50.0,
+                    'credit': 0.0,
+                },
+            ],
+        )
+
+
+@odoo.tests.tagged('post_install', '-at_install')
 class TestReconciliationWidget(TestReconciliation):
 
     def test_statement_suggestion_other_currency(self):


### PR DESCRIPTION
When reconciling with the widget, for currencies different from that of
the company, the amount was considered to be in the company currency.
Now, the amount sent is associated with the currency.

opw-2527631