### PR TITLE
[FIX] sale_mrp: correct delivery slip kit cost valuation

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -41,6 +41,7 @@ class StockMoveLine(models.Model):
                 unit_price = move_line.product_id.list_price
                 qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)
             move_line.sale_price = unit_price * qty
+        super(StockMoveLine, self)._compute_sale_price()
 
     def _get_aggregated_product_quantities(self, **kwargs):
         """Returns dictionary of products and corresponding values of interest + hs_code

--- a/addons/sale_mrp/models/__init__.py
+++ b/addons/sale_mrp/models/__init__.py
@@ -4,3 +4,4 @@
 from . import sale
 from . import account_move
 from . import mrp_production
+from . import stock_move

--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    def _compute_sale_price(self):
+        kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom')
+        for move_line in kit_lines:
+            unit_price = move_line.product_id.list_price
+            qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)
+            move_line.sale_price = unit_price * qty
+        super(StockMoveLine, self - kit_lines)._compute_sale_price()

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -674,3 +674,7 @@ class StockMoveLine(models.Model):
             else:
                 aggregated_move_lines[line_key]['qty_done'] += move_line.qty_done
         return aggregated_move_lines
+
+    def _compute_sale_price(self):
+        # To Override
+        pass


### PR DESCRIPTION
- Create a product with a kit BOM and weight
- kit components should have list price and weight as well
- Create SO with kit product
- Add shipping (fedex int. or bpost will do)
- Delivery product

A custom's form is generated but the value of the product it is not
correct as it take the valuation of the kit in the sale order
for every component of the kit, resulting in higher customs taxes for
the final customer

opw-2628309

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
