### PR TITLE
[FIX] website_rating: No round on product's rating

### DIFF
--- a/addons/website_rating/static/src/js/website_mail.js
+++ b/addons/website_rating/static/src/js/website_mail.js
@@ -62,7 +62,7 @@ odoo.define('website_rating.thread', function(require) {
                         if(0 < rating && rating <= 5){
                             rating_data['percent'].push({
                                 'num': rating,
-                                'percent': result['rating_stats']['percent'][rating],
+                                'percent': Math.round(result['rating_stats']['percent'][rating]),
                             });
                         }
                     });


### PR DESCRIPTION
Steps to reproduce the bug:

- Install website_sale
- Go to the shop and select a product P
- Enable ratings on P and add 3 ratings (4/5, 5/5, 5/5)

Bug:

The ratings displayed were 33.3333333... and 66.6666666... instead of 33 and 67

opw:2634167