### PR TITLE
Master time off accrual prorata wbr

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -24,6 +24,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_admin'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -34,6 +35,7 @@
         <field name="holiday_status_id" ref="holiday_status_comp"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_admin'))]"/>
         <field name="state">confirm</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -48,6 +50,7 @@
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_admin'))]"/>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
@@ -57,6 +60,7 @@
         <field name="holiday_status_id" ref="holiday_status_comp"/>
         <field name="number_of_days">12</field>
         <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_admin'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -71,6 +75,7 @@
         <field eval="(datetime.now() + relativedelta(day=1, weekday=0)).strftime('%Y-%m-%d 04:00:00')" name="request_date_from"/>
         <field eval="(datetime.now() + relativedelta(day=1, weekday=0) + relativedelta(weekday=2)).strftime('%Y-%m-%d 20:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_admin'))]"/>
     </record>
 
     <record id="hr_holidays_sl" model="hr.leave">
@@ -81,6 +86,7 @@
         <field eval="(datetime.now() + relativedelta(day=20, weekday=0)).strftime('%Y-%m-%d 04:00:00')" name="request_date_from"/>
         <field eval="(datetime.now() + relativedelta(day=20, weekday=0) + relativedelta(weekday=2)).strftime('%Y-%m-%d 20:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_admin"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_admin'))]"/>
         <field name="state">confirm</field>
     </record>
     <function model="hr.leave" name="action_validate">
@@ -111,6 +117,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_al"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_al'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -121,6 +128,7 @@
         <field name="holiday_status_id" ref="hr_holiday_status_dv"/>
         <field name="number_of_days">10</field>
         <field name="employee_id" ref="hr.employee_al"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_al'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -131,6 +139,7 @@
         <field name="holiday_status_id" ref="holiday_status_unpaid"/>
         <field name="number_of_days">12</field>
         <field name="employee_id" ref="hr.employee_al"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_al'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -145,6 +154,7 @@
         <field eval="time.strftime('%Y-%m-04')" name="request_date_from"/>
         <field eval="time.strftime('%Y-%m-10')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_al"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_al'))]"/>
     </record>
     <function model="hr.leave" name="action_validate">
         <value eval="ref('hr_holidays.hr_holidays_cl_al')"/>
@@ -158,6 +168,7 @@
         <field eval="(datetime.now()+relativedelta(months=1, day=17, weekday=0)).strftime('%Y-%m-%d 04:00:00')" name="request_date_from"/>
         <field eval="(datetime.now()+relativedelta(months=1, day=17, weekday=0) + relativedelta(weekday=2)).strftime('%Y-%m-%d 20:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_al"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_al'))]"/>
         <field name="state">confirm</field>
     </record>
     <function model="hr.leave" name="action_validate">
@@ -171,6 +182,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_mit"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_mit'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -182,6 +194,7 @@
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_mit"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_mit'))]"/>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
@@ -195,6 +208,7 @@
         <field eval="time.strftime('%Y-%m-18')" name="request_date_from"/>
         <field eval="time.strftime('%Y-%m-24')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_mit"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_mit'))]"/>
     </record>
     <function model="hr.leave" name="action_validate">
         <value eval="ref('hr_holidays.hr_holidays_cl_mit')"/>
@@ -208,6 +222,7 @@
         <field eval="(datetime.now() + relativedelta(day=5, weekday=0)).strftime('%Y-%m-%d 04:00:00')" name="request_date_from"/>
         <field eval="(datetime.now() + relativedelta(day=5, weekday=0) + relativedelta(weekday=2)).strftime('%Y-%m-%d 20:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_mit"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_mit'))]"/>
     </record>
 
     <!-- ++++++++++++++++++++++  Marc Demo  ++++++++++++++++++++++ -->
@@ -217,6 +232,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_qdp"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_qdp'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -227,6 +243,7 @@
         <field name="holiday_status_id" ref="holiday_status_unpaid"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_qdp"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_qdp'))]"/>
         <field name="state">confirm</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -244,6 +261,7 @@
         <field eval="(datetime.now()+relativedelta(months=1, day=3, weekday=0)).strftime('%Y-%m-%d 01:00:00')" name="request_date_from"/>
         <field eval="(datetime.now()+relativedelta(months=1, day=3, weekday=0) + relativedelta(weekday=2)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_qdp"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_qdp'))]"/>
         <field name="state">confirm</field>
     </record>
     <function model="hr.leave" name="action_validate">
@@ -258,6 +276,7 @@
         <field eval="(datetime.now() + relativedelta(day=1, weekday=0)).strftime('%Y-%m-%d 01:00:00')" name="request_date_from"/>
         <field eval="(datetime.now() + relativedelta(day=1, weekday=0) + relativedelta(days=2)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_qdp"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_qdp'))]"/>
         <field name="state">confirm</field>
     </record>
     <function model="hr.leave" name="action_validate">
