### PR TITLE
[FIX] mrp: backorder sequence fallback

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1417,7 +1417,7 @@ class MrpProduction(models.Model):
 
     def _get_backorder_mo_vals(self):
         self.ensure_one()
-        next_seq = max(self.procurement_group_id.mrp_production_ids.mapped("backorder_sequence"))
+        next_seq = max(self.procurement_group_id.mrp_production_ids.mapped("backorder_sequence"), default=1)
         return {
             'name': self._get_name_backorder(self.name, next_seq + 1),
             'backorder_sequence': next_seq + 1,


### PR DESCRIPTION
In case a production order lost is procurement group. The backorder
generation process do not have access to the last backorder sequence
used. This commit set a default value to avoid any traceback.

The new backorder  name will not be guaranteed exact related to the
production sequence but will be unique in any cases.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
