### PR TITLE
[FIX] project: apply default values in kanban view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -947,6 +947,19 @@
                         <field name="user_id" options="{'no_open': True,'no_create': True}" domain="[('share', '=', False)]"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>
+                        <field name="email_cc" invisible="1"/>
+                        <field name="project_id" invisible="1"/>
+                        <field name="date_deadline" invisible="1"/>
+                        <field name="partner_id" invisible="1"/>
+                        <field name="sequence" invisible="1"/>
+                        <field name="description" invisible="1"/>
+                        <field name="priority" invisible="1"/>
+                        <field name="kanban_state" invisible="1"/>
+                        <field name="active" invisible="1"/>
+                        <field name="planned_hours" invisible="1"/>
+                        <field name="displayed_image_id" invisible="1"/>
+                        <field name="stage_id" invisible="1"/>
+                        <field name="recurrence_update" invisible="1"/>
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
Currently, when default values are set by the user in project
they don't apply automatically when task is created from kanban
view of the project.

After this commit, user defined default values apply when
task is created from kanban view of project as well.

**TaskID: 2590214**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
