### PR TITLE
[FIX] point_of_sale,pos_sale: isRpcError no longer works

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -8,8 +8,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
     const { onChangeOrder } = require('point_of_sale.custom_hooks');
-    const { identifyError } = require('point_of_sale.utils');
-    const { ConnectionLostError, ConnectionAbortedError } = require('@web/core/network/rpc_service');
+    const { isConnectionError } = require('point_of_sale.utils');
 
     class PaymentScreen extends PosComponent {
         constructor() {
@@ -193,11 +192,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                     await this._handlePushOrderError(error);
                 } else {
                     // We don't block for connection error. But we rethrow for any other errors.
-                    const errorIdentity = identifyError(error);
-                    if (
-                        errorIdentity instanceof ConnectionLostError ||
-                        errorIdentity instanceof ConnectionAbortedError
-                    ) {
+                    if (isConnectionError(error)) {
                         this.showPopup('OfflineErrorPopup', {
                             title: this.env._t('Connection Error'),
                             body: this.env._t('Order is not synced. Check your internet connection'),

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -8,7 +8,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
     const Registries = require('point_of_sale.Registries');
     const { onChangeOrder, useBarcodeReader } = require('point_of_sale.custom_hooks');
     const { Gui } = require('point_of_sale.Gui');
-    const { isRpcError } = require('point_of_sale.utils');
+    const { isConnectionError } = require('point_of_sale.utils');
     const { useState, onMounted } = owl.hooks;
     const { parse } = require('web.field_utils');
 
@@ -221,7 +221,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                         context: this.env.session.user_context,
                     });
                 } catch (error) {
-                    if (isRpcError(error) && error.message.code < 0) {
+                    if (isConnectionError(error)) {
                         return this.showPopup('OfflineErrorPopup', {
                             title: this.env._t('Network Error'),
                             body: this.env._t("Product is not loaded. Tried loading the product from the server but there is a network error."),

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
@@ -2,7 +2,7 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
     'use strict';
 
     const { useListener } = require('web.custom_hooks');
-    const { isRpcError } = require('point_of_sale.utils');
+    const { isConnectionError } = require('point_of_sale.utils');
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
 
@@ -119,7 +119,7 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
             try {
                 await this._invoiceOrder();
             } catch (error) {
-                if (isRpcError(error) && error.message.code < 0) {
+                if (isConnectionError(error)) {
                     this.showPopup('ErrorPopup', {
                         title: this.env._t('Network Error'),
                         body: this.env._t('Unable to invoice order.'),

--- a/addons/point_of_sale/static/src/js/utils.js
+++ b/addons/point_of_sale/static/src/js/utils.js
@@ -2,7 +2,7 @@ odoo.define('point_of_sale.utils', function (require) {
     'use strict';
 
     const { EventBus } = owl.core;
-    const { ConnectionAbortedError } = require('@web/core/network/rpc_service');
+    const { ConnectionAbortedError, ConnectionLostError } = require('@web/core/network/rpc_service');
 
     function getFileAsText(file) {
         return new Promise((resolve, reject) => {
@@ -38,12 +38,9 @@ odoo.define('point_of_sale.utils', function (require) {
         });
     };
 
-    function isRpcError(error) {
-        return (
-            !(error instanceof Error) &&
-            error.message &&
-            [100, 200, 404, -32098].includes(error.message.code)
-        );
+    function isConnectionError(error) {
+        const _error = identifyError(error);
+        return _error instanceof ConnectionAbortedError || _error instanceof ConnectionLostError;
     }
 
     function identifyError(error) {
@@ -65,5 +62,5 @@ odoo.define('point_of_sale.utils', function (require) {
         return errorToHandle || error;
     }
 
-    return { getFileAsText, nextFrame, isRpcError, posbus: new EventBus(), identifyError };
+    return { getFileAsText, nextFrame, posbus: new EventBus(), identifyError, isConnectionError };
 });

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
@@ -3,7 +3,7 @@ odoo.define('pos_sale.SaleOrderFetcher', function (require) {
 
     const { EventBus } = owl.core;
     const { Gui } = require('point_of_sale.Gui');
-    const { isRpcError } = require('point_of_sale.utils');
+    const { isConnectionError } = require('point_of_sale.utils');
     const models = require('point_of_sale.models');
 
     class SaleOrderFetcher extends EventBus {
@@ -53,7 +53,7 @@ odoo.define('pos_sale.SaleOrderFetcher', function (require) {
 
                 this.trigger('update');
             } catch (error) {
-                if (isRpcError(error) && error.message.code < 0) {
+                if (isConnectionError(error)) {
                     Gui.showPopup('ErrorPopup', {
                         title: this.comp.env._t('Network Error'),
                         body: this.comp.env._t('Unable to fetch orders if offline.'),

--- a/addons/pos_sale/static/src/js/SetSaleOrderButton.js
+++ b/addons/pos_sale/static/src/js/SetSaleOrderButton.js
@@ -5,7 +5,7 @@ odoo.define('pos_sale.SetSaleOrderButton', function(require) {
     const ProductScreen = require('point_of_sale.ProductScreen');
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
-    const { isRpcError } = require('point_of_sale.utils');
+    const { isConnectionError } = require('point_of_sale.utils');
 
     class SetSaleOrderButton extends PosComponent {
         constructor() {
@@ -34,7 +34,7 @@ odoo.define('pos_sale.SetSaleOrderButton', function(require) {
               });
               this.showScreen('SaleOrderManagementScreen');
           } catch (error) {
-              if (isRpcError(error) && error.message.code < 0) {
+              if (isConnectionError(error)) {
                   this.showPopup('ErrorPopup', {
                       title: this.env._t('Network Error'),
                       body: this.env._t('Cannot access order management screen if offline.'),


### PR DESCRIPTION
Following wowl and https://github.com/odoo/odoo/pull/73725, isRpcError
no longer works. We introduce a new method called isConnectionError
since it's actually what we are interested of in the previous use of
isRpcError. After handling connection error, we just rethrow any other
errors such as RPCError (which includes server error such as UserError
or any programming error in the server) and let the errorHandler in
Chrome handle them.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
