### PR TITLE
[FIX] project: Fix user_ids access issues on project sharing

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -38,6 +38,7 @@ PROJECT_TASK_READABLE_FIELDS = {
     'displayed_image_id',
     'display_name',
     'priority',
+    'portal_user_names',
 }
 
 PROJECT_TASK_WRITABLE_FIELDS = {
@@ -956,6 +957,8 @@ class Task(models.Model):
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
         string='Assignees', default=lambda self: self.env.user)
+    # User names displayed in project sharing views
+    portal_user_names = fields.Char(compute='_compute_portal_user_names', compute_sudo=True, search='_search_portal_user_names')
     # Second Many2many containing the actual personal stage for the current user
     # See project_task_stage_personal.py for the model defininition
     personal_stage_type_ids = fields.Many2many('project.task.type', 'project_task_user_rel', column1='task_id', column2='stage_id',
@@ -1416,6 +1419,35 @@ class Task(models.Model):
                         ('fold', '=', False), ('is_closed', '=', False)])
             else:
                 task.stage_id = False
+
+    @api.depends('user_ids')
+    def _compute_portal_user_names(self):
+        """ This compute method allows to see all the names of assigned users to each task contained in `self`.
+
+            When we are in the project sharing feature, the `user_ids` contains only the users if we are a portal user.
+            That is, only the users in the same company of the current user.
+            So this compute method is a related of `user_ids.name` but with more records that the portal user
+            can normally see.
+            (In other words, this compute is only used in project sharing views to see all assignees for each task)
+        """
+        if self.ids:
+            # fetch 'user_ids' in superuser mode (and override value in cache)
+            self._read(['user_ids'])
+        for task in self.with_context(prefetch_fields=False):
+            task.portal_user_names = ', '.join(task.user_ids.mapped('name'))
+
+    def _search_portal_user_names(self, operator, value):
+        if operator != 'ilike' and not isinstance(value, str):
+            raise ValidationError('Not Implemented.')
+
+        query = """
+            SELECT task_user.task_id
+              FROM project_task_user_rel task_user
+        INNER JOIN res_users users ON task_user.user_id = users.id
+        INNER JOIN res_partner partners ON partners.id = users.partner_id
+             WHERE partners.name ILIKE %s
+        """
+        return [('id', 'inselect', (query, [f'%{value}%']))]
 
     @api.constrains('recurring_task')
     def _check_recurring_task(self):
@@ -1994,6 +2026,9 @@ class Task(models.Model):
 
     def action_assign_to_me(self):
         self.write({'user_ids': [(4, self.env.user.id)]})
+
+    def action_unassign_me(self):
+        self.write({'user_ids': [Command.unlink(self.env.uid)]})
 
     # If depth == 1, return only direct children
     # If depth == 3, return children to third generation

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -31,7 +31,9 @@
                 <field name="color"/>
                 <field name="priority"/>
                 <field name="stage_id" options='{"group_by_tooltip": {"description": "Description"}}'/>
-                <field name="user_ids"/>
+                <!-- TODO: [XBO] remove me in master -->
+                <field name="user_ids" invisible="1"/>
+                <field name="portal_user_names"/>
                 <field name="partner_id"/>
                 <field name="sequence"/>
                 <field name="is_closed"/>
@@ -89,8 +91,14 @@
                                     <field name="priority" widget="priority"/>
                                 </div>
                                 <div class="oe_kanban_bottom_right" t-if="!selection_mode">
+                                    <span t-if="record.portal_user_names.raw_value.length > 0" class="pr-2" t-att-title="record.portal_user_names.raw_value">
+                                        <t t-set="user_count" t-value="record.portal_user_names.raw_value.split(',').length"/>
+                                        <t t-set="display_nb_assignees" t-value="user_count + ' assignee' + (user_count > 1 ? 's' : '')"/>
+                                        <t t-out="display_nb_assignees"/>
+                                    </span>
                                     <field name="kanban_state" widget="state_selection"/>
-                                    <field name="user_ids" widget="many2many_avatar_user" options="{'no_open_chat': True}"/>
+                                    <!-- TODO: [XBO] remove me in master -->
+                                    <field name="user_ids" string="Assignees" widget="many2many_avatar_user" options="{'no_open_chat': True}" invisible="1"/>
                                 </div>
                             </div>
                         </div>
@@ -116,7 +124,9 @@
                 <field name="child_text" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="partner_id" optional="hide"/>
