### PR TITLE
[FIX] stock_account: product_category_form inherit

### DIFF
--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -12,10 +12,24 @@
             </field>
         </record>
 
+        <record id="view_category_property_form_stock" model="ir.ui.view">
+            <field name="name">product.category.stock.property.form.inherit.stock</field>
+            <field name="model">product.category</field>
+            <field name="inherit_id" ref="stock.product_category_form_view_inherit"/>
+            <field name="arch" type="xml">
+                <group name="logistics" position="after">
+                    <group string="Inventory Valuation">
+                        <field name="property_cost_method"/>
+                        <field name="property_valuation" groups="account.group_account_readonly,stock.group_stock_manager"/>
+                    </group>
+                </group>
+            </field>
+        </record>
+
         <record id="view_category_property_form" model="ir.ui.view">
             <field name="name">product.category.stock.property.form.inherit</field>
             <field name="model">product.category</field>
-            <field name="inherit_id" ref="stock.product_category_form_view_inherit"/>
+            <field name="inherit_id" ref="account.view_category_property_form"/>
             <field name="arch" type="xml">
                 <group name="account_property" position="inside">
                     <group name="account_stock_property" string="Account Stock Properties" groups="account.group_account_readonly" attrs="{'invisible':[('property_valuation', '=', 'manual_periodic')]}">
@@ -26,12 +40,6 @@
                         <div colspan="2" class="alert alert-info mt16" role="status">
                             <b>Set other input/output accounts on specific </b><button name="%(stock.action_prod_inv_location_form)d" role="button" type="action" class="btn-link" style="padding: 0;vertical-align: baseline;" string="locations"/>.
                         </div>
-                    </group>
-                </group>
-                <group name="logistics" position="after">
-                    <group string="Inventory Valuation">
-                        <field name="property_cost_method"/>
-                        <field name="property_valuation" groups="account.group_account_readonly,stock.group_stock_manager"/>
                     </group>
                 </group>
             </field>


### PR DESCRIPTION
Directly inheriting stock.product_category_form_view_inherit would raise
an error as group "account_property" wouldn't yet exist in the inherited
record.

Fixes 61d937f7d66c668c2809a07257a8cf188617b372

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
