### PR TITLE
[FIX] sale: Display same invoiced quantities on SO as on Invoice

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1060,9 +1060,9 @@ class SaleOrderLine(models.Model):
             for invoice_line in line.invoice_lines:
                 if invoice_line.invoice_id.state != 'cancel':
                     if invoice_line.invoice_id.type == 'out_invoice':
-                        qty_invoiced += invoice_line.uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
+                        qty_invoiced += invoice_line.uom_id._compute_quantity(invoice_line.quantity, line.product_uom, round=False)
                     elif invoice_line.invoice_id.type == 'out_refund':
-                        qty_invoiced -= invoice_line.uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
+                        qty_invoiced -= invoice_line.uom_id._compute_quantity(invoice_line.quantity, line.product_uom, round=False)
             line.qty_invoiced = qty_invoiced
 
     @api.depends('price_unit', 'discount')


### PR DESCRIPTION
Steps to reproduce:

- Create a service type of product with:
    - Invoicing policy on ordered quantity
    - Unit of Measure = Hour
- Decimal accuracy for Product Unit of Measure = 2
- Precision Rounding for Hour is 1.00
- Create SO with this service type of product for quantity 1.5
- Confirm and Create Invoice

Issue:

  Quantity on the Invoice is 1.5 but the invoiced quantity on SO is 2.

Cause:

  Using UOM rounding precision when getting the quantity from the invoice
  However, UOM rounding precision not used upstream of the flow (for ex.
  in the quotations lines before invoicing it).

Solution:

  Do not round quantity to match the whole flow behavior (meaning the
  quantity on Quotation order lines, and the quantity from Quotation to
  Invoice order lines).

opw-2479568