### PR TITLE
[IMP] website_event_questions: make error message clearer

### DIFF
--- a/addons/website_event_questions/models/event_question.py
+++ b/addons/website_event_questions/models/event_question.py
@@ -40,6 +40,11 @@ class EventQuestion(models.Model):
                     raise UserError(_("You cannot change the question type of a question that already has answers!"))
         return super(EventQuestion, self).write(vals)
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_answered_question(self):
+        if self.env['event.registration.answer'].search_count([('question_id', 'in', self.ids)]):
+            raise UserError(_('You cannot delete a question that has already been answered by attendees.'))
+
     def action_view_question_answers(self):
         """ Allow analyzing the attendees answers to event questions in a convenient way:
         - A graph view showing counts of each suggestions for simple_choice questions
@@ -63,3 +68,8 @@ class EventQuestionAnswer(models.Model):
     name = fields.Char('Answer', required=True, translate=True)
     question_id = fields.Many2one('event.question', required=True, ondelete='cascade')
     sequence = fields.Integer(default=10)
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_selected_answer(self):
+        if self.env['event.registration.answer'].search_count([('value_answer_id', 'in', self.ids)]):
+            raise UserError(_('You cannot delete an answer that has already been selected by attendees.'))


### PR DESCRIPTION
PURPOSE

If we try to delete an answer which is already been
selected by attendees, odoo will throw a validation
error "There must be suggested value or text value",
it is because the attendees with those answers are "broken"
by this change since their answer disappears.
Same thing happens if we try to delete a question which is
already answered.

SPECIFICATION

There is no way we could let the user do delete that because all
"historic" attendees need to refer to this answer/question record
(or they would be empty) , But we should at the very least
catch this and provide a clearer error message.

So in this commit we will updated the error message as
"You cannot delete an answer that has already been selected
by attendees." if they try to delete answer and "You cannot delete
a question that has already been answered by attendees." if they
try to delete questions.

LINKS
PR #76265
Task 2635599

