### PR TITLE
[IMP] website_event_track: quick create card

### DIFF
--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -12,11 +12,26 @@
         </field>
     </record>
 
+    <record id="event_track_view_form_quick_create" model="ir.ui.view">
+        <field name="name">event.track.view.form.quick.create</field>
+        <field name="model">event.track</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="event_id" invisible="context.get('default_event_id', False)"/>
+                    <field name="name" placeholder="e.g. Inspiring Business Talk"/>
+                    <field name="date"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="view_event_track_kanban">
         <field name="name">event.track.kanban</field>
         <field name="model">event.track</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="stage_id">
+            <kanban default_group_by="stage_id" quick_create_view="website_event_track.event_track_view_form_quick_create">
                 <field name="color"/>
                 <field name="partner_id"/>
                 <field name="stage_id" options='{"group_by_tooltip": {"description": "Description"}}'/>


### PR DESCRIPTION
PURPOSE

before this, we have only name to set for the track in
kanban quick create view

SPECIFICATION

after this PR, we can create a track with the name
and track date.

TaskId: 2635390

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
