### PR TITLE
[FIX] point_of_sale: consider scanned price as manual price

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -245,7 +245,12 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
 
             // update the options depending on the type of the scanned code
             if (code.type === 'price') {
-                Object.assign(options, { price: code.value });
+                Object.assign(options, {
+                    price: code.value,
+                    extras: {
+                        price_manually_set: true,
+                    },
+                });
             } else if (code.type === 'weight') {
                 Object.assign(options, {
                     quantity: code.value,


### PR DESCRIPTION
In a POS session, when using the scanner, if the seller changes the
customer, the prices may become incorrect

To reproduce the issue
1. Create a product P:
    - Sales Price: 38
    - Barcode: 2312345000002
    - Available in POS: True
2. Start a POS session (with debug Window)
3. Scan 2312345010001
    - This is product P with price $10
4. Set a Customer

Error: The price is now $38

Because the price has not been set manually, when changing the customer,
the pricelist is updated and so does the price.

When scanning a barcode that includes a price, the latter should be
considered as manually set.

OPW-2618934