### PR TITLE
[FIX] website: fix conversion of specific svgs on firefox

### DIFF
--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -194,11 +194,92 @@ function websiteDomain(self) {
     return ['|', ['website_id', '=', false], ['website_id', '=', websiteID]];
 }
 
+/**
+ * Converts a base64 SVG into a base64 PNG.
+ *
+ * @param {string|HTMLImageElement} src - an URL to a SVG or a *loaded* image
+ *      with such an URL. This allows the call to this method to be potentially
+ *      not return a Promise.
+ * @param {boolean} [noAsync=false] In case, the given first parameter is a
+ *      loaded image, this parameter allows to ignore problematic images and
+ *      return a (problematic) PNG result synchronously.
+ * @returns {Promise<string>|string} a base64 PNG (as result of a Promise or not)
+ */
+function svgToPNG(src, noAsync = false) {
+    function checkImg(imgEl) {
+        // Firefox does not support drawing SVG to canvas unless it has width
+        // and height attributes set on the root <svg>.
+        return (imgEl.naturalHeight !== 0);
+    }
+    function toPNGViaCanvas(imgEl) {
+        const canvas = document.createElement('canvas');
+        canvas.width = imgEl.width;
+        canvas.height = imgEl.height;
+        canvas.getContext('2d').drawImage(imgEl, 0, 0);
+        return canvas.toDataURL('image/png');
+    }
+
+    // In case we receive a loaded image with the given src and that this image
+    // is not problematic, we can convert it to PNG synchronously.
+    if (src instanceof HTMLImageElement) {
+        const loadedImgEl = src;
+        if (noAsync || checkImg(loadedImgEl)) {
+            return toPNGViaCanvas(loadedImgEl);
+        }
+        src = loadedImgEl.src;
+    }
+
+    // At this point, we either did not receive a loaded image or the received
+    // loaded image is problematic => we have to do some asynchronous code and
+    // the function will thus return a Promise.
+    return new Promise(resolve => {
+        const imgEl = new Image();
+        imgEl.onload = () => {
+            if (checkImg(imgEl)) {
+                resolve(imgEl);
+                return;
+            }
+
+            // Set arbitrary height on image and attach it to the DOM to force
+            // width computation.
+            imgEl.height = 1000;
+            imgEl.style.opacity = 0;
+            document.body.appendChild(imgEl);
+
+            const request = new XMLHttpRequest();
+            request.open('GET', imgEl.src, true);
+            request.onload = () => {
+                // Convert the data URI to a SVG element
+                const parser = new DOMParser();
+                const result = parser.parseFromString(request.responseText, 'text/xml');
+                const svgEl = result.getElementsByTagName("svg")[0];
+
+                // Add the attributes Firefox needs and remove the image from
+                // the DOM.
+                svgEl.setAttribute('width', imgEl.width);
+                svgEl.setAttribute('height', imgEl.height);
+                imgEl.remove();
+
+                // Convert the SVG element to a data URI
+                const svg64 = btoa(new XMLSerializer().serializeToString(svgEl));
+                const finalImg = new Image();
+                finalImg.onload = () => {
+                    resolve(finalImg);
+                };
+                finalImg.src = `data:image/svg+xml;base64,${svg64}`;
+            };
+            request.send();
+        };
+        imgEl.src = src;
+    }).then(loadedImgEl => toPNGViaCanvas(loadedImgEl));
+}
+
 return {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
     onceAllImagesLoaded: onceAllImagesLoaded,
     prompt: prompt,
     websiteDomain: websiteDomain,
+    svgToPNG: svgToPNG,
 };
 });

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -5,6 +5,7 @@ var core = require('web.core');
 var Dialog = require('web.Dialog');
 var publicWidget = require('web.public.widget');
 var utils = require('web.utils');
+var wUtils = require('website.utils');
 
 var QWeb = core.qweb;
 var _t = core._t;
