### PR TITLE
[FIX] mrp: don't merge move with same components

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1157,7 +1157,7 @@ class MrpProduction(models.Model):
                         'product_uom': move_finish.product_id.uom_id
                     })
             production.move_raw_ids._adjust_procure_method()
-            (production.move_raw_ids | production.move_finished_ids)._action_confirm()
+            (production.move_raw_ids | production.move_finished_ids)._action_confirm(merge=False)
             production.workorder_ids._action_confirm()
         # run scheduler for moves forecasted to not have enough in stock
         self.move_raw_ids._trigger_scheduler()

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1287,6 +1287,30 @@ class TestMrpOrder(TestMrpCommon):
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
 
+    def test_product_produce_14(self):
+        """ Check two component move with the same product are not merged."""
+        product = self.env['product.product'].create({
+            'name': 'Product no BoM',
+            'type': 'product',
+        })
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = product
+        mo = mo_form.save()
+        for i in range(2):
+            move = self.env['stock.move'].create({
+                'name': 'mrp_move',
+                'product_id': self.product_2.id,
+                'product_uom': self.ref('uom.product_uom_unit'),
+                'production_id': mo.id,
+                'location_id': self.ref('stock.stock_location_stock'),
+                'location_dest_id': self.ref('stock.stock_location_output'),
+                'product_uom_qty': 0,
+                'quantity_done': 0,
+            })
+            mo.move_raw_ids |= move
+        mo.action_confirm()
+        self.assertEqual(len(mo.move_raw_ids), 2)
+
     def test_product_produce_uom(self):
         """ Produce a finished product tracked by serial number. Set another
         UoM on the bom. The produce wizard should keep the UoM of the product (unit)


### PR DESCRIPTION
Component move with same product are not merge at confirmation as it
could be multiple different production steps.

opw-2583848

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
