### PR TITLE
[FIX] account_fleet: export multiple fleet_vehicle moves


### DIFF
--- a/addons/account_fleet/models/fleet_vehicle.py
+++ b/addons/account_fleet/models/fleet_vehicle.py
@@ -17,7 +17,7 @@ class FleetVehicle(models.Model):
             return
 
         for vehicle in self:
-            vehicle.account_move_ids = self.env['account.move.line'].search([('vehicle_id', '=', self.id), ('move_id.state', '!=', 'cancel')]).move_id
+            vehicle.account_move_ids = self.env['account.move.line'].search([('vehicle_id', '=', vehicle.id), ('move_id.state', '!=', 'cancel')]).move_id
             vehicle.bill_count = len(vehicle.account_move_ids)
 
     def action_view_bills(self):


### PR DESCRIPTION

The compute field for fleet_vehicle().account_move_ids can be using
self.id where self might be a recordset with more than one record.

opw-2630226
