### PR TITLE
[FIX] base: restore delivery and shipping image on contact in kanban

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -238,23 +238,23 @@ class Partner(models.Model):
         ('check_name', "CHECK( (type='contact' AND name IS NOT NULL) or (type!='contact') )", 'Contacts require a name'),
     ]
 
-    @api.depends('name', 'user_ids.share', 'image_1920', 'is_company')
+    @api.depends('name', 'user_ids.share', 'image_1920', 'is_company', 'type')
     def _compute_avatar_1920(self):
         super()._compute_avatar_1920()
 
-    @api.depends('name', 'user_ids.share', 'image_1024', 'is_company')
+    @api.depends('name', 'user_ids.share', 'image_1024', 'is_company', 'type')
     def _compute_avatar_1024(self):
         super()._compute_avatar_1024()
 
-    @api.depends('name', 'user_ids.share', 'image_512', 'is_company')
+    @api.depends('name', 'user_ids.share', 'image_512', 'is_company', 'type')
     def _compute_avatar_512(self):
         super()._compute_avatar_512()
 
-    @api.depends('name', 'user_ids.share', 'image_256', 'is_company')
+    @api.depends('name', 'user_ids.share', 'image_256', 'is_company', 'type')
     def _compute_avatar_256(self):
         super()._compute_avatar_256()
 
-    @api.depends('name', 'user_ids.share', 'image_128', 'is_company')
+    @api.depends('name', 'user_ids.share', 'image_128', 'is_company', 'type')
     def _compute_avatar_128(self):
         super()._compute_avatar_128()
 
@@ -268,6 +268,10 @@ class Partner(models.Model):
         path = "base/static/img/avatar_grey.png"
         if self.is_company:
             path = "base/static/img/company_image.png"
+        elif self.type == 'delivery':
+            path = "base/static/img/truck.png"
+        elif self.type == 'invoice':
+            path = "base/static/img/money.png"
         return base64.b64encode(tools.file_open(path, 'rb').read())
 
     @api.depends('is_company', 'name', 'parent_id.display_name', 'type', 'company_name')

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -254,6 +254,7 @@
                                     <field name="mobile"/>
                                     <field name="state_id"/>
                                     <field name="image_128"/>
+                                    <field name="avatar_128"/>
                                     <field name="lang"/>
                                     <!-- fields in form x2many view to diminish requests -->
                                     <field name="comment"/>
@@ -263,15 +264,7 @@
                                             <t t-set="color" t-value="kanban_color(record.color.raw_value)"/>
                                             <div t-att-class="color + (record.title.raw_value == 1 ? ' oe_kanban_color_alert' : '') + ' oe_kanban_global_click'">
                                                 <div class="o_kanban_image">
-                                                    <img alt="Contact image" t-if="record.image_128.raw_value" t-att-src="kanban_image('res.partner', 'image_128', record.id.raw_value)"/>
-                                                    <t t-if="!record.image_128.raw_value">
-                                                        <img alt="Delivery" t-if="record.type.raw_value === 'delivery'" t-att-src='_s + "/base/static/img/truck.png"'/>
-                                                        <img alt="Invoice" t-if="record.type.raw_value === 'invoice'" t-att-src='_s + "/base/static/img/money.png"'/>
-                                                        <t t-if="record.type.raw_value !== 'invoice' &amp;&amp; record.type.raw_value !== 'delivery'">
-                                                            <img alt="Logo" t-if="record.is_company.raw_value === true" t-att-src='_s + "/base/static/img/company_image.png"'/>
-                                                            <img alt="Avatar" t-if="record.is_company.raw_value === false" t-att-src='_s + "/base/static/img/avatar_grey.png"'/>
-                                                        </t>
-                                                    </t>
+                                                    <img alt="Contact image"  t-att-src="kanban_image('res.partner', 'avatar_128', record.id.raw_value)"/>
                                                 </div>
                                                 <div class="oe_kanban_details">
                                                     <field name="name"/>
@@ -464,19 +457,16 @@
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_res_partner_kanban">
                                 <t t-if="!record.is_company.raw_value">
-                                    <t t-if="record.type.raw_value === 'delivery'" t-set="placeholder" t-value="'/base/static/img/truck.png'"/>
-                                    <t t-elif="record.type.raw_value === 'invoice'" t-set="placeholder" t-value="'/base/static/img/money.png'"/>
-                                    <t t-else="" t-set="placeholder" t-value="'/base/static/img/avatar_grey.png'"/>
-                                    <div class="o_kanban_image_fill_left d-none d-md-block" t-attf-style="background-image:url('#{kanban_image('res.partner', 'avatar_128', record.id.raw_value,  placeholder)}')">
+                                    <t t-set="background_image" t-value="kanban_image('res.partner', 'avatar_128', record.id.raw_value)"/>
+                                    <div class="o_kanban_image_fill_left d-none d-md-block" t-attf-style="background-image:url('#{background_image}')">
                                         <img class="o_kanban_image_inner_pic" t-if="record.parent_id.raw_value" t-att-alt="record.parent_id.value" t-att-src="kanban_image('res.partner', 'avatar_128', record.parent_id.raw_value)"/>
                                     </div>
-                                    <div class="o_kanban_image d-md-none" t-attf-style="background-image:url('#{kanban_image('res.partner', 'avatar_128', record.id.raw_value,  placeholder)}')">
+                                    <div class="o_kanban_image d-md-none" t-attf-style="background-image: url(#{background_image})">
                                         <img class="o_kanban_image_inner_pic" t-if="record.parent_id.raw_value" t-att-alt="record.parent_id.value" t-att-src="kanban_image('res.partner', 'avatar_128', record.parent_id.raw_value)"/>
                                     </div>
                                 </t>
                                 <t t-else="">
-                                    <t t-set="placeholder" t-value="'/base/static/img/company_image.png'"/>
-                                    <div class="o_kanban_image_fill_left o_kanban_image_full" t-attf-style="background-image: url(#{kanban_image('res.partner', 'avatar_128', record.id.raw_value, placeholder)})" role="img"/>
+                                    <div class="o_kanban_image_fill_left o_kanban_image_full" t-attf-style="background-image: url(#{kanban_image('res.partner', 'avatar_128', record.id.raw_value)})" role="img"/>
                                 </t>
                                 <div class="oe_kanban_details d-flex flex-column">
                                     <strong class="o_kanban_record_title oe_partner_heading"><field name="display_name"/></strong>


### PR DESCRIPTION
Since c53724ebc35150d, the contact image in contact kanban view for a shipping
or delivery contact type would be the regular placeholder instead of the truck
or money image.
