### PR TITLE
[IMP] stock: hide SN clear all button when no mls

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -165,6 +165,7 @@ class StockMove(models.Model):
     package_level_id = fields.Many2one('stock.package_level', 'Package Level', check_company=True, copy=False)
     picking_type_entire_packs = fields.Boolean(related='picking_type_id.show_entire_packs', readonly=True)
     display_assign_serial = fields.Boolean(compute='_compute_display_assign_serial')
+    display_clear_serial = fields.Boolean(compute='_compute_display_clear_serial')
     next_serial = fields.Char('First SN')
     next_serial_count = fields.Integer('Number of SN')
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Original Reordering Rule', check_company=True)
@@ -186,6 +187,12 @@ class StockMove(models.Model):
                 not move.picking_type_id.use_existing_lots
                 and not move.origin_returned_move_id.id
             )
+
+    @api.depends('display_assign_serial', 'move_line_ids', 'move_line_nosuggest_ids')
+    def _compute_display_clear_serial(self):
+        self.display_clear_serial = False
+        for move in self:
+            move.display_clear_serial = move.display_assign_serial and move._get_move_lines()
 
     @api.depends('picking_id.priority')
     def _compute_priority(self):

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -142,6 +142,7 @@
                     <field name="display_assign_serial" invisible="1"/>
                     <field name="from_immediate_transfer" invisible="1"/>
                     <field name="product_uom_category_id" invisible="1"/>
+                    <field name="display_clear_serial" invisible="1"/>
                     <group>
                         <group>
                             <field name="product_id" readonly="1"/>
@@ -170,7 +171,7 @@
                                 <button name="action_clear_lines_show_details" type="object"
                                         class="btn-link" data-hotkey="y"
                                         title="Clear Lines"
-                                        attrs="{'invisible': [('display_assign_serial', '=', False)]}">
+                                        attrs="{'invisible': [('display_clear_serial', '=', False)]}">
                                     <span>Clear All</span>
                                 </button>
                             </div>


### PR DESCRIPTION
Hide the "Clear All" button next to "Assign Serial Numbers" button when
there are no move lines to clear.

Follow up to task: 2426281

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
