### PR TITLE
[FIX] base: avoid crashing when removing empty list from bundle

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -191,7 +191,7 @@ class IrAsset(models.Model):
             elif directive == BEFORE_DIRECTIVE:
                 asset_paths.insert(paths, addon, bundle, target_index)
             elif directive == REMOVE_DIRECTIVE:
-                asset_paths.remove(paths, addon, bundle, path_def)
+                asset_paths.remove(paths, addon, bundle)
             elif directive == REPLACE_DIRECTIVE:
                 asset_paths.insert(paths, addon, bundle, target_index)
                 asset_paths.remove(target_paths, addon, bundle)
@@ -414,16 +414,16 @@ class AssetPaths:
                 self.memo.add(path)
         self.list[index:index] = to_insert
 
-    def remove(self, paths, addon, bundle, path=None):
+    def remove(self, paths_to_remove, addon, bundle):
         """Removes the given paths from the current list."""
-        paths = {path for path in paths if path in self.memo}
+        paths = {path for path in paths_to_remove if path in self.memo}
         if paths:
             self.list[:] = [asset for asset in self.list if asset[0] not in paths]
             self.memo.difference_update(paths)
             return
 
-        if path:
-            self._raise_not_found(path, bundle)
+        if paths_to_remove:
+            self._raise_not_found(paths_to_remove, bundle)
 
     def _raise_not_found(self, path, bundle):
-        raise ValueError("File %s not found in bundle %s" % (path, bundle))
+        raise ValueError("File(s) %s not found in bundle %s" % (path, bundle))

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1069,7 +1069,7 @@ class TestAssetsManifest(AddonManifestPatched):
         with self.assertRaises(Exception) as cm:
             view._render()
         self.assertTrue(
-            "test_assetsbundle/static/src/js/test_doesntexist.js not found" in cm.exception.message
+            "['test_assetsbundle/static/src/js/test_doesntexist.js'] not found" in cm.exception.message
         )
 
     def test_09_remove_wholeglob(self):


### PR DESCRIPTION
Previously, having a remove directive in a bundle that didn't match any
file of that bundle's type would raise an error, saying that the path
we're attempting to remove could not be located in the current bundle.

This basically breaks the remove directive inside of xml/js-css hybrid
bundles, because getting the assets path in xml-mode will cause all
remove directives that only target css/js files to fail and vice versa.

This commit fixes that by only raising an error when there were files
that match the extensions currently enabled, and those files were not
found in the bundle.
