### PR TITLE
[FIX] web_editor: open palette below if insufficient space above

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1,5 +1,7 @@
 odoo.define('web_editor.wysiwyg', function (require) {
 'use strict';
+
+const dom = require('web.dom');
 const core = require('web.core');
 const Widget = require('web.Widget');
 const Dialog = require('web.Dialog');
@@ -1131,10 +1133,9 @@ const Wysiwyg = Widget.extend({
                         $dropdown.children('.dropdown-toggle').dropdown('show');
                         const $colorpicker = $dropdown.find('.colorpicker');
                         const colorpickerHeight = $colorpicker.outerHeight();
-                        const toolbarPos = this.toolbar.$el.offset();
-                        const colorpickerBottom = toolbarPos.top + this.toolbar.$el.outerHeight() + colorpickerHeight;
-                        const clientHeight = this.odooEditor.document.documentElement.clientHeight;
-                        $dropdown[0].classList.toggle('dropup', colorpickerBottom > clientHeight);
+                        const toolbarContainerTop = dom.closestScrollable(this.toolbar.el).getBoundingClientRect().top;
+                        const toolbarColorButtonTop = this.toolbar.el.querySelector('#colorInputButtonGroup').getBoundingClientRect().top;
+                        $dropdown[0].classList.toggle('dropup', colorpickerHeight + toolbarContainerTop <= toolbarColorButtonTop);
                         manualOpening = false;
                     });
                 });

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -663,6 +663,7 @@ body.editor_enable.editor_has_snippets {
             }
 
             .dropdown-menu.colorpicker-menu {
+                max-height: none;
                 left: auto;
                 right: 0;
                 border: $o-we-sidebar-content-field-dropdown-border-width solid $o-we-sidebar-content-field-dropdown-border-color;


### PR DESCRIPTION
Before this commit opening the color palette only checked for the
available space below the button to open the popup above instead.
Because of this the popup sometimes opened higher than the top of the
screen making it unusable.

After this commit an additional check is done on the space available
above the button. If there is not enough room above then just opens
below, which makes the area scrollable if there was insufficient space,
thus keeping the palette usable.

task-2599771

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
