### PR TITLE
[FIX] hr_holidays: count only valid allocations in dashboard

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -647,10 +647,10 @@ class HolidaysRequest(models.Model):
 
     @api.constrains('state', 'number_of_days', 'holiday_status_id')
     def _check_holidays(self):
-        mapped_days = self.mapped('holiday_status_id').get_employees_days(self.mapped('employee_id').ids)
         for holiday in self:
             if holiday.holiday_type != 'employee' or not holiday.employee_id or holiday.holiday_status_id.requires_allocation == 'no':
                 continue
+            mapped_days = holiday.holiday_status_id.get_employees_days([holiday.employee_id.id], holiday.date_from)
             leave_days = mapped_days[holiday.employee_id.id][holiday.holiday_status_id.id]
             if float_compare(leave_days['remaining_leaves'], 0, precision_digits=2) == -1 or float_compare(leave_days['virtual_remaining_leaves'], 0, precision_digits=2) == -1:
                 raise ValidationError(_('The number of remaining time off is not sufficient for this time off type.\n'

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -181,11 +181,13 @@ class HolidaysAllocation(models.Model):
         allocations = self.sudo().search(domain)
         return [('id', 'in', allocations.ids)]
 
-    @api.depends('employee_id', 'holiday_status_id')
+    @api.depends('employee_id', 'holiday_status_id', 'taken_leave_ids.number_of_days', 'taken_leave_ids.state')
     def _compute_leaves(self):
         for allocation in self:
             allocation.max_leaves = allocation.number_of_hours_display if allocation.type_request_unit == 'hour' else allocation.number_of_days
-            allocation.leaves_taken = sum(taken_leave.number_of_hours_display if taken_leave.leave_type_request_unit == 'hour' else taken_leave.number_of_days for taken_leave in allocation.taken_leave_ids)
+            allocation.leaves_taken = sum(taken_leave.number_of_hours_display if taken_leave.leave_type_request_unit == 'hour' else taken_leave.number_of_days\
+                for taken_leave in allocation.taken_leave_ids\
+                if taken_leave.state == 'validate')
 
     @api.depends('number_of_days')
     def _compute_number_of_days_display(self):

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -315,7 +315,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=846, admin=865):
+        with self.assertQueryCount(__system__=867, admin=865):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -12,8 +12,8 @@ class HRLeaveType(models.Model):
         "Deduct Extra Hours", default=False,
         help="Once a time off of this type is approved, extra hours in attendances will be deducted.")
 
-    def get_employees_days(self, employee_ids):
-        res = super().get_employees_days(employee_ids)
+    def get_employees_days(self, employee_ids, date=None):
+        res = super().get_employees_days(employee_ids, date)
         deductible_time_off_type_ids = self.env['hr.leave.type'].search([
             ('overtime_deductible', '=', True),
             ('requires_allocation', '=', 'no')]).ids


### PR DESCRIPTION
Since the recent time off B2B, time off validity has been moved from the
time off type to the time off allocation. Meaning that a company may use
the same time off type every year for their yearly time off.
This means that the dashboard must display currently valid data.
Remaining leaves and taken leaves will now be computed in function of
that data aswell in the dashboard.

This commit also fixes being able to take a leave if the current
allocation does not permit it if an expired one would have made it
possible.

TaskId-2636405
