### PR TITLE
[FIX] stock: When scrapping, required company_id, not shown in view

### DIFF
--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -53,7 +53,7 @@
                                 </div>
                             </group>
                             <group>
-                                <field name="lot_id" attrs="{'invisible': ['|',('product_id', '=', False),('tracking', '=', 'none')], 'required': [('tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
+                                <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" attrs="{'invisible': ['|',('product_id', '=', False),('tracking', '=', 'none')], 'required': [('tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
                                 <field name="tracking" invisible="1"/>
                                 <field name="package_id" groups="stock.group_tracking_lot"/>
                                 <field name="owner_id" groups="stock.group_tracking_owner"/>


### PR DESCRIPTION
Issue: When creating a scrap (Inventory > Operations > Scrap) for a
product tracked by lots, introducing a new lot number requires a company
which is hidden when the user is in single-company mode, but not filled.
And it is required by the model

Steps to reproduce:
Multi-Company environment, Lots&Serial enabled

1) Install Inventory
2) Create a product [Lot Product]
  Product Type: Storable Product
  Tracking (Inventory tab) : tracked by lot
3) Create a new user with access rights User to inventory module
4) Log in with new user
5) Inventory > Scrap Orders > Create
Product : Lot Product
Lot/serial: Create a new one
This will open a window, refill the product information and hit save
-> Bug field company_id not set but is required
`Error message
The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible,
archive it instead.

Model: Lot/Serial (stock.production.lot), Field: Company (company_id)`

Why is that a bug:
 Since we cannot see the company id to set it, and that we are in
 single company mode, by default the field should be filled by the
  env company

opw-2593476