### PR TITLE
[FIX] website: make search by "Visited Pages" work again

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -4767,6 +4767,12 @@ msgid ""
 msgstr ""
 
 #. module: website
+#: code:addons/website/models/website_visitor.py:0
+#, python-format
+msgid "This operator is not supported"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.page_404
 msgid ""
 "This page does not exist, but you can create it as you are administrator of "

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -48,7 +48,7 @@ class WebsiteVisitor(models.Model):
     visit_count = fields.Integer('Number of visits', default=1, readonly=True, help="A new visit is considered if last connection was more than 8 hours ago.")
     website_track_ids = fields.One2many('website.track', 'visitor_id', string='Visited Pages History', readonly=True)
     visitor_page_count = fields.Integer('Page Views', compute="_compute_page_statistics", help="Total number of visits on tracked pages")
-    page_ids = fields.Many2many('website.page', string="Visited Pages", compute="_compute_page_statistics")
+    page_ids = fields.Many2many('website.page', string="Visited Pages", compute="_compute_page_statistics", search="_search_page_ids")
     page_count = fields.Integer('# Visited Pages', compute="_compute_page_statistics", help="Total number of tracked page visited")
     last_visited_page_id = fields.Many2one('website.page', string="Last Visited Page", compute="_compute_last_visited_page_id")
 
@@ -108,6 +108,11 @@ class WebsiteVisitor(models.Model):
             visitor.page_ids = [(6, 0, visitor_info['page_ids'])]
             visitor.visitor_page_count = visitor_info['visitor_page_count']
             visitor.page_count = visitor_info['page_count']
+
+    def _search_page_ids(self, operator, value):
+        if operator not in ('like', 'ilike', 'not like', 'not ilike', '=like', '=ilike', '=', '!='):
+            raise ValueError(_('This operator is not supported'))
+        return [('website_track_ids.page_id.name', operator, value)]
 
     @api.depends('website_track_ids.page_id')
     def _compute_last_visited_page_id(self):


### PR DESCRIPTION
Field `website.visitor::page_ids` was storable initially [1], but then it was
refactored [2] and hence the search by "Visited Pages" [3] became broken.

Fix it by adding `search=` attribute

[1]: https://github.com/odoo/odoo/commit/6bec0e4d29e6b33b74962b2893a7a405667ef58c
[2]: https://github.com/odoo/odoo/commit/e33172e83210a5e0044a6fb92e315b84deefc440
[3]: https://github.com/odoo/odoo/blob/c6c7605cdae803aca4f441ef4e622a1b79f17019/addons/website/views/website_visitor_views.xml#L248-L257

opw-2622141
