### PR TITLE
[FIX] web: Correct notification service name in mocks

### DIFF
--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -252,7 +252,7 @@ export const mocks = {
     cookie: () => fakeCookieService,
     effect: () => effectService, // BOI The real service ? Is this what we want ?
     localization: makeFakeLocalizationService,
-    notifications: makeFakeNotificationService,
+    notification: makeFakeNotificationService,
     router: makeFakeRouterService,
     rpc: makeFakeRPCService,
     title: () => fakeTitleService,


### PR DESCRIPTION
The service is called `notifications` when mocked in tests,
instead of `notification`.

PR Enterprise https://github.com/odoo/enterprise/pull/20475

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
