### PR TITLE
 [FIX] project{,_mrp}: fix project update stat buttons

### DIFF
--- a/addons/account_sale_timesheet/models/project.py
+++ b/addons/account_sale_timesheet/models/project.py
@@ -14,13 +14,14 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'pencil-square-o',
-            'text': _('Invoices'),
-            'number': self.invoice_count,
-            'action_type': 'object',
-            'action': 'action_open_project_invoices',
-            'show': self.user_has_groups('account.group_account_readonly') and bool(self.analytic_account_id) and self.invoice_count > 0,
-            'sequence': 11,
-        })
+        if self.user_has_groups('account.group_account_readonly'):
+            buttons.append({
+                'icon': 'pencil-square-o',
+                'text': _('Invoices'),
+                'number': self.invoice_count,
+                'action_type': 'object',
+                'action': 'action_open_project_invoices',
+                'show': bool(self.analytic_account_id) and self.invoice_count > 0,
+                'sequence': 11,
+            })
         return buttons

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -204,15 +204,16 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'clock-o',
-            'text': _('Recorded'),
-            'number': '%s %s' % (self.total_timesheet_time, self.env.company.timesheet_encode_uom_id.name),
-            'action_type': 'object',
-            'action': 'action_show_timesheets_by_employee_invoice_type',
-            'show': self.user_has_groups('hr_timesheet.group_hr_timesheet_user') and self.allow_timesheets,
-            'sequence': 4,
-        })
+        if self.user_has_groups('hr_timesheet.group_hr_timesheet_user'):
+            buttons.append({
+                'icon': 'clock-o',
+                'text': _('Recorded'),
+                'number': '%s %s' % (self.total_timesheet_time, self.env.company.timesheet_encode_uom_id.name),
+                'action_type': 'object',
+                'action': 'action_show_timesheets_by_employee_invoice_type',
+                'show': self.allow_timesheets,
+                'sequence': 4,
+            })
         return buttons
 
 

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -719,48 +719,51 @@ class Project(models.Model):
             }),
             'show': True,
             'sequence': 2,
-        },
-        {
-            'icon': 'smile-o',
-            'text': _('Customer Satisfaction'),
-            'number': '%s %%' % (self.rating_percentage_satisfaction),
-            'action_type': 'object',
-            'action': 'action_view_all_rating',
-            'show': self.user_has_groups('project.group_project_rating') and self.rating_active and self.rating_percentage_satisfaction > -1,
-            'sequence': 5,
-        },
-        {
-            'icon': 'area-chart',
-            'text': _('Burndown Chart'),
-            'action_type': 'action',
-            'action': 'project.action_project_task_burndown_chart_report',
-            'additional_context': json.dumps({
-                'active_id': self.id,
-            }),
-            'show': self.user_has_groups('project.group_project_manager'),
-            'sequence': 7,
-        },
-        {
-            'icon': 'usd',
-            'text': _('Gross Margin'),
-            'number': format_amount(self.env, self.analytic_account_balance, self.company_id.currency_id),
-            'action_type': 'object',
-            'action': 'action_view_analytic_account_entries',
-            'show': self.user_has_groups('analytic.group_analytic_accounting'),
-            'sequence': 18,
-        },
-        {
-            'icon': 'users',
-            'text': _('Collaborators'),
-            'number': self.collaborator_count,
-            'action_type': 'action',
-            'action': 'project.project_collaborator_action',
-            'additional_context': json.dumps({
-                'active_id': self.id,
-            }),
-            'show': self.user_has_groups('project.group_project_manager'),
-            'sequence': 19,
         }]
+        if self.user_has_groups('project.group_project_rating'):
+            buttons.append({
+                'icon': 'smile-o',
+                'text': _('Customer Satisfaction'),
+                'number': '%s %%' % (self.rating_percentage_satisfaction),
+                'action_type': 'object',
+                'action': 'action_view_all_rating',
+                'show': self.rating_active and self.rating_percentage_satisfaction > -1,
+                'sequence': 5,
+            })
+        if self.user_has_groups('project.group_project_manager'):
+            buttons.append({
+                'icon': 'area-chart',
+                'text': _('Burndown Chart'),
+                'action_type': 'action',
+                'action': 'project.action_project_task_burndown_chart_report',
+                'additional_context': json.dumps({
+                    'active_id': self.id,
+                }),
+                'show': True,
+                'sequence': 7,
+            })
+            buttons.append({
+                'icon': 'users',
+                'text': _('Collaborators'),
+                'number': self.collaborator_count,
+                'action_type': 'action',
+                'action': 'project.project_collaborator_action',
+                'additional_context': json.dumps({
+                    'active_id': self.id,
+                }),
+                'show': True,
+                'sequence': 23,
+            })
+        if self.user_has_groups('analytic.group_analytic_accounting'):
+            buttons.append({
+                'icon': 'usd',
+                'text': _('Gross Margin'),
+                'number': format_amount(self.env, self.analytic_account_balance, self.company_id.currency_id),
+                'action_type': 'object',
+                'action': 'action_view_analytic_account_entries',
+                'show': True,
+                'sequence': 18,
+            })
         return buttons
 
     def _get_tasks_analysis_counts(self, created=False, updated=False):

