### PR TITLE
[FIX] payment_authorize: Expired card

### DIFF
--- a/addons/payment_authorize/models/payment.py
+++ b/addons/payment_authorize/models/payment.py
@@ -261,7 +261,7 @@ class TxAuthorize(models.Model):
     def authorize_s2s_void_transaction(self):
         self.ensure_one()
         transaction = AuthorizeAPI(self.acquirer_id)
-        tree = transaction.void(self.acquirer_reference or '')
+        tree = transaction.void(self.acquirer_reference or '0')
         return self._authorize_s2s_validate_tree(tree)
 
     def _authorize_s2s_validate_tree(self, tree):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a credit card CC with expiry date 09/21
- Let's go to the shop on the 30/08/21 and register CC by processing a payment
- In september 2021 return to the shop and try to process an other payment with CC

Bug:

A server error was raised due to ValueError: invalid literal for int() with base 10: ''

opw:2555654