### PR TITLE
support no_open attribute on list view arch

### DIFF
--- a/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
+++ b/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
@@ -4,7 +4,9 @@ odoo.define('mrp.MrpFieldOne2ManyWithCopy', function (require) {
 
 var FieldOne2Many = require('web.relational_fields').FieldOne2Many;
 var ListRenderer = require('web.ListRenderer');
+const ListView = require('web.ListView');
 var fieldRegistry = require('web.field_registry');
+const viewRegistry = require('web.view_registry');
 const {_t} = require('web.core');
 
 //----------------------------------------------------
@@ -79,6 +81,15 @@ var MrpFieldOne2ManyWithCopy = FieldOne2Many.extend({
 });
 
 fieldRegistry.add('mrp_one2many_with_copy', MrpFieldOne2ManyWithCopy);
+
+const MrpRoutingWorkcenterListView = ListView.extend({
+    init(viewInfo, params) {
+        this._super(...arguments);
+        this.rendererParams.no_open = true;
+    }
+});
+
+viewRegistry.add('mrp_routing_workcenter_no_open_tree_view', MrpRoutingWorkcenterListView);
 
 return MrpFieldOne2ManyWithCopy;
 

--- a/addons/mrp/static/tests/mrp_document_list_tests.js
+++ b/addons/mrp/static/tests/mrp_document_list_tests.js
@@ -1,0 +1,55 @@
+odoo.define('mrp.workcenter_routing_list_tests', function (require) {
+    "use strict";
+
+    const viewRegistry = require('web.view_registry');
+    const MrpRoutingWorkcenterNoOpenTreeView = viewRegistry.get('mrp_routing_workcenter_no_open_tree_view');
+    const testUtils = require('web.test_utils');
+
+    const createView = testUtils.createView;
+
+    QUnit.module('MRP List View', {}, function () {
+
+        QUnit.module('MrpRoutingListView', {
+            beforeEach: function () {
+                this.data = {
+                    'foo': {
+                        fields: {
+                            foo: { string: "Name", type: 'char', default: ' ' },
+                        },
+                        records: [
+                            { id: 1, foo: 'test1' },
+                            { id: 2, foo: 'test2' },
+                        ],
+                    },
+                };
+            },
+        }, function () {
+            QUnit.test('list with no_open="1"', async function (assert) {
+                assert.expect(1);
+
+                const list = await createView({
+                    View: MrpRoutingWorkcenterNoOpenTreeView,
+                    model: 'foo',
+                    data: this.data,
+                    viewOptions: { hasActionMenus: true },
+                    arch: `<tree js_class="mrp_routing_workcenter_no_open_tree_view">
+                        <field name="foo"/>
+                    </tree>`,
+                    debug: true,
+                });
+
+                testUtils.mock.intercept(list, "open_record", function () {
+                    assert.step("list view should trigger 'open_record' event");
+                });
+
+                await testUtils.dom.click(list.$('.o_data_cell:first'));
+                assert.verifySteps([]);
+
+                list.destroy();
+            });
+
+        });
+
+    });
+
+});

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -44,6 +44,7 @@
                 <xpath expr="//tree" position="attributes">
                     <attribute name="create">0</attribute>
                     <attribute name="export_xlsx">0</attribute>
+                    <attribute name="js_class">mrp_routing_workcenter_no_open_tree_view</attribute>
                 </xpath>
                 <xpath expr="//field[@name='name']" position="before">
                     <header>


### PR DESCRIPTION
PURPOSE
Add support of no_open attribute on tree tag in list view, with this attribute we allow user to disable row click on clicking list view row, in some cases we want list view but we do not want to open form or operation done by listview on row click.
For example: In MRP -> bill of material -> open form view -> Operations tab -> click on Copy Existing Operations will open list view in wizard, here clicking on row will change data in o2m, while we only want to select records and click on Copy selected operations.

SPEC
Add no_open attribute support on list view tree tag to disable row click.

TASK 2628922

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
