### PR TITLE
[FIX] mrp_account: wrong price if bom line in different UoM

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -50,11 +50,11 @@ class ProductProduct(models.Model):
         dummy, bom_lines = bom.explode(self, 1)
         bom_lines = {line: data for line, data in bom_lines}
         value = 0
-        for move in stock_moves:
+        for move in stock_moves.filtered(lambda x: x.state != 'cancel'):
             bom_line = move.bom_line_id
             if bom_line:
                 bom_line_data = bom_lines[bom_line]
-                line_qty = bom_line_data['qty']
+                line_qty = bom_line.product_uom_id._compute_quantity(bom_line_data['qty'], bom_line.product_id.uom_id)
             else:
                 # bom was altered (i.e. bom line removed) after being used
                 line_qty = move.product_qty


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- Create a Product A with compute cost by FIFO
- Create a Product B with compute cost by FIFO and cost of 10
- Create a BOM of product A, type is Kit
- Add product B in bom line, with qty = 1 and UoM = douzein
- Compute cost from bom of product A (it is 10*12 = 120)
- Add product A in sale.order, the cost of the line is 120
- Confirm order
--> Issue the cost is now 10.

https://user-images.githubusercontent.com/16716992/130666128-ad10ccc3-f168-4e35-98e6-5eb54a7f5199.mov

@tde-banana-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
