### PR TITLE
[FIX] website_forum: fixed forum back button url

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -517,4 +517,22 @@ publicWidget.registry.websiteForumSpam = publicWidget.Widget.extend({
     },
 });
 
+publicWidget.registry.WebsiteForumBackButton = publicWidget.Widget.extend({
+    selector: '.o_back_button',
+    events: {
+        'click': '_onBackButtonClick',
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     */
+    _onBackButtonClick() {
+        window.history.back();
+    },
+});
+
 });

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -128,7 +128,7 @@
 <template id="forum_nav_header">
     <div class="navbar navbar-expand-sm navbar-light">
         <div class="container flex-wrap flex-md-nowrap">
-            <a t-if="back_button_url" class="btn btn-light border mr-2" t-attf-href="#{back_button_url}" title="Back">
+            <a t-if="back_button_url" class="btn btn-light border mr-2 o_back_button" title="Back">
                 <i class="fa fa-chevron-left mr-1"/>Back
             </a>
             <!-- Desktop -->


### PR DESCRIPTION
Currently, when we click on the back button of the forum page,
it redirects the user to the app switcher. It happens because the
back button contains the homepage URL.

so this commit fixes the issue by changing the URL of the
back button so clicking on the back button redirects the user
to the form view of the ticket

TaskID-2602604