### PR TITLE
[FIX] mail: fix broken avatar on message from non-channel members

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -68,17 +68,23 @@ class DiscussController(http.Controller):
 
     @http.route('/mail/channel/<int:channel_id>/partner/<int:partner_id>/avatar_128', methods=['GET'], type='http', auth='public')
     def mail_channel_partner_avatar_128(self, channel_id, partner_id, **kwargs):
-        channel_partner_sudo = request.env['mail.channel.partner']._get_as_sudo_from_request_or_raise(request=request, channel_id=int(channel_id))
-        if not channel_partner_sudo.env['mail.channel.partner'].search([('channel_id', '=', int(channel_id)), ('partner_id', '=', int(partner_id))], limit=1):
-            raise NotFound()
-        return channel_partner_sudo.env['ir.http']._content_image(model='res.partner', res_id=int(partner_id), field='avatar_128')
+        channel_partner_sudo = request.env['mail.channel.partner']._get_as_sudo_from_request(request=request, channel_id=channel_id)
+        if not channel_partner_sudo or not channel_partner_sudo.env['mail.channel.partner'].search([('channel_id', '=', channel_id), ('partner_id', '=', partner_id)], limit=1):
+            if request.env.user.share:
+                placeholder = channel_partner_sudo.env['res.partner'].browse(partner_id).exists()._avatar_get_placeholder()
+                return channel_partner_sudo.env['ir.http']._placeholder_image_get_response(placeholder)
+            return channel_partner_sudo.sudo(False).env['ir.http']._content_image(model='res.partner', res_id=partner_id, field='avatar_128')
+        return channel_partner_sudo.env['ir.http']._content_image(model='res.partner', res_id=partner_id, field='avatar_128')
 
     @http.route('/mail/channel/<int:channel_id>/guest/<int:guest_id>/avatar_128', methods=['GET'], type='http', auth='public')
     def mail_channel_guest_avatar_128(self, channel_id, guest_id, **kwargs):
-        channel_partner_sudo = request.env['mail.channel.partner']._get_as_sudo_from_request_or_raise(request=request, channel_id=int(channel_id))
-        if not channel_partner_sudo.env['mail.channel.partner'].search([('channel_id', '=', int(channel_id)), ('guest_id', '=', int(guest_id))], limit=1):
-            raise NotFound()
-        return channel_partner_sudo.env['ir.http']._content_image(model='mail.guest', res_id=int(guest_id), field='avatar_128')
+        channel_partner_sudo = request.env['mail.channel.partner']._get_as_sudo_from_request(request=request, channel_id=channel_id)
+        if not channel_partner_sudo or not channel_partner_sudo.env['mail.channel.partner'].search([('channel_id', '=', channel_id), ('guest_id', '=', guest_id)], limit=1):
+            if request.env.user.share:
+                placeholder = channel_partner_sudo.env['mail.guest'].browse(guest_id).exists()._avatar_get_placeholder()
+                return channel_partner_sudo.env['ir.http']._placeholder_image_get_response(placeholder)
+            return channel_partner_sudo.sudo(False).env['ir.http']._content_image(model='mail.guest', res_id=guest_id, field='avatar_128')
+        return channel_partner_sudo.env['ir.http']._content_image(model='mail.guest', res_id=guest_id, field='avatar_128')
 
     @http.route('/mail/channel/<int:channel_id>/attachment/<int:attachment_id>', methods=['GET'], type='http', auth='public')
     def mail_channel_attachment(self, channel_id, attachment_id, **kwargs):

--- a/addons/mail/models/mail_channel_partner.py
+++ b/addons/mail/models/mail_channel_partner.py
@@ -108,4 +108,4 @@ class ChannelPartner(models.Model):
         guest = self.env['mail.guest']._get_guest_from_request(request)
         if guest:
             return guest.env['mail.channel.partner'].sudo().search([('channel_id', '=', channel_id), ('guest_id', '=', guest.id)], limit=1)
-        return self.env['mail.channel.partner']
+        return self.env['mail.channel.partner'].sudo()

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -175,6 +175,14 @@ class Http(models.AbstractModel):
         return response
 
     @api.model
+    def _placeholder_image_get_response(self, placeholder_base64):
+        content = base64.b64decode(placeholder_base64)
+        headers = http.set_safe_image_headers([], content)
+        response = request.make_response(content, headers)
+        response.status_code = 200
+        return response
+
+    @api.model
     def _placeholder(self, image=False):
         if not image:
             image = 'web/static/img/placeholder.png'

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1684,11 +1684,14 @@ def content_disposition(filename):
 def set_safe_image_headers(headers, content):
     """Return new headers based on `headers` but with `Content-Length` and
     `Content-Type` set appropriately depending on the given `content` only if it
-    is safe to do."""
+    is safe to do, as well as `X-Content-Type-Options: nosniff` so that if the
+    file is of an unsafe type, it is not interpreted as that type if the
+    `Content-type` header was already set to a different mimetype"""
     content_type = guess_mimetype(content)
     safe_types = ['image/jpeg', 'image/png', 'image/gif', 'image/x-icon']
     if content_type in safe_types:
         headers = set_header_field(headers, 'Content-Type', content_type)
+    headers = set_header_field(headers, 'X-Content-Type-Options', 'nosniff')
     set_header_field(headers, 'Content-Length', len(content))
     return headers
 


### PR DESCRIPTION
With the introduction of the guest feature, a lot of fields are now
accessed through a controller so that they can be available to guests,
with additional checking in the controllers.

Avatar is one such field, however the extra checks were too restrictive:
we only allowed people to see the avatar if the user whose avatar was
requested was also a member of the channel. This breaks the avatar on
previous messages if a user leaves a channel.

This commit relaxes this restriction for internal users (they can now
see all avatars through this route), and adds a fallback to the avatar
placeholder for people who do not have acces (ie: guests) so that the
UI doesn't look broken.
