### PR TITLE
[IMP] mail: copy summary from previous activity & overridable method for next activity value prep

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -540,6 +540,7 @@ class MailActivity(models.Model):
                     'res_id': activity.res_id,
                     'res_model': activity.res_model,
                     'res_model_id': self.env['ir.model']._get(activity.res_model).id,
+                    'summary': activity.summary,
                 })
                 virtual_activity = Activity.new(vals)
                 virtual_activity._onchange_previous_activity_type_id()


### PR DESCRIPTION
Current behavior before PR:
where no default summary exists on the mail.activity.type - new mail activities have no summary

Desired behavior after PR is merged:
the summary field for a triggered activity is copied from the previous mail.activity

[IMP] mail: next activities values in an overridable method
values for next activities are currently prepared inside the mail_activity._action_done() method. This commit extracts the code into a separate overridable method

required to support changes to enterprise documents
task 2627837