-                <field name="user_ids" optional="show" widget="many2many_avatar_user" options="{'no_open_chat': True}"/>
+                <field name="portal_user_names" string="Assignees" optional="show"/>
+                <!-- TODO: [XBO] remove me in master -->
+                <field name="user_ids" invisible="1" />
                 <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible': [('is_closed', '=', True)]}"/>
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                 <field name="kanban_state" widget="state_selection" optional="hide"/>
@@ -133,6 +143,10 @@
         <field name="arch" type="xml">
             <form string="Project Sharing: Task" class="o_form_project_tasks">
                 <header>
+                    <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
+                            attrs="{'invisible' : &quot;[('user_ids', 'in', [uid])]&quot;}" data-hotkey="q"/>
+                    <button name="action_unassign_me" string="Unassign Me" type="object" class="oe_highlight"
+                            attrs="{'invisible' : &quot;[('user_ids', 'not in', [uid])]&quot;}" data-hotkey="q"/>
                     <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}" />
                 </header>
                 <sheet string="Task">
@@ -151,11 +165,10 @@
                         <group>
                             <field name="project_id" invisible="1"/>
                             <field name="display_project_id" string="Project" invisible="1"/>
-                            <field name="user_ids"
-                                class="o_task_user_field"
-                                options="{'no_open': True, 'no_open_chat': True}"
-                                widget="many2many_avatar_user"
-                                domain="[('share', '=', False)]"/>
+                            <field name="user_ids" invisible="1" />
+                            <field name="portal_user_names"
+                                string="Assignees"
+                                class="o_task_user_field"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
@@ -182,7 +195,9 @@
                                     <field name="display_project_id" string="Project" optional="hide" invisible="1"/>
                                     <field name="company_id" invisible="1"/>
                                     <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide"/>
-                                    <field name="user_ids" widget="many2many_avatar_user" optional="show" options="{'no_open_chat': True}"/>
+                                    <!-- TODO: [XBO] remove me in master -->
+                                    <field name="user_ids" invisible="1"/>
+                                    <field name="portal_user_names" string="Assignees"/>
                                     <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}" optional="show"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                                     <field name="kanban_state" widget="state_selection" optional="hide"/>
@@ -208,7 +223,9 @@
             <search string="Tasks">
                 <field name="name" string="Task"/>
                 <field name="tag_ids"/>
-                <field name="user_ids"/>
+                <!-- TODO: [XBO] remove me in master -->
+                <field name="user_ids" invisible="1"/>
+                <field name="portal_user_names" string="Assignees"/>
                 <field name="partner_id" operator="child_of"/>
                 <field name="stage_id"/>
                 <field string="Project" name="display_project_id"/>
@@ -223,7 +240,8 @@
                     domain="[('activity_ids.date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                 <group expand="0" string="Group By">
                     <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
-                    <filter string="Assignees" name="user" context="{'group_by': 'user_ids'}"/>
+                    <!-- TODO: [XBO] remove me in master -->
+                    <filter string="Assignees" name="user" context="{'group_by': 'user_ids'}" invisible="1"/>
                     <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
                     <filter string="Customer" name="customer" context="{'group_by': 'partner_id'}"/>
                     <filter string="Kanban State" name="kanban_state" context="{'group_by': 'kanban_state'}"/>


### PR DESCRIPTION
Both developments 6c4910a and 7563b44 have been introduced nearly
at the same time in the saas-14.5 version, but the later one is
introducing a side effect that breaks the project sharing feature.

Indeed, before there was one assignee per task (user_id), and now
we can assign several collaborators (user_ids).

As the read on a M2O is just calling the name_get method, it wasn't
an issue.

Now, as it implies to read the res.users (and the res.partner) model,
the assigned users were filtered according to a specific ir.rule
for the portal users:

    <record id="res_partner_rule" model="ir.rule">
        <field name="name">openerp.portal.res.partner</field>
        <field name="model_id" ref="base.model_res_partner"/>
        <field name="groups" eval="[(6,0,[ref('group_openerp_portal')])]"/>
        <field name="domain_force">[('id','child_of',user.commercial_partner_id.id)]</field>
    </record>

This commit re-introduces a correct behavior on the project sharing
feature, by allowing a portal user reading on assignees on task he
has access to, according to the project configuration.

Co-authored-by: Xavier BOL (xbo) <xbo@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
