### PR TITLE
[FIX] sale: dont't show section/note in report

### DIFF
--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -148,7 +148,7 @@ class SaleReport(models.Model):
         if not fields:
             fields = {}
         with_ = ("WITH %s" % with_clause) if with_clause else ""
-        return '%s (SELECT %s FROM %s GROUP BY %s)' % \
+        return '%s (SELECT %s FROM %s WHERE l.display_type IS NULL GROUP BY %s)' % \
                (with_, self._select_sale(fields), self._from_sale(from_clause), self._group_by_sale(groupby))
 
     def init(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create sale order with section and note
- Go to Sale Analysis
--> Issue : you see count of section and note

![image](https://user-images.githubusercontent.com/16716992/130667857-2b17f563-1d3e-43d0-acd7-b93690ae2699.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
