### PR TITLE
Fix none type session token issue

### DIFF
--- a/doc/cla/individual/AleksanderVall.md
+++ b/doc/cla/individual/AleksanderVall.md
@@ -1,0 +1,9 @@
+Estonia, 2021-08-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Aleksander Vall aleksander.vall@eesti.ee https://github.com/aleksandervall/

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -22,7 +22,7 @@ def compute_session_token(session, env):
 def check_session(session, env):
     self = env['res.users'].browse(session.uid)
     expected = self._compute_session_token(session.sid)
-    if expected and odoo.tools.misc.consteq(expected, session.session_token):
+    if expected and odoo.tools.misc.consteq(expected, session.session_token or ''):
         return True
     self._invalidate_session_cache()
     return False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
https://www.odoo.com/es_ES/forum/ayuda-1/403-forbidden-166545

Current behavior before PR:
HTTP requests with NoneType session token gives error 403 to users and they need to delete cookies or use browser incognito mode to be able to log in again.

Desired behavior after PR is merged:
This fix will handle HTTP requests with NoneType session token by redirecting users to Odoo login page.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
