### PR TITLE
[FIX] product_expiry: fix expired lot used for another product

### DIFF
--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -35,8 +35,10 @@ class ConfirmExpiry(models.TransientModel):
     def process(self):
         picking_to_validate = self.env.context.get('button_validate_picking_ids')
         if picking_to_validate:
-            picking_to_validate = self.env['stock.picking'].browse(picking_to_validate).with_context(skip_expired=True)
-            return picking_to_validate.button_validate()
+            picking_to_validate = self.env['stock.picking'].browse(picking_to_validate)
+            ctx = dict(self.env.context, skip_expired=True)
+            ctx.pop('default_lot_ids')
+            return picking_to_validate.with_context(ctx).button_validate()
         return True
 
     def process_no_expired(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When validating a stock picking with expired products, in some cases a validation error is raised because default_lot_ids is passed back in context for creating new stock_move_line.

The behaviour is similar to the one fixed with https://github.com/odoo/odoo/pull/73209 but on stock picking when reference was on manufacturing.

Problem reproduced on runbot on v14.0 community edition

Current behavior before PR:

    

- Go to Inventory > Configuration > Settings and activate "Expiration Dates"
- Create a storable product tracked by lot with expiration date (i.e. Product A)
- Update quantity of Product A in a lot with an expired expiration date (i.e. Lot A)
- Create a storable product tracked by lot (i.e. Product B)
- Create a Stock Picking for Product A with a quantity to deliver set to 1
- Save the Picking and mark as To-Do
- Edit Picking to add Product B with quantity >= 1
- Validate Picking
- You get a confirmation popup : "You are going to deliver the product Product A, Lot A which is expired. Do you confirm you want to proceed ?"
- Click on Confirm
    The following Validation Error is triggered:
    "This lot Lot A is incompatible with this product Product B"


Desired behavior after PR is merged:
Validate picking and create extra stock move lines without error



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
