### PR TITLE
 [IMP] sale_stock, sale_timesheet, purchase_stock: accrual wizard now propose an amount taking care of the accrual date

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -967,7 +967,7 @@ class PurchaseOrderLine(models.Model):
         for line in self:
             # compute qty_invoiced
             qty = 0.0
-            for inv_line in line.invoice_lines:
+            for inv_line in line._get_invoice_lines():
                 if inv_line.move_id.state not in ['cancel']:
                     if inv_line.move_id.move_type == 'in_invoice':
                         qty += inv_line.product_uom_id._compute_quantity(inv_line.quantity, line.product_uom)
@@ -983,6 +983,15 @@ class PurchaseOrderLine(models.Model):
                     line.qty_to_invoice = line.qty_received - line.qty_invoiced
             else:
                 line.qty_to_invoice = 0
+
+    def _get_invoice_lines(self):
+        self.ensure_one()
+        if self._context.get('accrual_entry_date'):
+            return self.invoice_lines.filtered(
+                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= self._context['accrual_entry_date']
+            )
+        else:
+            return self.invoice_lines
 
     @api.depends('product_id')
     def _compute_qty_received_method(self):

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -11,7 +11,6 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
-        uom_unit = cls.env.ref('uom.product_uom_unit')
         uom_hour = cls.env.ref('uom.product_uom_hour')
         cls.alt_exp_account = cls.company_data['default_account_expense'].copy()
         cls.currency_a = cls.env['res.currency'].create({
@@ -23,17 +22,17 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             'currency_id': cls.currency_a.id,
             'rate': 1.5,
         })
