### PR TITLE
[FIX] web_editor: handle palette history better

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -856,13 +856,17 @@ const Wysiwyg = Widget.extend({
                             this.odooEditor.resetCursorOnLastHistoryCursor();
                         }
                         this._processAndApplyColor(eventName, ev.data.color);
-                        this.odooEditor.historyStep();
                     });
                     colorpicker.on('color_hover color_leave', null, ev => {
                         if (hadNonCollapsedSelection && !isCurrentSelectionInEditable()) {
                             this.odooEditor.resetCursorOnLastHistoryCursor();
                         }
-                        this._processAndApplyColor(eventName, ev.data.color);
+                        this.odooEditor.historyPauseSteps();
+                        try {
+                            this._processAndApplyColor(eventName, ev.data.color);
+                        } finally {
+                            this.odooEditor.historyUnpauseSteps();
+                        }
                     });
                     colorpicker.on('enter_key_color_colorpicker', null, () => {
                         $dropdown.children('.dropdown-toggle').dropdown('hide');


### PR DESCRIPTION
Before this commit several history steps were added when picking a color
and history steps were added when previewing a color.

After this commit history is only updated on color selection and not
during color preview: applying the color relies on execCommand which
adds an history step => no need to add another step upon picking a color
but must be prevented during preview.

task-2599771

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
