### PR TITLE
[FIX] sale: Disable option in select type field if excluded

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -365,6 +365,7 @@ var VariantMixin = {
             .removeClass('css_not_available')
             .attr('title', function () { return $(this).data('value_name') || ''; })
             .data('excluded-by', '');
+        $parent.find('option').attr('disabled', false);
 
         // exclusion rules: array of ptav
         // for each of them, contains array with the other ptav they exclude
@@ -437,7 +438,7 @@ var VariantMixin = {
         $input.closest('label').addClass('css_not_available');
 
         if (excludedBy && attributeNames) {
-            var $target = $input.is('option') ? $input : $input.closest('label').add($input);
+            var $target = $input.is('option') ? $input.attr('disabled', true) : $input.closest('label').add($input);
             var excludedByData = [];
             if ($target.data('excluded-by')) {
                 excludedByData = JSON.parse($target.data('excluded-by'));


### PR DESCRIPTION
Steps to reproduce:

  Test to do on mobile with chrome browser.
  - Install Ecommerce module
  - Go to Website -> Configuration -> Product -> Attribute
  - Create a new one with :
    - Name : Attr test
    - Type : Select
    - Create variants : Never
    - Add 2 attributes values: A & B
  - Go to products and select Customizable Desk then edit
  - Go to variants and add "Attr test" A and B then save
  - Click on Configure variants
  - Select attribute `Attr test : B` then edit
  - Exclude for `Color : Black` then save
  - Go to the shop and select product Customizable Desk
  - Choose black color then click on the select of Attr test

Issue:

  Excluded options (`B` in this case) are displayed as available.
  Note: a message will still display that the combination is not
  available.

Solution:

  Add/Remove attribute 'disabled' in option for select field type
  if variant is excluded.

opw-2605739