### PR TITLE
[FIX] stock: deadlock with scheduler

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -526,6 +526,8 @@ class ProcurementGroup(models.Model):
         # ensure that qty_* which depends on datetime.now() are correctly
         # recomputed
         orderpoints.sudo()._compute_qty_to_order()
+        if use_new_cursor:
+            self._cr.commit()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
 
         # Search all confirmed stock_moves and try to assign them


### PR DESCRIPTION
revert part of 4467734b77f19e3c4f4623e878d74c529a135bad

compute_qty_to_order is triggered manualy but not commited,
later in the scheduler task action_assign is call. However
product_id.stock_move_ids.state is a trigger of compute_qty_to_order
so it will be trigger a second time and deadlock itself

Also replace the cursor before procure_orderpoint_confirm,
so the procurement could have access to the data commited
by _compute_qty_to_order

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
