### PR TITLE
[FIX] sale_stock: test failing depending on actual date

### DIFF
--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -84,7 +84,7 @@ class TestSaleExpectedDate(common.TransactionCase):
             ml.qty_done = ml.product_uom_qty
         picking.action_done()
         self.assertEquals(picking.state, 'done', "Picking not processed correctly!")
-        self.assertEquals(fields.Date.today(), sale_order.effective_date, "Wrong effective date on sale order!")
+        self.assertEquals(fields.Date.context_today(sale_order), sale_order.effective_date, "Wrong effective date on sale order!")
 
     def test_sale_order_commitment_date(self):
 


### PR DESCRIPTION
After 0411dda6f2d1216b6c8b727523e7557cfbad7e91
the associated test fail in certain time frame due to the datetime check

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
