### PR TITLE
[FIX] sale_management: Set discount as per pricelist in optional product

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -123,10 +123,10 @@ class SaleOrderLine(models.Model):
         if self.event_ticket_id and (not self.event_id or self.event_id != self.event_ticket_id.event_id):
             self.event_ticket_id = None
 
-    @api.onchange('product_uom', 'product_uom_qty')
-    def product_uom_change(self):
-        if not self.event_ticket_id:
-            super(SaleOrderLine, self).product_uom_change()
+    @api.depends('product_uom', 'product_uom_qty')
+    def _compute_price_unit(self):
+        sol_without_event = self.filtered(lambda sol: not sol.event_ticket_id)
+        super(SaleOrderLine, sol_without_event)._compute_price_unit()
 
     @api.onchange('event_ticket_id')
     def _onchange_event_ticket_id(self):

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -118,8 +118,6 @@ class AccountMoveLine(models.Model):
 
         # create the sale lines in batch
         new_sale_lines = self.env['sale.order.line'].create(sale_line_values_to_create)
-        for sol in new_sale_lines:
-            sol._onchange_discount()
 
         # build result map by replacing index with newly created record of sale.order.line
         result = {}

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -159,13 +159,9 @@ class TestOnchangeProductId(TransactionCase):
 
         # force compute uom and prices
         order_line.product_id_change()
-        order_line.product_uom_change()
-        order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 90, "Christmas discount pricelist rule not applied")
         self.assertEqual(order_line.discount, 10, "Christmas discount not equalt to 10%")
         order_line.product_uom = new_uom
-        order_line.product_uom_change()
-        order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 900, "Christmas discount pricelist rule not applied")
         self.assertEqual(order_line.discount, 10, "Christmas discount not equalt to 10%")
 
@@ -217,7 +213,6 @@ class TestOnchangeProductId(TransactionCase):
 
         # force compute uom and prices
         order_line.product_id_change()
-        order_line._onchange_discount()
         self.assertEqual(order_line.price_subtotal, 81, "Second pricelist rule not applied")
         self.assertEqual(order_line.discount, 19, "Second discount not applied")
 
@@ -276,7 +271,6 @@ class TestOnchangeProductId(TransactionCase):
         order_line.product_id_change()
         self.assertEqual(order_line.price_unit, 180, "First pricelist rule not applied")
         order_line.product_uom = new_uom
-        order_line.product_uom_change()
         self.assertEqual(order_line.price_unit, 1800, "First pricelist rule not applied")
 
     def test_sale_warnings(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -284,7 +284,6 @@ class TestSaleOrder(TestSaleCommon):
         # Trigger onchange to reset discount, unit price, subtotal, ...
         for line in self.sale_order.order_line:
             line.product_id_change()
-            line._onchange_discount()
 
         for line in self.sale_order.order_line:
             if line.tax_id.price_include:
@@ -461,9 +460,6 @@ class TestSaleOrder(TestSaleCommon):
                 })
             ]
         })
-        for line in sales_order.order_line:
-            # Create values autofill does not compute discount.
-            line._onchange_discount()
 
         so_line_1 = sales_order.order_line[0]
         so_line_2 = sales_order.order_line[1]
@@ -492,8 +488,6 @@ class TestSaleOrder(TestSaleCommon):
                 })
             ]
         })
-        for line in sales_order.order_line:
-            line._onchange_discount()
 
         so_line_1 = sales_order.order_line[0]
         so_line_2 = sales_order.order_line[1]

--- a/addons/sale/tests/test_sale_pricelist.py
+++ b/addons/sale/tests/test_sale_pricelist.py
@@ -122,7 +122,6 @@ class TestSaleOrder(TestSaleCommon):
         # Trigger onchange to reset discount, unit price, subtotal, ...
         for line in self.sale_order.order_line:
             line.product_id_change()
-            line._onchange_discount()
         # Check that pricelist of the SO has been applied on the sale order lines or not
         for line in self.sale_order.order_line:
             if line.product_id == self.company_data['product_order_no']:
@@ -146,7 +145,6 @@ class TestSaleOrder(TestSaleCommon):
         # Trigger onchange to reset discount, unit price, subtotal, ...
         for line in self.sale_order.order_line:
             line.product_id_change()
-            line._onchange_discount()
 
         # Check pricelist of the SO apply or not on order lines where pricelist contains formula that add 15% on the cost price
         for line in self.sale_order.order_line:

--- a/addons/sale_management/controllers/portal.py
+++ b/addons/sale_management/controllers/portal.py
@@ -55,20 +55,16 @@ class CustomerPortal(portal.CustomerPortal):
 
         if unlink or quantity <= 0:
             order_line.unlink()
