### PR TITLE
[IMP] stock: Improvements in replenishment wizard

### DIFF
--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -25,7 +25,8 @@
         'report/purchase_report_templates.xml',
         'report/report_stock_forecasted.xml',
         'report/report_stock_rule.xml',
-        'wizard/stock_replenishment_info.xml'
+        'wizard/stock_replenishment_info.xml',
+        'wizard/product_replenish_views.xml'
     ],
     'demo': [
         'data/purchase_stock_demo.xml',

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -55,7 +55,7 @@ class StockRule(models.Model):
                 supplier = procurement.values['supplierinfo_id']
             else:
                 supplier = procurement.product_id.with_company(procurement.company_id.id)._select_seller(
-                    partner_id=procurement.values.get("supplierinfo_name"),
+                    partner_id=procurement.values.get("supplierinfo_partner_id"),
                     quantity=procurement.product_qty,
                     date=procurement_date_planned.date(),
                     uom_id=procurement.product_uom)

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -519,7 +519,7 @@ class TestReorderingRule(TransactionCase):
                     "rule_id": warehouse.buy_pull_id,
                     "group_id": False,
                     "route_ids": [],
-                    "supplierinfo_name": secondary_vendor,
+                    "supplierinfo_partner_id": secondary_vendor,
                 }
             )])
         po_line = self.env["purchase.order.line"].search(

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -39,7 +39,7 @@ class TestReplenishWizard(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': self.product1.id,
             'product_tmpl_id': self.product1.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': self.product_uom_qty,
             'warehouse_id': self.wh.id,
         })
