### PR TITLE
[FIX] sale_stock, purchase_stock : delivered qty is wrong

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -293,7 +293,7 @@ class PurchaseOrderLine(models.Model):
                 # the PO. Therefore, we can skip them since they will be handled later on.
                 for move in line.move_ids.filtered(lambda m: m.product_id == line.product_id):
                     if move.state == 'done':
-                        if move.location_dest_id.usage == "supplier":
+                        if move.location_dest_id.usage in ('supplier', 'transit'):
                             if move.to_refund:
                                 total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
@@ -545,9 +545,9 @@ class PurchaseOrderLine(models.Model):
         incoming_moves = self.env['stock.move']
 
         for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id):
-            if move.location_dest_id.usage == "supplier" and move.to_refund:
+            if move.location_dest_id.usage in ('supplier', 'transit') and move.to_refund:
                 outgoing_moves |= move
-            elif move.location_dest_id.usage != "supplier":
+            elif move.location_dest_id.usage not in ('supplier', 'transit'):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     incoming_moves |= move
 

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -535,10 +535,10 @@ class SaleOrderLine(models.Model):
         incoming_moves = self.env['stock.move']
 
         for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id):
-            if move.location_dest_id.usage == "customer":
+            if move.location_dest_id.usage in ('customer', 'transit'):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move
-            elif move.location_dest_id.usage != "customer" and move.to_refund:
+            elif move.location_dest_id.usage not in ('customer', 'transit') and move.to_refund:
                 incoming_moves |= move
 
         return outgoing_moves, incoming_moves


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Install sale_purchase_inter_company_rules
- On company 1 and company 2 set Inter-company location in Customer Location and Vendor Location.
- In setting set rule_type = 'sale_purchase' in both company
- In company 1 buy 10 product from company 2.
- In company 2, go to SO, delivery products.
--> Issue 1: qty delivered is not update on SO
- In company 1, on PO, delivery product, then make a return
--> Issue 2: qty delivered is not update

Note : I don't if this is the good configuration : On company 1 and company 2 set Inter-company location in Customer Location and Vendor Location.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