-            results = self._get_portal_order_details(order_sudo)
-            results.update({
-                'unlink': True,
-                'sale_template': request.env['ir.ui.view']._render_template('sale.sale_order_portal_content', {
-                    'sale_order': order_sudo,
-                    'report_type': "html"
-                }),
-            })
-            return results
+        else:
+            order_line.product_uom_qty = quantity
 
-        order_line.write({'product_uom_qty': quantity})
-        results = self._get_portal_order_details(order_sudo, order_line)
-
-        return results
+        return {
+            'sale_template': request.env['ir.ui.view']._render_template('sale.sale_order_portal_content', {
+                'sale_order': order_sudo,
+                'report_type': "html"
+            }),
+            **self._get_portal_order_details(order_sudo, False if (unlink or quantity <= 0) else order_line)
+        }
 
     @http.route(["/my/orders/<int:order_id>/add_option/<int:option_id>"], type='json', auth="public", website=True)
     def add(self, order_id, option_id, access_token=None, **post):

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -239,7 +239,7 @@ class SaleOrderOption(models.Model):
         # To compute the discount a so line is created in cache
         values = self._get_values_to_add_to_order()
         new_sol = self.env['sale.order.line'].new(values)
-        new_sol._onchange_discount()
+        new_sol._compute_discount()
         self.discount = new_sol.discount
         if self.order_id.pricelist_id and self.order_id.partner_id:
             self.price_unit = new_sol._get_display_price(product)

--- a/addons/sale_management/static/src/js/sale_management.js
+++ b/addons/sale_management/static/src/js/sale_management.js
@@ -35,6 +35,11 @@ publicWidget.registry.SaleUpdateLineButton = publicWidget.Widget.extend({
             'input_quantity': quantity >= 0 ? quantity : false,
             'access_token': self.orderDetail.token
         }).then((data) => {
+            const $saleTemplate = $(data['sale_template']);
+            if ($saleTemplate.length) {
+                self.$('#portal_sale_content').html($saleTemplate);
+                self.elems = self._getUpdatableElements();
+            }
             self._updateOrderLineValues($target.closest('tr'), data);
             self._updateOrderValues(data);
         });
@@ -55,7 +60,7 @@ publicWidget.registry.SaleUpdateLineButton = publicWidget.Widget.extend({
             'access_token': self.orderDetail.token
         }).then((data) => {
             var $saleTemplate = $(data['sale_template']);
-            if ($saleTemplate.length && data['unlink']) {
+            if ($saleTemplate.length) {
                 self.$('#portal_sale_content').html($saleTemplate);
                 self.elems = self._getUpdatableElements();
             }

--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -113,7 +113,6 @@ class SaleOrder(models.Model):
                 self.update(dict(order_line=new_lines))
                 for line in self.order_line.filtered(lambda line: line.product_template_id == product_template):
                     res = line.product_id_change() or res
-                    line._onchange_discount()
                     line._onchange_product_id_set_customer_lead()
                 return res
 

--- a/addons/sale_quotation_builder/models/sale_order.py
+++ b/addons/sale_quotation_builder/models/sale_order.py
@@ -64,7 +64,7 @@ class SaleOrderOption(models.Model):
 
     website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate)
 
-    @api.onchange('product_id', 'uom_id')
+    @api.onchange('product_id', 'uom_id', 'quantity')
     def _onchange_product_id(self):
         ret = super(SaleOrderOption, self)._onchange_product_id()
         if self.product_id:

--- a/addons/sale_timesheet/wizard/project_create_sale_order.py
+++ b/addons/sale_timesheet/wizard/project_create_sale_order.py
@@ -245,6 +245,7 @@ class ProjectCreateSalesOrder(models.TransientModel):
                 'so_line': map_entry.sale_line_id.id
             })
             map_entry.sale_line_id.with_context({'no_update_planned_hours': True}).write({
+                'price_unit': map_entry.sale_line_id.price_unit,
                 'product_uom_qty': map_entry.sale_line_id.qty_delivered
             })
 


### PR DESCRIPTION

Currently, on optional product quantity isn't considered to be calculated
a discount based on pricelist and also not applied pricelist when
change the qty from the portal.

So in this commit, when we set the min Qty on pricelist then priceslit
should be applied based on Quantity set on the optional product so added the
dependency for quantity on the optional products.

Also, onchange of quantity from portal applies the pricelist and replace
the orderline because we need to update almost all the details based
on pricelist in sale order line like a discount, unit price, taxes, total, etc..
portal user does not have right to group discount so based on context
calculate the discount for the portal user.

TaskID: 2180180