-        product_order = cls.env['product.product'].create({
-            'name': "Product",
+        product1 = cls.env['product.product'].create({
+            'name': "Product1",
             'list_price': 30.0,
-            'type': 'consu',
-            'uom_id': uom_unit.id,
-            'uom_po_id': uom_unit.id,
+            'type': 'service',
+            'uom_id': uom_hour.id,
+            'uom_po_id': uom_hour.id,
             'purchase_method': 'receive',
             'property_account_expense_id': cls.alt_exp_account.id,
         })
-        service_order = cls.env['product.product'].create({
-            'name': "Service",
+        product2 = cls.env['product.product'].create({
+            'name': "Product2",
             'list_price': 50.0,
             'type': 'service',
             'uom_id': uom_hour.id,
@@ -44,19 +43,19 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             'partner_id': cls.partner_a.id,
             'order_line': [
                 Command.create({
-                    'name': product_order.name,
-                    'product_id': product_order.id,
+                    'name': product1.name,
+                    'product_id': product1.id,
                     'product_qty': 10.0,
-                    'product_uom': product_order.uom_id.id,
-                    'price_unit': product_order.list_price,
+                    'product_uom': product1.uom_id.id,
+                    'price_unit': product1.list_price,
                     'taxes_id': False,
                 }),
                 Command.create({
-                    'name': service_order.name,
-                    'product_id': service_order.id,
+                    'name': product2.name,
+                    'product_id': product2.id,
                     'product_qty': 10.0,
-                    'product_uom': service_order.uom_id.id,
-                    'price_unit': service_order.list_price,
+                    'product_uom': product2.uom_id.id,
+                    'price_unit': product2.list_price,
                     'taxes_id': False,
                 }),
             ],
@@ -93,6 +92,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
         move = self.env['account.move'].browse(self.purchase_order.action_create_invoice()['res_id'])
         move.invoice_date = fields.Date.today()
         move.action_post()
+
         with self.assertRaises(UserError):
             self.wizard.create_entries()
 

--- a/addons/purchase_stock/tests/__init__.py
+++ b/addons/purchase_stock/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_reordering_rule
 from . import test_move_cancel_propagation
 from . import test_product_template
 from . import test_routes
+from . import test_purchase_stock_accrued_entries

--- a/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged, Form
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAccruedPurchaseStock(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        uom_unit = cls.env.ref('uom.product_uom_unit')
+        product = cls.env['product.product'].create({
+            'name': "Product",
+            'list_price': 30.0,
+            'type': 'consu',
+            'uom_id': uom_unit.id,
+            'uom_po_id': uom_unit.id,
+            'invoice_policy': 'delivery',
+        })
+
+        cls.purchase_order = cls.env['purchase.order'].with_context(tracking_disable=True).create({
+            'partner_id': cls.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_qty': 10.0,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': product.list_price,
+                    'taxes_id': False,
+                }),
+            ]
+        })
+        cls.purchase_order.button_confirm()
+        cls.account_expense = cls.company_data['default_account_expense']
+        cls.account_revenue = cls.company_data['default_account_revenue']
+
+    def test_purchase_stock_accruals(self):
+        # receive 2 on 2020-01-02
+        pick = self.purchase_order.picking_ids
+        pick.move_lines.write({'quantity_done': 2})
+        pick.button_validate()
+        wiz_act = pick.button_validate()
+        wiz = Form(self.env[wiz_act['res_model']].with_context(wiz_act['context'])).save()
+        wiz.process()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-02')})
+
+        # receive 3 on 2020-01-06
+        pick = pick.copy()
+        pick.move_lines.write({'quantity_done': 3})
+        wiz_act = pick.button_validate()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-06')})
+
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'purchase.order',
+            'active_ids': self.purchase_order.ids,
+        }).create({
+            'account_id': self.account_expense.id,
+            'date': '2020-01-01',
+        })
+        # nothing to invoice on 2020-01-01
+        with self.assertRaises(UserError):
+            wizard.create_entries()
+
+        # 2 to invoice on 2020-01-04
+        wizard.date = fields.Date.to_date('2020-01-04')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 60},
+            {'account_id': wizard.account_id.id, 'debit': 60, 'credit': 0},
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 60, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 60},
+        ])
+
+        # 5 to invoice on 2020-01-07
+        wizard.date = fields.Date.to_date('2020-01-07')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 150},
+            {'account_id': wizard.account_id.id, 'debit': 150, 'credit': 0},
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 150, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 150},
+        ])
+
+    def test_purchase_stock_invoiced_accrued_entries(self):
+        # deliver 2 on 2020-01-02
+        pick = self.purchase_order.picking_ids
+        pick.move_lines.write({'quantity_done': 2})
+        pick.button_validate()
+        wiz_act = pick.button_validate()
+        wiz = Form(self.env[wiz_act['res_model']].with_context(wiz_act['context'])).save()
+        wiz.process()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-02')})
+
+        # invoice on 2020-01-04
+        move = self.env['account.move'].browse(self.purchase_order.action_create_invoice()['res_id'])
+        move.invoice_date = fields.Date.to_date('2020-01-04')
+        move.action_post()
+
+        # deliver 3 on 2020-01-06
+        pick = pick.copy()
+        pick.move_lines.write({'quantity_done': 3})
+        wiz_act = pick.button_validate()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-06')})
+
+        # invoice on 2020-01-08
+        move = self.env['account.move'].browse(self.purchase_order.action_create_invoice()['res_id'])
+        move.invoice_date = fields.Date.to_date('2020-01-08')
+        move.action_post()
+
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'purchase.order',
+            'active_ids': self.purchase_order.ids,
+        }).create({
+            'account_id': self.company_data['default_account_expense'].id,
+            'date': '2020-01-02',
+        })
+
+        # 2 to invoice on 2020-01-07
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 60},
+            {'account_id': wizard.account_id.id, 'debit': 60, 'credit': 0},
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 60, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 60},
+        ])
+
+        # nothing to invoice on 2020-01-05
+        wizard.date = fields.Date.to_date('2020-01-05')
+        with self.assertRaises(UserError):
+            wizard.create_entries()
+
+        # 3 to invoice on 2020-01-07
+        wizard.date = fields.Date.to_date('2020-01-07')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 90},
+            {'account_id': wizard.account_id.id, 'debit': 90, 'credit': 0},
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 90, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 90},
+        ])
+
+        # nothing to invoice on 2020-01-09
+        wizard.date = fields.Date.to_date('2020-01-09')
+        with self.assertRaises(UserError):
+            wizard.create_entries()

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -527,7 +527,11 @@ class SaleOrderLine(models.Model):
         outgoing_moves = self.env['stock.move']
         incoming_moves = self.env['stock.move']
 
-        for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id):
+        moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id)
+        if self._context.get('accrual_entry_date'):
+            moves = moves.filtered(lambda r: fields.Date.to_date(r.date) <= self._context['accrual_entry_date'])
+
+        for move in moves:
             if move.location_dest_id.usage == "customer":
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move

--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_sale_stock_lead_time
 from . import test_sale_stock_report
 from . import test_sale_order_dates
 from . import test_sale_stock_multicompany
+from . import test_sale_stock_accrued_entries

