### PR TITLE
[IMP] repair/mrp UI improvement

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -20,7 +20,7 @@ class Repair(models.Model):
     _name = 'repair.order'
     _description = 'Repair Order'
     _inherit = ['mail.thread', 'mail.activity.mixin']
-    _order = 'create_date desc'
+    _order = 'priority desc, create_date desc'
 
     name = fields.Char(
         'Repair Reference',
@@ -65,6 +65,7 @@ class Repair(models.Model):
              "* The \'To be Invoiced\' status is used to generate the invoice before or after repairing done.\n"
              "* The \'Done\' status is set when repairing is completed.\n"
              "* The \'Cancelled\' status is used when user cancel repair order.")
+    schedule_date = fields.Date("Scheduled Date")
     location_id = fields.Many2one(
         'stock.location', 'Location',
         index=True, readonly=True, required=True, check_company=True,
@@ -118,6 +119,7 @@ class Repair(models.Model):
     amount_total = fields.Float('Total', compute='_amount_total', store=True)
     tracking = fields.Selection(string='Product Tracking', related="product_id.tracking", readonly=False)
     invoice_state = fields.Selection(string='Invoice State', related='invoice_id.state')
+    priority = fields.Selection([('0', 'Normal'), ('1', 'Urgent')], default='0', string="Priority", help="Important repair order")
 
     @api.depends('partner_id')
     def _compute_default_address_id(self):

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -7,8 +7,10 @@
         <field name="model">repair.order</field>
         <field name="arch" type="xml">
             <tree string="Repairs order" multi_edit="1" sample="1">
+                <field name="priority" optional="show" widget="priority" nolabel="1"/>
                 <field name="name"/>
-                <field name="description"/>
+                <field name="schedule_date" optional="show" widget="remaining_days"/>
+                <field name="description" optional="hide"/>
                 <field name="product_id" readonly="1" optional="show"/>
                 <field name="product_qty" optional="hide" string="Quantity"/>
                 <field name="product_uom" string="Unit of Measure" readonly="1" optional="hide"/>
@@ -16,6 +18,7 @@
                 <field name="partner_id" readonly="1" optional="show"/>
                 <field name="address_id" optional="show"/>
                 <field name="guarantee_limit" optional="show"/>
+                <field name="sale_order_id" optional="show"/>
                 <field name="location_id" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="show"/>
                 <field name="state" optional="show" widget='badge' decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')"/>
@@ -61,6 +64,7 @@
                     <div class="oe_title">
                         <label class="o_form_label" for="name"/>
                         <h1>
+                            <field name="priority" widget="priority" class="mr-3"/>
                             <field name="name"/>
                         </h1>
                     </div>
@@ -69,12 +73,12 @@
                             <field name="description"/>
                             <field name="invoice_state" invisible="1"/>
                             <field name="tracking" invisible="1" attrs="{'readonly': 1}"/>
-                            <field name="product_id" />
+                            <field name="product_id"/>
                             <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'required':[('tracking', 'in', ['serial', 'lot'])], 'invisible': [('tracking', 'not in', ['serial', 'lot'])], 'readonly': ['|', ('state', '=', 'done'), ('tracking', 'not in', ['serial', 'lot'])]}"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="product_qty"/>
                             <div class="o_row">
-                                <field name="product_qty" attrs="{'readonly':[('tracking', 'in', ['serial'])]}"/>
+                                <field name="product_qty" attrs="{'readonly':[('tracking', '=', 'serial')]}"/>
                                 <field name="product_uom" groups="uom.group_uom"/>
                             </div>
                             <field name="partner_id" widget="res_partner_many2one" attrs="{'required':[('invoice_method','!=','none')]}" context="{'res_partner_search_mode': 'customer', 'show_vat': True}"/>
@@ -83,6 +87,7 @@
                             <field name="user_id" domain="[('share', '=', False)]"/>
                         </group>
                         <group>
+                            <field name="schedule_date"/>
                             <field name="location_id" options="{'no_create': True}"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                             <field name="guarantee_limit"/>
@@ -269,6 +274,7 @@
                 <field name="name" string="Repair Order" filter_domain="['|', ('name', 'ilike', self), ('product_id', 'ilike', self)]"/>
                 <field name="product_id"/>
                 <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
+                <field name="sale_order_id"/>
                 <filter string="Quotations" name="quotations" domain="[('state', '=', 'draft')]"/>
                 <filter string="Confirmed" domain="[('state', '=', 'confirmed')]" name="current" />
                 <filter string="Ready To Repair" name="ready_to_repair" domain="[('state', '=', 'ready')]"/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -49,7 +49,7 @@
                 <field name="qty_forecast" force_save="1"/>
                 <button name="action_product_forecast_report" type="object" icon="fa-area-chart" attrs="{'invisible': [('id', '=', False)]}"/>
                 <field name="route_id" options="{'no_create': True, 'no_open': True}"/>
-                <button name="action_stock_replenishment_info" type="object" icon="fa-info" attrs="{'invisible': [('id', '=', False)]}"/>
+                <button name="action_stock_replenishment_info" type="object" icon="fa-info-circle" attrs="{'invisible': [('id', '=', False)]}"/>
                 <field name="trigger" optional="hide"/>
                 <field name="group_id" optional="hide" groups="stock.group_adv_location"/>
                 <field name="product_min_qty" optional="show"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

We doesn't have the possibilities to see which repair order have the highest priority (with a date or a star)

Desired behavior after PR is merged:

Repair module : 
    - add scheduled date for a repair Order
    - add priority star 

Task related: 2593256
PR: https://github.com/odoo/odoo/pull/75657

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
