### PR TITLE
[FIX] website: correctly set and sync custom account setting

### DIFF
--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -68,10 +68,10 @@ class ResConfigSettings(models.TransientModel):
     google_maps_api_key = fields.Char(related='website_id.google_maps_api_key', readonly=False)
     group_multi_website = fields.Boolean("Multi-website", implied_group="website.group_multi_website")
 
+    @api.onchange('website_id')
     @api.depends('website_id.auth_signup_uninvited')
     def _compute_auth_signup(self):
-        for config in self:
-            config.auth_signup_uninvited = config.website_id.auth_signup_uninvited
+        self.auth_signup_uninvited = self.website_id.auth_signup_uninvited
 
     def _set_auth_signup(self):
         for config in self:

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_attachment
+from . import test_auth_signup_uninvited
 from . import test_base_url
 from . import test_converter
 from . import test_crawl

--- a/addons/website/tests/test_auth_signup_uninvited.py
+++ b/addons/website/tests/test_auth_signup_uninvited.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestAuthSignupUninvited(common.TransactionCase):
+
+    def test_01_auth_signup_uninvited(self):
+        self.env['website'].browse(1).auth_signup_uninvited = 'b2c'
+        config = self.env['res.config.settings'].create({})
+        self.assertEqual(config.auth_signup_uninvited, 'b2c')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Video of the main issue: [Click here to see]( https://streamable.com/zx95bn)
A while back, the behavior of this setting was changed from a
related field to a computed as a fix to various issues with: cb9f48d
The setting's value synchronization with what is displayed on the
setting's page is broken, since its behavior changed with commit:
2ccc735 . It resets to its default value for the default website when
editing a  secondary one and is not only confusing but breaks the
setting in some scenarios.

**Desired behavior after PR is merged:**
When changing the auth_signup_uninvited setting, the changes
are correctly reflected and not reset to default upon changing
the website we are currently editing.

task-2612686