### PR TITLE
[IMP] website: theme avantgarde palette improvement

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -416,11 +416,12 @@ $o-color-palettes: map-merge($o-color-palettes,
             'o-color-4': #FFFFFF,
             'o-color-5': #000000,
 
+            'o-cc1-headings': 'o-color-1',
             'o-cc5-headings': 'o-color-1',
 
             'body': 'o-color-3',
             'footer': 1,
-            'copyright': 3,
+            'copyright': 1,
         ),
         'avantgarde-2': (
             'o-color-1': #38383b,
@@ -451,8 +452,9 @@ $o-color-palettes: map-merge($o-color-palettes,
             'o-cc4-headings': 'o-color-5',
             'o-cc5-headings': 'o-color-1',
 
-            'footer': 1,
-            'copyright': 1,
+            'menu': 3,
+            'footer': 4,
+            'copyright': 4,
         ),
         'avantgarde-4': (
             'o-color-1': #f78f4a,


### PR DESCRIPTION
Theme Avantgarde's palette has been improved, by using a more user-friendly
colour approach, increasing readability and using better default values.

This PR complements this one: https://github.com/odoo/design-themes/pull/485

--

Task-2573286

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
