### PR TITLE
[FIX] web: prevent mobile keyboard popping up on tablet

### DIFF
--- a/addons/web/static/src/js/views/control_panel/control_panel_renderer.js
+++ b/addons/web/static/src/js/views/control_panel/control_panel_renderer.js
@@ -185,8 +185,8 @@ var ControlPanelRenderer = Renderer.extend({
      * @private
      */
     _focusSearchInput: function () {
-        if (this.withSearchBar && !config.device.isMobile) {
-            // in mobile mode, we would rather not focus manually the
+        if (this.withSearchBar && !config.device.isMobileDevice) {
+            // in mobile device, we would rather not focus manually the
             // input, because it opens up the integrated keyboard, which is
             // not what you expect when you just selected a filter.
             this.searchBar.focus();

--- a/addons/web/static/tests/views/control_panel_tests.js
+++ b/addons/web/static/tests/views/control_panel_tests.js
@@ -3,6 +3,7 @@ odoo.define('web.control_panel_tests', function (require) {
 
 const AbstractAction = require('web.AbstractAction');
 const ControlPanelView = require('web.ControlPanelView');
+const config = require('web.config');
 const core = require('web.core');
 const testUtils = require('web.test_utils');
 
@@ -687,6 +688,48 @@ QUnit.module('Views', {
             "there should not be groupby dropdown");
 
         controlPanel.destroy();
+    });
+
+    QUnit.test('search field should be autofocused', async function (assert) {
+        assert.expect(2);
+
+        testUtils.mock.patch(config.device, {
+            isMobileDevice: false,
+        });
+
+        const controlPanel = await createControlPanel({
+            model: 'partner',
+            arch: '<search></search>',
+            data: this.data,
+        });
+
+        assert.containsOnce(controlPanel, '.o_searchview_input', "has a search field");
+        assert.containsOnce(controlPanel, '.o_searchview_input:focus-within',
+            "has autofocused search field");
+
+        controlPanel.destroy();
+        testUtils.mock.unpatch(config.device);
+    });
+
+    QUnit.test("search field's autofocus should be disabled on mobile device", async function (assert) {
+        assert.expect(2);
+
+        testUtils.mock.patch(config.device, {
+            isMobileDevice: true,
+        });
+
+        const controlPanel = await createControlPanel({
+            model: 'partner',
+            arch: '<search></search>',
+            data: this.data,
+        });
+
+        assert.containsOnce(controlPanel, '.o_searchview_input', "has a search field");
+        assert.containsNone(controlPanel, '.o_searchview_input:focus-within',
+            "hasn't autofocused search field");
+
+        controlPanel.destroy();
+        testUtils.mock.unpatch(config.device);
     });
 });
 });


### PR DESCRIPTION
Before this commit, when loading a view containing a searchbar on a
tablet, the device's keyboard is appearing once the searchbar's field is
autofocused.

Thanks to the backport of the mobile OS detection (see commit
odoo/odoo@0281a1d73af65006ec603da3e2df20d5a3dfcd5b ), we are now able to
properly target mobile OS (independent of the screen's resolution)
instead of only small screens.