@@ -271,6 +290,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_fpi"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_fpi'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -281,6 +301,7 @@
         <field name="holiday_status_id" ref="holiday_status_unpaid"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_fpi"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_fpi'))]"/>
         <field name="state">confirm</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -293,6 +314,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_niv"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_niv'))]"/>
         <field name="state">validate</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -303,6 +325,7 @@
         <field name="holiday_status_id" ref="holiday_status_unpaid"/>
         <field name="number_of_days">5</field>
         <field name="employee_id" ref="hr.employee_niv"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_niv'))]"/>
         <field name="state">confirm</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -320,6 +343,7 @@
         <field eval="time.strftime('%Y-%m-09')" name="request_date_from"/>
         <field eval="time.strftime('%Y-%m-16')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_niv"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_niv'))]"/>
         <field name="state">confirm</field>
     </record>
 
@@ -331,6 +355,7 @@
         <field eval="(datetime.now() + relativedelta(day=25, weekday=0)).strftime('%Y-%m-%d 01:00:00')" name="request_date_from"/>
         <field eval="(datetime.now() + relativedelta(day=25, weekday=0) + relativedelta(weekday=2)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_niv"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_niv'))]"/>
         <field name="state">confirm</field>
     </record>
     <function model="hr.leave" name="action_validate">
@@ -344,6 +369,7 @@
         <field name="holiday_status_id" ref="holiday_status_cl"/>
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_jve"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_jve'))]"/>
         <field name="state">confirm</field>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
@@ -355,6 +381,7 @@
         <field name="number_of_days">5</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_jve"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_jve'))]"/>
         <field name="date_from" eval="time.strftime('%Y-1-1')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
@@ -368,6 +395,7 @@
         <field eval="(datetime.now()+relativedelta(months=1, day=1, weekday=0)).strftime('%Y-%m-%d 01:00:00')" name="request_date_from"/>
         <field eval="(datetime.now()+relativedelta(months=1, day=1, weekday=0)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_jve"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_jve'))]"/>
         <field name="state">confirm</field>
     </record>
 
@@ -379,6 +407,7 @@
         <field eval="(datetime.now()+relativedelta(months=4, day=1, weekday=2)).strftime('%Y-%m-%d 01:00:00')" name="request_date_from"/>
         <field eval="(datetime.now()+relativedelta(months=4, day=1, weekday=2)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_jve"/>
+        <field name="employee_ids" eval="[(4, ref('hr.employee_jve'))]"/>
         <field name="state">confirm</field>
     </record>
 

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -783,7 +783,8 @@ class HolidaysRequest(models.Model):
     @api.constrains('holiday_allocation_id')
     def _check_allocation_id(self):
         for leave in self:
-            if leave.holiday_status_id.requires_allocation == 'yes' and not leave.holiday_allocation_id:
+            if leave.holiday_type == 'employee' and not leave.multi_employee and\
+                leave.holiday_status_id.requires_allocation == 'yes' and not leave.holiday_allocation_id:
                 raise ValidationError(_(
                     'Could not find an allocation of type %(leave_type)s for the requested time period.',
                     leave_type=leave.holiday_status_id.display_name,

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -471,7 +471,9 @@ class HolidaysRequest(models.Model):
         for holiday in self:
             if holiday.holiday_type == 'employee':
                 if not holiday.employee_ids:
-                    holiday.employee_ids = self.env.user.employee_id
+                    # This handles the case where a request is made with only the employee_id
+                    # but does not need to be recomputed on employee_id changes
+                    holiday.employee_ids = holiday.employee_id or self.env.user.employee_id
                 holiday.mode_company_id = False
                 holiday.category_id = False
             elif holiday.holiday_type == 'company':
@@ -487,7 +489,7 @@ class HolidaysRequest(models.Model):
                 holiday.employee_ids = False
                 holiday.mode_company_id = False
             else:
-                holiday.employee_ids = self.env.context.get('default_employee_id') or self.env.user.employee_id
+                holiday.employee_ids = self.env.context.get('default_employee_id') or holiday.employee_id or self.env.user.employee_id
 
     @api.depends('employee_id')
     def _compute_from_employee_id(self):
@@ -1024,6 +1026,7 @@ class HolidaysRequest(models.Model):
             'number_of_days': work_days_data[employee.id]['days'],
             'parent_id': self.id,
             'employee_id': employee.id,
+            'employee_ids': employee,
             'state': 'validate',
         } for employee in employees if work_days_data[employee.id]['days']]
 

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -9,7 +9,9 @@ class AccrualPlan(models.Model):
     _description = "Accrual Plan"
 
     name = fields.Char('Name', required=True)
