### PR TITLE
[IMP] profiling, base: add enable profiling wizard

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_service.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_service.js
@@ -46,11 +46,15 @@ const profilingService = {
                 params
             );
             const resp = await orm.call("ir.profile", "set_profiling", [], kwargs);
-            state.session = resp.session;
-            state.collectors = resp.collectors;
-            state.params = resp.params;
-            bus.trigger("UPDATE");
-            updateDebugIcon();
+            if (resp.type) {  // most likely an "ir.actions.act_window"
+                env.services.action.doAction(resp);
+            } else {
+                state.session = resp.session;
+                state.collectors = resp.collectors;
+                state.params = resp.params;
+                bus.trigger("UPDATE");
+                updateDebugIcon();
+            }
         }
 
         function profilingSeparator() {

--- a/addons/web/tests/test_profiler.py
+++ b/addons/web/tests/test_profiler.py
@@ -46,7 +46,7 @@ class TestProfilingWeb(ProfilingHttpCase):
         # Trying to start profiling when not enabled
         self.env['ir.config_parameter'].set_param('base.profiling_enabled_until', '')
         res = self.profile_rpc({'profile': 1})
-        self.assertEqual(res['error']['data']['message'], 'Profiling is not enabled on this database')
+        self.assertEqual(res['result']['res_model'], 'base.enable.profiling.wizard')
         self.assertEqual(last_profile, self.env['ir.profile'].search([], limit=1, order='id desc'))
 
         # Enable profiling and start blank profiling
@@ -92,7 +92,7 @@ class TestProfilingPublic(ProfilingHttpCase):
 
         res = self.url_open('/web/set_profiling?profile=1')
         self.assertEqual(res.status_code, 500)
-        self.assertEqual(res.text, 'error: Profiling is not enabled on this database')
+        self.assertEqual(res.text, 'error: Profiling is not enabled on this database. Please contact an administrator.')
 
         expiration = datetime.datetime.now() + datetime.timedelta(seconds=50)
         self.env['ir.config_parameter'].set_param('base.profiling_enabled_until', expiration)

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -122,3 +122,4 @@
 "access_base_partner_merge_line","access.base.partner.merge.line","model_base_partner_merge_line","base.group_partner_manager",1,1,1,0
 "access_base_partner_merge_automatic_wizard","access.base.partner.merge.automatic.wizard","model_base_partner_merge_automatic_wizard","base.group_partner_manager",1,1,1,0
 "access_ir_profile","ir_profile","model_ir_profile","group_system",1,1,1,1
+"access_base_enable_profiling_wizard","access.base.enable.profiling.wizard","model_base_enable_profiling_wizard","group_system",1,1,1,0

--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -43,6 +43,30 @@
         </field>
     </record>
 
+    <record id="enable_profiling_wizard" model="ir.ui.view">
+        <field name="name">Enable profiling</field>
+        <field name="model">base.enable.profiling.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Enable profiling">
+                <div class="alert alert-warning" role="alert">
+                    <h3>Profiling is currently disabled.</h3>
+                    Profiling is a developer feature that should be used with caution on production database.
+                    It may add some load on the server, and potentially make it less responsive.
+                    Enabling the profiling here allows all users to activate profiling on their session.
+                    Profiling can be disabled at any moment in the settings.
+                </div>
+                <group>
+                    <field name="duration"/>
+                    <field name="expiration"/>
+                </group>
+                <footer>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                    <button string="Enable profiling" type="object" name="submit" class="btn btn-primary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
     <record id="action_menu_ir_profile" model="ir.actions.act_window">
         <field name="name">Ir profile</field>
         <field name="type">ir.actions.act_window</field>


### PR DESCRIPTION
When using profiling on a fresh test database, it can be tedious to
access settings to enable the feature. This commit adds a wizard to help
enabling profiling without accessing the settings when trying to
activate profiling on a administrator session.

![image](https://user-images.githubusercontent.com/35262360/132174286-256cec3f-6864-4a28-85cd-ea3df816235c.png)
