### PR TITLE
[FIX] stock_landed_costs: use the precision of currency for rounding …

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -205,7 +205,7 @@ class StockLandedCost(models.Model):
         AdjustementLines = self.env['stock.valuation.adjustment.lines']
         AdjustementLines.search([('cost_id', 'in', self.ids)]).unlink()
 
-        digits = self.env['decimal.precision'].precision_get('Product Price')
+        digits = self.currency_id.decimal_places
         towrite_dict = {}
         for cost in self.filtered(lambda cost: cost._get_targeted_move_ids()):
             total_qty = 0.0


### PR DESCRIPTION
…landed cost

There is a rounding problem because of decimal precision so we are change it to currency precision.

opw-2524218

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
