### PR TITLE
[FIX] account: Setting opening debit or credit

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -333,6 +333,7 @@ class AccountAccount(models.Model):
                         field: amount,
                         'move_id': opening_move.id,
                         'account_id': self.id,
+                        'currency_id': self.currency_id.id or self.company_id.currency_id.id,
                 })
 
             # Then, we automatically balance the opening move, to make sure it stays valid


### PR DESCRIPTION
Steps to reproduce the bug:

- Create new company
- Set location to Chile, currency to CLP
- Install Chilean localization
- Create a new account A in USD
- Attempt to set an opening balance on A

Bug:

- "The account selected in your journal entry forces you to provide a secondary currency. You must remove the secondary currency in the account."

opw:2540969