### PR TITLE
[IMP] website: configurator, handle svg preview text readability

### DIFF
--- a/addons/website/static/src/scss/configurator.scss
+++ b/addons/website/static/src/scss/configurator.scss
@@ -261,6 +261,15 @@
             .theme_svg_container svg {
                 width: 100%;
                 height: auto;
+
+                // Handle text and other components readability when
+                // placed over a coloured bg. Both the element and the
+                // underlying bg must have the same color, eg [FILL="#FFF"].
+                .svgc_text {
+                    filter: saturate(0) invert(1) contrast(1000%);
+                    -moz-filter: saturate(0) invert(1) contrast(1000%);
+                    -webkit-filter: saturate(0) invert(1) contrast(1000%);
+                }
             }
 
             .button_area {


### PR DESCRIPTION
Handle text and other components readability when placed over a colored
background. Both the element and the underlying bg must use the same
color, eg [fill="#FFF"].

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
