### PR TITLE
[DRAFT] Master l10n fr holidays wbr

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -670,7 +670,7 @@ class HolidaysRequest(models.Model):
         """ Returns a float equals to the timedelta between two dates given as string."""
         if employee_id:
             employee = self.env['hr.employee'].browse(employee_id)
-            result = employee._get_work_days_data_batch(date_from, date_to)[employee.id]
+            result = employee._get_work_days_data_batch(date_from, date_to, calendar=self._get_calendar())[employee.id]
             if self.request_unit_half and result['hours'] > 0:
                 result['days'] = 0.5
             return result

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -668,6 +668,7 @@ class HolidaysRequest(models.Model):
 
     def _get_number_of_days(self, date_from, date_to, employee_id):
         """ Returns a float equals to the timedelta between two dates given as string."""
+        self.ensure_one()
         if employee_id:
             employee = self.env['hr.employee'].browse(employee_id)
             result = employee._get_work_days_data_batch(date_from, date_to, calendar=self._get_calendar())[employee.id]

--- a/addons/l10n_fr_hr_holidays/__init__.py
+++ b/addons/l10n_fr_hr_holidays/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_fr_hr_holidays/__manifest__.py
+++ b/addons/l10n_fr_hr_holidays/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'France - Time Off',
+    'version': '1.0',
+    'icon': '/l10n_fr/static/description/icon.png',
+    'summary': 'Management of leaves for part-time workers in France',
+    'depends': ['hr_holidays'],
+    'auto_install': False,
+    'data': [
+        'views/res_config_settings_views.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_fr_hr_holidays/models/__init__.py
+++ b/addons/l10n_fr_hr_holidays/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import hr_leave
+from . import res_company
+from . import res_config_settings

--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
+
+class HrLeave(models.Model):
+    _inherit = 'hr.leave'
+
+    l10n_fr_date_to = fields.Datetime('End Date For French Rules', readonly=True)
+
+    def _compute_fr_number_of_days(self, employee, date_from, date_to, employee_calendar, company_calendar):
+        self.ensure_one()
+
+        self.l10n_fr_date_to = False
+        # We can fill the holes using the company calendar as default
+        # What we need to compute is how much we will need to push date_to in order to account for the lost days
+        # This gets even more complicated in two_weeks_calendars
+        def calendar_works_on_date(CalendarAttendance, calendar, date):
+            """
+            Returns whether the calendar has attendances planned for that day of the week
+            """
+            weektype = str(CalendarAttendance.get_week_type(date))
+            dayofweek_str = str(date.weekday())
+            return any(attendance.dayofweek == dayofweek_str and\
+                    (not calendar.two_weeks_calendar or attendance.week_type == weektype)\
+                    for attendance in calendar.attendance_ids)
+
+        CalendarAttendance = self.env['resource.calendar.attendance']
+        if self.request_unit_half:
+            # In normal workflows request_unit_half implies that date_from and date_to are the same
+            # request_unit_half allows us to choose between `am` and `pm`
+            # In a case where we work from mon-wed and request a half day in the morning
+            # we do not want to push date_to since the next work attendance is actually in the afternoon
+            date_from_weektype = str(CalendarAttendance.get_week_type(date_from))
+            date_from_dayofweek = str(date_from.weekday())
+            # Fetch the attendances we care about
+            attendance_ids = employee_calendar.attendance_ids.filtered(lambda a:
+                a.dayofweek == date_from_dayofweek and\
+                (not employee_calendar.two_weeks_calendar or a.week_type == date_from_weektype))
+            if len(attendance_ids) == 2 and self.request_date_from_period == 'am':
+                # The employee took the morning off on a day where he works the afternoon aswell
+                attendance = attendance_ids[0] if attendance_ids[0].day_period == 'morning' else attendance_ids[1]
+                return {'days': 0.5, 'hours': attendance.hour_to - attendance.hour_from}
+        # Check calendars for working days until we find the right target, start at date_to + 1 day
+        # Postpone date_target until the next working day
+        date_target = date_to + relativedelta(days=1)
+        counter = 0
+        while not calendar_works_on_date(CalendarAttendance, employee_calendar, date_target):
+            date_target += relativedelta(days=1)
+            counter += 1
+            # Check that we aren't running an infinite loop (it would mean that employee_calendar is empty and
+            # company_calendar works every day)
+            # Allow up to 14 days for two weeks calendars.
+            if counter > 14:
+                # Default behaviour
+                result = employee._get_work_days_data_batch(date_from, date_to, calendar=employee_calendar)[employee.id]
+                if self.request_unit_half and result['hours'] > 0:
+                    result['days'] = 0.5
+                return result
+        date_target = datetime.combine(date_target.date(), datetime.min.time())
+        self.l10n_fr_date_to = date_target
+        return employee._get_work_days_data_batch(date_from, date_target, calendar=company_calendar)[employee.id]
+
+    def _get_number_of_days(self, date_from, date_to, employee_id):
+        """
+        In french time off laws, if an employee has a part time contract, when taking time off
+        before one of his off day (compared to the company's calendar) it should also count the time
+        between the time off and the next calendar work day/company off day (weekends).
+
+        For example take an employee working mon-wed in a company where the regular calendar is mon-fri.
+        If the employee were to take a time off ending on wednesday, the legal duration would count until friday.
+
+        Returns a dict containing two keys: 'days' and 'hours' with the value being the duration for the requested time period.
+        """
+        if employee_id:
+            employee = self.env['hr.employee'].browse(employee_id).sudo()
+            company = employee.company_id
+            if company.country_id.code == 'FR' and company.time_off_reference_calendar:
+                calendar = self._get_calendar()
+                if calendar and calendar != company.time_off_reference_calendar:
+                    return self._compute_fr_number_of_days(employee, date_from, date_to, calendar, company.time_off_reference_calendar)
+        return super()._get_number_of_days(date_from, date_to, employee_id)

--- a/addons/l10n_fr_hr_holidays/models/res_company.py
+++ b/addons/l10n_fr_hr_holidays/models/res_company.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    time_off_reference_calendar = fields.Many2one('resource.calendar', string='Reference Calendar', ondelete='restrict')

--- a/addons/l10n_fr_hr_holidays/models/res_config_settings.py
+++ b/addons/l10n_fr_hr_holidays/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    company_country_code = fields.Char(related='company_id.country_id.code', string='Company Country Code')
+    time_off_reference_calendar = fields.Many2one(
+        'resource.calendar', string='Reference Calendar',
+        related='company_id.time_off_reference_calendar', readonly=False)

--- a/addons/l10n_fr_hr_holidays/tests/__init__.py
+++ b/addons/l10n_fr_hr_holidays/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_french_leaves

--- a/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
+++ b/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase, tagged
+
+@tagged('post_install_l10n', 'post_install', '-at_install', 'french_leaves')
+class TestFrenchLeaves(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        country_fr = cls.env.ref('base.fr')
+        cls.company = cls.env['res.company'].create({
+            'name': 'French Company',
+            'country_id': country_fr.id,
+        })
+
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Louis',
+            'gender': 'other',
+            'birthday': '1973-03-29',
+            'country_id': country_fr.id,
+            'company_id': cls.company.id,
+        })
+
+        cls.time_off_type = cls.env['hr.leave.type'].create({
+            'name': 'Time Off',
+            'requires_allocation': 'no',
+        })
+
+        cls.base_calendar = cls.env['resource.calendar'].create({
+            'name': 'default calendar',
+        })
+
+    def test_no_differences(self):
+        # Base case that should not have a different behaviour
+        self.company.time_off_reference_calendar = self.base_calendar
+        self.employee.resource_calendar_id = self.base_calendar
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-10 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 5, 'The number of days should be equal to 5.')
+
+    def test_end_of_week(self):
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.time_off_reference_calendar = self.base_calendar
+        self.employee.resource_calendar_id = employee_calendar
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-08 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 5, 'The number of days should be equal to 5.')
+
+    def test_start_of_week(self):
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.time_off_reference_calendar = self.base_calendar
+        self.employee.resource_calendar_id = employee_calendar
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-08',
+            'date_to': '2021-09-10 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 5, 'The number of days should be equal to 5.')
+
+    def test_last_day_half(self):
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.time_off_reference_calendar = self.base_calendar
+        self.employee.resource_calendar_id = employee_calendar
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-10',
+            'date_to': '2021-09-10 12:00:00',
+            'request_date_from': '2021-09-10',
+            'request_date_to': '2021-09-10 12:00:00',
+            'request_unit_half': True,
+            'request_date_from_period': 'am',
+        })
+        # Since the employee works on the afternoon, the date_to (l10n_fr_date_to) is not post-poned
+        self.assertEqual(leave.number_of_days, 0.5, 'The number of days should be equal to 0.5.')
+        leave.request_date_from_period = 'pm'
+        # This however should push the date_to (l10n_fr_date_to)
+        self.assertEqual(leave.number_of_days, 2.5, 'The number of days should be equal to 2.5.')
+
+
+    def test_calendar_with_holes(self):
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.time_off_reference_calendar = self.base_calendar
+        self.employee.resource_calendar_id = employee_calendar
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-10 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 5, 'The number of days should be equal to 5.')
+
+    def test_calendar_end_week_hole(self):
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.time_off_reference_calendar = self.base_calendar
+        self.employee.resource_calendar_id = employee_calendar
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-08 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 5, 'The number of days should be equal to 5.')
+
+    def test_2_weeks_calendar(self):
+        company_calendar = self.env['resource.calendar'].create({
+            'name': 'Company Calendar',
+            'two_weeks_calendar': True,
+            'attendance_ids': [
+                (0, 0, {'week_type': '0', 'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '0', 'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'week_type': '0', 'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '0', 'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'week_type': '0', 'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '0', 'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'week_type': '0', 'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '0', 'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'week_type': '0', 'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '0', 'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+
+                (0, 0, {'week_type': '1', 'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '1', 'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'week_type': '1', 'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '1', 'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'week_type': '1', 'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'week_type': '1', 'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.time_off_reference_calendar = company_calendar
+        self.employee.resource_calendar_id = employee_calendar
+
+        # Week type 0
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-08 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 5, 'The number of days should be equal to 5.')
+        leave.unlink()
+
+        # Week type 1
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-13',
+            'date_to': '2021-09-15 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 3, 'The number of days should be equal to 3.')
+        leave.unlink()
+
+        # Both ending with week type 1
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-15 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 8, 'The number of days should be equal to 3.')
+        leave.unlink()
+
+        # Both ending with week type 0
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-13',
+            'date_to': '2021-09-22 23:59:59',
+        })
+        self.assertEqual(leave.number_of_days, 8, 'The number of days should be equal to 3.')
+        leave.unlink()

--- a/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit_l10n_fr_holidays" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.l10n.fr.holidays</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="hr.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='work_organization_setting_container']" position="after">
+                <field name="company_country_code" invisible="1"/>
+                <h2 attrs="{'invisible': [('company_country_code', '!=', 'FR')]}">Time Off</h2>
+                <div class="row mt16 o_settings_container" name="l10n_fr_timeoff_settings_container" attrs="{'invisible': [('company_country_code', '!=', 'FR')]}">
+                    <div class="col-12 col-lg-6 o_setting_box" id="reference_calendar_setting">
+                        <div class="o_setting_right_pane">
+                            <label for="time_off_reference_calendar"/>
+                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific" role="img"
+                                aria-label="Values set here are company-specific" groups="base.group_multi_company"/>
+                            <div class="row">
+                                <div class="text-muted col-lg-8">
+                                    Set the reference calendar for time off, this calendar will be used to compute the amount of days a time off will take from the employee.
+                                </div>
+                            </div>
+                            <div class="content-group">
+                                <div class="mt16">
+                                    <field name="time_off_reference_calendar" required="1" class="o_light_label"
+                                        domain="[('company_id', '=', company_id)]" context="{'default_company_id': company_id}"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_fr_hr_work_entry_holidays/__init__.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_fr_hr_work_entry_holidays/__manifest__.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/__manifest__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'France - Work Entries Time Off',
+    'version': '1.0',
+    'icon': '/l10n_fr/static/description/icon.png',
+    'summary': 'Management of leaves for part-time workers in France',
+    'depends': ['l10n_fr_hr_holidays', 'hr_work_entry_holidays'],
+    'auto_install': True,
+    'data': [
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_fr_hr_work_entry_holidays/models/__init__.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import hr_contract
+from . import hr_leave

--- a/addons/l10n_fr_hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/models/hr_contract.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+import pytz
+
+from odoo import models
+from odoo.addons.resource.models.resource import datetime_to_string
+
+class HrContract(models.Model):
+    _inherit = 'hr.contract'
+
+    def _get_contract_work_entries_values(self, date_start, date_stop):
+        # Add the work entries difference for french payroll
+        # Work entries by default are not generated on days the employee does not work
+        # So we have to fill the gaps with work entries for those periods
+        result = super()._get_contract_work_entries_values(date_start, date_stop)
+        start_dt = pytz.utc.localize(date_start) if not date_start.tzinfo else date_start
+        end_dt = pytz.utc.localize(date_stop) if not date_stop.tzinfo else date_stop
+        fr_contracts = self.filtered(lambda c: c.company_id.country_id.code == 'FR')
+        # l10n_fr_date_to is False when no adjustment had to be done
+        all_leaves = self.env['hr.leave'].search([
+            ('employee_id', 'in', fr_contracts.employee_id.ids),
+            ('state', '=', 'validate'),
+            ('date_from', '<=', datetime_to_string(end_dt)),
+            ('l10n_fr_date_to', '>=', datetime_to_string(start_dt)),
+        ]) if fr_contracts else []
+        leaves_per_employee = defaultdict(lambda: self.env['hr.leave'])
+        for leave in all_leaves:
+            leaves_per_employee[leave.employee_id] |= leave
+        for contract in fr_contracts:
+            if contract.company_id.country_id.code != 'FR':
+                continue
+            employee = contract.employee_id
+            employee_calendar = contract.resource_calendar_id
+            company = contract.company_id
+            company_calendar = company.time_off_reference_calendar
+            resource = employee.resource_id
+            tz = pytz.timezone(employee_calendar.tz)
+
+            for leave in leaves_per_employee[employee]:
+                leave_start_dt = max(start_dt, leave.date_from.astimezone(tz))
+                leave_end_dt = min(end_dt, leave.date_to.astimezone(tz))
+                leave_end_dt_fr = min(end_dt, leave.l10n_fr_date_to.astimezone(tz))
+
+                # Compute the attendances for the company calendar and the employee calendar
+                # and then compute and keep the difference between those two
+                employee_attendances = employee_calendar._attendance_intervals_batch(
+                    leave_start_dt, leave_end_dt, resources=resource, tz=tz,
+                )[resource.id]
+                company_attendances = company_calendar._attendance_intervals_batch(
+                    leave_start_dt, leave_end_dt_fr, resources=resource, tz=tz,
+                )[resource.id]
+                # Dates on which work entries should already be generated
+                employee_dates = set()
+                for interval in employee_attendances:
+                    employee_dates.add(interval[0].date())
+                    employee_dates.add(interval[1].date())
+                leave_work_entry_type = leave.holiday_status_id.work_entry_type_id
+                result += [{
+                    'name': '%s%s' % (leave_work_entry_type.name + ': ' if leave_work_entry_type else "", employee.name),
+                    'date_start': interval[0].astimezone(pytz.utc).replace(tzinfo=None),
+                    'date_stop': interval[1].astimezone(pytz.utc).replace(tzinfo=None),
+                    'work_entry_type_id': leave_work_entry_type.id,
+                    'employee_id': employee.id,
+                    'company_id': contract.company_id.id,
+                    'state': 'draft',
+                    'contract_id': contract.id,
+                    'leave_id': leave.id,
+                } for interval in company_attendances if interval[0].date() not in employee_dates]
+
+        return result

--- a/addons/l10n_fr_hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/models/hr_leave.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+class HrLeave(models.Model):
+    _inherit = 'hr.leave'
+
+    def _work_entry_generation_date_to(self):
+        return self.l10n_fr_date_to or super()._work_entry_generation_date_to()

--- a/addons/l10n_fr_hr_work_entry_holidays/tests/__init__.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_french_work_entries

--- a/addons/l10n_fr_hr_work_entry_holidays/tests/test_french_work_entries.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/tests/test_french_work_entries.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from odoo.tests.common import TransactionCase, tagged
+
+@tagged('post_install_l10n', 'post_install', '-at_install', 'french_work_entries')
+class TestFrenchWorkEntries(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        country_fr = cls.env.ref('base.fr')
+        cls.company = cls.env['res.company'].create({
+            'name': 'French Company',
+            'country_id': country_fr.id,
+        })
+
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Louis',
+            'gender': 'other',
+            'birthday': '1973-03-29',
+            'country_id': country_fr.id,
+            'company_id': cls.company.id,
+        })
+
+        cls.employee_contract = cls.env['hr.contract'].create({
+            'date_start': '2020-01-01',
+            'date_end': '2023-01-01',
+            'name': 'Louis\'s contract',
+            'wage': 2,
+            'employee_id': cls.employee.id,
+            'company_id': cls.company.id,
+        })
+
+        cls.time_off_type = cls.env['hr.leave.type'].create({
+            'name': 'Time Off',
+            'requires_allocation': 'no',
+        })
+
+    def test_fill_gaps(self):
+        company_calendar = self.env['resource.calendar'].create({
+            'name': 'Company Calendar',
+        })
+        employee_calendar = self.env['resource.calendar'].create({
+            'name': 'Employee Calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+            ],
+        })
+        self.company.resource_calendar_id = company_calendar
+        self.company.time_off_reference_calendar = company_calendar
+        self.employee.resource_calendar_id = employee_calendar
+        self.employee_contract.resource_calendar_id = employee_calendar
+
+        # Get the create values for a week of work entries, it should only give us 4 entries ((am+pm) * 2)
+        work_entry_create_vals = self.employee_contract._get_contract_work_entries_values(datetime(2021, 9, 6), datetime(2021, 9, 10, 23, 59, 59))
+        self.assertEqual(len(work_entry_create_vals), 4, 'Should have generated 4 work entries.')
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id': self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2021-09-06',
+            'date_to': '2021-09-08 23:59:59', # This should fill the gap up to the 10th
+        })
+        leave.action_validate()
+
+        # Since the gaps have been filled, we should now get 10 work entries
+        work_entry_create_vals = self.employee_contract._get_contract_work_entries_values(datetime(2021, 9, 6), datetime(2021, 9, 10, 23, 59, 59))
+        self.assertEqual(len(work_entry_create_vals), 10, 'Should have generated 10 work entries.')
+
+        # Make sure that the gap filling does not go past the requested date
+        work_entry_create_vals = self.employee_contract._get_contract_work_entries_values(datetime(2021, 9, 6), datetime(2021, 9, 9, 23, 59, 59))
+        self.assertEqual(len(work_entry_create_vals), 8, 'Should have generated 8 work entries.')


### PR DESCRIPTION
l10n_fr_hr_holidays:
Adds a new module for french time off.
This module contains the time off logic for France.

In France, when taking a time off using a different calendar from the
company's calendar you have to count the days as if you were taking time
off in the company calendar.

For example let's say you have an employee working only monday through
wednesday, if that employee were to take a time off ending with
wednesday afternoon, the time off would count up until friday (if the
company calendar if monday->friday), so that a whole week is always 5
days regardless of the employee calendar.

This is also the case for 'holes' in the employee calendar, for example
a calendar where one would work monday, wednesday and friday only.


l10n_fr_work_entry_holidays:
By default time off only generate work entries for intersections between
time off and attendance period, so that when taking a time off for a
whole month you wouldn't get work entries on the weekend if you normally
don't work that day.

But since l10n_fr_hr_holidays computes the number of days it would
normally cost with french rules. We also have to make sure that the work
entries are generated appropriately. Essentially this modules adds the
logic required to fill the holes needed using the company calendar
instead of the employee one.

OTHER:
Fixes a redundant call to super function in `hr.leave`.`_get_number_of_days`, improving its performance a bit 