### PR TITLE
[IMP] crm_*: add more fields when we merge multiple leads

### DIFF
--- a/addons/crm/data/crm_lead_merge_template.xml
+++ b/addons/crm/data/crm_lead_merge_template.xml
@@ -40,14 +40,33 @@
                 <div t-if="lead.priority">
                     Priority: <span t-field="lead.priority"/>
                 </div>
+                <div t-if="lead.lost_reason">
+                    Lost Reason: <span t-field="lead.lost_reason"/>
+                </div>
                 <div>
                     Created on: <span t-field="lead.create_date"/>
                 </div>
                 <div t-if="lead.date_action_last">
                     Last Action: <span t-field="lead.date_action_last"/>
                 </div>
+                <div t-if="lead.date_deadline">
+                    Expected Closing: <span t-field="lead.date_deadline"/>
+                </div>
                 <div t-if="not is_html_empty(lead.description)">
                     Notes: <span t-field="lead.description"/>
+                </div>
+                <div t-if="lead.lang_id" name="lang_id">
+                    Language: <span t-field="lead.lang_id"/>
+                </div>
+                <div t-if="lead.referred" name="referred">
+                    Referred By: <span t-field="lead.referred"/>
+                </div>
+                <div t-if="lead.tag_ids" name="tag_ids" class="d-flex flex-row">
+                    Tags:
+                    <div class="ml-2 d-flex flex-row">
+                        <div t-foreach="lead.tag_ids" t-as="tag" t-esc="tag.name"
+                            t-attf-class="badge badge-pill o_tag_color_#{tag.color} d-inline-block"/>
+                    </div>
                 </div>
                 <div t-if="lead.user_id" class="mt-3">
                     Salesperson: <span t-field="lead.user_id"/>
@@ -85,10 +104,14 @@
                         <div t-if="lead.website">
                             Website: <span t-field="lead.website"/>
                         </div>
+                        <div t-if="lead.function">
+                            Job Position: <span t-field="lead.function"/>
+                        </div>
                     </div>
                 </div>
                 <div class="mt-3"
-                        t-if="lead.street or lead.street2 or lead.zip or lead.city or lead.state_id or lead.country_id">
+                        t-if="lead.street or lead.street2 or lead.zip or lead.city or lead.state_id or lead.country_id"
+                        name="address">
                     <div class="font-weight-bold">
                         Address:
                     </div>

--- a/addons/crm/data/crm_lead_merge_template.xml
+++ b/addons/crm/data/crm_lead_merge_template.xml
@@ -122,7 +122,7 @@
                     <div t-if="lead.state_id" t-field="lead.state_id"/>
                     <div t-if="lead.country_id" t-field="lead.country_id"/>
                 </div>
-                <div class="mt-3 mb-3" name="marketing"
+                <div class="mt-3" name="marketing"
                         t-if="lead.campaign_id or lead.medium_id or lead.source_id">
                     <div class="font-weight-bold">
                         Marketing:
@@ -136,6 +136,22 @@
                     <div t-if="lead.source_id">
                         Source: <span t-field="lead.source_id"/>
                     </div>
+                </div>
+                <t t-set="lead_followers" t-value="merged_followers and merged_followers.get(lead.id)"/>
+                <div class="mt-3 mb-3" name="merged_followers" t-if="lead_followers">
+                    <div>
+                        The contacts below have been added as followers of this lead
+                        because they have been contacted less than 30 days ago on
+                        <span class="font-weight-bold" t-esc="lead.name"/>.
+                    </div>
+                    <ul>
+                      <li t-foreach="lead_followers" t-as="follower">
+                        <t t-esc="follower.partner_id.name"/>
+                        <t t-if="follower.partner_id.email">
+                            (<t t-esc="follower.partner_id.email"/>)
+                        </t>
+                      </li>
+                    </ul>
                 </div>
             </blockquote>
         </t>

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -146,14 +146,12 @@ class Lead(models.Model):
     # Revenues
     expected_revenue = fields.Monetary('Expected Revenue', currency_field='company_currency', tracking=True)
     prorated_revenue = fields.Monetary('Prorated Revenue', currency_field='company_currency', store=True, compute="_compute_prorated_revenue")
