### PR TITLE
[IMP] l10n_ar: Argentina Localization config

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -100,6 +100,7 @@ Master Data:
         'views/account_journal_view.xml',
         'views/l10n_latam_document_type_view.xml',
         'views/report_invoice.xml',
+        'views/res_config_settings_view.xml',
         'report/invoice_report_view.xml',
         'data/account_chart_template_configure_data.xml',
     ],

--- a/addons/l10n_ar/views/res_config_settings_view.xml
+++ b/addons/l10n_ar/views/res_config_settings_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="res_config_settings_view_form">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='account']/div" position="after">
+                <div  id="argentina_localization_section" invisible="1">
+                    <h2 attrs="{'invisible':[('country_code', '!=', 'AR')]}">Argentinean Localization</h2>
+                    <div class="row mt16 o_settings_container" id="argentina_localization" attrs="{'invisible':[('country_code', '!=', 'AR')]}">
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
### related to Latam ticket 579 / Adhoc ticket 36712


Move Argentina Localization section from l10n_ar_edi module to l10n_ar module.
This config will be extended from both l10n_ar_report and l10n_ar_edi modules.
