### PR TITLE
FIX: Debug menu error

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -70,8 +70,8 @@ export function editSearchView({ accessRights, component, env }) {
     if (!accessRights.canEditView) {
         return null;
     }
-    let { searchViewId } = component.props.info || {}; // fallback is there for legacy
-    if ("viewParams" in component.props) {
+    let { view_id: searchViewId } = component.props.viewInfo || {}; // fallback is there for legacy
+    if (!searchViewId && "viewParams" in component.props) {
         //legacy
         searchViewId = component.props.viewParams.action.controlPanelFieldsView.view_id;
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Cannot open the debug menu due to this error: `Cannot read property 'view_id' of undefined`.
The error occurs on `master` branch. I Also checked the `runbot`, with the same issue (see the screenshot).

Current behavior before PR:
![image](https://user-images.githubusercontent.com/6513072/132650584-2aa44403-a107-47ab-97b4-98573caa4df6.png)

Desired behavior after PR is merged:



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
