### PR TITLE
[IMP] hr_holidays: delete from dashboard in year view

### DIFF
--- a/addons/web/static/src/legacy/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_controller.js
@@ -179,6 +179,34 @@ var CalendarController = AbstractController.extend({
         return this.model.updateRecord(record).then(reload, reload);
     },
 
+    /**
+     * @private
+     */
+    _getEventId(event) {
+        var id = event.data._id;
+        id = id && parseInt(id).toString() === id ? parseInt(id) : id;
+        return id;
+    },
+
+    /**
+     * @private
+     */
+    _getFormDialogOptions: function(self, event) {
+        var id = this._getEventId(event);
+        return {
+            res_model: self.modelName,
+            res_id: id || null,
+            context: event.context || self.context,
+            title: _.str.sprintf(_t("Open: %s"), event.data.title),
+            on_saved: function () {
+                if (event.data.on_save) {
+                    event.data.on_save();
+                }
+                self.reload();
+            },
+        };
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -412,8 +440,7 @@ var CalendarController = AbstractController.extend({
      */
     _onOpenEvent: function (event) {
         var self = this;
-        var id = event.data._id;
-        id = id && parseInt(id).toString() === id ? parseInt(id) : id;
+        var id = self._getEventId(event);
 
         if (!this.eventOpenPopup) {
             this._rpc({
@@ -435,18 +462,8 @@ var CalendarController = AbstractController.extend({
             return;
         }
 
-        var options = {
-            res_model: self.modelName,
-            res_id: id || null,
-            context: event.context || self.context,
-            title: _.str.sprintf(_t("Open: %s"), event.data.title),
-            on_saved: function () {
-                if (event.data.on_save) {
-                    event.data.on_save();
-                }
-                self.reload();
-            },
-        };
+        var options = self._getFormDialogOptions(self, event);
+
         if (this.formViewId) {
             options.view_id = parseInt(this.formViewId);
         }

--- a/addons/web/static/src/legacy/js/views/view_dialogs.js
+++ b/addons/web/static/src/legacy/js/views/view_dialogs.js
@@ -292,7 +292,7 @@ var FormViewDialog = ViewDialog.extend({
     _setRemoveButtonOption(options, btnClasses) {
         const self = this;
         options.buttons.push({
-            text: _t("Remove"),
+            text: options.removeButtonText || _t("Remove"),
             classes: 'btn-secondary ' + btnClasses,
             click: function() {
                 self._remove().then(self.close.bind(self));


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the previous version, the hr_holidays had the month view by default. It was possible to edit/delete a time off directly by clicking on the time off.
Now the landing page is year view. The popup form for the leave has a save and discard button but no delete.

Current behavior before PR:
The popup form on the year view has a save and discard button but no delete button

Desired behavior after PR is merged:
The popup form on the year view has save, discard and delete buttons

task-2638305


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
