### PR TITLE
[FIX] core: missing cursor commit in module installation

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -598,6 +598,7 @@ class Module(models.Model):
 
         self._cr.commit()
         registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
+        self._cr.commit()
         self._cr.reset()
         assert self.env.registry is registry
 


### PR DESCRIPTION
Right after some module operation (install, uninstall), the framework
looks for some ir.actions.todo to execute.  Currently those actions
cannot be found, because the cursor seems to see the database in the
state it was just before the operation.  Simply add the commit() which
was removed by revision 1595c0ee27c7a261f8903dccb9dc550224c2aa05.