### PR TITLE
[FIX] gamification: use context_today instead of today

### DIFF
--- a/addons/gamification/models/goal.py
+++ b/addons/gamification/models/goal.py
@@ -410,7 +410,7 @@ class Goal(models.Model):
         If the current value is changed and the report frequency is set to On
         change, a report is generated
         """
-        vals['last_update'] = fields.Date.today()
+        vals['last_update'] = fields.Date.context_today(self)
         result = super(Goal, self).write(vals)
         for goal in self:
             if goal.state != "draft" and ('definition_id' in vals or 'user_id' in vals):


### PR DESCRIPTION
`fields.Date.today` doesn't give date based on TZ which might be wrong
in some cases as it doesn't respect TZ.

With this commit, we are using `fields.Date.context_today` as default date.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
