### PR TITLE
[IMP] web: don't check for bad dom after test on failure

### DIFF
--- a/addons/web/static/lib/qunit/qunit-2.9.1.js
+++ b/addons/web/static/lib/qunit/qunit-2.9.1.js
@@ -2977,6 +2977,7 @@
   }
 
   Test.prototype = {
+  	get moduleName() { return this.module.name; },
   	before: function before() {
   		var _this = this;
 
@@ -3142,7 +3143,7 @@
   			this.pushFailure("Expected at least one assertion, but none were run - call " + "expect(0) to accept zero assertions.", this.stack);
   		}
 
-        emit("OdooAfterTestHook", { moduleName: this.module.name, testName: this.testName }); // Odoo customization
+        emit("OdooAfterTestHook", this); // Odoo customization
 
   		var i,
   		    module = this.module,


### PR DESCRIPTION
Currently, if a test fails there's very high chances the DOM will not be clean, because qunit doesn't have good cleanup APIs. This means a test failure will always be prefixed by a dump of the page DOM (and a cascading failure) which is just confusing and makes it hard to find the actual error.

This change updates the OdooAfterTestHook handler to:

* Receive the `Test` itself, instead of adding more information to the synthetic object it currently receives.
* Only show the leftover DOM if the test otherwise succeeded.
* Do the entire reporting via `pushFailure`, rather than having duplication between an explicit `console.error` and a test failure.
* Update the QUnit.log handler to
  - not show `undefined`
  - try to improve readability by removing the bracketing and quoting
