### PR TITLE
[FIX] website_slides: fix a traceback when creating a new tag

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -257,26 +257,24 @@ class WebsiteSlides(WebsiteProfile):
             return request.env['slide.channel.tag']
         # handle creation of new channel tag
         if tag_id[0] == 0:
-            group_id = self._create_or_get_channel_tag_group(group_id)
+            group_id = self._create_or_get_channel_tag_group_id(group_id)
             if not group_id:
                 return {'error': _('Missing "Tag Group" for creating a new "Tag".')}
 
-            new_tag = request.env['slide.channel.tag'].create({
+            return request.env['slide.channel.tag'].create({
                 'name': tag_id[1]['name'],
                 'group_id': group_id,
             })
-            return new_tag
         return request.env['slide.channel.tag'].browse(tag_id[0])
 
-    def _create_or_get_channel_tag_group(self, group_id):
+    def _create_or_get_channel_tag_group_id(self, group_id):
         if not group_id:
             return False
         # handle creation of new channel tag group
         if group_id[0] == 0:
-            tag_group = request.env['slide.channel.tag.group'].create({
+            return request.env['slide.channel.tag.group'].create({
                 'name': group_id[1]['name'],
-            })
-            group_id = tag_group.id
+            }).id
         # use existing channel tag group
         return group_id[0]
 

--- a/addons/website_slides/static/src/js/website_slides.editor.js
+++ b/addons/website_slides/static/src/js/website_slides.editor.js
@@ -3,7 +3,9 @@
 import { _t } from 'web.core';
 import Dialog from 'web.Dialog';
 import WebsiteNewMenu from 'website.newMenu';
-import { TagCourseDialog }from '@website_slides/js/slides_course_tag_add';
+import SlidesCourseTagAdd from '@website_slides/js/slides_course_tag_add';
+
+const TagCourseDialog = SlidesCourseTagAdd.TagCourseDialog;
 
 var ChannelCreateDialog = Dialog.extend({
     template: 'website.slide.channel.create',


### PR DESCRIPTION
Bug
===
Open a website page and click on "New" to create a new course from the
frontend. Then create a new tag from this view, a traceback is raised.

Since 51ff8b09dbadf8c0f15a62d2b26e6df6d6630f31 the code has been
refactored to use the new JS import, but the way we import doesn't work
with the "default export" used in "slides_course_tag_add".

Task-2636073
