### PR TITLE
[FIX] web_editor, website: restore backend HTML fields in no-website DBs

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -829,3 +829,18 @@ $o-bg-shapes: ('web_editor': (
 @function add-footer-shape-colors-mapping($module, $shape-name, $mapping, $shapes: $o-bg-shapes) {
     @return add-extra-shape-colors-mapping($module, $shape-name, 'footer', $mapping, $shapes);
 }
+
+@mixin o-input-number-no-arrows() {
+    // Remove arrows/spinners from input type number
+    // => Chrome, Safari, Edge, Opera
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    // => Firefox
+    input[type=number] {
+        -moz-appearance: textfield;
+    }
+};

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2057,18 +2057,3 @@ $o-theme-font-configs: (
         background-image: $-gradient;
     }
 };
-
-@mixin o-input-number-no-arrows() {
-    // Remove arrows/spinners from input type number
-    // => Chrome, Safari, Edge, Opera
-    input::-webkit-outer-spin-button,
-    input::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-        margin: 0;
-    }
-
-    // => Firefox
-    input[type=number] {
-        -moz-appearance: textfield;
-    }
-};


### PR DESCRIPTION
The SCSS compilation failed if website was not installed since [1] as
a mixin was used in web_editor while defined in website...
    
[1]: https://github.com/odoo/odoo/commit/5ffce116a6f8d4775cffe4daef09674db6c159d0
