### PR TITLE
keep focus on widget with resetOnAnyFieldChange on navigation

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1022,10 +1022,15 @@ var FieldMonetary = NumericField.extend({
      * @private
      */
     _renderEdit: function () {
+        const input = this.$input ? this.$input[0] : false;
+        const hasFocus = document.activeElement === input;
         this.$el.empty();
 
         // Prepare and add the input
         var def = this._prepareInput(this.$input).appendTo(this.$el);
+        if (hasFocus && this.$input) {
+            this.$input[0].focus();
+        }
 
         if (this.currency) {
             // Prepare and add the currency symbol

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4507,6 +4507,40 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('navigation on resetOnAnyFieldChange(e.g. Monetary) widget with tab key in form view', async function (assert) {
+        assert.expect(2);
+
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<group>' +
+                            '<field name="foo"/>' +
+                            '<field name="qux" widget="monetary"/>' +
+                        '</group>' +
+                    '</sheet>' +
+                '</form>',
+        });
+
+        // focus first input, trigger tab
+        form.$('input[name="foo"]').focus();
+
+        // we do not have a way to simulate change on TAB, so we are first changing focus
+        // to qux field and then manually changing foo field which will reset qux field
+        // so after reset focus should still be there in qux field.
+        form.$('input[name="foo"]').trigger($.Event('keydown', { which: $.ui.keyCode.TAB }));
+        assert.strictEqual(form.$('div[name="qux"] .o_input')[0], document.activeElement,
+            "qux field should be focused");
+        await testUtils.fields.editInput(form.$('input[name=foo]'), 'let us trigger an onchange');
+        assert.strictEqual(form.$('div[name="qux"] .o_input')[0], document.activeElement,
+            "qux field should still be focused");
+
+        form.destroy();
+    });
+
     QUnit.test('should keep the focus when being edited in x2many lists', async function (assert) {
         assert.expect(6);
 


### PR DESCRIPTION
PURPOSE
When navigating using keyboard to widget which has resetOnAnyFieldChange is true, it does not work because resetOnAnyFieldChange resets widget and renderEdit is called again, on some widget  is replaced and because of that focusout is called, so focus is not removed from that widget, expected behaviour is even after reset widget should have focus.

SPEC
When widget is reset and element of widget is replaced still focus should remain on widget.

TASK 2636133


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
