### PR TITLE
[FIX] link_tracker,test_mail_full: fix traceback while converting links

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -178,6 +178,8 @@ class LinkTracker(models.Model):
         return html
 
     def _convert_links_text(self, body, vals, blacklist=None):
+        if not body:
+            return body
         shortened_schema = self.env['ir.config_parameter'].sudo().get_param('web.base.url') + '/r/'
         unsubscribe_schema = self.env['ir.config_parameter'].sudo().get_param('web.base.url') + '/sms/'
         for original_url in re.findall(TEXT_URL_REGEX, body):

--- a/addons/test_mail_full/tests/test_sms_sms.py
+++ b/addons/test_mail_full/tests/test_sms_sms.py
@@ -90,6 +90,9 @@ class TestSMSPost(test_mail_full_common.BaseFunctionalTest, sms_common.MockSMS, 
         })
         link = self.env['link.tracker'].search([('url', '=', link)])
         self.assertIn(link.short_url, new_body)
+        # Bugfix: ensure void content convert does not crash
+        new_body = self.env['link.tracker']._convert_links_text(False, self.tracker_values)
+        self.assertFalse(new_body)
 
     def test_body_link_shorten_wshort(self):
         link = 'https://test.odoo.com/r/RAOUL'


### PR DESCRIPTION
PURPOSE

Traceback  occurs while converting links in link tracker.

SPECIFICATION

Currently, when we try to shorten the links from content with help of
`_convert_links_text` method, it throws traceback.

This happens because the body(content) we pass is 'False', this case
happen when we directly pass a model field of
textual type but the field doesn't have a value yet. The `re` expects
the content to be string / bytestring,  but boolean value passed.

The goal of this commit is to avoid shorten the links if the body(content)
is `False`, by this way we can avoid the traceback.

LINKS
PR #75920
Task 2628586