### PR TITLE
[FIX] base: infos for act_window_close

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -306,6 +306,7 @@ VIEW_TYPES = [
     ('kanban', 'Kanban'),
 ]
 
+
 class IrActionsActWindowView(models.Model):
     _name = 'ir.actions.act_window.view'
     _description = 'Action Window View'
@@ -336,9 +337,9 @@ class IrActionsActWindowclose(models.Model):
 
     def _get_readable_fields(self):
         return super()._get_readable_fields() | {
-            # 'effect' is not a real field of ir.actions.act_window_close but is
-            # used to display the rainbowman
-            "effect"
+            # 'effect' and 'infos' are not real fields of `ir.actions.act_window_close` but they are
+            # used to display the rainbowman ('effect') and waited by the action_service ('infos').
+            "effect", "infos"
         }
 
 


### PR DESCRIPTION
Clientside, the only key got from an `ir.actions.act_window_close` type action is 'infos'. But this key isn't a part of the whitelisted readable fields server side, which means you will get a warning if you use it.