### PR TITLE
[FIX] web_editor, website: re-introduce link double click

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -127,12 +127,14 @@ const Link = Widget.extend({
         this._updateOptionsUI();
         this._adaptPreview();
 
-        // ensure the focus in the first input of the link modal
-        setTimeout(()=> {
-            const firstInput = this.$('input:visible:first');
-            firstInput.focus();
-            firstInput.select();
-        }, 0);
+        if (!this.options.noFocusUrl) {
+            // ensure the focus in the first input of the link modal
+            setTimeout(()=> {
+                const firstInput = this.$('input:visible:first');
+                firstInput.focus();
+                firstInput.select();
+            }, 0);
+        }
 
         return this._super.apply(this, arguments);
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -53,7 +53,13 @@ const LinkPopoverWidget = Widget.extend({
             html: true,
             content: this.$el,
             placement: 'bottom',
-            trigger: 'click',
+            // We need the popover to:
+            // 1. Open when the link is clicked or double clicked
+            // 2. Remain open when the link is clicked again (which `trigger: 'click'` is not doing)
+            // 3. Remain open when the popover content is clicked..
+            // 4. ..except if it the click was on a button of the popover content
+            // 5. Close when the user click somewhere on the page (not being the link or the popover content)
+            trigger: 'focus',
             boundary: 'viewport',
         })
         .on('show.bs.popover.link_popover', () => {
@@ -162,7 +168,7 @@ const LinkPopoverWidget = Widget.extend({
     /**
      * Opens the Link Dialog.
      *
-     * TODO Call business methods once new editor is released instead of click
+     * TODO The editor instance should be reached a proper way
      *
      * @private
      * @param {Event} ev

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -168,7 +168,10 @@ const LinkPopoverWidget = Widget.extend({
      * @param {Event} ev
      */
     _onEditLinkClick(ev) {
-        $('#toolbar #create-link').click();
+        $('#wrapwrap').data('wysiwyg').toggleLinkTools({
+            forceOpen: true,
+            link: this.$target[0],
+        });
         ev.stopImmediatePropagation();
     },
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -796,6 +796,7 @@ const Wysiwyg = Widget.extend({
      * @param {boolean} [options.forceOpen] default: false
      * @param {boolean} [options.forceDialog] force to open the dialog
      * @param {boolean} [options.link] The anchor element to edit if it is known.
+     * @param {boolean} [options.noFocusUrl=false] Disable the automatic focusing of the URL field.
      */
     toggleLinkTools(options = {}) {
         if (this.snippetsMenu && !options.forceDialog) {
@@ -804,7 +805,7 @@ const Wysiwyg = Widget.extend({
             }
             if (options.forceOpen || !this.linkTools) {
                 const $btn = this.toolbar.$el.find('#create-link');
-                this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this}, this.odooEditor.editable, {}, $btn, options.link || this.lastMediaClicked);
+                this.linkTools = new weWidgets.LinkTools(this, {wysiwyg: this, noFocusUrl: options.noFocusUrl}, this.odooEditor.editable, {}, $btn, options.link || this.lastMediaClicked);
                 const _onMousedown = ev => {
                     if (!ev.target.closest('.oe-toolbar') && !ev.target.closest('.ui-autocomplete')) {
                         // Destroy the link tools on click anywhere outside the

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -168,17 +168,16 @@ const Wysiwyg = Widget.extend({
 
             self.openMediaDialog(params);
         });
-        if (!this.options.preventLinkDoubleClick) {
-            this.$editable.on('dblclick', 'a', function () {
-                if (!this.getAttribute('data-oe-model') && self.toolbar.$el.is(':visible')) {
-                    self.showTooltip = false;
-                    self.toggleLinkTools({
-                        forceOpen: true,
-                        link: this,
-                    });
-                }
-            });
-        }
+        this.$editable.on('dblclick', 'a', function (ev) {
+            if (!this.getAttribute('data-oe-model') && self.toolbar.$el.is(':visible')) {
+                self.showTooltip = false;
+                self.toggleLinkTools({
+                    forceOpen: true,
+                    link: this,
+                    noFocusUrl: $(ev.target).data('popover-widget-initialized'),
+                });
+            }
+        });
 
         if (options.snippets) {
             $(this.odooEditor.document.body).addClass('editor_enable');
@@ -1287,7 +1286,7 @@ const Wysiwyg = Widget.extend({
             this._updateFaResizeButtons();
         }
         const link = getInSelection(this.odooEditor.document, 'a');
-        if (isInMedia || link && !this.options.preventLinkDoubleClick) {
+        if (isInMedia || link) {
             // Handle the media/link's tooltip.
             this.showTooltip = true;
             setTimeout(() => {

--- a/addons/website/static/src/js/editor/wysiwyg.js
+++ b/addons/website/static/src/js/editor/wysiwyg.js
@@ -50,15 +50,13 @@ Wysiwyg.include({
      */
     start: function () {
         this.options.toolbarHandler = $('#web_editor-top-edit');
-        this.options.preventLinkDoubleClick = true;
-
 
         $(document.body).on('mousedown', (ev) => {
             const $target = $(ev.target);
+
             // Keep popover open if clicked inside it, but not on a button
-            if (!($target.parents('.o_edit_menu_popover').length && !$target.parent('a').addBack('a').length)) {
-                $('.o_edit_menu_popover').popover('hide');
-                $('.o_edit_menu_popover').find('[data-toggle="tooltip"]').tooltip('hide');
+            if ($target.parents('.o_edit_menu_popover').length && !$target.parent('a').addBack('a').length) {
+                ev.preventDefault();
             }
 
             if ($target.is('a') && !$target.attr('data-oe-model') && !$target.find('> [data-oe-model]').length && $target.closest('#wrapwrap').length) {


### PR DESCRIPTION
It was previously decided that double clicking on a link shouldn't do anything
other than opening the popover (which happen on single click).

It was recently decided that we should actually open the right panel link tool
on double click.

Adding double click behavior, it was needed to refactor the way the popover is
opening/closing -> We now use `focus` as trigger instead of `click`.
Side effect, it will also fix 2641448 (part about double click on word)

task-2618494