### PR TITLE
[FIX] mail: cleanup onbeforeunload and rpc button locks

### DIFF
--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -80,6 +80,9 @@ export class ChatWindowHeader extends Component {
      */
     async _onClickCamera(ev) {
         ev.stopPropagation();
+        if (this.chatWindow.thread.hasPendingRtcRequest) {
+            return;
+        }
         await this.chatWindow.thread.toggleCall({ startWithVideo: true });
     }
 
@@ -89,6 +92,9 @@ export class ChatWindowHeader extends Component {
      */
     async _onClickPhone(ev) {
         ev.stopPropagation();
+        if (this.chatWindow.thread.hasPendingRtcRequest) {
+            return;
+        }
         await this.chatWindow.thread.toggleCall();
     }
 

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
@@ -27,6 +27,9 @@ export class RtcInvitationCard extends Component {
      */
     async _onClickAccept(ev) {
         this.thread.open();
+        if (this.thread.hasPendingRtcRequest) {
+            return;
+        }
         await this.thread.toggleCall();
     }
 
@@ -43,6 +46,9 @@ export class RtcInvitationCard extends Component {
      * @param {MouseEvent} ev
      */
     _onClickRefuse(ev) {
+        if (this.thread.hasPendingRtcRequest) {
+            return;
+        }
         this.thread.leaveCall();
     }
 

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.js
@@ -38,6 +38,9 @@ export class ThreadViewTopbar extends Component {
      * @param {MouseEvent} ev
      */
     async _onClickPhone(ev) {
+        if (this.threadViewTopBar.thread.hasPendingRtcRequest) {
+            return;
+        }
         await this.threadViewTopBar.thread.toggleCall();
     }
 
@@ -46,6 +49,9 @@ export class ThreadViewTopbar extends Component {
      * @param {MouseEvent} ev
      */
     async _onClickCamera(ev) {
+        if (this.threadViewTopBar.thread.hasPendingRtcRequest) {
+            return;
+        }
         await this.threadViewTopBar.thread.toggleCall({
             startWithVideo: true,
         });

--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -74,9 +74,9 @@ function factory(dependencies) {
             this._onKeyUp = this._onKeyUp.bind(this);
             browser.addEventListener('keydown', this._onKeyDown);
             browser.addEventListener('keyup', this._onKeyUp);
-            browser.addEventListener('beforeunload', async () => {
-                this.channel && await this.channel.leaveCall();
-            });
+            // Disconnects the RTC session if the page is closed or reloaded.
+            this._onBeforeUnload = this._onBeforeUnload.bind(this);
+            browser.addEventListener('beforeunload', this._onBeforeUnload);
             /**
              * Call all sessions for which no peerConnection is established at
              * a regular interval to try to recover any connection that failed
@@ -94,6 +94,7 @@ function factory(dependencies) {
          * @override
          */
         async _willDelete() {
+            browser.removeEventListener('beforeunload', this._onBeforeUnload);
             browser.removeEventListener('keydown', this._onKeyDown);
             browser.removeEventListener('keyup', this._onKeyUp);
             return super._willDelete(...arguments);
@@ -966,6 +967,16 @@ function factory(dependencies) {
         //----------------------------------------------------------------------
         // Handlers
         //----------------------------------------------------------------------
+
+        /**
+         * @private
+         * @param {Event} ev
+         */
+        async _onBeforeUnload(ev) {
+            if (this.channel) {
+                await this.channel.performRpcLeaveCall();
+            }
+        }
 
         /**
          * @private

--- a/addons/mail/static/src/models/rtc_controller/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller/rtc_controller.js
@@ -51,6 +51,9 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         async onClickRejectCall(ev) {
+            if (this.callViewer.threadView.thread.hasPendingRtcRequest) {
+                return;
+            }
             await this.callViewer.threadView.thread.leaveCall();
         }
 
@@ -65,6 +68,9 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         async onClickToggleAudioCall(ev) {
+            if (this.callViewer.threadView.thread.hasPendingRtcRequest) {
+                return;
+            }
             await this.callViewer.threadView.thread.toggleCall();
         }
 
@@ -72,6 +78,9 @@ function factory(dependencies) {
          * @param {MouseEvent} ev
          */
         async onClickToggleVideoCall(ev) {
+            if (this.callViewer.threadView.thread.hasPendingRtcRequest) {
+                return;
+            }
             await this.callViewer.threadView.thread.toggleCall({
                 startWithVideo: true,
             });


### PR DESCRIPTION
This commits adds a proper event listener removal for `onbeforeunload`
to facilitate testing and cleans up the join/leave rpc button locking.