### PR TITLE
[FIX] purchase_stock: check if picking_type has a warehouse

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -444,7 +444,7 @@ class PurchaseOrderLine(models.Model):
 
     def _check_orderpoint_picking_type(self):
         warehouse_loc = self.order_id.picking_type_id.warehouse_id.view_location_id
-        if self.orderpoint_id and not warehouse_loc.parent_path in self.orderpoint_id.location_id.parent_path:
+        if warehouse_loc and self.orderpoint_id and not warehouse_loc.parent_path in self.orderpoint_id.location_id.parent_path:
             raise UserError(_('For the product %s, the warehouse of the operation type (%s) is inconsistent with the location (%s) of the reordering rule (%s). Change the operation type or cancel the request for quotation.',
                               self.product_id.display_name, self.order_id.picking_type_id.display_name, self.orderpoint_id.location_id.display_name, self.orderpoint_id.display_name))
     


### PR DESCRIPTION
Commit 643e093a4bc9d46973705831697036b56a89b143 adds a security on
orderpoints triggering purchase orders. But this new check fails in case
the picking type on the purchase order is not linked to a warehouse (e.g
in a subcontracting flow).

This commit ensure the check is done only if we have a warehouse linked
to the purchase order.

opw: 2631979

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
