### PR TITLE
keep disabled attribute on button

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -188,6 +188,9 @@ var FormRenderer = BasicRenderer.extend({
      */
     enableButtons: function () {
         this.$('.o_statusbar_buttons button, .oe_button_box button')
+            .filter((index, btn) => {
+                return !btn.classList.contains('o_disabled');
+            })
             .removeAttr('disabled');
     },
     /**
@@ -710,6 +713,9 @@ var FormRenderer = BasicRenderer.extend({
         var $button = viewUtils.renderButtonFromNode(node, {
             extraClass: 'oe_stat_button',
         });
+        if (node.attrs.disabled) {
+            $button.addClass('o_disabled');
+        }
         $button.append(_.map(node.children, this._renderNode.bind(this)));
         if (node.attrs.help) {
             this._addButtonTooltip(node, $button);


### PR DESCRIPTION
PURPOSE
When disabled attribute is given on button and creating record in form view and save the record then disabled attribute is removed from button and it is clickable, button should have disabled attribute even after new record is saved.

SPEC
Saving new record in form view disabled attribute is removed only from those buttons where disabled attribute is not given, disabled attribute should not be removed.

TASK 2600312

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
