### PR TITLE
[IMP] l10n_cl, l10n_latam_invoice_document: move field

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -10,7 +10,6 @@ SII_VAT = '60805000-0'
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    l10n_latam_document_type_id_code = fields.Char(related='l10n_latam_document_type_id.code', string='Doc Type')
     partner_id_vat = fields.Char(related='partner_id.vat', string='VAT No')
     l10n_latam_internal_type = fields.Selection(
         related='l10n_latam_document_type_id.internal_type', string='L10n Latam Internal Type')

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -54,6 +54,7 @@ class AccountMove(models.Model):
         string='Document Number', readonly=True, states={'draft': [('readonly', False)]})
     l10n_latam_use_documents = fields.Boolean(related='journal_id.l10n_latam_use_documents')
     l10n_latam_manual_document_number = fields.Boolean(compute='_compute_l10n_latam_manual_document_number', string='Manual Number')
+    l10n_latam_document_type_id_code = fields.Char(related='l10n_latam_document_type_id.code', string='Doc Type')
 
     @api.depends('l10n_latam_document_type_id')
     def _compute_name(self):


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

related to latam task 569

Move l10n_latam_document_type_id_code field definition to latam module in order to be re used by another latam localizations

### Current behavior before PR:

Only Chile localization can see/use this field

### Desired behavior after PR is merged:

Another latam localizations can use this field

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
