### PR TITLE
[IMP] fleet: New fields in Bills screen

### DIFF
--- a/addons/account_fleet/models/fleet_vehicle.py
+++ b/addons/account_fleet/models/fleet_vehicle.py
@@ -24,7 +24,7 @@ class FleetVehicle(models.Model):
         self.ensure_one()
 
         form_view_ref = self.env.ref('account.view_move_form', False)
-        tree_view_ref = self.env.ref('account.view_move_tree', False)
+        tree_view_ref = self.env.ref('account_fleet.account_move_view_tree', False)
 
         result = self.env['ir.actions.act_window']._for_xml_id('account.action_move_in_invoice_type')
         result.update({

--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -15,4 +15,19 @@
             </xpath>
         </field>
     </record>
+
+    <record id="account_move_view_tree" model="ir.ui.view">
+        <field name="name">account.move.tree.inherit.fleet</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_tree"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date']" position="attributes">
+                <attribute name="string">Creation Date</attribute>
+            </xpath>
+            <xpath expr="//field[@name='date']" position="after">
+                <field name="invoice_date" optional="show"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In Fleet, on the Bills tree view for a specific car:
- "Date" needs to be renamed "Creation Date"
- "Invoice/Bill Date" needs to be added added between the "Creation Date" and the "Number" columns, the default is optional:show

Current behavior before PR:
- The field "Date" is called "Date"
- The field "Invoice/Bill Date" is not existing in the tree view

Desired behavior after PR is merged:
- "Date" is renamed "Creation Date"
- "Invoice/Bill Date" is added between the "Creation Date" and the "Number" columns, the default is optional:show

task-2629316
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
