### PR TITLE
[FIX] account : resequencing showed a ghost state change draft -> posted

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -130,9 +130,6 @@ class ReSequenceWizard(models.TransientModel):
 
     def resequence(self):
         new_values = json.loads(self.new_values)
-        # Can't change the name of a posted invoice, but we do not want to have the chatter
-        # logging 3 separate changes with [state to draft], [change of name], [state to posted]
-        self.with_context(tracking_disable=True).move_ids.state = 'draft'
         if self.move_ids.journal_id and self.move_ids.journal_id.restrict_mode_hash_table:
             if self.ordering == 'date':
                 raise UserError(_('You can not reorder sequence by date when the journal is locked with a hash.'))
@@ -142,4 +139,3 @@ class ReSequenceWizard(models.TransientModel):
                     move_id.name = new_values[str(move_id.id)]['new_by_name']
                 else:
                     move_id.name = new_values[str(move_id.id)]['new_by_date']
-                move_id.with_context(tracking_disable=True).state = new_values[str(move_id.id)]['state']


### PR DESCRIPTION
Issue: When resequencing an account_move, the chatter showed the
resequencing but also a ghost change of state from draft to posted

Steps to reproduce :
 1) Create an invoice and post it
 2) Look up the journal entry for the invoice and resequence it to some
 arbitrary other name
 3) Check the chatter for that invoice, it shows a change from draft to
 posted

Why is that a bug:
 The state isn't changed so it shouldn't be logged

Side-Note: I don't understand why in the code until this commit we had
to force change the state to draft to change the name of the move, when
I tested, we can change the name of a posted move without any issue

opw-2581248