### PR TITLE
[FIX] mail: prevent video auto fullScreen and add autoplay on safari

### DIFF
--- a/addons/mail/static/src/components/rtc_video/rtc_video.js
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.js
@@ -60,11 +60,22 @@ export class RtcVideo extends Component {
     //--------------------------------------------------------------------------
 
     /**
+     * Plays the video as some browsers may not support or block autoplay.
+     *
      * @private
      * @param {Event} ev
      */
     async _onVideoLoadedMetaData(ev) {
-        await ev.target.play();
+        try {
+            await ev.target.play();
+        } catch (error)  {
+            if (typeof error === 'object' && error.name === 'NotAllowedError') {
+                // Ignored as some browsers may reject play() calls that do not
+                // originate from a user input.
+                return;
+            }
+            throw error;
+        }
     }
 }
 

--- a/addons/mail/static/src/components/rtc_video/rtc_video.xml
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.xml
@@ -4,7 +4,11 @@
     <t t-name="mail.RtcVideo" owl="1">
         <video class="o_RtcVideo_video"
            t-ref="video"
-           t-on-loadedmetadata="_onVideoLoadedMetaData"/>
+           playsinline="true"
+           autoplay="true"
+           muted="true"
+           t-on-loadedmetadata="_onVideoLoadedMetaData"
+        />
     </t>
 
 </templates>


### PR DESCRIPTION
Before this commit, safari mobile would immediately launch new videos
as fullScreen, while safari would prevent the autoplay of videos, as
the play request didn't originate from a user input.

