### PR TITLE
[IMP] product: improve name_get performance

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -518,7 +518,9 @@ class ProductTemplateAttributeValue(models.Model):
 
     def _get_combination_name(self):
         """Exclude values from single value lines or from no_variant attributes."""
-        return ", ".join([ptav.name for ptav in self._without_no_variant_attributes()._filter_single_value_lines()])
+        ptavs = self._without_no_variant_attributes().with_prefetch(self._prefetch_ids)
+        ptavs = ptavs._filter_single_value_lines().with_prefetch(self._prefetch_ids)
+        return ", ".join([ptav.name for ptav in ptavs])
 
     def _filter_single_value_lines(self):
         """Return `self` with values from single value lines filtered out


### PR DESCRIPTION
Improve `name_get` performance by retrieving
`product_template_attribute_value_ids` names in batch before
looping on self.

The following line can be pretty slow when called inside a for loop.
https://github.com/odoo/odoo/blob/f4b7c3eb8138c08873ecc6e23a1bb6cf5b8ceef2/addons/product/models/product_attribute.py#L521

Constructing a ptav name map beforehand makes the call to `_get_combination_name`
much faster.

#### speed-up

Customer database with 30K products and 3 product_template_attribute_value on average.
`product.product.name_get` average time

| Number of Products | Before PR | After PR |
|:--------------------------:|:---------------:|:-----------:|
| 1 | 0.15s | 0.01s |
| 25 | 0.07s | 0.02s |
| 100 | 0.14s | 0.03s |
| 500 | 0.59s | 0.11s |
| 2000 | 1.84s | 0.34s |
| 10000 | 5.71s | 1.21s |

opw-2624261

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
