### PR TITLE
Better cursor API and environment management

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -34,7 +34,7 @@ def after_commit(func):
         @self.env.cr.postcommit.add
         def called_after():
             db_registry = registry(dbname)
-            with api.Environment.manage(), db_registry.cursor() as cr:
+            with db_registry.cursor() as cr:
                 env = api.Environment(cr, uid, context)
                 try:
                     func(self.with_env(env), *args, **kwargs)

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -21,6 +21,10 @@ class TestMultiCompany(TestHrCommon):
             (4, self.company_2.id),
         ]
         self.res_users_hr_officer.company_id = self.company_1.id
+        # flush and invalidate the cache, otherwise a full cache may prevent
+        # access rights to be checked
+        self.employees.flush()
+        self.employees.invalidate_cache()
 
     def test_multi_company_report(self):
         content, content_type = self.env.ref('hr.hr_employee_print_badge').with_user(self.res_users_hr_officer).with_context(

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2286,7 +2286,7 @@ class MailThread(models.AbstractModel):
                 @self.env.cr.postcommit.add
                 def send_notifications():
                     db_registry = registry(dbname)
-                    with api.Environment.manage(), db_registry.cursor() as cr:
+                    with db_registry.cursor() as cr:
                         env = api.Environment(cr, SUPERUSER_ID, _context)
                         env['mail.mail'].browse(email_ids).send()
             else:

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -506,7 +506,7 @@ class MailCase(MockEmail):
     def flush_tracking(self):
         """ Force the creation of tracking values. """
         self.env['base'].flush()
-        self.cr.precommit.run()
+        self.cr.flush()
 
     # ------------------------------------------------------------
     # MAIL MOCKS

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -36,7 +36,7 @@ def after_commit(func):
         @self.env.cr.postcommit.add
         def called_after():
             db_registry = registry(dbname)
-            with api.Environment.manage(), db_registry.cursor() as cr:
+            with db_registry.cursor() as cr:
                 env = api.Environment(cr, uid, context)
                 try:
                     func(self.with_env(env), *args, **kwargs)

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -46,7 +46,6 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
 
     @users('Internal user', 'Portal user')
     def test_project_no_read(self):
-        self.project_pigs.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).name
 
@@ -55,19 +54,18 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         self.project_pigs.privacy_visibility = 'portal'
         self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.project_pigs.privacy_visibility = 'followers'
-        self.project_pigs.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).name
 
     @users('Internal user')
     def test_project_allowed_internal_read(self):
         self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
+        self.project_pigs.flush()
         self.project_pigs.invalidate_cache()
         self.project_pigs.with_user(self.env.user).name
 
     @users('Internal user', 'Portal user')
     def test_task_no_read(self):
-        self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
@@ -76,13 +74,13 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         self.project_pigs.privacy_visibility = 'portal'
         self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.project_pigs.privacy_visibility = 'followers'
-        self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
     @users('Internal user')
     def test_task_allowed_internal_read(self):
         self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
+        self.task.flush()
         self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 
@@ -121,18 +119,20 @@ class TestCRUDVisibilityPortal(TestAccessRights):
 
     @users('Portal user')
     def test_task_portal_no_read(self):
-        self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
     @users('Portal user')
     def test_task_allowed_portal_read(self):
         self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
+        self.task.flush()
         self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 
     @users('Internal user')
     def test_task_internal_read(self):
+        self.task.flush()
+        self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 
 class TestCRUDVisibilityEmployees(TestAccessRights):
@@ -143,17 +143,16 @@ class TestCRUDVisibilityEmployees(TestAccessRights):
 
     @users('Portal user')
     def test_task_portal_no_read(self):
-        self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
         self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
-        self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
     @users('Internal user')
     def test_task_allowed_portal_read(self):
+        self.task.flush()
         self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 

--- a/addons/project/tests/test_burndown_chart.py
+++ b/addons/project/tests/test_burndown_chart.py
@@ -88,55 +88,55 @@ class TestBurndownChart(TransactionCase):
         self.set_create_date('project_task', task_f.id, datetime(current_year - 1, 12, 20))
 
         # Precommit to have the records in db and allow to rollback at the end of test
