### PR TITLE
[FIX] web_editor: fix empty save on dialogs

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -1338,15 +1338,16 @@ var VideoWidget = MediaWidget.extend({
      */
     save: function () {
         this._updateVideo();
+        const videoSrc = this.$content.attr('src');
         if (this.isForBgVideo) {
-            return Promise.resolve({bgVideoSrc: this.$content.attr('src')});
+            return Promise.resolve({bgVideoSrc: videoSrc});
         }
-        if (this.$('.o_video_dialog_iframe').is('iframe')) {
+        if (this.$('.o_video_dialog_iframe').is('iframe') && videoSrc) {
             this.$media = $(
-                '<div class="media_iframe_video" data-oe-expression="' + this.$content.attr('src') + '">' +
+                '<div class="media_iframe_video" data-oe-expression="' + videoSrc + '">' +
                     '<div class="css_editable_mode_display">&nbsp;</div>' +
                     '<div class="media_iframe_video_size" contenteditable="false">&nbsp;</div>' +
-                    '<iframe src="' + this.$content.attr('src') + '" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>' +
+                    '<iframe src="' + videoSrc + '" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>' +
                 '</div>'
             );
             this.media = this.$media[0];

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -576,6 +576,9 @@ const Wysiwyg = Widget.extend({
             const restoreSelection = preserveCursor(this.odooEditor.document);
             linkDialog.open();
             linkDialog.on('save', this, data => {
+                if (!data) {
+                    return;
+                }
                 const linkWidget = linkDialog.linkWidget;
                 getDeepRange(this.$editable[0], {range: data.range, select: true});
                 if (!linkWidget.$link.length) {
@@ -645,6 +648,9 @@ const Wysiwyg = Widget.extend({
         mediaDialog.open();
 
         mediaDialog.on('save', this, function (element) {
+            if (!element) {
+                return;
+            }
             // restore saved html classes
             if (params.htmlClass) {
                 element.className += " " + params.htmlClass;


### PR DESCRIPTION
I- mediaDialog/linkDialog:

1- Website editor > Add image/link using "/" commands.
2- The mediaDliaog/linkDialog will be shown to select item.
3- Click on "Add/Save" without selecting any image/setting
   any link.
4- traceback.

II- mediaDialog (Video):

The same flow for videos will add an empty <iframe> (with
no src specified) to the DOM.

The goal of this PR is to prevent this behaviour
by adding a test on values passed to the 'save' event
listeners.

task-2628964