### PR TITLE
[FIX] l10n_in_pos: Fixed the xpath in pos_receipt template 

### DIFF
--- a/addons/l10n_in_pos/static/src/xml/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/xml/pos_receipt.xml
@@ -15,7 +15,10 @@
                 </div>
             </t>
         </xpath>
-        <xpath expr="//div[hasclass('orderlines')]" position="after">
+    </t>
+
+    <t t-name="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
+        <xpath expr="//t[@t-foreach='receipt.orderlines']" position="inside">
             <t t-if="line.l10n_in_hsn_code and env.pos.company.country and env.pos.company.country.code == 'IN'">
                 <div class="pos-receipt-left-padding">
                     <span>HSN Code: </span>


### PR DESCRIPTION
Before this commit:
===============
when we have installed module l10n_in_pos at the time of printing receipt it give error

After this commit:
=============
print POS receipt successfully.

Issue and Fix:
===========
it was showing an error because of changes made in commit: 8610a4bf38917d1f9384c87008ff2cb7dc14589a
fixed the issue by inherit the OrderLinesReceipt template and adding the correct xpath in pos_receipt template


task-id: 2623512

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
