### PR TITLE
13.0 fix purchase delivery qty fja

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -253,7 +253,7 @@ class PurchaseOrderLine(models.Model):
                     if move.state == 'done':
                         if move.location_dest_id.usage == "supplier":
                             if move.to_refund:
-                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
                             # Edge case: the dropship is returned to the stock, no to the supplier.
                             # In this case, the received quantity on the PO is set although we didn't
@@ -268,9 +268,9 @@ class PurchaseOrderLine(models.Model):
                                 [("id", "child_of", move.warehouse_id.view_location_id.id)]
                             )
                         ):
-                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         else:
-                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                 line.qty_received = total
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Create the UOM Yard with:
type: bigger
factor_inv: 0.91440

Create a product with uom: Meter and purchase uom: Yards

Create a PO for 4 yards of the product created previously.
Validate the delivery
The qty delivered is 4.01

On SO if you create a sale for 4 yards and validate the delivery the qty delivered will be 4

Desired behavior after PR is merged:

qty should be 4


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
