### PR TITLE
[FIX] mail, web: don't refresh chatter when opening a dialog

### DIFF
--- a/addons/mail/static/src/js/form_renderer.js
+++ b/addons/mail/static/src/js/form_renderer.js
@@ -16,6 +16,7 @@ FormRenderer.include({
         this._super.apply(this, arguments);
         this.mailFields = params.mailFields;
         this.chatter = undefined;
+        this.isFromFormViewDialog = params.isFromFormViewDialog;
     },
 
     //--------------------------------------------------------------------------
@@ -52,6 +53,9 @@ FormRenderer.include({
     _renderNode: function (node) {
         var self = this;
         if (node.tag === 'div' && node.attrs.class === 'oe_chatter') {
+            if(this.isFromFormViewDialog) {
+                return $('<div/>');
+            }
             if (!this.chatter) {
                 this.chatter = new Chatter(this, this.state, this.mailFields, {
                     isEditable: this.activeActions.edit,

--- a/addons/web/static/src/js/views/form/form_view.js
+++ b/addons/web/static/src/js/views/form/form_view.js
@@ -47,6 +47,7 @@ var FormView = BasicView.extend({
         this.controllerParams.mode = mode;
 
         this.rendererParams.mode = mode;
+        this.rendererParams.isFromFormViewDialog = params.isFromFormViewDialog;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -209,6 +209,7 @@ var FormViewDialog = ViewDialog.extend({
                 model: self.model,
                 parentID: self.parentID,
                 recordID: self.recordID,
+                isFromFormViewDialog: true
             });
             return formview.getController(self);
         }).then(function (formView) {


### PR DESCRIPTION
Steps to follow

- Add an attachment in the chatter of a customer
- Create an invoice with this customer
- Open the customer form dialog from the sidearrow
-> The attachment from the customer is displayed

Solution

Don't refresh the chatter if the form is from a dialog
This is a backport from v14

opw-2525091