### PR TITLE
[IMP] account: avoid fetching debit, credit in aged partner balance

### DIFF
--- a/addons/account/report/account_aged_partner_balance.py
+++ b/addons/account/report/account_aged_partner_balance.py
@@ -128,9 +128,9 @@ class ReportAgedPartnerBalance(models.AbstractModel):
             # which look up the cache to determine the records to read, and has
             # quadratic complexity when the number of records is large...
             move_lines = self.env['account.move.line'].browse(aml_ids)
-            move_lines.read(['partner_id', 'company_id', 'balance', 'matched_debit_ids', 'matched_credit_ids'])
-            move_lines.mapped('matched_debit_ids').read(['max_date', 'company_id', 'amount'])
-            move_lines.mapped('matched_credit_ids').read(['max_date', 'company_id', 'amount'])
+            move_lines._read_from_database(['partner_id', 'company_id', 'balance'])
+            move_lines.mapped('matched_debit_ids')._read_from_database(['max_date', 'company_id', 'amount'])
+            move_lines.mapped('matched_credit_ids')._read_from_database(['max_date', 'company_id', 'amount'])
             for line in move_lines:
                 partner_id = line.partner_id.id or False
                 if partner_id not in partners_amount:


### PR DESCRIPTION
Perform fetching, using `read` or `_read_from_database` on matched debit
and credit takes a huge amount of time, if there are too many acml being
processed. Delay fetching to `mapped` improve the performance greatly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

- With the current implementation, while processing period with around 190k account move lines, the report need to fetch up to 900k partial reconciliation entries (matched debit and credit), and the result is very slow loading time (around 2mins)

Desired behavior after PR is merged:

- With changes, same data as above, the load time is improved by 2x (around 1min)
- Also, I suggest to change `read` to `_read_from_database` which also slightly improve the performance and also being used in `13.0`, see [this line](https://github.com/odoo/odoo/blob/71c3b588575f73f4d618359ce081336f4e9262b9/addons/account/report/account_aged_partner_balance.py#L139)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
