### PR TITLE
[FIX] crm: Don't allow to change stage of an archived lead

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -10,7 +10,7 @@ from odoo import api, fields, models, tools, SUPERUSER_ID
 from odoo.osv import expression
 from odoo.tools.translate import _
 from odoo.tools import email_re, email_split
-from odoo.exceptions import UserError, AccessError
+from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.addons.phone_validation.tools import phone_validation
 from collections import OrderedDict, defaultdict
 
@@ -694,6 +694,8 @@ class Lead(models.Model):
         leads_leave_lost = Lead
         won_stage_ids = self.env['crm.stage'].search([('is_won', '=', True)]).ids
         for lead in self:
+            if not lead.active and 'stage_id' in vals:
+                    raise ValidationError(_(f'Not allowed to change stage of archived leads.'))
             if 'stage_id' in vals:
                 if vals['stage_id'] in won_stage_ids:
                     if lead.probability == 0:


### PR DESCRIPTION
Steps to reproduce:

  - Install "CRM" module
  - Go to CRM, and move any lead to Won stage
  - Edit lead and archived it
  - Back to kanban view, filter to display only archived leads
  - Move lead to Proposition stage (ribbon should be on Lost)
  - Move lead to Won stage again

Issue:

    Able to change stage of an archived lead.

Solution:

    Add constrains on `stage_id` field to now allow to be changed if lead archived.
 
opw-2634668