### PR TITLE
[IMP] point_of_sale: load partners after server data

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -230,14 +230,15 @@ class PosConfig(models.Model):
         help="If you deliver all products at once, the delivery order will be scheduled based on the greatest "
         "product lead time. Otherwise, it will be based on the shortest.")
     limited_products_loading = fields.Boolean('Limited Product Loading',
-                                              help="we load all starred products (favorite), all services, recent inventory movements of products, and the most recently updated products.\n"
-                                                   "When the session is open, we keep on loading all remaining products in the background.\n"
-                                                   "In the meantime, you can click on the 'database icon' in the searchbar to load products from database.")
+                                              help="By default, 20k products are loaded (in debug mode to modify the value).\n"
+                                                   "Loading rule : we load all starred products (favorite), all services, recent inventory movements of products, and the most recently updated products.\n"
+                                                   "When the session is open, if set below, we keep on loading all remaining products in the background.\n"
+                                                   "In the meantime, you can click on the 'database icon' in the searchbar to load products from database")
     limited_products_amount = fields.Integer(default=20000)
     product_load_background = fields.Boolean()
     limited_partners_loading = fields.Boolean('Limited Partners Loading',
-                                              help="By default, 100 partners are loaded.\n"
-                                                   "When the session is open, we keep on loading all remaining partners in the background.\n"
+                                              help="By default, 100 partners are loaded (in debug mode to modify the value).\n"
+                                                   "When the session is open, if set below, we keep on loading all remaining partners in the background.\n"
                                                    "In the meantime, you can use the 'Load Customers' button to load partners from database.")
     limited_partners_amount = fields.Integer(default=100)
     partner_load_background = fields.Boolean()

--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -176,6 +176,13 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             this.deactivateEditMode();
         }
         async searchClient() {
+            if(!this.state.query || !this.state.query.length) {
+                await this.showPopup('ErrorPopup', {
+                    title: this.env._t(''),
+                    body: this.env._t("Please first, write some customer's information within the search bar to look for it in the back-office database !"),
+                });
+                return;
+            }
             let result = await this.getNewClient();
             this.env.pos.db.add_partners(result);
             if(!result.length) {

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
@@ -40,8 +40,13 @@ odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
             this.trigger('update-search', productName);
         }
         async loadProductFromDB() {
-            if(!this.searchWordInput.el.value)
+            if(!this.searchWordInput.el.value) {
+                await this.showPopup('ErrorPopup', {
+                    title: this.env._t(''),
+                    body: this.env._t("Please first, write a product name within the search bar to look for it in the back-office database !"),
+                });
                 return;
+            }
 
             try {
                 let ProductIds = await this.rpc({


### PR DESCRIPTION
Change the way the the partners are load after the server data if the
option in the pos config is true. Before we used a different domain,
now we check it after the data are loaded.

This commit also change the tooltips of the settings in the pos config.
It also add errors messages when doing search with empty search bar.

This commit is link to the previous PR on this task: 1737
PR linked: https://github.com/odoo/odoo/pull/72108

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
