### PR TITLE
[IMP] calendar: improve mail.activities meetings management

### DIFF
--- a/addons/calendar/__manifest__.py
+++ b/addons/calendar/__manifest__.py
@@ -39,6 +39,8 @@ If you need to manage your meetings, you should install the CRM module.
     'auto_install': False,
     'assets': {
         'web.assets_backend': [
+            'calendar/static/src/models/activity/activity.js',
+            'calendar/static/src/components/activity/activity.js',
             'calendar/static/src/scss/calendar.scss',
             'calendar/static/src/js/base_calendar.js',
             'calendar/static/src/js/calendar_renderer.js',
@@ -53,6 +55,7 @@ If you need to manage your meetings, you should install the CRM module.
         ],
         'web.assets_qweb': [
             'calendar/static/src/xml/base_calendar.xml',
+            'calendar/static/src/components/activity/activity.xml',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/calendar/static/src/components/activity/activity.js
+++ b/addons/calendar/static/src/components/activity/activity.js
@@ -1,0 +1,35 @@
+/** @odoo-module */
+
+import { Activity } from '@mail/components/activity/activity';
+import { patch } from 'web.utils';
+import Dialog from 'web.Dialog';
+import core from 'web.core';
+const _t = core._t;
+
+patch(Activity.prototype, 'calendar/static/src/components/activity/activity.js', {
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Small override that asks for confirmation in case there is a meeting linked to this activity.
+     *
+     * @override
+     */
+    _onClickCancel(ev) {
+        const superMethod = this._super;
+        if (!this.activity.calendar_event_id){
+            this._super(ev);
+        } else {
+            Dialog.confirm(
+                this,
+                _t("The activity is linked to a meeting. Deleting it will remove the meeting as well. Do you want to proceed ?"), {
+                    confirm_callback: function () {
+                        superMethod(ev);
+                    },
+                }
+            );
+        }
+    }
+
+});

--- a/addons/calendar/static/src/components/activity/activity.xml
+++ b/addons/calendar/static/src/components/activity/activity.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-inherit="mail.Activity" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('o_Activity_editButton')]" position="attributes">
+            <attribute name="t-if">!activity.calendar_event_id</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('o_Activity_editButton')]" position="after">
+            <t t-if="activity.calendar_event_id">
+                <button class="o_Activity_toolButton o_Activity_editButton btn btn-link" t-on-click="_onClickEdit">
+                    <i class="fa fa-calendar"/> Reschedule
+                </button>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/calendar/static/src/models/activity/activity.js
+++ b/addons/calendar/static/src/models/activity/activity.js
@@ -1,0 +1,63 @@
+/** @odoo-module **/
+
+import {
+    registerClassPatchModel,
+    registerInstancePatchModel,
+    registerFieldPatchModel
+} from'@mail/model/model_core';
+import { attr } from '@mail/model/model_field';
+
+registerFieldPatchModel('mail.activity', 'calendar/static/src/models/activity/activity.js', {
+    calendar_event_id: attr({ default: false }),
+});
+
+registerClassPatchModel('mail.activity', 'calendar/static/src/models/activity/activity.js', {
+    /**
+     * @override
+     */
+    convertData(data) {
+        const res = this._super(data);
+        if ('calendar_event_id' in data) {
+            res.calendar_event_id = data.calendar_event_id[0];
+        }
+        return res;
+    },
+});
+
+registerInstancePatchModel('mail.activity', 'calendar/static/src/models/activity/activity.js', {
+    /**
+     * @override
+     */
+    async deleteServerRecord() {
+        if (!this.calendar_event_id){
+            await this._super();
+        } else {
+            await this.async(() => this.env.services.rpc({
+                model: 'mail.activity',
+                method: 'unlink_w_meeting',
+                args: [[this.id]],
+            }));
+            this.delete();
+        }
+    },
+
+    /**
+     * In case the activity is linked to a meeting, we want to open the calendar view instead.
+     *
+     * @override
+     */
+    async edit() {
+        if (!this.calendar_event_id){
+            this._super();
+        } else {
+            const action = await this.async(() => this.env.services.rpc({
+                model: 'mail.activity',
+                method: 'action_create_calendar_event',
+                args: [[this.id]],
+            }));
+            this.env.bus.trigger('do-action', {
+                action
+            });
+        }
+    }
+});

--- a/addons/calendar/views/mail_activity_views.xml
+++ b/addons/calendar/views/mail_activity_views.xml
@@ -12,21 +12,21 @@
             <xpath expr="//field[@name='user_id']" position="attributes">
                   <attribute name="attrs">{'invisible': [('activity_category', '=', 'meeting')]}</attribute>
             </xpath>
