### PR TITLE
Draft [FIX] mail: error if empty body

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1310,6 +1310,8 @@ class MailThread(models.AbstractModel):
                         body = tools.append_content_to_html(body, html, plaintext=False)
                     # we only strip_classes here everything else will be done in by html field of mail.message
                     body = tools.html_sanitize(body, sanitize_tags=False, strip_classes=True)
+                    if not '<p' in body:
+                        body = '<p%sp>' % body
                 # 4) Anything else -> attachment
                 else:
                     attachments.append(self._Attachment(filename or 'attachment', part.get_content(), {}))

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -883,3 +883,88 @@ OyI+T2RvbzwvYT4uCjwvcD4KPC9kaXY+CiAgICAgICAg
 
 --92726A5F09.1555335666/mail2.test.ironsky--
 """
+
+MAIL_EMPTY_BODY = '''\
+Return-Path: <{email_from}>
+Delivered-To: catchall@xxxx.xxxx
+Received: from localhost (HELO queue) (127.0.0.1)
+	by localhost with SMTP; 8 Jul 2021 12:30:13 +0200
+Received: from unknown (HELO output30.mail.ovh.net) (10.108.117.192)
+  by mail103.ha.ovh.net with AES256-GCM-SHA384 encrypted SMTP; 8 Jul 2021 12:30:13 +0200
+Received: from vr38.mail.ovh.net (unknown [10.101.8.38])
+	by out30.mail.ovh.net (Postfix) with ESMTP id 4GLCGs0v6MzGkHZmJ
+	for <catchall@xxxx.xxxx>; Thu,  8 Jul 2021 10:30:13 +0000 (UTC)
+Received: from in66.mail.ovh.net (unknown [10.101.4.66])
+	by vr38.mail.ovh.net (Postfix) with ESMTP id 4GLCGr70Kyz1myr75
+	for <catchall@xxxx.xxxx>; Thu,  8 Jul 2021 10:30:12 +0000 (UTC)
+X-Comment: SPF check N/A for local connections - client-ip=213.186.33.59; helo=mail663.ha.ovh.net; envelope-from={email_from}; receiver=catchall@xxxx.xxxx 
+Authentication-Results: in66.mail.ovh.net; dkim=none; dkim-atps=neutral
+Received: from mail663.ha.ovh.net (b9.ovh.net [213.186.33.59])
+	by in66.mail.ovh.net (Postfix) with SMTP id 4GLCGr69xwz1BcVSC
+	for <catchall@xxxx.xxxx>; Thu,  8 Jul 2021 10:30:12 +0000 (UTC)
+Received: from localhost (HELO queueout) (127.0.0.1)
+	by localhost with SMTP; 8 Jul 2021 12:30:12 +0200
+Delivered-To: xxxx.xxxx-{email_to}
+Received: from localhost (HELO queue) (127.0.0.1)
+	by localhost with SMTP; 8 Jul 2021 12:30:12 +0200
+Received: from unknown (HELO output52.mail.ovh.net) (10.108.97.123)
+  by mail663.ha.ovh.net with AES256-GCM-SHA384 encrypted SMTP; 8 Jul 2021 12:30:12 +0200
+Received: from vr38.mail.ovh.net (unknown [10.101.8.38])
+	by out52.mail.ovh.net (Postfix) with ESMTP id 4GLCGr27DKzGd1X2w
+	for <{email_to}>; Thu,  8 Jul 2021 10:30:12 +0000 (UTC)
+Received: from in75.mail.ovh.net (unknown [10.101.4.75])
+	by vr38.mail.ovh.net (Postfix) with ESMTP id 4GLCGr1Dyqz1myr6S
+	for <{email_to}>; Thu,  8 Jul 2021 10:30:12 +0000 (UTC)
+Received-SPF: None (mailfrom) identity=mailfrom; client-ip=80.12.242.135; helo=smtp.smtpout.orange.fr; envelope-from={email_from}; receiver={email_to} 
+Authentication-Results: in75.mail.ovh.net; dkim=none; dkim-atps=neutral
+Received: from smtp.smtpout.orange.fr (smtp13.smtpout.orange.fr [80.12.242.135])
+	by in75.mail.ovh.net (Postfix) with ESMTPS id 4GLCGr02Y6z1BXjwW
+	for <{email_to}>; Thu,  8 Jul 2021 10:30:11 +0000 (UTC)
+Received: from opme11oxm23aub.bagnolet.francetelecom.fr ([10.110.82.23])
+	by mwinf5d71 with ME
+	id SaWB2500Q0WBUMW03aWBi8; Thu, 08 Jul 2021 12:30:11 +0200
+X-ME-Helo: opme11oxm23aub.bagnolet.francetelecom.fr
+X-ME-Auth: ZnJlZGVyaWMuYmxhY2hvbjA3QG9yYW5nZS5mcg==
+X-ME-Date: Thu, 08 Jul 2021 12:30:11 +0200
+X-ME-IP: 86.221.151.111
+Date: Thu, 8 Jul 2021 12:30:11 +0200 (CEST)
+From: =?UTF-8?Q?Fr=C3=A9d=C3=A9ric_BLACHON?= <{email_from}>
+Reply-To: 
+	=?UTF-8?Q?Fr=C3=A9d=C3=A9ric_BLACHON?= <{email_from}>
+To: {email_to}
+Message-ID: <1024471522.82574.1625740211606.JavaMail.open-xchange@opme11oxm23aub.bagnolet.francetelecom.fr>
+Subject: transport autorisation 19T
+MIME-Version: 1.0
+Content-Type: multipart/mixed; 
+	boundary="----=_Part_82573_178179506.1625740211587"
+X-Priority: 3
+Importance: Medium
+X-Mailer: Open-Xchange Mailer v7.6.3-Rev58
+X-Originating-IP: 86.221.151.111
+X-Originating-Client: open-xchange-appsuite
+X-Ovh-Tracer-Id: 15254817838504580122
+X-VR-SPAMSTATE: OK
+X-VR-SPAMSCORE: 20
+X-VR-SPAMCAUSE: gggruggvucftvghtrhhoucdtuddrgedvtddrtdeggddvjecutefuodetggdotefrodftvfcurfhrohhfihhlvgemucfqggfjpdevjffgvefmvefgnecuuegrihhlohhuthemucehtddtnecuogfthfevqddquegrugfkmhhpohhrthgrnhgtvgculddvtddmnecujfgurhepfffhrhfvkffugggtrfgkofhisehmtdgtsgertdejnecuhfhrohhmpefhrhorugorrhhitggpuefnteevjffqpfcuoehfrhgvuggvrhhitgdrsghlrggthhhonhdtjeesohhrrghnghgvrdhfrheqnecuggftrfgrthhtvghrnhepteduieekieeigfetgfdvveeljeeggfekudfghfefjefghfelkeduffdvfeevfffgnecukfhppedtrddtrddtrddtpdekiedrvddvuddrudehuddrudduuddpkedtrdduvddrvdegvddrudefheenucevlhhushhtvghrufhiiigvpedtnecurfgrrhgrmhepmhhouggvpehsmhhtphdphhgvlhhopehinhejhedrmhgrihhlrdhovhhhrdhnvghtpdhinhgvtheptddrtddrtddrtddpmhgrihhlfhhrohhmpehfrhgvuggvrhhitgdrsghlrggthhhonhdtjeesohhrrghnghgvrdhfrhdprhgtphhtthhopehsvghrvhhitggvtghlihgvnhhtsehsihhmphhlhihfvghurdgtohhm
+X-Ovh-Spam-Status: OK
+X-Ovh-Spam-Reason: vr: OK; dkim: disabled; spf: disabled
+X-Ovh-Message-Type: OK
+X-OVH-Remote: 213.186.33.59
+X-VR-SPAMSTATE: OK
+X-VR-SPAMSCORE: 20
+X-VR-SPAMCAUSE: gggruggvucftvghtrhhoucdtuddrgedvtddrtdeggddvjecutefuodetggdotefrodftvfcurfhrohhfihhlvgemucfqggfjpdevjffgvefmvefgnecuuegrihhlohhuthemucehtddtnecuogfthfevqddquegrugfkmhhpohhrthgrnhgtvgculddvtddmnecujfgurhepfffhrhfvkffugggtrfgkofhisehmtdgtsgertdejnecuhfhrohhmpefhrhorugorrhhitggpuefnteevjffqpfcuoehfrhgvuggvrhhitgdrsghlrggthhhonhdtjeesohhrrghnghgvrdhfrheqnecuggftrfgrthhtvghrnhepteduieekieeigfetgfdvveeljeeggfekudfghfefjefghfelkeduffdvfeevfffgnecukfhppedtrddtrddtrddtpdekiedrvddvuddrudehuddrudduuddpkedtrdduvddrvdegvddrudefheenucevlhhushhtvghrufhiiigvpedtnecurfgrrhgrmhepmhhouggvpehsmhhtphdphhgvlhhopehinheiiedrmhgrihhlrdhovhhhrdhnvghtpdhinhgvtheptddrtddrtddrtddpmhgrihhlfhhrohhmpehfrhgvuggvrhhitgdrsghlrggthhhonhdtjeesohhrrghnghgvrdhfrhdprhgtphhtthhopegtrghttghhrghllhesshhimhhplhihfhgvuhdrtghomhdphhgvlhhopehinhejhedrmhgrihhlrdhovhhhrdhnvghtpdhrtghpthhtohepshgvrhhvihgtvggtlhhivghnthesshhimhhplhihfhgvuhdrtghomh
+X-Ovh-Spam-Status: OK
+X-Ovh-Spam-Reason: vr: OK; dkim: disabled; spf: disabled
+X-Ovh-Message-Type: OK
+
+------=_Part_82573_178179506.1625740211587
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+ </head><body style="font-family: arial,helvetica,sans-serif; font-size: 13pt"></body></html>
+'''

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -55,6 +55,9 @@ class TestEmailParsing(TestMailCommon):
         res = self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_MULTIPART_WEIRD_FILENAME))
         self.assertEqual(res['attachments'][0][0], '62_@;,][)=.(ÇÀÉ.txt')
 
+        # test mail with empty body
+        self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_EMPTY_BODY))
+
     def test_message_parse_eml(self):
         # Test that the parsing of mail with embedded emails as eml(msg) which generates empty attachments, can be processed.
         mail = self.format(test_mail_data.MAIL_EML_ATTACHMENT, email_from='"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>', to='generic@test.com')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If an email is:

```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

<html xmlns="http://www.w3.org/1999/xhtml"><head>
    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head><body style="font-family: arial,helvetica,sans-serif; font-size: 13pt"></body></html>
```

An error occur and the email is not process. (it is an issue if the email contain a binary)

@tde-banana-odoo it is an ugly fix, do you have any idea to fix that ?


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
