### PR TITLE
[FIX] web_editor: remove color border from link style option

### DIFF
--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -506,22 +506,20 @@
         <we-row>
             <we-select class="o_we_user_value_widget">
                 <we-title>⌙ Style</we-title>
-                <div t-attf-class="#{widget.colorCombinationClass ? ('p-2 ' + widget.colorCombinationClass) : ''}">
-                    <div class="dropdown">
-                        <button class="dropdown-toggle"
-                            data-toggle="dropdown" title="" tabindex="-1"
-                            data-original-title="Link Style" aria-expanded="false">
-                            <we-toggler/>
-                        </button>
-                        <we-selection-items class="dropdown-menu" name="link_style_color">
-                            <t t-foreach="widget.colorsData" t-as="colorData">
-                                <we-button class="dropdown-item" href="#" t-att-data-value="colorData.type">
-                                    <t t-esc="colorData.label"/>
-                                </we-button>
-                            </t>
-                        </we-selection-items>
-                        <span class="o_we_dropdown_caret"></span>
-                    </div>
+                <div class="dropdown">
+                    <button class="dropdown-toggle"
+                        data-toggle="dropdown" title="" tabindex="-1"
+                        data-original-title="Link Style" aria-expanded="false">
+                        <we-toggler/>
+                    </button>
+                    <we-selection-items class="dropdown-menu" name="link_style_color">
+                        <t t-foreach="widget.colorsData" t-as="colorData">
+                            <we-button class="dropdown-item" href="#" t-att-data-value="colorData.type">
+                                <t t-esc="colorData.label"/>
+                            </we-button>
+                        </t>
+                    </we-selection-items>
+                    <span class="o_we_dropdown_caret"></span>
                 </div>
             </we-select>
         </we-row>


### PR DESCRIPTION
Before this fix applied color combinations were shown on the style
option.

After this fix the style option is displayed as any other plain option.

task-2612755

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
