### PR TITLE
[IMP] hr_holidays: Validity date on dashboard

### DIFF
--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -42,6 +42,10 @@
         border-right: 0px;
     }
 
+    .o_timeoff_normal {
+        font-size: 10px;
+    }
+
     .o_timeoff_big {
         font-size: 15px;
     }

--- a/addons/hr_holidays/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays/static/src/xml/time_off_calendar.xml
@@ -21,6 +21,21 @@
                         <t t-if="timeoff[1]['request_unit'] == 'hour'"><span class="o_timeoff_purple">HOURS</span></t><t t-else=""><span class="o_timeoff_purple">DAYS</span></t> <span class="o_timeoff_purple">TAKEN</span>
                     </t>
                 </div>
+
+                <t t-if="requires_allocation and timeoff[1]['closest_allocation_expire'] != false">
+                    <t t-if="timeoff[1]['closest_allocation_remaining'] == timeoff[1]['virtual_remaining_leaves']">
+                        <span class="o_timeoff_purple o_timeoff_normal">
+                            (VALID UNTIL <span t-esc="timeoff[1]['closest_allocation_expire']"/>)
+                        </span>
+                    </t>
+                    <t t-else="">
+                    <span class="o_timeoff_purple o_timeoff_normal">
+                        (<span t-esc="timeoff[1]['closest_allocation_remaining']"/> <t t-if="timeoff[1]['request_unit'] == 'hour'"><span>HOURS</span></t><t t-else=""><span>DAYS</span></t>
+                        VALID UNTIL <span t-esc="timeoff[1]['closest_allocation_expire']"/>)
+                    </span>
+                    </t>
+                </t>
+
             </div>
         </div>
     </t>


### PR DESCRIPTION
After this commit, in the Time Off dashboard, the user can see the validity
period of the available days in case if the related allocation
has a validity end.

If the time off has more than one allocation, we display the validity of the closest one.

task - 2636403
