### PR TITLE
[FIX] mail: prevent blocking datachannel access if one is unavailable

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -633,7 +633,7 @@ function factory(dependencies) {
                 for (const token of targetTokens) {
                     const dataChannel = this._dataChannels[token];
                     if (!dataChannel || dataChannel.readyState !== 'open') {
-                        return;
+                        continue;
                     }
                     dataChannel.send(content);
                 }


### PR DESCRIPTION
Before this commit, if one RTCDataChannel was not available, signaling
using the RTDDataChannels was faulty.

This commit fixes this issue by skipping unavailable dataChannels.
