### PR TITLE
Master timesheets demo data improvements bbh

### DIFF
--- a/addons/hr_timesheet/data/hr_timesheet_demo.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_demo.xml
@@ -11,9 +11,81 @@
         <field name="timesheet_cost">100</field>
     </record>
 
+    <record id="hr.employee_vad" model="hr.employee">
+        <field name="timesheet_cost">35</field>
+    </record>
+
+    <record id="hr.employee_jth" model="hr.employee">
+        <field name="timesheet_cost">25</field>
+    </record>
+
+    <record id="hr.employee_niv" model="hr.employee">
+        <field name="timesheet_cost">45</field>
+    </record>
+
+    <record id="hr.employee_jod" model="hr.employee">
+        <field name="timesheet_cost">55</field>
+    </record>
+
+    <record id="hr.employee_jve" model="hr.employee">
+        <field name="timesheet_cost">15</field>
+    </record>
+
+    <record id="hr.employee_fme" model="hr.employee">
+        <field name="timesheet_cost">45</field>
+    </record>
+
+    <record id="hr.employee_chs" model="hr.employee">
+        <field name="timesheet_cost">20</field>
+    </record>
+
+    <record id="hr.employee_ngh" model="hr.employee">
+        <field name="timesheet_cost">40</field>
+    </record>
+
+    <record id="hr.employee_jgo" model="hr.employee">
+        <field name="timesheet_cost">45</field>
+    </record>
+
+    <record id="hr.employee_lur" model="hr.employee">
+        <field name="timesheet_cost">35</field>
+    </record>
+
+    <record id="hr.employee_jep" model="hr.employee">
+        <field name="timesheet_cost">25</field>
+    </record>
+
+    <record id="hr.employee_jog" model="hr.employee">
+        <field name="timesheet_cost">40</field>
+    </record>
+
+    <record id="hr.employee_fpi" model="hr.employee">
+        <field name="timesheet_cost">50</field>
+    </record>
+
+    <record id="hr.employee_mit" model="hr.employee">
+        <field name="timesheet_cost">15</field>
+    </record>
+
+    <record id="hr.employee_hne" model="hr.employee">
+        <field name="timesheet_cost">10</field>
+    </record>
+
     <record id="hr.employee_qdp" model="hr.employee">
         <field name="timesheet_cost">75</field>
         <field name="parent_id" ref="hr.employee_admin"/>
+    </record>
+
+    <record id="hr.employee_stw" model="hr.employee">
+        <field name="timesheet_cost">65</field>
+    </record>
+
+    <record id="hr.employee_al" model="hr.employee">
+        <field name="timesheet_cost">50</field>
+    </record>
+
+    <record id="hr.employee_han" model="hr.employee">
+        <field name="timesheet_cost">35</field>
     </record>
 
     <!-- Projects -->


### PR DESCRIPTION
Currently 'Timesheet cost' is not set in demo data.
This commit sets the 'Timesheet cost' on each employee of the demo data.

task-2531416

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
