### PR TITLE
[IMP] core: savepoint interface and semantics

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -451,11 +451,11 @@ class ModelConverter(ir_http.ModelConverter):
             return value.env.context.get('_converter_value', str(value.id))
         return super().to_url(value)
 
-    def generate(self, uid, dom=None, args=None):
-        Model = request.env[self.model].with_user(uid)
+    def generate(self, env, args, dom=None):
+        Model = env[self.model]
         # Allow to current_website_id directly in route domain
-        args.update(current_website_id=request.env['website'].get_current_website().id)
-        domain = safe_eval(self.domain, (args or {}).copy())
+        args['current_website_id'] = env['website'].get_current_website().id
+        domain = safe_eval(self.domain, args)
         if dom:
             domain += dom
         for record in Model.search(domain):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1170,7 +1170,7 @@ class Website(models.Model):
                         if query == FALSE_DOMAIN:
                             continue
 
-                    for rec in converter.generate(uid=self.env.uid, dom=query, args=val):
+                    for rec in converter.generate(self.env, args=val, dom=query):
                         newval.append(val.copy())
                         newval[-1].update({name: rec})
                 values = newval

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -3,17 +3,18 @@
 
 from odoo.tests.common import HttpCase
 
-EXTRA_REQUEST = 5
+EXTRA_REQUEST = 4 - 1
 """ During tests, the query on 'base_registry_signaling, base_cache_signaling'
-    won't be executed on hot state, but 6 new queries related to the test cursor
-    will be added:
-        SAVEPOINT "test_cursor_4"
-        SAVEPOINT "test_cursor_4"
-        ROLLBACK TO SAVEPOINT "test_cursor_4"
-        SAVEPOINT "test_cursor_5"
-        [.. usual SQL Queries .. ]
-        SAVEPOINT "test_cursor_5"
-        ROLLBACK TO SAVEPOINT "test_cursor_5"
+won't be executed on hot state, but new queries related to the test cursor
+will be added::
+
+    cr = Cursor() # SAVEPOINT
+    cr.commit() # RELEASE
+    cr.close()
+    cr = Cursor()
+    cr.execute(...) # SAVEPOINT
+    cr.commit() # RELEASE
+    cr.close()
 """
 
 

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -371,6 +371,21 @@ class Cursor(BaseCursor):
         self.sql_log_count = 0
         self.sql_log = False
 
+    @contextmanager
+    def _enable_logging(self):
+        """ Forcefully enables logging for this cursor, restores it afterwards.
+
+        Updates the logger in-place, so not thread-safe.
+        """
+        previous, self.sql_log = self.sql_log, True
+        level = _logger.level
+        _logger.setLevel(logging.DEBUG)
+        try:
+            yield
+        finally:
+            _logger.setLevel(level)
+            self.sql_log = previous
+
     @check
     def close(self):
         return self._close(False)


### PR DESCRIPTION
Replacement of #74345 because I had to update a bunch of things due to various technical issues when trying to actually use it, and the end result is different enough that the old discussion doesn't make much sense and it should start anew.

The goal is still to reify a savepoint as an object which can be manipulated and rolled back and closed independently from or inside the span of a context manager.

This is achieved through the introduction of a `Savepoint` type which is a contextmanager, and exposes the relevant methods (`rollback` and `close`). The core usage should be relatively straightforward.

* The `Savepoint` objects (now) emits a `SAVEPOINT` at construction, I'd forgotten that this was necessary for `contextlib.closing`: `closing` works with non-CM objects so it doesn't propagate the `__enter__` call, and thus the previous version of `Savepoint` would not get initialised (at all) before being closed. I considered and explored adding a flag to `Savepoint` but that made the UI much less clear and much more annoying. This change also improves the behaviour outside of CMs.

  There is no `__del__` on `Savepoint` by design: doing nothing to a savepoint is "innocent" and there is no requirement that the connection hasn't been committed or rolled back, so explicitly closing the savepoint on `__del__` only adds risk, it's better for nothing to happen.
* `savepoint` now returns a "proper" CM object in all cases: while usually nice, the `_GeneratorContextManager` is problematic when there's a use case for holding onto what it yields (which is the case here): the `_GeneratorContextManager` will be GC'd, which will GC the wrapped generator, which will `close()` it, which will *raise `GeneratorExit` from the yield point*. This means any CM held across the yield will immediately be exit-ed while still alive.
* This requires making the flushing operation into a (private) CM, after more consideration that's probably a good idea: if we want the flushing to be implicit and automatic, it should probably happen when the savepoint is `rollback`-ed.

Note that the savepoint is *not* released on `TestCursor.commit`: this matches the old behaviour, and trying to `release` the savepoint generates weird interleavings during some RPC requests, which breaks [one of the website tests](https://runbot.odoo.com/runbot/build/9876667). I tried tracking why that happens but in the end just removed the closing as that matches the previous TestCursor behaviour.

Also added a utility CM on `Cursor` to enable scoped logging, because currently doing that by hand is a pain in the ass and setting `--log-level=debug_sql` is completely unusable.