### PR TITLE
[FIX] website: properly define snippets for footer and header templates 

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -387,7 +387,7 @@
                         </div>
                         <!-- Social -->
                         <div class="col-lg-6 pb16">
-                            <div class="s_share text-left no_icon_color" data-name="Social Media">
+                            <div class="s_share text-left no_icon_color" data-snippet="s_share" data-name="Social Media">
                                 <h5 class="s_share_title d-none">Follow us</h5>
                                 <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                                     <i class="fa fa-facebook m-1"/>
@@ -490,7 +490,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_vertical_1">
             <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
-                    <div class="s_share no_icon_color" data-name="Social Media">
+                    <div class="s_share no_icon_color" data-snippet="s_share" data-name="Social Media">
                         <h6 class="s_share_title d-none">Follow us</h6>
                         <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                             <i class="fa fa-facebook m-1"/>
@@ -592,7 +592,7 @@
             <section class="s_text_block" data-snippet="s_text_block" data-name="Text">
                 <div class="container">
                     <!-- Social -->
-                    <div class="s_share mt-3" data-name="Social Media">
+                    <div class="s_share mt-3" data-snippet="s_share" data-name="Social Media">
                         <h5 class="s_share_title d-none">Follow us</h5>
                         <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                             <i class="fa fa-facebook rounded-circle shadow-sm"/>
@@ -778,7 +778,7 @@
                             </small>
                         </div>
                         <div class="col-lg-4 text-lg-right">
-                            <div class="s_share no_icon_color" data-name="Social Media">
+                            <div class="s_share no_icon_color" data-snippet="s_share" data-name="Social Media">
                                 <small class="s_share_title text-muted"><b>Follow us</b></small>
                                 <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                                     <i class="fa fa-facebook m-1"/>
@@ -906,7 +906,7 @@
         <div class="oe_structure oe_structure_solo" id="oe_structure_header_boxed_1">
             <section class="s_text_block" data-snippet="s_text_block" name="Text">
                 <div class="container">
-                    <div class="s_share text-left" data-name="Social Media">
+                    <div class="s_share text-left" data-snippet="s_share" data-name="Social Media">
                         <h6 class="s_share_title d-none">Follow us</h6>
                         <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                             <i class="fa fa-facebook m-1"/>
@@ -1103,10 +1103,10 @@
 <template id="template_header_hamburger_full_oe_structure_header_hamburger_full_1" inherit_id="website.template_header_hamburger_full" name="Template Header Hamburger Full (oe_structure_header_hamburger_full_1)">
     <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_header_hamburger_full_1']" position="replace">
         <div class="oe_structure oe_structure_solo w-100" id="oe_structure_header_hamburger_full_1">
-            <div class="s_hr pt32 pb32" data-name="Separator">
+            <div class="s_hr pt32 pb32" data-snippet="s_hr" data-name="Separator">
                 <hr class="w-100 mx-auto" style="border-top-width: 1px; border-top-style: solid; border-color: var(--400);"/>
             </div>
-            <div class="s_share text-center" data-name="Social Media">
+            <div class="s_share text-center" data-snippet="s_share" data-name="Social Media">
                 <h5 class="s_share_title d-none">Follow us</h5>
                 <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                     <i class="fa fa-facebook rounded-circle shadow-sm"/>
@@ -1186,7 +1186,7 @@
                             <p class="mb-0"><small>We help you grow your business</small></p>
                         </div>
                         <div class="col-lg-4 text-lg-right pt16">
-                            <div class="s_share no_icon_color" data-name="Social Media">
+                            <div class="s_share no_icon_color" data-snippet="s_share" data-name="Social Media">
                                 <small class="s_share_title d-none"><b>Follow us</b></small>
                                 <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                                     <i class="fa fa-facebook m-1"/>
@@ -1374,7 +1374,7 @@
                                 <li><i class="fa fa-envelope fa-fw mr-2"/><span><a href="mailto:info@yourcompany.example.com">info@yourcompany.example.com</a></span></li>
                                 <li><i class="fa fa-phone fa-fw mr-2"/><span class="o_force_ltr"><a href="tel:+1 (650) 555-0111">+1 (650) 555-0111</a></span></li>
                             </ul>
