### PR TITLE
[IMP] mrp: imp duration on MO view

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -17,8 +17,6 @@
                     <field name="date_planned_start" readonly="1" optional="show" widget="remaining_days"/>
                     <field name="date_deadline" widget="remaining_days" attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}" optional="hide"/>
                     <field name="product_id" readonly="1" optional="show"/>
-                    <field name="production_duration_expected" attrs="{'invisible': [('production_duration_expected', '=', 0)]}" widget="float_time" sum="Total expected duration"/>
-                    <field name="production_real_duration" attrs="{'invisible': [('production_real_duration', '=', 0)]}" widget="float_time" sum="Total real duration"/>
                     <field name="lot_producing_id" optional="hide"/>
                     <field name="bom_id" readonly="1" optional="hide"/>
                     <field name="origin" optional="show"/>
@@ -26,6 +24,8 @@
                     <field name="reservation_state" optional="show" decoration-danger="reservation_state == 'confirmed'" decoration-success="reservation_state == 'assigned'"/>
                     <field name="product_qty" sum="Total Qty" string="Quantity" readonly="1" optional="show"/>
                     <field name="product_uom_id" string="UoM" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" optional="show"/>
+                    <field name="production_duration_expected" attrs="{'invisible': [('production_duration_expected', '=', 0)]}" groups="mrp.group_mrp_routings" widget="float_time" sum="Total expected duration" optional="show"/>
+                    <field name="production_real_duration" attrs="{'invisible': [('production_real_duration', '=', 0)]}" groups="mrp.group_mrp_routings" widget="float_time" sum="Total real duration" optional="show"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
                     <field name="state" optional="show" widget='badge' decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

The expected duration and real duration are always visible

Desired behavior after PR is merged:

Expected duration and real duration should be hide when the user doesn't use the Work Order aren't active

Task id: 2633131

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
