### PR TITLE
[FIX] mrp: create MO from a mobile

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -350,7 +350,8 @@
                 <field name="workcenter_id"/>
                 <field name="product_id"/>
                 <field name="qty_production"/>
-                <field name="product_uom_id"/>
+                <field name="product_uom_id" force_save="1"/>
+                <field name="consumption"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click">


### PR DESCRIPTION
It is currently impossible to create a MO from a mobile if there are
some work orders

To reproduce the issue:
1. In Settings, enable "Work Orders"
2. Create two products P_finished, P_compo
3. Create a BoM:
    - Product: P_finished
    - Components:
        - 1 x P_compo
    - Operations:
        - Create a new one
4. Switch to mobile mode
5. Create a MO with P_finished

Error: When saving the MO, a Validation Error is raised "The operation
cannot be completed: - Create/update: a mandatory field is not set.
[...] Model: Work Order (mrp.workorder), Field: Unit of Measure
(product_uom_id)"

For a work order to be created, the request needs to provide two
additional fields: `product_uom_id` and `consumption`. When setting the
product P_finished, an onchange is triggered and does not return
`consumption`. `product_uom_id` is returned but not included in the save
request (because the field is declared as `readonly`)

OPW-2557181