### PR TITLE
[FIX] web: executeReportAction correctly pass the context

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -942,9 +942,9 @@ function makeActionManager(env) {
             report_file: action.report_file,
             report_name: action.report_name,
             report_url: _getReportUrl(action, "html"),
+            context: Object.assign({}, action.context),
         });
         const clientActionOptions = Object.assign({}, options, {
-            context: action.context,
             props,
         });
         return doAction("report.client_action", clientActionOptions);

--- a/addons/web/static/tests/helpers/mock_env.js
+++ b/addons/web/static/tests/helpers/mock_env.js
@@ -57,6 +57,7 @@ export function prepareRegistriesWithCleanup() {
     clearRegistryWithCleanup(registry.category("command_categories"));
     clearRegistryWithCleanup(registry.category("debug"));
     clearRegistryWithCleanup(registry.category("error_dialogs"));
+    clearRegistryWithCleanup(registry.category("ir.actions.report handlers"));
 
     clearRegistryWithCleanup(registry.category("services"));
     clearServicesMetadataWithCleanup();


### PR DESCRIPTION
Before this commit, the context given to the client action report was incorrect
and produced a crash server-side.

After this commit the context is correctly given to the ReportAction and to the print

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
