### PR TITLE
[IMP] web: Add zoom on employee avatar

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2198,6 +2198,7 @@ var FieldBinaryImage = AbstractFieldBinary.extend({
                     timer: zoomDelay,
                     attach: '.o_content',
                     attachToTarget: true,
+                    disabledOnMobile: false,
                     onShow: function () {
                         var zoomHeight = Math.ceil(this.$zoom.height());
                         var zoomWidth = Math.ceil(this.$zoom.width());


### PR DESCRIPTION
This commit enables the zoom on mobile.

To avoid any issue in website, we first only activate it in the backend.
Note that it's not, strictly speaking, a zoom. It only shows the
original size of the picture.

Steps to reproduce:
* Open Employee
* Select an employee
* Touch on the photos

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
