### PR TITLE
[IMP] l10n_fr_reports: Round lines of tax report and closing entries to the nearest euro

### DIFF
--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -890,6 +890,7 @@
                                 <field name="engine">aggregation</field>
                                 <field name="formula">box_27.balance</field>
                                 <field name="carryover_target">box_22._applied_carryover_balance</field>
+                                <field name="subformula">round(0)</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_fr/models/res_company.py
+++ b/addons/l10n_fr/models/res_company.py
@@ -11,6 +11,9 @@ class ResCompany(models.Model):
     siret = fields.Char(related='partner_id.siret', string='SIRET', size=14, readonly=False)
     ape = fields.Char(string='APE')
 
+    l10n_fr_rounding_difference_loss_account_id = fields.Many2one('account.account')
+    l10n_fr_rounding_difference_profit_account_id = fields.Many2one('account.account')
+
     @api.model
     def _get_unalterable_country(self):
         return ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF'] # These codes correspond to France and DOM-TOM.

--- a/addons/l10n_fr/models/template_fr.py
+++ b/addons/l10n_fr/models/template_fr.py
@@ -29,6 +29,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'expense_currency_exchange_account_id': 'pcg_666',
                 'account_journal_early_pay_discount_loss_account_id': 'pcg_665',
                 'account_journal_early_pay_discount_gain_account_id': 'pcg_765',
+                'l10n_fr_rounding_difference_loss_account_id': 'pcg_658',
+                'l10n_fr_rounding_difference_profit_account_id': 'pcg_758',
             },
         }
 


### PR DESCRIPTION
French tax reports require that each line is rounded to the nearest euro.
 In the l10n_fr localisation add default rounding accounts to the chart template and the company, add them to the try loading section of account chart template data xml

== PRs ==
odoo/enterprise#20245

task: 2610752
