### PR TITLE
[FIX] website_sale_slides: force sudo addition of course members at SO confirmation

### DIFF
--- a/addons/website_sale_slides/models/sale_order.py
+++ b/addons/website_sale_slides/models/sale_order.py
@@ -29,6 +29,6 @@ class SaleOrder(models.Model):
                         channels_per_so[so_line.order_id] = channels_per_so[so_line.order_id] | related_channel
 
         for sale_order, channels in channels_per_so.items():
-            channels._action_add_members(sale_order.partner_id)
+            channels.sudo()._action_add_members(sale_order.partner_id)
 
         return result

--- a/addons/website_sale_slides/tests/test_course_purchase_flow.py
+++ b/addons/website_sale_slides/tests/test_course_purchase_flow.py
@@ -5,6 +5,16 @@ from odoo.addons.website_slides.tests import common
 
 
 class TestCoursePurchaseFlow(common.SlidesCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_salesman = cls.env['res.users'].create({
+            'name': 'salesman',
+            'login': 'salesman',
+            'email': 'salesman007@example.com',
+            'groups_id': [(6, 0, cls.env.ref('sales_team.group_sale_salesman').ids)],
+        })
+
     def test_course_purchase_flow(self):
         # Step1: create a course product and assign it to 2 slide.channels
         course_product = self.env['product.product'].create({
@@ -24,7 +34,8 @@ class TestCoursePurchaseFlow(common.SlidesCase):
         self.channel_2 = self.env['slide.channel'].with_user(self.user_publisher).create({
             'name': 'Test Channel',
             'enroll': 'payment',
-            'product_id': course_product.id
+            'product_id': course_product.id,
+            'is_published': True,
         })
 
         # Step 2: create a sale_order with the course product
@@ -45,3 +56,21 @@ class TestCoursePurchaseFlow(common.SlidesCase):
         # Step 3: check that the customer is now a member of both channel
         self.assertIn(self.customer, self.channel.partner_ids)
         self.assertIn(self.customer, self.channel_2.partner_ids)
+
+        # Step 4: Same test as salesman
+        salesman_sale_order = self.env['sale.order'].with_user(self.user_salesman).create({
+            'partner_id': self.user_portal.partner_id.id,
+            'order_line': [
+                (0, 0, {
+                    'name': course_product.name,
+                    'product_id': course_product.id,
+                    'product_uom_qty': 1,
+                    'price_unit': course_product.list_price,
+                })
+            ],
+        })
+
+        salesman_sale_order.action_confirm()
+
+        self.assertIn(self.user_portal.partner_id, self.channel.partner_ids)
+        self.assertIn(self.user_portal.partner_id, self.channel_2.partner_ids)


### PR DESCRIPTION
When a sale.order containing a slide.channel registration product is confirmed
by a person that does not have rights on slide.channel (typically a salesman),
the system will throw an error.

This commit forces the addition of members by using a sudo on the
"_action_add_members" method.

We assume that when confirming a sale.order, we want to add the members and
enable their access to the course even if the person confirming the sale.order
does not have e-learning privileges.

OPW-2580128