### PR TITLE
[FIX] l10n_ch: display the qr_iban fields for Swiss partners

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -85,7 +85,7 @@ class ResPartnerBank(models.Model):
     def _compute_l10n_ch_show_subscription(self):
         for bank in self:
             if bank.partner_id:
-                bank.l10n_ch_show_subscription = bank.partner_id.ref_company_ids.country_id.code =='CH'
+                bank.l10n_ch_show_subscription = bank.partner_id.country_id.code =='CH'
             elif bank.company_id:
                 bank.l10n_ch_show_subscription = bank.company_id.country_id.code == 'CH'
             else:


### PR DESCRIPTION
Steps to reproduce the bug:
- install contact, accounting and l10n_cl
- Go to contact > create a new contact, e.g: “User CH” and choose Switzerland as country
- Go to configuration > Bank Accounts > create a new account
- Choose in the account holder field: "User CH"

Problem:
The QR-IBAN fields must be visible:
https://github.com/odoo/odoo/blob/13.0/addons/l10n_ch/views/res_bank_view.xml#L10-L15

The `"l10n_ch_show_subscription"` field is based on the country of companies that refer to the partner to check if it is swiss
while we must directly check the partner's country

Opw-2634006

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
