### PR TITLE
[FIX] web: prevent error if subscriptions.update is undefined

### DIFF
--- a/addons/web/static/src/js/model.js
+++ b/addons/web/static/src/js/model.js
@@ -429,7 +429,7 @@ odoo.define("web/static/src/js/model.js", function (require) {
          */
         async _notifyComponents() {
             const rev = ++this.rev;
-            const subscriptions = this.subscriptions.update;
+            const subscriptions = this.subscriptions.update || [];
             const groups = partitionBy(subscriptions, (s) =>
                 s.owner ? s.owner.__owl__.depth : -1
             );


### PR DESCRIPTION
Steps to follow

- Install web_dashboard,website_sale
- Go to the eCommerce Dashboard
- Click on Favorites
- Click on Add to my dashboard
- Go to the Dashboard app
- Click on orders
-> A traceback occurs

Cause of the issue

`this.subscriptions.update` is undefined

opw-2630849