-    time_off_type_id = fields.Many2one('hr.leave.type', string="Time Off Type")
+    time_off_type_id = fields.Many2one('hr.leave.type', string="Time Off Type",
+        help="""Specify if this accrual plan can only be used with this Time Off Type.
+                Leave empty if this accrual plan can be used with any Time Off Type.""")
     employees_count = fields.Integer("Employees", compute='_compute_employee_count')
     level_ids = fields.One2many('hr.leave.accrual.level', 'accrual_plan_id', copy=True)
     allocation_ids = fields.One2many('hr.leave.allocation', 'accrual_plan_id')

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -11,7 +11,7 @@ class AccrualPlan(models.Model):
     name = fields.Char('Name', required=True)
     time_off_type_id = fields.Many2one('hr.leave.type', string="Time Off Type")
     employees_count = fields.Integer("Employees", compute='_compute_employee_count')
-    level_ids = fields.One2many('hr.leave.accrual.level', 'accrual_plan_id')
+    level_ids = fields.One2many('hr.leave.accrual.level', 'accrual_plan_id', copy=True)
     allocation_ids = fields.One2many('hr.leave.allocation', 'accrual_plan_id')
     transition_mode = fields.Selection([
         ('immediately', 'Immediately'),

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -37,19 +37,20 @@ class AccrualPlanLevel(models.Model):
     accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', "Accrual Plan", required=True)
     start_count = fields.Integer(
         "Start after",
-        help="The accrual starts after a defined period from the employee start date. This field define the number of days, month or years after which accrual is used.", default="1")
+        help="The accrual starts after a defined period from the employee start date. This field defines the number of days, months or years after which accrual is used.", default="1")
     start_type = fields.Selection(
         [('day', 'day(s)'),
          ('month', 'month(s)'),
          ('year', 'year(s)')],
         default='day', string=" ", required=True,
-        help="This field define the unit of time after which the accrual starts.")
-    is_based_on_worked_time = fields.Boolean("Based on worked time")
+        help="This field defines the unit of time after which the accrual starts.")
+    is_based_on_worked_time = fields.Boolean("Based on worked time",
+        help="Only accrue for the time worked by the employee. This is the time when the employee did not take time off.")
 
     # Accrue of
     added_value = fields.Float(
-        "Gain", required=True,
-        help="The number of days that will be incremented for every period")
+        "Rate", required=True,
+        help="The number of hours/days that will be incremented in the specified Time Off Type for every period")
     added_value_type = fields.Selection(
         [('days', 'Days'),
          ('hours', 'Hours')],
@@ -93,7 +94,7 @@ class AccrualPlanLevel(models.Model):
         _get_selection_days, compute='_compute_days_display', inverse='_inverse_second_month_day_display')
     second_month = fields.Selection([
         ('jul', 'July'),
-        ('aug', 'Augustus'),
+        ('aug', 'August'),
         ('sep', 'September'),
         ('oct', 'October'),
         ('nov', 'November'),
@@ -107,7 +108,7 @@ class AccrualPlanLevel(models.Model):
         ('may', 'May'),
         ('jun', 'June'),
         ('jul', 'July'),
-        ('aug', 'Augustus'),
+        ('aug', 'August'),
         ('sep', 'September'),
         ('oct', 'October'),
         ('nov', 'November'),
@@ -118,14 +119,14 @@ class AccrualPlanLevel(models.Model):
         _get_selection_days, compute='_compute_days_display', inverse='_inverse_yearly_day_display')
     maximum_leave = fields.Float(
         'Limit to', required=False, default=100,
-        help="Choose a maximum limit of days for this accrual. 0 means no limit.")
+        help="Choose a cap for this accrual. 0 means no cap.")
     parent_id = fields.Many2one(
         'hr.leave.accrual.level', string="Previous Level",
         help="If this field is empty, this level is the first one.")
     action_with_unused_accruals = fields.Selection(
-        [('postponed', 'Postponed to next year'),
+        [('postponed', 'Transferred to the next year'),
          ('lost', 'Lost')],
-        string="At the end of the year, unused accruals will be",
+        string="At the end of the calendar year, unused accruals will be",
         default='postponed', required='True')
 
     _sql_constraints = [
@@ -138,7 +139,7 @@ class AccrualPlanLevel(models.Model):
          "(yearly_day > 0 AND yearly_day <= 31 AND frequency = 'yearly'))",
          "The dates you've set up aren't correct. Please check them."),
         ('start_count_check', "CHECK( start_count >= 0 )", "You can not start an accrual in the past."),
-        ('added_value_greater_than_zero', 'CHECK(added_value > 0)', 'You must give the gain greater than 0 in accrual plan levels.')
+        ('added_value_greater_than_zero', 'CHECK(added_value > 0)', 'You must give a rate greater than 0 in accrual plan levels.')
     ]
 
     @api.depends('start_count', 'start_type')

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -5,23 +5,25 @@ import datetime
 import calendar
 
 from dateutil.relativedelta import relativedelta
+from num2words import num2words
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.tools.date_utils import get_timedelta
+from odoo.tools.misc import get_lang
 
 
 DAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
 MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+# Used for displaying the days and reversing selection -> integer
+DAY_SELECT_VALUES = [str(i) for i in range(1, 29)] + ['last']
 
