### PR TITLE
[FIX] mrp : Confirm MO twice generates multiple stock move

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -686,6 +686,9 @@ class MrpProduction(models.Model):
     def action_confirm(self):
         self._check_company()
         for production in self:
+            # Avoid confirming it twice
+            if production.state != 'draft':
+                continue
             if not production.move_raw_ids:
                 raise UserError(_("Add some materials to consume before marking this MO as to do."))
             for move_raw in production.move_raw_ids:


### PR DESCRIPTION
Issue: When two Odoo webpage are open on a Manufacturing order, it is
possible to mark the MO as todo twice, then when trying to record the
production, there will be a traceback Expected Singleton

Steps to reproduce:
 1) Install MRP
 2) Create a Manufacturing order for a Product with a BO
 3) Save, open a new odoo webclient and go to the same MO
 4) Mark as todo on each webclient
 5) Check availability on each webclient
 6) Produce on each webclient, and save the wizard
 -> Traceback Expected Singleton

opw-2636556