### PR TITLE
[FIX] hr_recruitment: Add back description to message subtype

### DIFF
--- a/addons/hr_recruitment/data/hr_recruitment_data.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_data.xml
@@ -282,6 +282,7 @@
         <field name="res_model">hr.applicant</field>
         <field name="default" eval="False"/>
         <field name="hidden" eval="True"/>
+        <field name="description">Applicant created</field>
     </record>
     <record id="mt_applicant_stage_changed" model="mail.message.subtype">
         <field name="name">Stage Changed</field>


### PR DESCRIPTION
Backport of the **fix** from https://github.com/odoo/odoo/pull/75736

Reverts 62bf009 as that is causing that no message is posted in the chatter upon creation.
Althought this might have been an issue before, #56631 removed the addition of the "Application created" message in the message body, so now there was nothing adding it, making the message invisible in the chatter.

---

**Description of the issue/feature this PR addresses:** 62bf009bebe46010ee04376f32b0a996a5d694e0 removed the `description` of the "New Application" message subtype. Although it was true that the creation message might be doubled before, https://github.com/odoo/odoo/pull/56631 removed the addition of the "Application created" message in the message body, so now there was nothing adding it, making the message invisible in the chatter. This adds back the `description` in the message subtype. Now, although that text is not passed to the message body, it is displayed in the chatter as expected.

**Current behavior before PR:** Tested in community and enterprise runbots, for v14 and master. 

If you create a new Job Application, you will see that no creation message is generated:
![image](https://user-images.githubusercontent.com/38977934/131329849-d12e097d-fd89-4fdc-8a35-6162a66337e9.png)

**Desired behavior after PR is merged:** Now, if we add a description to the associated message subtype:

![image](https://user-images.githubusercontent.com/38977934/131330003-7cb4d1c4-972b-4c7c-8c86-d603e6420c37.png)

(the same that is done in this commit)

We can create a new job application and see that the message is created correctly:

![image](https://user-images.githubusercontent.com/38977934/131330141-e9fcb1a3-fcfe-414b-99f8-b1bc3cdb8c06.png)

---

@Tecnativa
TT30413

ping @pedrobaeza @tivisse 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