-            <xpath expr="//button[@name='action_close_dialog']" position="attributes">
-                  <attribute name="attrs">{'invisible': ['|', ('activity_category', '=', 'meeting'), ('id', '!=', False)]}</attribute>
+            <xpath expr="//button[@id='mail_activity_schedule']" position="attributes">
+                  <attribute name="attrs">{'invisible': ['|', ('activity_category', 'in', ['meeting', 'phonecall']), ('id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//button[@id='mail_activity_save']" position="attributes">
+                  <attribute name="attrs">{'invisible': [('activity_category', '!=', 'phonecall'), ('id', '=', False)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_done']" position="attributes">
                   <attribute name="attrs">{'invisible': ['|', ('activity_category', '=', 'meeting'), ('chaining_type', '=', 'trigger')]}</attribute>
-            </xpath>
-            <xpath expr="//button[@special='cancel']" position="attributes">
-                  <attribute name="attrs">{'invisible': [('activity_category', '=', 'meeting')]}</attribute>
             </xpath>
             <xpath expr="//field[@name='note']" position="attributes">
                   <attribute name="attrs">{'invisible': [('activity_category', '=', 'meeting')]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_close_dialog']" position="before">
                 <button string="Open Calendar"
-                    attrs="{'invisible': [('activity_category', '!=', 'meeting')]}"
+                    attrs="{'invisible': ['|', ('activity_category', 'not in', ['meeting', 'phonecall']), ('id', '!=', False)]}"
                     name="action_create_calendar_event"
                     type="object"
                     class="btn-primary"/>

--- a/addons/crm/data/mail_activity_demo.xml
+++ b/addons/crm/data/mail_activity_demo.xml
@@ -12,11 +12,13 @@
         <field name="res_model">crm.lead</field>
         <field name="delay_count">15</field>
     </record>
+
     <record id="mail_activity_demo_call_demo" model="mail.activity.type">
         <field name="name">Call for Demo</field>
         <field name="icon">fa-phone</field>
         <field name="res_model">crm.lead</field>
         <field name="delay_count">10</field>
+        <field name="category">phonecall</field>
     </record>
 
     <record id="mail_activity_type_demo_email_with_template" model="mail.activity.type">

--- a/addons/crm/models/__init__.py
+++ b/addons/crm/models/__init__.py
@@ -15,3 +15,4 @@ from . import digest
 from . import crm_lead_scoring_frequency
 from . import utm
 from . import crm_recurring_plan
+from . import mail_activity

--- a/addons/crm/models/mail_activity.py
+++ b/addons/crm/models/mail_activity.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class MailActivity(models.Model):
+    _inherit = "mail.activity"
+
+    def action_create_calendar_event(self):
+        """ Small override of the action that creates a calendar.
+
+        If the activity is linked to a crm.lead through the "opportunity_id" field, we include in
+        the action context the default values used when scheduling a meeting from the crm.lead form
+        view.
+        e.g: It will set the partner_id of the crm.lead as default attendee of the meeting. """
+
+        action = super(MailActivity, self).action_create_calendar_event()
+        opportunity = self.calendar_event_id.opportunity_id
+        if opportunity:
+            opportunity_action_context = opportunity.action_schedule_meeting(smart_calendar=False).get('context', {})
+            opportunity_action_context['initial_date'] = self.calendar_event_id.start
+
+            action['context'].update(opportunity_action_context)
+
+        return action

--- a/addons/mail/data/mail_activity_data.xml
+++ b/addons/mail/data/mail_activity_data.xml
@@ -9,6 +9,7 @@
         <record id="mail_activity_data_call" model="mail.activity.type">
             <field name="name">Call</field>
             <field name="icon">fa-phone</field>
+            <field name="category">phonecall</field>
             <field name="delay_count">2</field>
             <field name="sequence">6</field>
         </record>

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -63,7 +63,9 @@ class MailActivityType(models.Model):
         domain="['|', ('res_model', '=', False), ('res_model', '=', res_model)]",
         string='Preceding Activities')
     category = fields.Selection([
-        ('default', 'None'), ('upload_file', 'Upload Document')
+        ('default', 'None'),
+        ('upload_file', 'Upload Document'),
+        ('phonecall', 'Phonecall')
     ], default='default', string='Action',
         help='Actions may trigger specific behavior like opening calendar view or automatically mark as done when a document is uploaded')
     mail_template_ids = fields.Many2many('mail.template', string='Email templates')

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -129,9 +129,9 @@
                     <field name="note" placeholder="Log a note..."/>
                     <footer>
                         <field name="id" invisible="1"/>
-                        <button string="Schedule" name="action_close_dialog" type="object" class="btn-primary"
+                        <button id="mail_activity_schedule" string="Schedule" name="action_close_dialog" type="object" class="btn-primary"
                             attrs="{'invisible': [('id', '!=', False)]}" data-hotkey="q"/>
-                        <button string="Save" name="action_close_dialog" type="object" class="btn-primary"
+                        <button id="mail_activity_save" string="Save" name="action_close_dialog" type="object" class="btn-primary"
                             attrs="{'invisible': [('id', '=', False)]}" data-hotkey="q"/>
                         <button attrs="{'invisible': [('chaining_type', '=', 'trigger')]}" string="Mark as Done" name="action_done"
                             type="object" class="btn-secondary" data-hotkey="w"


### PR DESCRIPTION
Before this commit, editing a mail.activity with the "meeting" category would
open a modal form for the mail.activity, which did not make much sense.

When editing a mail.activity that is linked to a calendar.event, you will now
jump on the calendar view to edit the related event, which is much more
convenient.

In addition, when scheduling such an activity, the "Edit" button in the chatter
is renamed to "Reschedule", to show the user that he will land on the calendar
view.

Furthermore, trying to delete an activity that is linked to a meeting will now
prompt a confirmation dialog warning the user that the meeting will be deleted
as well.

Finally, we moved the 'phonecall' activity category from the 'voip' module
(enterprise) to the base 'mail' module.
Scheduling a phonecall activity will let the user choose if he wants to:
- Simply save the activity, which will schedule a regular mail.activity
- Open the calendar to create a related calendar.event
  Used typically when you want your colleagues to see that you are busy in your
  calendar during this call.

Task-2486126
COM PR odoo/odoo#
