### PR TITLE
[FIX] website: avoid displaying the link popover when opening user menu

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -186,7 +186,7 @@ const LinkPopoverWidget = Widget.extend({
 });
 
 LinkPopoverWidget.createFor = async function (parent, targetEl) {
-    const noLinkPopoverClass = ".o_no_link_popover, .carousel-control-prev, .carousel-control-next";
+    const noLinkPopoverClass = ".o_no_link_popover, .carousel-control-prev, .carousel-control-next, .dropdown-toggle";
     // Target might already have a popover, eg cart icon in navbar
     const alreadyPopover = $(targetEl).data('bs.popover');
     if (alreadyPopover || $(targetEl).is(noLinkPopoverClass) || !!$(targetEl).parents(noLinkPopoverClass).length) {


### PR DESCRIPTION
Before this commit toggling the user menu did display the link popover.

After this commit no link popover is displayed when clicking on the user
menu anymore.

task-2612755

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
