### PR TITLE
Log loudly if addons data dir can't be created

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -694,7 +694,7 @@ class configmanager(object):
                 # try to make +rx placeholder dir, will need manual +w to activate it
                 os.makedirs(d, 0o500)
             except OSError:
-                logging.getLogger(__name__).debug('Failed to create addons data dir %s', d)
+                logging.getLogger(__name__).error('Failed to create addons data dir %s', d)
         return d
 
     @property


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
#28718

Current behavior before PR:
The log is hidden in the debug messages.

Desired behavior after PR is merged:
The log is more visible and easily reported by log monitoring tools.

--
I confirm I have read the PR guidelines at www.odoo.com/submit-pr
