### PR TITLE
[FIX] account move: Due date not updated when invoice_date changed

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -407,6 +407,8 @@ class AccountMove(models.Model):
             if accounting_date != self.date:
                 self.date = accounting_date
                 self._onchange_currency()
+            else:
+                self._onchange_recompute_dynamic_lines()
 
     @api.onchange('journal_id')
     def _onchange_journal(self):

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from freezegun import freeze_time
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests.common import Form
 from odoo.tests import tagged
@@ -148,6 +150,22 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             with Form(self.invoice) as move_form:
                 move_form.invoice_date = invoice_date
             self.assertEqual(self.invoice.date, fields.Date.to_date(accounting_date))
+
+    @freeze_time('2021-09-16')
+    def test_in_invoice_onchange_invoice_date_2(self):
+        invoice_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice', account_predictive_bills_disable_prediction=True))
+        invoice_form.partner_id = self.partner_a
+        invoice_form.invoice_payment_term_id = self.env.ref('account.account_payment_term_30days')
+        with invoice_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_a
+        invoice_form.invoice_date = fields.Date.from_string('2021-09-01')
+        invoice = invoice_form.save()
+
+        self.assertRecordValues(invoice, [{
+            'date': fields.Date.from_string('2021-09-16'),
+            'invoice_date': fields.Date.from_string('2021-09-01'),
+            'invoice_date_due': fields.Date.from_string('2021-10-01'),
+        }])
 
     def test_in_invoice_line_onchange_product_1(self):
         move_form = Form(self.invoice)


### PR DESCRIPTION
Issue: When changing the bill date (invoice_date) of a vendor bill,
the due date (invoice_payment_term_id) is not updated correctly

Steps to reproduce :
1) Install Accounting, Purchase
2) Create a vendor bill
3) (debug) Edit the view, remove the invisible attr for the div with
label invoice_payment_term_id
4) For the vendor bill, in that order, set the Vendor, then the due date
to 30 days, then bill date, then add a product
5) Due date is now set to 30 days after the bill date
6) Change the Bill Date
-> Due Date stays unchanged

opw-2627686