### PR TITLE
[FIX] website_slides : wrong embed detection

### DIFF
--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_from_url
+from . import test_embed_detection

--- a/addons/website_slides/tests/test_embed_detection.py
+++ b/addons/website_slides/tests/test_embed_detection.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.tests import HttpCase
+
+
+class TestEmbedDetection(HttpCase):
+
+    def setUp(self):
+        super(TestEmbedDetection, self).setUp()
+        self.website_true_url = self.env['website'].create({
+            'name': 'a_website',
+            'domain': 'https://trueurl.com'
+        })
+        self.website_other = self.env['website'].create({
+            'name': 'another_website',
+            'domain': 'https://otherurl.com'
+        })
+
+        self.channel_with_website = self.env['slide.channel'].create({
+            'name': 'Website Channel',
+            'promote_strategy': 'most_voted',
+            'visibility': 'public',
+            'is_published': True,
+            'website_id': self.website_true_url.id
+        })
+        self.channel_with_another_website = self.env['slide.channel'].create({
+            'name': 'Another Website Channel',
+            'promote_strategy': 'most_voted',
+            'visibility': 'public',
+            'is_published': True,
+            'website_id': self.website_other.id
+        })
+        self.channel_no_website = self.env['slide.channel'].create({
+            'name': 'Test Channel',
+            'promote_strategy': 'most_voted',
+            'visibility': 'public',
+            'is_published': True,
+        })
+
+        self.slide_no_website = self.env['slide.slide'].create({
+            'name': 'Radioactive meditation : The Art of Growing a Third Ear with your Mind',
+            'channel_id': self.channel_no_website.id,
+            'slide_type': 'document',
+            'is_published': True,
+        })
+        self.slide_website = self.env['slide.slide'].create({
+            'name': 'Biology 101 : How to create Zombies',
+            'channel_id': self.channel_with_website.id,
+            'slide_type': 'document',
+            'is_published': True,
+        })
+
+        self.csrf_token_data = {'csrf_token': http.WebRequest.csrf_token(self)}
+
+    def test_01_no_referer_no_website_id(self):
+        """
+        No referer, slide available for all websites -> Not embedded
+        """
+        headers = {
+            'Referer': ''
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_no_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "There is no referer, we will assume it's not embedded")
+
+    def test_02_no_referer_with_website(self):
+        """
+        No referer, slide just available for one website -> Not embedded
+        """
+        headers = {
+            'Referer': ''
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "There is no referer, we will assume it's not embedded")
+
+    def test_03_referer_ill_formed(self):
+        """
+        No usable information in the referer -> Not embedded
+        """
+        headers = {
+            'Referer': 'hello'
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_no_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "No usable information in the referer (and no website), we will assume it's not embedded")
+
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "No usable information in the referer (and website), we will assume it's not embedded")
+
+    def test_04_referer_outside_no_website(self):
+        """
+        Referer outside of DB and no website_id -> Embedded
+        """
+        headers = {
+            'Referer': 'https://jagnkjllngnlnafja.com'
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_no_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertNotEqual(embeds, new_embeds, "That website is not part of the domains of the DB, so embedded")
+
+    def test_05_referer_outside_with_website(self):
+        """
+        Referer outside of DB and website_id -> Embedded
+        """
+        headers = {
+            'Referer': 'https://jagnkjllngnlnafja.com'
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertNotEqual(embeds, new_embeds, "That website is not equal to the website domain, so embedded")
+
+    def test_06_referer_inside_no_website(self):
+        """
+        Referer inside of the DB and no website_id (available for all websites) -> Not Embedded
+        """
+        headers = {
+            'Referer': self.website_true_url.domain
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_no_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "That website is part of the domains of the DB and the slide is available for all domains, so not embedded")
+
+    def test_07_referer_inside_correct_website(self):
+        """
+        Referer inside of DB and correspond to the slide website -> Not embedded
+        """
+        headers = {
+            'Referer': self.website_true_url.domain
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "That website is equal to the slide website, so not embedded")
+
+    def test_08_referer_inside_incorrect_website(self):
+        """
+        Referer outside of DB and website_id -> Embedded
+        """
+        headers = {
+            'Referer': self.website_true_url.domain
+        }
+        self.slide_website.channel_id = self.channel_with_another_website
+
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertNotEqual(embeds, new_embeds, "That website is not equal to the slide website, so embedded")
+
+    def test_09_longer_referer_inside_correct_website(self):
+        """
+        Testing for referer_url equality will fail this test, since it's here to test that we actually check for the
+        domain of the referer url
+        Referer inside the correct website but with a longer URL -> Not embedded
+        """
+        headers = {
+            'Referer': self.website_true_url.domain + '/some_page/with_html.html'
+        }
+        embeds = self.env['slide.embed'].search([])
+        self.url_open(f'/slides/embed/{self.slide_website.id}', data=self.csrf_token_data, headers=headers)
+        new_embeds = self.env['slide.embed'].search([])
+        self.assertEqual(embeds, new_embeds, "That website is equal to the slide website, so not embedded")

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1002,12 +1002,12 @@ class HttpCase(TransactionCase):
         self.opener = requests.Session()
         self.opener.cookies['session_id'] = self.session_id
 
-    def url_open(self, url, data=None, timeout=10):
+    def url_open(self, url, data=None, timeout=10, headers=None):
         if url.startswith('/'):
             url = "http://%s:%s%s" % (HOST, PORT, url)
         if data:
-            return self.opener.post(url, data=data, timeout=timeout)
-        return self.opener.get(url, timeout=timeout)
+            return self.opener.post(url, data=data, timeout=timeout, headers=headers)
+        return self.opener.get(url, timeout=timeout, headers=headers)
 
     def _wait_remaining_requests(self):
         t0 = int(time.time())

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -13,6 +13,7 @@ import time
 
 from email.header import decode_header, Header
 from email.utils import getaddresses, formataddr
+import werkzeug.urls
 from lxml import etree
 
 import odoo
@@ -635,3 +636,15 @@ def encapsulate_email(old_email, new_email):
         name_part,
         new_email_split[0][1],
     ))
