### PR TITLE
[REF] web: Allow to get ir.filter values without creating the record

### DIFF
--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -252,7 +252,7 @@ export const mocks = {
     cookie: () => fakeCookieService,
     effect: () => effectService, // BOI The real service ? Is this what we want ?
     localization: makeFakeLocalizationService,
-    notifications: makeFakeNotificationService,
+    notification: makeFakeNotificationService,
     router: makeFakeRouterService,
     rpc: makeFakeRPCService,
     title: () => fakeTitleService,

--- a/addons/web/static/tests/legacy/control_panel/control_panel_model_extension_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/control_panel_model_extension_tests.js
@@ -328,6 +328,34 @@ odoo.define("web/static/tests/control_panel/control_panel_model_extension_tests.
 
         });
 
+        QUnit.test('ir.filter values', async function (assert) {
+            assert.expect(1);
+
+            const context = {
+                search_default_filter: true,
+                search_default_bar: 0,
+                search_default_groupby: 2,
+            };
+            const arch = `
+                <search>
+                    <filter name="filter" string="Hello" domain="[['foo', '=', 'hello']]"/>
+                    <filter name="groupby" string="Goodbye" context="{'group_by': 'foo'}"/>
+                    <field name="bar"/>
+                </search>`;
+            const fields = this.fields;
+            const model = createModel({ arch, fields, context });
+            assert.deepEqual(model.get("irFilterValues"), {
+                action_id: undefined,
+                context: {
+                    group_by: ["foo"],
+                },
+                domain: '[["foo", "=", "hello"]]',
+                model_id: undefined,
+                sort: "[]",
+                user_id: undefined
+            });
+        });
+
         QUnit.test('falsy search defaults are not activated', async function (assert) {
             assert.expect(1);
 


### PR DESCRIPTION
In the spreadsheet app, we need the exact same values which are saved
for "ir.filter" records.

This commit refactor a bit things to allows getting those values without
actually creating the "ir.filter" record.

Task 2572184

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
