### PR TITLE
[IMP+FIX] Add back correct creation message for new Applications + Add option to subscribe users to new applications automatically

### DIFF
--- a/addons/hr_recruitment/data/mail_data.xml
+++ b/addons/hr_recruitment/data/mail_data.xml
@@ -50,6 +50,13 @@
         <field name="parent_id" ref="mt_applicant_hired"/>
         <field name="relation_field">job_id</field>
     </record>
+    <record id="mt_job_applicant_new" model="mail.message.subtype">
+        <field name="name">New Applicant</field>
+        <field name="res_model">hr.job</field>
+        <field name="default" eval="False"/>
+        <field name="parent_id" ref="mt_applicant_new" />
+        <field name="relation_field">job_id</field>
+    </record>
 
     <!-- Department-related (parent) subtypes for messaging / Chatter -->
     <record id="mt_department_new" model="mail.message.subtype">

--- a/addons/hr_recruitment/data/mail_data.xml
+++ b/addons/hr_recruitment/data/mail_data.xml
@@ -15,6 +15,7 @@
         <field name="res_model">hr.applicant</field>
         <field name="default" eval="False"/>
         <field name="hidden" eval="True"/>
+        <field name="description">Applicant created</field>
     </record>
     <record id="mt_applicant_stage_changed" model="mail.message.subtype">
         <field name="name">Stage Changed</field>


### PR DESCRIPTION
This PR includes 2 important changes to the message flow when new job applications are created:

## FIX: Add back correct creation message for new Applications

**Description of the issue/feature this PR addresses:** 62bf009bebe46010ee04376f32b0a996a5d694e0 removed the `description` of the "New Application" message subtype. Although it was true that the creation message might be doubled before, https://github.com/odoo/odoo/pull/56631 removed the addition of the "Application created" message in the message body, so now there was nothing adding it, making the message invisible in the chatter. This adds back the `description` in the message subtype. Now, although that text is not passed to the message body, it is displayed in the chatter as expected.

**Current behavior before PR:** Tested in community and enterprise runbots, for v14 and master. 

If you create a new Job Application, you will see that no creation message is generated:
![image](https://user-images.githubusercontent.com/38977934/131329849-d12e097d-fd89-4fdc-8a35-6162a66337e9.png)

**Desired behavior after PR is merged:** Now, if we add a description to the associated message subtype:

![image](https://user-images.githubusercontent.com/38977934/131330003-7cb4d1c4-972b-4c7c-8c86-d603e6420c37.png)

(the same that is done in this commit)

We can create a new job application and see that the message is created correctly:

![image](https://user-images.githubusercontent.com/38977934/131330141-e9fcb1a3-fcfe-414b-99f8-b1bc3cdb8c06.png)

## IMP: Add option to subscribe users to new applications automatically

**Description of the issue/feature this PR addresses:** Right now, there is no way to automatically subscribe users to a new Job Application, besides making one of them responsible for the associated Job. However, you might want to subscribe more users to all new job applications associated to a job position, similar to what happens with project tasks and the subscription to the "Task created" subtype in the associated project. This commit adds that data, so that a user can be subscribed to that event associated to a job position. 

**Current behavior before PR:** There is no way to automatically subscribe users to a new Job Application

**Desired behavior after PR is merged:** We can now go to a Job Position and subscribe a user to the "New Application" subtype:

![image](https://user-images.githubusercontent.com/38977934/131330738-1657e741-1797-4532-ab7e-ea0c838ccd4d.png)

![image](https://user-images.githubusercontent.com/38977934/131330806-adcab540-76e3-411d-8407-bd7a208689a4.png)

![image](https://user-images.githubusercontent.com/38977934/131330850-bb082bda-3d7b-4b28-8234-e823e754f28e.png)


@Tecnativa
TT30413

ping @Yajo @pedrobaeza 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
