### PR TITLE
14.0 x2m no open las

### DIFF
--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -38,12 +38,14 @@
                     </div>
                 </xpath>
                 <xpath expr="//div[@name='journal_div']" position="after">
-                    <field name="edi_document_ids" invisible="1" />
                     <field name="edi_state" attrs="{'invisible': ['|', ('edi_state', '=', False), ('state', '=', 'draft')]}"/>
                 </xpath>
                 <xpath expr="//page[@id='other_tab']" position="after">
-                    <page id="edi_documents" string="EDI Documents" groups="base.group_no_one" attrs="{'invisible': [('edi_document_ids', '=', [])]}">
-                        <field name="edi_document_ids">
+                    <page id="edi_documents"
+                          string="EDI Documents"
+                          groups="base.group_no_one"
+                          attrs="{'invisible': [('edi_document_ids', '=', [])]}">
+                        <field name="edi_document_ids" options="{'no_open': '1'}">
                             <tree create="false" delete="false" edit="false" decoration-danger="error">
                                 <field name="name"/>
                                 <field name="edi_format_name"/>

--- a/addons/account_edi/views/account_payment_views.xml
+++ b/addons/account_edi/views/account_payment_views.xml
@@ -30,12 +30,15 @@
                     </div>
                 </xpath>
                 <xpath expr="//field[@name='journal_id']" position="after">
-                    <field name="edi_document_ids" invisible="1" />
                     <field name="edi_state" attrs="{'invisible': ['|', ('edi_state', '=', False), ('state', '=', 'draft')]}"/>
                 </xpath>
                 <xpath expr="//group[@name='group3']" position="after">
                     <group groups="base.group_no_one">
-                        <field name="edi_document_ids" string="EDI Documents" attrs="{'invisible': [('edi_document_ids', '=', [])]}">
+                        <field name="edi_document_ids"
+                               string="EDI Documents"
+                               groups="base.group_no_one"
+                               options="{'no_open': '1'}"
+                               attrs="{'invisible': [('edi_document_ids', '=', [])]}">
                             <tree create="false" delete="false" edit="false" decoration-danger="error">
                                 <field name="name"/>
                                 <field name="edi_format_name"/>

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1909,6 +1909,9 @@ var FieldOne2Many = FieldX2Many.extend({
         }
     },
     /**
+     * Trigger the event to open a dialog containing the corresponding Form view for the current record.
+     * If the options 'no_open' is specified, the dialog will not be opened.
+     *
      * @private
      * @param {Object} params
      * @param {Object} [params.context] We allow additional context, this is
@@ -1920,6 +1923,11 @@ var FieldOne2Many = FieldX2Many.extend({
             this.recordParams,
             { additionalContext: params.context }
         ));
+
+        if (this.nodeOptions.no_open) {
+            return;
+        }
+
         this.trigger_up('open_one2many_record', _.extend(params, {
             domain: this.record.getDomain(this.recordParams),
             context: context,


### PR DESCRIPTION
**[IMP] web: Manage 'no_open' options for x2many fields**

options="{'no_open': '1'}" is managed for many2one fields.
This commit aims to do the same for x2many fields.

**[FIX] account_edi: Prevent opening the EDI documents in any case**

Also, remove the duplicated 'edi_document_ids' field inside the view.
'edi_document_ids' is now in debug mode for payments.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
