### PR TITLE
[FIX][13.0] payment: fix some warning in console log

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -444,7 +444,7 @@ class PaymentAcquirer(models.Model):
                 'partner_zip': partner.zip,
                 'partner_city': partner.city,
                 'partner_address': _partner_format_address(partner.street, partner.street2),
-                'partner_country_id': partner.country_id.id or self.env['res.company']._company_default_get().country_id.id,
+                'partner_country_id': partner.country_id.id or self.env.company.country_id.id,
                 'partner_country': partner.country_id,
                 'partner_phone': partner.phone,
                 'partner_state': partner.state_id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
The method '_company_default_get' on res.company is deprecated and was using.

Desired behavior after PR is merged:
The method '_company_default_get' on res.company is deprecated and shouldn't be used anymore.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
