### PR TITLE
[FIX] website_event_track_live: fix widescreen detection for YouTube …

### DIFF
--- a/addons/website_event_track_live/controllers/session.py
+++ b/addons/website_event_track_live/controllers/session.py
@@ -11,7 +11,7 @@ class WebsiteEventSessionLiveController(EventTrackController):
 
     def _event_track_page_get_values(self, event, track, **options):
         if 'widescreen' not in options:
-            options['widescreen'] = bool(track.youtube_video_url)
+            options['widescreen'] = track.youtube_video_url and (track.is_youtube_replay or track.is_track_soon or track.is_track_live or track.is_track_done)
         values = super(WebsiteEventSessionLiveController, self)._event_track_page_get_values(event, track, **options)
         # Youtube disables the chat embed on all mobile devices
         # This regex is a naive attempt at matching their behavior (should work for most cases)


### PR DESCRIPTION
…tracks

Currently, when there is a YouTube URL configured on the track, we
automatically set the layout of the track page as "widescreen".

This implies that we hide some menus and adapt the layout to display the full
video player.

However, in the XML template of the track view, we only display the video
player if there is a YouTube URL configured AND one or more of those conditions
is respected:
- The track is configured as a "YouTube Replay"
- The track is "coming soon" (< 30 minutes)
- The track is live
- The track is done

This is done to match the two behaviors and get a consistent display.

Task-2643147
