### PR TITLE
[FIX] web: re render stat buttons after computation of attrs

### DIFF
--- a/addons/web/static/src/legacy/js/views/form/form_renderer.js
+++ b/addons/web/static/src/legacy/js/views/form/form_renderer.js
@@ -192,6 +192,11 @@ var FormRenderer = BasicRenderer.extend({
                 self.canBeSaved(self.state.id);
             }
             self._postProcessLabels();
+            if (self._button_box_node) {
+                self.defs = [];
+                $('.oe_button_box').replaceWith(self._renderButtonBox(self._button_box_node));
+                delete self.defs;
+            }
             return resetWidgets;
         });
     },
@@ -797,6 +802,7 @@ var FormRenderer = BasicRenderer.extend({
             return renderer.call(this, node);
         }
         if (node.tag === 'div' && node.attrs.name === 'button_box') {
+            this._button_box_node = node;
             return this._renderButtonBox(node);
         }
         if (_.isString(node)) {

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -5487,6 +5487,43 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('recompute buttonbox based on attrs', async function (assert) {
+        assert.expect(2);
+
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:
+                '<form>' +
+                    '<div name="button_box" class="oe_button_box">' +
+                        '<field name="foo"/>' +
+                        '<field name="bar" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<field name="int_field" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<field name="qux" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<field name="display_name" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<field name="state" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<field name="date" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<field name="datetime" attrs="{\'invisible\': [(\'foo\', \'=\', \'bli\')]}"/>' +
+                        '<button type="object" class="oe_stat_button" icon="fa-check-square"/>' +
+                    '</div>' +
+                '</form>',
+            res_id: 2,
+        });
+
+        assert.doesNotHaveClass(form.$('.oe_button_box'), 'o_not_full',
+            "the buttonbox should be full");
+
+
+        await testUtils.form.clickEdit(form);
+        await testUtils.fields.editInput(form.$('input[name="foo"]'), 'bli');
+
+        assert.hasClass(form.$('.oe_button_box'), 'o_not_full',
+            "the buttonbox should not be full");
+
+        form.destroy();
+    });
+
     QUnit.test('display correctly buttonbox, in large size class', async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
When buttons in the stat button bar are added or removed by attrs, they
are not rendered correctly:
* the left border on the leftmost button can be missing
* there might be too many buttons to fit on one line



To reproduce:
* On master with all modules installed (default runbot build)
* Go to Product Variants: Sales / Products / Product Variants
* Create a new one

The first issue can be seen by switching the product type to Service
![image](https://user-images.githubusercontent.com/44770049/132498745-7d633f44-8161-44d1-a935-051333e25e23.png)

The second issue can be seen by switching the product type to Storable Product
![image](https://user-images.githubusercontent.com/44770049/132498848-528066ff-06fc-4914-a95d-a044ee1adbf5.png)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
