### PR TITLE
[FIX] mail: prevent traceback when getting audio when no longer needed

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -301,7 +301,15 @@ function factory(dependencies) {
                         ),
                         type: 'warning',
                     });
-                    this.currentRtcSession.updateAndBroadcast({ isMuted: true });
+                    if (this.currentRtcSession) {
+                        this.currentRtcSession.updateAndBroadcast({ isMuted: true });
+                    }
+                    return;
+                }
+                if (!this.currentRtcSession) {
+                    // The getUserMedia promise could resolve when the call is ended
+                    // in which case the track is no longer relevant.
+                    audioTrack.stop();
                     return;
                 }
                 audioTrack.addEventListener('ended', async () => {


### PR DESCRIPTION
Before this commit, leaving the call before the request for the audio
stream was complete would lead to a traceback as the following
operations were no longer relevant when a call is ended.


