### PR TITLE
[FIX] project: follow-up the project overview removal

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -661,7 +661,7 @@ class Project(models.Model):
             'user': self._get_user_values(),
             'tasks_analysis': self._get_tasks_analysis(),
             'milestones': self._get_milestones(),
-            'buttons': sorted(self._get_stat_buttons(), key=lambda k: k['sequence'])
+            'buttons': sorted(self._get_stat_buttons(), key=lambda k: k['sequence']),
         }
 
     def _get_user_values(self):

--- a/addons/project/static/src/js/right_panel/project_right_panel.js
+++ b/addons/project/static/src/js/right_panel/project_right_panel.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { AddMilestone, OpenMilestone } from '@project/js/right_panel/project_utils';
+import { formatFloat } from "@web/fields/formatters";
 const { useState } = owl.hooks;
 
 export default class ProjectRightPanel extends owl.Component {
@@ -17,6 +18,10 @@ export default class ProjectRightPanel extends owl.Component {
                 user: {},
             }
         });
+    }
+
+    formatFloat(value) {
+        return formatFloat(value, { digits: [false, 1] });
     }
 
     async willStart() {

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -130,9 +130,9 @@ tour.register('project_update_tour', {
     trigger: ".o_field_widget[name=description] div[name='milestone'] ul li:contains('(12/12/2099 => 12/12/2100)')",
     run: function () {},
 }, {
-    trigger: ".o_field_widget[name=description] div[name='milestone'] ul li span:contains('(due on 12/12/2022)')",
+    trigger: ".o_field_widget[name=description] div[name='milestone'] ul li span:contains('(due 12/12/2022)')",
     run: function () {},
 }, {
-    trigger: ".o_field_widget[name=description] div[name='milestone'] ul li span:contains('(due on 12/12/2100)')",
+    trigger: ".o_field_widget[name=description] div[name='milestone'] ul li span:contains('(due 12/12/2100)')",
     run: function () {},
 }]);

--- a/addons/project/views/project_update_templates.xml
+++ b/addons/project/views/project_update_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="project.milestone_deadline">
 <t t-if="milestone['deadline']">
-(due on <t t-esc="milestone['deadline']" t-options='{"widget": "date"}'/><t t-if="not milestone['is_reached'] or not milestone['reached_date']">)</t><t t-else=""> - reached on<t t-if="milestone['reached_date'] &gt; milestone['deadline']">
+(due <t t-esc="milestone['deadline']" t-options='{"widget": "date"}'/><t t-if="not milestone['is_reached'] or not milestone['reached_date']">)</t><t t-else=""> - reached on<t t-if="milestone['reached_date'] &gt; milestone['deadline']">
 <font t-att-style="'color: rgb(' + str(color_level) + ', 0, 0)'"><b><t t-esc="milestone['reached_date']" t-options='{"widget": "date"}'/></b></font>)</t><t t-else="">
 <font t-att-style="'color: rgb(0, ' + str(color_level) + ', 0)'"><b><t t-esc="milestone['reached_date']" t-options='{"widget": "date"}'/></b></font>)</t></t>
 </t>
@@ -11,18 +11,18 @@
     <template id="project_update_default_description" name="Project Update Description">
 <!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
 <div name="summary">
-<h1>Sprint Summary</h1>
-<p>How’s this project going?</p><br/>
+<br/><h1 style="font-weight: bolder;">Sprint Summary</h1>
+<br/><p>How’s this project going?</p><br/><br/>
 </div>
 
-<div name="activities" t-if="milestones['show_section']">
-<h1>Activities</h1>
+<div name="activities" t-if="show_activities">
+<h1 style="font-weight: bolder;">Activities</h1>
 </div>
 
 <div name="milestone">
 <t t-if="milestones['show_section']">
 <br/>
-<h3><b><u>Milestones</u></b></h3>
+<h3 style="font-weight: bolder"><u>Milestones</u></h3>
 
 <ul class="o_checklist" t-if="milestones['list']">
 <t t-foreach="milestones['list']" t-as="milestone" t-key="milestone['id']">
@@ -35,8 +35,9 @@
 </ul>
 
 <t t-if="milestones['updated']">
