### PR TITLE
[FIX] snailmail: Updating country in snailmail.letter.missing.required.fields

### DIFF
--- a/addons/snailmail/wizard/snailmail_letter_missing_required_fields_views.xml
+++ b/addons/snailmail/wizard/snailmail_letter_missing_required_fields_views.xml
@@ -11,7 +11,7 @@
                 <group>
                     <label for="partner_id" string="Address"/>
                     <div class="o_address_format">
-                        <field name="partner_id" readonly="1" options="{'no_open': True}"/>
+                        <field name="partner_id" readonly="1" options="{'no_open': True}" force_save="1"/>
                         <field name="street" placeholder="Street..." class="o_address_street"/>
                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                         <field name="city" placeholder="City" class="o_address_city"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Open a customer invoice I for a customer C
- Remove the country from the address of C
- Click on button Print & send on I
- Set the country of C with CTR
- Click on Update and send

Bug:

The country of C was not saved.

opw:2633425