### PR TITLE
[FIX] pos_sale: rename compute function

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -38,8 +38,8 @@ class SaleOrderLine(models.Model):
             sale_line.qty_delivered += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids if sale_line.product_id.type != 'service'], 0)
 
     @api.depends('pos_order_line_ids.qty')
-    def _get_invoice_qty(self):
-        super()._get_invoice_qty()
+    def _compute_qty_invoiced(self):
+        super()._compute_qty_invoiced()
         for sale_line in self:
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 


### PR DESCRIPTION
Invoiced quantity was wronglyy computed from Pos sale, because of
renaming of compute function in following commit: https://github.com/odoo/odoo/commit/36fc80777ec5c0065b8a253861378a5f05ed0b6e

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
