### PR TITLE
[IMP] mass_mailing_sale, * : make fa icons (cart, card, ...) consistent

### DIFF
--- a/addons/mass_mailing_sale/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sale/views/mailing_mailing_views.xml
@@ -8,7 +8,7 @@
     		<xpath expr="//button[@id='button_view_delivered']" position="before">
                 <button name="action_redirect_to_quotations"
                     type="object"
-                    icon="fa-pencil"
+                    icon="fa-pencil-square-o"
                     class="oe_stat_button"
                     groups="sales_team.group_sale_salesman"
                     attrs="{'invisible': [('state', '=', 'draft')]}">

--- a/addons/mrp_subcontracting_purchase/views/stock_picking_views.xml
+++ b/addons/mrp_subcontracting_purchase/views/stock_picking_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button 
                     class="oe_stat_button" name="action_view_subcontracting_source_purchase" 
-                    type="object" icon="fa-shopping-cart" attrs="{'invisible': [('subcontracting_source_purchase_count', '=', 0)]}" groups="stock.group_stock_user">
+                    type="object" icon="fa-credit-card" attrs="{'invisible': [('subcontracting_source_purchase_count', '=', 0)]}" groups="stock.group_stock_user">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value"><field name="subcontracting_source_purchase_count"/></span>
                         <span class="o_stat_text">Source PO</span>

--- a/addons/payment/views/res_partner_views.xml
+++ b/addons/payment/views/res_partner_views.xml
@@ -10,7 +10,7 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button type="action" class="oe_stat_button"
-                        icon="fa-credit-card"
+                        icon="fa-credit-card-alt"
                         name="%(payment.action_payment_token)d"
                         context="{'search_default_partner_id': active_id, 'create': False, 'edit': False}"
                         attrs="{'invisible': [('payment_token_count', '=', 0)]}">

--- a/addons/purchase/views/analytic_account_views.xml
+++ b/addons/purchase/views/analytic_account_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button class="oe_stat_button" type="object" name="action_view_purchase_orders"
-                    icon="fa-shopping-cart" attrs="{'invisible': [('purchase_order_count', '=', 0)]}">
+                    icon="fa-credit-card" attrs="{'invisible': [('purchase_order_count', '=', 0)]}">
                     <field string="Purchase Orders" name="purchase_order_count" widget="statinfo"/>
                 </button>
             </div>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -96,7 +96,7 @@
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
-                        type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
+                        type="object" icon="fa-credit-card" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="mr4"/>
@@ -128,7 +128,7 @@
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
-                        type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
+                        type="object" icon="fa-credit-card" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value">
                                 <field name="purchased_product_qty" widget="statinfo" nolabel="1" class="mr4"/>

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -49,7 +49,7 @@
                     <field name="purchase_order_count"/>
                 </field>
                 <xpath expr="//span[hasclass('oe_kanban_partner_links')]" position="inside">
-                    <span t-if="record.purchase_order_count.value>0" class="badge badge-pill"><i class="fa fa-fw fa-shopping-cart" role="img" aria-label="Purchases" title="Purchases"/><t t-esc="record.purchase_order_count.value"/></span>
+                    <span t-if="record.purchase_order_count.value>0" class="badge badge-pill"><i class="fa fa-fw fa-credit-card" role="img" aria-label="Purchases" title="Purchases"/><t t-esc="record.purchase_order_count.value"/></span>
                 </xpath>
             </field>
         </record>
@@ -82,7 +82,7 @@
                 <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(purchase.act_res_partner_2_purchase_order)d" type="action"
                         groups="purchase.group_purchase_user"
-                        icon="fa-shopping-cart">
+                        icon="fa-credit-card">
                         <field string="Purchases" name="purchase_order_count" widget="statinfo"/>
                     </button>
                 </div>

--- a/addons/purchase_stock/report/report_stock_rule.xml
+++ b/addons/purchase_stock/report/report_stock_rule.xml
@@ -17,14 +17,14 @@
         </xpath>
         <xpath expr="//div[hasclass('o_report_stock_rule_rule_name')]/span" position="before">
             <t t-if="rule[0].action == 'buy'">
-                <i class="fa fa-shopping-cart fa-fw" t-attf-style="color: #{color};"/>
+                <i class="fa fa-credit-card fa-fw" t-attf-style="color: #{color};"/>
             </t>
         </xpath>
         <xpath expr="//div[hasclass('o_report_stock_rule_legend')]" position="inside">
             <div class="o_report_stock_rule_legend_line">
                 <div class="o_report_stock_rule_legend_label">Buy</div>
                 <div class="o_report_stock_rule_legend_symbol">
-                    <div class="fa fa-shopping-cart fa-fw" t-attf-style="color: #{color};"/>
+                    <div class="fa fa-credit-card fa-fw" t-attf-style="color: #{color};"/>
                 </div>
             </div>
         </xpath>

--- a/addons/purchase_stock/views/stock_production_lot_views.xml
+++ b/addons/purchase_stock/views/stock_production_lot_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]/button" position="before">
                 <button class="oe_stat_button" name="action_view_po"
-                        type="object" icon="fa-shopping-cart" help="Purchase Orders"
+                        type="object" icon="fa-credit-card" help="Purchase Orders"
                         attrs="{'invisible': ['|', ('purchase_order_count', '=', 0), ('display_complete', '=', False)]}">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">


### PR DESCRIPTION
*: mrp_subcontracting_purchase,payment,purchase_(stock)

BEFORE THIS COMMIT

fa-shopping-cart was used for different purchase-related contexts.
This icon should only be used for online shopping / ecommerce.

AFTER THIS COMMIT

Wa make sure one icon is used for one concept.
- fa-shopping-cart : ecommerce / add to cart
- fa-credit-card : purchases
- fa-credit-card-alt : replaces other uses of fa-credit-card

Icons are updated accordingly. Other icons are also changed to
increase readablity.

--- Links ---

Task Id - 2593306
