### PR TITLE
[FIX] planning: fix default hours of employees

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -957,7 +957,7 @@ class ResourceResource(models.Model):
                 # Make sure to only search end after start
                 search_range = (
                     start,
-                    end + relativedelta(days=1, hour=0, minute=0, second=0),
+                    end + relativedelta(hour=23, minute=59, second=59),
                 )
             calendar_end = resource.calendar_id._get_closest_work_time(end, match_end=True, resource=resource, search_range=search_range)
             result[resource] = (


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The search range for the closest work time is not assigned any value if the start date is different than the end date. The dates can be different if the employee is in another timezone.

Current behavior before PR:
If the browser time is UTC+2 and a shift of an employee in UTC+6 is scheduled, the start time in UTC time will be 01/01/2000 22:00 and the end time will be 02/01/2000 21:59:59.
Converted to the resource.tz timezone, the start date will become 02/01/2000 and the end date will be 03/01/2000.
Due to the date difference, the search range is not assigned a value, the start of the shift will be at the employee start time on 02/01/2000 and the end of the shift will be around lunch break one day later.

Desired behavior after PR is merged:
The shift of the employee for a certain day doesn't span over two days or exceeds the hours per day for the employee

Related to odoo/enterprise#20428
Task-2628876
ref #75527

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
