### PR TITLE
[FIX] web: keep context on form dialog save&new by default

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -143,7 +143,7 @@ var FormViewDialog = ViewDialog.extend({
                                 .then(function () {
                                     // reset default name field from context when Save & New is clicked, pass additional
                                     // context so that when getContext is called additional context resets it
-                                    var additionalContext = self._createContext && self._createContext(false) || {};
+                                    const additionalContext = self._createContext && self._createContext(false);
                                     self.form_view.createRecord(self.parentID, additionalContext);
                                 })
                                 .then(function () {

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -433,6 +433,85 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test("Form dialog replaces the context with _createContext method when specified", async function (assert) {
+        assert.expect(5);
+
+        const parent = await createParent({
+            data: this.data,
+            archs: {
+                "partner,false,form":
+                    `<form string="Partner">
+                        <sheet>
+                            <group><field name="foo"/></group>
+                        </sheet>
+                    </form>`,
+            },
+
+            mockRPC: function (route, args) {
+                if (args.method === "create") {
+                    assert.step(JSON.stringify(args.kwargs.context));
+                }
+                return this._super(route, args);
+            },
+        });
+
+        new dialogs.FormViewDialog(parent, {
+            res_model: "partner",
+            context: { answer: 42 },
+            _createContext: () => ({ dolphin: 64 }),
+        }).open();
+        await testUtils.nextTick();
+
+        assert.notOk($(".modal-body button").length,
+            "should not have any button in body");
+        assert.strictEqual($(".modal-footer button").length, 3,
+            "should have 3 buttons in footer");
+
+        await testUtils.dom.click($(".modal-footer button:contains(Save & New)"));
+        await testUtils.dom.click($(".modal-footer button:contains(Save & New)"));
+        assert.verifySteps(['{"answer":42}', '{"dolphin":64}']);
+        parent.destroy();
+    });
+
+    QUnit.test("Form dialog keeps full context when no _createContext is specified", async function (assert) {
+        assert.expect(5);
+
+        const parent = await createParent({
+            data: this.data,
+            archs: {
+                "partner,false,form":
+                    `<form string="Partner">
+                        <sheet>
+                            <group><field name="foo"/></group>
+                        </sheet>
+                    </form>`,
+            },
+
+            mockRPC: function (route, args) {
+                if (args.method === "create") {
+                    assert.step(JSON.stringify(args.kwargs.context));
+                }
+                return this._super(route, args);
+            },
+        });
+
+        new dialogs.FormViewDialog(parent, {
+            res_model: "partner",
+            context: { answer: 42 }
+        }).open();
+        await testUtils.nextTick();
+
+        assert.notOk($(".modal-body button").length,
+            "should not have any button in body");
+        assert.strictEqual($(".modal-footer button").length, 3,
+            "should have 3 buttons in footer");
+
+        await testUtils.dom.click($(".modal-footer button:contains(Save & New)"));
+        await testUtils.dom.click($(".modal-footer button:contains(Save & New)"));
+        assert.verifySteps(['{"answer":42}', '{"answer":42}']);
+        parent.destroy();
+    });
+
     QUnit.test('SelectCreateDialog: save current search', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
ISSUE ADDRESSED
- Open Project > Tasks > Gantt view
- Click the ADD button to open the form dialog
- Fill the form and click on SAVE&NEW button
- Fill again the form and click on SAVE&CLOSE button
- Both tasks are created, but only the first has been planned, because the second one has lost a part of the context (plan dates...)

BEFORE
Opening a form view dialog without passing a _createContext method (see commit c14b17c485 where it was introduced) was still passing an empty object additionalContext argument when save&new was hit.
This was leading to not take into account the full context (see BasicModel._getContext).

AFTER
If no _createContext method is passed to a form view dialog, then no empty object additionalContext is passed to evaluate the context, resulting in the full context being used.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
