### PR TITLE
[FIX] sale_stock: fix actual_date forward_port

### DIFF
--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -86,7 +86,6 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
             ml.qty_done = ml.product_uom_qty
         picking._action_done()
         self.assertEqual(picking.state, 'done', "Picking not processed correctly!")
-        self.assertEqual(fields.Date.today(), sale_order.effective_date, "Wrong effective date on sale order!")
         self.assertEqual(fields.Date.context_today(sale_order), sale_order.effective_date, "Wrong effective date on sale order!")
 
     def test_sale_order_commitment_date(self):


### PR DESCRIPTION
This fixes the forward port of #75624 that became incorrect at #75697
because of the assertEqual -> assertEquals conflict resolution.
