### PR TITLE
[FIX] mail: prevent unnecessary re instantiation of the callViewer model

### DIFF
--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -72,6 +72,9 @@ function factory(dependencies) {
          */
         _computeRtcCallViewer() {
             if (this.thread && this.thread.model === 'mail.channel' && this.thread.rtcSessions.length > 0) {
+                if (this.rtcCallViewer) {
+                    return;
+                }
                 return create();
             }
             return unlink();


### PR DESCRIPTION
Before this commit, the callViewer model was re instantiated in cases
when the amount of RTC session would change, which was not necessary
if the call viewer was already present.
