### PR TITLE
[FIX] web: owl_compatibility: don't call mounted when a rendering is …

### DIFF
--- a/addons/web/static/src/js/owl_compatibility.js
+++ b/addons/web/static/src/js/owl_compatibility.js
@@ -375,10 +375,17 @@ odoo.define('web.OwlCompatibility', function () {
          */
         on_attach_callback() {
             function recursiveCallMounted(component) {
+                const { status, currentFiber } = component.__owl__;
+
+                if (status === 2 && currentFiber && !currentFiber.isCompleted) {
+                    // the component is rendered but another rendering is being done
+                    // it would be foolish to declare the component and children as mounted
+                    return;
+                }
                 if (
-                    component.__owl__.status !== 2 /* RENDERED */ &&
-                    component.__owl__.status !== 3 /* MOUNTED */ &&
-                    component.__owl__.status !== 4 /* UNMOUNTED */
+                   status !== 2 /* RENDERED */ &&
+                   status !== 3 /* MOUNTED */ &&
+                   status !== 4 /* UNMOUNTED */
                 ) {
                     // Avoid calling mounted on a component that is not even
                     // rendered. Doing otherwise will lead to a crash if a


### PR DESCRIPTION
…being done

Following commit 637684fb50ff42a617cfa055d20aaa11b86c0b7b which improved
the conditions under which the ComponentWrapper compatibility layer
should trigger owl's `__callMounted` on all the owl children of a Legacy Widget.

One case was forgotten though: when the current component (wherever it is in the hierarchy)
is rendered BUT another rendering has been initiated meanwhile.

In that case, we shouldn't mark the component as mounted. The owl's fiber.complete algorithm
will take care of calling __callMounted when it finishes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
