### PR TITLE
[FIX] purchase_stock: include qty in lead days computation

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -620,7 +620,7 @@ class ProductProduct(models.Model):
                 continue
             if partner_id and seller.name not in [partner_id, partner_id.parent_id]:
                 continue
-            if float_compare(quantity_uom_seller, seller.min_qty, precision_digits=precision) == -1:
+            if quantity is not None and float_compare(quantity_uom_seller, seller.min_qty, precision_digits=precision) == -1:
                 continue
             if seller.product_id and seller.product_id != self:
                 continue

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -150,7 +150,7 @@ class StockRule(models.Model):
         delay, delay_description = super()._get_lead_days(product)
         bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')
-        seller = product.with_company(buy_rule.company_id)._select_seller()
+        seller = product.with_company(buy_rule.company_id)._select_seller(quantity=None)
         if not buy_rule or not seller:
             return delay, delay_description
         buy_rule.ensure_one()


### PR DESCRIPTION
The combination of a RR and a supplier that has a minimum quantity and a
lead time leads to incorrect results

To reproduce the issue:
1. Create a product P:
    - Type: Storable
2. Add a reordering rule for P (min: 10, max: 50)
3. Add a vendor to P
    - Quantity: 1
    - Price: 1
    - Delivery Lead Time: 7
4. Run the scheduler
5. Open the generated PO

Error: The order deadline is <today minus 7 days> instead of today. The
receipt date is today instead of <today plus 7 days>

When computing the quantity to order, the method needs the value of
`qty_forecast` (L254 in [1]) The computation of `qty_forecast` leads to
the computation of `lead_days_date`. To do so, it gets the lead days of
the associated stock rule `_get_lead_days`. In this method, a seller is
selected: [2] However, none of the parameter is defined: [3]

In the above case, the seller has a minimum quantity of 1. Therefore,
since this information is not given in [2], the vendor is not selected
and his lead time is therefore not taken into account. So,
`lead_days_date` will be equal to 0 and won't be recomputed. As a
result, the planned delivery date is today. Then, the quantity to order
is computed (L260 in [1]), so later, the module is able to select the
correct seller. However, this one has a lead time of 7 days -> the
generated PO will have the planned date to today and the order deadline
to <today minus 7 days>

Once an orderpoint has its quantity to order defined, its lead time
should be recomputed because it may be different depending to the
selected seller (and thus we should take this quantity into account when
searching for a seller)

[1]
https://github.com/odoo/odoo/blob/59ac8d891de6e20604494d6cfc6fc357a88d226c/addons/stock/models/stock_orderpoint.py#L254-L260
[2]
https://github.com/odoo/odoo/blob/1b03087524080f1a9751b1561cd8891466e72367/addons/purchase_stock/models/stock_rule.py#L153
[3]
https://github.com/odoo/odoo/blob/045c6ad3353bb0849d3f93d3488d8dcd8b8975b0/addons/product/models/product.py#L602

OPW-2614798