### PR TITLE
[FIX] l10n_cl: adds l10n_cl_active field

### DIFF
--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -6,7 +6,7 @@
     'version': "3.0",
     'description': """
 Chilean accounting chart and tax localization.
-Plan contable chileno e impuestos de acuerdo a disposiciones vigentes
+Plan contable chileno e impuestos de acuerdo a disposiciones vigentes.
     """,
     'author': 'Blanco Martín & Asociados',
     'website': 'https://www.odoo.com/documentation/15.0/applications/finance/accounting/fiscal_localizations/localizations/chile.html',

--- a/addons/l10n_cl/data/account_tax_data.xml
+++ b/addons/l10n_cl/data/account_tax_data.xml
@@ -81,7 +81,7 @@
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">Ret. 2da Categoría</field>
         <field name="description">Ret. 2da Cat</field>
-        <field name="amount">-10.75</field>
+        <field name="amount">-11.5</field>
         <field name="sequence" eval="2"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_cl/data/l10n_cl_chart_data.xml
+++ b/addons/l10n_cl/data/l10n_cl_chart_data.xml
@@ -1580,7 +1580,7 @@
     <record id="account_410235" model="account.account.template">
         <field name="code">410235</field>
         <field name="name">Costo de Mercaderías Vendidas - Prod. 1ra Categoría</field>
-        <field ref="account.data_account_type_expenses" name="user_type_id"/>
+        <field ref="account.data_account_type_direct_costs" name="user_type_id"/>
         <field name="reconcile" eval="False"/>
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="tag_ids"

