### PR TITLE
[REF] im_livechat: make translatable some fields in im_livechat.channel model

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -29,10 +29,11 @@ class ImLivechatChannel(models.Model):
     # attribute fields
     name = fields.Char('Name', required=True, help="The name of the channel")
     button_text = fields.Char('Text of the Button', default='Have a Question? Chat with us.',
-        help="Default text displayed on the Livechat Support Button")
+        help="Default text displayed on the Livechat Support Button", translate=True)
     default_message = fields.Char('Welcome Message', default='How may I help you?',
-        help="This is an automated 'welcome' message that your visitor will see when they initiate a new conversation.")
-    input_placeholder = fields.Char('Chat Input Placeholder', help='Text that prompts the user to initiate the chat.')
+        help="This is an automated 'welcome' message that your visitor will see when they initiate a new conversation.",
+        translate=True)
+    input_placeholder = fields.Char('Chat Input Placeholder', help='Text that prompts the user to initiate the chat.', translate=True)
     header_background_color = fields.Char(default="#875A7B", help="Default background color of the channel header once open")
     title_color = fields.Char(default="#FFFFFF", help="Default title color of the channel once open")
     button_background_color = fields.Char(default="#878787", help="Default background color of the Livechat button")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Following fields are used in the channel setting:

1. button_text
2. default_message
3. input_placeholder

![Screen Shot 2021-08-31 at 16 15 53](https://user-images.githubusercontent.com/54731581/131576988-8aa01315-c3ec-4e93-a9c8-5cbb3c6a98e1.png)

but cannot translate them because fields are not translatable.

PR makes those fields translatable.

Current behavior before PR:

We are not able to make translations to the above fields.

Desired behavior after PR is merged:

We are able to make translations to above fields.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
