### PR TITLE
[FIX] account: use current date as fallback to convert currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3693,7 +3693,7 @@ class AccountMoveLine(models.Model):
     def _onchange_amount_currency(self):
         for line in self:
             company = line.move_id.company_id
-            balance = line.currency_id._convert(line.amount_currency, company.currency_id, company, line.move_id.date)
+            balance = line.currency_id._convert(line.amount_currency, company.currency_id, company, line.move_id.date or fields.Date.context_today(line))
             line.debit = balance if balance > 0.0 else 0.0
             line.credit = -balance if balance < 0.0 else 0.0
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fixes #76177

Current behavior before PR:
Before this commit, There will be tracback on adding new
Journal Item if there is not date on Journal Entry.

Desired behavior after PR is merged:
Now we use current date to as fallback to convert currency.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