--- a/addons/l10n_cl/data/l10n_latam.document.type.csv
+++ b/addons/l10n_cl/data/l10n_latam.document.type.csv
@@ -1,53 +1,59 @@
-id,sequence,code,name,report_name,internal_type,doc_code_prefix,country_id/id,active
-dc_a_f_dte,1,33,Factura Electrónica,FACTURA,invoice,FAC,base.cl,True
-dc_y_f_dte,2,34,Factura no Afecta o Exenta Electrónica,F-EXENTA,invoice,FNA,base.cl,True
-dc_nc_f_dte,3,61,Nota de Crédito Electrónica,NOTA DE CREDITO,credit_note,N/C,base.cl,True
-dc_nd_f_dte,4,56,Nota de Débito Electrónica,NOTA DE DEBITO,debit_note,N/D,base.cl,True
-dc_b_f_dte,5,39,Boleta Electrónica,BEL,invoice,BEL,base.cl,True
-dc_m_d_dtn,6,71,Boleta de Honorarios Electrónica,BHE,invoice,BHE,base.cl,True
-dc_b_e_dtn,7,38,Boleta exenta,BEX,invoice,BEX,base.cl,False
-dc_I_f_dtn,10,29,Factura de Inicio,FAI,invoice,FAI,base.cl,False
-dc_a_f_dtn,10,30,Factura,FACTURA,invoice,FAC,base.cl,False
-dc_y_f_dtn,10,32,Factura de Ventas y Servicios no Afectos o Exentos de IVA,F-EXENTA,invoice,FNA,base.cl,False
-dc_l_f_dtn,10,40,Liquidación Factura,L-FACTURAM,invoice,FAL,base.cl,False
-dc_l_f_dte,10,43,Liquidación Factura Electrónica,L-FACTURAE,invoice,FAL,base.cl,False
-dc_fc_f_dtn,10,45,Factura de Compra,FACTURA,invoice_in,FAC,base.cl,False
-dc_fc_f_dte,10,46,Factura de Compra Electrónica,FACTURA,invoice_in,FAC,base.cl,True
-dc_nd_f_dtn,10,55,Nota de Débito,NOTA DE DEBITO,debit_note,N/D,base.cl,False
-dc_nc_f_dtn,10,60,Nota de Crédito,NOTA DE CREDITO,credit_note,N/C,base.cl,False
-dc_s_f_dtn,10,108,SRF Solicitud de Registro de Factura,SOL REGISTRO,,REG,base.cl,False
-dc_ftf_f_dtn,10,901,Factura de ventas a empresas del territorio preferencial ( Res. Ex. N° 1057,FACTURA,invoice,FAC,base.cl,False
-dc_din_f_dtn,10,914,Declaración de Ingreso (DIN),DEC ING,invoice_in,DIN,base.cl,False
-dc_dizf_f_dtn,10,911,Declaración de Ingreso a Zona Franca Primaria,DEC ING,invoice_in,DIN,base.cl,False
-dc_ftt_f_dtn,10,904,Factura de Traspaso,FACT TR,invoice,FTR,base.cl,False
-dc_frr_f_dtn,10,905,Factura de Reexpedición,FACT RX,invoice,FRX,base.cl,False
-dc_bzf_f_dtn,10,906,Boletas Venta Módulos ZF (todas),BOLETA ZF,invoice,BZF,base.cl,False
-dc_fzf_f_dtn,10,907,Facturas Venta Módulo ZF (todas),FACTURA ZF,invoice,FZF,base.cl,False
-dc_tca_f_dtn,10,500,Ajuste aumento Tipo de Cambio (código 500),TC-A,,TCA,base.cl,False
-dc_tcd_f_dtn,10,501,Ajuste disminución Tipo de Cambio (código 501),TC-D,,TCD,base.cl,False
-dc_b_f_dtn,10,35,Boleta de Venta,BOL,invoice,BOL,base.cl,False
-dc_b_e_dte,10,41,Boleta Exenta Electrónica,BXE,invoice,BXE,base.cl,False
-dc_m_f_dtn,10,70,Boleta de Honorarios,BHO,invoice,BHO,base.cl,False
-dc_hes,10,HES,Hoja de Entrada de Servicio (HES),HES,,HES,base.cl,False
-dc_hem,10,HEM,Hoja de Entrada de Materiales (HEM),HEM,,HEM,base.cl,False
-dc_migo,10,MIG,Movimiento de Mercancías (MIGO),MIGO,,MIGO,base.cl,False
-dc_li,10,103,Liquidación,LIQ,,LIQ,base.cl,False
-dc_fe_dte,10,110,Factura de Exportación Electrónica,FCXE,invoice,FCXE,base.cl,False
-dc_ndex_dte,10,111,Nota de Débito de Exportación Electrónica,NDXE,debit_note,NDXE,base.cl,False
-dc_ncex_dte,10,112,Nota de Crédito de Exportación Electrónica,NCXE,credit_note,NCXE,base.cl,False
-dc_odc,10,801,Orden de Compra,OC,,OC,base.cl,False
-dc_ndp,10,802,Nota de pedido,NP,,NP,base.cl,False
-dc_cont,10,803,Contrato,CONT,,CONT,base.cl,False
-dc_resol,10,804,Resolución,RES,,RES,base.cl,False
-dc_prchc,10,805,Proceso ChileCompra,PCHC,,PCHC,base.cl,False
-dc_fichc,10,806,Ficha ChileCompra,FCHC,,FCHC,base.cl,False
-dc_dus,10,807,DUS,DUS,,DUS,base.cl,False
-dc_bl_cemb,10,808,B/L (Conocimiento de embarque),B/L,,B/L,base.cl,False
-dc_awb,10,809,AWB Airway Bill,AWB,,AWB,base.cl,False
-dc_mic_dta,10,810,MIC/DTA,MDT,,MDT,base.cl,False
-dc_cpor,10,811,Carta de Porte,CPR,,CPR,base.cl,False
-dc_res_sna,10,812,Resolución del SNA donde califica Servicios de Exportación,RSN,,RSN,base.cl,False
-dc_pasap,10,813,Pasaporte,PSP,,PSP,base.cl,False
-dc_cd_bol,10,814,Certificado de Depósito Bolsa Prod. Chile.,CRTD,,CRTD,base.cl,False
-dc_vp_pren,10,815,Vale de Prenda Bolsa Prod. Chile,VLPR,,VLPR,base.cl,False
-dc_oc,300,10,Orden de Compra,OC,,OC,base.cl,False
+id,sequence,code,name,report_name,internal_type,doc_code_prefix,country_id/id,l10n_cl_active,active
+dc_a_f_dte,1,33,Factura Electrónica,FACTURA,invoice,FAC,base.cl,True,True
+dc_y_f_dte,2,34,Factura no Afecta o Exenta Electrónica,F-EXENTA,invoice,FNA,base.cl,True,True
+dc_nc_f_dte,3,61,Nota de Crédito Electrónica,NOTA DE CREDITO,credit_note,N/C,base.cl,True,True
+dc_nd_f_dte,4,56,Nota de Débito Electrónica,NOTA DE DEBITO,debit_note,N/D,base.cl,True,True
+dc_b_f_dte,5,39,Boleta Electrónica,BEL,invoice,BEL,base.cl,True,True
+dc_m_d_dtn,6,71,Boleta de Honorarios Electrónica,BHE,invoice,BHE,base.cl,True,True
+dc_b_e_dtn,7,38,Boleta exenta,BEX,invoice,BEX,base.cl,False,False
+dc_gd_dte,8,52,Guía de Despacho Electrónica,GDE,stock_picking,GDE,base.cl,False,True
+dc_I_f_dtn,10,29,Factura de Inicio,FAI,invoice,FAI,base.cl,False,False
+dc_a_f_dtn,10,30,Factura,FACTURA,invoice,FAC,base.cl,False,False
+dc_y_f_dtn,10,32,Factura de Ventas y Servicios no Afectos o Exentos de IVA,F-EXENTA,invoice,FNA,base.cl,False,False
+dc_b_f_dtn,10,35,Boleta de Venta,BOL,invoice,BOL,base.cl,False,False
+dc_l_f_dtn,10,40,Liquidación Factura,L-FACTURAM,invoice,FAL,base.cl,False,False
+dc_b_e_dte,10,41,Boleta Exenta Electrónica,BXE,invoice,BXE,base.cl,True,True
+dc_l_f_dte,10,43,Liquidación Factura Electrónica,L-FACTURAE,invoice,FAL,base.cl,False,False
+dc_fc_f_dtn,10,45,Factura de Compra,FACTURA,invoice_in,FAC,base.cl,False,False
+dc_fc_f_dte,10,46,Factura de Compra Electrónica,FACTURA,invoice_in,FAC,base.cl,False,True
+dc_gd,10,50,Guía de Despacho,GD,stock_picking,GD,base.cl,False,False
+dc_nd_f_dtn,10,55,Nota de Débito,NOTA DE DEBITO,debit_note,N/D,base.cl,False,False
+dc_nc_f_dtn,10,60,Nota de Crédito,NOTA DE CREDITO,credit_note,N/C,base.cl,False,False
+dc_m_f_dtn,10,70,Boleta de Honorarios,BHO,invoice,BHO,base.cl,False,False
+dc_li,10,103,Liquidación,LIQ,,LIQ,base.cl,False,True
+dc_s_f_dtn,10,108,SRF Solicitud de Registro de Factura,SOL REGISTRO,,REG,base.cl,False,True
+dc_fe_dte,10,110,Factura de Exportación Electrónica,FCXE,invoice,FCXE,base.cl,False,True
+dc_ndex_dte,10,111,Nota de Débito de Exportación Electrónica,NDXE,debit_note,NDXE,base.cl,False,True
+dc_ncex_dte,10,112,Nota de Crédito de Exportación Electrónica,NCXE,credit_note,NCXE,base.cl,False,True
+dc_oc,10,300,Orden de Compra,OC,,OC,base.cl,False,True
+dc_tca_f_dtn,10,500,Ajuste aumento Tipo de Cambio (código 500),TC-A,,TCA,base.cl,False,True
+dc_tcd_f_dtn,10,501,Ajuste disminución Tipo de Cambio (código 501),TC-D,,TCD,base.cl,False,True
+dc_odc,10,801,Orden de Compra,OC,,OC,base.cl,False,True
+dc_ndp,10,802,Nota de pedido,NP,,NP,base.cl,False,True
+dc_cont,10,803,Contrato,CONT,,CONT,base.cl,False,True
+dc_resol,10,804,Resolución,RES,,RES,base.cl,False,True
+dc_prchc,10,805,Proceso ChileCompra,PCHC,,PCHC,base.cl,False,True
+dc_fichc,10,806,Ficha ChileCompra,FCHC,,FCHC,base.cl,False,True
+dc_dus,10,807,Documento Único de Salida (DUS),DUS,,DUS,base.cl,False,True
+dc_bl_cemb,10,808,B/L (Conocimiento de embarque),B/L,,B/L,base.cl,False,True
+dc_awb,10,809,AWB Airway Bill,AWB,,AWB,base.cl,False,True
+dc_mic_dta,10,810,MIC/DTA,MDT,,MDT,base.cl,False,True
+dc_cpor,10,811,Carta de Porte,CPR,,CPR,base.cl,False,True
+dc_res_sna,10,812,Resolución del SNA donde califica Servicios de Exportación,RSN,,RSN,base.cl,False,True
+dc_pasap,10,813,Pasaporte,PSP,,PSP,base.cl,False,True
+dc_cd_bol,10,814,Certificado de Depósito Bolsa Prod. Chile.,CRTD,,CRTD,base.cl,False,True
+dc_vp_pren,10,815,Vale de Prenda Bolsa Prod. Chile,VLPR,,VLPR,base.cl,False,True
+dc_ftf_f_dtn,10,901,Factura de ventas a empresas del territorio preferencial ( Res. Ex. N° 1057,FACTURA,invoice,FAC,base.cl,False,False
+dc_cem_ma,10,902,Conocimiento de Embarque (Marítimo o aéreo),CEM,,CEM,base.cl,False,True
+dc_ftt_f_dtn,10,904,Factura de Traspaso,FACT TR,invoice,FTR,base.cl,False,False
+dc_frr_f_dtn,10,905,Factura de Reexpedición,FACT RX,invoice,FRX,base.cl,False,False
+dc_bzf_f_dtn,10,906,Boletas Venta Módulos ZF (todas),BOLETA ZF,invoice,BZF,base.cl,False,False
+dc_fzf_f_dtn,10,907,Facturas Venta Módulo ZF (todas),FACTURA ZF,invoice,FZF,base.cl,False,False
+dc_dizf_f_dtn,10,911,Declaración de Ingreso a Zona Franca Primaria,DEC ING,invoice_in,DIN,base.cl,False,False
+dc_din_f_dtn,10,914,Declaración de Ingreso (DIN),DEC ING,invoice_in,DIN,base.cl,False,True
+dc_res_vn_sf,10,919,Resumen Ventas de nacionales pasajes sin Factura,PASJ,,PASJ,base.cl,False,True
+dc_chq,10,CHQ,Cheque,CHQ,,CHQ,base.cl,False,True
+dc_hem,10,HEM,Hoja de Entrada de Materiales (HEM),HEM,,HEM,base.cl,False,True
+dc_hes,10,HES,Hoja de Entrada de Servicio (HES),HES,,HES,base.cl,False,True
+dc_migo,10,MIG,Movimiento de Mercancías (MIGO),MIGO,,MIGO,base.cl,False,True
+dc_pag,10,PAG,Pagaré,PAG,,PAG,base.cl,False,True

--- a/addons/l10n_cl/i18n/es.po
+++ b/addons/l10n_cl/i18n/es.po
@@ -261,7 +261,7 @@ msgstr "Nombre mostrado"
 #: model:ir.model.fields,field_description:l10n_cl.field_account_move__l10n_latam_document_type_id_code
 #: model:ir.model.fields,field_description:l10n_cl.field_account_payment__l10n_latam_document_type_id_code
 msgid "Doc Type"
-msgstr "Tipo documento"
+msgstr "T.doc"
 
 #. module: l10n_cl
 #: code:addons/l10n_cl/models/account_move.py:0

--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -13,7 +13,12 @@ class L10nLatamDocumentType(models.Model):
             ('invoice_in', 'Purchase Invoices'),
             ('debit_note', 'Debit Notes'),
             ('credit_note', 'Credit Notes'),
-            ('receipt_invoice', 'Receipt Invoice')])
+            ('receipt_invoice', 'Receipt Invoice'),
+            ('stock_picking', 'Stock Delivery'),
+        ],
+    )
+    l10n_cl_active = fields.Boolean(
+        'Active in localization', help='This boolean enables document to be included on invoicing')
 
     def _format_document_number(self, document_number):
         """ Make validation of Import Dispatch Number

--- a/addons/l10n_cl/views/l10n_latam_document_type_view.xml
+++ b/addons/l10n_cl/views/l10n_latam_document_type_view.xml
@@ -5,9 +5,24 @@
         <field name="model">l10n_latam.document.type</field>
         <field name="inherit_id" ref="l10n_latam_invoice_document.view_document_type_form"/>
         <field name="arch" type="xml">
-            <field name="sequence" position="attributes">
-                    <attribute name="widget">handle</attribute>
+            <field name="internal_type" position="before">
+                <field name="l10n_cl_active" widget="boolean_toggle"/>
             </field>
         </field>
     </record>
+
+    <record id="l10n_cl_latam_document_type_view_tree" model="ir.ui.view">
+        <field name="name">l10n_cl_latam_document_type_view_tree</field>
+        <field name="model">l10n_latam.document.type</field>
+        <field name="inherit_id" ref="l10n_latam_invoice_document.view_document_type_tree"/>
+        <field name="arch" type="xml">
+            <field name="sequence" position="attributes">
+                <attribute name="widget">handle</attribute>
+            </field>
+            <field name="active" position="before">
+                <field name="l10n_cl_active" widget="boolean_toggle"/>
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
This PR solves the problem that is produced in l10n_cl_edi, when trying to select as a reference, a document type that is not active. 
We replaced the use of the active field with l10n_cl_active field. This new field is used to indicate odoo, which active documents should be included as usable in invoicing, instead of using the active field.

#20565


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
