### PR TITLE
[FIX] website: open the editor from a translated homepage

### DIFF
--- a/addons/website/static/src/js/menu/translate.js
+++ b/addons/website/static/src/js/menu/translate.js
@@ -144,8 +144,11 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         var current = document.createElement('a');
         current.href = window.location.toString();
         current.search += (current.search ? '&' : '?') + 'enable_editor=1';
-        // we are in translate mode, the pathname starts with '/<url_code/'
-        current.pathname = current.pathname.substr(Math.max(0, current.pathname.indexOf('/', 1)));
+        // We are in translate mode, the pathname starts with '/<url_code>'. By
+        // adding a trailing slash we can simply search for the first slash
+        // after the language code to remove the language part.
+        const startPath = (current.pathname + '/').indexOf('/', 1);
+        current.pathname = current.pathname.substring(startPath);
 
         var link = document.createElement('a');
         link.href = '/website/lang/default';

--- a/addons/website/static/tests/tours/edit_translated_page.js
+++ b/addons/website/static/tests/tours/edit_translated_page.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+
+import tour from "web_tour.tour";
+
+tour.register('edit_translated_page_redirect', {
+    test: true,
+    url: '/nl/contactus',
+}, [
+    {
+        content: 'click edit master',
+        trigger: 'a[data-action="edit_master"]',
+    },
+    {
+        content: 'check editor dashboard',
+        trigger: '#oe_snippets',
+        run: () => {
+            // After checking the presence of the editor dashboard, we visit a
+            // translated version of the homepage. The homepage is a special
+            // case (there is no trailing slash), so we test it separately.
+            location.href = '/nl';
+        },
+    },
+    {
+        content: 'click edit master',
+        trigger: 'a[data-action="edit_master"]',
+    },
+    {
+        content: 'check editor dashboard',
+        trigger: '#oe_snippets',
+        run: () => {},
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -202,3 +202,8 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_09_website_edit_link_popover(self):
         self.start_tour("/", "edit_link_popover", login="admin")
+
+    def test_10_edit_translated_page_redirect(self):
+        lang = self.env['res.lang']._activate_lang('nl_NL')
+        self.env['website'].browse(1).write({'language_ids': [(4, lang.id, 0)]})
+        self.start_tour("/nl/contactus", 'edit_translated_page_redirect', login='admin')


### PR DESCRIPTION
A bug currently prevents opening the editor from a translated version of the homepage, for example `/nl_BE` (it works for other paths though). It is caused because the method `_goToMasterPage` can't find a trailing forward slash after the language code in the url path.

When clicking on the "Edit in master" button, the page now correctly redirects to the master version, solving the problem.

task-2622270