### PR TITLE
[FIX] l10_de product_template : wrong account when PO

### DIFF
--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -46,12 +46,14 @@ class ProductTemplate(models.Model):
         if company.country_id.code == "DE":
             if not self.property_account_income_id:
                 taxes = self.taxes_id.filtered(lambda t: t.company_id == company)
-                if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):
+                # If income account not set, or that the taxes amount do not correspond, we find the first account that matches the tax id of taxes
+                if not result['income'] or (result['income'].tax_ids and taxes and taxes[0].amount not in result['income'].tax_ids.mapped("amount")):
                     result['income'] = self.env['account.account'].search([('internal_group', '=', 'income'), ('deprecated', '=', False),
                                                                    ('tax_ids', 'in', taxes.ids)], limit=1)
             if not self.property_account_expense_id:
                 supplier_taxes = self.supplier_taxes_id.filtered(lambda t: t.company_id == company)
-                if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0] not in result['expense'].tax_ids):
+                # If expense account not set, or that the taxes amount do not correspond, we find the first account that matches the tax id of supplier_taxes
+                if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0].amount not in result['expense'].tax_ids.mapped("amount")):
                     result['expense'] = self.env['account.account'].search([('internal_group', '=', 'expense'), ('deprecated', '=', False),
                                                                    ('tax_ids', 'in', supplier_taxes.ids)], limit=1)
         return result


### PR DESCRIPTION
Issue: When creating a bill from a purchase order in German anglo-saxon
accounting, and that the expense account default tax is different
(by id) from the default tax set in the settings (purchase_tax_id), we
find the first account that matches the tax id.

BUT, maybe the tax are different by ID but similar by amount, in which
case there is no need to find another ('random') account with the
correct ID and the correct amount, when we already have an account with
the correct ID and the correct amount, that is 'less random' (it's not
the first one we find, it's one that has been specifically set)

Steps to reproduce :
 1) Set your company country to German
 2) Install Purchase, Inventory, Accounting
 3) Ensures anglo-saxon accounting is enabled
 4) Ensures that the Default taxes are :
   - Sales Tax             : 19% Umsatzsteuer
   - Purchase Tax          : 19% Vorsteuer
 5) Create a Product Category with :
   - Income Account        : 8400 Erlöse 19% USt
   - Expense Account       : 3425 EG-Erwerb 19% Vorsteuer und 19% USt
   For which the default taxes are (already by default):
     - 8400 Erlöse 19% USt : 19% Umsatzsteuer
     - 3425 EG-Erwerb 19% Vorsteuer und 19% USt
               : Innergem. Erwerb 19%USt/19%VSt (Purchases)
 6) Create a Product with that product category
 7) Create a Purchase Order (rfq) for that product
     - !! For a company in another country than Germany !!
 8) Confirm, Receive products, validate
 9) Go back to the Purchase Order, create bill
 Bug -> The Account is 3030, or at least neither 3425 (expense account)
 nor 3970 (Stock Interim Input Account)

Why is that a bug:
 There is an account set, with a tax amount corresponding to the default
 tax amount, so we should use that one instead of trying to find another
 account with the same tax amount

Side-Note:
 Comes from commit 6b6387e
 "Because there is a constraint, upon validation of the invoice, that
 the accounts used must correspond with the tax rate"
 -> We should use the amount for comparaison, as different tax_id can
 still have the same amount

opw-2615301