### PR TITLE
[FIX] sale, sale_crm: Wrong salesperson when creating SO from lead

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -397,7 +397,7 @@ class SaleOrder(models.Model):
         }
         user_id = partner_user.id
         if not self.env.context.get('not_self_saleperson'):
-            user_id = user_id or self.env.uid
+            user_id = user_id or self.env.context.get('default_user_id', self.env.uid)
         if user_id and self.user_id.id != user_id:
             values['user_id'] = user_id
 

--- a/addons/sale_crm/models/crm_lead.py
+++ b/addons/sale_crm/models/crm_lead.py
@@ -75,7 +75,6 @@ class CrmLead(models.Model):
             'default_opportunity_id': self.id,
             'search_default_partner_id': self.partner_id.id,
             'default_partner_id': self.partner_id.id,
-            'default_team_id': self.team_id.id,
             'default_campaign_id': self.campaign_id.id,
             'default_medium_id': self.medium_id.id,
             'default_origin': self.name,
@@ -83,6 +82,10 @@ class CrmLead(models.Model):
             'default_company_id': self.company_id.id or self.env.company.id,
             'default_tag_ids': self.tag_ids.ids,
         }
+        if self.team_id:
+            action['context']['default_team_id'] = self.team_id.id,
+        if self.user_id:
+            action['context']['default_user_id'] = self.user_id.id
         return action
 
     def action_view_sale_quotation(self):


### PR DESCRIPTION
Steps to reproduce the issue:

- Let's log in Odoo with a user U1
- Create a lead with user U2 as salesperson
- Click on New quotation

Bug:

A SO was suggested with U1 as salesperson instead of U2

opw:2520827