### PR TITLE
[FIX] website: set "Free sign up" as default setting

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -110,7 +110,7 @@ class Website(models.Model):
     auth_signup_uninvited = fields.Selection([
         ('b2b', 'On invitation'),
         ('b2c', 'Free sign up'),
-    ], string='Customer Account', default='b2b')
+    ], string='Customer Account', default='b2c')
 
     @api.onchange('language_ids')
     def _onchange_language_ids(self):


### PR DESCRIPTION
Further discussion and new commits moved to [this pull request](https://github.com/odoo/odoo/pull/76262),
as the problem is on another version and is more than simply modifying
a default, and I'm dumb and didn't retarget the branch but made a new
PR instead.

Description of the issue/feature this PR addresses:
Free sign up is the default option for website's authentication setting.
Even though it is set, the "Don't have an account?" link does not
appear by default. One needs to remove the option and then set it
back on to make the link appear.

Desired behavior after PR is merged:
When website is installed, "Free sign up" is set as the default,
and the "Don't have an account?" link appears straight away.

task-2612686
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
