### PR TITLE
[FIX] survey: correctly consider all non-answered questions as skipped

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -393,6 +393,7 @@ class SurveyQuestion(models.Model):
             if question.question_type in ['simple_choice', 'multiple_choice', 'matrix']:
                 answer_lines = all_lines.filtered(
                     lambda line: line.answer_type == 'suggestion' or (
+                        line.skipped and not line.answer_type) or (
                         line.answer_type == 'char_box' and question.comment_count_as_answer)
                     )
                 comment_line_ids = all_lines.filtered(lambda line: line.answer_type == 'char_box')

--- a/addons/survey/models/survey_user.py
+++ b/addons/survey/models/survey_user.py
@@ -268,6 +268,12 @@ class SurveyUserInput(models.Model):
     def _save_line_choice(self, question, old_answers, answers, comment):
         if not (isinstance(answers, list)):
             answers = [answers]
+
+        if not answers:
+            # add a False answer to force saving a skipped line
+            # this will make this question correctly considered as skipped in statistics
+            answers = [False]
+
         vals_list = []
 
         if question.question_type == 'simple_choice':
@@ -284,6 +290,11 @@ class SurveyUserInput(models.Model):
 
     def _save_line_matrix(self, question, old_answers, answers, comment):
         vals_list = []
+
+        if not answers and question.matrix_row_ids:
+            # add a False answer to force saving a skipped line
+            # this will make this question correctly considered as skipped in statistics
+            answers = {question.matrix_row_ids[0].id: [False]}
 
         if answers:
             for row_key, row_answer in answers.items():

--- a/addons/survey/static/src/js/survey_result.js
+++ b/addons/survey/static/src/js/survey_result.js
@@ -94,22 +94,24 @@ publicWidget.registry.SurveyResultChart = publicWidget.Widget.extend({
         return this._super.apply(this, arguments).then(function () {
             self.graphData = self.$el.data("graphData");
 
-            switch (self.$el.data("graphType")) {
-                case 'multi_bar':
-                    self.chartConfig = self._getMultibarChartConfig();
-                    break;
-                case 'bar':
-                    self.chartConfig = self._getBarChartConfig();
-                    break;
-                case 'pie':
-                    self.chartConfig = self._getPieChartConfig();
-                    break;
-                case 'doughnut':
-                    self.chartConfig = self._getDoughnutChartConfig();
-                    break;
-            }
+            if (self.graphData && self.graphData.length !== 0) {
+                switch (self.$el.data("graphType")) {
+                    case 'multi_bar':
+                        self.chartConfig = self._getMultibarChartConfig();
+                        break;
+                    case 'bar':
+                        self.chartConfig = self._getBarChartConfig();
+                        break;
+                    case 'pie':
+                        self.chartConfig = self._getPieChartConfig();
+                        break;
+                    case 'doughnut':
+                        self.chartConfig = self._getDoughnutChartConfig();
+                        break;
+                }
 
-            self._loadChart();
+                self._loadChart();
+            }
         });
     },
 

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -147,7 +147,7 @@ class SurveyCase(common.SavepointCase):
         return self.env['survey.user_input.line'].create(base_alvals)
 
     # ------------------------------------------------------------
-    # UTILS
+    # UTILS / CONTROLLER ENDPOINTS FLOWS
     # ------------------------------------------------------------
 
     def _access_start(self, survey):
@@ -217,6 +217,36 @@ class SurveyCase(common.SavepointCase):
             post_data['page_id'] = question.page_id.id
         post_data.update(**additional_post_data)
         return post_data
+
+    # ------------------------------------------------------------
+    # UTILS / TOOLS
+    # ------------------------------------------------------------
+
+    def _assert_skipped_question(self, question, survey_user):
+        statistics = question._prepare_statistics(survey_user.user_input_line_ids)
+        question_data = next(
+            (question_data
+            for question_data in statistics
+            if question_data.get('question') == question),
+            False
+        )
+        self.assertTrue(bool(question_data))
+        self.assertEqual(len(question_data.get('answer_input_skipped_ids')), 1)
+
+    def _create_one_question_per_type(self):
+        all_questions = self.env['survey.question']
+        for (question_type, text) in self.env['survey.question']._fields['question_type'].selection:
+            kwargs = {}
+            if question_type == 'multiple_choice':
+                kwargs['labels'] = [{'value': 'MChoice0'}, {'value': 'MChoice1'}]
+            elif question_type == 'simple_choice':
+                kwargs['labels'] = []
+            elif question_type == 'matrix':
+                kwargs['labels'] = [{'value': 'Column0'}, {'value': 'Column1'}]
+                kwargs['labels_2'] = [{'value': 'Row0'}, {'value': 'Row1'}]
+            all_questions |= self._add_question(self.page_0, 'Q0', question_type, **kwargs)
+
+        return all_questions
 
 
 class TestSurveyCommon(SurveyCase):

--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -352,7 +352,7 @@
             </div>
             <div role="tabpanel" class="tab-pane" t-att-id="'survey_data_question_%d' % question.id">
                 <table class="table table-hover table-sm text-right">
-                    <thead>
+                    <thead t-if="table_data">
                         <tr>
                             <th></th>
                             <th class="text-right" t-foreach="table_data[0]['columns']" t-as="column_data">


### PR DESCRIPTION
Currently, if the survey participant does not answer questions of type:
- simple_choice
- multiple_choice
- matrix

The system does not register any survey.user_input_line with the "skipped"
attribute set to True. Meaning that this question's answer will not appear in
the survey statistics as skipped (in fact it will not appear at all).

This commit makes sure we correctly save a user_input_line set as skipped=True
when not answering to those types of questions.

A unit test has been added to make sure that we consider every non-answered
question type as properly skipped within the survey statistics.

Task-2622869

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