@@ -89,7 +89,7 @@ class TestReplenishWizard(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': product_to_buy.id,
             'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
@@ -144,7 +144,7 @@ class TestReplenishWizard(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': product_to_buy.id,
             'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
@@ -189,7 +189,7 @@ class TestReplenishWizard(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': product_to_buy.id,
             'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
@@ -237,7 +237,7 @@ class TestReplenishWizard(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': product_to_buy.id,
             'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })

--- a/addons/purchase_stock/wizard/__init__.py
+++ b/addons/purchase_stock/wizard/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import stock_replenishment_info
+from . import product_replenish

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ProductReplenish(models.TransientModel):
+    _inherit = 'product.replenish'
+
+    supplier_id = fields.Many2one("product.supplierinfo", string="Vendor")
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        product_id = self.env['product.product'].browse(res.get('product_id'))
+        product_tmpl_id = product_id.product_tmpl_id
+        orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', '=', product_tmpl_id.product_variant_id.id)])
+        if orderpoint:
+            res['supplier_id'] = orderpoint.supplier_id.id
+        elif product_tmpl_id.seller_ids:
+            res['supplier_id'] = product_tmpl_id.seller_ids[0].id
+        return res
+
+    def _prepare_run_values(self):
+        res = super()._prepare_run_values()
+        res['supplierinfo_partner_id'] = self.supplier_id.partner_id
+        return res

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_replenish_form_inherit_stock" model="ir.ui.view">
+        <field name="name">product.replenish.form.inherit.stock</field>
+        <field name="model">product.replenish</field>
+        <field name="inherit_id" ref="stock.view_product_replenish"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='route_id']" position="after">
+                <label for="supplier_id" attrs="{'invisible': [('show_vendor', '=', False)]}"/>
+                <div class="o_row">
+                    <field name="supplier_id" attrs="{'invisible': [('show_vendor', '=', False)], 'required': [('show_vendor', '=', True)]}" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
+                    <button name="action_stock_replenishment_info"
+                        type="object"
+                        title="Show Vendor"
+                        icon="fa-info-circle"
+                        attrs="{'invisible': [('show_vendor', '=', False)]}"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2499,7 +2499,7 @@ class TestRoutes(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': self.product1.id,
             'product_tmpl_id': self.product1.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': self.product_uom_qty,
             'warehouse_id': self.wh.id,
         })

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -1736,7 +1736,7 @@ class TestStockFlow(TestStockCommon):
         replenish_wizard = self.env['product.replenish'].create({
             'product_id': product.id,
             'product_tmpl_id': product.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
+            'uom_id': self.uom_unit.id,
             'quantity': '5',
             'warehouse_id': warehouse_company_1.id,
         })

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -16,17 +16,21 @@ class ProductReplenish(models.TransientModel):
     product_tmpl_id = fields.Many2one('product.template', string='Product Template', required=True)
     product_has_variants = fields.Boolean('Has variants', default=False, required=True)
     product_uom_category_id = fields.Many2one('uom.category', related='product_id.uom_id.category_id', readonly=True, required=True)
-    product_uom_id = fields.Many2one('uom.uom', string='Unity of measure', required=True)
+    product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id')
+    uom_id = fields.Many2one('uom.uom', string='Unity of measure', required=True)
     quantity = fields.Float('Quantity', default=1, required=True)
     date_planned = fields.Datetime('Scheduled Date', required=True, help="Date at which the replenishment should take place.")
     warehouse_id = fields.Many2one(
         'stock.warehouse', string='Warehouse', required=True,
         domain="[('company_id', '=', company_id)]")
-    route_ids = fields.Many2many(
-        'stock.location.route', string='Preferred Routes',
-        help="Apply specific route(s) for the replenishment instead of product's default routes.",
+    route_id = fields.Many2one(
+        'stock.location.route', string='Preferred Route',
+        help="Apply specific route for the replenishment instead of product's default routes.",
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     company_id = fields.Many2one('res.company')
+    forecasted_quantity = fields.Float(string="Forecasted Quantity", compute="_compute_forecasted_quantity")
+    allowed_route_ids = fields.Many2many("stock.location.route", compute="_compute_allowed_route_ids")
+    show_vendor = fields.Boolean(compute="_compute_show_vendor")
 
     @api.model
     def default_get(self, fields):
@@ -45,8 +49,8 @@ class ProductReplenish(models.TransientModel):
                 if len(product_tmpl_id.product_variant_ids) > 1:
                     res['product_has_variants'] = True
         company = product_tmpl_id.company_id or self.env.company
-        if 'product_uom_id' in fields:
-            res['product_uom_id'] = product_tmpl_id.uom_id.id
+        if 'uom_id' in fields:
+            res['uom_id'] = product_tmpl_id.uom_id.id
         if 'company_id' in fields:
             res['company_id'] = company.id
         if 'warehouse_id' in fields and 'warehouse_id' not in res:
@@ -80,8 +84,41 @@ class ProductReplenish(models.TransientModel):
 
         values = {
             'warehouse_id': self.warehouse_id,
-            'route_ids': self.route_ids,
+            'route_ids': self.route_id,
             'date_planned': self.date_planned,
             'group_id': replenishment,
         }
         return values
+
+    @api.depends('warehouse_id', 'product_id')
+    def _compute_forecasted_quantity(self):
+        self.forecasted_quantity = self.product_id.with_context(warehouse=self.warehouse_id.id).virtual_available
+
+    @api.depends('route_id')
+    def _compute_show_vendor(self):
+        for rec in self:
+            rec.show_vendor = rec.route_id.name == "Buy"
+
+    @api.depends('product_id', 'product_tmpl_id')
+    def _compute_allowed_route_ids(self):
+        route_ids = self.env['stock.rule'].search([('picking_type_id.active', '=', True), ('picking_type_id.sequence_code', '!=', 'DS'), ('company_id', '=?', self.company_id.id)]).route_id.ids
+        for rec in self:
+            rec.allowed_route_ids = list(set(route_ids).intersection(rec.product_id.route_ids.ids))
+
+    @api.onchange('route_id')
+    def _onchange_route_id(self):
+        for rec in self:
+            if rec.route_id.name == (_("Buy")) and not rec.product_id.product_tmpl_id.seller_ids:
+                raise UserError(_("No vendor list defined for product %s. Go on the product form and complete the list of vendors.", rec.product_id.name))
+
+    def action_stock_replenishment_info(self):
+        self.ensure_one()
+        action = self.env['ir.actions.actions']._for_xml_id('stock.action_stock_replenishment_info')
+        orderpoint = self.env["stock.warehouse.orderpoint"].search([("product_id", "=", self.product_id.id)])
+        if not orderpoint:
+            orderpoint = self.env["stock.warehouse.orderpoint"].create({
+                "product_id": self.product_id.id,
+                "warehouse_id": self.warehouse_id.id,
+            })
+        action["context"] = {"default_orderpoint_id": orderpoint.id}
+        return action

--- a/addons/stock/wizard/product_replenish_views.xml
+++ b/addons/stock/wizard/product_replenish_views.xml
@@ -11,26 +11,34 @@
                 a manufacturing order or a transfer.
                 </p>
                 <group>
-                    <field name="product_tmpl_id" invisible="1"/>
-                    <field name="product_has_variants" invisible="1"/>
-                    <field name="product_id"
-                        domain="[('product_tmpl_id', '=', product_tmpl_id)]"
-                        attrs="{'readonly': [('product_has_variants', '=', False)]}"
-                        options="{'no_create_edit':1}"/>
-                    <field name="product_uom_category_id" invisible="1"/>
-                    <label for="quantity"/>
-                    <div class="o_row">
-                        <field name="quantity" />
-                        <field name="product_uom_id"
-                            domain="[('category_id', '=', product_uom_category_id)]"
-                            groups="uom.group_uom"/>
-                    </div>
-                    <field name="date_planned"/>
-                    <field name="warehouse_id"
-                        groups="stock.group_stock_multi_warehouses"/>
-                    <field name="route_ids"
-                        widget="many2many_tags"/>
-                    <field name="company_id" invisible="1"/>
+                    <group>
+                        <field name="product_tmpl_id" invisible="1"/>
+                        <field name="product_has_variants" invisible="1"/>
+                        <field name="product_uom_category_id" invisible="1"/>
+                        <field name="allowed_route_ids" invisible="1"/>
+                        <field name="company_id" invisible="1"/>
+                        <field name="show_vendor" invisible="1"/>
+                        <field name="product_id"
+                            domain="[('product_tmpl_id', '=', product_tmpl_id)]"
+                            attrs="{'readonly': [('product_has_variants', '=', False)]}"
+                            options="{'no_open': 1, 'no_create': 1}"/>
+                        <label for="quantity"/>
+                        <div class="o_row">
+                            <field name="quantity" />
+                            <field name="uom_id"
+                                domain="[('category_id', '=', product_uom_category_id)]"
+                                groups="uom.group_uom"/>
+                        </div>
+                        <label for="forecasted_quantity"/>
+                        <div class="o_row">
+                            <field name="forecasted_quantity" readonly="1"/>
+                            <field name="product_uom_id" domain="[('category_id', '=', product_uom_category_id)]" groups="uom.group_uom" readonly="1"/>
+                        </div>
+                        <field name="date_planned" widget="date"/>
+                        <field name="warehouse_id"
+                            groups="stock.group_stock_multi_warehouses"/>
+                        <field name="route_id" domain="[('id', 'in', allowed_route_ids)]"/>
+                    </group>
                 </group>
                 <footer>
                     <button name="launch_replenishment"


### PR DESCRIPTION
In this commit:
========================
1. Reduced the width of all the fields by adding group
2. Added a new field `forecasted_qty` in replenishment to display the
forecasted qty based on selected warehouse in the wizard
3. Changed `route_ids`(m2m) field to `route_id`(m2o)
4. Hide Dropship route from the Route
5. Display Supplier Info for the selected product if `Buy` route is selected

task: 2579425

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
