### PR TITLE
[FIX] web_editor: fix editor history for image shapes

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4674,126 +4674,6 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
     },
 });
 
-/**
- * General options of an image.
- */
-registry.ImageTools = SnippetOptionWidget.extend({
-
-    //--------------------------------------------------------------------------
-    // Options
-    //--------------------------------------------------------------------------
-
-    /**
-     * Displays the image cropping tools
-     *
-     * @see this.selectClass for parameters
-     */
-    async crop() {
-        this.trigger_up('hide_overlay');
-        this.trigger_up('disable_loading_effect');
-        new weWidgets.ImageCropWidget(this, this.$target[0]).appendTo(this.options.wysiwyg.$editable);
-
-        await new Promise(resolve => {
-            this.$target.one('image_cropper_destroyed', resolve);
-        });
-        this.trigger_up('enable_loading_effect');
-    },
-    /**
-     * Displays the image transformation tools
-     *
-     * @see this.selectClass for parameters
-     */
-    async transform() {
-        this.trigger_up('hide_overlay');
-        this.trigger_up('disable_loading_effect');
-
-        const document = this.$target[0].ownerDocument;
-        this.$target.transfo({document});
-        const mousedown = mousedownEvent => {
-            if (!$(mousedownEvent.target).closest('.transfo-container').length) {
-                this.$target.transfo('destroy');
-                $(document).off('mousedown', mousedown);
-            }
-        };
-        $(document).on('mousedown', mousedown);
-
-        await new Promise(resolve => {
-            document.addEventListener('mouseup', resolve, {once: true});
-        });
-        this.trigger_up('enable_loading_effect');
-    },
-    /**
-     * Resets the image cropping
-     *
-     * @see this.selectClass for parameters
-     */
-    async resetCrop() {
-        const cropper = new weWidgets.ImageCropWidget(this, this.$target[0]);
-        await cropper.appendTo(this.options.wysiwyg.$editable);
-        await cropper.reset();
-    },
-    /**
-     * Resets the image rotation and translation
-     *
-     * @see this.selectClass for parameters
-     */
-    async resetTransform() {
-        this.$target
-            .attr('style', (this.$target.attr('style') || '')
-            .replace(/[^;]*transform[\w:]*;?/g, ''));
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-￼    * @private
-￼    */
-    _isTransformed() {
-        return this.$target.is('[style*="transform"]');
-    },
-    /**
-￼    * @private
-￼    */
-    _isCropped() {
-        return this.$target.hasClass('o_we_image_cropped');
-    },
-    /**
-     * @override
-     */
-    async _computeWidgetState(methodName, params) {
-        if (methodName === 'selectStyle' && params.cssProperty === 'width') {
-            // TODO check how to handle this the right way (here using inline
-            // style instead of computed because of the messy %-px convertion
-            // and the messy auto keyword).
-            const width = this.$target[0].style.width.trim();
-            if (width[width.length - 1] === '%') {
-                return `${parseInt(width)}%`;
-            } else {
-                return '';
-            }
-        } else if (methodName === 'transform') {
-            return this._isTransformed() ? 'true' : '';
-        } else if (methodName === 'crop') {
-            return this._isCropped() ? 'true' : '';
-        }
-        return this._super(...arguments);
-    },
-    /**
-     * @override
-     */
-    _computeWidgetVisibility(widgetName, params) {
-        if (params.optionsPossibleValues.resetTransform) {
-            return this._isTransformed();
-        }
-        if (params.optionsPossibleValues.resetCrop) {
-            return this._isCropped();
-        }
-        return this._super(...arguments);
-    },
-});
-
 /*
  * Abstract option to be extended by the ImageOptimize and BackgroundOptimize
  * options that handles all the common parts.
@@ -4902,6 +4782,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     async _computeWidgetState(methodName, params) {
         const img = this._getImg();
+        const _super = this._super.bind(this);
 
         // Make sure image is loaded because we need its naturalWidth
         await new Promise((resolve, reject) => {
@@ -4929,7 +4810,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
                 return options[filterProperty] || defaultValue;
             }
         }
-        return this._super(...arguments);
+        return _super(...arguments);
     },
     /**
      * @abstract
@@ -4940,6 +4821,9 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     async _renderCustomXML(uiFragment) {
         const img = this._getImg();
+        if (this._isAllowedOnAllImages()) {
+            return;
+        }
         if (!this.originalSrc || !this._isImageSupportedForProcessing(img)) {
             [...uiFragment.childNodes].forEach(node => node.remove());
             return;
@@ -4950,7 +4834,10 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         });
 
         if (this._getImageMimetype(img) !== 'image/jpeg') {
-            uiFragment.querySelector('we-range[data-set-quality]').remove();
+            const optQuality = uiFragment.querySelector('we-range[data-set-quality]');
+            if (optQuality) {
+                optQuality.remove();
+            }
         }
     },
     /**
@@ -5080,6 +4967,15 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     _isImageSupportedForProcessing(img) {
         return isImageSupportedForProcessing(this._getImageMimetype(img));
     },
+    /**
+     * TODO: adapt in master (used to keep ImageTools related options available
+     * for all images).
+     *
+     * @returns {Boolean}
+     */
+    _isAllowedOnAllImages() {
+        return false;
+    },
 });
 
 /**
@@ -5102,7 +4998,7 @@ const _addAnimatedShapeLabel = function addAnimatedShapeLabel(containerEl) {
 /**
  * Controls image width and quality.
  */
