### PR TITLE
[FIX] website_sale: fix text color preview of ribbons

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -448,6 +448,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
      */
     createRibbon(previewMode, widgetValue, params) {
         this.saveMethod = 'create';
+        this.setRibbon(false);
         this.$ribbon.html('Ribbon text');
         this.$ribbon.addClass('bg-primary o_ribbon_left');
         this._toggleEditingUI(true);

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -427,7 +427,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         $ribbons.removeClass(htmlClasses);
 
         $ribbons.addClass(ribbon.html_class || '');
-        $ribbons.css('color', ribbon.text_color);
+        $ribbons.css('color', ribbon.text_color || '');
         $ribbons.css('background-color', ribbon.bg_color || '');
 
         if (!this.ribbons[widgetValue]) {
@@ -585,7 +585,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
                 colorClasses,
                 isTag: /o_tag_(left|right)/.test(ribbon.html_class),
                 isLeft: /o_(tag|ribbon)_left/.test(ribbon.html_class),
-                textColor: ribbon.text_color || colorClasses ? 'currentColor' : defaultTextColor,
+                textColor: ribbon.text_color || (colorClasses ? 'currentColor' : defaultTextColor),
             }));
         });
     },


### PR DESCRIPTION
Before this commit, the text color preview of the ribbons in the
ribbon selector was wrong. But also, if we selected another ribbon
just after changing the text color of a ribbon. This color was applied
to the selected ribbon.

task-2501515

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
