### PR TITLE
[FIX] account: accrued SO/PO process

### DIFF
--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -105,9 +105,9 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             # reverse move lines
             {'account_id': self.alt_exp_account.id, 'debit': 0, 'credit': 150 / 1.5, 'amount_currency': -150},
             {'account_id': self.account_expense.id, 'debit': 0, 'credit': 250 / 1.5, 'amount_currency': -250},
-            {'account_id': self.account_revenue.id, 'debit': 400 / 1.5, 'credit': 0, 'amount_currency': 400},
+            {'account_id': self.account_revenue.id, 'debit': 400 / 1.5, 'credit': 0, 'amount_currency': 0.0},
             # move lines
             {'account_id': self.alt_exp_account.id, 'debit': 150 / 1.5, 'credit': 0, 'amount_currency': 150},
             {'account_id': self.account_expense.id, 'debit': 250 / 1.5, 'credit': 0, 'amount_currency': 250},
-            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 400 / 1.5, 'amount_currency': -400},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 400 / 1.5, 'amount_currency': 0.0},
         ])

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -102,9 +102,9 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
             # reverse move lines
             {'account_id': self.alt_inc_account.id, 'debit': 150 / 1.5, 'credit': 0, 'amount_currency': 150},
             {'account_id': self.account_revenue.id, 'debit': 250 / 1.5, 'credit': 0, 'amount_currency': 250},
-            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 400 / 1.5, 'amount_currency': -400},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 400 / 1.5, 'amount_currency': 0.0},
             # move lines
             {'account_id': self.alt_inc_account.id, 'debit': 0, 'credit': 150 / 1.5, 'amount_currency': -150},
             {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 250 / 1.5, 'amount_currency': -250},
-            {'account_id': self.account_expense.id, 'debit': 400 / 1.5, 'credit': 0, 'amount_currency': 400},
+            {'account_id': self.account_expense.id, 'debit': 400 / 1.5, 'credit': 0, 'amount_currency': 0.0},
         ])


### PR DESCRIPTION
* the cache_invalidate() was invalidating the changes made in the wizard as well, make it impossible to set any value other than the default one, even though the preview entry was updated accordingly. That also prevented to simply validate the wizard as the accrual account was required but reset anytime we changed its value.
* the preview_data field was incorrectly set as Binary while the widget only supports Text


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
