### PR TITLE
[IMP] web_enterprise: keep control panel visible after horizontal scroll

### DIFF
--- a/addons/web/static/src/legacy/scss/kanban_view.scss
+++ b/addons/web/static/src/legacy/scss/kanban_view.scss
@@ -2,7 +2,6 @@
 .o_kanban_view {
     display: flex;
     align-content: stretch;
-    overflow-x: visible;
 
     @include media-breakpoint-down(sm) {
         padding: 0px!important;


### PR DESCRIPTION
Before this commit, every view had to have its own rules to avoid
breaking the control panel when there was an horizontal scroll.

a) We now always use 'overflow-x: auto' to be able to scroll the content
of the view if there is not enough space available.
However, we doesn't want double vertical scroll; one for the page and
another one for the content. It's why we added visible to the previous rule:
"overflow-x: auto visible".

b) overflow: visible; is the default value. We simply deleted this line.

c) We need to set height: 100%; to allow the pivot view to grow when a
dropdown pops out. Otherwise, it will be cutted.

Steps to reproduce:
* Go to Sale
* Select the 'Pivot' view
* Add 'Customer' to group horizontally
* Scroll to the right => BUG

Task ID: 2232265


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
