### PR TITLE
[FIX] mail,web: Change command palette shortcut

### DIFF
--- a/addons/mail/static/tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/m2x_avatar_user_tests.js
@@ -442,7 +442,7 @@ QUnit.module('mail', {}, function () {
         });
         assert.strictEqual(webClient.el.querySelector(".o_m2o_avatar > span").textContent, "Mario")
 
-        triggerHotkey("control+k")
+        triggerHotkey("control+m")
         await nextTick();
         const idx = [...webClient.el.querySelectorAll(".o_command")].map(el => el.textContent).indexOf("Assign to ...ALT + I")
         assert.ok(idx >= 0);
@@ -489,7 +489,7 @@ QUnit.module('mail', {}, function () {
             'views': [[false, 'form']],
         });
         assert.strictEqual(webClient.el.querySelector(".o_m2o_avatar > span").textContent, "Mario")
-        triggerHotkey("control+k")
+        triggerHotkey("control+m")
         await nextTick();
         const idx = [...webClient.el.querySelectorAll(".o_command")].map(el => el.textContent).indexOf("Assign/unassign to meALT + SHIFT + I")
         assert.ok(idx >= 0);
@@ -500,7 +500,7 @@ QUnit.module('mail', {}, function () {
         assert.strictEqual(webClient.el.querySelector(".o_m2o_avatar > span").textContent, "Luigi")
 
         // Unassign me
-        triggerHotkey("control+k");
+        triggerHotkey("control+m");
         await nextTick();
         await click([...webClient.el.querySelectorAll(".o_command")][idx])
         await legacyExtraNextTick();
@@ -536,7 +536,7 @@ QUnit.module('mail', {}, function () {
         let userNames = [...webClient.el.querySelectorAll(".o_tag_badge_text")].map((el => el.textContent));
         assert.deepEqual(userNames, ["Mario", "Yoshi"]);
 
-        triggerHotkey("control+k")
+        triggerHotkey("control+m")
         await nextTick();
         const idx = [...webClient.el.querySelectorAll(".o_command")].map(el => el.textContent).indexOf("Assign to ...ALT + I")
         assert.ok(idx >= 0);
@@ -585,7 +585,7 @@ QUnit.module('mail', {}, function () {
         let userNames = [...webClient.el.querySelectorAll(".o_tag_badge_text")].map((el => el.textContent));
         assert.deepEqual(userNames, ["Mario", "Yoshi"]);
 
-        triggerHotkey("control+k");
+        triggerHotkey("control+m");
         await nextTick();
         const idx = [...webClient.el.querySelectorAll(".o_command")].map(el => el.textContent).indexOf("Assign/unassign to meALT + SHIFT + I");
         assert.ok(idx >= 0);
@@ -597,7 +597,7 @@ QUnit.module('mail', {}, function () {
         assert.deepEqual(userNames, ["Mario", "Yoshi", "Luigi"]);
 
         // Unassign me
-        triggerHotkey("control+k");
+        triggerHotkey("control+m");
         await nextTick();
         await click([...webClient.el.querySelectorAll(".o_command")][idx]);
         await legacyExtraNextTick();

--- a/addons/mail/static/tests/webclient/commands/mail_providers_tests.js
+++ b/addons/mail/static/tests/webclient/commands/mail_providers_tests.js
@@ -46,7 +46,7 @@ QUnit.module('mail', {}, function () {
                 hasChatWindow: true,
                 hasWebClient: true,
             });
-        triggerHotkey("control+k");
+        triggerHotkey("control+m");
         await nextTick();
 
         // Switch to partners
@@ -85,7 +85,7 @@ QUnit.module('mail', {}, function () {
                 hasChatWindow: true,
                 hasWebClient: true,
             });
-        triggerHotkey("control+k");
+        triggerHotkey("control+m");
         await nextTick();
 
         // Switch to channels

--- a/addons/web/static/src/webclient/commands/command_service.js
+++ b/addons/web/static/src/webclient/commands/command_service.js
@@ -50,7 +50,7 @@ export const commandService = {
         let nextToken = 0;
         let isPaletteOpened = false;
 
-        hotkeyService.add("control+k", openMainPalette, {
+        hotkeyService.add("control+m", openMainPalette, {
             global: true,
         });
 

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -6594,7 +6594,7 @@ QUnit.module('basic_fields', {
         });
         assert.containsOnce(webClient, ".fa-star")
 
-        triggerHotkey("control+k")
+        triggerHotkey("control+m")
         await nextTick();
         const idx = [...webClient.el.querySelectorAll(".o_command")].map(el => el.textContent).indexOf("Set priority...ALT + R")
         assert.ok(idx >= 0);
@@ -6893,7 +6893,7 @@ QUnit.module('basic_fields', {
         });
         assert.containsOnce(webClient, ".o_status_red")
 
-        triggerHotkey("control+k")
+        triggerHotkey("control+m")
         await nextTick();
         const idx = [...webClient.el.querySelectorAll(".o_command")].map(el => el.textContent).indexOf("Set kanban state...ALT + SHIFT + R")
         assert.ok(idx >= 0);

--- a/addons/web/static/tests/webclient/commands/command_service_tests.js
+++ b/addons/web/static/tests/webclient/commands/command_service_tests.js
@@ -112,7 +112,7 @@ QUnit.test("useCommand hook", async (assert) => {
     }
     testComponent = await mount(MyComponent, { env, target });
 
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     assert.containsOnce(target, ".o_command");
     assert.deepEqual(target.querySelector(".o_command").textContent, "Take the throne");
@@ -121,7 +121,7 @@ QUnit.test("useCommand hook", async (assert) => {
     assert.verifySteps(["Hodor"]);
 
     testComponent.unmount();
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     assert.containsNone(target, ".o_command");
 });
@@ -145,7 +145,7 @@ QUnit.test("useCommand hook when the activeElement change", async (assert) => {
     OtherComponent.template = xml`<div></div>`;
 
     await mount(MyComponent, { env, target });
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     assert.containsN(target, ".o_command", 2);
     assert.deepEqual(
@@ -156,7 +156,7 @@ QUnit.test("useCommand hook when the activeElement change", async (assert) => {
 
     await mount(OtherComponent, { env, target });
 
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     assert.containsN(target, ".o_command", 2);
     assert.deepEqual(
@@ -234,7 +234,7 @@ QUnit.test("data-hotkey added to command palette", async (assert) => {
     testComponent = await mount(MyComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.containsN(target, ".o_command", 2);
@@ -248,7 +248,7 @@ QUnit.test("data-hotkey added to command palette", async (assert) => {
     assert.containsNone(target, ".o_command_palette", "palette is closed due to command action");
 
     // Reopen palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     // Click on second command
@@ -296,7 +296,7 @@ QUnit.test("access to hotkeys from the command palette", async (assert) => {
     testComponent = await mount(MyComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.containsN(target, ".o_command", 3);
@@ -311,7 +311,7 @@ QUnit.test("access to hotkeys from the command palette", async (assert) => {
     assert.containsNone(target, ".o_command_palette", "palette is closed due to command action");
 
     // Reopen palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     // Trigger the command b
@@ -320,7 +320,7 @@ QUnit.test("access to hotkeys from the command palette", async (assert) => {
     assert.containsNone(target, ".o_command_palette", "palette is closed due to command action");
 
     // Reopen palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     // Trigger the command c
@@ -345,7 +345,7 @@ QUnit.test("can be searched", async (assert) => {
     await nextTick();
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -402,7 +402,7 @@ QUnit.test("configure the empty message based on the namespace", async (assert) 
     testComponent = await mount(TestComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.strictEqual(
@@ -445,7 +445,7 @@ QUnit.test("defined multiple providers with the same namespace", async (assert) 
     testComponent = await mount(TestComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -489,7 +489,7 @@ QUnit.test("can switch between command providers", async (assert) => {
     testComponent = await mount(TestComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -554,7 +554,7 @@ QUnit.test("multi level commands", async (assert) => {
     testComponent = await mount(TestComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -628,7 +628,7 @@ QUnit.test("multi level commands with hotkey", async (assert) => {
     testComponent = await mount(TestComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -677,7 +677,7 @@ QUnit.test("command categories", async (assert) => {
     await nextTick();
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.containsN(target, ".o_command_category", 3);
@@ -708,7 +708,7 @@ QUnit.test("data-command-category", async (assert) => {
     testComponent = await mount(MyComponent, { env, target });
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.containsN(target, ".o_command", 4);
@@ -756,7 +756,7 @@ QUnit.test("display shortcuts correctly for non-MacOS ", async (assert) => {
     await nextTick();
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -797,7 +797,7 @@ QUnit.test("display shortcuts correctly for MacOS ", async (assert) => {
     await nextTick();
 
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(
@@ -825,7 +825,7 @@ QUnit.test(
 
         testComponent = await mount(MyComponent, { env, target });
         // Open palette
-        triggerHotkey("control+k");
+        triggerHotkey("control+m");
         await nextTick();
 
         assert.deepEqual(
@@ -858,7 +858,7 @@ QUnit.test("display shortcuts correctly for MacOS with a new overlayModifier", a
 
     testComponent = await mount(MyComponent, { env, target });
     // Open palette
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
 
     assert.deepEqual(

--- a/addons/web/static/tests/webclient/commands/menu_provider_tests.js
+++ b/addons/web/static/tests/webclient/commands/menu_provider_tests.js
@@ -70,7 +70,7 @@ QUnit.test("displays only apps if the search value is '/'", async (assert) => {
     const webClient = await createWebClient({ serverData });
     assert.containsNone(webClient, ".o_menu_brand");
 
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     await editSearchBar("/");
     assert.containsOnce(webClient, ".o_command_palette");
@@ -85,7 +85,7 @@ QUnit.test("displays only apps if the search value is '/'", async (assert) => {
 QUnit.test("displays apps and menu items if the search value is not only '/'", async (assert) => {
     const webClient = await createWebClient({ serverData });
 
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     await editSearchBar("/sal");
     assert.containsOnce(webClient, ".o_command_palette");
@@ -100,7 +100,7 @@ QUnit.test("opens an app", async (assert) => {
     const webClient = await createWebClient({ serverData });
     assert.containsNone(webClient, ".o_menu_brand");
 
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     await editSearchBar("/");
     assert.containsOnce(webClient, ".o_command_palette");
@@ -119,7 +119,7 @@ QUnit.test("opens a menu items", async (assert) => {
     const webClient = await createWebClient({ serverData });
     assert.containsNone(webClient, ".o_menu_brand");
 
-    triggerHotkey("control+k");
+    triggerHotkey("control+m");
     await nextTick();
     await editSearchBar("/sal");
     assert.containsOnce(webClient, ".o_command_palette");


### PR DESCRIPTION
Change the command palette shortcut from CTRL+K to CTRL+M,
in order to avoid conflict with link creation shortcut in editor.

task-2635043

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
