### PR TITLE
[FIX] website: restore pricelist snippet options

### DIFF
--- a/addons/website/views/snippets/s_masonry_block.xml
+++ b/addons/website/views/snippets/s_masonry_block.xml
@@ -250,7 +250,7 @@
 </template>
 
 <!-- Options -->
-<template id="s_product_catalog_options" inherit_id="website.snippet_options">
+<template id="s_masonry_block_options" inherit_id="website.snippet_options">
     <xpath expr="//div[@data-js='layout_column']" position="after">
         <div data-js="MasonryLayout" data-selector=".s_masonry_block">
             <we-select string="Template"


### PR DESCRIPTION
Commit [1] did a shameless copy-paste of a <template> definition to
define the new masonry snippet options... forgetting to rename the xml
ID. This ends up with two website.s_product_catalog_options views
since [2], the second one overriding the first one.

[1]: https://github.com/odoo/odoo/commit/c90ab7b6646b603dcd0a49387b5eeba60ce17f59
[2]: https://github.com/odoo/odoo/commit/c90ab7b6646b603dcd0a49387b5eeba60ce17f59#diff-2a1ab0acc5a21712b0cd75d3f8d89815505f8341571bc3ab28c0c07bf549ceb2R253
