### PR TITLE
[FIX] mrp production: Workorders of backorder are created cancelled

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1465,7 +1465,7 @@ class MrpProduction(models.Model):
                     wo.qty_producing = 1
                 else:
                     wo.qty_producing = wo.qty_remaining
-                if wo.qty_producing == 0:
+                if wo.qty_produced == 0:
                     wo.action_cancel()
 
             # We need to adapt `duration_expected` on both the original workorders and their


### PR DESCRIPTION
Issue: When marking as done a MO for which the work orders have all
been done, but the quantity was reduced (from 0.2/0.2 to 1.0/2.0
for example), the workorder for the back order generated are cancelled

Steps to reproduce :
1) Install MRP, enable workcenters
2) Create a BoM for a new product with 2 operations
3) Create a Manufacturing Order for that BoM for 2 units
4) Plan it, finish the operations, then set the quantity produced to 1
5) Mark as done and create a back order
-> The operations of the back order are in canceled state

Side-note:
related to fix #63728

opw-2605862