### PR TITLE
[FIX] mass_mailing: fix assets call in layout

### DIFF
--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -119,7 +119,7 @@
         <t t-call="web.layout">
             <t t-set="head">
                 <t t-call-assets="web.assets_common"/>
-                <t t-call-assets="mass_mailing.assets_backend"/>
+                <t t-call-assets="web.assets_backend"/>
             </t>
             <body class="o_white_body">
                 <header>


### PR DESCRIPTION
Some assets are missing from layout due to an incorrect namespace since conversion to new assets system.

opw-2638542



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
