### PR TITLE
[FIX] mass_mailing: properly save into two separate fields and load quicker

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -140,8 +140,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
      * @override
      */
     _renderEdit: function () {
-        this._isFromInline = !!this.value;
-        this._wysiwygSnippetsActive = !(this._isFromInline && $(this.value).is('.o_layout.o_basic_theme'));
+        this._wysiwygSnippetsActive = !$(this.value).is('.o_layout.o_basic_theme');
         if (!this.value) {
             this.value = this.recordData[this.nodeOptions['inline-field']];
         }
@@ -337,9 +336,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
      * @override
      */
     _onLoadWysiwyg: function () {
-        if (this._isFromInline) {
-            this._fromInline();
-        }
         if (this.snippetsLoaded) {
             this._onSnippetsLoaded(this.snippetsLoaded);
         }

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -65,6 +65,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         return this.wysiwyg.saveModifiedImages(this.$content).then(function () {
             self._isDirty = self.wysiwyg.isDirty();
+            self._doAction();
 
             convertInline.attachmentThumbnailToLinkImg($editable);
             convertInline.fontToImg($editable);
@@ -84,6 +85,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
                 changes: _.object([fieldName], [self._unWrap($editable.html())])
             });
 
+            $editable.html(self.value);
             if (self._isDirty && self.mode === 'edit') {
                 return self._doAction();
             }

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -341,7 +341,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         this._super();
         this.wysiwyg.odooEditor.observerFlush();
-        this.wysiwyg.odooEditor.resetHistory();
+        this.wysiwyg.odooEditor.historyReset();
         this.wysiwyg.$iframeBody.addClass('o_mass_mailing_iframe');
         this.trigger_up('iframe_updated', { $iframe: this.wysiwyg.$iframe });
     },
@@ -527,7 +527,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
             // Wait the next tick because some mutation have to be processed by
             // the Odoo editor before resetting the history.
             setTimeout(() => {
-                this.wysiwyg.resetHistory();
+                this.wysiwyg.historyReset();
             }, 0);
         });
 

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_editor_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_editor_tour.js
@@ -1,0 +1,28 @@
+odoo.define('mass_mailing.mass_mailing_editor_tour', function (require) {
+    "use strict";
+
+    var tour = require('web_tour.tour');
+
+    tour.register('mass_mailing_editor_tour', {
+        url: '/web',
+        test: true,
+    }, [tour.stepUtils.showAppsMenuItem(), {
+        trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',
+    }, {
+        trigger: 'button.o_list_button_add',
+    }, {
+        trigger: 'input[name="subject"]',
+        run: 'text Test',
+    }, {
+        trigger: 'div[name="contact_list_ids"] .o_input_dropdown > input[type="text"]',
+    }, {
+        trigger: 'li.ui-menu-item',
+    }, {
+        trigger: 'iframe #default',
+        run: () => $('iframe').contents().find('o_editable').html('<p><br/></p>'),
+    }, {
+        trigger: 'button.o_form_button_save',
+    }, {
+        trigger: 'iframe.o_readonly',
+    }]);
+});

--- a/addons/mass_mailing/tests/__init__.py
+++ b/addons/mass_mailing/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_mailing_internals
 from . import test_mailing_list
 from . import test_mailing_controllers
 from . import test_mailing_mailing_schedule_date
+from . import test_mailing_ui

