### PR TITLE
update duplicate records in kanban when groupby m2m

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -580,7 +580,7 @@ var KanbanActivity = BasicActivity.extend({
      * @private
      */
     _reload: function () {
-        this.trigger_up('reload', { db_id: this.record_id, keepChanges: true });
+        this.trigger_up('reload', { db_id: this.record_id, keepChanges: true, reload_duplicates: true });
     },
     /**
      * @override

--- a/addons/web/static/src/legacy/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_controller.js
@@ -847,10 +847,11 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         ev.stopPropagation(); // prevent other controllers from handling this request
         var data = ev && ev.data || {};
         var handle = data.db_id;
+        const reload_duplicates = data.reload_duplicates;
         var prom;
         if (handle) {
             // reload the relational field given its db_id
-            prom = this.model.reload(handle).then(this._confirmSave.bind(this, handle));
+            prom = this.model.reload(handle, { reload_duplicates }).then(this._confirmSave.bind(this, handle));
         } else {
             // no db_id given, so reload the main record
             prom = this.reload({

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -5004,7 +5004,12 @@ var BasicModel = AbstractModel.extend({
             element.offset = _.indexOf(element.res_ids, element.res_id);
         }
         var loadOptions = _.pick(options, 'fieldNames', 'viewType');
-        return this._load(element, loadOptions).then(function (result) {
+        return this._load(element, loadOptions).then((result) => {
+            if (element.type === 'record' && options.reload_duplicates) {
+                this._updateDuplicateRecords(element.id, (id) => {
+                    Object.assign(this.localData[id].data, element.data);
+                });
+            }
             return result.id;
         });
     },

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_controller.js
@@ -112,8 +112,11 @@ var KanbanController = BasicController.extend({
      * @returns {Promise}
      */
     _confirmSave: function (id) {
-        var data = this.model.get(this.handle, {raw: true});
-        var grouped = data.groupedBy.length;
+        const state = this.model.get(this.handle);
+        const grouped = state.groupedBy.length;
+        if (grouped && state.isM2MGrouped) {
+            return this._updateRendererState(state);
+        }
         if (grouped) {
             var columnState = this.model.getColumn(id);
             return this.renderer.updateColumn(columnState.id, columnState);


### PR DESCRIPTION
PURPOSE
Since many2many grouping is supported with commit: dab4539513a650de2a0adbfab011686188912f5e
user can do grouping on many2many field and with m2m grouping same record can be in multiple columns, in listview we support duplicate recocrd update when one of the record is changed but in kanban view we did not consider this case.
So purpose of this task is to update duplicate records in kanban view.

SPEC
When same record is available in multiple column and field is changed like priority or state_selection then other records in other column should also updated.

TASK 2631801


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
