### PR TITLE
[FIX] account: auto_join to speedup _kanban_dashboard

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -507,7 +507,7 @@ class AccountBankStatementLine(models.Model):
     # == Business fields ==
     move_id = fields.Many2one(
         comodel_name='account.move',
-        string='Journal Entry', required=True, readonly=True, ondelete='cascade',
+        string='Journal Entry', required=True, readonly=True, auto_join=True, ondelete='cascade',
         check_company=True)
     statement_id = fields.Many2one(
         comodel_name='account.bank.statement',


### PR DESCRIPTION
Add `auto_join=True` to `account.bank.statement.line.move_id`
to speedup `account.journal._get_last_bank_statement`, in turn
speeding up `account_journal_dashboard._kanban_dashboard`.

This avoids adding ORDER BY account_move.id in the IN subquery corresponding
to the leaf (move_id.state, '=', 'posted).

`account.bank.statement.line.move_id` is a delegate field. If I'm not mistaken,
rco argument in 22b0142d4e9d is also valid for v14. Mainly, adding
`auto_join = True` to `move_id` should not weaken `account_bank_statement_line`
security, as `_apply_ir_rules` will inject the parent model's security rules.

#### speedup

Customer DB, 65 cash/bank account_journal, 30k account_bank_statement_line,
330k account_move.

- account_journal._get_last_bank_statement (state = "posted") avg time: `119 ms -> 7 ms`.
- account_journal_dashboard._kanban_dashboard (33 journals) avg time: `7.5s -> 1.06s`.
- Accounting App search_read: `12.20s -> 3.40s`.

This branch, if merged, should probably be up-to 14.2 as 22b0142d4e9d adds `auto_join = True` to
delegate fields by default starting 14.3.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
