### PR TITLE
[FIX] mail: prevents video access traceback after ending a call

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -795,6 +795,9 @@ function factory(dependencies) {
                 const sendDisplay = force !== undefined ? force : !this.sendDisplay;
                 await this._updateLocalVideoTrack(type, sendDisplay);
             }
+            if (!this.currentRtcSession) {
+                return;
+            }
             if (!this.videoTrack) {
                 this.currentRtcSession.removeVideo();
             } else {


### PR DESCRIPTION
Before this commit, it was assumed that the call was still active when
the video permission was granted, this assumption was false and this
commit fixes this issue.
