### PR TITLE
[IMP] project: add dependent tasks stat button

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1019,6 +1019,7 @@ class Task(models.Model):
     dependent_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="depends_on_id",
                                      column2="task_id", string="Block",
                                      domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
+    dependent_tasks_count = fields.Integer(string="Dependent Tasks", compute='_compute_dependent_tasks_count')
 
     # recurrence fields
     allow_recurring_tasks = fields.Boolean(related='project_id.allow_recurring_tasks')
@@ -1273,6 +1274,21 @@ class Task(models.Model):
         tasks_count = {c.get('recurrence_id')[0]: c.get('recurrence_id_count') for c in count}
         for task in recurring_tasks:
             task.recurring_count = tasks_count.get(task.recurrence_id.id, 0)
+
+    @api.depends('dependent_ids')
+    def _compute_dependent_tasks_count(self):
+        tasks_with_dependency = self.filtered('allow_task_dependencies')
+        (self - tasks_with_dependency).dependent_tasks_count = 0
+        if tasks_with_dependency:
+            group_dependent = self.env['project.task'].read_group([
+                ('depend_on_ids', 'in', tasks_with_dependency.ids),
+            ], ['depend_on_ids'], ['depend_on_ids'])
+            dependent_tasks_count_dict = {
+                group['depend_on_ids'][0]: group['depend_on_ids_count']
+                for group in group_dependent
+            }
+            for task in tasks_with_dependency:
+                task.dependent_tasks_count = dependent_tasks_count_dict.get(task.id, 0)
 
     @api.depends('partner_id.email')
     def _compute_partner_email(self):
@@ -2007,6 +2023,22 @@ class Task(models.Model):
             'type': 'ir.actions.act_window',
             'context': self._context
         }
+
+    def action_dependent_tasks(self):
+        self.ensure_one()
+        action = {
+            'res_model': 'project.task',
+            'type': 'ir.actions.act_window',
+            'context': {**self._context, 'default_depend_on_ids': [Command.link(self.id)]},
+        }
+        if self.dependent_tasks_count == 1:
+            action['view_mode'] = 'form'
+            action['res_id'] = self.dependent_ids.id
+        else:
+            action['name'] = _('Dependent Tasks')
+            action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,gantt,activity,map'
+            action['domain'] = [('depend_on_ids', '=', self.id)]
+        return action
 
     def action_recurring_tasks(self):
         return {

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -806,6 +806,15 @@
                                 <span class="o_stat_text">in Recurrence</span>
                             </div>
                         </button>
+                        <button name="action_dependent_tasks" type="object" attrs="{'invisible': [('dependent_tasks_count', '=', 0)]}" class="oe_stat_button" icon="fa-tasks" groups="project.group_project_task_dependencies">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Blocking</span>
+                                <span class="o_stat_value ">
+                                    <field name="dependent_tasks_count" widget="statinfo" nolabel="1" />
+                                    Tasks
+                                </span>
+                            </div>
+                        </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title pr-0">


### PR DESCRIPTION
This commit adds a stat button representing the number of dependent
tasks, the current task is blocking.

This is the inverse relation of "Blocked by".

task-2638359
closes #76166

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
