### PR TITLE
[FIX] account_edi*: retrieve records within allowed companies

### DIFF
--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -144,6 +144,9 @@ class AccountEdiFormat(models.Model):
         :returns:       the invoice where the factur-x data was imported.
         """
 
+        def _find_value(xpath, element=tree):
+            return self._find_value(xpath, element, tree.nsmap)
+
         amount_total_import = None
 
         default_move_type = False
@@ -261,20 +264,14 @@ class AccountEdiFormat(models.Model):
                             invoice_line_form.sequence = int(line_elements[0].text)
 
                         # Product.
-                        line_elements = element.xpath('.//ram:SpecifiedTradeProduct/ram:Name', namespaces=tree.nsmap)
-                        if line_elements:
-                            invoice_line_form.name = line_elements[0].text
-                        line_elements = element.xpath('.//ram:SpecifiedTradeProduct/ram:SellerAssignedID', namespaces=tree.nsmap)
-                        if line_elements and line_elements[0].text:
-                            product = self.env['product.product'].search([('default_code', '=', line_elements[0].text)])
-                            if product:
-                                invoice_line_form.product_id = product
-                        if not invoice_line_form.product_id:
-                            line_elements = element.xpath('.//ram:SpecifiedTradeProduct/ram:GlobalID', namespaces=tree.nsmap)
-                            if line_elements and line_elements[0].text:
-                                product = self.env['product.product'].search([('barcode', '=', line_elements[0].text)])
-                                if product:
-                                    invoice_line_form.product_id = product
+                        name = _find_value('.//ram:SpecifiedTradeProduct/ram:Name', element)
+                        if name:
+                            invoice_line_form.name = name
+                        invoice_line_form.product_id = self._retrieve_product(
+                            default_code=_find_value('.//ram:SpecifiedTradeProduct/ram:SellerAssignedID', element),
+                            name=_find_value('.//ram:SpecifiedTradeProduct/ram:Name', element),
+                            barcode=_find_value('.//ram:SpecifiedTradeProduct/ram:GlobalID', element)
+                        )
 
                         # Quantity.
                         line_elements = element.xpath('.//ram:SpecifiedLineTradeDelivery/ram:BilledQuantity', namespaces=tree.nsmap)
@@ -303,18 +300,13 @@ class AccountEdiFormat(models.Model):
                             invoice_line_form.discount = float(line_elements[0].text)
 
                         # Taxes
-                        line_elements = element.xpath('.//ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent', namespaces=tree.nsmap)
+                        tax_element = element.xpath('.//ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent', namespaces=tree.nsmap)
                         invoice_line_form.tax_ids.clear()
-                        for tax_element in line_elements:
-                            percentage = float(tax_element.text)
-
-                            tax = self.env['account.tax'].search([
-                                ('company_id', '=', invoice_form.company_id.id),
-                                ('amount_type', '=', 'percent'),
-                                ('type_tax_use', '=', invoice_form.journal_id.type),
-                                ('amount', '=', percentage),
-                            ], limit=1)
-
+                        for eline in tax_element:
+                            tax = self._retrieve_tax(
+                                amount=eline.text,
+                                type_tax_use=invoice_form.journal_id.type
+                            )
                             if tax:
                                 invoice_line_form.tax_ids.add(tax)
             elif amount_total_import:

--- a/addons/account_edi_facturx/test_file/test_facturx.xml
+++ b/addons/account_edi_facturx/test_file/test_facturx.xml
@@ -42,6 +42,9 @@ Conference room table</ram:Name>
                 <ram:SpecifiedTradeSettlementLineMonetarySummation>
                     <ram:LineTotalAmount currencyID="USD">3210.00</ram:LineTotalAmount>
                 </ram:SpecifiedTradeSettlementLineMonetarySummation>
+                <ram:ApplicableTradeTax>
+                    <ram:RateApplicablePercent>0.0</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
             </ram:SpecifiedLineTradeSettlement>
 
         </ram:IncludedSupplyChainTradeLineItem>

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -54,6 +54,9 @@ class AccountEdiFormat(models.Model):
 
         namespaces = _get_ubl_namespaces()
 
+        def _find_value(xpath, element=tree):
+            return self._find_value(xpath, element, namespaces)
+
         with Form(invoice.with_context(account_predictive_bills_disable_prediction=True)) as invoice_form:
 
             # Reference
@@ -88,55 +91,23 @@ class AccountEdiFormat(models.Model):
                 invoice_form.invoice_incoterm_id = self.env['account.incoterms'].search([('code', '=', elements[0].text)], limit=1)
 
             # Partner
-            partner_element = tree.xpath('//cac:AccountingSupplierParty/cac:Party', namespaces=namespaces)
-            if partner_element:
-                domains = []
-                partner_element = partner_element[0]
-                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:Name', namespaces=namespaces)
-                if elements:
-                    partner_name = elements[0].text
-                    domains.append([('name', 'ilike', partner_name)])
-                else:
-                    partner_name = ''
-                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:Telephone', namespaces=namespaces)
-                if elements:
-                    partner_telephone = elements[0].text
-                    domains.append([('phone', '=', partner_telephone), ('mobile', '=', partner_telephone)])
-                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:ElectronicMail', namespaces=namespaces)
-                if elements:
-                    partner_mail = elements[0].text
-                    domains.append([('email', '=', partner_mail)])
-                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:CompanyID', namespaces=namespaces)
-                if elements:
-                    partner_id = elements[0].text
-                    domains.append([('vat', 'like', partner_id)])
-
-                if domains:
-                    partner = self.env['res.partner'].search(expression.OR(domains), limit=1)
-                    if partner:
-                        invoice_form.partner_id = partner
-                        partner_name = partner.name
-                    else:
-                        invoice_form.partner_id = self.env['res.partner']
+            invoice_form.partner_id = self._retrieve_partner(
+                name=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:Name'),
+                phone=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:Telephone'),
+                mail=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:ElectronicMail'),
+                vat=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:CompanyID'),
+            )
 
             # Lines
             lines_elements = tree.xpath('//cac:InvoiceLine', namespaces=namespaces)
             for eline in lines_elements:
                 with invoice_form.invoice_line_ids.new() as invoice_line_form:
                     # Product
-                    elements = eline.xpath('cac:Item/cac:SellersItemIdentification/cbc:ID', namespaces=namespaces)
-                    domains = []
-                    if elements:
-                        product_code = elements[0].text
-                        domains.append([('default_code', '=', product_code)])
-                    elements = eline.xpath('cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID=\'GTIN\']', namespaces=namespaces)
-                    if elements:
-                        product_ean13 = elements[0].text
-                        domains.append([('barcode', '=', product_ean13)])
-                    if domains:
-                        product = self.env['product.product'].search(expression.OR(domains), limit=1)
-                        if product:
-                            invoice_line_form.product_id = product
+                    invoice_line_form.product_id = self._retrieve_product(
+                        default_code=_find_value('cac:Item/cac:SellersItemIdentification/cbc:ID', eline),
+                        name=_find_value('cac:Item/cbc:Name', eline),
+                        barcode=_find_value('cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID=\'0160\']', eline)
+                    )
 
                     # Quantity
                     elements = eline.xpath('cbc:InvoicedQuantity', namespaces=namespaces)
@@ -157,22 +128,19 @@ class AccountEdiFormat(models.Model):
                         invoice_line_form.name = invoice_line_form.name.replace('%month%', str(fields.Date.to_date(invoice_form.invoice_date).month))  # TODO: full name in locale
                         invoice_line_form.name = invoice_line_form.name.replace('%year%', str(fields.Date.to_date(invoice_form.invoice_date).year))
                     else:
+                        partner_name = _find_value('//cac:AccountingSupplierParty/cac:Party//cbc:Name')
                         invoice_line_form.name = "%s (%s)" % (partner_name or '', invoice_form.invoice_date)
 
                     # Taxes
-                    taxes_elements = eline.xpath('cac:TaxTotal/cac:TaxSubtotal', namespaces=namespaces)
+                    tax_element = eline.xpath('cac:TaxTotal/cac:TaxSubtotal', namespaces=namespaces)
                     invoice_line_form.tax_ids.clear()
-                    for etax in taxes_elements:
-                        elements = etax.xpath('cbc:Percent', namespaces=namespaces)
-                        if elements:
-                            tax = self.env['account.tax'].search([
-                                ('company_id', '=', self.env.company.id),
-                                ('amount', '=', float(elements[0].text)),
-                                ('type_tax_use', '=', invoice_form.journal_id.type),
-                            ], order='sequence ASC', limit=1)
-                            if tax:
-                                invoice_line_form.tax_ids.add(tax)
-
+                    for eline in tax_element:
+                        tax = self._retrieve_tax(
+                            amount=_find_value('cbc:Percent', eline),
+                            type_tax_use=invoice_form.journal_id.type
+                        )
+                        if tax:
+                            invoice_line_form.tax_ids.add(tax)
         invoice = invoice_form.save()
 
         # Regenerate PDF

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -58,6 +58,7 @@ class AccountEdiFormat(models.Model):
             return self._find_value(xpath, element, namespaces)
 
         with Form(invoice.with_context(account_predictive_bills_disable_prediction=True)) as invoice_form:
+            self_ctx = self.with_company(invoice.company_id.id)
 
             # Reference
             elements = tree.xpath('//cbc:ID', namespaces=namespaces)
@@ -91,7 +92,7 @@ class AccountEdiFormat(models.Model):
                 invoice_form.invoice_incoterm_id = self.env['account.incoterms'].search([('code', '=', elements[0].text)], limit=1)
 
             # Partner
-            invoice_form.partner_id = self._retrieve_partner(
+            invoice_form.partner_id = self_ctx._retrieve_partner(
                 name=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:Name'),
                 phone=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:Telephone'),
                 mail=_find_value('//cac:AccountingSupplierParty/cac:Party//cbc:ElectronicMail'),
@@ -103,7 +104,7 @@ class AccountEdiFormat(models.Model):
             for eline in lines_elements:
                 with invoice_form.invoice_line_ids.new() as invoice_line_form:
                     # Product
-                    invoice_line_form.product_id = self._retrieve_product(
+                    invoice_line_form.product_id = self_ctx._retrieve_product(
                         default_code=_find_value('cac:Item/cac:SellersItemIdentification/cbc:ID', eline),
                         name=_find_value('cac:Item/cbc:Name', eline),
                         barcode=_find_value('cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID=\'0160\']', eline)
@@ -135,7 +136,7 @@ class AccountEdiFormat(models.Model):
                     tax_element = eline.xpath('cac:TaxTotal/cac:TaxSubtotal', namespaces=namespaces)
                     invoice_line_form.tax_ids.clear()
                     for eline in tax_element:
-                        tax = self._retrieve_tax(
+                        tax = self_ctx._retrieve_tax(
                             amount=_find_value('cbc:Percent', eline),
                             type_tax_use=invoice_form.journal_id.type
                         )


### PR DESCRIPTION
`_retrieve_{partner,product,tax}` methods were not taking into account a scope of a company, and methods like `_import_ubl` or `_import_facturx` could end up on creating an invoice with a company mismatch between the company of the journal and the company of the partner, product or tax.
    
With this commit, these methods will consider the `allowed_company_ids` context value, and calling code should set it to an acceptable value.

OPW-2560795

The two first commits are backporting changes from saas-14.1 and saas-14.4 so that this should forward-port smoothly :crossed_fingers: