### PR TITLE
[IMP] profiling: enable nested Execution context

### DIFF
--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -100,8 +100,7 @@ class Collector:
         # todo add entry count limit
         self._entries.append({
             'stack': self._get_stack_trace(frame),
-            # make a copy of the current context, because it will change
-            'exec_context': dict(getattr(self.profiler.init_thread, 'exec_context', ())),
+            'exec_context': getattr(self.profiler.init_thread, 'exec_context', ()),
             'start': time.time(),
             **(entry or {}),
         })
@@ -250,17 +249,15 @@ class ExecutionContext:
     """
     def __init__(self, **context):
         self.context = context
-        self.stack_trace_level = None
+        self.previous_context = None
 
     def __enter__(self):
         current_thread = threading.current_thread()
-        self.stack_trace_level = stack_size()
-        if not hasattr(current_thread, 'exec_context'):
-            current_thread.exec_context = {}
-        current_thread.exec_context[self.stack_trace_level] = self.context
+        self.previous_context = getattr(current_thread, 'exec_context', ())
+        current_thread.exec_context = self.previous_context + ((stack_size(), self.context),)
 
     def __exit__(self, *_args):
-        threading.current_thread().exec_context.pop(self.stack_trace_level)
+        threading.current_thread().exec_context = self.previous_context
 
 
 class Profiler:


### PR DESCRIPTION
The initial behaviour of ExecutionContext was to
- add the context for the current level of the stack on enter
- remove the context at this same level on exit.

When two ExecutionContext are nested at the same stack level:

```python
    def call():
        with ExecutionContext(foo=1):
            with ExecutionContext(bar=2):
                execute()
```

- the first one adds it's context
- the second one overrides the current context
- the second one remove it at the end
- the first one fails trying to remove the context at the same level a
second time.

In this case we could imagine to combine both Execution manager in one:

```python
    def call():
        with ExecutionContext(foo=1, bar=2)
            execute()
```

But the semantic is different: ExecutionContext should add one level to
the stack. In the first example we would expect to have two additionnal
levels:

```
    call
    foo=1
    bar=2
    execute
```

A simple solution would be to transform the value of the context at some
level to a list of dict, but this would make the copy more difficult.
The decision was taken to change the context storage strategy, going
from a dict where the keys are the level to a tuple of tuple where the
first element is the level.

```
     {3: {foo: 1}, 4: {bar: 2}} 
         =>  
     ((3, {foo: 1}), (4, {bar: 2}))
 ```

The first benefit is to allow multiple context at the same level. The
second one is that we don't need to copy the context since tuple are
immutable and the dicts are comming from kwargs. This means thats saving
the context is faster, and the tuple is shared between multiple samples.
This is interresting if we assume that we will do more sample than
exec_context mutations.
