### PR TITLE
[FIX] gamification: Allow users to verify their emails even when disconnected

### DIFF
--- a/addons/gamification/views/mail_templates.xml
+++ b/addons/gamification/views/mail_templates.xml
@@ -6,6 +6,7 @@
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">New rank: ${object.rank_id.name}</field>
             <field name="email_to"></field>
+            <field name="email_from">${user.email_formatted or object.company_id.partner_id.email_formatted or object.email_formatted | safe}</field>
             <field name="partner_to">${object.partner_id.id}</field>
             <field name="body_html" type="html">
 <div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">


### PR DESCRIPTION
When a user clicks on the link in the verification email to verify his email while being disconnected there is an error specifying that the sender is not defined

This pr defines the `email_from` field via the `User: New rank reached` template

opw-2469306