### PR TITLE
Fixed many2many_binary-Widget

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1540,7 +1540,7 @@
             <t t-set="fileupload_action" t-translation="off">/web/binary/upload_attachment</t>
             <t t-set="multi_upload" t-value="true"/>
             <input type="hidden" name="model" t-att-value="widget.model"/>
-            <input type="hidden" name="id" value="0"/>
+            <input type="hidden" name="id" t-att-value="widget.res_id"/>
         </t>
     </div>
 </div>


### PR DESCRIPTION
Widget did set res_id to default value "0".
Now it sets the res_id to the correspondig related res_id.

Description of the issue/feature this PR addresses:
Widget did set res_id to default value "0".

Current behavior before PR:
every time a file gets uploaded the res_id was set to "0". 

Desired behavior after PR is merged:
the res_id is set to the correct res_id from correspondig res_model



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
