### PR TITLE
[FIX] mrp: `qty_available` computation of a nested bom kits asked together

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -112,6 +112,8 @@ class ProductProduct(models.Model):
         bom_kits = self.env['mrp.bom']._get_product2bom(self, bom_type='phantom')
         kits = self.filtered(lambda p: bom_kits.get(p))
         res = super(ProductProduct, self - kits)._compute_quantities_dict(lot_id, owner_id, package_id, from_date=from_date, to_date=to_date)
+        qties = self.env.context.get("mrp_compute_quantities", {})
+        qties.update(res)
         for product in bom_kits:
             boms, bom_sub_lines = bom_kits[product].explode(product, 1)
             ratios_virtual_available = []
@@ -120,7 +122,7 @@ class ProductProduct(models.Model):
             ratios_outgoing_qty = []
             ratios_free_qty = []
             for bom_line, bom_line_data in bom_sub_lines:
-                component = bom_line.product_id
+                component = bom_line.product_id.with_context(mrp_compute_quantities=qties)
                 if component.type != 'product' or float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
                     # As BoMs allow components with 0 qty, a.k.a. optionnal components, we simply skip those
                     # to avoid a division by zero. The same logic is applied to non-storable products as those
@@ -130,7 +132,7 @@ class ProductProduct(models.Model):
                 qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, raise_if_failure=False)
                 if not qty_per_kit:
                     continue
-                component_res = res.get(component.id, {
+                component_res = qties.get(component.id, {
                     "virtual_available": component.virtual_available,
                     "qty_available": component.qty_available,
                     "incoming_qty": component.incoming_qty,


### PR DESCRIPTION
This revision has a similar goal than the previous revision
62c5b8d95c1ba5634e201c0c8a3e2d91fb2305a7
but this times, it's a kit/phantom bom which is nested in another
kit/phantom bom, and their computation is asked in the same time.

```
2021-08-20 11:29:54,835 1689 ERROR db_22687 odoo.upgrade.stock.tests.test_on_hand_quantity: FAIL: TestOnHandQuantityUnchanged.test_check
Traceback (most recent call last):
  File "/tmp/tmpv3ujv2vr/migrations/testing.py", line 208, in test_check
    self.check(value)
  File "/tmp/tmpv3ujv2vr/migrations/stock/tests/test_on_hand_quantity.py", line 20, in check
    self.assertEqual(before_results, self.convert_check(after_results), self.message)
AssertionError: Lists differ: [[551[14585 chars] [8988, '137'], [8989, '137'], [8990, '20'], [[1793 chars]91']] != [[551[14585 chars] [8989, '137'], [8990, '20'], [8991, '126'], [[1778 chars]91']]

First differing element 1007:
[8988, '137']
[8989, '137'
```

```
SELECT b.id, b.type,  p.id as kit_product_id, b.product_tmpl_id as kit_product_tmpl_id, pt.name as
kit_product_name FROM mrp_bom b JOIN product_template pt ON pt.id = b.product_tmpl_id JOIN product_product p ON p.pr
oduct_tmpl_id = pt.id WHERE p.id = 8988;
-[ RECORD 1 ]-------+-----------------
id                  | 2208
type                | phantom
kit_product_id      | 8988
kit_product_tmpl_id | 9049
kit_product_name    | KIT Poulie AR G4
```

```
SELECT b.id, p.id as kit_product_id, b.product_tmpl_id as kit_product_tmpl_id, pt.name as kit_product_name, l.product_id as component_product_id, component_t.name as component_name FROM mrp_bom_line l JOIN mrp_bom b ON l.bom_id = b.id JOIN product_product p ON p.product_tmpl_id = b.product_tmpl_id JOIN product_template pt ON pt.id = b.product_tmpl_id JOIN product_product component ON component.id = l.product_id JOIN product_template component_t ON component_t.id = component.product_tmpl_id WHERE l.product_id = 8988;
-[ RECORD 1 ]--------+---------------------
id                   | 2213
kit_product_id       | 8761
kit_product_tmpl_id  | 8879
kit_product_name     | VEL BP KIT direction
component_product_id | 8988
component_name       | KIT Poulie AR G4
```

upg-22687
