### PR TITLE
[FIX] stock: `report_stock_quantity` ambiguous column product_qty

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -44,8 +44,8 @@ FROM (
         END AS state,
         m.date_expected::date AS date,
         CASE
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qty
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN product_qty
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -m.product_qty
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN m.product_qty
         END AS product_qty,
         m.company_id,
         CASE
@@ -62,7 +62,7 @@ FROM (
     LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
     WHERE
         pt.type = 'product' AND
-        product_qty != 0 AND
+        m.product_qty != 0 AND
         (whs.id IS NULL or whd.id IS NULL OR whs.id != whd.id) AND
         m.state NOT IN ('cancel', 'draft', 'done')
     UNION
@@ -97,10 +97,10 @@ FROM (
             ELSE m.date::date - interval '1 day'
         END, '1 day'::interval)::date date,
         CASE
-            WHEN ((whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit') AND m.state = 'done' THEN product_qty
-            WHEN ((whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit') AND m.state = 'done' THEN -product_qty
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qty
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN product_qty
+            WHEN ((whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit') AND m.state = 'done' THEN m.product_qty
+            WHEN ((whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit') AND m.state = 'done' THEN -m.product_qty
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -m.product_qty
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN m.product_qty
         END AS product_qty,
         m.company_id,
         CASE
@@ -117,7 +117,7 @@ FROM (
     LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
     WHERE
         pt.type = 'product' AND
-        product_qty != 0 AND
+        m.product_qty != 0 AND
         (whs.id IS NULL or whd.id IS NULL OR whs.id != whd.id) AND
         m.state NOT IN ('cancel', 'draft')) as forecast_qty
 GROUP BY product_id, state, date, company_id, warehouse_id


### PR DESCRIPTION
In case there is a `product_qty` column added by a custom module,
`product_qty`, without specifying from which table to take it from
in the view definition, can lead to an ambiguous definition.

```
2021-08-25 12:25:31,624 1145 ERROR db_23001 odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/home/odoo/src/odoo/13.0/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/13.0/odoo/modules/loading.py", line 424, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check)
  File "/home/odoo/src/odoo/13.0/odoo/modules/loading.py", line 315, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/home/odoo/src/odoo/13.0/odoo/modules/loading.py", line 202, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/src/odoo/13.0/odoo/modules/registry.py", line 370, in init_models
    model.init()
  File "/home/odoo/src/odoo/13.0/addons/stock/report/report_stock_quantity.py", line 126, in init
    self.env.cr.execute(query)
  File "/home/odoo/src/odoo/13.0/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/13.0/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.AmbiguousColumn: column reference "product_qty" is ambiguous
LINE 21: ...AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qt...
```

upg-23001