### PR TITLE
revert autofocus hook to previous implementation

### DIFF
--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -40,22 +40,22 @@ export function useAutofocus(params = {}) {
         return () => {};
     }
     const selector = params.selector || "[autofocus]";
-    let forceFocusCount = 0;
-    useEffect(
-        function autofocus(target) {
-            if (target) {
-                target.focus();
-                if (["INPUT", "TEXTAREA"].includes(target.tagName)) {
-                    const inputEl = target;
-                    inputEl.selectionStart = inputEl.selectionEnd = inputEl.value.length;
-                }
+    let target = null;
+    const autofocus = () => {
+        const prevTarget = target;
+        target = comp.el.querySelector(selector);
+        if (target && target !== prevTarget) {
+            target.focus();
+            if (["INPUT", "TEXTAREA"].includes(target.tagName)) {
+                const inputEl = target;
+                inputEl.selectionStart = inputEl.selectionEnd = inputEl.value.length;
             }
-        },
-        () => [comp.el.querySelector(selector), forceFocusCount]
-    );
+        }
+    };
+    useEffect(autofocus);
 
     return function focusOnUpdate() {
-        forceFocusCount++; // force the effect to rerun on next patch
+        target = null;
     };
 }
 

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { useBus, useEffect, useListener, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useBus, useEffect, useListener, useService } from "@web/core/utils/hooks";
+import { uiService } from "@web/core/ui/ui_service";
 import { registry } from "@web/core/registry";
 import { makeTestEnv } from "../../helpers/mock_env";
 import { click, getFixture, nextTick } from "../../helpers/utils";
@@ -35,6 +36,29 @@ QUnit.module("utils", () => {
             env.bus.trigger("test-event");
             await nextTick();
             assert.verifySteps([]);
+
+            comp.destroy();
+        });
+
+        QUnit.module("useAutofocus");
+
+        QUnit.test("useAutofocus hook: simple usecase", async function (assert) {
+            assert.expect(1);
+
+            class MyComponent extends Component {
+                setup() {
+                    this.uiService = useService("ui");
+                    useAutofocus({ selector: 'input' });
+                }
+            }
+            MyComponent.template = tags.xml`<div><input /></div>`;
+
+            serviceRegistry.add("ui", uiService);
+            const env = await makeTestEnv();
+            const target = getFixture();
+            const comp = await mount(MyComponent, { env, target });
+            assert.strictEqual(document.activeElement, comp.el.querySelector('input'),
+                "active element should be input");
 
             comp.destroy();
         });


### PR DESCRIPTION
PURPOSE
since commit: ff870d8d15cf65e156f35e3651b670cba2a9d72b autofocus hook was not working in some cases for example: open studio -> create new app -> dialog to enter app name is displayed but input do not have focus.

SPEC
Revert commit and move to the previous implementation for autofocus hook which was working without checking dependency computation.

TASK 2610975


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
