### PR TITLE
[FIX] pos_sale: remove redundant payment information in invoice

### DIFF
--- a/addons/pos_sale/views/point_of_sale_report.xml
+++ b/addons/pos_sale/views/point_of_sale_report.xml
@@ -25,12 +25,5 @@
                 </div>
             </t>
         </xpath>
-        <xpath expr="//p[@name='payment_communication']" position="replace">
-            <t t-if="not o.pos_order_ids">
-                <p t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference" name="payment_communication">
-                    Please use the following communication for your payment : <b><span t-field="o.payment_reference"/></b>
-                </p>
-            </t>
-        </xpath>
     </template>
 </odoo>

--- a/addons/pos_sale/views/point_of_sale_report.xml
+++ b/addons/pos_sale/views/point_of_sale_report.xml
@@ -32,24 +32,5 @@
                 </p>
             </t>
         </xpath>
-        <xpath expr="//div[@id='total']/div/table" position="inside">
-            <t t-if="o.pos_order_ids">
-                <tr>
-                    <td>
-                        <i class="oe_form_field text-right oe_payment_label">Paid on <t t-esc="o.invoice_date" t-options='{"widget": "date"}'/></i>
-                    </td>
-                </tr>
-                <t t-foreach="o.pos_order_ids.mapped('payment_ids')" t-as="payment">
-                    <tr>
-                        <td>
-                            Paid with <t t-esc="payment.payment_method_id.name"/>
-                        </td>
-                        <td class="text-right">
-                            <t t-esc="payment.amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        </td>
-                    </tr>
-                </t>
-            </t>
-        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Since the merge of https://github.com/odoo/odoo/pull/74870, pos
is now using the invoice template that contains payment information.
We can now remove this customization in pos_sale since it's already
native in point_of_sale that payments are listed in the invoice.

We are now calling the `account.account_invoices` action which prints
the invoice with payments.

https://github.com/odoo/odoo/blob/79804719fec06d40da5d5203e03a2cf47a2283b4/addons/point_of_sale/static/src/js/models.js#L1029

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
