### PR TITLE
[FIX] survey: email html field better height

### DIFF
--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -45,7 +45,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>


### PR DESCRIPTION
Adjust the height of the HTML field for the email body
On the survey sharing email.

Regression introduced in 607c5ea4 (#75863)

task-2586137

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
