### PR TITLE
[FIX] account_bank_statement_import: correct fill in of bank account

### DIFF
--- a/addons/account_bank_statement_import/account_bank_statement_import.py
+++ b/addons/account_bank_statement_import/account_bank_statement_import.py
@@ -192,7 +192,8 @@ class AccountBankStatementImport(models.TransientModel):
                     # reconciliation process will be linked to the bank when the statement is closed.
                     identifying_string = line_vals.get('account_number')
                     if identifying_string:
-                        partner_bank = self.env['res.partner.bank'].search([('acc_number', '=', identifying_string)], limit=1)
+                        partner_bank = self.env['res.partner.bank']\
+                            .search([('acc_number', '=', identifying_string), ('company_id', 'in', (False, journal.company_id.id))], limit=1)
                         if partner_bank:
                             line_vals['bank_account_id'] = partner_bank.id
                             line_vals['partner_id'] = partner_bank.partner_id.id


### PR DESCRIPTION
When importing bank statements, we are filling in automatically the bank account
id if an existing record matching the number is found. However, we should restrict
the search to retrieve only bank accounts belonging to the current company,
otherwise it will create a multi-company inconsistency.

Description of the issue/feature this PR addresses:
opw-2602912

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