+
+
+def url_domain_extract(url):
+    """ Extract the company domain to be used by IAP services notably. Domain
+    is extracted from an URL e.g:
+        - www.info.proximus.be -> proximus.be
+    """
+    parser_results = werkzeug.urls.url_parse(url)
+    company_hostname = parser_results.netloc
+    if company_hostname and '.' in company_hostname:
+        return '.'.join(company_hostname.split('.')[-2:])  # remove subdomains
+    return False


### PR DESCRIPTION
Issue: When viewing the slides in a odoo website, the PDF viewer shows a
 "Share, Email, Embed" banner that should only appear when the slide is
 viewed from outside of the client Odoo DB

Steps to reproduce :
 1) Run a local odoo server with the website_slides module
 2) Set up a ngrox tunneling service to your localhost and good port 
 3) Find or create a **infographic** slide and get its id (<slide_id>)
 4) Access the slide via the website url on the slide 
 5) Go down the page in the Share tab and copy the iframe
    - Replace http by https in the src attribute of the iframe if necessary
 6) go back to the dashboard, open the inspector and add the iframe in the body of the webpage
 -> The slide is correctly detected as non embed
 7) Access your Odoo database with the ngrox https forward (example : https://0dfc-2a02-a03f-6b9b-b300-bd6c-8048-90f1-3f25.eu.ngrok.io)
 8) Repeat step 3 to 6 included
 -> The slide is detected as embed, even though the iframe sources the ngrox, and the dashboard is also on the ngrox url

Why is that a bug:
 The current embedding detection only check base_url field but it's not a reliable way to detect the embedding

opw-2499110