### PR TITLE
[google_calendar,microsoft_calendar] hide sync button other modules

### DIFF
--- a/addons/calendar/static/src/js/calendar_renderer.js
+++ b/addons/calendar/static/src/js/calendar_renderer.js
@@ -104,6 +104,8 @@ const AttendeeCalendarPopover = CalendarPopover.extend({
 
 
 const AttendeeCalendarRenderer = CalendarRenderer.extend({
+    template: 'calendar.CalendarView',
+
 	config: _.extend({}, CalendarRenderer.prototype.config, {
         CalendarPopover: AttendeeCalendarPopover,
         eventTemplate: 'Calendar.calendar-box',

--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <template>
+
+    <t t-name="calendar.CalendarView" t-extend="CalendarView">
+        <t t-jquery="div.o_calendar_sidebar" t-operation="append">
+            <div id="calendar_sync" class="o_calendar_sync container inline btn-group"/>
+        </t>
+    </t>
+
     <div t-name="calendar.RecurrentEventUpdate">
         <div class="form-check o_radio_item">
             <input name="recurrence-update" type="radio" class="form-check-input o_radio_input" checked="true" value="self_only" id="self_only"/>

--- a/addons/google_calendar/static/src/xml/base_calendar.xml
+++ b/addons/google_calendar/static/src/xml/base_calendar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-inherit="web.CalendarView" t-inherit-mode="extension">
+    <t t-inherit="calendar.CalendarView" t-inherit-mode="extension">
         <xpath expr="//div[@id='calendar_sync']" position="inside">
             <button type="button" id="google_sync_pending" class="o_google_sync_button o_google_sync_pending btn btn-secondary btn">
                 <b><i class='fa fa-refresh'/> Google</b>

--- a/addons/microsoft_calendar/static/src/xml/base_calendar.xml
+++ b/addons/microsoft_calendar/static/src/xml/base_calendar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-inherit="web.CalendarView" t-inherit-mode="extension">
+    <t t-inherit="calendar.CalendarView" t-inherit-mode="extension">
         <xpath expr="//div[@id='calendar_sync']" position="inside">
             <button type="button" id="microsoft_sync_pending" class="o_microsoft_sync_button o_microsoft_sync_pending btn btn-secondary btn">
                 <b><i class='fa fa-refresh'/> Outlook</b>

--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -7,7 +7,6 @@
         <div class="o_calendar_sidebar_container d-none d-md-block">
             <div class="o_calendar_sidebar">
                 <div class="o_calendar_mini"/>
-                <div id="calendar_sync" class="o_calendar_sync container inline btn-group"/>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Before this commit, the sync buttons refactored in https://github.com/odoo/odoo/pull/68700 would appears in all calendar views (sale,time-off,...).

This commit only displays them in the calendar event view.
    
taskid: 2633415


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
