### PR TITLE
[FIX] mrp stock_picking : count to do and filter not matching

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -29,7 +29,7 @@ class StockPickingType(models.Model):
             return
         domains = {
             'count_mo_waiting': [('reservation_state', '=', 'waiting')],
-            'count_mo_todo': ['|', ('state', 'in', ('confirmed', 'draft', 'planned', 'progress'))],
+            'count_mo_todo': ['|', ('state', 'in', ('confirmed', 'draft', 'planned', 'progress', 'to_close'))],
             'count_mo_late': [('date_planned_start', '<', fields.Date.today()), ('state', '=', 'confirmed')],
         }
         for field in domains:


### PR DESCRIPTION
Issue: The button # To Process in mrp/views/stock_picking_views.xml
 at line 33 uses the domain state confirmed, draft, planned, or progress

But the default filter, which is called "to do", show those 4 states +
to_close (in mrp/views/mrp_production_views.xml line 309)

Side-Note: Issue also present in 14.0, so starting the bug fix from
here. 12.0 doesn't seem to have a to_close state but the count and
filter domain also do not match

Steps to reproduce in 14.0
 On Runbot, go to Inventory click on the "# to process" button on a
 Manufacturing card.
- Choose any MO and create a work order. On this work order, click
"Start", then "Done".
- The MO is now in the "To Close" stage.
- Go back to Inventory Overview. The number to process has gone down by
 one.
- Click on the "# to process" button, you will see that the "To Close"
 MO appears in the list but is not counted by the button.
(written by dido)

For 13.0 I haven't been able to find steps to reproduce but the button
has not changed between the two versions

opw-2636447