### PR TITLE
[IMP] crm: my activities menu accessed by all crm user

### DIFF
--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -28,7 +28,7 @@
         id="crm_lead_menu_my_activities"
         name="My Activities"
         parent="crm_menu_sales"
-        groups="sales_team.group_sale_manager"
+        groups="sales_team.group_sale_salesman"
         sequence="2"/>
 
     <menuitem


### PR DESCRIPTION
PURPOSE

The "My Activities" feature of CRM can be accessible by all CRM users.
The purpose of this commit is to 'Own Documents Only' users can
access the "My Activities" feature.

SPECIFICATIONS

Currently, the 'My Activities' menu of CRM is accessible only by Sales Admins.
This will change the menu accessibility, 'Own Documents Only' users 
can access this menu and see their activities.

This is the goal of this commit.

LINKS
PR #75521
Task-2624721

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
