### PR TITLE
[FIX] stock : Settings change triggered a change of show_operations

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -64,28 +64,27 @@ class ResConfigSettings(models.TransientModel):
             self.group_stock_multi_locations = True
 
     def set_values(self):
+        previous_group = self.default_get(['group_stock_multi_locations', 'group_stock_production_lot', 'group_stock_tracking_lot'])
         res = super(ResConfigSettings, self).set_values()
 
         if not self.user_has_groups('stock.group_stock_manager'):
             return
 
-        """ If we are not in multiple locations, we can deactivate the internal
+        """ If we disable multiple locations, we can deactivate the internal
         operation types of the warehouses, so they won't appear in the dashboard.
         Otherwise, activate them.
         """
         warehouse_obj = self.env['stock.warehouse']
-        if self.group_stock_multi_locations:
+        if self.group_stock_multi_locations and not previous_group.get('group_stock_multi_locations'):
             # override active_test that is false in set_values
-            warehouses = warehouse_obj.with_context(active_test=True).search([])
-            active = True
-        else:
-            warehouses = warehouse_obj.search([
+            warehouse_obj.with_context(active_test=True).search([]).mapped('int_type_id').write({'active': True})
+        elif not self.group_stock_multi_locations and previous_group.get('group_stock_multi_locations'):
+            warehouse_obj.search([
                 ('reception_steps', '=', 'one_step'),
-                ('delivery_steps', '=', 'ship_only')])
-            active = False
-        warehouses.mapped('int_type_id').write({'active': active})
+                ('delivery_steps', '=', 'ship_only')]
+            ).mapped('int_type_id').write({'active': False})
 
-        if self.group_stock_multi_locations or self.group_stock_production_lot or self.group_stock_tracking_lot:
+        if any(self[group] and not prev_value for group, prev_value in previous_group.items()):
             picking_types = self.env['stock.picking.type'].with_context(active_test=False).search([
                 ('code', '!=', 'incoming'),
                 ('show_operations', '=', False)


### PR DESCRIPTION
Issue: When changing a settings and saving, all the operation types
(stock_picking.type) that had a code different than incoming had their
Show Detailed Operations (show_operations) forced to be True, even when
the change in settings was totally unrelated

Steps to reproduce :
 1) Go to Inventory (stock) / Configuration / Warehouse Management /
 Operations Types
 2) Find or create an Operation Type with Type of Operation set to
 something else than Receipt (incoming)
 3) Ensures that the checkbox Show Detailed Operations (show_operations)
 is **unchecked**
 4) Go to Settings and check or uncheck any setting, for example
 Permissions > Default Access Rights
 5) Save
 6) Go back to the Operation Type seen before
 7) Show Detailed Operation is now **checked**

Why is that a bug:
 The intended behaviour was to check that Show Detailed Operations box
 every time we change group_stock_multi_locations
 group_stock_production_lot,
 or group_stock_tracking_lot from **unchecked
 to checked**, but the actual behaviour was to check that SDO box every
 time one of the **3 was checked when changing settings**

backporting from PR #74786
14.0 ticket : opw-2604730
opw-2604730