### PR TITLE
[FIX] website_slides : fixed different progression in same course for merged user

### DIFF
--- a/addons/website_slides/wizard/__init__.py
+++ b/addons/website_slides/wizard/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import slide_channel_invite
+from . import base_partner_merge

--- a/addons/website_slides/wizard/base_partner_merge.py
+++ b/addons/website_slides/wizard/base_partner_merge.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class WebsiteSlideMergePartnerAutomatic(models.TransientModel):
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        super(WebsiteSlideMergePartnerAutomatic, self)._merge(partner_ids, dst_partner, extra_checks)
+        if not dst_partner:
+            return
+
+        channel_partners = self.env['slide.channel.partner'].sudo().search([('partner_id', '=', dst_partner.id)],
+                                                                           order='completion DESC')
+        seen_channel = set()
+        to_unlink = self.env['slide.channel.partner']
+        for channel_partner in channel_partners:
+            if channel_partner.channel_id in seen_channel:
+                to_unlink += channel_partner
+            else:
+                seen_channel.add(channel_partner.channel_id)
+
+        to_unlink.unlink()


### PR DESCRIPTION
… merged user

Reproduce :
- Create an e-learning course with two contents (quiz 1 and quiz 2)
- Publish the course and the contents on the website
- Signup as portal user A
- Join the course and take the two quizzes
- Signup as portal user B
- Join the course and take only one of two quizzes
- Merge the two contacts A and B (you now have two portal users linked to the same contact)
- Sign in as user A or B
- Go to the  user profile (/profile/user/xx where xx = the user id)

Result :
  The same course appears under both the "Completed Courses" section with 100% progress (completed by A) and "Followed Courses" with 50% progress (not completed by B).

Solution :
  Merge users process is now overwritten in order to keep only de most complete progression in each course.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