--- a/addons/mass_mailing/tests/test_mailing_ui.py
+++ b/addons/mass_mailing/tests/test_mailing_ui.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestUi(HttpCaseWithUserDemo):
+    def setUp(self):
+        super().setUp()
+        self.user_demo.groups_id |= self.env.ref('mass_mailing.group_mass_mailing_user')
+        self.user_demo.groups_id |= self.env.ref('mail.group_mail_template_editor')
+
+    def test_01_mass_mailing_editor_tour(self):
+        self.start_tour("/web", 'mass_mailing_editor_tour', login="demo")
+        mail = self.env['mailing.mailing'].search([('subject', '=', 'Test')])[0]
+        # The tour created and saved an email. The edited version should be
+        # saved in body_arch, and its transpiled version (see convert_inline)
+        # for email client compatibility should be saved in body_html. This
+        # ensures both fields have different values.
+        self.assertEqual(mail.body_arch, '<p><br></p>')
+        self.assertEqual(mail.body_html, '<p style="margin:0px 0 1rem 0;"><br></p>')

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -227,12 +227,8 @@ export class OdooEditor extends EventTarget {
         this.editable.before(this._collabSelectionsContainer);
 
         this.idSet(editable);
-        this.historyReset();
         this._historyStepsActive = true;
-        const firstStep = this._historyGetSnapshotStep();
-        this._firstStepId = firstStep.id;
-        this._historySnapshots = [{ step: firstStep }];
-        this._historySteps.push(firstStep);
+        this.historyReset();
 
         this._createCommandBar();
 
@@ -562,19 +558,11 @@ export class OdooEditor extends EventTarget {
     // -------------------------------------------------------------------------
 
     historyReset() {
-        this._historySteps = [];
-        this._currentStep = {
-            selection: {
-                anchorNodeOid: undefined,
-                anchorOffset: undefined,
-                focusNodeOid: undefined,
-                focusOffset: undefined,
-            },
-            mutations: [],
-            id: undefined,
-            clientId: undefined,
-        };
-        this._historyStepsStates = new Map();
+        this._historyClean();
+        const firstStep = this._historyGetSnapshotStep();
+        this._firstStepId = firstStep.id;
+        this._historySnapshots = [{ step: firstStep }];
+        this._historySteps.push(firstStep);
     }
     historyGetSnapshotSteps() {
         // If the current snapshot has no time, it means that there is the no
@@ -607,7 +595,7 @@ export class OdooEditor extends EventTarget {
         for (const node of [...this.editable.childNodes]) {
             node.remove();
         }
-        this.historyReset();
+        this._historyClean();
         for (const step of steps) {
             this.historyApply(step.mutations);
         }
@@ -886,6 +874,21 @@ export class OdooEditor extends EventTarget {
     }
     historyUnpauseSteps() {
         this._historyStepsActive = true;
+    }
+    _historyClean() {
+        this._historySteps = [];
+        this._currentStep = {
+            selection: {
+                anchorNodeOid: undefined,
+                anchorOffset: undefined,
+                focusNodeOid: undefined,
+                focusOffset: undefined,
+            },
+            mutations: [],
+            id: undefined,
+            clientId: undefined,
+        };
+        this._historyStepsStates = new Map();
     }
     _historyGetSnapshotStep() {
         return {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -24,7 +24,7 @@ function getMatchedCSSRules(a) {
             try {
                 rules = sheets[i].rules || sheets[i].cssRules;
             } catch (e) {
-                console.warn("Can't read the css rules of: " + sheets[i].href, e);
+                console.log("Can't read the css rules of: " + sheets[i].href, e);
                 continue;
             }
             if (rules) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -210,23 +210,6 @@ function fontToImg($editable) {
     });
 }
 
-/**
- * Converts images which were the result of a font icon convertion to a font
- * icon again.
- *
- * @param {jQuery} $editable - the element in which the images will be converted
- *                           back to font icons
- */
-function imgToFont($editable) {
-    $editable.find('img[src*="/web_editor/font_to_img/"]').each(function () {
-        var $img = $(this);
-        $img.replaceWith($('<span/>', {
-            class: $img.data('class'),
-            style: $img.data('style')
-        }));
-    });
-}
-
 /*
  * Utility function to apply function over descendants elements
  *
@@ -310,44 +293,6 @@ function classToStyle($editable) {
 }
 
 /**
- * Removes the inline style which is not necessary (because, for example, a
- * class on an element will induce the same style).
- *
- * @param {jQuery} $editable
- */
-function styleToClass($editable) {
-    // Outlook revert
-    $editable.find('.o_outlook_hack').each(function () {
-        $(this).after($('a,img', this));
-    }).remove();
-
-    var $c = $('<span/>').appendTo($editable[0].ownerDocument.body);
-
-    applyOverDescendants($editable[0], function (node) {
-        var $target = $(node);
-        var css = getMatchedCSSRules(node);
-        var style = '';
-        _.each(css, function (v,k) {
-            if (!(new RegExp('(^|;)\s*' + k).test(style))) {
-                style = k+':'+v+';'+style;
-            }
-        });
-        css = ($c.attr('style', style).attr('style') || '').split(/\s*;\s*/);
-        style = ($target.attr('style') || '').replace(/\s*:\s*/, ':').replace(/\s*;\s*/, ';');
-        _.each(css, function (v) {
-            style = style.replace(v, '');
-        });
-        style = style.replace(/;+(\s;)*/g, ';').replace(/^;/g, '');
-        if (style !== '') {
-            $target.attr('style', style);
-        } else {
-            $target.removeAttr('style');
-        }
-    });
-    $c.remove();
-}
-
-/**
  * Converts css display for attachment link to real image.
  * Without this post process, the display depends on the css and the picture
  * does not appear when we use the html without css (to send by email for e.g.)
@@ -363,16 +308,6 @@ function attachmentThumbnailToLinkImg($editable) {
             .css('width', Math.max(1, $link.width()) + 'px');
         $link.prepend($img);
     });
-}
-
-/**
- * Revert attachmentThumbnailToLinkImg changes
- *
- * @see attachmentThumbnailToLinkImg
- * @param {jQuery} $editable
- */
-function linkImgToAttachmentThumbnail($editable) {
-    $editable.find('a[href*="/web/content/"][data-mimetype] > img').remove();
 }
 
 
@@ -429,49 +364,11 @@ FieldHtml.include({
             notifyChange: false,
         });
     },
-    /**
-     * Revert _toInline changes.
-     *
-     * @private
-     */
-    _fromInline: function () {
-        var $editable = this.wysiwyg.getEditable();
-        var html = this.wysiwyg.getValue();
-        $editable.html(html);
-
-        styleToClass($editable);
-        imgToFont($editable);
-        linkImgToAttachmentThumbnail($editable);
-
-        // fix outlook image rendering bug
-        $editable.find('img[style*="width"], img[style*="height"]').removeAttr('height width');
-
-        this.wysiwyg.setValue($editable.html(), {
-            notifyChange: false,
-        });
-    },
-
-    //--------------------------------------------------------------------------
-    // Handler
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    _onLoadWysiwyg: function () {
-        if (this.nodeOptions['style-inline'] && this.mode === "edit") {
-            this._fromInline();
-        }
-        this._super();
-    },
 });
 
 return {
     fontToImg: fontToImg,
-    imgToFont: imgToFont,
     classToStyle: classToStyle,
-    styleToClass: styleToClass,
     attachmentThumbnailToLinkImg: attachmentThumbnailToLinkImg,
-    linkImgToAttachmentThumbnail: linkImgToAttachmentThumbnail,
 };
 });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -565,8 +565,8 @@ const Wysiwyg = Widget.extend({
     /**
      * Reset the history.
      */
-    resetHistory: function () {
-        this.odooEditor.resetHistory();
+    historyReset: function () {
+        this.odooEditor.historyReset();
     },
 
     /**


### PR DESCRIPTION
This fixes the mechanism that saves mailings into two separate fields, and removes outdated backward conversion of emails that is unnecessary since aforementioned mechanism is in place. That in turns massively speeds up the loading of the edit mode of previously saved mailings.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
