### PR TITLE
[IMP] point_of_sale: Enable scanning of barcode packaging

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -65,7 +65,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
         get currentOrder() {
             return this.env.pos.get_order();
         }
-        async _getAddProductOptions(product) {
+        async _getAddProductOptions(product, base_code) {
             let price_extra = 0.0;
             let draftPackLotLines, weight, description, packLotLinesToEdit;
 
@@ -138,6 +138,10 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 } else {
                     await this._onScaleNotAvailable();
                 }
+            }
+
+            if (base_code && this.env.pos.db.product_packaging_by_barcode[base_code.code]) {
+                weight = this.env.pos.db.product_packaging_by_barcode[base_code.code].qty;
             }
 
             return { draftPackLotLines, quantity: weight, description, price_extra };
@@ -238,7 +242,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                     return this._barcodeErrorAction(code);
                 }
             }
-            const options = await this._getAddProductOptions(product);
+            const options = await this._getAddProductOptions(product, code);
             // Do not proceed on adding the product when no options is returned.
             // This is consistent with _clickProduct.
             if (!options) return;

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -26,6 +26,7 @@ var PosDB = core.Class.extend({
         this.product_by_id = {};
         this.product_by_barcode = {};
         this.product_by_category_id = {};
+        this.product_packaging_by_barcode = {};
 
         this.partner_sorted = [];
         this.partner_by_id = {};
@@ -216,6 +217,14 @@ var PosDB = core.Class.extend({
             }
         }
     },
+    add_packagings: function(product_packagings){
+        var self = this;
+        _.map(product_packagings, function (product_packaging) {
+            if (_.find(self.product_by_id, {'id': product_packaging.product_id[0]})) {
+                self.product_packaging_by_barcode[product_packaging.barcode] = product_packaging;
+            }
+        });
+    },
     _partner_search_string: function(partner){
         var str =  partner.name || '';
         if(partner.barcode){
@@ -354,9 +363,10 @@ var PosDB = core.Class.extend({
     get_product_by_barcode: function(barcode){
         if(this.product_by_barcode[barcode]){
             return this.product_by_barcode[barcode];
-        } else {
-            return undefined;
+        } else if (this.product_packaging_by_barcode[barcode]) {
+            return this.product_by_id[this.product_packaging_by_barcode[barcode].product_id[0]];
         }
+        return undefined;
     },
     get_product_by_category: function(category_id){
         var product_ids  = this.product_by_category_id[category_id];

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -505,6 +505,13 @@ exports.PosModel = Backbone.Model.extend({
             }));
         },
     },{
+        model: 'product.packaging',
+        fields: ['name', 'barcode', 'product_id', 'qty'],
+        domain: function(self){return [['barcode', '!=', '']]; },
+        loaded: function(self, product_packagings) {
+            self.db.add_packagings(product_packagings);
+        }
+    },{
         model: 'product.attribute',
         fields: ['name', 'display_type'],
         condition: function (self) { return self.config.product_configurator; },


### PR DESCRIPTION
Actually we can't gie more one barcode for a product
In inventory we can make "package" with various quantity

So with this commit we add the possibility to add a package
of product (1-n) with a specific barcode

Task: 2610279

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
