### PR TITLE
[FIX] survey: fix the timer in survey

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -265,6 +265,7 @@ class Survey(http.Controller):
 
         if not answer_sudo.is_session_answer and survey_sudo.is_time_limited and answer_sudo.start_datetime:
             data.update({
+                'server_time': fields.Datetime.now(),
                 'timer_start': answer_sudo.start_datetime.isoformat(),
                 'time_limit_minutes': survey_sudo.time_limit
             })

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -881,6 +881,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend({
         var questionTimeLimitReached = $timerData.data('questionTimeLimitReached');
         var timeLimitMinutes = $timerData.data('timeLimitMinutes');
         var hasAnswered = $timerData.data('hasAnswered');
+        const serverTime = $timerData.data('serverTime');
 
         if (!questionTimeLimitReached && !hasAnswered && timeLimitMinutes) {
             var timer = $timerData.data('timer');
@@ -889,6 +890,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend({
             });
             this.$('.o_survey_timer_container').append($timer);
             this.surveyTimerWidget = new publicWidget.registry.SurveyTimerWidget(this, {
+                'serverTime': serverTime,
                 'timer': timer,
                 'timeLimitMinutes': timeLimitMinutes
             });

--- a/addons/survey/static/src/js/survey_timer.js
+++ b/addons/survey/static/src/js/survey_timer.js
@@ -16,11 +16,18 @@ publicWidget.registry.SurveyTimerWidget = publicWidget.Widget.extend({
         this.timer = params.timer;
         this.timeLimitMinutes = params.timeLimitMinutes;
         this.surveyTimerInterval = null;
+        this.timeDifference = null;
+        if (params.serverTime) {
+            this.timeDifference = moment.utc().diff(moment.utc(params.serverTime), 'milliseconds');
+        }
     },
 
 
     /**
     * Two responsabilities : Validate that time limit is not exceeded and Run timer otherwise.
+    * If end-user's clock OR the system clock  is de-synchronized before the survey is started, we apply the
+    * difference in timer (if time difference is more than 5 seconds) so that we can
+    * display the 'absolute' counter
     *
     * @override
     */
@@ -28,6 +35,9 @@ publicWidget.registry.SurveyTimerWidget = publicWidget.Widget.extend({
         var self = this;
         return this._super.apply(this, arguments).then(function () {
             self.countDownDate = moment.utc(self.timer).add(self.timeLimitMinutes, 'minutes');
+            if (Math.abs(self.timeDifference) >= 5000) {
+                self.countDownDate = self.countDownDate.add(self.timeDifference, 'milliseconds');
+            }
             if (self.timeLimitMinutes <= 0 || self.countDownDate.diff(moment.utc(), 'seconds') < 0) {
                 self.trigger_up('time_up');
             } else {

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -160,6 +160,7 @@
             t-att-data-question-time-limit-reached="answer.question_time_limit_reached"
             t-att-data-has-answered="bool(has_answered)"
             t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
+            t-att-data-server-time="server_time"
             t-att-data-timer="timer_start"
             t-att-data-time-limit-minutes="time_limit_minutes"/>
         <t t-if="survey.questions_layout == 'one_page'">


### PR DESCRIPTION
PURPOSE

To fix the timer in survey. It should not be affected if user's system clock is behind or ahead of real time.

SPECIFICATION

Current:
Let's consider the following two scenarios while answering time limited survey:

1) attendee's system clock is de-synchronized compared to the real time
2) Odoo server clock is de-synchronized compared to the real time

In any/both of the above cases, it will lead to a wrong timer display, and will
confuse the user and/or make him fail the test because he will think he still has
more time to submit when he does not.

TO BE:
To fix the timer in survey. It should not be affected in user's system clock is behind or ahead of real time.

Task Id: 2612972

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
