### PR TITLE
[IMP] mrp: Improve MRP Planning features

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -53,7 +53,7 @@ class MrpBom(models.Model):
     ready_to_produce = fields.Selection([
         ('all_available', ' When all components are available'),
         ('asap', 'When components for 1st operation are available')], string='Manufacturing Readiness',
-        default='asap', help="Defines when a Manufacturing Order is considered as ready to be started", required=True)
+        default='all_available', help="Defines when a Manufacturing Order is considered as ready to be started", required=True)
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type', domain="[('code', '=', 'mrp_operation'), ('company_id', '=', company_id)]",
         check_company=True,

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -111,6 +111,8 @@ class StockMove(models.Model):
     cost_share = fields.Float(
         "Cost Share (%)", digits=(5, 2),  # decimal = 2 is important for rounding calculations!!
         help="The percentage of the final production cost for this by-product. The total of all by-products' cost share must be smaller or equal to 100.")
+    product_qty_available = fields.Float('Product On Hand Quantity', related='product_id.qty_available')
+    product_virtual_available = fields.Float('Product Forecasted Quantity', related='product_id.virtual_available')
 
     @api.depends('raw_material_production_id.priority')
     def _compute_priority(self):

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -131,6 +131,7 @@ class TestMrpCommon(common2.TestStockCommon):
             'product_id': cls.product_6.id,
             'product_tmpl_id': cls.product_6.product_tmpl_id.id,
             'product_uom_id': cls.uom_dozen.id,
+            'ready_to_produce': 'asap',
             'consumption': 'flexible',
             'product_qty': 2.0,
             'operation_ids': [

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -166,8 +166,25 @@
                             <span>minutes</span>
                         </div>
                     </group>
+                    <group>
+                        <field name="production_id"/>
+                    </group>
                 </group>
                 <notebook>
+                <page string="Components" name="components">
+                    <field name="move_raw_ids" readonly="1">
+                        <tree>
+                            <field name="state" invisible="1"/>
+                            <field name="product_type" invisible="1"/>
+                            <field name="product_id"/>
+                            <field name="product_qty" string="To Consume"/>
+                            <field name="reserved_availability" string ="Reserved"/>
+                            <field name="quantity_done" string="Consumed"/>
+                            <field name="product_qty_available" string="On Hand" attrs="{'invisible': [('product_type', '!=', 'product')]}"/>
+                            <field name="product_virtual_available" string="Forecasted" attrs="{'invisible': [('product_type', '!=', 'product')]}"/>
+                        </tree>
+                    </field>
+                </page>
                 <page string="Time Tracking" name="time_tracking" groups="mrp.group_mrp_manager">
                     <group>
                         <field name="time_ids" nolabel="1" context="{'default_workcenter_id': workcenter_id, 'default_workorder_id': id}">


### PR DESCRIPTION
Review Work Order pop up design:
- add mo reference and Components tab at first
Manufacturing Readiness:
- set 'When all components are available' as default

task: 2527408

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
