### PR TITLE
[FIX] cloc: also exclude module's "upgrades" folder by default

### DIFF
--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -17,6 +17,7 @@ DEFAULT_EXCLUDE = [
     "static/lib/**/*",
     "static/tests/**/*",
     "migrations/**/*",
+    "upgrades/**/*",
 ]
 
 STANDARD_MODULES = ['web', 'web_enterprise', 'website_animate', 'base']


### PR DESCRIPTION
Since commit bbb1a8f151b, module's upgrade script can also be added
into special 'upgrades' folder as an alternative to the old 'migrations'
folder.

  As those upgrade scripts are not maintained from version to version, we
should not count them as maintenance.

OPW-2536046
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
