### PR TITLE
[FIX] web: select all feature now works as intended

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -461,14 +461,9 @@ var SelectCreateDialog = ViewDialog.extend({
                 classes: 'btn-primary o_select_button',
                 disabled: true,
                 close: true,
-                click: function () {
-                    var records = this.viewController.getSelectedRecords();
-                    var values = _.map(records, function (record) {
-                        return {
-                            id: record.res_id,
-                            display_name: record.data.display_name,
-                        };
-                    });
+                click: async () => {
+                    const resIds = await this.viewController.getSelectedIdsWithDomain();
+                    const values = resIds.map(e => ({id: e}));
                     this.on_selected(values);
                 },
             });

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -503,6 +503,40 @@ QUnit.module('Views', {
         parent.destroy();
     });
 
+    QUnit.test('SelectCreateDialog calls on_selected with every record matching the domain', async function (assert) {
+        assert.expect(1);
+
+        const parent = await createParent({
+            data: this.data,
+            archs: {
+                'partner,false,list':
+                    '<tree limit="2" string="Partner">' +
+                        '<field name="display_name"/>' +
+                        '<field name="foo"/>' +
+                    '</tree>',
+                'partner,false,search':
+                    '<search>' +
+                        '<field name="foo"/>' +
+                    '</search>',
+            },
+            session: {},
+        });
+
+        new dialogs.SelectCreateDialog(parent, {
+            res_model: 'partner',
+            on_selected: function(records) {
+                assert.equal(records.length, 3)
+            }
+        }).open();
+        await testUtils.nextTick();
+
+        await testUtils.dom.click($('thead .o_list_record_selector input'));
+        await testUtils.dom.click($('.o_list_selection_box .o_list_select_domain'));
+        await testUtils.dom.click($('.modal .o_select_button'));
+
+        parent.destroy();
+    });
+
     QUnit.test('propagate can_create onto the search popup o2m', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
Steps to follow

  - Go to the variant tab of a product
  - Add an attribute and click search more
  - Select the checkbox at the top to select all records from the current page
  - Click on Select all
  - Click on Select
  -> Only the records from the first page are added

Cause of the issue

  `getSelectedRecords` doesn't return the record from all pages
  but only from the current one

Solution

  If the domain is selected, use all the records

opw-2586877