### PR TITLE
[FIX] sale_stock{_margin}: enforce implicit dependency

### DIFF
--- a/addons/sale_stock_margin/models/__init__.py
+++ b/addons/sale_stock_margin/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_module
 from . import sale_order_line

--- a/addons/sale_stock_margin/models/ir_module.py
+++ b/addons/sale_stock_margin/models/ir_module.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+
+
+class IrModule(models.Model):
+    _inherit = 'ir.module.module'
+
+
+    @api.returns('self')
+    def downstream_dependencies(
+            self,
+            known_deps=None,
+            exclude_states=('uninstalled', 'uninstallable', 'to remove'),
+            ):
+        # sale_stock_margin implicitly depends on sale_stock, but sale_stock is not marked as one of
+        # its dependencies, thus uninstalling sale_stock without uninstalling sale_stock_margin
+        # will make the registry crash, the install works purely because sale_stock is auto-installed
+        # when the dependencies of sale_stock_margin are installed
+        if 'sale_stock' in self.mapped('name'):
+            # we force sale_stock_margin as a dependant of sale_stock
+            known_deps = (known_deps or self.browse()) | self.search([
+                ('name', '=', 'sale_stock_margin'),
+                ('state', '=', 'installed'),
+            ], limit=1)
+        return super().downstream_dependencies(known_deps, exclude_states)


### PR DESCRIPTION
Strap yourself in, we're in for a ride:

The module sale_stock_margin overrides
`SaleOrderLine._compute_purchase_price` and adds some extra dependencies,
the key dependency here is 'move_ids'.

The field `move_ids` is defined in sale_stock's override of
sale.order.line, however sale_stock is **not** a dependency of
sale_stock_margin, but since they implicitly share the same dependencies
and are both `auto_install=True` it is impossible to install
sale_stock_margin without having sale_stock be automatically installed.

However, since sale_stock_margin does not **explicitly** depend on
sale_stock, if one were to uninstall sale_stock without uninstalling
sale_stock_margin first, the registry would crash because
sale_stock_margin's override of `_compute_purchase_price` would depend
on a field that no longer exists (`move_ids`).

This commit fixes this in an odd way, because of the following reasons:

- We cannot change a dependency in a stable branch.
- An uninstall_hook cannot inject an uninstall dependency because the
  hook step is too late into the process (we'd need a
  pre_uninstall_hook)
- A post_install_hook could create a dependency between
  sale_stock_margin and sale_stock, however this would only apply to
  **new** installs of sale_stock_margin and the bug would persist for
  existing users

Thus the only solution left is to extend ir.module.module and override
the downstream_dependencies to inject sale_stock_margin as a sale_stock
dependant if sale_stock is one of the modules for which we're
calculating the downstream dependencies.