### PR TITLE
Issues with mouse hit locations on Chrome 92

### DIFF
--- a/addons/web/static/src/js/libs/fullcalendar.js
+++ b/addons/web/static/src/js/libs/fullcalendar.js
@@ -211,12 +211,10 @@ odoo.define('/web/static/src/js/libs/fullcalendar.js', function () {
              */
             _onYearDateClick(info) {
                 const calendar = this.context.calendar;
-                const events = Object.values(this.events)
+                const events = this.events
                     .filter(event => {
-                        const startUTC = calendar.dateEnv.toDate(event._instance.range.start);
-                        const endUTC = calendar.dateEnv.toDate(event._instance.range.end);
-                        const start = moment(startUTC);
-                        const end = moment(endUTC);
+                        const start = moment(event.start);
+                        const end = moment(event.end);
                         const inclusivity = start.isSame(end, 'day') ? '[]' : '[)';
                         return moment(info.date).isBetween(start, end, 'day', inclusivity);
                     })

--- a/addons/web/static/tests/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/helpers/test_utils_dom.js
@@ -22,15 +22,15 @@ odoo.define('web.test_utils_dom', function (require) {
     const mouseEventMapping = args => Object.assign({}, args, {
         bubbles: true,
         cancelable: true,
-        clientX: args ? args.pageX : undefined,
-        clientY: args ? args.pageY : undefined,
+        clientX: args ? args.clientX || args.pageX : undefined,
+        clientY: args ? args.clientY || args.pageY : undefined,
         view: window,
     });
     const mouseEventNoBubble = args => Object.assign({}, args, {
         bubbles: false,
         cancelable: false,
-        clientX: args ? args.pageX : undefined,
-        clientY: args ? args.pageY : undefined,
+        clientX: args ? args.clientX || args.pageX : undefined,
+        clientY: args ? args.clientY || args.pageY : undefined,
         view: window,
     });
     const noBubble = args => Object.assign({}, args, { bubbles: false });
@@ -497,14 +497,11 @@ odoo.define('web.test_utils_dom', function (require) {
             throw new Error(`no target found to trigger MouseEvent`);
         }
         const rect = el.getBoundingClientRect();
-        // little fix since it seems on chrome, it triggers 1px too on the left
-        const left = rect.x + 1;
-        const top = rect.y;
-        return triggerEvent($el, type, {
-            which: 1,
-            pageX: left, layerX: left, screenX: left,
-            pageY: top, layerY: top, screenY: top,
-        });
+        // try to click around the center of the element, biased to the bottom
+        // right as chrome  messes up when clicking on the top-left corner...
+        const left = rect.x + Math.ceil(rect.width / 2);
+        const top = rect.y + Math.ceil(rect.height / 2);
+        return triggerEvent(el, type, {which: 1, clientX: left, clientY: top});
     }
 
     /**

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -3113,8 +3113,12 @@ QUnit.module('Views', {
             arch: '<tree><field name="foo"/><field name="text"/></tree>',
         });
 
-        const fooWidth = list.$('th[data-name="foo"]')[0].offsetWidth;
-        const textWidth = list.$('th[data-name="text"]')[0].offsetWidth;
+        const foo = list.el.querySelector('th[data-name="foo"]');
+        const fooWidth = Math.ceil(foo.getBoundingClientRect().width);
+
+        const text = list.el.querySelector('th[data-name="text"]');
+        const textWidth = Math.ceil(text.getBoundingClientRect().width);
+
         assert.strictEqual(fooWidth, textWidth, "both columns should have been given the same width");
 
         const firstRowHeight = list.$('.o_data_row:nth(0)')[0].offsetHeight;


### PR DESCRIPTION
On my system in chrome 92 there are issues of chrome's hitboxes (and rounding) being off leading to tests failures, something which given the adjustment in `triggerMouseEvent` had been an issue in the past. It started occurring a week or two back but that might be because it's been a long time since I last run web tests locally (and I left it for a bit as I thought it was an issue with recent calendar updates e.g. #74933 which had been flagged on discord).

### incorrect hit box on synthetic mouse click

The first test failure was / is in the "correctly display year view" calendar test, where the very first event dialog would fail to open when clicking on the `2016-11-16`.

After tracing through fullcalendar, it turned out fullcalendar was told to hit `2016-11-*09*`, suspiciously 7 days before the cell we were looking for in a monthly calendar, hinting to an incorrect vertical offset / hitbox.

Fix by offsetting the top coordinate in `triggerMouseEvent`, but rather than just increment by one update the entire thing by trigger the event right in the middle of the element being targeted, that seems more reliable long-term, though it could be slightly confusing for events like mouseenter/mouseover/...

#### Aside 1:

Before finding out the actual root cause I landed in `_onYearDateClick` with missing data in the events so looked at the API to figure what I was looking at, and turns out fullcalendar's event object has documented properties to get the date-converted start and end bounds of the event, so use that directly instead of doing the same thing by hand.

#### Aside 2:

The attributes passed to `triggerEvent` in `triggerMouseEvent` are pretty much nonsensical, we're getting the element's location using `getBoundingClientRect` which is based off of the viewport, but setting the keys

* `screen(X|Y)`, which should be the location of the hit relative to *the physical screen*
* `page(X|Y)`, which should be the location of the hit relative to the page / document (so takes in account the content scrolled off-screen)
* `layer(X|Y)`, which is the position of the hit relative to the nearest positioned (non-static) element, falling back to page if there isn't one

The one attribute which matches the semantics / reference of` getBoundingClientRect` we didn't even set, instead it would be automatically copied from `pageX`/`pageY` by the events mapping.

Fix that by just providing `clientX`/`clientY` and updating the mapping functions to not overwrite it.

If the others are needed they should be computed properly based on the document's bounding client rect and scroll information, as well as the window's `screenX`/`screenY` (and offsetParent for `layerX`/`layerY` though that seems unlikely to be necessary).

#### incorrect sizing rounding

The second issue was with a list test, where two cells are supposed to be sized equally. Apparently the offset sizes are supposed to be the rounded version of the actual size (which can be fractional), but dumping the information of `foo` and `text` I'd get real widths (via getBoundingClientRect) of respectively 480.46875 and 480.5, and
offsetWidths of 481 and 480 (the smaller of the two in "real size" is rounded higher than the other one).

In Python we might use `assertAlmostEqual` for this, but we've apparently not introduced this in JS take the real width and round up by hand, this fixes the issue as both end up at 481.
