### PR TITLE
fix unfolded menu hover effect

### DIFF
--- a/addons/web/static/src/legacy/scss/navbar.scss
+++ b/addons/web/static/src/legacy/scss/navbar.scss
@@ -83,10 +83,7 @@
     @extend %-main-navbar-entry-bg-hover;
     border: 0;
     white-space: nowrap;
-
-    &, &:focus {
-      background: none;
-    }
+    background: none;
   }
 
   .o-dropdown {


### PR DESCRIPTION
PURPOSE
In the systray, when hovering parent dropdowns, the unfolded dropdown doesn't have the dark purple when hovering

SPEC
In the systray, when hovering parent dropdowns, the unfolded dropdown should have the dark purple when hovering

TASK 2635015

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
