### PR TITLE
[MOV] project: move the dependent_ids fields to community

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -955,7 +955,12 @@ class Task(models.Model):
     # Task Dependencies fields
     allow_task_dependencies = fields.Boolean(related='project_id.allow_task_dependencies')
     # Tracking of this field is done in the write function
-    depend_on_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="task_id", column2="depends_on_id", string="Blocked By", domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
+    depend_on_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="task_id",
+                                     column2="depends_on_id", string="Blocked By",
+                                     domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
+    dependent_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="depends_on_id",
+                                     column2="task_id", string="Block",
+                                     domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
 
     # recurrence fields
     allow_recurring_tasks = fields.Boolean(related='project_id.allow_recurring_tasks')


### PR DESCRIPTION
This commit moves the project.task dependent_ids field to the community
project module in order to take advantage of this relation for further
development.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