-def _get_date_check_month(year, month, day):
-    """
-    Returns the day it would be if day is outside of the month's range
-    Example: 2021 feb 30 -> 2021 mar 2
-    """
-    month_range = calendar.monthrange(year, month)
-    if day > month_range[1]:
-        return datetime.date(year, month, month_range[1]) + relativedelta(days=(day - month_range[1]))
-    return datetime.date(year, month, day)
+def _get_selection_days(self):
+    lang = get_lang(self.env).code
+    return [
+        (DAY_SELECT_VALUES[i - 1],
+        num2words(i, lang=lang, to='ordinal_num') if i < 29 else _('last day'))
+        for i in range(1, 30)
+    ]
 
 class AccrualPlanLevel(models.Model):
     _name = "hr.leave.accrual.level"
@@ -70,8 +72,14 @@ class AccrualPlanLevel(models.Model):
         ('sun', 'Sunday'),
     ], default='mon', required=True, string="Allocation on")
     first_day = fields.Integer(default=1)
+    first_day_display = fields.Selection(
+        _get_selection_days, compute='_compute_days_display', inverse='_inverse_first_day_display')
     second_day = fields.Integer(default=15)
+    second_day_display = fields.Selection(
+        _get_selection_days, compute='_compute_days_display', inverse='_inverse_second_day_display')
     first_month_day = fields.Integer(default=1)
+    first_month_day_display = fields.Selection(
+        _get_selection_days, compute='_compute_days_display', inverse='_inverse_first_month_day_display')
     first_month = fields.Selection([
         ('jan', 'January'),
         ('feb', 'February'),
@@ -81,6 +89,8 @@ class AccrualPlanLevel(models.Model):
         ('jun', 'June'),
     ], default="jan")
     second_month_day = fields.Integer(default=1)
+    second_month_day_display = fields.Selection(
+        _get_selection_days, compute='_compute_days_display', inverse='_inverse_second_month_day_display')
     second_month = fields.Selection([
         ('jul', 'July'),
         ('aug', 'Augustus'),
@@ -104,6 +114,8 @@ class AccrualPlanLevel(models.Model):
         ('dec', 'December')
     ], default="jan")
     yearly_day = fields.Integer(default=1)
+    yearly_day_display = fields.Selection(
+        _get_selection_days, compute='_compute_days_display', inverse='_inverse_yearly_day_display')
     maximum_leave = fields.Float(
         'Limit to', required=False, default=100,
         help="Choose a maximum limit of days for this accrual. 0 means no limit.")
@@ -125,7 +137,7 @@ class AccrualPlanLevel(models.Model):
          "(first_month_day > 0 AND first_month_day <= 31 AND second_month_day > 0 AND second_month_day <= 31 AND frequency = 'biyearly') or "
          "(yearly_day > 0 AND yearly_day <= 31 AND frequency = 'yearly'))",
          "The dates you've set up aren't correct. Please check them."),
-        ('start_count_check', "CHECK( start_count >= 1 )", "You must start after more than 0 days."),
+        ('start_count_check', "CHECK( start_count >= 0 )", "You can not start an accrual in the past."),
         ('added_value_greater_than_zero', 'CHECK(added_value > 0)', 'You must give the gain greater than 0 in accrual plan levels.')
     ]
 
@@ -153,90 +165,50 @@ class AccrualPlanLevel(models.Model):
             else:
                 level.level = 1
 