-    recurring_revenue = fields.Monetary('Recurring Revenues', currency_field='company_currency', groups="crm.group_use_recurring_revenues", tracking=True)
-    recurring_plan = fields.Many2one('crm.recurring.plan', string="Recurring Plan", groups="crm.group_use_recurring_revenues")
+    recurring_revenue = fields.Monetary('Recurring Revenues', currency_field='company_currency', tracking=True)
+    recurring_plan = fields.Many2one('crm.recurring.plan', string="Recurring Plan")
     recurring_revenue_monthly = fields.Monetary('Expected MRR', currency_field='company_currency', store=True,
-                                               compute="_compute_recurring_revenue_monthly",
-                                               groups="crm.group_use_recurring_revenues")
+                                                compute="_compute_recurring_revenue_monthly")
     recurring_revenue_monthly_prorated = fields.Monetary('Prorated MRR', currency_field='company_currency', store=True,
-                                               compute="_compute_recurring_revenue_monthly_prorated",
-                                               groups="crm.group_use_recurring_revenues")
+                                                         compute="_compute_recurring_revenue_monthly_prorated")
     company_currency = fields.Many2one("res.currency", string='Currency', related='company_id.currency_id', readonly=True)
     # Dates
     date_closed = fields.Datetime('Closed Date', readonly=True, copy=False)

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -36,4 +36,34 @@
     blockquote {
         font-style: normal;
     }
+
+    // Tag colors
+    @for $size from 1 through length($o-colors) {
+        .o_tag_color_#{$size - 1} {
+            border: transparent;
+            line-height: normal;
+            $background-color: white;
+            // no color selected
+            @if $size == 1 {
+                & {
+                    color: black;
+                    background-color: $background-color;
+                    box-shadow: inset 0 0 0 1px nth($o-colors, $size);
+                }
+            } @else {
+                $background-color: nth($o-colors, $size);
+                & {
+                    color: white;
+                    background-color: $background-color;
+                }
+            }
+            @at-root a#{&} {
+                &:hover {
+                    color: color-yiq($background-color);
+                    background-color: darken($background-color, 10%);
+                }
+            }
+        }
+    }
 }
+

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -462,7 +462,7 @@
                             <field name="expected_revenue" class="oe_inline mr-5" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                             <field name="priority" class="oe_inline" nolabel="1" widget="priority"/>
                         </div>
-                        <div class="o_row">
+                        <div class="o_row" groups="crm.group_use_recurring_revenues">
                             <field name="recurring_revenue" class="oe_inline pr-4" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                             <field name="recurring_plan" class="oe_inline" placeholder="E.g. Monthly"
                                    attrs="{'required': [('recurring_revenue', '!=', 0)]}" options="{'no_create': True, 'no_open': True}"/>
@@ -559,11 +559,11 @@
                                     <div class="o_kanban_record_subtitle">
                                         <t t-if="record.expected_revenue.raw_value">
                                             <field name="expected_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                                            <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value"> + </span>
+                                            <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value" groups="crm.group_use_recurring_revenues"> + </span>
                                         </t>
                                         <t t-if="record.recurring_revenue and record.recurring_revenue.raw_value">
-                                            <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                                            <field name="recurring_plan"/>
+                                            <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
+                                            <field name="recurring_plan" groups="crm.group_use_recurring_revenues"/>
                                         </t>
                                     </div>
                                     <div>
@@ -634,11 +634,11 @@
                     <div class="o_kanban_record_subtitle">
                         <t t-if="record.prorated_revenue.raw_value">
                             <field name="prorated_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                            <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value"> + </span>
+                            <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value" groups="crm.group_use_recurring_revenues"> + </span>
                         </t>
                         <t t-if="record.recurring_revenue and record.recurring_revenue.raw_value">
-                            <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                            <field name="recurring_plan"/>
+                            <field name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
+                            <field name="recurring_plan" groups="crm.group_use_recurring_revenues"/>
                         </t>
                     </div>
                 </xpath>
@@ -772,9 +772,11 @@
                     <field name="source_id" optional="hide"/>
                     <field name="company_currency" invisible="1"/>
                     <field name="expected_revenue" sum="Expected Revenues" optional="show" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                    <field name="recurring_revenue_monthly" sum="Expected MRR" optional="show" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                    <field name="recurring_revenue" sum="Recurring Revenue" optional="hide" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                    <field name="recurring_plan" optional="hide"/>
