### PR TITLE
[FIX] mrp: make planned dates required

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -76,13 +76,13 @@ class MrpWorkorder(models.Model):
         compute='_compute_dates_planned',
         inverse='_set_dates_planned',
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
-        store=True, copy=False)
+        store=True, copy=False, required=True)
     date_planned_finished = fields.Datetime(
         'Scheduled End Date',
         compute='_compute_dates_planned',
         inverse='_set_dates_planned',
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
-        store=True, copy=False)
+        store=True, copy=False, required=True)
     date_start = fields.Datetime(
         'Start Date', copy=False,
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]})


### PR DESCRIPTION
We are setting values of `date_planned_start` and `date_planned_finished`
on the related the `leave_id` into `date_from` and `date_to` which are required
fields.

Before this commit there, was traceback on Removing on of these value
or creating Workorder with setting these dates. 

With this commit, These fields are required so it will correctly set values on
related `leave_id`.

Fixes #55963

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
