### PR TITLE
[FIX] account_qr_code_sepa : Fixed format of 'amount of transfer' not correct in QR-code

### DIFF
--- a/addons/account_qr_code_sepa/models/res_bank.py
+++ b/addons/account_qr_code_sepa/models/res_bank.py
@@ -21,7 +21,7 @@ class ResPartnerBank(models.Model):
                 self.bank_bic or '',                                    # BIC of the Beneficiary Bank
                 (self.acc_holder_name or self.partner_id.name)[:71],    # Name of the Beneficiary
                 self.sanitized_acc_number,                              # Account Number of the Beneficiary
-                str(amount),                                            # Amount of the Transfer in EUR
+                currency.name + str(amount),                            # Currency + Amount of the Transfer in EUR
                 '',                                                     # Purpose of the Transfer
                 (structured_communication or '')[:36],                  # Remittance Information (Structured)
                 comment[:141],                                          # Remittance Information (Unstructured) (can't be set if there is a structured one)


### PR DESCRIPTION
Reproduce :
- Create an invoice with a sepa QR-code

Result :
  When reading the QR-code, German banks assume the fisrt 3 characters are the currency name/code, so the first 3 digits of the amount are cut from this amount.

Solution :
  The amount now starts with the currency name/code (3 letters)

opw-2591454

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
