### PR TITLE
[FIX] website_payment: obtain country and currency in donation form

### DIFF
--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -23,7 +23,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         :raise: werkzeug.exceptions.NotFound if the access token is invalid
         """
         kwargs['is_donation'] = True
-        kwargs['currency_id'] = int(kwargs.get('currency', request.env.company.currency_id.id))
+        kwargs['currency_id'] = int(kwargs.get('currency_id', request.env.company.currency_id.id))
         kwargs['amount'] = float(kwargs.get('amount', 25))
         kwargs['donation_options'] = kwargs.get('donation_options', json_safe.dumps(dict(customAmount="freeAmount")))
 

--- a/addons/website_payment/views/donation_templates.xml
+++ b/addons/website_payment/views/donation_templates.xml
@@ -22,15 +22,15 @@
                         </label>
                         <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" />
                     </div>
-                    <t t-set="country" t-value="partner_details.get('country')"/>
+                    <t t-set="country_id" t-value="partner_details.get('country_id')"/>
                     <div t-attf-class="form-group #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
                         <label class="col-form-label font-weight-bold" for="country_id">Country
                             <span class="s_website_form_mark"> *</span>
                         </label>
-                        <select t-att-disabled="'1' if country and country.id and partner_id else None" id="country_id" name="country_id" t-attf-class="o_wpayment_fee_impact form-control #{error.get('country_id') and 'is-invalid' or ''}">
+                        <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="o_wpayment_fee_impact form-control #{error.get('country_id') and 'is-invalid' or ''}">
                             <option value="">Country...</option>
                             <t t-foreach="countries" t-as="c">
-                                <option t-att-value="c.id" t-att-selected="c.id == (country and country.id or -1)">
+                                <option t-att-value="c.id" t-att-selected="c.id == (country_id or -1)">
                                     <t t-out="c.name" />
                                 </option>
                             </t>


### PR DESCRIPTION
Before this commit country and currency were not correctly populated in
the donation form.

After this commit country of a logged in user is correctly pre-populated
and donations can be done in the current currency of the user.

task-2398403

Description of the issue/feature this PR addresses:
Something did go wrong during the last rebase before the merge, all these changes we normally already done.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