@@ -151,20 +152,38 @@ var SlideUploadDialog = Dialog.extend({
                 'datas': this.file.data
             });
         } else if (values['slide_type'] === 'webpage') {
+            let fileData = this.file.type === 'image/svg+xml' ? this.__svgToPNG() : this.file.data;
+            if (fileData instanceof Promise) {
+                const fileDataProm = fileData;
+                this.__svgLoadingExec = () => fileDataProm.then(result => values['image_1920'] = result);
+                fileData = this._svgToPng();
+            }
             _.extend(values, {
                 'mime_type': 'text/html',
-                'image_1920': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data,
+                'image_1920': fileData,
             });
         } else if (/^image\/.*/.test(this.file.type)) {
+            let fileData = this.file.type === 'image/svg+xml' ? this.__svgToPNG() : this.file.data;
+            let fileDataProm;
+            if (fileData instanceof Promise) {
+                fileDataProm = fileData;
+                fileData = this._svgToPng();
+            }
             if (values['slide_type'] === 'presentation') {
+                if (fileDataProm) {
+                    this.__svgLoadingExec = () => fileDataProm.then(result => values['datas'] = result);
+                }
                 _.extend(values, {
                     'slide_type': 'infographic',
                     'mime_type': this.file.type === 'image/svg+xml' ? 'image/png' : this.file.type,
-                    'datas': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data
+                    'datas': fileData,
                 });
             } else {
+                if (fileDataProm) {
+                    this.__svgLoadingExec = () => fileDataProm.then(result => values['image_1920'] = result);
+                }
                 _.extend(values, {
-                    'image_1920': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data,
+                    'image_1920': fileData,
                 });
             }
         }
@@ -374,13 +393,22 @@ var SlideUploadDialog = Dialog.extend({
     // TODO: Remove this part, as now SVG support in image resize tools is included
     //Python PIL does not support SVG, so converting SVG to PNG
     _svgToPng: function () {
-        var img = this.$el.find('img#slide-image')[0];
-        var canvas = document.createElement('canvas');
-        canvas.width = img.width;
-        canvas.height = img.height;
-        canvas.getContext('2d').drawImage(img, 0, 0);
-        return canvas.toDataURL('image/png').split(',')[1];
+        return this.__svgToPNG(true);
     },
+    /**
+     * Bug fixed version of the original _svgToPng, it can return a Promise
+     *
+     * @returns {Promise<string>|string}
+     */
+    __svgToPNG: function (noAsync = false) {
+        const imgEl = this.$el.find('img#slide-image')[0];
+        const result = wUtils.svgToPNG(imgEl, noAsync);
+        if (typeof(result) === 'string') {
+            return result.split(',')[1];
+        }
+        return result.then(png => png.split(',')[1]);
+    },
+
     //--------------------------------------------------------------------------
     // Handler
     //--------------------------------------------------------------------------
@@ -598,9 +626,18 @@ var SlideUploadDialog = Dialog.extend({
             var values = this._formValidateGetValues($btn.hasClass('o_w_slide_upload_published')); // get info before changing state
             var oldType = this.get('state');
             this.set('state', '_upload');
-            return this._rpc({
-                route: '/slides/add_slide',
-                params: values,
+
+            return new Promise(async resolve => {
+                if (this.__svgLoadingExec) {
+                    await this.__svgLoadingExec();
+                }
+                delete this.__svgLoadingExec;
+                resolve();
+            }).then(() => {
+                return this._rpc({
+                    route: '/slides/add_slide',
+                    params: values,
+                });
             }).then(function (data) {
                 if (data.error) {
                     self.set('state', oldType);


### PR DESCRIPTION
A function allowing to convert a SVG to a PNG has been added as
an utility function in website.utils and is used for the upload
of document in website_slides. This function add support for a
specific case which was not supported by the previous conversion
function used for the document upload in website_slides: SVG
without width and height attributes on Firefox.

task-2602521

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
