### PR TITLE
[FIX] account: unlink moves lines in batch

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1785,7 +1785,7 @@ class AccountMove(models.Model):
         for move in self:
             if move.name != '/' and not self._context.get('force_delete'):
                 raise UserError(_("You cannot delete an entry which has been posted once."))
-            move.line_ids.unlink()
+        self.line_ids.unlink()
         return super(AccountMove, self).unlink()
 
     @api.returns('self', lambda value: value.id)


### PR DESCRIPTION
To reproduce performance problem one can use following scenario:

* Use Enterprise v13
* go to Accounting / Assets, select the chair and click on "Set To Running"
* Click "Modify Deprecation" and enter the following values:
Reason: x
Number of Deprecations: 1000 Months
Deprecation Amount: 1000
Account Asset Counterpart: 101000 Current Assets
* click on "Modify"

---

opw-2621292

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
