### PR TITLE
[FIX] mail: show the name of the guest who started a meeting

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -477,8 +477,8 @@ class Channel(models.Model):
                     },
                 },
             ])
-        notification = _('%s started a live conference', partner.name)
-        self.message_post(body=notification, message_type="notification")
+        notification = _("%s started a live conference", partner.name or guest.name)
+        self.message_post(body=notification, message_type='notification')
         self.env['bus.bus'].sendmany(notifications)
         return invited_partners, invited_guests
 


### PR DESCRIPTION
The notification sent when starting a meeting used `partner.name` to
display the name of the one who started the meeting. Therefore, it
did not work properly with guests, for whom no partner is defined,
resulting in `False started a live conference` being displayed.

This commit fixes the issue by using `guest.name` instead of
`partner.name` when no partner is defined.

Also change some quotes to stick to the guidelines.