--- a/addons/project_hr_expense/models/project.py
+++ b/addons/project_hr_expense/models/project.py
@@ -46,13 +46,14 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'money',
-            'text': _('Expenses'),
-            'number': self.expenses_count,
-            'action_type': 'object',
-            'action': 'action_open_project_expenses',
-            'show': self.user_has_groups('hr_expense.group_hr_expense_team_approver') and self.expenses_count > 0,
-            'sequence': 10,
-        })
+        if self.user_has_groups('hr_expense.group_hr_expense_team_approver'):
+            buttons.append({
+                'icon': 'money',
+                'text': _('Expenses'),
+                'number': self.expenses_count,
+                'action_type': 'object',
+                'action': 'action_open_project_expenses',
+                'show': self.expenses_count > 0,
+                'sequence': 10,
+            })
         return buttons

--- a/addons/project_mrp/models/project.py
+++ b/addons/project_mrp/models/project.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, _
 
 
 class Project(models.Model):
@@ -13,12 +13,57 @@ class Project(models.Model):
 
     def action_view_mrp_production(self):
         self.ensure_one()
-        return self.analytic_account_id.action_view_mrp_production()
+        action = self.analytic_account_id.action_view_mrp_production()
+        if self.production_count > 1:
+            action["view_mode"] = 'tree,form,kanban,calendar,pivot,graph'
+        return action
 
     def action_view_mrp_bom(self):
         self.ensure_one()
-        return self.analytic_account_id.action_view_mrp_bom()
+        action = self.analytic_account_id.action_view_mrp_bom()
+        if self.bom_count > 1:
+            action['view_mode'] = 'tree,form,kanban'
+        return action
 
     def action_view_workorder(self):
         self.ensure_one()
-        return self.analytic_account_id.action_view_workorder()
+        action = self.analytic_account_id.action_view_workorder()
+        if self.workorder_count > 1:
+            action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,gantt'
+        return action
+
+    # ----------------------------
+    #  Project Updates
+    # ----------------------------
+
+    def _get_stat_buttons(self):
+        buttons = super(Project, self)._get_stat_buttons()
+        if self.user_has_groups('mrp.group_mrp_user'):
+            buttons.extend([{
+                'icon': 'wrench',
+                'text': _('Manufacturing Orders'),
+                'number': self.production_count,
+                'action_type': 'object',
+                'action': 'action_view_mrp_production',
+                'show': self.production_count > 0,
+                'sequence': 19,
+            },
+            {
+                'icon': 'cog',
+                'text': _('Work Orders'),
+                'number': self.workorder_count,
+                'action_type': 'object',
+                'action': 'action_view_workorder',
+                'show': self.workorder_count > 0,
+                'sequence': 20,
+            },
+            {
+                'icon': 'flask',
+                'text': _('Bills of Materials'),
+                'number': self.bom_count,
+                'action_type': 'object',
+                'action': 'action_view_mrp_bom',
+                'show': self.bom_count > 0,
+                'sequence': 21,
+            }])
+        return buttons

--- a/addons/project_mrp/views/project_views.xml
+++ b/addons/project_mrp/views/project_views.xml
@@ -8,15 +8,18 @@
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_view_analytic_account_entries']" position="after">
                 <button class="oe_stat_button" type="object" name="action_view_mrp_production"
-                    icon="fa-wrench" attrs="{'invisible': [('production_count', '=', 0)]}">
+                    icon="fa-wrench" attrs="{'invisible': [('production_count', '=', 0)]}"
+                    groups="mrp.group_mrp_user">
                     <field string="Manufacturing Orders" name="production_count" widget="statinfo"/>
                 </button>
                 <button class="oe_stat_button" type="object" name="action_view_workorder"
