### PR TITLE
[FIX] product_expiry: set the expiration_date when creating the “stock_move_line”

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -9,19 +9,18 @@ from odoo import api, fields, models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    expiration_date = fields.Datetime(string='Expiration Date',
+    expiration_date = fields.Datetime(string='Expiration Date', compute='_compute_expiration_date', store=True,
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
 
-    @api.onchange('product_id', 'product_uom_id')
-    def _onchange_product_id(self):
-        res = super(StockMoveLine, self)._onchange_product_id()
-        if self.picking_type_use_create_lots:
-            if self.product_id.use_expiration_date:
-                self.expiration_date = fields.Datetime.today() + datetime.timedelta(days=self.product_id.expiration_time)
-            else:
-                self.expiration_date = False
-        return res
+    @api.depends('product_id', 'picking_type_use_create_lots')
+    def _compute_expiration_date(self):
+        for move_line in self:
+            if move_line.picking_type_use_create_lots:
+                if move_line.product_id.use_expiration_date:
+                    move_line.expiration_date = fields.Datetime.today() + datetime.timedelta(days=move_line.product_id.expiration_time)
+                else:
+                    move_line.expiration_date = False
 
     @api.onchange('lot_id')
     def _onchange_lot_id(self):


### PR DESCRIPTION
Steps to reproduce the bug:
- Install inventory, purchase and product_expiry
- Create a new storable product that is tracked by lots or serial numbers and expiration date
- Go to inventory > configuration > Warehouse Management > Operations Types
- In “San Francisco: Receipts” > Enable "Create New Lots/Serial Numbers", “Pre-fill Detailed Operations”, and "Show Detailed Operations"
- Create a new RFQ > select the created product > Confirm the order
- Click on “Receipt”

Problem:
In the created “stock_move_line” the expiration date field is not set

Solution:
When we add a new "stock_move_line" and choose a product, an onchange is triggered in order to set
the expiration_date field even if we do not choose a "lot /serial number name".
So we can replace the onchange with a compute function to do the same thing in the creation.


opw-2634583

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
