### PR TITLE
[FIX] point_of_sale: html2canvas letterRendering is configurable

### DIFF
--- a/addons/point_of_sale/static/lib/html2canvas.js
+++ b/addons/point_of_sale/static/lib/html2canvas.js
@@ -1211,7 +1211,7 @@
           textNode.nodeValue = textTransform(textNode.nodeValue, getCSS(el, "textTransform"));
           textAlign = textAlign.replace(["-webkit-auto"],["auto"]);
     
-          textList = (!options.letterRendering && /^(left|right|justify|auto)$/.test(textAlign) && noLetterSpacing(getCSS(el, "letterSpacing"))) ?
+          textList = (!options.letterRendering && /^(left|right|justify|auto|center)$/.test(textAlign) && noLetterSpacing(getCSS(el, "letterSpacing"))) ?
           textNode.nodeValue.split(/(\b| )/)
           : textNode.nodeValue.split("");
     

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1386,6 +1386,9 @@ exports.PosModel = Backbone.Model.extend({
     },
 
     electronic_payment_interfaces: {},
+    htmlToImgLetterRendering() {
+        return false;
+    }
 });
 
 /**

--- a/addons/point_of_sale/static/src/js/printers.js
+++ b/addons/point_of_sale/static/src/js/printers.js
@@ -8,6 +8,7 @@ var _t = core._t;
 var PrinterMixin = {
     init: function () {
         this.receipt_queue = [];
+        this.htmlToImgLetterRendering = false; // Whether to render each letter seperately. Necessary if letter-spacing is used.
     },
 
     /**
@@ -57,7 +58,7 @@ var PrinterMixin = {
                     $('.pos-receipt-print').empty();
                     resolve(self.process_canvas(canvas));
                 },
-                letterRendering: true,
+                letterRendering: self.htmlToImgLetterRendering,
             })
         });
         return promise;
@@ -86,6 +87,7 @@ var Printer = core.Class.extend(PrinterMixin, {
     init: function (url, pos) {
         PrinterMixin.init.call(this, arguments);
         this.pos = pos;
+        this.htmlToImgLetterRendering = pos.htmlToImgLetterRendering();
         this.connection = new Session(undefined, url || 'http://localhost:8069', { use_cors: true});
     },
 

--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -2439,7 +2439,7 @@ var PaymentScreenWidget = ScreenWidget.extend({
         };
 
         var receipt = QWeb.render('OrderReceipt', data);
-        var printer = new Printer();
+        var printer = new Printer(null, this.pos);
 
         return new Promise(function (resolve, reject) {
             printer.htmlToImg(receipt).then(function(ticket) {


### PR DESCRIPTION
The `letterRendering` option from the html2canvas broke the receipt's characters of some localizations/languages such as the arabic one.

With this commit, we can simply override the `htmlToImgLetterRendering()` method from the `PosModel` when needed.

