### PR TITLE
[FIX] microsoft_calendar: rename sync range ICP parameter

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -71,7 +71,7 @@ class Meeting(models.Model):
     def _get_microsoft_sync_domain(self):
         # in case of full sync, limit to a range of 1y in past and 1y in the future by default
         ICP = self.env['ir.config_parameter'].sudo()
-        day_range = int(ICP.get_param('google_calendar.sync.range_days', default=365))
+        day_range = int(ICP.get_param('microsoft_calendar.sync.range_days', default=365))
         lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)
         upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)
         return [


### PR DESCRIPTION
Before this commit, the ICP used to get the date range of events to sync was improperly named.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
