### PR TITLE
[FIX] crm: prevent division by zero in lead probability computation

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1452,7 +1452,9 @@ class Lead(models.Model):
                 if value_result:
                     total_won = team_won if field == 'stage_id' else field_result['won_total']
                     total_lost = team_lost if field == 'stage_id' else field_result['lost_total']
-
+                    # if one count = 0, we cannot compute lead probability
+                    if not total_won or not total_lost:
+                        continue
                     s_lead_won *= value_result['won'] / total_won
                     s_lead_lost *= value_result['lost'] / total_lost
 


### PR DESCRIPTION
If for some reason we cannot compute lead probability, we should simply
continue to the next value without causing a division by zero.

Description of the issue/feature this PR addresses:
opw-2602874

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
