### PR TITLE
[FIX] purchase: Changing currency requires change quantity for update

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -194,6 +194,11 @@ class PurchaseOrder(models.Model):
             result.append((po.id, name))
         return result
 
+    @api.onchange('currency_id')
+    def onchange_currency_id(self):
+        for record in self:
+            record.order_line.onchange_currency_id()
+
     @api.onchange('date_planned')
     def onchange_date_planned(self):
         if self.date_planned:
@@ -1002,6 +1007,10 @@ class PurchaseOrderLine(models.Model):
             )
             rec.account_analytic_id = rec.account_analytic_id or default_analytic_account.analytic_id
             rec.analytic_tag_ids = rec.analytic_tag_ids or default_analytic_account.analytic_tag_ids
+
+    @api.onchange('currency_id')
+    def onchange_currency_id(self):
+        self._onchange_quantity()
 
     @api.onchange('product_id')
     def onchange_product_id(self):


### PR DESCRIPTION
Issue: When changing the currency of the PO with multi-currency enabled,
the price didn't automatically change according to the currency like
when we change the product quantity

Steps to reproduce :
 1) Install Purchase, enable multi-currencies
 2) Create a product with a cost of 1$
 3) Create a PO for that product
 4) Change PO currency to USD
 -> Nothing happens
 5) Update quantity
 -> The price_unit changes but since the quantity is changed as well it
 can be confusing

Why is that a bug:
 If we decide to recompute the cost when the quantity change and take
 into consideration the currency, when changing the currency we should
 also recompute the cost

Side-Note:
 There is also a secondary issue but I think it's not very important to
 change it : When changing the unit price on the PO and then changing
 the quantity (or with this commit changing the currency), the new price
 won't be the set unit price (modified by the user) multiplied by the
 quantity, but will be reset to the product cost times the quantity

opw-2638277