### PR TITLE
[REM] obsolete dependency: feedparser

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -68,7 +68,6 @@ PKGS_TO_INSTALL="
     python3-dateutil \
     python3-decorator \
     python3-docutils \
-    python3-feedparser \
     python3-pil \
     python3-jinja2 \
     python3-ldap \

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Depends:
  python3-dateutil,
  python3-decorator,
  python3-docutils,
- python3-feedparser,
  python3-html2text,
  python3-pil,
  python3-jinja2,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ chardet==3.0.4
 decorator==4.0.10
 docutils==0.12
 ebaysdk==2.1.5
-feedparser==5.2.1
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version >= '3.7'
 greenlet==0.4.10 ; python_version < '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ requires =
   python3-babel
   python3-decorator
   python3-docutils
-  python3-feedparser
   python3-gevent
   python3-greenlet
   python3-html2text

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'babel >= 1.0',
         'decorator',
         'docutils',
-        'feedparser',
         'gevent',
         'html2text',
         'Jinja2',

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -27,7 +27,6 @@ RUN apt-get update -qq &&  \
         python3-dateutil \
         python3-decorator \
         python3-docutils \
-        python3-feedparser \
         python3-gevent \
         python3-html2text \
         python3-pil \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -13,7 +13,6 @@ RUN dnf update -d 0 -e 0 -y && \
 		python3-babel \
 	  python3-decorator \
 	  python3-docutils \
-	  python3-feedparser \
 	  python3-gevent \
 	  python3-greenlet \
 	  python3-html2text \


### PR DESCRIPTION
- Up to odoo 10.0, `feedparser` dependency was optionally used in the cli of [vendored `html2text.py`](https://github.com/odoo/odoo/blob/10.0/addons/mail/models/html2text.py#L437)
- Since 11.0, vendored `html2text.py` has been [removed](https://github.com/odoo/odoo/commit/67c17cb37f6ed0fde5e4bffa0d363e2502100f5b) in favor of maintained package
- Turns out the `feedparser` part in html2text was [dead code for a long time](https://github.com/Alir3z4/html2text/issues/220) anyway
- So we can safely drop this dependency, at least in master

What brought me here, is that odoo didn't install with pip anymore:
- [`feedparser==5.2.1` relies on 2to3](https://github.com/kurtmckee/feedparser/blob/5.2.1/setup.py#L6)
- but [2to3 support has been removed from setuptools since 58.0.0](https://setuptools.readthedocs.io/en/latest/history.html#breaking-changes)