### PR TITLE
[FIX] purchase_stock: fix uom conversion for received qty

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -253,7 +253,7 @@ class PurchaseOrderLine(models.Model):
                     if move.state == 'done':
                         if move.location_dest_id.usage == "supplier":
                             if move.to_refund:
-                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
                             # Edge case: the dropship is returned to the stock, no to the supplier.
                             # In this case, the received quantity on the PO is set although we didn't
@@ -268,9 +268,9 @@ class PurchaseOrderLine(models.Model):
                                 [("id", "child_of", move.warehouse_id.view_location_id.id)]
                             )
                         ):
-                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         else:
-                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                 line.qty_received = total
 
     @api.model

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -765,3 +765,32 @@ class TestSaleStock(TestSale):
         so.picking_ids.action_cancel()
 
         self.assertEqual(so.invoice_status, 'no')
+
+    def test_14_multi_uom(self):
+        yards_uom = self.env['uom.uom'].create({
+            'category_id': self.env.ref('uom.uom_categ_length').id,
+            'name': 'Yards',
+            'factor_inv': 0.9144,
+            'uom_type': 'bigger',
+        })
+        product = self.env.ref('product.product_product_11').copy({
+            'uom_id': self.env.ref('uom.product_uom_meter').id,
+            'uom_po_id': yards_uom.id,
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_uom_qty': 4.0,
+                    'product_uom': yards_uom.id,
+                    'price_unit': 1.0,
+                })
+            ],
+        })
+        so.action_confirm()
+        picking = so.picking_ids[0]
+        picking.move_lines.write({'quantity_done': 3.66})
+        picking.button_validate()
+        self.assertEqual(so.order_line.mapped('qty_delivered'), [4.0], 'Sale: no conversion error on delivery in different uom"')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Create the UOM Yard with:
type: bigger
factor_inv: 0.91440

Create a product with uom: Meter and purchase uom: Yards

Create a PO for 4 yards of the product created previously.
Validate the delivery
The qty received is 4.01

On SO if you create a sale for 4 yards and validate the receipt the qty received will be 4

Desired behavior after PR is merged:

received qty should be 4



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
