### PR TITLE
[IMP] [website_]crm: post crm.leads merge message using a full template

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -28,6 +28,7 @@
         'security/crm_security.xml',
         'security/ir.model.access.csv',
 
+        'data/crm_lead_merge_template.xml',
         'data/crm_lead_prediction_data.xml',
         'data/crm_lost_reason_data.xml',
         'data/crm_stage_data.xml',

--- a/addons/crm/data/crm_lead_merge_template.xml
+++ b/addons/crm/data/crm_lead_merge_template.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="crm_lead_merge_summary" name="crm_lead_merge_summary">
+    <div class="crm_lead_merge_summary">
+        <t t-foreach="opportunities" t-as="lead">
+            <div>
+                <span>Merged the Lead/Opportunity</span>
+                <span class="font-weight-bold" t-field="lead.name"/>
+                <span>into this one.</span>
+            </div>
+            <blockquote class="border-left" data-o-mail-quote="1">
+                <div t-if="lead.expected_revenue">
+                    <span>Expected Revenues:</span>
+                    <span t-if="lead.expected_revenue">
+                        <span t-field="lead.expected_revenue"
+                            t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                        <span t-if="lead.recurring_revenue" groups="crm.group_use_recurring_revenues"> + </span>
+                    </span>
+                    <span t-if="lead.recurring_revenue" groups="crm.group_use_recurring_revenues">
+                        <span t-field="lead.recurring_revenue"
+                            t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                        <span t-field="lead.recurring_plan.name"/>
+                    </span>
+                </div>
+                <div t-elif="lead.recurring_revenue" groups="crm.group_use_recurring_revenues">
+                    <span t-field="lead.recurring_revenue"
+                        t-options='{"widget": "monetary", "display_currency": lead.company_currency}'/>
+                    <span t-field="lead.recurring_plan.name"/>
+                </div>
+                <div t-if="lead.probability">
+                    Probability: <span t-field="lead.probability"/>%
+                </div>
+                <div>
+                    Type: <span t-field="lead.type"/>
+                </div>
+                <div t-if="lead.type != 'lead'">
+                    Stage: <span t-field="lead.stage_id"/>
+                </div>
+                <div t-if="lead.priority">
+                    Priority: <span t-field="lead.priority"/>
+                </div>
+                <div>
+                    Created on: <span t-field="lead.create_date"/>
+                </div>
+                <div t-if="lead.date_action_last">
+                    Last Action: <span t-field="lead.date_action_last"/>
+                </div>
+                <div t-if="not is_html_empty(lead.description)">
+                    Notes: <span t-field="lead.description"/>
+                </div>
+                <div t-if="lead.user_id" class="mt-3">
+                    Salesperson: <span t-field="lead.user_id"/>
+                </div>
+                <div t-if="lead.team_id">
+                    Sales Team: <span t-field="lead.team_id"/>
+                </div>
+                <div name="company" groups="base.group_multi_company">
+                    Company: <span t-field="lead.company_id"/>
+                </div>
+                <div>
+                    <div class="mt-3"
+                            t-if="lead.contact_name or lead.partner_name or lead.phone or lead.mobile or lead.email_from or lead.website">
+                        <div class="font-weight-bold">
+                            Contact Details:
+                        </div>
+                        <div t-if="lead.contact_name">
+                            Contact: <span t-field="lead.contact_name"/>
+                        </div>
+                        <div t-if="lead.partner_name">
+                            Company Name: <span t-field="lead.partner_name"/>
+                        </div>
+                        <div t-if="lead.phone">
+                            Phone: <span t-field="lead.phone"/>
+                        </div>
+                        <div t-if="lead.mobile">
+                            Mobile: <span t-field="lead.mobile"/>
+                        </div>
+                        <div t-if="lead.email_from">
+                            Email: <span t-field="lead.email_from"/>
+                        </div>
+                        <div t-if="lead.email_cc">
+                            Email cc: <span t-field="lead.email_cc"/>
+                        </div>
+                        <div t-if="lead.website">
+                            Website: <span t-field="lead.website"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="mt-3"
+                        t-if="lead.street or lead.street2 or lead.zip or lead.city or lead.state_id or lead.country_id">
+                    <div class="font-weight-bold">
+                        Address:
+                    </div>
+                    <div t-if="lead.street" t-field="lead.street"/>
+                    <div t-if="lead.street2" t-field="lead.street2"/>
+                    <div t-if="lead.zip" t-field="lead.zip"/>
+                    <div t-if="lead.city" t-field="lead.city"/>
+                    <div t-if="lead.state_id" t-field="lead.state_id"/>
+                    <div t-if="lead.country_id" t-field="lead.country_id"/>
+                </div>
+                <div class="mt-3 mb-3" name="marketing"
+                        t-if="lead.campaign_id or lead.medium_id or lead.source_id">
+                    <div class="font-weight-bold">
+                        Marketing:
+                    </div>
+                    <div t-if="lead.campaign_id">
+                        Campaign: <span t-field="lead.campaign_id"/>
+                    </div>
+                    <div t-if="lead.medium_id">
+                        Medium: <span t-field="lead.medium_id"/>
+                    </div>
+                    <div t-if="lead.source_id">
+                        Source: <span t-field="lead.source_id"/>
+                    </div>
+                </div>
+            </blockquote>
+        </t>
+    </div>
+</template>
+
+</odoo>

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1234,54 +1234,6 @@ class Lead(models.Model):
 
         return data
 
