### PR TITLE
[FIX] calendar : Fixed meeting accept page shows invalid logo

### DIFF
--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -66,6 +66,7 @@ class CalendarController(http.Controller):
         timezone = attendee.partner_id.tz
         lang = attendee.partner_id.lang or get_lang(request.env).code
         event = request.env['calendar.event'].with_context(tz=timezone, lang=lang).sudo().browse(int(id))
+        company = event.user_id and event.user_id.company_id or event.create_uid.company_id
 
         # If user is internal and logged, redirect to form view of event
         # otherwise, display the simplifyed web page with event informations
@@ -78,6 +79,7 @@ class CalendarController(http.Controller):
         #   request.render())
         response_content = request.env['ir.ui.view'].with_context(lang=lang)._render_template(
             'calendar.invitation_page_anonymous', {
+                'company': company,
                 'event': event,
                 'attendee': attendee,
             })

--- a/addons/calendar/views/calendar_templates.xml
+++ b/addons/calendar/views/calendar_templates.xml
@@ -30,7 +30,7 @@
 
             <div class="container">
                 <div class="o_logo">
-                    <img class="img img-fluid d-block mx-auto" src="/web/binary/company_logo" alt="Logo"/>
+                    <img t-attf-src="/web/binary/company_logo?company={{ company.id }}" alt="Logo"/>
                 </div>
 
                 <div class="card">


### PR DESCRIPTION
Reproduce :
- Login to the latest runbot 14.0 (BASE, not the main!) with the admin user
- Install the apps "contacts" and "calendar".
- Go to contacts and create a new contact with an email
- Make a new company "Company B" and make sure that this is set as default company for the administrator user.
- Set two different logo's on these companies so you can differentiate them.
- Create a new meeting invitation and add the contact you created in step 2 to it.
- Use the "Send mail" option on the meeting invite to make sure it gets sent. Then check in mailhog (it only comes in here after executing the queue cron for mails).
- Now copy the link behind the "accept" button and copy it in an incognito.

Result :
  The logo shown on the calendar invitation page is wrong as it uses the company logo from the company with ID 1 (first created company) while your logo in the email is the right one from your default company.

Solution :
  The logo shown on the calendar invitation page is the right one from your default company.

opw-2579398

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
