### PR TITLE
[FIX] core: inherited computed fields in onchange

### DIFF
--- a/odoo/addons/base/models/avatar_mixin.py
+++ b/odoo/addons/base/models/avatar_mixin.py
@@ -35,7 +35,7 @@ class AvatarMixin(models.AbstractModel):
         for record in self:
             avatar = record[image_field]
             if not avatar:
-                if record[record._avatar_name_field]:
+                if record.id and record[record._avatar_name_field]:
                     avatar = record._avatar_generate_svg()
                 else:
                     avatar = record._avatar_get_placeholder()

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -548,6 +548,8 @@ class TestOnChange(SavepointCaseWithUserDemo):
                     <field name="move_id" readonly="1" required="0"/>
                     <field name="tag_id"/>
                     <field name="tag_name"/>
+                    <field name="tag_repeat"/>
+                    <field name="tag_string"/>
                 </form>
             """,
         })
@@ -556,19 +558,32 @@ class TestOnChange(SavepointCaseWithUserDemo):
         # assigning 'tag_id' should modify 'move_id.tag_id' accordingly, which
         # should in turn recompute `move.tag_name` and `tag_name`
         form = Form(self.env['test_new_api.payment'], view)
+        self.assertEqual(form.tag_name, False)
         form.tag_id = foo
         self.assertEqual(form.tag_name, 'Foo')
+        self.assertEqual(form.tag_string, '')
+        form.tag_repeat = 2
+        self.assertEqual(form.tag_name, 'Foo')
+        self.assertEqual(form.tag_string, 'FooFoo')
 
         payment = form.save()
         self.assertEqual(payment.tag_id, foo)
         self.assertEqual(payment.tag_name, 'Foo')
+        self.assertEqual(payment.tag_repeat, 2)
+        self.assertEqual(payment.tag_string, 'FooFoo')
 
         with Form(payment, view) as form:
             form.tag_id = bar
             self.assertEqual(form.tag_name, 'Bar')
+            self.assertEqual(form.tag_string, 'BarBar')
+            form.tag_repeat = 3
+            self.assertEqual(form.tag_name, 'Bar')
+            self.assertEqual(form.tag_string, 'BarBarBar')
 
         self.assertEqual(payment.tag_id, bar)
         self.assertEqual(payment.tag_name, 'Bar')
+        self.assertEqual(payment.tag_repeat, 3)
+        self.assertEqual(payment.tag_string, 'BarBarBar')
 
 
 class TestComputeOnchange(common.TransactionCase):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1122,8 +1122,10 @@ class Field(MetaField('DummyField', (object,), {})):
                     for name, value in record._cache.items()
                     if is_inherited_field(name)
                 })
-                value = self.convert_to_cache(parent, record)
-                env.cache.set(record, self, value)
+                # in case the delegate field has inverse one2many fields, this
+                # updates the inverse fields as well
+                record._update_cache({self.name: parent}, validate=False)
+                value = env.cache.get(record, self)
 
             else:
                 # non-stored field or stored field on new record: default value


### PR DESCRIPTION
Assume that model A has a computed field G that depends on both fields F1 and F2.  Assume that model B inherits from A (_inherits).  When G is computed during an onchange, it must use the form values for all its dependencies F1 and F2.  Before this commit, only the field triggering the onchange was assigned on the parent record (see (*) below.)
    
state | record | parent
---|---|---
initial state  | F1=0, F2=0  | F1=0, F2=0
assign F1=1    | F1=1, F2=0  | F1=1, F2=0
assign F2=2    | F1=1, F2=1  | F1=0, F2=1 (*)
    
The commit also includes another patch: when assigning the parent record, the ORM determines the dependent records (in this case, the main record in the onchange).  If the delegate field (many2one from B to A) has an inverse one2many field, the ORM uses that field to determine dependent records.  However, in the case of a new record, that field is not in cache, and its value is determined to be... empty!  The patch consists in "fixing" the value of that field when we determine the parent record (when the delegate field is accessed.)
