### PR TITLE
[FIX] mrp_subcontracting: fix details move button

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -73,7 +73,7 @@ class StockMove(models.Model):
         subcontracted product. Otherwise use standard behavior.
         """
         self.ensure_one()
-        if self._subcontrating_can_be_record():
+        if self._subcontrating_should_be_record() or self._subcontrating_can_be_record():
             return self._action_record_components()
         action = super(StockMove, self).action_show_details()
         if self.is_subcontract and self._get_subcontract_production():


### PR DESCRIPTION
The detail move button (`action_show_details`) should also
return record component wizard in case of tracked component
for a strict BoM.

task-2637543

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
