### PR TITLE
[FIX] calendar: display start and end of events without datetimerange…

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -140,16 +140,12 @@
                         <page name="page_details" string="Meeting Details">
                             <group>
                                 <group>
-                                     <field name="start_date" string="Starting at"
-                                           attrs="{'required': [('allday','=',True)], 'invisible': [('allday','=',False)]}"
-                                           widget="daterange" options="{'related_end_date': 'stop_date'}" force_save="1"/>
-                                    <field name="stop_date" string="Ending at"
-                                           attrs="{'required': [('allday','=',True)],'invisible': [('allday','=',False)]}"
-                                           widget="daterange" options="{'related_start_date': 'start_date'}" force_save="1"/>
 
-                                    <field name="start" string="Starting at" attrs="{'required': [('allday','=',False)], 'invisible': [('allday','=',True)]}" widget="daterange" options="{'related_end_date': 'stop'}"/>
-                                    <field name="stop" string="Ending At" attrs="{'invisible': [('allday','=',True)]}" widget="daterange" options="{'related_start_date': 'start'}"/>
+                                    <field name="start_date" string="Starting at" attrs="{'required': [('allday','=',True)], 'invisible': [('allday','=',False)]}" force_save="1"/>
+                                    <field name="stop_date" string="Ending at" attrs="{'required': [('allday','=',True)],'invisible': [('allday','=',False)]}" force_save="1"/>
 
+                                    <field name="start" string="Starting at" attrs="{'required': [('allday','=',False)], 'invisible': [('allday','=',True)]}"/>
+                                    <field name="stop" string="Ending At" attrs="{'invisible': [('allday','=',True)]}"/>
                                     <label for="duration" attrs="{'invisible': [('allday','=',True)]}"/>
                                     <div attrs="{'invisible': [('allday','=',True)]}">
                                         <field name="duration" widget="float_time" string="Duration" class="oe_inline" attrs="{'readonly': [('id', '!=', False), ('recurrency','=',True)]}"/>


### PR DESCRIPTION
… widget

Before this commit, the datetime range widget was used to set these values in for calendar form view.
Unfortunately, some glitches appeared in mobile view. This commit, revert this change because fixing the mobile view for this specific case was not trivial.
Datetime range widget works in mobile for regular form view (not launched from the calendar view).

taskid: 2635704


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
