### PR TITLE
[FIX] account: reference correct move type field for tax group

### DIFF
--- a/addons/account/static/src/js/tax_group.js
+++ b/addons/account/static/src/js/tax_group.js
@@ -37,7 +37,7 @@ odoo.define('account.tax_group', function (require) {
                 let creditAmount = 0;
                 let amount_currency = 0;
                 if (line_id.data.currency_id) { // If multi currency enable
-                    if (self.record.data.move_type === "in_invoice") {
+                    if (self.record.data.type === "in_invoice") {
                         amount_currency = line_id.data.amount_currency - deltaAmount;
                     } else {
                         amount_currency = line_id.data.amount_currency + deltaAmount;
@@ -45,7 +45,7 @@ odoo.define('account.tax_group', function (require) {
                 } else {
                     let balance = line_id.data.price_subtotal;
                     balance -= deltaAmount;
-                    if (self.record.data.move_type === "in_invoice") { // For vendor bill
+                    if (self.record.data.type === "in_invoice") { // For vendor bill
                         if (balance > 0) {
                             debitAmount = balance;
                         } else if (balance < 0) {

--- a/doc/cla/individual/njmaeff.md
+++ b/doc/cla/individual/njmaeff.md
@@ -1,0 +1,11 @@
+Canada, 2021-08-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Nik Jmaeff nik@jmaeff.me https://github.com/njmaeff


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- The `move_type` property is undefined, and we miss the `in_invoice` branch condition. You can reproduce this issue by creating a vendor bill and editing the tax amount manually. The error is most noticeable when the account move does not have a `currency_id` set. If you manually edit the tax amount, it will invert the value to a negative tax.

Current behavior before PR:
- We completely miss the `in_invoice` branch condition resulting in the incorrect debit/credit amounts on tax journal items when manually editing the tax.

Desired behavior after PR is merged:
- We hit the correct branch, and debit/credit amounts are correct on tax journal items.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
