### PR TITLE
[IMP] hr_holidays: Number of weeks layout

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -164,6 +164,21 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                 self.$el.parent().find('.o_calendar_mini').hide();
             });
         },
+        /**
+         * @override
+         * @private
+         */
+        _renderCalendar: function() {
+            this._super.apply(this, arguments);
+            let weekNumbers = this.$el.find('.fc-week-number');
+            weekNumbers.each( function() {
+                let weekRow = this.parentNode;
+                // By default, each month has 6 weeks displayed, hide the week number if there is no days for the week
+                if(!weekRow.children[1].classList.length && !weekRow.children[weekRow.children.length-1].classList.length) {
+                    this.innerHTML = '';
+                }
+            });
+        },
     });
 
     var TimeOffCalendarRenderer = TimeOffPopoverRenderer.extend({

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -60,4 +60,19 @@
     .fc-week-number {
         color: #adb5bd;
     }
+
+    .o_calendar_view .o_calendar_widget .fc-dayGridMonth-view {
+        .fc-week-number {
+            padding-top: 0.2rem !important;
+            padding-bottom: 0.3rem !important;
+            padding-left: 0.3rem !important;
+            line-height: unset;
+            span {
+                font-size: 0.85rem;
+            }
+        }
+        .fc-week-number.fc-widget-header {
+            font-size: 0.85rem;
+        }
+    }
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Improve readability of the year view dashboard of hr_holidays

Current behavior before PR:
- The week number on the year view of hr_holidays are not aligned with the dates
- The week number are of the same size than the dates
- The empty weeks have a week number (https://tinyurl.com/yzkmwbm5)

Desired behavior after PR is merged:
- Align the week number with the days
- Size the week number to be smaller than the number of days
- Remove number when the week is not displayed

task-2637136

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
