### PR TITLE
[IMP] hr_holidays: Time Off smartbutton

### DIFF
--- a/addons/hr/models/hr_plan.py
+++ b/addons/hr/models/hr_plan.py
@@ -23,7 +23,6 @@ class HrPlanActivityType(models.Model):
         ('manager', 'Manager'),
         ('employee', 'Employee'),
         ('other', 'Other')], default='employee', string='Responsible', required=True)
-    # sgv todo change back to 'Responsible Person'
     responsible_id = fields.Many2one('res.users', 'Name', help='Specific responsible of activity if not linked to the employee.')
     note = fields.Html('Note')
 

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -33,11 +33,10 @@ class HrEmployeeBase(models.AbstractModel):
     leaves_count = fields.Float('Number of Time Off', compute='_compute_remaining_leaves')
     allocation_count = fields.Float('Total number of days allocated.', compute='_compute_allocation_count')
     allocations_count = fields.Integer('Total number of allocations', compute="_compute_allocation_count")
-    allocation_used_count = fields.Float('Total number of days off used', compute='_compute_total_allocation_used')
     show_leaves = fields.Boolean('Able to see Remaining Time Off', compute='_compute_show_leaves')
     is_absent = fields.Boolean('Absent Today', compute='_compute_leave_status', search='_search_absent_employee')
     allocation_display = fields.Char(compute='_compute_allocation_count')
-    allocation_used_display = fields.Char(compute='_compute_total_allocation_used')
+    allocation_remaining_display = fields.Char(compute='_compute_allocation_remaining_display')
     hr_icon_display = fields.Selection(selection_add=[('presence_holiday_absent', 'On leave'),
                                                       ('presence_holiday_present', 'Present but on leave')])
 
@@ -77,10 +76,16 @@ class HrEmployeeBase(models.AbstractModel):
             employee.remaining_leaves = value
 
     def _compute_allocation_count(self):
+        # Don't get allocations that are expired
+        current_date = datetime.date.today()
         data = self.env['hr.leave.allocation'].read_group([
             ('employee_id', 'in', self.ids),
             ('holiday_status_id.active', '=', True),
+            ('holiday_status_id.requires_allocation', '=', 'yes'),
             ('state', '=', 'validate'),
+            '|',
+            ('date_to', '=', False),
+            ('date_to', '>=', current_date),
         ], ['number_of_days:sum', 'employee_id'], ['employee_id'])
         rg_results = dict((d['employee_id'][0], {"employee_id_count": d['employee_id_count'], "number_of_days": d['number_of_days']}) for d in data)
         for employee in self:
@@ -89,10 +94,22 @@ class HrEmployeeBase(models.AbstractModel):
             employee.allocation_display = "%g" % employee.allocation_count
             employee.allocations_count = result['employee_id_count'] if result else 0.0
 
-    def _compute_total_allocation_used(self):
+    def _compute_allocation_remaining_display(self):
+        current_date = datetime.date.today()
+        data_leave = self.env['hr.leave'].read_group([
+            ('employee_id', 'in', self.ids),
+            ('holiday_status_id.active', '=', True),
+            ('holiday_status_id.requires_allocation', '=', 'yes'),
+            ('state', '=', 'validate'),
+            '|',
+            ('holiday_allocation_id.date_to', '=', False),
+            ('holiday_allocation_id.date_to', '>=', current_date),
+        ], ['number_of_days:sum', 'employee_id'], ['employee_id'])
+        results_leave = dict((d['employee_id'][0], {"employee_id_count": d['employee_id_count'], "number_of_days": d['number_of_days']}) for d in data_leave)
         for employee in self:
-            employee.allocation_used_count = float_round(employee.allocation_count - employee.remaining_leaves, precision_digits=2)
-            employee.allocation_used_display = "%g" % employee.allocation_used_count
+            result = results_leave.get(employee.id)
+            leaves_taken = float_round(result['number_of_days'], precision_digits=2) if result else 0.0
+            employee.allocation_remaining_display = "%g" % float_round(employee.allocation_count - leaves_taken, precision_digits=2)
 
     def _compute_presence_state(self):
         super()._compute_presence_state()

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -9,11 +9,10 @@ class User(models.Model):
 
     leave_manager_id = fields.Many2one(related='employee_id.leave_manager_id')
     show_leaves = fields.Boolean(related='employee_id.show_leaves')
-    allocation_used_count = fields.Float(related='employee_id.allocation_used_count')
     allocation_count = fields.Float(related='employee_id.allocation_count')
     leave_date_to = fields.Date(related='employee_id.leave_date_to')
     is_absent = fields.Boolean(related='employee_id.is_absent')
-    allocation_used_display = fields.Char(related='employee_id.allocation_used_display')
+    allocation_remaining_display = fields.Char(related='employee_id.allocation_remaining_display')
     allocation_display = fields.Char(related='employee_id.allocation_display')
     hr_icon_display = fields.Selection(related='employee_id.hr_icon_display')
 
@@ -22,11 +21,10 @@ class User(models.Model):
         return super().SELF_READABLE_FIELDS + [
             'leave_manager_id',
             'show_leaves',
-            'allocation_used_count',
             'allocation_count',
             'leave_date_to',
             'is_absent',
-            'allocation_used_display',
+            'allocation_remaining_display',
             'allocation_display',
             'hr_icon_display',
         ]

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -24,7 +24,13 @@
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 <separator/>
                 <filter name="year" string="Current Year"
-                    domain="[('holiday_status_id.active', '=', True)]" help="Active Allocations"/>
+                    domain="[
+                        ('date_from', '&lt;=', context_today().strftime('%Y-12-31')),
+                    '|',
+                        ('date_to', '=', False),
+                        ('date_to', '&gt;=', context_today().strftime('%Y-1-1'))
+                    ]"
+                     help="Active Allocations"/>
                 <separator/>
                 <filter string="My Allocations" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <separator/>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -196,12 +196,17 @@
                         context="{'search_default_employee_id': active_id}"
                         groups="base.group_user"
                         help="Remaining leaves">
-                    <div class="o_field_widget o_stat_info">
+                    <div class="o_field_widget o_stat_info" attrs="{'invisible': [('allocation_display', '=', '0')]}">
                         <span class="o_stat_value">
-                            <field name="allocation_used_display"/>/<field name="allocation_display"/> Days
+                            <field name="allocation_remaining_display"/>/<field name="allocation_display"/> Days
                         </span>
                         <span class="o_stat_text">
                             Time Off
+                        </span>
+                    </div>
+                    <div class="o_field_widget o_stat_info" attrs="{'invisible': [('allocation_display', '!=', '0')]}">
+                        <span class="o_stat_text">
+                           Time Off
                         </span>
                     </div>
                 </button>
@@ -324,7 +329,7 @@
                         help="Remaining leaves">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="allocation_used_display"/>/<field name="allocation_display"/> Days
+                            <field name="allocation_remaining_display"/>/<field name="allocation_display"/> Days
                         </span>
                         <span class="o_stat_text">
                             Time Off


### PR DESCRIPTION
The smartbutton needs to display the total of days available to the user to take holidays.
It should include unpaid allocations as well in the count of remaining days available.

Before this commit, the unpaid allocations were not included in the calculation of the remaining days available.

task - 2634892
