### PR TITLE
[FIX] stock_landed_cost : traceback division by 0 when no quantity

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -199,7 +199,7 @@ class StockLandedCost(models.Model):
 
         for move in self._get_targeted_move_ids():
             # it doesn't make sense to make a landed cost for a product that isn't set as being valuated in real time at real cost
-            if move.product_id.valuation != 'real_time' or move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel':
+            if move.product_id.valuation != 'real_time' or move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel' or not move.product_qty:
                 continue
             vals = {
                 'product_id': move.product_id.id,


### PR DESCRIPTION
Issue: When computing the landed cost for a transfer with quantity 0,
the validation of the LC wasn't working since there was a quantity 0

Steps to reproduce :
 1) Create a PO for some items
 2) Confirm, validate the delivery
 3) Edit and unlock the delivery, set one quantity to 0, save
 4) Create a landed cost for that transfer
 5) Compute it
 6) Validate -> Traceback

Why is that a bug:
 There should not be a traceback, this is caused by trying to validate
 a landed cost for a product where there is no quantity, if there is no
 quantity, it should be part of the landed cost computation

opw-2599799