### PR TITLE
[REF] web: search param: domains --> comparison

### DIFF
--- a/addons/board/static/src/add_to_board/add_to_board.js
+++ b/addons/board/static/src/add_to_board/add_to_board.js
@@ -38,11 +38,10 @@ export class AddToBoard extends Component {
             action,
             displayName,
             domain,
-            comparison,
             context,
             groupBy,
             orderedBy,
-            view
+            view,
         } = this.env.searchModel;
 
         // Retrieves view context
@@ -57,8 +56,9 @@ export class AddToBoard extends Component {
             ...viewContext,
         };
 
-        if (comparison) {
-            contextToSave.comparison = comparison;
+        const detailedComparison = this.env.searchModel.getFullComparison();
+        if (detailedComparison) {
+            contextToSave.comparison = detailedComparison;
         }
 
         const result = await this.rpc("/board/add_to_dashboard", {

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -7,7 +7,7 @@ import { CallbackRecorder, useSetupAction } from "@web/webclient/actions/action_
 const { Component, hooks } = owl;
 const { useSubEnv } = hooks;
 
-export const SEARCH_KEYS = ["context", "domain", "domains", "groupBy", "orderBy"];
+export const SEARCH_KEYS = ["comparison", "context", "domain", "groupBy", "orderBy"];
 const OTHER_SEARCH_KEYS = ["irFilters", "searchViewArch", "searchViewFields", "searchViewId"];
 
 export class WithSearch extends Component {
@@ -63,7 +63,7 @@ export class WithSearch extends Component {
     async willUpdateProps(nextProps) {
         const config = {};
         for (const key of SEARCH_KEYS) {
-            if (nextProps[key]) {
+            if (nextProps[key] !== undefined) {
                 config[key] = nextProps[key];
             }
         }
@@ -122,9 +122,10 @@ WithSearch.props = {
     display: { type: Object, optional: true },
 
     // search query elements
+    comparison: { validate: () => true, optional: true }, // fix problem with validation with type: [Object, null]
+    // Issue OWL: https://github.com/odoo/owl/issues/910
     context: { type: Object, optional: true },
     domain: { type: Array, element: [String, Array], optional: true },
-    domains: { type: Array, element: Object, optional: true },
     groupBy: { type: Array, element: String, optional: true },
     orderBy: { type: Array, element: String, optional: true },
 

--- a/addons/web/static/src/views/graph/graph_view.xml
+++ b/addons/web/static/src/views/graph/graph_view.xml
@@ -31,7 +31,7 @@
                 t-att-class="{ active: model.metaData.stacked }"
             />
         </div>
-        <div t-if="model.metaData.mode !== 'pie' and env.searchModel.domains.length === 1" class="btn-group ml-3" role="toolbar" aria-label="Sort graph">
+        <div t-if="model.metaData.mode !== 'pie' and model.metaData.domains.length === 1" class="btn-group ml-3" role="toolbar" aria-label="Sort graph">
             <button class="btn btn-secondary fa fa-sort-amount-desc o_graph_button" data-tooltip="Descending" aria-label="Descending"
                 t-on-click="toggleOrder('DESC')"
                 t-att-class="{ active: model.metaData.order === 'DESC' }"

--- a/addons/web/static/src/views/helpers/model.js
+++ b/addons/web/static/src/views/helpers/model.js
@@ -7,6 +7,10 @@ const { core, hooks } = owl;
 const { EventBus } = core;
 const { onWillStart, onWillUpdateProps, useComponent } = hooks;
 
+/**
+ * @typedef {import("@web/search/search_model").SearchParams} SearchParams
+ */
+
 export class Model extends EventBus {
     /**
      * @param {Object} env
@@ -25,7 +29,7 @@ export class Model extends EventBus {
     setup(params, services) {}
 
     /**
-     * @param {Object} searchParams
+     * @param {SearchParams} searchParams
      */
     load(searchParams) {}
 
@@ -35,6 +39,10 @@ export class Model extends EventBus {
 }
 Model.services = [];
 
+/**
+ * @param {Object} props
+ * @returns {SearchParams}
+ */
 function getSearchParams(props) {
     const params = {};
     for (const key of SEARCH_KEYS) {

--- a/addons/web/static/src/views/helpers/standard_view_props.js
+++ b/addons/web/static/src/views/helpers/standard_view_props.js
@@ -19,9 +19,10 @@ export const standardViewProps = {
     },
     resModel: String,
     arch: { type: String },
+    comparison: { validate: () => true }, // fix problem with validation with type: [Object, null]
+    // Issue OWL: https://github.com/odoo/owl/issues/910
     context: { type: Object },
     domain: { type: Array },
-    domains: { type: Array, elements: Object },
     fields: { type: Object, elements: Object },
     groupBy: { type: Array, elements: String },
     limit: { type: Number, optional: 1 },

--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -309,12 +309,7 @@ import { computeReportMeasures, processMeasure } from "@web/views/helpers/utils"
  */
 
 /**
- * @typedef SearchParams
- * @property {Array[]} domain
- * @property {Object} context
- * @property {string[]} groupBy
- * @property {Array[]} domains
- * @property {string[]} origins
+ * @typedef {import("@web/search/search_model").SearchParams} SearchParams
  */
 
 /**
@@ -669,13 +664,7 @@ export class PivotModel extends Model {
     }
     /**
      * @override
-     *
-     * @param {Object} searchParams
-     * @param {Object} params.context
-     * @param {Array[]} params.domain
-     * @param {string[]} params.groupBy
-     * @param {string[]} params.measures
-     * @param {Object} [params.domains]
+     * @param {SearchParams} searchParams
      */
     async load(searchParams) {
         this.orm2Use = this.realORM;
@@ -1475,17 +1464,23 @@ export class PivotModel extends Model {
         }
     }
     /**
+     * @todo review comment
      * Determine this.searchParams.domains and this.searchParams.origins from
      * this.searchParams.domains.
      *
      * @private
+     * @param {SearchParams} searchParams
      */
-    _computeDerivedParams(params) {
-        const domains = params.domains.reverse();
-        return {
-            domains: domains.map((d) => d.arrayRepr),
-            origins: domains.map((d) => d.description || ""),
-        };
+    _computeDerivedParams(searchParams) {
+        const { comparison, domain } = searchParams;
+        if (comparison) {
+            const domains = searchParams.comparison.domains.slice().reverse();
+            return {
+                domains: domains.map((d) => d.arrayRepr),
+                origins: domains.map((d) => d.description),
+            };
+        }
+        return { domains: [domain], origins: [""] };
     }
     /**
      * Make any group in tree a leaf if it was a leaf in oldTree.

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -27,9 +27,9 @@ const { Component } = owl;
  *  @property {Object[]} [irFilters]
  *  @property {boolean} [loadIrFilters=false]
  *
+ *  @property {Object} [comparison]
  *  @property {Object} [context={}]
  *  @property {DomainRepr} [domain]
- *  @property {Object[]} [domains]
  *  @property {string[]} [groupBy]
  *  @property {string[]} [orderBy]
  *
@@ -71,9 +71,9 @@ const STANDARD_PROPS = new Set([
     "irFilters",
     "loadIrFilters",
 
+    "comparison",
     "context",
     "domain",
-    "domains",
     "groupBy",
     "orderBy",
 
@@ -280,9 +280,9 @@ export class View extends Component {
 
     async willUpdateProps(nextProps) {
         // we assume that nextProps can only vary in the search keys:
-        // context, domain, domains, groupBy, orderBy
-        const { context, domain, domains, groupBy, orderBy } = nextProps;
-        Object.assign(this.withSearchProps, { context, domain, domains, groupBy, orderBy });
+        // comparison, context, domain, groupBy, orderBy
+        const { comparison, context, domain, groupBy, orderBy } = nextProps;
+        Object.assign(this.withSearchProps, { comparison, context, domain, groupBy, orderBy });
     }
 }
 

--- a/addons/web/static/tests/search/favorite_menu_tests.js
+++ b/addons/web/static/tests/search/favorite_menu_tests.js
@@ -233,7 +233,7 @@ QUnit.module("Search", (hooks) => {
 
             let domain = controlPanel.env.searchModel.domain;
             let groupBy = controlPanel.env.searchModel.groupBy;
-            let comparison = controlPanel.env.searchModel._getComparison();
+            let comparison = controlPanel.env.searchModel.getFullComparison();
 
             assert.deepEqual(domain, [
                 "&",
@@ -257,7 +257,7 @@ QUnit.module("Search", (hooks) => {
 
             domain = controlPanel.env.searchModel.domain;
             groupBy = controlPanel.env.searchModel.groupBy;
-            comparison = controlPanel.env.searchModel._getComparison();
+            comparison = controlPanel.env.searchModel.getFullComparison();
 
             assert.deepEqual(domain, [["foo", "ilike", "a"]]);
             assert.deepEqual(groupBy, ["date_field:month"]);
@@ -285,7 +285,7 @@ QUnit.module("Search", (hooks) => {
 
             domain = controlPanel.env.searchModel.domain;
             groupBy = controlPanel.env.searchModel.groupBy;
-            comparison = controlPanel.env.searchModel._getComparison();
+            comparison = controlPanel.env.searchModel.getFullComparison();
 
             assert.deepEqual(domain, ["!", ["foo", "=", "qsdf"]]);
             assert.deepEqual(groupBy, ["foo"]);

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -381,10 +381,12 @@ QUnit.module("Views", (hooks) => {
                 </graph>
             `,
             groupBy: [],
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["Total"]);
         checkDatasets(
@@ -449,10 +451,12 @@ QUnit.module("Views", (hooks) => {
                     <field name="foo"/>
                 </graph>
             `,
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["1", "2", "3", "4"]);
         checkDatasets(
@@ -530,23 +534,6 @@ QUnit.module("Views", (hooks) => {
                 { date: "2021-02-17", revenue: false },
                 { date: false, revenue: 0 },
             ];
-            const domains = [
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-02-01"],
-                        ["date", "<=", "2021-02-28"],
-                    ],
-                    description: "February 2021",
-                },
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-01-01"],
-                        ["date", "<=", "2021-01-31"],
-                    ],
-                    description: "January 2021",
-                },
-            ];
-            domains.fieldName = "date";
             const graph = await makeView({
                 serverData,
                 type: "graph",
@@ -557,7 +544,25 @@ QUnit.module("Views", (hooks) => {
                         <field name="date" interval="week"/>
                     </graph>
                 `,
-                domains,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
             });
             checkLabels(assert, graph, ["W05 2021", "W07 2021", "", ""]);
             checkDatasets(
@@ -644,23 +649,6 @@ QUnit.module("Views", (hooks) => {
                 { date: "2021-02-17", bar: false, revenue: false },
                 { date: false, bar: true, revenue: 0 },
             ];
-            const domains = [
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-02-01"],
-                        ["date", "<=", "2021-02-28"],
-                    ],
-                    description: "February 2021",
-                },
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-01-01"],
-                        ["date", "<=", "2021-01-31"],
-                    ],
-                    description: "January 2021",
-                },
-            ];
-            domains.fieldName = "date";
             const graph = await makeView({
                 serverData,
                 type: "graph",
@@ -672,7 +660,25 @@ QUnit.module("Views", (hooks) => {
                         <field name="date" interval="week"/>
                     </graph>
                 `,
-                domains,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
             });
             checkLabels(assert, graph, ["true", "false"]);
             checkDatasets(
@@ -863,10 +869,12 @@ QUnit.module("Views", (hooks) => {
                     <field name="revenue" type="measure"/>
                 </graph>
             `,
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["", "Total", ""]);
         checkDatasets(
@@ -923,10 +931,12 @@ QUnit.module("Views", (hooks) => {
                     <field name="foo"/>
                 </graph>
             `,
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["1", "2", "3", "4"]);
         checkDatasets(
@@ -1012,23 +1022,6 @@ QUnit.module("Views", (hooks) => {
                 { date: "2021-02-17", revenue: false },
                 { date: false, revenue: 0 },
             ];
-            const domains = [
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-02-01"],
-                        ["date", "<=", "2021-02-28"],
-                    ],
-                    description: "February 2021",
-                },
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-01-01"],
-                        ["date", "<=", "2021-01-31"],
-                    ],
-                    description: "January 2021",
-                },
-            ];
-            domains.fieldName = "date";
             const graph = await makeView({
                 serverData,
                 type: "graph",
@@ -1039,7 +1032,25 @@ QUnit.module("Views", (hooks) => {
                         <field name="date" interval="week"/>
                     </graph>
                 `,
-                domains,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
             });
             checkLabels(assert, graph, ["W05 2021", "W07 2021", "", ""]);
             checkDatasets(
@@ -1118,23 +1129,6 @@ QUnit.module("Views", (hooks) => {
                 { date: "2021-02-17", bar: false, revenue: false },
                 { date: false, bar: true, revenue: 0 },
             ];
-            const domains = [
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-02-01"],
-                        ["date", "<=", "2021-02-28"],
-                    ],
-                    description: "February 2021",
-                },
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-01-01"],
-                        ["date", "<=", "2021-01-31"],
-                    ],
-                    description: "January 2021",
-                },
-            ];
-            domains.fieldName = "date";
             const graph = await makeView({
                 serverData,
                 type: "graph",
@@ -1146,7 +1140,25 @@ QUnit.module("Views", (hooks) => {
                         <field name="date" interval="week"/>
                     </graph>
                 `,
-                domains,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
             });
             checkLabels(assert, graph, ["true", "false"]);
             checkDatasets(
@@ -1316,10 +1328,12 @@ QUnit.module("Views", (hooks) => {
                     <field name="revenue" type="measure"/>
                 </graph>
             `,
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["Total"]);
         checkDatasets(
@@ -1384,10 +1398,12 @@ QUnit.module("Views", (hooks) => {
                     <field name="foo"/>
                 </graph>
             `,
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["1", "2", "4"]);
         checkDatasets(
@@ -1465,23 +1481,6 @@ QUnit.module("Views", (hooks) => {
                 { date: "2021-02-17" },
                 { date: false },
             ];
-            const domains = [
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-02-01"],
-                        ["date", "<=", "2021-02-28"],
-                    ],
-                    description: "February 2021",
-                },
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-01-01"],
-                        ["date", "<=", "2021-01-31"],
-                    ],
-                    description: "January 2021",
-                },
-            ];
-            domains.fieldName = "date";
             const graph = await makeView({
                 serverData,
                 type: "graph",
@@ -1491,7 +1490,25 @@ QUnit.module("Views", (hooks) => {
                         <field name="date" interval="week"/>
                     </graph>
                 `,
-                domains,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
             });
             checkLabels(assert, graph, [
                 "W05 2021, W01 2021",
@@ -1592,23 +1609,6 @@ QUnit.module("Views", (hooks) => {
                 { date: "2021-02-17", bar: false, revenue: false },
                 { date: false, bar: true, revenue: 0 },
             ];
-            const domains = [
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-02-01"],
-                        ["date", "<=", "2021-02-28"],
-                    ],
-                    description: "February 2021",
-                },
-                {
-                    arrayRepr: [
-                        ["date", ">=", "2021-01-01"],
-                        ["date", "<=", "2021-01-31"],
-                    ],
-                    description: "January 2021",
-                },
-            ];
-            domains.fieldName = "date";
             const graph = await makeView({
                 serverData,
                 type: "graph",
@@ -1620,7 +1620,25 @@ QUnit.module("Views", (hooks) => {
                         <field name="date" interval="week"/>
                     </graph>
                 `,
-                domains,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
             });
             checkLabels(assert, graph, ["true / W05 2021", "true / W01 2021", "false / W02 2021"]);
             checkDatasets(
@@ -1715,10 +1733,12 @@ QUnit.module("Views", (hooks) => {
                     <field name="product_id"/>
                 <graph/>
             `,
-            domains: [
-                { arrayRepr: [["bar", "=", true]], description: "True group" },
-                { arrayRepr: [["bar", "=", false]], description: "False group" },
-            ],
+            comparison: {
+                domains: [
+                    { arrayRepr: [["bar", "=", true]], description: "True group" },
+                    { arrayRepr: [["bar", "=", false]], description: "False group" },
+                ],
+            },
         });
         checkLabels(assert, graph, ["xphone", "No data"]);
         checkDatasets(


### PR DESCRIPTION
The search param "domains" of type Array was not satisfactory for
several reasons:
 - useless for non reporting views
 - too close from the search param "domain"
 - a key "fieldName" was put on the value (resulting in a loss of
   information in case of stringification)

We change it for a search param "comparison" of type null or Object.