--- a/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
+++ b/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged, Form
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAccruedStockSaleOrders(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.product_order = cls.env['product.product'].create({
+            'name': "Product",
+            'list_price': 30.0,
+            'type': 'consu',
+            'uom_id': uom_unit.id,
+            'uom_po_id': uom_unit.id,
+            'invoice_policy': 'delivery',
+        })
+        cls.sale_order = cls.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': cls.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': cls.product_order.name,
+                    'product_id': cls.product_order.id,
+                    'product_uom_qty': 10.0,
+                    'product_uom': cls.product_order.uom_id.id,
+                    'price_unit': cls.product_order.list_price,
+                    'tax_id': False,
+                })
+            ]
+        })
+        cls.sale_order.action_confirm()
+        cls.account_expense = cls.company_data['default_account_expense']
+        cls.account_revenue = cls.company_data['default_account_revenue']
+
+    def test_sale_stock_accruals(self):
+        # deliver 2 on 2020-01-02
+        pick = self.sale_order.picking_ids
+        pick.move_lines.write({'quantity_done': 2})
+        pick.button_validate()
+        wiz_act = pick.button_validate()
+        wiz = Form(self.env[wiz_act['res_model']].with_context(wiz_act['context'])).save()
+        wiz.process()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-02')})
+
+        # deliver 3 on 2020-01-06
+        pick = pick.copy()
+        pick.move_lines.write({'quantity_done': 3})
+        wiz_act = pick.button_validate()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-06')})
+
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': self.sale_order.ids,
+        }).create({
+            'account_id': self.account_expense.id,
+            'date': '2020-01-01',
+        })
+        # nothing to invoice on 2020-01-01
+        with self.assertRaises(UserError):
+            wizard.create_entries()
+
+        # 2 to invoice on 2020-01-04
+        wizard.date = fields.Date.to_date('2020-01-04')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 60, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 60},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 60},
+            {'account_id': wizard.account_id.id, 'debit': 60, 'credit': 0},
+        ])
+
+        # 5 to invoice on 2020-01-07
+        wizard.date = fields.Date.to_date('2020-01-07')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 150, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 150},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 150},
+            {'account_id': wizard.account_id.id, 'debit': 150, 'credit': 0},
+        ])
+
+    def test_sale_stock_invoiced_accrued_entries(self):
+        # deliver 2 on 2020-01-02
+        pick = self.sale_order.picking_ids
+        pick.move_lines.write({'quantity_done': 2})
+        pick.button_validate()
+        wiz_act = pick.button_validate()
+        wiz = Form(self.env[wiz_act['res_model']].with_context(wiz_act['context'])).save()
+        wiz.process()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-02')})
+
+        # invoice on 2020-01-04
+        inv = self.sale_order._create_invoices()
+        inv.invoice_date = fields.Date.to_date('2020-01-04')
+        inv.action_post()
+
+        # deliver 3 on 2020-01-06
+        pick = pick.copy()
+        pick.move_lines.write({'quantity_done': 3})
+        wiz_act = pick.button_validate()
+        pick.move_lines.write({'date': fields.Date.to_date('2020-01-06')})
+
+        # invoice on 2020-01-08
+        inv = self.sale_order._create_invoices()
+        inv.invoice_date = fields.Date.to_date('2020-01-08')
+        inv.action_post()
+
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': self.sale_order.ids,
+        }).create({
+            'account_id': self.company_data['default_account_expense'].id,
+            'date': '2020-01-02',
+        })
+        # 2 to invoice on 2020-01-07
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 60, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 60},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 60},
+            {'account_id': wizard.account_id.id, 'debit': 60, 'credit': 0},
+        ])
+
+        # nothing to invoice on 2020-01-05
+        wizard.date = fields.Date.to_date('2020-01-05')
+        with self.assertRaises(UserError):
+            wizard.create_entries()
+
+        # 3 to invoice on 2020-01-07
+        wizard.date = fields.Date.to_date('2020-01-07')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 90, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 90},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 90},
+            {'account_id': wizard.account_id.id, 'debit': 90, 'credit': 0},
+        ])
+
+        # nothing to invoice on 2020-01-09
+        wizard.date = fields.Date.to_date('2020-01-09')
+        with self.assertRaises(UserError):
+            wizard.create_entries()

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -233,7 +233,10 @@ class SaleOrderLine(models.Model):
 
     def _timesheet_compute_delivered_quantity_domain(self):
         """ Hook for validated timesheet in addionnal module """
-        return [('project_id', '!=', False)]
+        domain = [('project_id', '!=', False)]
+        if self._context.get('accrual_entry_date'):
+            domain += [('date', '<=', self._context['accrual_entry_date'])]
+        return domain
 
     ###########################################
     # Service : Project and task generation

--- a/addons/sale_timesheet/tests/__init__.py
+++ b/addons/sale_timesheet/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_so_line_determined_in_timesheet
 from . import test_sale_timesheet_ui
 from . import test_project_pricing_type
 from . import test_project_update
+from . import test_sale_timesheet_accrued_entries

