### PR TITLE
[FIX] google_recaptcha: Add key in session_info

### DIFF
--- a/addons/google_recaptcha/models/ir_http.py
+++ b/addons/google_recaptcha/models/ir_http.py
@@ -15,6 +15,16 @@ class Http(models.AbstractModel):
 
     def session_info(self):
         session_info = super().session_info()
+        return self._add_public_key_to_session_info(session_info)
+
+    @api.model
+    def get_frontend_session_info(self):
+        frontend_session_info = super().get_frontend_session_info()
+        return self._add_public_key_to_session_info(frontend_session_info)
+
+    @api.model
+    def _add_public_key_to_session_info(self, session_info):
+        """Add the ReCaptcha public key to the given session_info object"""
         public_key = self.env['ir.config_parameter'].sudo().get_param('recaptcha_public_key')
         if public_key:
             session_info['recaptcha_public_key'] = public_key


### PR DESCRIPTION
Before this commit, if there was a Google ReCaptcha public key
registered on the database, it was given to the backend along with
the assets in the `session_info` global key.

Since this key is meant to be used on the frontend to generate recaptcha
tokens, it should be available there as well.

Now, it is also given to the frontend version of the `session_info` key.

Task: [2639095](https://www.odoo.com/web#active_id=2639095&cids=1&id=2639095&model=project.task&menu_id=)