### PR TITLE
[FIX] survey: properly display filter label

### DIFF
--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -37,7 +37,7 @@
                 <span t-att-class="'badge only_left_radius filter-all %s' % 'badge-secondary' if search_finished else 'badge-primary o_active_filter'">All surveys</span>
                 <span t-att-class="'badge only_right_radius filter-finished %s' % 'badge-secondary' if not search_finished else 'badge-primary o_active_filter'">Finished surveys</span>
                 <span t-foreach="search_filters" t-as="filter_data">
-                    <span class="badge badge-primary only_left_radius"><i class="fa fa-filter" role="img" aria-label="Filter" title="Filter"></i></span><span class="badge badge-primary no_radius" t-esc="filter_data['question']"></span><span class="badge badge-success only_right_radius" t-esc="' > '.join(filter_data['answers'])"></span>
+                    <span class="badge badge-primary only_left_radius"><i class="fa fa-filter" role="img" aria-label="Filter" title="Filter"></i></span><span class="badge badge-primary no_radius" t-esc="filter_data['question']"></span><span class="badge badge-success only_right_radius" t-esc="filter_data['answers']"></span>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
PURPOSE

This commit removes the '>' (greater than) character between each letter
of the filtered result of the survey.

SPECIFICATIONS

Currently, while seeing the survey results, the User can filter the answers.
While filtering the answers the '>' (greater than) character is added
between each letter.

This is the goal of this commit.


LINKS

PR #76245
Task-2638463

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