-    def _merge_notify_get_merged_fields_message(self):
-        """ Generate the message body with the changed values
-
-        :param fields : list of fields to track
-        :returns a list of message bodies for the corresponding leads
-        """
-        bodies = []
-        for lead in self:
-            title = "%s : %s\n" % (_('Merged opportunity') if lead.type == 'opportunity' else _('Merged lead'), lead.name)
-            body = [title]
-            _fields = self.env['ir.model.fields'].sudo().search([
-                ('name', 'in', self._merge_get_fields()),
-                ('model_id.model', '=', lead._name),
-            ])
-            for field in _fields:
-                value = getattr(lead, field.name, False)
-                if field.ttype == 'selection':
-                    selections = lead.fields_get()[field.name]['selection']
-                    value = next((v[1] for v in selections if v[0] == value), value)
-                elif field.ttype == 'many2one':
-                    if value:
-                        value = value.sudo().display_name
-                elif field.ttype == 'many2many':
-                    if value:
-                        value = ','.join(
-                            val.display_name
-                            for val in value.sudo()
-                        )
-                body.append("%s: %s" % (field.field_description, value or ''))
-            bodies.append("<br/>".join(body + ['<br/>']))
-        return bodies
-
-    def _merge_notify(self, opportunities):
-        """ Post a message gathering merged leads/opps informations. It explains
-        which fields has been merged and their new value. `self` is the resulting
-        merge crm.lead record.
-
-        :param opportunities: see ``_merge_dependences``
-        """
-        # TODO JEM: mail template should be used instead of fix body, subject text
-        self.ensure_one()
-        merge_message = _('Merged leads') if self.type == 'lead' else _('Merged opportunities')
-        subject = merge_message + ": " + ", ".join(opportunities.mapped('name'))
-        # message bodies
-        message_bodies = opportunities._merge_notify_get_merged_fields_message()
-        message_body = "\n\n".join(message_bodies)
-        return self.message_post(body=message_body, subject=subject)
-
     def merge_opportunity(self, user_id=False, team_id=False, auto_unlink=True):
         """ Merge opportunities in one. Different cases of merge:
                 - merge leads together = 1 new lead
@@ -1325,7 +1277,14 @@ class Lead(models.Model):
             merged_data['team_id'] = team_id
 
         # log merge message
-        opportunities_head._merge_notify(opportunities_tail)
+        opportunities_head.message_post_with_view(
+            "crm.crm_lead_merge_summary",
+            values={
+                "opportunities": opportunities_tail,
+                "is_html_empty": is_html_empty
+            },
+            subtype_id=self.env.ref('mail.mt_note').id
+        )
         # merge other data (mail.message, attachments, ...) from tail into head
         opportunities_head._merge_dependences(opportunities_tail)
 

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -31,3 +31,9 @@
         }
     }
 }
+
+.crm_lead_merge_summary {
+    blockquote {
+        font-style: normal;
+    }
+}

--- a/addons/website_crm/__manifest__.py
+++ b/addons/website_crm/__manifest__.py
@@ -15,6 +15,7 @@ This module includes contact phone and mobile numbers validation.""",
     'depends': ['website', 'crm'],
     'data': [
         'security/ir.model.access.csv',
+        'data/crm_lead_merge_template.xml',
         'data/ir_actions_data.xml',
         'data/ir_model_data.xml',
         'views/crm_lead_views.xml',

--- a/addons/website_crm/data/crm_lead_merge_template.xml
+++ b/addons/website_crm/data/crm_lead_merge_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="crm_lead_merge_summary_inherit_website" inherit_id="crm.crm_lead_merge_summary">
+    <xpath expr="//div[@name='marketing']" position="attributes">
+        <attribute name="t-if">lead.campaign_id or lead.medium_id or lead.source_id or lead.visitor_ids</attribute>
+    </xpath>
+
+    <xpath expr="//div[@name='marketing']" position="inside">
+        <div t-if="lead.visitor_ids">
+            Web Visitors: <t t-out="', '.join(lead.visitor_ids.mapped('name'))"/>
+        </div>
+    </xpath>
+</template>
+
+</odoo>

--- a/addons/website_crm_partner_assign/__manifest__.py
+++ b/addons/website_crm_partner_assign/__manifest__.py
@@ -24,6 +24,7 @@ The automatic assignment is figured from the weight of partner levels and the ge
     'depends': ['base_geolocalize', 'crm', 'account',
                 'website_partner', 'website_google_map', 'portal'],
     'data': [
+        'data/crm_lead_merge_template.xml',
         'data/crm_tag_data.xml',
         'data/mail_template_data.xml',
         'security/ir.model.access.csv',

--- a/addons/website_crm_partner_assign/data/crm_lead_merge_template.xml
+++ b/addons/website_crm_partner_assign/data/crm_lead_merge_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="crm_lead_merge_summary_inherit_partner_assign" inherit_id="crm.crm_lead_merge_summary">
+    <xpath expr="//div[@name='company']" position="after">
+        <br t-if="lead.date_partner_assign or lead.partner_assigned_id" />
+        <div t-if="lead.partner_assigned_id">
+            Assigned Partner: <span t-field="lead.partner_assigned_id"/>
+        </div>
+        <div name="date_partner_assign" t-if="lead.date_partner_assign">
+            Partner Assignment Date: <span t-field="lead.date_partner_assign"/>
+        </div>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
Use a template for merge post messages and clean how fields are displayed,
notably by fixing the display format, and the field order.

Indeed, previously posted lead merge message contained all fields in an
alphabetical order, even ones that had empty values, which is not very user
friendly in terms of display.

The merged leads information are included in a "read more/read less" enabled
block using the "data-o-mail-quote" feature to get a nice rendering and avoid
cluttering the Odoo UI.

Within the sent mail however, the full text is directly visible when viewing
through a mail client.

Task-2451164

Co-authored-by: Aurélien Warnon <awa@odoo.com>