### PR TITLE
[FIX] website_slides: prevent crash due to incorrect import

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -5,14 +5,14 @@
     import  { qweb as QWeb, _t } from 'web.core';
     import session from 'web.session';
     import { Markup } from 'web.utils';
-    import courseJoinWidget from '@website_slides/js/slides_course_join';
+    import CourseJoin from '@website_slides/js/slides_course_join';
     import QuestionFormWidget from '@website_slides/js/slides_course_quiz_question_form';
     import SlideQuizFinishModal from '@website_slides/js/slides_course_quiz_finish';
 
-    import slideEnrollDialog from '@website_slides/js/slides_course_enroll_email';
+    import SlideEnroll from '@website_slides/js/slides_course_enroll_email';
 
-    const { CourseJoinWidget } = courseJoinWidget;
-    const { SlideEnrollDialog } = slideEnrollDialog;
+    const CourseJoinWidget = CourseJoin.courseJoinWidget;
+    const SlideEnrollDialog = SlideEnroll.slideEnrollDialog;
 
     /**
      * This widget is responsible of displaying quiz questions and propositions. Submitting the quiz will fetch the


### PR DESCRIPTION
task-2510656

**Current behavior before PR:**

When users taking a quiz on the course page before enrollment, the error below will show up 
```
UncaughtPromiseError > TypeError
Uncaught Promise > CourseJoinWidget is not a constructor
```

**Desired behavior after PR is merged:**

Quiz should work well.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