-                    icon="fa-cog" attrs="{'invisible': [('workorder_count', '=', 0)]}">
+                    icon="fa-cog" attrs="{'invisible': [('workorder_count', '=', 0)]}"
+                    groups="mrp.group_mrp_user">
                     <field string="Work Orders" name="workorder_count" widget="statinfo"/>
                 </button>
                 <button class="oe_stat_button" type="object" name="action_view_mrp_bom"
-                    icon="fa-flask" attrs="{'invisible': [('bom_count', '=', 0)]}">
+                    icon="fa-flask" attrs="{'invisible': [('bom_count', '=', 0)]}"
+                    groups="mrp.group_mrp_user">
                     <field string="Bills of Materials" name="bom_count" widget="statinfo"/>
                 </button>
             </xpath>

--- a/addons/project_purchase/models/project.py
+++ b/addons/project_purchase/models/project.py
@@ -49,13 +49,14 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'credit-card',
-            'text': _('Purchase Orders'),
-            'number': self.purchase_orders_count,
-            'action_type': 'object',
-            'action': 'action_open_project_purchase_orders',
-            'show': self.user_has_groups('purchase.group_purchase_user') and self.purchase_orders_count > 0,
-            'sequence': 13,
-        })
+        if self.user_has_groups('purchase.group_purchase_user'):
+            buttons.append({
+                'icon': 'credit-card',
+                'text': _('Purchase Orders'),
+                'number': self.purchase_orders_count,
+                'action_type': 'object',
+                'action': 'action_open_project_purchase_orders',
+                'show': self.purchase_orders_count > 0,
+                'sequence': 13,
+            })
         return buttons

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -76,14 +76,15 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'dollar',
-            'text': _('Sales Order'),
-            'action_type': 'object',
-            'action': 'action_view_so',
-            'show': self.user_has_groups('sales_team.group_sale_salesman_all_leads') and bool(self.sale_order_id),
-            'sequence': 1,
-        })
+        if self.user_has_groups('sales_team.group_sale_salesman_all_leads'):
+            buttons.append({
+                'icon': 'dollar',
+                'text': _('Sales Order'),
+                'action_type': 'object',
+                'action': 'action_view_so',
+                'show': bool(self.sale_order_id),
+                'sequence': 1,
+            })
         return buttons
 
 class ProjectTask(models.Model):

--- a/addons/sale_project_account/models/project.py
+++ b/addons/sale_project_account/models/project.py
@@ -35,13 +35,14 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'pencil-square-o',
-            'text': _('Vendor Bills'),
-            'number': self.vendor_bill_count,
-            'action_type': 'object',
-            'action': 'action_open_project_vendor_bills',
-            'show': self.user_has_groups('account.group_account_readonly') and self.vendor_bill_count > 0,
-            'sequence': 14,
-        })
+        if self.user_has_groups('account.group_account_readonly'):
+            buttons.append({
+                'icon': 'pencil-square-o',
+                'text': _('Vendor Bills'),
+                'number': self.vendor_bill_count,
+                'action_type': 'object',
+                'action': 'action_open_project_vendor_bills',
+                'show': self.vendor_bill_count > 0,
+                'sequence': 14,
+            })
         return buttons

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -387,19 +387,20 @@ class Project(models.Model):
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()
-        buttons.append({
-            'icon': 'clock-o',
-            'text': _('Billable Time'),
-            'number': '%s %%' % (self.billable_percentage),
-            'action_type': 'object',
-            'action': 'action_billable_time_button',
-            'additional_context': json.dumps({
-                'active_id': self.id,
-                'default_project_id': self.id
-            }),
-            'show': self.user_has_groups('hr_timesheet.group_hr_timesheet_approver') and self.allow_timesheets and bool(self.analytic_account_id),
-            'sequence': 9,
-        })
+        if self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
+            buttons.append({
+                'icon': 'clock-o',
+                'text': _('Billable Time'),
+                'number': '%s %%' % (self.billable_percentage),
+                'action_type': 'object',
+                'action': 'action_billable_time_button',
+                'additional_context': json.dumps({
+                    'active_id': self.id,
+                    'default_project_id': self.id
+                }),
+                'show': self.allow_timesheets and bool(self.analytic_account_id),
+                'sequence': 9,
+            })
         return buttons
 
 class ProjectTask(models.Model):


### PR DESCRIPTION
We are copying 3 stats buttons from the project
view form (manufacturing orders, work orders and bills of materials)
 and we add them to the project update page.

See task-2638359
See odoo/enterprise#20703

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
