### PR TITLE
[FIX] Add missing scss files for report templates

### DIFF
--- a/addons/web_editor/views/editor.xml
+++ b/addons/web_editor/views/editor.xml
@@ -260,4 +260,14 @@
         </div>
     </colorpicker>
 </template>
+
+<template id="report_assets_common" inherit_id="web.report_assets_common">
+    <xpath expr="//t" position="inside">
+        <link rel="stylesheet" type="text/scss" href="/web_editor/static/src/scss/bootstrap_overridden.scss"/>
+    </xpath>
+    <xpath expr="link[last()]" position="after">
+        <link rel="stylesheet" type="text/scss" href="/web_editor/static/src/scss/web_editor.common.scss"/>
+    </xpath>
+</template>
+
 </odoo>


### PR DESCRIPTION
Many CSS classes are missing in reports layout like mt32 etc...  since two scss files have been dereferenced in https://github.com/odoo/odoo/pull/56415
Example : `<div class="row mt32 mb32" id="informations">` in addons/sale/report/sale_report_templates.xml : mt32 and mb32 are ignored.
Fix https://github.com/odoo/odoo/issues/75671

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
