### PR TITLE
[FIX] base: Allow empty thousands separator in reports

### DIFF
--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -193,8 +193,7 @@ class Lang(models.Model):
 
     @tools.ormcache('self.code', 'monetary')
     def _data_get(self, monetary=False):
-        conv = locale.localeconv()
-        thousands_sep = self.thousands_sep or conv[monetary and 'mon_thousands_sep' or 'thousands_sep']
+        thousands_sep = self.thousands_sep or ''
         decimal_point = self.decimal_point
         grouping = self.grouping
         return grouping, thousands_sep, decimal_point


### PR DESCRIPTION
Steps to follow

- Set the thousands_sep of the current lang to an empty string or null
- Create a report
-> The thousand separator from the system locale will be used instead to format numbers

opw-2507441