### PR TITLE
[FIX] web_editor: restore linked date field edition

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -103,9 +103,16 @@ const Wysiwyg = Widget.extend({
             function () {
                 self.odooEditor.observerUnactive();
                 const $field = $(this);
-                if (($field.data('oe-type') === "datetime" || $field.data('oe-type') === "date") && !$field.hasClass('o_editable_date_field_format_changed')) {
-                    $field.text($field.data('oe-original-with-format'));
-                    $field.addClass('o_editable_date_field_format_changed');
+                if (($field.data('oe-type') === "datetime" || $field.data('oe-type') === "date")) {
+                    let selector = '[data-oe-id="' + $field.data('oe-id') + '"]';
+                    selector += '[data-oe-field="' + $field.data('oe-field') + '"]';
+                    selector += '[data-oe-model="' + $field.data('oe-model') + '"]';
+                    const $linkedFieldNodes = self.$editable.find(selector).addBack(selector);
+                    $linkedFieldNodes.addClass('o_editable_date_field_linked');
+                    if (!$field.hasClass('o_editable_date_field_format_changed')) {
+                        $linkedFieldNodes.text($field.data('oe-original-with-format'));
+                        $linkedFieldNodes.addClass('o_editable_date_field_format_changed');
+                    }
                 }
                 if ($field.data('oe-type') === "monetary") {
                     $field.attr('contenteditable', false);
@@ -1482,6 +1489,9 @@ const Wysiwyg = Widget.extend({
         return new Promise(function () {});
     },
     _onDocumentMousedown: function (e) {
+        if (!e.target.classList.contains('o_editable_date_field_linked')) {
+            this.$editable.find('.o_editable_date_field_linked').removeClass('o_editable_date_field_linked');
+        }
         if (e.target.closest('.oe-toolbar')) {
             this._onToolbar = true;
         } else {


### PR DESCRIPTION
4eafd788470da was not correctly adapted with new editor.
The `removeClass` and the css for that class was left in the code but the code
in charge of adding that class was just removed, breaking the behavior.
