### PR TITLE
increase pos grouped kanban card width

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -1,5 +1,10 @@
-.o_kanban_view.o_kanban_dashboard.o_pos_kanban.o_kanban_ungrouped {
-	.o_kanban_record {
-        width: 500px;
-	}
+.o_kanban_view.o_kanban_dashboard.o_pos_kanban {
+    &.o_kanban_ungrouped {
+        .o_kanban_record {
+            width: 500px;
+        }
+    }
+    .o_kanban_group:not(.o_column_folded) {
+        width: 400px;
+    }
 }


### PR DESCRIPTION
PURPOSE
When kanban view is grouped in point of sale dashboard text goes of out of kanban card, it should not go outside card.

SPEC
When kanban view is grouped in point of sale dashboard text should not go outside kanban card.

TASK 2636169



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
