### PR TITLE
[FIX] account: label instead of description on invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3188,7 +3188,7 @@ class AccountMoveLine(models.Model):
     account_internal_group = fields.Selection(related='account_id.user_type_id.internal_group', string="Internal Group", readonly=True)
     account_root_id = fields.Many2one(related='account_id.root_id', string="Account Root", store=True, readonly=True)
     sequence = fields.Integer(default=10)
-    name = fields.Char(string='Label', tracking=True)
+    name = fields.Char(string='Description', tracking=True)
     quantity = fields.Float(string='Quantity',
         default=1.0, digits='Product Unit of Measure',
         help="The optional quantity expressed by this line, eg: number of product sold. "


### PR DESCRIPTION
Up to v.12.0, product description column on invoices was named Description, as it was and currently is on SO, quotations, RFQ etc.
Now invoices are journal entries, so the column name changed into Label.
If a user adds a new invoice line (w/o selecting a product), he'd expect to enter a "Description of the line" not a "Label" of the line. This fix restores the original term.

Description of the issue/feature this PR addresses:

Fix #75420 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