+                    <field name="recurring_revenue_monthly" sum="Expected MRR" optional="show" widget="monetary"
+                        options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue" sum="Recurring Revenue" optional="hide" widget="monetary"
+                        options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_plan" optional="hide" groups="crm.group_use_recurring_revenues"/>
                     <field name="stage_id" optional="show" decoration-bf="1"/>
                     <field name="active" invisible="1"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
@@ -896,7 +898,7 @@
                     <field name="create_date" interval="month" type="row"/>
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
-                    <field name="recurring_revenue_monthly" type="measure"/>
+                    <field name="recurring_revenue_monthly" type="measure" groups="crm.group_use_recurring_revenues"/>
                     <field name="color" invisible="1"/>
                 </pivot>
             </field>

--- a/addons/crm_iap_enrich/models/crm_lead.py
+++ b/addons/crm_iap_enrich/models/crm_lead.py
@@ -159,3 +159,9 @@ class Lead(models.Model):
                 values=template_values,
                 subtype_id=self.env.ref('mail.mt_note').id
             )
+
+    def _merge_get_fields_specific(self):
+        return {
+            ** super(Lead, self)._merge_get_fields_specific(),
+            'iap_enrich_done': lambda fname, leads: any(lead.iap_enrich_done for lead in leads),
+        }

--- a/addons/crm_iap_enrich/tests/__init__.py
+++ b/addons/crm_iap_enrich/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_crm_lead_merge
 from . import test_lead_enrich

--- a/addons/crm_iap_enrich/tests/test_crm_lead_merge.py
+++ b/addons/crm_iap_enrich/tests/test_crm_lead_merge.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo.addons.crm.tests.test_crm_lead_merge import TestLeadMergeCommon
+from odoo.tests.common import tagged, users
+from odoo.tools import mute_logger
+
+
+@tagged('lead_manage')
+class TestLeadMerge(TestLeadMergeCommon):
+
+    @users('user_sales_manager')
+    @mute_logger('odoo.models.unlink')
+    def test_merge_method_iap_enrich_done(self):
+        """Test that the "iap_enrich_done" is set to True if at least one lead have this value True"""
+        self.leads.iap_enrich_done = False
+        self.lead_w_contact.write({
+            'reveal_id': 'test_reveal_id',
+            'iap_enrich_done': True,
+        })
+
+        leads = self.env['crm.lead'].browse(self.leads.ids)._sort_by_confidence_level(reverse=True)
+
+        with self.assertLeadMerged(leads[0], leads, iap_enrich_done=True, reveal_id='test_reveal_id'):
+            leads._merge_opportunity(auto_unlink=False, max_length=None)

--- a/addons/crm_iap_mine/models/crm_lead.py
+++ b/addons/crm_iap_mine/models/crm_lead.py
@@ -8,3 +8,6 @@ class Lead(models.Model):
     _inherit = 'crm.lead'
 
     lead_mining_request_id = fields.Many2one('crm.iap.lead.mining.request', string='Lead Mining Request', index=True)
+
+    def _merge_get_fields(self):
+        return super(Lead, self)._merge_get_fields() + ['lead_mining_request_id']

