### PR TITLE
[IMP] account: add hook to pre-process taxes_map

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -483,6 +483,10 @@ class AccountMove(models.Model):
         self.ensure_one()
         return -1 if self.type in ('out_invoice', 'in_refund', 'out_receipt') else 1
 
+    def _preprocess_taxes_map(self, taxes_map):
+        """ Useful in case we want to pre-process taxes_map """
+        return taxes_map
+
     def _recompute_tax_lines(self, recompute_tax_base_amount=False):
         ''' Compute the dynamic tax lines of the journal entry.
 
@@ -642,6 +646,9 @@ class AccountMove(models.Model):
                 taxes_map_entry['grouping_dict'] = grouping_dict
             if not recompute_tax_base_amount:
                 line.tax_exigible = tax_exigible
+
+        # ==== Pre-process taxes_map ====
+        taxes_map = self._preprocess_taxes_map(taxes_map)
 
         # ==== Process taxes_map ====
         for taxes_map_entry in taxes_map.values():


### PR DESCRIPTION
Currently, the `_recompute_tax_lines` method is too long and there is no way to customize the _taxes_map_ before move line creation. This commit adds a hook to be able to customize the tax dict values.

NOTE: In previous versions (before _account-pocalypse_), it was possible to customize it because `get_taxes_values` was a separated method. So this commit in fact restores the ability to be able to customize it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr