### PR TITLE
[IMP] website: adapt theme_nano default palette

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -1247,6 +1247,7 @@ $o-color-palettes: map-merge($o-color-palettes,
             'o-cc4-link': 'o-color-4',
             'o-cc5-btn-secondary': 'o-color-2',
 
+            'body': 'o-color-5',
             'preheader': 4,
             'menu': 5,
             'footer': 2,


### PR DESCRIPTION
Set background color to the body 
in the default palette of the Nano theme.

Related PR: [PR#494](https://github.com/odoo/design-themes/pull/494)
[task-2590182
](https://www.odoo.com/web#id=2590182&action=333&active_id=4733&model=project.task&view_type=form&cids=1&menu_id=4720)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
