### PR TITLE
[FIX] core: load all bases for ir.model before adding manual models

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -263,6 +263,11 @@ class Registry(Mapping):
                 env.all.tocompute, stack_info=True,
             )
 
+        # we must setup ir.model before adding manual fields because _add_manual_models may
+        # depend on behavior that is implemented through overrides, such as is_mail_thread which
+        # is implemented through an override to env['ir.model']._instanciate
+        env['ir.model']._prepare_setup()
+
         # add manual models
         if self._init_modules:
             env['ir.model']._add_manual_models()


### PR DESCRIPTION
Commit cd122933867c096f61fae945f11e842ea84d06b8 introduced an
optimization in the way that models and their inheritances are loaded,
with this commit we defer the setting of each model class' bases
from the _build_model method to the _prepare_setup method.

This has the advantage of setting any given model class' `__bases__`
attribute only once, but it also means that when _add_manual_models is
called, the __bases__ for ir.model are not yet set (only the default
implementation exists), therefore any module overrides to ir.model do
not take effect when creating the custom models.

This meant that if one creates a custom model with chatter support (i.e.
custom ir.model behaviour implemented in mail) and one restarted the
server, the registry would not properly setup ir.model before creating
the custom model (yielding warnings about tracking and such not being
valid fields) and when creating a record of the custom model, the
registry would crash.

With this commit, ir.model's _prepare_setup is explicitly called before
_add_manual_models to ensure that all overrides to ir.model are taken
into account.