### PR TITLE
[FIX] payment_authorize: charge tokens via the sandbox when disabled

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -30,10 +30,10 @@ class AuthorizeAPI():
 
         :param record acquirer: payment.acquirer account that will be contacted
         """
-        if acquirer.state == 'test':
-            self.url = 'https://apitest.authorize.net/xml/v1/request.api'
-        else:
+        if acquirer.state == 'enabled':
             self.url = 'https://api.authorize.net/xml/v1/request.api'
+        else:
+            self.url = 'https://apitest.authorize.net/xml/v1/request.api'
 
         self.state = acquirer.state
         self.name = acquirer.authorize_login


### PR DESCRIPTION
It's possible for a payment.acquirer to charge tokens when it's
disabled via the subscription app (_cron_recurring_create_invoice()).

Before this patch it would use the production endpoint. It's
unexpected and can cause accidental charges in a database meant for
testing.

opw-2637659
