### PR TITLE
[FIX] mail: sets the proper record name for `mail.channel.partner`

### DIFF
--- a/addons/mail/models/mail_channel_partner.py
+++ b/addons/mail/models/mail_channel_partner.py
@@ -11,7 +11,6 @@ class ChannelPartner(models.Model):
     _name = 'mail.channel.partner'
     _description = 'Listeners of a Channel'
     _table = 'mail_channel_partner'
-    _rec_name = 'partner_id'
 
     # identity
     partner_id = fields.Many2one('res.partner', string='Recipient', ondelete='cascade', readonly=True, index=True)
@@ -28,6 +27,9 @@ class ChannelPartner(models.Model):
     is_pinned = fields.Boolean("Is pinned on the interface", default=True)
     last_interest_dt = fields.Datetime("Last Interest", default=fields.Datetime.now, help="Contains the date and time of the last interesting event that happened in this channel for this partner. This includes: creating, joining, pinning, and new message posted.")
     rtc_inviting_session_id = fields.Many2one('mail.channel.rtc.session', string='Ringing session')
+
+    def name_get(self):
+        return [(record.id, record.partner_id.name or record.guest_id.name) for record in self]
 
     def _remove_rtc_invitation(self):
         """ Removes the invitation to the rtc call and notifies the inviting partner if removed. """

--- a/addons/mail/views/mail_channel_partner_views.xml
+++ b/addons/mail/views/mail_channel_partner_views.xml
@@ -7,7 +7,7 @@
         <field name="priority">10</field>
         <field name="arch" type="xml">
             <tree string="Channels">
-                <field name="partner_id"/>
+                <field name="display_name"/>
                 <field name="channel_id"/>
                 <field name="seen_message_id"/>
             </tree>
@@ -22,6 +22,7 @@
                 <sheet>
                     <group>
                         <field name="partner_id"/>
+                        <field name="guest_id"/>
                         <field name="channel_id"/>
                         <field name="seen_message_id"/>
                         <field name="rtc_inviting_session_id"/>


### PR DESCRIPTION
Since the addition of guests, it isn't enough to rely on the
`partner_id` of the record to get the name.

This commit adds an override of `name_get` so that the `display_name` of
the record remains consistent for both partners and guests.
