### PR TITLE
[FIX] mail: prevent useless write

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -712,7 +712,7 @@ class Channel(models.Model):
             channel = self.browse(result[0].get('channel_id'))
             # pin up the channel for the current partner
             if pin:
-                self.env['mail.channel.partner'].search([('partner_id', '=', self.env.user.partner_id.id), ('channel_id', '=', channel.id)]).write({'is_pinned': True})
+                self.env['mail.channel.partner'].search([('partner_id', '=', self.env.user.partner_id.id), ('channel_id', '=', channel.id), ('is_pinned', '=', False)]).write({'is_pinned': True})
             channel._broadcast(self.env.user.partner_id.ids)
         else:
             # create a new one


### PR DESCRIPTION
In database with frontend and live chat there are lot of bad query error.
```
2021-08-30 02:59:47,797 1433 INFO production werkzeug: 37.120.204.140 - - [30/Aug/2021 02:59:47] "POST /web/dataset/call_kw/mail.channel/channel_get HTTP/1.0" 200 - 104 0.151 0.075
2021-08-30 02:59:47,847 1432 ERROR production odoo.sql_db: bad query: UPDATE "mail_channel_partner" SET "write_uid"=2,"write_date"=(now() at time zone 'UTC') WHERE id IN (365007)
ERROR: ERROR:  Could not serialize access due to concurrent update
```

On real database I have 200 error per days.

@tde-banana-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
