### PR TITLE
[FIX] planning: Fix sorting of records in Gantt view

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -862,6 +862,7 @@ class ResourceCalendarAttendance(models.Model):
 class ResourceResource(models.Model):
     _name = "resource.resource"
     _description = "Resources"
+    _order = "name"
 
     @api.model
     def default_get(self, fields):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Open the gantt view and add a few shifts for different resources

Current behavior before PR:
https://nimb.ws/1t38Jl resources are not sorted by alphabetical order

Desired behavior after PR is merged:
https://nimb.ws/NqIAG3 resources should be sorted by alphabetical order




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
