### PR TITLE
[FIX] stock reordering_rules : wrong description in PO line use case

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -460,10 +460,14 @@ class ProductProduct(models.Model):
         product_template_ids = self.sudo().mapped('product_tmpl_id').ids
 
         if partner_ids:
-            supplier_info = self.env['product.supplierinfo'].sudo().search([
-                ('product_tmpl_id', 'in', product_template_ids),
-                ('name', 'in', partner_ids),
-            ])
+            # name_get() of product with different quantities of the same supplier will be ambiguous, so
+            # we can pass a supplier_info in the context if we already know which one we want
+            supplier_info = self.env.context.get('supplier_info', False)
+            if not supplier_info:
+                supplier_info = self.env['product.supplierinfo'].sudo().search([
+                    ('product_tmpl_id', 'in', product_template_ids),
+                    ('name', 'in', partner_ids),
+                ])
             # Prefetch the fields used by the `name_get`, so `browse` doesn't fetch other fields
             # Use `load=False` to not call `name_get` for the `product_tmpl_id` and `product_id`
             supplier_info.sudo().read(['product_tmpl_id', 'product_id', 'product_name', 'product_code'], load=False)

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -233,8 +233,13 @@ class StockRule(models.Model):
         product_lang = product_id.with_prefetch().with_context(
             lang=partner.lang,
             partner_id=partner.id,
+            supplier_info=seller,
         )
-        name = product_lang.display_name
+        name_product_description = product_lang.name_get()
+        if not name_product_description:
+            name = product_lang.display_name  # Fallback to original behavior in case of problem
+        else:
+            name = name_product_description[0][1]  # name_product_description will be of the form list[tuple(product_id, name)]
         if product_lang.description_purchase:
             name += '\n' + product_lang.description_purchase
 


### PR DESCRIPTION
Issue: In a setup where the same supplier can provide one product with
varying amount (example one dozen and also by the unit), we could have
the wrong description (`name` field) on the PO line

Steps to reproduce :
 - Create a product with 2 or more supplier, all with different
 product name, price, quantity, and vendor reference, but
 **same vendor** (and same product of course)
- Create a reordering rule for that product, and trigger it
-> The RFQ will contain the right product, the right vendor,
 but the description of the  product (`name` field) will correspond to
 any of the vendor reference defined on the product supplier, whether
 it is the description of the correct supply (the supply which has the
 quantity and price of the PO line), or not

Side-Note:
 The issue could be quite complicated to deterministically replicate,
but in my opinion adding as much different supply path as possible will
increase the chance that the wrong one is selected
 But the key elements are : multiple "suppliers" (but same vendor !)
 for one product, as the way the name is currently set, is by looking at
 the suppliers and searching by `lang` and `partner.id`

opw-2633829