-    def _get_accrual_values(self, allocation_create_date):
-        """
-        This method returns all the accrual linked to their accrual_plan with the updated dynamic parameters depending
-        on the date.
-        :return: dict: {accrual_id, accrual_start, accrual_stop, nextcall, sufficient_seniority}
-         where accrual_start and accrual_stop are start and stop of the current period
-        """
-        today = fields.Date.context_today(self, )
-        results = []
-        for accrual in self:
-            seniority = allocation_create_date + get_timedelta(accrual.start_count, accrual.start_type)
-            frequency = accrual.frequency
-            if frequency == 'daily':
-                accrual_start = max(today, seniority.date())
-                accrual_stop = accrual_start + relativedelta(days=1)
-                nextcall = accrual_stop
-            elif frequency == 'weekly':
-                min_accrual_date = max(today, seniority.date())
-                if min_accrual_date.isoweekday() == DAYS.index(accrual.week_day):
-                    accrual_stop = min_accrual_date
-                else:
-                    accrual_stop = accrual._get_next_weekday(min_accrual_date, accrual.week_day)
-                accrual_start = accrual_stop - relativedelta(days=7)
-                nextcall = accrual._get_next_weekday(min_accrual_date, accrual.week_day)
-            elif frequency == 'bimonthly':
-                if today.day <= accrual.first_day:
-                    accrual_start = datetime.date(today.year, today.month, accrual.second_day) - relativedelta(months=1)
-                    accrual_stop = datetime.date(today.year, today.month, accrual.first_day)
-                    nextcall = datetime.date(today.year, today.month, accrual.second_day)
-                else:
-                    if today.day <= accrual.second_day:
-                        accrual_start = datetime.date(today.year, today.month, accrual.first_day)
-                        accrual_stop = datetime.date(today.year, today.month, accrual.second_day)
-                        nextcall = datetime.date(today.year, today.month, accrual.first_day) + relativedelta(months=1)
-                    else:
-                        accrual_start = datetime.date(today.year, today.month, accrual.second_day)
-                        accrual_stop = datetime.date(today.year, today.month, accrual.first_day) + relativedelta(months=1)
-                        nextcall = datetime.date(today.year, today.month, accrual.second_day) + relativedelta(months=1)
-            elif frequency == 'monthly':
-                if today.day <= accrual.first_day:
-                    accrual_start = datetime.date(today.year, today.month, accrual.first_day) - relativedelta(months=1)
-                    accrual_stop = datetime.date(today.year, today.month, accrual.first_day)
-                    nextcall = datetime.date(today.year, today.month, accrual.first_day) + relativedelta(months=1)
-                else:
-                    accrual_start = datetime.date(today.year, today.month, accrual.first_day)
-                    accrual_stop = datetime.date(today.year, today.month, accrual.first_day) + relativedelta(months=1)
-                    nextcall = datetime.date(today.year, today.month, accrual.first_day) + relativedelta(months=2)
-            elif frequency == 'biyearly':
-                first_month = MONTHS.index(accrual.first_month) + 1
-                second_month = MONTHS.index(accrual.second_month) + 1
-                potential_first_accrual_date = datetime.date(today.year, first_month, accrual.first_month_day)
-                potential_second_accrual_date = datetime.date(today.year, second_month, accrual.second_month_day)
-                if today <= potential_first_accrual_date:
-                    accrual_start = potential_second_accrual_date - relativedelta(years=1)
-                    accrual_stop = potential_first_accrual_date
-                    nextcall = potential_second_accrual_date
-                else:
-                    if today <= potential_second_accrual_date:
-                        accrual_start = potential_first_accrual_date
-                        accrual_stop = potential_second_accrual_date
-                        nextcall = potential_first_accrual_date + relativedelta(years=1)
-                    else:
-                        accrual_start = potential_second_accrual_date
-                        accrual_stop = potential_first_accrual_date + relativedelta(years=1)
-                        nextcall = potential_first_accrual_date + relativedelta(years=1)
-            elif frequency == 'yearly':
-                month = MONTHS.index(accrual.yearly_month) + 1
-                potential_accrual_date = datetime.date(today.year, month, accrual.yearly_day)
-                if today <= potential_accrual_date:
-                    accrual_start = potential_accrual_date - relativedelta(years=1)
-                    accrual_stop = potential_accrual_date
-                    nextcall = potential_accrual_date + relativedelta(years=1)
-                else:
-                    accrual_start = potential_accrual_date
-                    accrual_stop = potential_accrual_date + relativedelta(years=1)
-                    nextcall = accrual_stop
+    @api.depends('first_day', 'second_day', 'first_month_day', 'second_month_day', 'yearly_day')
+    def _compute_days_display(self):
+        days_select = _get_selection_days(self)
+        for level in self:
+            level.first_day_display = days_select[min(level.first_day - 1, 28)][0]
+            level.second_day_display = days_select[min(level.second_day - 1, 28)][0]
+            level.first_month_day_display = days_select[min(level.first_month_day - 1, 28)][0]
+            level.second_month_day_display = days_select[min(level.second_month_day - 1, 28)][0]
+            level.yearly_day_display = days_select[min(level.yearly_day - 1, 28)][0]
 
