### PR TITLE
[FIX] project: Calculate the right task next occurrences dates

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -761,6 +761,9 @@ class Task(models.Model):
             return [fn(n) for day, fn in DAYS.items() if self[day]]
         return [DAYS.get(self.repeat_weekday)(n)]
 
+    def _get_recurrence_start_date(self):
+        return fields.Date.today()
+
     @api.depends(
         'recurring_task', 'repeat_interval', 'repeat_unit', 'repeat_type', 'repeat_until',
         'repeat_number', 'repeat_on_month', 'repeat_on_year', 'mon', 'tue', 'wed', 'thu', 'fri',
@@ -768,7 +771,7 @@ class Task(models.Model):
     def _compute_recurrence_message(self):
         self.recurrence_message = False
         for task in self.filtered(lambda t: t.recurring_task and t._is_recurrence_valid()):
-            date = fields.Date.today()
+            date = self._get_recurrence_start_date()
             number_occurrences = min(5, task.repeat_number if task.repeat_type == 'after' else 5)
             delta = task.repeat_interval if task.repeat_unit == 'day' else 1
             recurring_dates = self.env['project.task.recurrence']._get_next_recurring_dates(


### PR DESCRIPTION
Steps to reproduce:

  - Install "Field Service" module
  - Go to settings and activate "Recurring Tasks"
  - Go to Field Service -> All tasks and create new one
  - Set for Planned Date : 10/01/2021 14:00 -> 10/02/2021 14:30
  - Check Recurrent and go to Recurrence tab
  - Select repeat every 1 weeks
  - Select Monday

Issue:

  Wrong date for next occurrences (first occurrence is 09/06 instead
  of 10/04).

Cause:

  Calculation based on today date.

Solution:

  Calculate next occurrences based on planned_start_date if set.

opw-2628777