### PR TITLE
[FIX] web : Fixed datetime filter search based on wrong hours

### DIFF
--- a/addons/web/static/src/js/control_panel/custom_filter_item.js
+++ b/addons/web/static/src/js/control_panel/custom_filter_item.js
@@ -118,9 +118,9 @@ odoo.define('web.CustomFilterItem', function (require) {
                     }
                     break;
                 case 'datetime':
-                    condition.value = [moment('00:00:00', 'hh:mm:ss')];
+                    condition.value = [moment('00:00:00', 'hh:mm:ss').utcOffset(0, true)];
                     if (operator.symbol === 'between') {
-                        condition.value.push(moment('23:59:59', 'hh:mm:ss'));
+                        condition.value.push(moment('23:59:59', 'hh:mm:ss').utcOffset(0, true));
                     }
                     break;
                 case 'selection':


### PR DESCRIPTION
Reproduce :
(With timezone GMT+3)
- Create any record R1 with previous day's date and time after 21:00.
- Create any record R2 with today's date and time after 21:00.
- Create a filter to show all todays records (Date is between "<TODAY'S DATE> 00:00:00 and <TODAY'S DATE> 23:59:59".

Result :
  Even though R1 is in yesterday's date, it will show in the list.
  R2 will not show in this list.

Explanation :
  This behaviour has been observed in several modules, for any timezone but UTC & only with custom filters default datetime values.
  The search was applied on [datetime(UTC) + 2 * offset] because the timezone wasn't correctly set.

Solution :
  Timezone is now correctly set on default datetime values.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
