### PR TITLE
[FIX] l10n_cl: correct Chilean VAT formatting

### DIFF
--- a/addons/l10n_cl/demo/demo_company.xml
+++ b/addons/l10n_cl/demo/demo_company.xml
@@ -3,6 +3,7 @@
     <record id="partner_demo_company_cl" model="res.partner">
         <field name="name">CL Company</field>
         <field name="vat">CL22060449-7</field>
+        <field name="l10n_latam_identification_type_id">4</field>
         <field name="l10n_cl_sii_taxpayer_type">1</field>
         <field name="street">1</field>
         <field name="city">Santiago</field>

--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -54,7 +54,7 @@ class ResPartner(models.Model):
         return super().create(values)
 
     def write(self, values):
-        if 'vat' in values or 'l10n_latam_identification_type_id' in values:      
+        if any(field in values for field in ['vat', 'l10n_latam_identification_type_id', 'country_id']): 
             for record in self:
                 vat_values = {
                     'vat': values.get('vat', record.vat),


### PR DESCRIPTION
Problem 1 steps to reproduce the bug:
- Install `l10n_cl`
- Create a new company
    - Choose for example Algeria in country.
    - Enter this VAT number: CL220604497
- Save
- edit
- Change the country to Chile

problem:
VAT number is not formatted according to the Chilean VAT formatting,
Because in the write function we do not trigger the VAT formatting when the country changes

Bug introduced in this commit: https://github.com/odoo/odoo/commit/11ec94df926db98265d26af1072a0c8bf1843083

Problem 2, steps to reproduce the bug:
When you install `l10n_cl`, a Chilean company is created with these demo data: https://github.com/odoo/odoo/blob/7cc252908b33b7d77d45d0630464e203b25b09dc/addons/l10n_cl/demo/demo_company.x15ml#L

- The VAT is formatted according to the standard formatting instead of the Chilean vat formatting,
Because the field `" l10n_latam_identification_type_id "` is not defined: https://github.com/odoo/odoo/blob/f3a66dd65d041ffc7367d85d5603e9627efb9f2b/addons/l10n_cl/models/res_partner.py#L33-L34

so we will have this result: CL220604497 instead of 22060449-7

- create a vendor bill with this company
- try to print it
- a traceback is triggered, because we call the `_format_dotted_vat_cl` function which divides the vat in two parts
based on the dash and then processes the result without checking that there are two elements in the result.
As in our case here. The vat has no dash in the middle, so we will only have one part
an error is triggered when the function tries to access the 2nd element

https://github.com/odoo/odoo/blob/2b500c12c2540e593f3a243bf80de28bd335b7be/addons/l10n_cl/views/report_invoice.xml#L53

FYI: https://www.fonoa.com/countries/chile#:~:text=Chilean%20VAT%20number%20contains%207,567%2D8).


opw-2630877


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