-<t t-if="len(milestones['updated']) > 1">The deadline of the following milestones has been updated <t t-if="milestones['last_update_date']">since the last project update (<t t-esc="milestones['last_update_date']" t-options='{"widget": "date"}'/>) </t> :</t>
-<t t-else="">The deadline of the following milestone has been updated <t t-if="milestones['last_update_date']">since the last project update (<t t-esc="milestones['last_update_date']" t-options='{"widget": "date"}'/>) </t> :</t>
+<t t-if="milestones['last_update_date']">Since <t t-esc="milestones['last_update_date']" t-options='{"widget": "date"}'/> (last project update), </t>
+<t t-if="len(milestones['updated']) > 1">the deadline of the following milestones has been updated:</t>
+<t t-else="">the deadline of the following milestone has been updated:</t>
 <ul>
 <t t-foreach="milestones['updated']" t-as="milestone" t-key="milestone['id']">
 <li>
@@ -47,8 +48,8 @@
 </t>
 
 <t t-if="milestones['created']">
-<t t-if="len(milestones['created']) > 1">The following milestones have been added <t t-if="milestones['last_update_date']">since the last project update (<t t-esc="milestones['last_update_date']" t-options='{"widget": "date"}'/>) </t>:</t>
-<t t-else="">The following milestone has been added <t t-if="milestones['last_update_date']">since the last project update (<t t-esc="milestones['last_update_date']" t-options='{"widget": "date"}'/>) </t>:</t>
+<t t-if="len(milestones['created']) > 1">The following milestones have been added:</t>
+<t t-else="">The following milestone has been added:</t>
 <ul>
 <t t-foreach="milestones['created']" t-as="milestone" t-key="milestone['id']">
 <li>

--- a/addons/sale_timesheet/static/src/xml/sale_project_templates.xml
+++ b/addons/sale_timesheet/static/src/xml/sale_project_templates.xml
@@ -41,20 +41,20 @@
                     <div class="o_rightpanel_title">
                         <span class="o_rightpanel_left_col o_rightpanel_left_text"> Total Sold </span>
                     </div>
-                    <span class="o_rightpanel_right_col font-weight-bold float-right"><t t-esc="sold_items.total_sold"/> <t t-esc="sold_items.company_unit_name"/></span>
+                    <span class="o_rightpanel_right_col font-weight-bold float-right"><t t-esc="formatFloat(sold_items.total_sold)"/> <t t-esc="sold_items.company_unit_name"/></span>
                 </div>
                 <div class="o_rightpanel_data">
                     <div class="o_rightpanel_data_row">
                         <span class="o_rightpanel_left_col o_rightpanel_left_text">Effective</span>
-                        <span class="o_rightpanel_right_col"><t t-esc="sold_items.effective_sold"/> <t t-esc="sold_items.company_unit_name"/></span>
+                        <span class="o_rightpanel_right_col"><t t-esc="formatFloat(sold_items.effective_sold)"/> <t t-esc="sold_items.company_unit_name"/></span>
                     </div>
                     <div class="o_rightpanel_data_row" t-if="sold_items.planned_sold > 0 and sold_items.allow_forecast">
                         <span class="o_rightpanel_left_col o_rightpanel_left_text">Planned</span>
-                        <span class="o_rightpanel_right_col"><t t-esc="sold_items.planned_sold"/> <t t-esc="sold_items.company_unit_name"/></span>
+                        <span class="o_rightpanel_right_col"><t t-esc="formatFloat(sold_items.planned_sold)"/> <t t-esc="sold_items.company_unit_name"/></span>
                     </div>
                     <div class="o_rightpanel_data_row">
                         <span class="o_rightpanel_left_col o_rightpanel_left_text">Remaining</span>
-                        <span class="o_rightpanel_right_col" t-attf-class="o_color_{{sold_items.remaining.color}}"><t t-esc="sold_items.remaining.value"/> <t t-esc="sold_items.company_unit_name"/></span>
+                        <span class="o_rightpanel_right_col" t-attf-class="o_color_{{sold_items.remaining.color}}"><t t-esc="formatFloat(sold_items.remaining['value'])"/> <t t-esc="sold_items.company_unit_name"/></span>
                     </div>
                 </div>
             </div>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -24,7 +24,8 @@
                 </button>
             </xpath>
             <xpath expr="//header" position="inside">
-                <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>
+                <!-- To be removed in master -->
+                <button name="action_make_billable" string="Create Sales Order" type="object" groups="sales_team.group_sale_salesman" invisible="1"/>
             </xpath>
             <xpath expr="//page[@name='settings']" position="after">
                 <page name="billing_employee_rate" string="Invoicing" attrs="{'invisible': ['|', ('allow_billable', '=', False), ('partner_id', '=', False)]}">
@@ -104,7 +105,7 @@
             </xpath>
             <xpath expr="//div[hasclass('o_kanban_manage_reporting')]" position="inside">
                 <div role="menuitem" t-if="record.rating_active.raw_value" groups="project.group_project_manager">
