### PR TITLE
[IMP] mrp: kits revamp

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPickingType(models.Model):
@@ -52,6 +52,13 @@ class StockPickingType(models.Model):
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
+
+    has_kits = fields.Boolean(compute='_compute_has_kits')
+
+    @api.depends('move_lines')
+    def _compute_has_kits(self):
+        for picking in self:
+            picking.has_kits = any(picking.move_lines.mapped('bom_line_id'))
 
     def _less_quantities_than_expected_add_documents(self, moves, documents):
         documents = super(StockPicking, self)._less_quantities_than_expected_add_documents(moves, documents)

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -13,6 +13,9 @@
                         <field name="produce_delay" class="oe_inline"/> days
                     </div>
                 </xpath>
+                <xpath expr="//field[@name='product_variant_count']" position="after">
+                    <field name="is_kits" invisible="1"/>
+                </xpath>
             </field>
         </record>
 

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -98,6 +98,32 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_picking_form_inherit_mrp" model="ir.ui.view">
+        <field name="name">view.picking.form.inherit.mrp</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='use_create_lots']" position="after">
+                <field name="has_kits" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='description_picking']" position="after">
+                <field name="description_bom_line" optional="show" attrs="{'column_invisible': [('parent.has_kits', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_stock_move_line_detailed_operation_tree_mrp" model="ir.ui.view">
+        <field name="name">stock.move.line.operations.tree.mrp</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="description_bom_line" optional="show" attrs="{'column_invisible': [('parent.has_kits', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_picking_type_form_inherit_mrp" model="ir.ui.view">
         <field name="name">Operation Types</field>
         <field name="model">stock.picking.type</field>

--- a/addons/mrp_repair/__init__.py
+++ b/addons/mrp_repair/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/mrp_repair/__manifest__.py
+++ b/addons/mrp_repair/__manifest__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': 'Mrp Repairs',
+    'version': '1.0',
+    'category': 'Inventory/Inventory',
+    'depends': ['repair', 'mrp'],
+    'installable': True,
+    'auto_install': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/addons/mrp_repair/models/__init__.py
+++ b/addons/mrp_repair/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import repair

--- a/addons/mrp_repair/models/repair.py
+++ b/addons/mrp_repair/models/repair.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class Repair(models.Model):
+    _inherit = 'repair.order'
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        res.action_explode()
+        return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        self.action_explode()
+        return res
+
+    def action_explode(self):
+        lines_to_unlink_ids = set()
+        line_vals_list = []
+        for op in self.operations:
+            bom = self.env['mrp.bom'].sudo()._bom_find(op.product_id, company_id=op.company_id.id, bom_type='phantom')[op.product_id]
+            if not bom:
+                continue
+            factor = op.product_uom._compute_quantity(op.product_uom_qty, bom.product_uom_id) / bom.product_qty
+            _boms, lines = bom.sudo().explode(op.product_id, factor, picking_type=bom.picking_type_id)
+            for bom_line, line_data in lines:
+                if bom_line.product_id.type != 'service':
+                    line_vals_list.append(op._prepare_phantom_line_vals(bom_line, line_data['qty']))
+            lines_to_unlink_ids.add(op.id)
+
+        self.env['repair.line'].browse(lines_to_unlink_ids).sudo().unlink()
+        if line_vals_list:
+            self.env['repair.line'].create(line_vals_list)
+
+
+class RepairLine(models.Model):
+    _inherit = 'repair.line'
+
+    def _prepare_phantom_line_vals(self, bom_line, qty):
+        self.ensure_one()
+        product = bom_line.product_id
+        uom = bom_line.product_uom_id
+        partner = self.repair_id.partner_id
+        price = self.repair_id.pricelist_id.get_product_price(product, qty, partner, uom_id=uom.id)
+        tax = self.env['account.tax']
+        if partner:
+            partner_invoice = self.repair_id.partner_invoice_id or partner
+            fpos = self.env['account.fiscal.position'].get_fiscal_position(partner_invoice.id, delivery_id=self.repair_id.address_id.id)
+            taxes = self.product_id.taxes_id.filtered(lambda x: x.company_id == self.repair_id.company_id)
+            tax = fpos.map_tax(taxes)
+        return {
+            'name': self.name,
+            'repair_id': self.repair_id.id,
+            'type': self.type,
+            'product_id': product.id,
+            'price_unit': price,
+            'tax_id': [(4, t.id) for t in tax],
+            'product_uom_qty': qty,
+            'product_uom': uom.id,
+            'location_id': self.location_id.id,
+            'location_dest_id': self.location_dest_id.id,
+            'state': 'draft',
+        }

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -97,6 +97,13 @@ class Product(models.Model):
         compute='_compute_nbr_reordering_rules', compute_sudo=False)
     putaway_rule_ids = fields.One2many('stock.putaway.rule', 'product_id', 'Putaway Rules')
     storage_category_capacity_ids = fields.One2many('stock.storage.category.capacity', 'product_id', 'Storage Category Capacity')
