### PR TITLE
[FIX] mass_mailing: fix assets in unsubscribe page

### DIFF
--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -119,7 +119,7 @@
         <t t-call="web.layout">
             <t t-set="head">
                 <t t-call-assets="web.assets_common"/>
-                <t t-call-assets="mass_mailing.assets_backend"/>
+                <t t-call-assets="web.assets_backend"/>
             </t>
             <body class="o_white_body">
                 <header>


### PR DESCRIPTION
Since assets refactoring [1], old link `mass_mailing.assets_backend` [2] doesn't work.

Steps:

- create a local database, install mass_mailing on it
- go to settings - technical - outgoing mail servers and set up a mailcatcher
- create a mailing with recipients = mailing list and send it
- go to scheduled actions and run manually the Mail Marketing cron
- go to the mailcatcher, and open one unsubscribe links

[1] https://github.com/odoo/odoo/commit/03641610c2b4a6b832ea87795fd21e1d7af10b59
[2] https://github.com/odoo/odoo/blob/3cc4f7773fe5c2a5d5e8af72ce295264cc9b3117/addons/mass_mailing/views/assets.xml#L3

---

opw-2638520

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
