### PR TITLE
[FIX] web: Display properly company phone in report

### DIFF
--- a/addons/web/static/src/scss/report.scss
+++ b/addons/web/static/src/scss/report.scss
@@ -14,7 +14,7 @@ body {
 }
 
 span.o_force_ltr {
-    display: inline-block;
+    display: inline;
 }
 .o_force_ltr, .o_field_phone {
     unicode-bidi: embed; // ensure element has level of embedding for direction

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -105,7 +105,7 @@
 }
 
 span.o_force_ltr {
-    display: inline-block;
+    display: inline;
 }
 .o_force_ltr, .o_field_phone {
     unicode-bidi: embed; // ensure element has level of embedding for direction


### PR DESCRIPTION
Steps to reproduce :

  - Install Sales
  - Modify the report, use the theme "Clean" and the font "Open Sans"
  - Modify the company phone to: +41 26 322 01 02
  - Print a quotation

Issue :

  Company phone is on 2 lines

Cause :

  CSS issue with wkhtmltopdf.

Solution :

  Replace css display value `inline-block` by `inline`.

opw-2567836
