### PR TITLE
[FIX] web_editor: prevent traceback when InputEvent.data = null

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1677,7 +1677,7 @@ export class OdooEditor extends EventTarget {
                     setCursor(range.endContainer, range.endOffset);
                 }
                 // Check for url after user insert a space so we won't transform an incomplete url.
-                if (ev.data.includes(' ') && selection && selection.anchorNode) {
+                if (ev.data && ev.data.includes(' ') && selection && selection.anchorNode) {
                     ev.preventDefault();
                     this._convertUrlInElement(closestElement(selection.anchorNode));
                     this.execCommand('insertText', ev.data);


### PR DESCRIPTION
Step to follow

1. open any record with a chatter enabled
2. start to write a log note in the the full composer
3. write a line with at least one character, then shift+enter
-> There is a traceback

Cause of the issue

InputEvent.data can be null

opw-2622051