### PR TITLE
pressing tab on required m2m should activate next field

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2329,7 +2329,15 @@ var FieldMany2ManyTags = AbstractField.extend({
                 },
             });
         };
+        this.many2one._onNavigationMove = () => { };
         return this.many2one.appendTo(this.$el);
+    },
+    _onNavigationMove(ev) {
+        if (this.isSet()) {
+            return this._super(...arguments);
+        } else {
+            return basicFields.InputField.prototype._onNavigationMove.apply(this.many2one, arguments);
+        }
     },
     /**
      * @private

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -684,6 +684,50 @@ QUnit.module('relational_fields', {
         form.destroy();
     });
 
+    QUnit.test('navigation on required many2many_tags using TAB', async function (assert) {
+        assert.expect(3);
+
+        this.data.turtle.records[0].partner_ids = [2];
+
+        var form = await createView({
+            View: FormView,
+            model: 'turtle',
+            data: this.data,
+            arch: '<form string="Turtles">' +
+                    '<sheet>' +
+                        '<field name="partner_ids" required="1" widget="many2many_tags"/>' +
+                        '<field name="display_name"/>' +
+                    '</sheet>' +
+                '</form>',
+        });
+
+        assert.strictEqual(form.$('div[name="partner_ids"] .o_input')[0],
+            document.activeElement,
+            "focus should be on partner_ids");
+
+        // press TAB to go to next field
+        form.$('div[name="partner_ids"] .o_input').trigger($.Event('keydown', {
+            which: $.ui.keyCode.TAB,
+            keyCode: $.ui.keyCode.TAB,
+        }));
+        assert.strictEqual(form.$('div[name="partner_ids"] .o_input')[0],
+            document.activeElement,
+            "focus should still be on partner_ids");
+
+        await testUtils.fields.many2one.clickOpenDropdown('partner_ids');
+        await testUtils.fields.many2one.clickHighlightedItem('partner_ids');
+        // press TAB to go to next field
+        form.$('div[name="partner_ids"] .o_input').trigger($.Event('keydown', {
+            which: $.ui.keyCode.TAB,
+            keyCode: $.ui.keyCode.TAB,
+        }));
+        assert.strictEqual(form.$('input[name="display_name"]')[0],
+            document.activeElement,
+            "focus should be on partner_ids");
+
+        form.destroy();
+    });
+
     QUnit.test('many2many read, field context is properly sent', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
PURPOSE
When many2many_tags widget is required and when focus is on many2many widget and many2many field is set and pressing TAB is not moving focus to next field, should move focus to next field.

SPEC
When many2many_tags widget is required and value is set on many2many field and pressing TAB should move focus to next field.

TASK 2497106


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
