### PR TITLE
[FIX] mail: group chat item should not have ThreadIcon

### DIFF
--- a/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item/discuss_sidebar_category_item.js
@@ -126,7 +126,6 @@ function factory(dependencies) {
                 case 'channel':
                     return this.channel.public === 'private';
                 case 'chat':
-                case 'group':
                     return true;
                 case 'group':
                     return false;


### PR DESCRIPTION
Small fix in discuss_sidebar_category_item. An item with type "group" should not have a ThreadIcon.
