### PR TITLE
[FIX] l10n_pe: l10n_pe_vat_code for VAT must be 0

### DIFF
--- a/addons/l10n_pe/data/l10n_latam_identification_type_data.xml
+++ b/addons/l10n_pe/data/l10n_latam_identification_type_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record model='l10n_latam.identification.type' id='l10n_latam_base.it_vat'>
-        <field name='l10n_pe_vat_code'>6</field>
+        <field name='l10n_pe_vat_code'>0</field>
     </record>
     <record model='l10n_latam.identification.type' id='l10n_latam_base.it_pass'>
         <field name='l10n_pe_vat_code'>7</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The VAT document type, which is used for foreigners, is the equivalent of: Non-Domiciled Tax Document.

The Non-Domiciled Tax Document has l10n_pe_vat_code = 0

This change has an impact on electronic invoicing in Peru, since non-domiciled persons must be referenced code 0, which is why currently invoices for foreigners are rejected by the sunat in Odoo

Legal Reference:  https://orientacion.sunat.gob.pe/sites/default/files/inline-files/TABLA_ANEXA_5.pdf

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
