### PR TITLE
quick edit on remaining_days widget

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -1067,6 +1067,7 @@ var FieldDateTime = FieldDate.extend({
 const RemainingDays = AbstractField.extend({
     description: _lt("Remaining Days"),
     supportedFieldTypes: ['date', 'datetime'],
+    isQuickEditable: true,
 
     /**
      * @override
@@ -1121,6 +1122,15 @@ const RemainingDays = AbstractField.extend({
             return new datepicker.DateWidget(this, this.datepickerOptions);
         }
         return new datepicker.DateTimeWidget(this, this.datepickerOptions);
+    },
+    /**
+     * @private
+     * @override
+     */
+    _quickEdit: function () {
+        if (this.datewidget) {
+            this.datewidget.$input.click();
+        }
     },
     /**
      * Displays date/datetime picker in edit mode.

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -5317,6 +5317,31 @@ QUnit.module('basic_fields', {
         unpatchDate();
     });
 
+    QUnit.test('remaining_days field with quickedit', async function (assert) {
+        assert.expect(4);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form><field name="datetime" widget="remaining_days"/></form>',
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, 'div.o_field_widget[name=datetime]');
+
+        // open the datetime picker with quick edit
+        await testUtils.dom.click(form.$('div.o_field_widget[name=datetime]'));
+        await testUtils.nextTick(); // wait for quick edit
+
+        assert.containsOnce(form, '.o_form_view.o_form_editable');
+        assert.strictEqual(document.activeElement, form.$('.o_datepicker_input[name=datetime]')[0]);
+        assert.containsOnce(document.body, '.bootstrap-datetimepicker-widget',
+            "should initialize 1 date picker");
+
+        form.destroy();
+    });
+
     QUnit.module('FieldMonetary');
 
     QUnit.test('monetary field in form view', async function (assert) {


### PR DESCRIPTION
PURPOSE
Since commit: https://github.com/odoo/odoo/pull/70578/commits/150ef9ed8c2d9f98dedb3c9c71d0314bbde22ba4 is merged, remaining_days widget is not editable in edit mode, clicking on remaining_days widget value should change form mode to Edit and should open date/datetime picker.

SPEC
Click on remaining_days widget should change form mode to edit and should open date/datetime picker.

TASK 2526851



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
