### PR TITLE
[FIX] sale_stock: prevent cancelling of pending deliveries

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -207,6 +207,9 @@ class SaleOrder(models.Model):
         return action
 
     def action_cancel(self):
+        res = super(SaleOrder, self).action_cancel()
+        if(isinstance(res, dict)):
+            return res
         documents = None
         for sale_order in self:
             if sale_order.state == 'sale' and sale_order.order_line:
@@ -221,7 +224,7 @@ class SaleOrder(models.Model):
                         continue
                 filtered_documents[(parent, responsible)] = rendering_context
             self._log_decrease_ordered_quantity(filtered_documents, cancel=True)
-        return super(SaleOrder, self).action_cancel()
+        return res
 
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()


### PR DESCRIPTION
Steps to reproduce the bug:
- Install sale and inventory
- Create a SO with Qty 10 and confirm it
- Go to the delivery
- Make partial delivery of 5 units and create back-order of remaining 5 units.
- the status of backorder is “waitting”
- Get back to the sale order and cancel it
- the wizard “sale_order_cancel” is displayed, which gives a reminder of some partial deliveries are already done and asks to confirm the cancellation of SO
- Do not confirm the cancellation of SO and click on the cancel button
- Go to the delivery
- The pending deliveries are cancelled

Problem:
The `"action_cancel"` function in the `"sale_order"` model is first called to cancel pending deliveries,
then the `"action_cancel"` function of the `"sale"` model is called, but in that we check if whether one of the deliveries
is already completed in order to display the wizard.

But if the customer clicks the cancel button in the wizard, the SO will not be canceled, but the pending deliveries will already be.

Solution:
Check in the `"action_cancel"` function of the `"sale.order"` model if whether one of the deliveries is already been completed,
if so, do not cancel the pending deliveries and wait for user confirmation in the wizard.

opw-2623404

customer video:

https://user-images.githubusercontent.com/78867936/132174980-6a42b925-5356-45f4-b090-c4e2880dbc81.mp4


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
