### PR TITLE
[FIX] point_of_sale,pos_sale: missing context and styles

### DIFF
--- a/addons/point_of_sale/static/src/js/PosContext.js
+++ b/addons/point_of_sale/static/src/js/PosContext.js
@@ -6,6 +6,7 @@ odoo.define('point_of_sale.PosContext', function (require) {
     // Create global context objects
     // e.g. component.env.device = new Context({ isMobile: false });
     return {
+        orderManagement: new Context({ searchString: '', selectedOrder: null }),
         chrome: new Context({ showOrderSelector: true }),
     };
 });

--- a/addons/pos_sale/static/src/css/pos_sale.css
+++ b/addons/pos_sale/static/src/css/pos_sale.css
@@ -4,3 +4,91 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.order-management-screen .flex-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.order-management-screen .orders {
+    display: flex;
+    flex-direction: column;
+}
+
+.order-management-screen .order-list {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.order-management-screen .control-panel {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0.5rem;
+}
+
+.order-management-screen .control-panel .item {
+    font-size: medium;
+}
+
+.order-management-screen .control-panel .search-box {
+    flex: 1;
+    position: relative;
+    text-align: center;
+    margin: 0.2rem;
+}
+
+.order-management-screen .control-panel .search-box .clear {
+    position: relative;
+    right: 25px;
+    cursor: pointer;
+    color: #808080;
+    font-size: 13px;
+}
+
+.order-management-screen .control-panel .search-box .icon {
+    position: relative;
+    left: 25px;
+    color: #808080;
+    font-size: 13px;
+}
+
+.order-management-screen .control-panel .search-box input {
+    border: 1px solid #cecbcb;
+    padding: 10px 30px;
+    margin: auto;
+    background-color: white;
+    border-radius: 20px;
+    font-family: "Lato","Lucida Grande", Helvetica, Verdana, Arial;
+    font-size: 13px;
+}
+
+.order-management-screen .control-panel .search-box input:focus {
+    outline: none;
+    box-shadow: 0px 0px 0px 2px rgb(153, 153, 255) inset;
+    color: rgb(153, 153, 255);
+}
+
+.order-management-screen .control-panel .button {
+    line-height: 32px;
+    padding: 3px 13px;
+    font-size: 20px;
+    background: rgb(230, 230, 230);
+    border-radius: 3px;
+    border: solid 1px rgb(209, 209, 209);
+    cursor: pointer;
+    transition: all 150ms linear;
+}
+
+.order-management-screen .control-panel .button:hover {
+    background: #efefef;
+}
+
+.order-management-screen .back-to-list {
+    font-size: large;
+    padding: 10px;
+    background-color: #6EC89B;
+    color: white;
+}


### PR DESCRIPTION
After merging https://github.com/odoo/odoo/pull/75322, orderManagement
context and order-management-screen styles were removed by which
pos_sale was dependent. Because of this, settling quotations in pos_sale
doesn't work. We restore the needed context and styles in this commit.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
