### PR TITLE
[IMP] sale_project: move project stat button on SO

### DIFF
--- a/addons/hr_contract/data/hr_contract_demo.xml
+++ b/addons/hr_contract/data/hr_contract_demo.xml
@@ -18,6 +18,17 @@
         <field name="kanban_state">normal</field>
     </record>
 
+    <record id="hr_contract_admin_new" model="hr.contract">
+        <field name="name">Contract For Mitchell Admin</field>
+        <field name="date_start" eval="time.strftime('%Y-%m')+'-1'"/>
+        <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
+        <field name="structure_type_id" ref="hr_contract.structure_type_employee"/>
+        <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="notes">This is Mitchell Admin's contract</field>
+        <field eval="5500.0" name="wage"/>
+        <field name="state">open</field>
+    </record>
+
     <record id="hr_contract_al" model="hr.contract">
         <field name="name">Ronnie Hart Contract</field>
         <field name="date_start" eval="time.strftime('%Y')+'-1-1'"/>

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -108,6 +108,7 @@ class Contract(models.Model):
             domain = [
                 ('id', '!=', contract.id),
                 ('employee_id', '=', contract.employee_id.id),
+                ('company_id', '=', contract.company_id.id),
                 '|',
                     ('state', 'in', ['open', 'close']),
                     '&',
@@ -124,7 +125,12 @@ class Contract(models.Model):
 
             domain = expression.AND([domain, start_domain, end_domain])
             if self.search_count(domain):
-                raise ValidationError(_('An employee can only have one contract at the same time. (Excluding Draft and Cancelled contracts)'))
+                raise ValidationError(
+                    _(
+                        'An employee can only have one contract at the same time. (Excluding Draft and Cancelled contracts).\n\nEmployee: %(employee_name)s',
+                        employee_name=contract.employee_id.name
+                    )
+                )
 
     @api.constrains('date_start', 'date_end')
     def _check_dates(self):

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -5,17 +5,18 @@
         <field name="name">sale.order.form.sale.project</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="priority">10</field>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_view_invoice']" position="before">
-                <button type="object" name="action_view_task" class="oe_stat_button" icon="fa-tasks" attrs="{'invisible': [('tasks_count', '=', 0)]}" groups="project.group_project_user">
-                    <field name="tasks_count" widget="statinfo" string="Tasks"/>
-                </button>
+            <xpath expr="//button[@name='preview_sale_order']" position="before">
                 <button type="object" name="action_view_project_ids" class="oe_stat_button" icon="fa-puzzle-piece" attrs="{'invisible': ['|', ('project_ids', '=', []), ('project_overview', '=', True)]}" groups="project.group_project_manager">
                     <field name="project_ids" invisible="1"/>
                     <field name="project_overview" invisible="1"/>
                     <field name="project_count" widget="statinfo" string="Projects"/>
                 </button>
                 <button type="object" name="action_view_project_ids" class="oe_stat_button" icon="fa-puzzle-piece" string="Project Overview" attrs="{'invisible': ['|', ('project_ids', '=', []), ('project_overview', '=', False)]}" groups="project.group_project_manager"/>
+                <button type="object" name="action_view_task" class="oe_stat_button" icon="fa-tasks" attrs="{'invisible': [('tasks_count', '=', 0)]}" groups="project.group_project_user">
+                    <field name="tasks_count" widget="statinfo" string="Tasks"/>
+                </button>
             </xpath>
             <xpath expr="//field[@name='analytic_account_id']" position="after">
                 <field name="visible_project" invisible="1"/>


### PR DESCRIPTION
Prior to this PR, the project and task stat buttons were placed
before the invoice one.

After this PR, the project stat button will be placed before the
tasks stat button which will be before the sale order preview.

task-2559061

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