+    show_on_hand_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
+    show_forecasted_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
+
+    def _compute_show_qty_status_button(self):
+        for product in self:
+            product.show_on_hand_qty_status_button = product.product_tmpl_id.show_on_hand_qty_status_button
+            product.show_forecasted_qty_status_button = product.product_tmpl_id.show_forecasted_qty_status_button
 
     @api.depends('stock_move_ids.product_qty', 'stock_move_ids.state')
     @api.depends_context(
@@ -664,6 +671,13 @@ class ProductTemplate(models.Model):
     route_from_categ_ids = fields.Many2many(
         relation="stock.location.route", string="Category Routes",
         related='categ_id.total_route_ids', related_sudo=False)
+    show_on_hand_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
+    show_forecasted_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
+
+    def _compute_show_qty_status_button(self):
+        for template in self:
+            template.show_on_hand_qty_status_button = template.type == 'product'
+            template.show_forecasted_qty_status_button = template.type == 'product'
 
     @api.depends('type')
     def _compute_has_available_route_ids(self):

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -250,10 +250,13 @@
                             attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
                     <div name="button_box" position="inside">
+                        <field name="show_on_hand_qty_status_button" invisible="1"/>
+                        <field name="show_forecasted_qty_status_button" invisible="1"/>
                         <button class="oe_stat_button"
                                name="action_open_quants"
                                icon="fa-cubes"
-                               type="object" attrs="{'invisible':[('type', '!=', 'product')]}">
+                               type="object"
+                               attrs="{'invisible':[('show_on_hand_qty_status_button', '=', False)]}">
                                <div class="o_field_widget o_stat_info">
                                     <span class="o_stat_value">
                                         <field name="qty_available" widget="statinfo" nolabel="1" class="mr4"/>
@@ -264,7 +267,7 @@
                         </button>
                         <button type="object"
                             name="action_product_forecast_report"
-                            attrs="{'invisible':[('type', '!=', 'product')]}"
+                            attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
                             context="{'default_product_id': id}"
                             class="oe_stat_button" icon="fa-cubes">
                             <div class="o_field_widget o_stat_info">
@@ -352,9 +355,11 @@
                             attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
                     <div name="button_box" position="inside">
+                        <field name="show_on_hand_qty_status_button" invisible="1"/>
+                        <field name="show_forecasted_qty_status_button" invisible="1"/>
                         <button type="object"
                             name="action_open_quants"
-                            attrs="{'invisible':[('type', '!=', 'product')]}"
+                            attrs="{'invisible':[('show_on_hand_qty_status_button', '=', False)]}"
                             class="oe_stat_button" icon="fa-cubes">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value" widget="statinfo">
@@ -366,7 +371,7 @@
                         </button>
                         <button type="object"
                             name="action_product_tmpl_forecast_report"
-                            attrs="{'invisible':[('type', '!=', 'product')]}"
+                            attrs="{'invisible':[('show_forecasted_qty_status_button', '=', False)]}"
                             context="{'default_product_tmpl_id': id}"
                             class="oe_stat_button" icon="fa-cubes">
                             <div class="o_field_widget o_stat_info">


### PR DESCRIPTION
Whenever there is a kits bom for a product, we consider it a kit product.

1. For a kit product, we show its "on hand" and "forecast" qty based on how many we can produce according to its bom instead of showing the number in stock. 
2. When purchase a kit product, it will be decomposed in the picking. We add a new column to the move and move.line to show its bom infomation.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