-            results.append({'accrual_level_id': accrual.id,
-                            'start_after': accrual.start_count,
-                            'accrual_start': datetime.datetime.combine(accrual_start, datetime.datetime.min.time()),
-                            'accrual_stop': datetime.datetime.combine(accrual_stop, datetime.datetime.min.time()),
-                            'nextcall': nextcall,
-                            'sufficient_seniority': seniority.date() <= today})
-        return results
+    def _inverse_first_day_display(self):
+        for level in self:
+            if level.first_day_display == 'last':
+                level.first_day = 31
+            else:
+                level.first_day = DAY_SELECT_VALUES.index(level.first_day_display) + 1
+
+    def _inverse_second_day_display(self):
+        for level in self:
+            if level.second_day_display == 'last':
+                level.second_day = 31
+            else:
+                level.second_day = DAY_SELECT_VALUES.index(level.second_day_display) + 1
+
+    def _inverse_first_month_day_display(self):
+        for level in self:
+            if level.first_month_day_display == 'last':
+                level.first_month_day = 31
+            else:
+                level.first_month_day = DAY_SELECT_VALUES.index(level.first_month_day_display) + 1
+
+    def _inverse_second_month_day_display(self):
+        for level in self:
+            if level.second_month_day_display == 'last':
+                level.second_month_day = 31
+            else:
+                level.second_month_day = DAY_SELECT_VALUES.index(level.second_month_day_display) + 1
+
+    def _inverse_yearly_day_display(self):
+        for level in self:
+            if level.yearly_day_display == 'last':
+                level.yearly_day = 31
+            else:
+                level.yearly_day = DAY_SELECT_VALUES.index(level.yearly_day_display) + 1
 
     def _get_next_date(self, last_call):
         """
@@ -246,47 +218,90 @@ class AccrualPlanLevel(models.Model):
         if self.frequency == 'daily':
             return last_call + relativedelta(days=1)
         elif self.frequency == 'weekly':
-            return self._get_next_weekday(last_call, self.week_day)
+            daynames = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+            weekday = daynames.index(self.week_day)
+            return last_call + relativedelta(days=1, weekday=weekday)
         elif self.frequency == 'bimonthly':
-            if last_call.day < self.first_day:
-                return _get_date_check_month(last_call.year, last_call.month, self.first_day)
-            elif last_call.day < self.second_day:
-                return _get_date_check_month(last_call.year, last_call.month, self.second_day)
+            first_date = last_call + relativedelta(day=self.first_day)
+            second_date = last_call + relativedelta(day=self.second_day)
+            if last_call < first_date:
+                return first_date
+            elif last_call < second_date:
+                return second_date
             else:
-                return _get_date_check_month(last_call.year, last_call.month, self.first_day) + relativedelta(months=1)
+                return last_call + relativedelta(months=1, day=self.first_day)
         elif self.frequency == 'monthly':
-            if last_call.day < self.first_day:
-                return _get_date_check_month(last_call.year, last_call.month, self.first_day)
+            date = last_call + relativedelta(self.first_day)
+            if last_call < date:
+                return date
             else:
-                return _get_date_check_month(last_call.year, last_call.month, self.first_day) + relativedelta(months=1)
+                return last_call + relativedelta(months=1, day=self.first_day)
         elif self.frequency == 'biyearly':
             first_month = MONTHS.index(self.first_month) + 1
             second_month = MONTHS.index(self.second_month) + 1
-            if last_call < _get_date_check_month(last_call.year, first_month, self.first_month_day):
-                return _get_date_check_month(last_call.year, first_month, self.first_month_day)
-            elif last_call < _get_date_check_month(last_call.year, second_month, self.second_month_day):
-                return _get_date_check_month(last_call.year, second_month, self.second_month_day)
+            first_date = last_call + relativedelta(month=first_month, day=self.first_month_day)
+            second_date = last_call + relativedelta(month=second_month, day=self.second_month_day)
+            if last_call < first_date:
+                return first_date
+            elif last_call < second_date:
+                return second_date
             else:
-                return _get_date_check_month(last_call.year, first_month, self.first_month_day) + relativedelta(years=1)
+                return last_call + relativedelta(years=1, month=first_month, day=self.first_month_day)
         elif self.frequency == 'yearly':
             month = MONTHS.index(self.yearly_month) + 1
-            if last_call < _get_date_check_month(last_call.year, month, self.yearly_day):
-                return _get_date_check_month(last_call.year, month, self.yearly_day)
+            date = last_call + relativedelta(month=month, day=self.yearly_day)
+            if last_call < date:
+                return date
             else:
-                return _get_date_check_month(last_call.year, month, self.yearly_day) + relativedelta(years=1)
+                return last_call + relativedelta(years=1, month=month, day=self.yearly_day)
         else:
             return False
 
-    @api.model
-    def _get_next_weekday(self, day, weekday):
+    def _get_previous_date(self, last_call):
         """
