### PR TITLE
[FIX] stock: use context_today instead of today

### DIFF
--- a/addons/stock/wizard/stock_orderpoint_snooze.py
+++ b/addons/stock/wizard/stock_orderpoint_snooze.py
@@ -20,7 +20,7 @@ class StockOrderpointSnooze(models.TransientModel):
 
     @api.onchange('predefined_date')
     def _onchange_predefined_date(self):
-        today = fields.Date.today()
+        today = fields.Date.context_today(self)
         if self.predefined_date == 'day':
             self.snoozed_until = add(today, days=1)
         elif self.predefined_date == 'week':


### PR DESCRIPTION
`fields.Date.today` doesn't give date based on TZ which might be wrong
in some cases as it doesn't respect TZ.

With this commit, we are using `fields.Date.context_today` as default date.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