-registry.ImageOptimize = ImageHandlerOption.extend({
+registry.ImageTools = ImageHandlerOption.extend({
     MAX_SUGGESTED_WIDTH: 1920,
 
     /**
@@ -5132,6 +5028,69 @@ registry.ImageOptimize = ImageHandlerOption.extend({
     // Options
     //--------------------------------------------------------------------------
 
+    /**
+     * Displays the image cropping tools
+     *
+     * @see this.selectClass for parameters
+     */
+    async crop() {
+        this.trigger_up('hide_overlay');
+        this.trigger_up('disable_loading_effect');
+        new weWidgets.ImageCropWidget(this, this.$target[0]).appendTo(this.options.wysiwyg.$editable);
+
+        await new Promise(resolve => {
+            this.$target.one('image_cropper_destroyed', async () => {
+                await this._reapplyCurrentShape();
+                resolve();
+            });
+        });
+        this.trigger_up('enable_loading_effect');
+    },
+    /**
+     * Displays the image transformation tools
+     *
+     * @see this.selectClass for parameters
+     */
+    async transform() {
+        this.trigger_up('hide_overlay');
+        this.trigger_up('disable_loading_effect');
+
+        const document = this.$target[0].ownerDocument;
+        this.$target.transfo({document});
+        const mousedown = mousedownEvent => {
+            if (!$(mousedownEvent.target).closest('.transfo-container').length) {
+                this.$target.transfo('destroy');
+                $(document).off('mousedown', mousedown);
+            }
+        };
+        $(document).on('mousedown', mousedown);
+
+        await new Promise(resolve => {
+            document.addEventListener('mouseup', resolve, {once: true});
+        });
+        this.trigger_up('enable_loading_effect');
+    },
+    /**
+     * Resets the image cropping
+     *
+     * @see this.selectClass for parameters
+     */
+    async resetCrop() {
+        const cropper = new weWidgets.ImageCropWidget(this, this.$target[0]);
+        await cropper.appendTo(this.options.wysiwyg.$editable);
+        await cropper.reset();
+        await this._reapplyCurrentShape();
+    },
+    /**
+     * Resets the image rotation and translation
+     *
+     * @see this.selectClass for parameters
+     */
+    async resetTransform() {
+        this.$target
+            .attr('style', (this.$target.attr('style') || '')
+            .replace(/[^;]*transform[\w:]*;?/g, ''));
+    },
     /**
      * @see this.selectClass for parameters
      */
@@ -5186,6 +5145,18 @@ registry.ImageOptimize = ImageHandlerOption.extend({
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+￼    * @private
+￼    */
+    _isTransformed() {
+        return this.$target.is('[style*="transform"]');
+    },
+    /**
+￼    * @private
+￼    */
+    _isCropped() {
+        return this.$target.hasClass('o_we_image_cropped');
+    },
     /**
      * @override
      */
@@ -5331,6 +5302,10 @@ registry.ImageOptimize = ImageHandlerOption.extend({
     _relocateWeightEl() {
         const leftPanelEl = this.$overlay.data('$optionsSection')[0];
         const titleTextEl = leftPanelEl.querySelector('we-title > span');
+        const weightEl = titleTextEl.querySelector('.o_we_image_weight');
+        if (weightEl) {
+            weightEl.remove();
+        }
         this.$weight.appendTo(titleTextEl);
     },
     /**
@@ -5346,6 +5321,12 @@ registry.ImageOptimize = ImageHandlerOption.extend({
             const colors = img.dataset.shapeColors.split(';');
             return colors[parseInt(params.colorId)];
         }
+        if (params.optionsPossibleValues.resetTransform) {
+            return this._isTransformed();
+        }
+        if (params.optionsPossibleValues.resetCrop) {
+            return this._isCropped();
+        }
         return this._super();
     },
     /**
@@ -5353,8 +5334,28 @@ registry.ImageOptimize = ImageHandlerOption.extend({
      */
     _computeWidgetState(methodName, params) {
         switch (methodName) {
-            case 'setImgShape':
+            case 'selectStyle': {
+                if (params.cssProperty === 'width') {
+                    // TODO check how to handle this the right way (here using
+                    // inline style instead of computed because of the messy
+                    // %-px convertion and the messy auto keyword).
+                    const width = this.$target[0].style.width.trim();
+                    if (width[width.length - 1] === '%') {
+                        return `${parseInt(width)}%`;
+                    }
+                    return '';
+                }
+                break;
+            }
+            case 'transform': {
+                return this._isTransformed() ? 'true' : '';
+            }
+            case 'crop': {
+                return this._isCropped() ? 'true' : '';
+            }
+            case 'setImgShape': {
                 return this._getImg().dataset.shape || '';
+            }
             case 'setImgShapeColor': {
                 const img = this._getImg();
                 return (img.dataset.shapeColors && img.dataset.shapeColors.split(';')[parseInt(params.colorId)]) || '';
@@ -5439,6 +5440,22 @@ registry.ImageOptimize = ImageHandlerOption.extend({
             img.dataset.mimetype = 'image/svg+xml';
         }
     },
+    /**
+     * @private
+     */
+    async _reapplyCurrentShape() {
+        const img = this._getImg();
+        if (img.dataset.shape) {
+            await this._loadShape(img.dataset.shape);
+            await this._applyShapeAndColors(true, (img.dataset.shapeColors && img.dataset.shapeColors.split(';')));
+        }
+    },
+    /**
+     * @override
+     */
+    _isAllowedOnAllImages() {
+        return true;
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -5463,12 +5480,22 @@ registry.ImageOptimize = ImageHandlerOption.extend({
      * @param {Event} ev
      */
     async _onImageCropped(ev) {
-        const img = this._getImg();
-        if (img.dataset.shape) {
-            await this._loadShape(img.dataset.shape);
-            await this._applyShapeAndColors(true, (img.dataset.shapeColors && img.dataset.shapeColors.split(';')));
-        }
         await this._rerenderXML();
+    },
+});
+
+// TODO: adapt in master to only use ImageTools.
+registry.ImageOptimize = registry.ImageTools.extend({
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _isAllowedOnAllImages() {
+        return false;
     },
 });
 


### PR DESCRIPTION
Issue:

1- Website editor > Set shape on image
2- Crop > shape is reapplied on the croped image
3- Change another option (e.g. image width)
4- Undo > image will be shown cropped but without any
shape applied on it.

In the current code we apply shapes on cropped images using
the event listener 'ImageOptimize > _onImageCropped', so in
'ImageTools', the 'crop()' option method will record the
"crop" action but the step where the shape is added is lost.
(see `SnippetOptionWidget` > `_onUserValueUpdate`).

The goal of this PR is to move the shapes related logic
to a "mixin" (for all widgets handeling image shapes),
so we can simply use its methods to apply shapes when the
'crop()' method is called.
This way, the step to record will be a "cropped image with
a shape on it" instead of just a "cropped image".

task-2628964