-        :param day: a datetime object
-        :param weekday: Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.
-        :return: datetime of the next weekday
+        Returns the date a potential previous call would have been at
+        For example if you have a monthly level giving 16/02 would return 01/02
+        Contrary to `_get_next_date` this function will return the 01/02 if that date is given
         """
-        daynames = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
-        weekday = daynames.index(weekday)
-        days_ahead = weekday - day.isoweekday()
-        if days_ahead <= 0:
-            days_ahead += 7
-        return day + relativedelta(days=days_ahead)
+        self.ensure_one()
+        if self.frequency == 'daily':
+            return last_call
+        elif self.frequency == 'weekly':
+            daynames = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+            weekday = daynames.index(self.week_day)
+            return last_call + relativedelta(days=-6, weekday=weekday)
+        elif self.frequency == 'bimonthly':
+            second_date = last_call + relativedelta(day=self.second_day)
+            first_date = last_call + relativedelta(day=self.first_day)
+            if last_call >= second_date:
+                return second_date
+            elif last_call >= first_date:
+                return first_date
+            else:
+                return last_call + relativedelta(months=-1, day=self.second_day)
+        elif self.frequency == 'monthly':
+            date = last_call + relativedelta(day=self.first_day)
+            if last_call >= date:
+                return date
+            else:
+                return last_call + relativedelta(months=-1, day=self.first_day)
+        elif self.frequency == 'biyearly':
+            first_month = MONTHS.index(self.first_month) + 1
+            second_month = MONTHS.index(self.second_month) + 1
+            first_date = last_call + relativedelta(month=first_month, day=self.first_month_day)
+            second_date = last_call + relativedelta(month=second_month, day=self.second_month_day)
+            if last_call >= second_date:
+                return second_date
+            elif last_call >= first_date:
+                return first_date
+            else:
+                return last_call + relativedelta(years=-1, month=second_month, day=self.second_month_day)
+        elif self.frequency == 'yearly':
+            month = MONTHS.index(self.yearly_month) + 1
+            year_date = last_call + relativedelta(month=month, day=self.yearly_day)
+            if last_call >= year_date:
+                return year_date
+            else:
+                return last_call + relativedelta(years=-1, month=month, day=self.yearly_day)
+        else:
+            return False

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -282,13 +282,11 @@ class HolidaysAllocation(models.Model):
         for allocation in self:
             allocation.manager_id = allocation.employee_id and allocation.employee_id.parent_id
 
-    @api.depends('employee_id', 'accrual_plan_id')
+    @api.depends('accrual_plan_id')
     def _compute_holiday_status_id(self):
         default_holiday_status_id = None
         for holiday in self:
-            if holiday.employee_id.user_id != self.env.user and holiday._origin.employee_id != holiday.employee_id:
-                holiday.holiday_status_id = False
-            elif not holiday.holiday_status_id:
+            if not holiday.holiday_status_id:
                 if holiday.accrual_plan_id:
                     holiday.holiday_status_id = holiday.accrual_plan_id.time_off_type_id
                 else:

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -315,7 +315,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=867, admin=865):
+        with self.assertQueryCount(__system__=870, admin=865):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -26,12 +26,20 @@
                         <label for="frequency"/>
                         <div class="o_col">
                             <field name="frequency"/>
-                            <div class="o_row">
-                                <label for="week_day" string="on" attrs="{'invisible': [('frequency', '!=', 'weekly')]}"/><field name="week_day" attrs="{'invisible': [('frequency', '!=', 'weekly')]}"/>
-                                <label for="first_day" string="on the" attrs="{'invisible': [('frequency', '!=', 'monthly')]}"/><field name="first_day" attrs="{'invisible': [('frequency', '!=', 'monthly')]}"/>
-                                <label for="first_day" string="on the" attrs="{'invisible': [('frequency', '!=', 'bimonthly')]}"/><field name="first_day" attrs="{'invisible': [('frequency', '!=', 'bimonthly')]}"/><span attrs="{'invisible': [('frequency', '!=', 'bimonthly')]}">and on the</span><field name="second_day" attrs="{'invisible': [('frequency', '!=', 'bimonthly')]}"/>
-                                <label for="first_month_day" string="on the" attrs="{'invisible': [('frequency', '!=', 'biyearly')]}"/><field name="first_month_day" attrs="{'invisible': [('frequency', '!=', 'biyearly')]}"/><field name="first_month" attrs="{'invisible': [('frequency', '!=', 'biyearly')]}"/><span attrs="{'invisible': [('frequency', '!=', 'biyearly')]}">and on the</span><field name="second_month_day" attrs="{'invisible': [('frequency', '!=', 'biyearly')]}"/><field name="second_month" attrs="{'invisible': [('frequency', '!=', 'biyearly')]}"/>
-                                <label for="yearly_day" string="on" attrs="{'invisible': [('frequency', '!=', 'yearly')]}"/><field name="yearly_day" attrs="{'invisible': [('frequency', '!=', 'yearly')]}"/><field name="yearly_month" attrs="{'invisible': [('frequency', '!=', 'yearly')]}"/>
+                            <div class="o_row" attrs="{'invisible': [('frequency', '!=', 'weekly')]}">
+                                <label for="week_day" string="on"/><field name="week_day"/>
+                            </div>
+                            <div class="o_row" attrs="{'invisible': [('frequency', '!=', 'monthly')]}">
+                                <label for="first_day_display" string="on the"/><field name="first_day_display" required="1"/> of the month
+                            </div>
+                            <div class="o_row" attrs="{'invisible': [('frequency', '!=', 'bimonthly')]}">
+                                <label for="first_day_display" string="on the"/><field name="first_day_display" required="1"/> and on the <field name="second_day_display" required="1"/> of the month
+                            </div>
+                            <div class="o_row" attrs="{'invisible': [('frequency', '!=', 'biyearly')]}">
+                                <label for="first_month_day_display" string="on the"/><field name="first_month_day_display" required="1"/> of <field name="first_month"/> and on the <field name="second_month_day_display" required="1"/> of <field name="second_month"/>
+                            </div>
+                            <div class="o_row" attrs="{'invisible': [('frequency', '!=', 'yearly')]}">
+                                <label for="yearly_day_display" string="on the"/><field name="yearly_day_display" required="1"/> of <field name="yearly_month"/>
                             </div>
                         </div>
                         <label for="maximum_leave"/>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -169,7 +169,7 @@
                                                     </t>
                                                 </div>
                                                 <div t-if="record.maximum_leave.value">
-                                                    Limit of <field name="maximum_leave"/> <field name="start_type"/>
+                                                    Limit of <field name="maximum_leave"/> <field name="added_value_type"/>
                                                 </div>
                                                 <div t-if="record.action_with_unused_accruals.raw_value">
                                                     At the end of the year, unused accruals will be <t t-if="record.action_with_unused_accruals.raw_value == 'postponed'">postponed</t><t t-else="">lost</t>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -46,7 +46,9 @@
                         <div class="o_col">
                             <div class="o_row">
                                 <field name="maximum_leave"/>
-                                <field name="added_value_type" nolabel="1" readonly="1"/>
+                                <!-- force_save is required here since it would otherwise not be saved due to the readonly
+                                     there is an issue when the field is present twice in the view. -->
+                                <field name="added_value_type" nolabel="1" readonly="1" force_save="1"/>
                             </div>
                         </div>
                         <field name="action_with_unused_accruals"/>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -62,9 +62,10 @@
         <field name="model">hr.leave.accrual.plan</field>
         <field name="arch" type="xml">
             <tree string="Accrual Plans">
-                <field name="name" class="col-3"/>
-                <field name="time_off_type_id" class="col-3"/>
-                <field name="employees_count" class="col-6"/>
+                <field name="name"/>
+                <field name="level_count"/>
+                <field name="time_off_type_id"/>
+                <field name="employees_count"/>
             </tree>
         </field>
     </record>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -162,7 +162,7 @@
                 <field name="employee_ids" widget="many2many_tags"
                     groups="hr_holidays.group_hr_holidays_user"
                     attrs="{'required': [('holiday_type', '=', 'employee'), ('state', 'in', ('draft', 'cancel', 'confirm'))],
-                    'invisible': ['|', ('holiday_type', '!=', 'employee'), ('state', 'not in', ('draft', 'cancel', 'confirm'))]}"/>
+                    'invisible': ['|', ('holiday_type', '!=', 'employee'), '&amp;', ('state', 'not in', ('draft', 'cancel', 'confirm')), ('employee_id', '!=', False)]}"/>
             </xpath>
             <xpath expr="//field[@name='employee_id']" position="after">
                 <field name="category_id"

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -406,7 +406,7 @@
                         'invisible': ['|', '|', ('holiday_type', '!=', 'employee'), ('state', '!=', 'validate'), ('employee_id', '=', False)]
                         }" widget="many2one_avatar_employee"/>
                     <field name="employee_ids" groups="hr_holidays.group_hr_holidays_user" attrs="{
-                        'required': [('holiday_type', '=', 'employee')],
+                        'required': [('holiday_type', '=', 'employee'), ('state', 'in', ('draft', 'cancel', 'refuse'))],
                         'invisible': ['|', ('holiday_type', '!=', 'employee'), '&amp;', ('state', '=', 'validate'), ('employee_id', '!=', False)],
                         }" widget="many2many_tags"/>
             </label>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -230,6 +230,7 @@
                 <div name="title">
                     <field name="display_name" invisible="1"/>
                     <field name="employee_id" nolabel="1" readonly="1" force_save="1" invisible="1"/>
+                    <field name="employee_ids" invisible="1"/>
                 </div>
                 <group>
                     <group name="col_left">

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -150,7 +150,7 @@ class HrLeave(models.Model):
     def create(self, vals_list):
         start_dates = [v.get('date_from') for v in vals_list if v.get('date_from')]
         stop_dates = [v.get('date_to') for v in vals_list if v.get('date_to')]
-        if any(vals.get('holiday_type', 'employee') == 'employee' and not vals.get('employee_id', False) for vals in vals_list):
+        if any(vals.get('holiday_type', 'employee') == 'employee' and not vals.get('multi_employee', False) and not vals.get('employee_id', False) for vals in vals_list):
             raise ValidationError(_("There is no employee set on the time off. Please make sure you're logged in the correct company."))
         with self.env['hr.work.entry']._error_checking(start=min(start_dates, default=False), stop=max(stop_dates, default=False)):
             return super().create(vals_list)

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -40,14 +40,14 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_write(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=25, admin=29):
+        with self.assertQueryCount(__system__=25, admin=30):
             leave.date_to = datetime(2018, 1, 1, 19, 0)
         leave.action_refuse()
 
     @users('__system__', 'admin')
     @warmup
     def test_performance_leave_create(self):
-        with self.assertQueryCount(__system__=26, admin=30):
+        with self.assertQueryCount(__system__=27, admin=30):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
 


### PR DESCRIPTION
Adds the necessary logic to make accrual plans prorated
compared to the period they represent.
For example:
- You have an accrual plan that gives 5 days every week on monday.
- You create a new allocation on a wednesday.
- On the monday following the creation of the allocation the allocation
  will receive 3/5 * 5 days (3 days) instead of 5 since the 'period'
  required for the full 5 days was not completed.

And other fixes related to time off B2B