--- a/addons/event_crm/__manifest__.py
+++ b/addons/event_crm/__manifest__.py
@@ -11,6 +11,7 @@
     'data': [
         'security/event_crm_security.xml',
         'security/ir.model.access.csv',
+        'data/crm_lead_merge_template.xml',
         'views/crm_lead_views.xml',
         'views/event_registration_views.xml',
         'views/event_lead_rule_views.xml',

--- a/addons/event_crm/data/crm_lead_merge_template.xml
+++ b/addons/event_crm/data/crm_lead_merge_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="crm_lead_merge_summary_inherit_event_crm" inherit_id="crm.crm_lead_merge_summary">
+    <xpath expr="//div[@name='marketing']" position="after">
+        <div class="mt-3 mb-3" name="event" t-if="lead.event_lead_rule_id or lead.event_id">
+            <div class="font-weight-bold">
+                Event:
+            </div>
+            <div t-if="lead.event_id">
+                Event: <span t-field="lead.event_id"/>
+            </div>
+            <div t-if="lead.event_lead_rule_id">
+                Registration Rule: <span t-field="lead.event_lead_rule_id"/>
+            </div>
+        </div>
+    </xpath>
+</template>
+
+</odoo>

--- a/addons/event_crm/models/crm_lead.py
+++ b/addons/event_crm/models/crm_lead.py
@@ -30,3 +30,6 @@ class Lead(models.Model):
         self.sudo().write({
             'registration_ids': [(4, registration.id) for registration in opportunities.sudo().registration_ids]
         })
+
+    def _merge_get_fields(self):
+        return super(Lead, self)._merge_get_fields() + ['event_lead_rule_id', 'event_id']

--- a/addons/iap_crm/models/crm_lead.py
+++ b/addons/iap_crm/models/crm_lead.py
@@ -8,3 +8,6 @@ class Lead(models.Model):
     _inherit = 'crm.lead'
 
     reveal_id = fields.Char(string='Reveal ID', help="Technical ID of reveal request done by IAP.")
+
+    def _merge_get_fields(self):
+        return super(Lead, self)._merge_get_fields() + ['reveal_id']

--- a/addons/sale_crm/__manifest__.py
+++ b/addons/sale_crm/__manifest__.py
@@ -19,6 +19,7 @@ modules.
     'depends': ['sale_management', 'crm'],
     'data': [
         'security/ir.model.access.csv',
+        'data/crm_lead_merge_template.xml',
         'views/partner_views.xml',
         'views/sale_order_views.xml',
         'views/crm_lead_views.xml',

--- a/addons/sale_crm/data/crm_lead_merge_template.xml
+++ b/addons/sale_crm/data/crm_lead_merge_template.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="crm_lead_merge_summary_inherit_sale_crm" inherit_id="crm.crm_lead_merge_summary">
+    <xpath expr="//blockquote/*[last()]" position="after">
+        <div t-if="lead.order_ids">
+            <br/>
+            <div class="font-weight-bold">
+                Sale Orders
+            </div>
+            <ul>
+                <li t-foreach="lead.order_ids" t-as="order" t-esc="order.name"/>
+            </ul>
+        </div>
+    </xpath>
+</template>
+
+</odoo>

--- a/addons/website_crm_iap_reveal/models/crm_lead.py
+++ b/addons/website_crm_iap_reveal/models/crm_lead.py
@@ -10,3 +10,6 @@ class Lead(models.Model):
     reveal_ip = fields.Char(string='IP Address')
     reveal_iap_credits = fields.Integer(string='IAP Credits')
     reveal_rule_id = fields.Many2one('crm.reveal.rule', string='Lead Generation Rule', index=True)
+
+    def _merge_get_fields(self):
+        return super(Lead, self)._merge_get_fields() + ['reveal_ip', 'reveal_iap_credits', 'reveal_rule_id']

--- a/addons/website_crm_partner_assign/data/crm_lead_merge_template.xml
+++ b/addons/website_crm_partner_assign/data/crm_lead_merge_template.xml
@@ -11,6 +11,17 @@
             Partner Assignment Date: <span t-field="lead.date_partner_assign"/>
         </div>
     </xpath>
+    <xpath expr="//div[@name='address']" position="attributes">
+        <attribute name="t-if">
+            lead.street or lead.street2 or lead.zip or lead.city or lead.state_id or lead.country_id
+            or lead.partner_latitude or lead.partner_longitude
+        </attribute>
+    </xpath>
+    <xpath expr="//div[@name='address']/*[last()]" position="after">
+        <div name="partner_geolocation" t-if="lead.partner_latitude or lead.partner_longitude">
+            Geolocation: <t t-esc="lead.partner_latitude"/> latitude, <t t-esc="lead.partner_longitude"/> longitude
+        </div>
+    </xpath>
 </template>
 
 </odoo>


### PR DESCRIPTION
Purpose
=======
Add more fields when we merge multiple leads to be sure not to lose
valuable information.

Specifications
==============
New fields merged
-----------------
Those fields are now propagated to the destination,
- referred
- color
- recurring_revenue
- recurring_plan
- function
- lang_id
- date_deadline
- reveal_id
- lead_mining_request_id
- reveal_ip
- reveal_iap_credits
- reveal_rule_id
- event_lead_rule_id
- event_id
- lost_reason (if the destination lead is lost)
- iap_enrich_done
- tag_ids

The address is taken from the lead with the most non-empty address
fields (sorted by highest rank if multiple leads have the same amount
of non-empty fields).

Followers
---------
When merging multiple leads, we want to move the followers to the
destination lead if they posted a message in the last 30 days.

A message will be added in the merge note to know which followers have
been added.

Views
-----
Remove the "groups" attribute  on the recurring revenue
fields. Instead we hide them directly in the views.

Task-2447721