-                   <a name="action_view_all_rating" type="object" context="{'search_default_rating_last_30_days':1}"> 
+                   <a name="action_view_all_rating" type="object">
                     Customer Ratings
                     </a>
                 </div> 

--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -4,35 +4,37 @@
         <!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
         <xpath expr="//div[@name='milestone']" position="before">
 <br/>
-<div t-if="project.allow_billable and 'data' in services and len(services['data']) > 0">
-<h3><b><u>Sold</u></b></h3>
+<div t-if="show_sold">
+<h3 style="font-weight: bolder"><u>Sold</u></h3>
 <table class="table table-bordered">
 <tbody>
 <thead>
-<td>Service</td>
-<td>Sold</td>
-<td>Effective</td>
-<td>Remaining</td>
+<td style="font-weight: bolder">Service</td>
+<td style="font-weight: bolder">Sold</td>
+<td style="font-weight: bolder">Effective</td>
+<td style="font-weight: bolder">Remaining</td>
 </thead>
 <tr t-foreach="services['data']" t-as="service">
-<td><t t-esc="service['name']"/></td>
-<td><t t-esc="service['sold_value']"/> <t t-esc="service['uom']"/></td>
-<td><t t-esc="service['effective_value']"/> <t t-esc="service['uom']"/></td>
-<td><t t-esc="service['remaining_value']"/> <t t-esc="service['uom']"/></td>
+<t t-set="is_unit" t-value="service['is_unit']"/>
+<td t-attf-class="#{ 'font-italic' if is_unit else ''}"><t t-esc="service['name']"/></td>
+<td t-attf-class="#{ 'font-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-esc="format_lang(service['sold_value'], 1)"/> <t t-esc="service['unit']"/></td>
+<td t-attf-class="#{ 'font-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-esc="format_lang(service['effective_value'], 1)"/> <t t-esc="service['unit']"/></td>
+<td t-attf-class="#{ 'font-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-esc="format_lang(service['remaining_value'], 1)"/> <t t-esc="service['unit']"/></td>
 </tr>
 <tfoot>
-<td>Total</td>
-<td><t t-esc="services['total_sold']"/> Hours</td>
-<td><t t-esc="services['total_effective']"/> Hours</td>
-<td><t t-esc="services['total_remaining']"/> Hours</td>
+<td style="font-weight: bolder; text-align: right">Total</td>
+<td style="font-weight: bolder; text-align: right; vertical-align: middle;"><t t-esc="format_lang(services['total_sold'], 1)"/> <t t-esc="services['company_unit_name']"/></td>
+<td style="font-weight: bolder; text-align: right; vertical-align: middle;"><t t-esc="format_lang(services['total_effective'], 1)"/> <t t-esc="services['company_unit_name']"/></td>
+<td style="font-weight: bolder; text-align: right; vertical-align: middle;"><t t-esc="format_lang(services['total_remaining'], 1)"/> <t t-esc="services['company_unit_name']"/></td>
 </tfoot>
 </tbody>
 </table>
+<br/>
 </div>        
         
-<div name="profitability" t-if="profitability">
+<div name="profitability" t-if="show_profitability">
 <t t-if="project.analytic_account_id and project.allow_billable and user.has_group('project.group_project_manager')" name="costs">
-<h3><b><u>Profitability</u></b></h3>
+<h3 style="font-weight: bolder"><u>Profitability</u></h3>
 The cost of the project is now at <t t-esc="profitability['costs']"/>, for a revenue of <t t-esc="profitability['revenues']"/>, leading to a
 <span>
 <font t-if="profitability['margin'] &gt; 0"  style="color: rgb(0, 128, 0)">


### PR DESCRIPTION
-- This is a follow-up of odoo/odoo#72736 --

The project overview is a significant technical debt
as it is a custom qweb view. It is quite limited:

It is not possible to group the data, to filter on dates,
SOs or Field Service projects.
Improving this is very difficult and would require weeks
of development that are not worth it.
In any case, all the information provided by the project overview
can be found elsewhere. The stat buttons of the report are basically
duplicates of the ones from the project form view.
Therefore, we are removing this report and its twin,
the Project Costs and Revenues.
In addition, analytic items lack context for the user to understand
what generated a certain cost or revenue:

there is no link to the source document;
the entries are not categorized (e.g. it is not easy to understand
if a cost comes from a timesheet cost, a purchase order or an expense);
the billable type group by works fine for timesheets but then all
the other entries are flagged as Undefined, which is not very helpful;
there is no option to easily isolate costs from revenues.

task-2637495
See odoo/enterprise#20740