### PR TITLE
[FIX] website_crm: allow salesman to see page views of a lead

### DIFF
--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -33,7 +33,7 @@ class Lead(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("website.website_visitor_page_action")
         action['domain'] = [('visitor_id', 'in', visitors.ids)]
         # avoid grouping if only few records
-        if len(visitors.website_track_ids.ids) > 15 and len(visitors.page_ids.ids) > 1:
+        if len(visitors.website_track_ids) > 15 and len(visitors.website_track_ids.page_id) > 1:
             action['context'] = {'search_default_group_by_page': '1'}
         return action
 


### PR DESCRIPTION
Side effect of https://github.com/odoo/odoo/commit/69cc2911b52fd17b37fb71544574f63cf09dd17e.

On a lead, there is a smart button allowing to see his page views on the website.
In case we have many views, we are grouping them by page. Currently, the check on
the pages is made through field page_ids which is restricted to Website Editor
access group. We should allow a regular salesman to see page views without error,
and this can be achived by using field website_track_ids.page_id instead.

Description of the issue/feature this PR addresses:
opw-2630487

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
