### PR TITLE
[FIX] hr_recruitment : no template response when receiving appl. mail

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -420,6 +420,9 @@ class Applicant(models.Model):
         # want the gateway user to be responsible if no other responsible is
         # found.
         self = self.with_context(default_user_id=False)
+        stage = False
+        if custom_values and 'job_id' in custom_values:
+            stage = self.env['hr.job'].browse(custom_values['job_id'])._get_first_stage()
         val = msg.get('from').split('<')[0]
         defaults = {
             'name': msg.get('subject') or _("No Subject"),
@@ -429,6 +432,8 @@ class Applicant(models.Model):
         }
         if msg.get('priority'):
             defaults['priority'] = msg.get('priority')
+        if stage and stage.id:
+            defaults['stage_id'] = stage.id
         if custom_values:
             defaults.update(custom_values)
         return super(Applicant, self).message_new(msg, custom_values=defaults)


### PR DESCRIPTION
Issue: When receiving a mail on a alias for a job position, the
application is created correctly in the right stage but the e-mail
template for that stage is not sent to the applicant

Steps to reproduce :
 1) Set an alias and a external mail server
 2) Configure incoming mail server
 3) Create a job position with a mail alias and a email template
 4) Receive a mail for that job position
 5) The application is created but no mail is sent to the applicant

Why is that a bug:
 When we create an application manually the mail is sent to the
 applicant but when creating it via e-mail reception, it's not sent
 even though it should. This is due to stage_id missing from the flow
 when receiving an e-mail

opw-2533310