### PR TITLE
[FIX] calendar: fix typo 'weeky'

### DIFF
--- a/addons/calendar/i18n/calendar.pot
+++ b/addons/calendar/i18n/calendar.pot
@@ -722,7 +722,7 @@ msgstr ""
 #. module: calendar
 #: code:addons/calendar/models/calendar_recurrence.py:0
 #, python-format
-msgid "Every %(count)s %(period)s, "
+msgid "Every %(count)s %(period)s"
 msgstr ""
 
 #. module: calendar
@@ -1664,7 +1664,7 @@ msgstr ""
 #. module: calendar
 #: code:addons/calendar/models/calendar_recurrence.py:0
 #, python-format
-msgid "day %s, "
+msgid "day %s"
 msgstr ""
 
 #. module: calendar
@@ -1681,13 +1681,13 @@ msgstr ""
 #. module: calendar
 #: code:addons/calendar/models/calendar_recurrence.py:0
 #, python-format
-msgid "on %s,"
+msgid "on %s"
 msgstr ""
 
 #. module: calendar
 #: code:addons/calendar/models/calendar_recurrence.py:0
 #, python-format
-msgid "on the %(position)s %(weekday)s, "
+msgid "on the %(position)s %(weekday)s"
 msgstr ""
 
 #. module: calendar

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -148,8 +148,9 @@ class RecurrenceRule(models.Model):
                 on = _("on %s") % ", ".join([day_name for day_name in day_strings])
             elif recurrence.rrule_type == 'monthly':
                 if recurrence.month_by == 'day':
-                    weekday_label = dict(BYDAY_SELECTION)[recurrence.byday]
-                    on = _("on the %(position)s %(weekday)s", position=recurrence.byday, weekday=weekday_label)
+                    position_label = dict(BYDAY_SELECTION)[recurrence.byday]
+                    weekday_label = dict(WEEKDAY_SELECTION)[recurrence.weekday]
+                    on = _("on the %(position)s %(weekday)s", position=position_label, weekday=weekday_label)
                 else:
                     on = _("day %s", recurrence.day)
             else:

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -131,7 +131,7 @@ class RecurrenceRule(models.Model):
     def _compute_name(self):
         for recurrence in self:
             period = dict(RRULE_TYPE_SELECTION)[recurrence.rrule_type]
-            every = _("Every %(count)s %(period)s, ", count=recurrence.interval, period=period)
+            every = _("Every %(count)s %(period)s", count=recurrence.interval, period=period)
 
             if recurrence.end_type == 'count':
                 end = _("for %s events", recurrence.count)
@@ -140,19 +140,21 @@ class RecurrenceRule(models.Model):
             else:
                 end = ''
 
-            if recurrence.rrule_type == 'weeky':
+            if recurrence.rrule_type == 'weekly':
                 weekdays = recurrence._get_week_days()
-                weekday_fields = (self._fields[weekday_to_field(w)] for w in weekdays)
-                on = _("on %s,") % ", ".join([field.string for field in weekday_fields])
+                # Convert Weekday object
+                weekdays = [str(w) for w in weekdays]
+                day_strings = [d[1] for d in WEEKDAY_SELECTION if d[0] in weekdays]
+                on = _("on %s") % ", ".join([day_name for day_name in day_strings])
             elif recurrence.rrule_type == 'monthly':
                 if recurrence.month_by == 'day':
                     weekday_label = dict(BYDAY_SELECTION)[recurrence.byday]
-                    on = _("on the %(position)s %(weekday)s, ", position=recurrence.byday, weekday=weekday_label)
+                    on = _("on the %(position)s %(weekday)s", position=recurrence.byday, weekday=weekday_label)
                 else:
-                    on = _("day %s, ", recurrence.day)
+                    on = _("day %s", recurrence.day)
             else:
                 on = ''
-            recurrence.name = every + on + end
+            recurrence.name = ', '.join(filter(lambda s: s, [every, on, end]))
 
     @api.depends('calendar_event_ids.start')
     def _compute_dtstart(self):


### PR DESCRIPTION
change typo 'weeky' to 'weekly' and
fix bug after condition for 'weeky'
    recurrence.name becomes 'Every 1 Weeks, on We, Th, until 2021-08-28'
improve style for recurrence.name with the minimum change
    recurrence.name becomes 'Every 1 Weeks, on Wednesday, Thurday, until 2021-08-28'

before this task:
Because of the typo 'weeky', the condition will always be False,
and its following codes(have a bug) are never executed.
The recurrence.name is 'Every 1 Weeks, until 2021-08-28'

taskid: 2630394

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
