### PR TITLE
[IMP] tests: improve subtest failure message

### DIFF
--- a/odoo/tests/runner.py
+++ b/odoo/tests/runner.py
@@ -59,7 +59,7 @@ class OdooTestResult(unittest.result.TestResult):
 
     def getDescription(self, test):
         if isinstance(test, unittest.case._SubTest):
-            return 'Subtest %s' % test._subDescription()
+            return 'Subtest %s.%s %s' % (test.test_case.__class__.__qualname__, test.test_case._testMethodName, test._subDescription())
         if isinstance(test, unittest.TestCase):
             # since we have the module name in the logger, this will avoid to duplicate module info in log line
             # we only apply this for TestCase since we can receive error handler or other special case


### PR DESCRIPTION
When a subtest fails, the failure message maybe a bit cryptic like
`Fail: Subtest (login=admin)`

With this commit, the parent test case and test method are displayed
too.