-                            <div class="s_share text-left" data-name="Social Media">
+                            <div class="s_share text-left" data-snippet="s_share" data-name="Social Media">
                                 <h5 class="s_share_title d-none">Follow us</h5>
                                 <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                                     <i class="fa fa-facebook rounded-circle shadow-sm"/>
@@ -1400,7 +1400,7 @@
 <template id="template_footer_descriptive" inherit_id="website.layout" name="Descriptive" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo" t-ignore="true" t-if="not no_footer">
-            <section class="s_title pt48 pb24">
+            <section class="s_title pt48 pb24" data-vcss="001" data-snippet="s_title">
                 <div class="container s_allow_columns">
                     <h4><b>Designed</b> for companies</h4>
                 </div>
@@ -1419,7 +1419,7 @@
                                 <li><i class="fa fa-phone fa-fw mr-2"/><span class="o_force_ltr"><a href="tel:+1 (650) 555-0111">+1 (650) 555-0111</a></span></li>
                                 <li><i class="fa fa-envelope fa-fw mr-2"/><span><a href="mailto:hello@mycompany.com">hello@mycompany.com</a></span></li>
                             </ul>
-                            <div class="s_share text-left no_icon_color" data-name="Social Media">
+                            <div class="s_share text-left no_icon_color" data-snippet="s_share" data-name="Social Media">
                                 <h5 class="s_share_title d-none">Follow us</h5>
                                 <a href="/website/social/github" class="s_share_github" target="_blank">
                                     <i class="fa fa-2x fa-github m-1"/>
@@ -1447,7 +1447,7 @@
         <div id="footer" class="oe_structure oe_structure_solo" t-ignore="true" t-if="not no_footer">
             <section class="s_text_block pt32" data-snippet="s_text_block" data-name="Text">
                 <div class="container s_allow_columns">
-                    <div class="s_share text-center mb-4" data-name="Social Media">
+                    <div class="s_share text-center mb-4" data-snippet="s_share" data-name="Social Media">
                         <h5 class="s_share_title d-none">Follow us</h5>
                         <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                             <i class="fa fa-facebook rounded-circle rounded shadow-sm"/>
@@ -1552,7 +1552,7 @@
                             </ul>
                         </div>
                         <div class="col-lg-3 pt16 pb16">
-                            <div class="s_share text-right no_icon_color" data-name="Social Media">
+                            <div class="s_share text-right no_icon_color" data-snippet="s_share" data-name="Social Media">
                                 <h5 class="s_share_title d-none">Follow us</h5>
                                 <a href="/website/social/github" class="s_share_github" target="_blank">
                                     <i class="fa fa-2x fa-github m-1"/>
@@ -1594,7 +1594,7 @@
                             <h5><a href="mailto:hello@mycompany.com">hello@mycompany.com</a></h5>
                         </div>
                         <div class="col-lg-3 pt16 pb16">
-                            <div class="s_share text-right no_icon_color" data-name="Social Media">
+                            <div class="s_share text-right no_icon_color" data-snippet="s_share" data-name="Social Media">
                                 <p class="s_share_title d-block mb-2">Follow us</p>
                                 <a href="/website/social/twitter" class="s_share_twitter" target="_blank">
                                     <i class="fa fa-twitter m-1"/>
@@ -1715,7 +1715,7 @@
                             </ul>
                         </div>
                         <div class="col-lg-3 pb24">
-                            <div class="s_share text-right" data-name="Social Media">
+                            <div class="s_share text-right" data-snippet="s_share" data-name="Social Media">
                                 <h5 class="s_share_title d-none">Share</h5>
                                 <a href="/website/social/facebook" class="s_share_facebook" target="_blank">
                                     <i class="fa fa-1x fa-facebook rounded-circle shadow-sm"/>


### PR DESCRIPTION
Some footer and header templates, introduced in [1] were using snippet
classes without the snippet data attribute. Therefore, they were not
using the snippets versioning system.

For example, the template_footer_descriptive was using an outdated
version of the s_title snippet, when a V001 css version had already been
introduced by [2].

[1]: 34ed29c
[2]: f34d7f4

task-2212216

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