--- a/addons/sale_timesheet/tests/test_sale_timesheet_accrued_entries.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_accrued_entries.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from odoo import fields
+from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
+from odoo.tests import tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAccruedTimeSheetSaleOrders(TestCommonSaleTimesheet):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.sale_order = cls.env['sale.order'].create({
+            'partner_id': cls.partner_a.id,
+            'partner_invoice_id': cls.partner_a.id,
+            'partner_shipping_id': cls.partner_a.id,
+            'pricelist_id': cls.company_data['default_pricelist'].id,
+            'date_order': '2020-01-01',
+        })
+        so_line_deliver_global_project = cls.env['sale.order.line'].create({
+            'name': cls.product_delivery_timesheet2.name,
+            'product_id': cls.product_delivery_timesheet2.id,
+            'product_uom_qty': 50,
+            'product_uom': cls.product_delivery_timesheet2.uom_id.id,
+            'price_unit': cls.product_delivery_timesheet2.list_price,
+            'order_id': cls.sale_order.id,
+        })
+        cls.sale_order.action_confirm()
+
+        cls.task = cls.env['project.task'].search([('sale_line_id', '=', so_line_deliver_global_project.id)])
+        cls.account_revenue = cls.company_data['default_account_revenue']
+
+    def _log_hours(self, unit_amount, date):
+        self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'project_id': self.task.project_id.id,
+            'task_id': self.task.id,
+            'unit_amount': unit_amount,
+            'employee_id': self.employee_manager.id,
+            'date': date,
+        })
+
+    def test_timesheet_accrued_entries(self):
+        # log 10 hours on 2020-01-02
+        self._log_hours(10, '2020-01-02')
+        # log 10 hours on 2020-01-05
+        self._log_hours(10, '2020-01-05')
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': self.sale_order.ids,
+        }).create({
+            'account_id': self.company_data['default_account_expense'].id,
+            'date': '2020-01-01',
+        })
+
+        # nothing to invoice on 2020-01-01
+        with self.assertRaises(UserError):
+            wizard.create_entries()
+
+        # 10 hours to invoice on 2020-01-03
+        wizard.date = fields.Date.to_date('2020-01-03')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 900, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 900},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 900},
+            {'account_id': wizard.account_id.id, 'debit': 900, 'credit': 0},
+        ])
+
+        # 20 hours to invoice on 2020-01-07
+        wizard.date = fields.Date.to_date('2020-01-07')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 1800, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 1800},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 1800},
+            {'account_id': wizard.account_id.id, 'debit': 1800, 'credit': 0},
+        ])
+
+    def test_timesheet_invoiced_accrued_entries(self):
+        # log 10 hours on 2020-01-02
+        self._log_hours(10, '2020-01-02')
+
+        # invoice on 2020-01-04
+        inv = self.sale_order._create_invoices()
+        inv.invoice_date = fields.Date.to_date('2020-01-04')
+        inv.action_post()
+
+        # log 10 hours on 2020-01-06
+        self._log_hours(10, '2020-01-06')
+
+        # invoice on 2020-01-08
+        inv = self.sale_order._create_invoices()
+        inv.invoice_date = fields.Date.to_date('2020-01-08')
+        inv.action_post()
+
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': self.sale_order.ids,
+        }).create({
+            'account_id': self.company_data['default_account_expense'].id,
+            'date': '2020-01-02',
+        })
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 900, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 900},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 900},
+            {'account_id': wizard.account_id.id, 'debit': 900, 'credit': 0},
+        ])
+
+        # nothing to invoice on 2020-01-05
+        wizard.date = fields.Date.to_date('2020-01-05')
+        with self.assertRaises(UserError):
+            wizard.create_entries()
+
+        # 20 hours to invoice on 2020-01-07
+        wizard.date = fields.Date.to_date('2020-01-07')
+        self.assertRecordValues(self.env['account.move'].search(wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 900, 'credit': 0},
+            {'account_id': wizard.account_id.id, 'debit': 0, 'credit': 900},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 900},
+            {'account_id': wizard.account_id.id, 'debit': 900, 'credit': 0},
+        ])
+
+        # nothing to invoice on 2020-01-05
+        wizard.date = fields.Date.to_date('2020-01-09')
+        with self.assertRaises(UserError):
+            wizard.create_entries()


### PR DESCRIPTION
This allows to solve the following use case:
* we are in March
* a SO created during January shows currently a delivered quantity (timesheet on service or delivered goods on storable products): timesheets/pickings were done in February
* creating the accrued entry for January 31 should display accordingly an amount of 0 by default since everything was done in February

followup of task 2255642