### PR TITLE
[FIX] stock_account: ignore correction svls of origin move

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -675,7 +675,7 @@ class ProductProduct(models.Model):
             candidate_quantity = abs(candidate.quantity)
             if candidate.stock_move_id.id in returned_quantities:
                 candidate_quantity -= returned_quantities[candidate.stock_move_id.id]
-            if float_is_zero(candidate_quantity, precision_rounding=candidate.uom_id.rounding):
+            if float_is_zero(candidate.quantity, precision_rounding=candidate.uom_id.rounding):
                 continue  # correction entries
             if not float_is_zero(qty_invoiced, precision_rounding=candidate.uom_id.rounding):
                 qty_ignored = min(qty_invoiced, candidate_quantity)


### PR DESCRIPTION
to avoid division by zero.

Before this commit in a case when current move is a return
and origin move has correction layers with some value and zero quantity
such layers were not ignored bacause candidate's quantity was deducted
by returned quantity and was not zero any more.

fixes commit: 3831649


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
