### PR TITLE
[FIX] point_of_sale: product info

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1174,7 +1174,7 @@ td {
         margin: 0px !important;
     }
     .pos .product:active {
-        border: solid 50px #6ec89b;
+        border: solid 3px #6ec89b;
         box-sizing: border-box;
     }
     .pos .product:after {

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/ProductInfoButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ControlButtons/ProductInfoButton.js
@@ -21,9 +21,9 @@ odoo.define('point_of_sale.ProductInfoButton', function(require) {
         }
         onClick() {
             const orderline = this.env.pos.get_order().get_selected_orderline();
-            const product = orderline.get_product();
-            const quantity = orderline.get_quantity();
             if (orderline) {
+                const product = orderline.get_product();
+                const quantity = orderline.get_quantity();
                 this.showPopup('ProductInfoPopup', { product, quantity });
             }
         }


### PR DESCRIPTION
This PR add 2 fixes to the product info task:
 - In mobile version, the current css made the button unclickable, thus the method linked to the (i) button was not properly called. The css of the `active` state has been changed to a smaller border
 - Due to some refactoring, when clicking on the info button of the control buttons, if there's no orderline, a traceback error appeared.

Related task id: 2518884