-        self.env.cr.precommit.run()
+        self.env.cr.flush()
 
         with freeze_time('%s-02-10' % (current_year - 1)):
             (task_a + task_b).write({'stage_id': in_progress_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-02-20' % (current_year - 1)):
             task_c.write({'stage_id': in_progress_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-03-15' % (current_year - 1)):
             (task_d + task_e).write({'stage_id': in_progress_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-04-10' % (current_year - 1)):
             (task_a + task_b).write({'stage_id': testing_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-05-12' % (current_year - 1)):
             task_c.write({'stage_id': testing_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-06-25' % (current_year - 1)):
             task_d.write({'stage_id': testing_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-07-25' % (current_year - 1)):
             task_e.write({'stage_id': testing_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-08-01' % (current_year - 1)):
             task_a.write({'stage_id': done_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-09-10' % (current_year - 1)):
             task_b.write({'stage_id': done_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-10-05' % (current_year - 1)):
             task_c.write({'stage_id': done_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-11-25' % (current_year - 1)):
             task_d.write({'stage_id': done_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with freeze_time('%s-12-12' % (current_year - 1)):
             task_e.write({'stage_id': done_stage.id})
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         read_group_result = self.env['project.task.burndown.chart.report'].with_context(fill_temporal=True).read_group([('project_id', '=', project.id), ('display_project_id', '!=', False)], ['date', 'stage_id', 'nb_tasks'], ['date:month', 'stage_id'], lazy=False)
         read_group_result_dict = {(res['date:month'], res['stage_id'][0]): res['nb_tasks'] for res in read_group_result}

--- a/addons/stock/wizard/stock_scheduler_compute.py
+++ b/addons/stock/wizard/stock_scheduler_compute.py
@@ -6,7 +6,7 @@
 #    - Order if the virtual stock of today is below the min of the defined order point
 #
 
-from odoo import api, models, tools
+from odoo import models, tools
 
 import logging
 import threading
@@ -19,28 +19,27 @@ class StockSchedulerCompute(models.TransientModel):
     _description = 'Run Scheduler Manually'
 
     def _procure_calculation_orderpoint(self):
-        with api.Environment.manage():
-            # As this function is in a new thread, I need to open a new cursor, because the old one may be closed
-            new_cr = self.pool.cursor()
-            self = self.with_env(self.env(cr=new_cr))
-            scheduler_cron = self.sudo().env.ref('stock.ir_cron_scheduler_action')
-            # Avoid to run the scheduler multiple times in the same time
-            try:
-                with tools.mute_logger('odoo.sql_db'):
-                    self._cr.execute("SELECT id FROM ir_cron WHERE id = %s FOR UPDATE NOWAIT", (scheduler_cron.id,))
-            except Exception:
-                _logger.info('Attempt to run procurement scheduler aborted, as already running')
-                self._cr.rollback()
-                self._cr.close()
-                return {}
-
-            for company in self.env.user.company_ids:
-                cids = (self.env.user.company_id | self.env.user.company_ids).ids
-                self.env['procurement.group'].with_context(allowed_company_ids=cids).run_scheduler(
-                    use_new_cursor=self._cr.dbname,
-                    company_id=company.id)
-            new_cr.close()
+        # As this function is in a new thread, I need to open a new cursor, because the old one may be closed
+        new_cr = self.pool.cursor()
+        self = self.with_env(self.env(cr=new_cr))
+        scheduler_cron = self.sudo().env.ref('stock.ir_cron_scheduler_action')
+        # Avoid to run the scheduler multiple times in the same time
+        try:
+            with tools.mute_logger('odoo.sql_db'):
+                self._cr.execute("SELECT id FROM ir_cron WHERE id = %s FOR UPDATE NOWAIT", (scheduler_cron.id,))
+        except Exception:
+            _logger.info('Attempt to run procurement scheduler aborted, as already running')
+            self._cr.rollback()
+            self._cr.close()
             return {}
+
+        for company in self.env.user.company_ids:
+            cids = (self.env.user.company_id | self.env.user.company_ids).ids
+            self.env['procurement.group'].with_context(allowed_company_ids=cids).run_scheduler(
+                use_new_cursor=self._cr.dbname,
+                company_id=company.id)
+        new_cr.close()
+        return {}
 
     def procure_calculation(self):
         threaded_calculation = threading.Thread(target=self._procure_calculation_orderpoint, args=())

--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -13,7 +13,7 @@ from functools import partial
 def uninstall_hook(cr, registry):
     def rem_website_id_null(dbname):
         db_registry = odoo.modules.registry.Registry.new(dbname)
-        with api.Environment.manage(), db_registry.cursor() as cr:
+        with db_registry.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
             env['ir.model.fields'].search([
                 ('name', '=', 'website_id'),

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -14,7 +14,7 @@ from werkzeug import urls
 from werkzeug.datastructures import OrderedMultiDict
 from werkzeug.exceptions import NotFound
 
-from odoo import api, fields, models, tools, http, release
+from odoo import api, fields, models, tools, http, release, registry
 from odoo.addons.http_routing.models.ir_http import slugify, _guess_mimetype, url_for
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.portal.controllers.portal import pager
@@ -395,10 +395,7 @@ class Website(models.Model):
 
             if modules:
                 modules.button_immediate_install()
-                # Force to refresh env after install of modules
-                self._cr.commit()
-                api.Environment.reset()
-                self.env = api.Environment(modules._cr, modules._uid, modules._context)
+                assert self.env.registry is registry()
 
             self.env['website'].browse(website.id).configurator_set_menu_links(menu_company, module_data)
 
@@ -463,9 +460,7 @@ class Website(models.Model):
         url = theme.button_choose_theme()
 
         # Force to refresh env after install of module
-        self._cr.commit()
-        api.Environment.reset()
-        self.env = api.Environment(theme._cr, theme._uid, theme._context)
+        assert self.env.registry is registry()
 
         website.configurator_done = True
 

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -90,7 +90,7 @@ class TestWebsitePerformance(UtilPerf):
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 20)
+        self.assertEqual(self._get_url_hot_query('/'), 18)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # website.page with no call to layout templates

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -13,7 +13,7 @@ class TestBlogPerformance(UtilPerf):
             self.env['website'].search([]).channel_id = False
 
     def test_10_perf_sql_blog_standard_data(self):
-        self.assertEqual(self._get_url_hot_query('/blog'), 28)
+        self.assertEqual(self._get_url_hot_query('/blog'), 26)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -25,8 +25,8 @@ class TestBlogPerformance(UtilPerf):
         for blog_post in blog_posts:
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
-        self.assertEqual(self._get_url_hot_query('/blog'), 28)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 31)
+        self.assertEqual(self._get_url_hot_query('/blog'), 26)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 29)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -251,7 +251,7 @@ class ir_cron(models.Model):
         # 3: now
         # 4: future_nextcall, the cron nextcall as seen from now
 
-        with api.Environment.manage(), db.cursor() as job_cr:
+        with cls.pool.cursor() as job_cr:
             lastcall = fields.Datetime.to_datetime(job['lastcall'])
             interval = _intervalTypes[job['interval_type']](job['interval_number'])
             env = api.Environment(job_cr, job['user_id'], {'lastcall': lastcall})

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2077,7 +2077,7 @@ class IrModelData(models.Model):
                 records_items.append((data.model, data.res_id))
 
         # avoid prefetching fields that are going to be deleted: during uninstall, it is
-        # possible to perform a recompute (via flush_env) after the database columns have been
+        # possible to perform a recompute (via flush) after the database columns have been
         # deleted but before the new registry has been created, meaning the recompute will
         # be executed on a stale registry, and if some of the data for executing the compute
         # methods is not in cache it will be fetched, and fields that exist in the registry but not

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -597,18 +597,17 @@ class Module(models.Model):
         function(self)
 
         self._cr.commit()
-        api.Environment.reset()
-        modules.registry.Registry.new(self._cr.dbname, update_module=True)
+        registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
+        self._cr.reset()
+        assert self.env.registry is registry
 
-        self._cr.commit()
-        env = api.Environment(self._cr, self._uid, self._context)
         # pylint: disable=next-method-called
-        config = env['ir.module.module'].next() or {}
+        config = self.env['ir.module.module'].next() or {}
         if config.get('type') not in ('ir.actions.act_window_close',):
             return config
 
         # reload the client; open the first available root menu
-        menu = env['ir.ui.menu'].search([('parent_id', '=', False)])[:1]
+        menu = self.env['ir.ui.menu'].search([('parent_id', '=', False)])[:1]
         return {
             'type': 'ir.actions.client',
             'tag': 'reload',

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -591,7 +591,7 @@ class Users(models.Model):
             # This is unlikely in a business code to change the company of a user and then do business stuff
             # but in case it happens this is handled.
             # e.g. `account_test_savepoint.py` `setup_company_data`, triggered by `test_account_invoice_report.py`
-            for env in list(self.env.envs):
+            for env in list(self.env.transaction.envs):
                 if env.user in self:
                     lazy_property.reset_all(env)
 

--- a/odoo/addons/base/wizard/base_module_upgrade.py
+++ b/odoo/addons/base/wizard/base_module_upgrade.py
@@ -70,8 +70,8 @@ class BaseModuleUpgrade(models.TransientModel):
 
         # terminate transaction before re-creating cursor below
         self._cr.commit()
-        api.Environment.reset()
         odoo.modules.registry.Registry.new(self._cr.dbname, update_module=True)
+        self._cr.reset()
 
         return {'type': 'ir.actions.act_window_close'}
 

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -190,7 +190,7 @@ class MergePartnerAutomatic(models.TransientModel):
                 return
             records = Model.sudo().search([(field_model, '=', 'res.partner'), (field_id, '=', src.id)])
             try:
-                with mute_logger('odoo.sql_db'), self._cr.savepoint(), self.env.clear_upon_failure():
+                with mute_logger('odoo.sql_db'), self._cr.savepoint():
                     records.sudo().write({field_id: dst_partner.id})
                     records.flush()
             except psycopg2.Error:

--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -26,12 +26,11 @@ class Populate(Command):
         opt = odoo.tools.config.parse_config(cmdargs)
         populate_models = opt.populate_models and set(opt.populate_models.split(','))
         population_size = opt.population_size
-        with odoo.api.Environment.manage():
-            dbname = odoo.tools.config['db_name']
-            registry = odoo.registry(dbname)
-            with registry.cursor() as cr:
-                env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
-                self.populate(env, population_size, populate_models)
+        dbname = odoo.tools.config['db_name']
+        registry = odoo.registry(dbname)
+        with registry.cursor() as cr:
+            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            self.populate(env, population_size, populate_models)
 
 
     @classmethod

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -102,10 +102,9 @@ def export_translation():
 
     with open(config["translate_out"], "wb") as buf:
         registry = odoo.modules.registry.Registry.new(dbname)
-        with odoo.api.Environment.manage():
-            with registry.cursor() as cr:
-                odoo.tools.trans_export(config["language"],
-                    config["translate_modules"] or ["all"], buf, fileformat, cr)
+        with registry.cursor() as cr:
+            odoo.tools.trans_export(config["language"],
+                config["translate_modules"] or ["all"], buf, fileformat, cr)
 
     _logger.info('translation file written successfully')
 
@@ -115,11 +114,10 @@ def import_translation():
     dbname = config['db_name']
 
     registry = odoo.modules.registry.Registry.new(dbname)
-    with odoo.api.Environment.manage():
-        with registry.cursor() as cr:
-            odoo.tools.trans_load(
-                cr, config["translate_in"], config["language"], overwrite=overwrite,
-            )
+    with registry.cursor() as cr:
+        odoo.tools.trans_load(
+            cr, config["translate_in"], config["language"], overwrite=overwrite,
+        )
 
 def main(args):
     check_root_user()

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -106,19 +106,18 @@ class Shell(Command):
             'openerp': odoo,
             'odoo': odoo,
         }
-        with odoo.api.Environment.manage():
-            if dbname:
-                registry = odoo.registry(dbname)
-                with registry.cursor() as cr:
-                    uid = odoo.SUPERUSER_ID
-                    ctx = odoo.api.Environment(cr, uid, {})['res.users'].context_get()
-                    env = odoo.api.Environment(cr, uid, ctx)
-                    local_vars['env'] = env
-                    local_vars['self'] = env.user
-                    self.console(local_vars)
-                    cr.rollback()
-            else:
+        if dbname:
+            registry = odoo.registry(dbname)
+            with registry.cursor() as cr:
+                uid = odoo.SUPERUSER_ID
+                ctx = odoo.api.Environment(cr, uid, {})['res.users'].context_get()
+                env = odoo.api.Environment(cr, uid, ctx)
+                local_vars['env'] = env
+                local_vars['self'] = env.user
                 self.console(local_vars)
+                cr.rollback()
+        else:
+            self.console(local_vars)
 
     def run(self, args):
         self.init(args)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -50,7 +50,6 @@ except ImportError:
 import odoo
 from .service.server import memory_info
 from .service import security, model as service_model
-from .sql_db import flush_env
 from .tools.func import lazy_property
 from .tools import profiler
 from .tools import ustr, consteq, frozendict, pycompat, unique, date_utils
@@ -353,8 +352,7 @@ class WebRequest(object):
             if self._cr is not None:
                 # flush here to avoid triggering a serialization error outside
                 # of this context, which would not retry the call
-                flush_env(self._cr)
-                self._cr.precommit.run()
+                self._cr.flush()
             return result
 
         if self.db:

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -71,33 +71,32 @@ class Registry(Mapping):
         """ Create and return a new registry for the given database name. """
         t0 = time.time()
         with cls._lock:
-            with odoo.api.Environment.manage():
-                registry = object.__new__(cls)
-                registry.init(db_name)
+            registry = object.__new__(cls)
+            registry.init(db_name)
 
-                # Initializing a registry will call general code which will in
-                # turn call Registry() to obtain the registry being initialized.
-                # Make it available in the registries dictionary then remove it
-                # if an exception is raised.
-                cls.delete(db_name)
-                cls.registries[db_name] = registry
+            # Initializing a registry will call general code which will in
+            # turn call Registry() to obtain the registry being initialized.
+            # Make it available in the registries dictionary then remove it
+            # if an exception is raised.
+            cls.delete(db_name)
+            cls.registries[db_name] = registry  # pylint: disable=unsupported-assignment-operation
+            try:
+                registry.setup_signaling()
+                # This should be a method on Registry
                 try:
-                    registry.setup_signaling()
-                    # This should be a method on Registry
-                    try:
-                        odoo.modules.load_modules(registry._db, force_demo, status, update_module)
-                    except Exception:
-                        odoo.modules.reset_modules_state(db_name)
-                        raise
+                    odoo.modules.load_modules(registry, force_demo, status, update_module)
                 except Exception:
-                    _logger.error('Failed to load registry')
-                    del cls.registries[db_name]
+                    odoo.modules.reset_modules_state(db_name)
                     raise
+            except Exception:
+                _logger.error('Failed to load registry')
+                del cls.registries[db_name]     # pylint: disable=unsupported-delete-operation
+                raise
 
-                # load_modules() above can replace the registry by calling
-                # indirectly new() again (when modules have to be uninstalled).
-                # Yeah, crazy.
-                registry = cls.registries[db_name]
+            # load_modules() above can replace the registry by calling
+            # indirectly new() again (when modules have to be uninstalled).
+            # Yeah, crazy.
+            registry = cls.registries[db_name]  # pylint: disable=unsubscriptable-object
 
             registry._init = False
             registry.ready = True
@@ -694,11 +693,15 @@ class Registry(Mapping):
         """ Return a new cursor for the database. The cursor itself may be used
             as a context manager to commit/rollback and close automatically.
         """
-        if self.test_cr is not None:
-            # When in test mode, we use a proxy object that uses 'self.test_cr'
-            # underneath.
-            return TestCursor(self.test_cr, self.test_lock)
-        return self._db.cursor()
+        if self.test_cr is None:
+            cr = self._db.cursor()
+        else:
+            # in test mode we use a proxy object that uses 'self.test_cr' underneath
+            cr = TestCursor(self.test_cr, self.test_lock)
+
+        # bind the cursor to a Transaction object, which manages environments
+        cr.transaction = odoo.api.Transaction(self)
+        return cr
 
 
 class DummyRLock(object):

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -152,7 +152,8 @@ def check(f):
     return wrapper
 
 def execute_cr(cr, uid, obj, method, *args, **kw):
-    odoo.api.Environment.reset()  # clean cache etc if we retry the same transaction
+    # clean cache etc if we retry the same transaction
+    cr.reset()
     recs = odoo.api.Environment(cr, uid, {}).get(obj)
     if recs is None:
         raise UserError(_("Object %s doesn't exist", obj))

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1254,8 +1254,7 @@ def preload_registries(dbnames):
                     _logger.warning('test file %s is not a python file', test_file)
                 else:
                     _logger.info('loading test file %s', test_file)
-                    with odoo.api.Environment.manage():
-                        load_test_file_py(registry, test_file)
+                    load_test_file_py(registry, test_file)
 
             # run post-install tests
             if config['test_enable']:
@@ -1265,9 +1264,8 @@ def preload_registries(dbnames):
                                 sorted(registry._init_modules))
                 _logger.info("Starting post tests")
                 tests_before = registry._assertion_report.testsRun
-                with odoo.api.Environment.manage():
-                    result = loader.run_suite(loader.make_suite(module_names, 'post_install'))
-                    registry._assertion_report.update(result)
+                result = loader.run_suite(loader.make_suite(module_names, 'post_install'))
+                registry._assertion_report.update(result)
                 _logger.info("%d post-tests in %.2fs, %s queries",
                              registry._assertion_report.testsRun - tests_before,
                              time.time() - t0,

--- a/odoo/service/wsgi_server.py
+++ b/odoo/service/wsgi_server.py
@@ -95,10 +95,9 @@ def application_unproxied(environ, start_response):
     if hasattr(threading.current_thread(), 'url'):
         del threading.current_thread().url
 
-    with odoo.api.Environment.manage():
-        result = odoo.http.root(environ, start_response)
-        if result is not None:
-            return result
+    result = odoo.http.root(environ, start_response)
+    if result is not None:
+        return result
 
     # We never returned from the loop.
     return werkzeug.exceptions.NotFound("No handler found.\n")(environ, start_response)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -443,14 +443,14 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
 
         if flush:
             self.env.user.flush()
-            self.env.cr.precommit.run()
+            self.env.cr.flush()
 
         with patch('odoo.sql_db.Cursor.execute', execute):
             with patch('odoo.osv.expression.get_unaccent_wrapper', get_unaccent_wrapper):
                 yield actual_queries
                 if flush:
                     self.env.user.flush()
-                    self.env.cr.precommit.run()
+                    self.env.cr.flush()
 
         self.assertEqual(
             len(actual_queries), len(expected),
@@ -485,12 +485,12 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
                 expected = counters.get(login, default)
                 if flush:
                     self.env.user.flush()
-                    self.env.cr.precommit.run()
+                    self.env.cr.flush()
                 count0 = self.cr.sql_log_count
                 yield
                 if flush:
                     self.env.user.flush()
-                    self.env.cr.precommit.run()
+                    self.env.cr.flush()
                 count = self.cr.sql_log_count - count0
                 if count != expected:
                     # add some info on caller to allow semi-automatic update of query count
@@ -509,11 +509,11 @@ class BaseCase(unittest.TestCase, metaclass=MetaCase):
             # same operations, otherwise the caches might not be ready!
             if flush:
                 self.env.user.flush()
-                self.env.cr.precommit.run()
+                self.env.cr.flush()
             yield
             if flush:
                 self.env.user.flush()
-                self.env.cr.precommit.run()
+                self.env.cr.flush()
 
     def assertRecordValues(self, records, expected_values):
         ''' Compare a recordset with a list of dictionaries representing the expected results.

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -174,12 +174,11 @@ class Cloc(object):
         self.count_customization(env)
 
     def count_database(self, database):
-        with odoo.api.Environment.manage():
-            registry = odoo.registry(config['db_name'])
-            with registry.cursor() as cr:
-                uid = odoo.SUPERUSER_ID
-                env = odoo.api.Environment(cr, uid, {})
-                self.count_env(env)
+        registry = odoo.registry(config['db_name'])
+        with registry.cursor() as cr:
+            uid = odoo.SUPERUSER_ID
+            env = odoo.api.Environment(cr, uid, {})
+            self.count_env(env)
 
     #------------------------------------------------------
     # Report


### PR DESCRIPTION
This proposal makes the following replacements/refactorings:
* function `flush_env()` → method `cr.flush()` (also taking care of precommit hooks)
* function `clear_env()` → method `cr.clear()`
* thread-local `Environments` → cursor-specific `Transaction` (holding common ORM data structures)
* context manager `Environment.manage()` → (no longer needed)
* static method `Environment.reset()` → method `cr.reset()`

Overall, this simplifies a bit the design of the ORM (no more thread-local vars) and also makes it correct (no more caches shared across transactions when you open several cursors).