### PR TITLE
[FIX] sale_stock_margin: make implicit dependency explicit

### DIFF
--- a/addons/sale_stock_margin/__manifest__.py
+++ b/addons/sale_stock_margin/__manifest__.py
@@ -5,7 +5,7 @@
     'summary': '',
     'description': 'Once the delivery is validated, update the cost on the SO to have an exact margin computation.',
     'version': '0.1',
-    'depends': ['stock_account', 'sale_margin'],
+    'depends': ['sale_stock', 'sale_margin'],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',


### PR DESCRIPTION
Strap yourself in, we're in for a ride:

The module sale_stock_margin overrides
SaleOrderLine._compute_purchase_price and adds some extra dependencies,
the key dependency here is 'move_ids'.

The field move_ids is defined in sale_stock's override of
sale.order.line, however sale_stock is not a dependency of
sale_stock_margin, but since they implicitly share the same dependencies
and are both auto_install=True it is impossible to install
sale_stock_margin without having sale_stock be automatically installed.

However, since sale_stock_margin does not explicitly depend on
sale_stock, if one were to uninstall sale_stock without uninstalling
sale_stock_margin first, the registry would crash because
sale_stock_margin's override of _compute_purchase_price would depend
on a field that no longer exists (move_ids).

This commit changes sale_stock_margin's dependency graph to explicitly
depend on `sale_stock`, this in turn means we can forego the
`stock_account` dependency since it's an explicit dependency of
`sale_stock`.