### PR TITLE
[FIX] website: fix alignment for narrow size of mega menu

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1160,9 +1160,13 @@ header {
     }
 }
 .o_mega_menu_container_size {
-    @include media-breakpoint-up(md) {
-        left: 50%;
-        transform: translateX(-50%);
+    $-header-template: o-website-value('header-template');
+    @if not index(('sidebar', 'hamburger', 'magazine'), $-header-template) {
+        $bp: if($-header-template == 'minimalist', md, lg);
+        @include media-breakpoint-up($bp) {
+            left: 50%;
+            transform: translateX(-50%);
+        }
     }
 
     $-mm-max-widths: ();


### PR DESCRIPTION
This fixes a bug about alignment, which shifted the mega menu with the
narrow size by 50%. This bug was triggered in multiple headers :

- sidebar
- hamburger
- magazine
- minimalist

task-2502208


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
