### PR TITLE
[FIX] mrp_account: don't duplication analytic_account_line_id

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -3,7 +3,7 @@
 
 from ast import literal_eval
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.tools import float_is_zero, float_round
 
 
@@ -38,7 +38,9 @@ class MrpProduction(models.Model):
         if vals.get('name'):
             for production in self:
                 production.move_raw_ids.analytic_account_line_id.ref = production.display_name
-                production.workorder_ids.mo_analytic_account_line_id.ref = production.display_name
+                for workorder in production.workorder_ids:
+                    workorder.mo_analytic_account_line_id.ref = production.display_name
+                    workorder.mo_analytic_account_line_id.name = _("[WC] %s", workorder.display_name)
         return res
 
     def action_view_stock_valuation_layers(self):

--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -8,8 +8,8 @@ from odoo.tools import float_is_zero
 class MrpWorkorder(models.Model):
     _inherit = 'mrp.workorder'
 
-    mo_analytic_account_line_id = fields.Many2one('account.analytic.line')
-    wc_analytic_account_line_id = fields.Many2one('account.analytic.line')
+    mo_analytic_account_line_id = fields.Many2one('account.analytic.line', copy=False)
+    wc_analytic_account_line_id = fields.Many2one('account.analytic.line', copy=False)
 
     def _compute_duration(self):
         res = super()._compute_duration()


### PR DESCRIPTION
Both mo_analytic_account_line_id and wc_analytic_account_line_id are
copied when duplicate the workorder. This is not correct.

Task-2638896





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
