### PR TITLE
[IMP] stock, barcodes_gs1_nomenclature: scan package type

### DIFF
--- a/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
+++ b/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
@@ -130,7 +130,6 @@
             <field name="type">qty_done</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">False</field>
-
         </record>
 
         <record id="barcode_rule_gs1_37" model="barcode.rule">
@@ -203,6 +202,17 @@
             <field name="type">qty_done</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>
+        </record>
+
+        <!-- Company internal information (91 to 99): Custom rules  -->
+        <record id="barcode_rule_gs1_91" model="barcode.rule">
+            <field name="name">Package type</field>
+            <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
+            <field name="sequence">200</field>
+            <field name="encoding">gs1-128</field>
+            <field name="pattern">(91)([!"%-/0-9:-?A-Z_a-z]{0,90})</field>
+            <field name="type">package_type</field>
+            <field name="gs1_content_type">alpha</field>
         </record>
     </data>
 </odoo>

--- a/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
+++ b/addons/barcodes_gs1_nomenclature/data/barcodes_gs1_rules.xml
@@ -109,12 +109,12 @@
             <field name="gs1_content_type">date</field>
         </record>
 
-        <record id="barcode_rule_gs1_16" model="barcode.rule">
+        <record id="barcode_rule_gs1_17" model="barcode.rule">
             <field name="name">Expiration date (YYMMDD)</field>
             <field name="barcode_nomenclature_id" ref="default_gs1_nomenclature"/>
             <field name="sequence">109</field>
             <field name="encoding">gs1-128</field>
-            <field name="pattern">(16)(\d{6})</field>
+            <field name="pattern">(17)(\d{6})</field>
             <field name="type">expiration_date</field>
             <field name="gs1_content_type">date</field>
         </record>
@@ -127,7 +127,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(30)(\d{0,8})</field>
             <field name="associated_uom_id" ref="uom.product_uom_unit"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">False</field>
         </record>
@@ -139,7 +139,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(37)(\d{0,8})</field>
             <field name="associated_uom_id" ref="uom.product_uom_unit"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">False</field>
         </record>
@@ -151,7 +151,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(310[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_kgm"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>
         </record>
@@ -163,7 +163,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(311[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_meter"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>
         </record>
@@ -175,7 +175,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(315[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_litre"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>
         </record>
@@ -187,7 +187,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(321[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_inch"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>
         </record>
@@ -199,7 +199,7 @@
             <field name="encoding">gs1-128</field>
             <field name="pattern">(357[0-5])(\d{6})</field>
             <field name="associated_uom_id" ref="uom.product_uom_oz"/>
-            <field name="type">qty_done</field>
+            <field name="type">quantity</field>
             <field name="gs1_content_type">measure</field>
             <field name="gs1_decimal_usage">True</field>
         </record>

--- a/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
@@ -15,7 +15,7 @@ class BarcodeRule(models.Model):
         ondelete={'gs1-128': 'set default'})
     type = fields.Selection(
         selection_add=[
-            ('qty_done', 'Quantity'),
+            ('quantity', 'Quantity'),
             ('location', 'Location'),
             ('location_dest', 'Destination location'),
             ('lot', 'Lot number'),
@@ -25,7 +25,7 @@ class BarcodeRule(models.Model):
             ('package_type', 'Packaging Type'),
             ('packaging_date', 'Packaging Date'),
         ], ondelete={
-            'qty_done': 'set default',
+            'quantity': 'set default',
             'location': 'set default',
             'location_dest': 'set default',
             'lot': 'set default',

--- a/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
@@ -22,6 +22,7 @@ class BarcodeRule(models.Model):
             ('package', 'Package'),
             ('use_date', 'Best before Date'),
             ('expiration_date', 'Expiration Date'),
+            ('package_type', 'Packaging Type'),
             ('packaging_date', 'Packaging Date'),
         ], ondelete={
             'qty_done': 'set default',
@@ -31,6 +32,7 @@ class BarcodeRule(models.Model):
             'package': 'set default',
             'use_date': 'set default',
             'expiration_date': 'set default',
+            'package_type': 'set default',
             'packaging_date': 'set default',
         })
     is_gs1_nomenclature = fields.Boolean(related="barcode_nomenclature_id.is_gs1_nomenclature")

--- a/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
@@ -70,7 +70,7 @@ class TestBarcodeGS1Nomenclature(TestBarcodeNomenclature):
         default_barcode_rule_vals = {
             'default_encoding': 'gs1-128',
             'default_barcode_nomenclature_id': barcode_nomenclature.id,
-            'default_type': 'qty_done',
+            'default_type': 'quantity',
             'default_gs1_content_type': 'measure',
         }
         # Creates a rule who don't take any decimal.

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -11,6 +11,25 @@
             <field name="company_id" ref="base.main_company"/>
         </record>
 
+        <record id="package_type_01" model="stock.package.type">
+            <field name="name">Pallet</field>
+            <field name="barcode">PAL</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="max_weight">4000</field>
+            <field name="width">800</field>
+            <field name="height">130</field>
+            <field name="packaging_length">1200</field>
+        </record>
+
+        <record id="package_type_02" model="stock.package.type">
+            <field name="name">Box</field>
+            <field name="barcode">BOX</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="max_weight">30</field>
+            <field name="width">362</field>
+            <field name="height">374</field>
+            <field name="packaging_length">562</field>
+        </record>
 
         <!-- Resource: stock.quant, i.e. initial inventory -->
 

--- a/addons/stock/models/stock_package_type.py
+++ b/addons/stock/models/stock_package_type.py
@@ -27,6 +27,7 @@ class PackageType(models.Model):
     storage_category_capacity_ids = fields.One2many('stock.storage.category.capacity', 'package_type_id', 'Storage Category Capacity', copy=True)
 
     _sql_constraints = [
+        ('barcode_uniq', 'unique(barcode)', "A barcode can only be assigned to one package type !"),
         ('positive_height', 'CHECK(height>=0)', 'Height must be positive'),
         ('positive_width', 'CHECK(width>=0)', 'Width must be positive'),
         ('positive_length', 'CHECK(packaging_length>=0)', 'Length must be positive'),


### PR DESCRIPTION
**[IMP] stock,barcodes_gs1_nomenclature: demo data**
> For `stock`, adds package type demo data (pallet and box).
> 
> For `barcodes_gs1_nomenclature`, adds a custom rule (AI 91) to recognize the package type in the Barcode Application.
> As there is no standard GS1 nomenclature's rule for the package as defined by Odoo and there is a bunch of free-to-use AI (from 91 to 99), using one of them for the package type could be useful to be able to scan a new package and create it on the fly with the wanted type.

**[FIX] stock: uniq package type barcode**
> Before this commit, multiple package types can have the same barcode.
> As it makes no sense and could lead to confusion, it's no more possible.

task-2627002

**TODO:** migration script for the `qty_done` > `quantity` change.