### PR TITLE
[FIX] website_slides : iframe code block appearing when pdfviewer loaded

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -42,13 +42,13 @@
                                 t-attf-data-downloadable="#{False}"
                                 t-att-data-defaultpage="page">
                             <t t-if="is_embedded">
-                                <div id="slide_share" class="oe_slide_embed_option">
+                                <div id="slide_share" class="oe_slide_embed_option" style="display: none;">
                                     <t t-call="website_slides.slide_social_media"/>
                                 </div>
-                                <div id="slide_email" class="oe_slide_embed_option">
+                                <div id="slide_email" class="oe_slide_embed_option" style="display: none;">
                                     <t t-call="website_slides.slide_social_email"/>
                                 </div>
-                                <div id="slide_embed" class="oe_slide_embed_option">
+                                <div id="slide_embed" class="oe_slide_embed_option" style="display: none;">
                                     <t t-call="website_slides.slide_social_embed"/>
                                 </div>
                             </t>


### PR DESCRIPTION
Issue: When viewing a pdf in a website_slide, in certain conditions (
odoo detect the slide is externally embedded), a <iframe> code block
is displayed on the pdf rendering it really hard to read. As a work
around, one could click on the "<\> Embed" button to make it disapear

Steps to reproduce :
 1) Run a local odoo server with the website_slides module
 2) Set up a ngrox tunneling service to your localhost and good port
 3) Find or create a **document** slide and get its id (<slide_id>)
 4) Access the slide via the website url on the slide
 5) Go down the page in the Share tab and copy the iframe
  -Replace http by https in the src attribute of the iframe if necessary
 6) go back to the dashboard, open the inspector and add the iframe in
 the body of the webpage
 -> The slide is correctly detected as non embed
 7) Access your Odoo database with the ngrox https forward (example :
 https://0dfc-2a02-a03f-6b9b-b300-bd6c-8048-90f1-3f25.eu.ngrok.io)
 8) Repeat step 3 to 6 included
 -> The slide is detected as embed, so a <iframe> text area appears
 and make the pdf hard to read

Alternative steps to reproduce :
 1) Run a local odoo server with the website_slides module
 2) Go to the usual http://localhost:8069/ to access your database and
 navigate to a PDF slide in eLearning
 3) Change the localhost in the URL to 127.0.0.1 (Example
 http://localhost:8069/slides/slide/gardening-the-know-how-1 becomes
 http://127.0.0.1:8069/slides/slide/gardening-the-know-how-1) and press
 Enter to go to the new URL
 4) Change back the 127.0.0.1 to localhost and press Enter to go to the
 new URL
 5) You might have to repeat the back and forth between the two domains
 -> The slide is detected as embed, so a <iframe> text area appears
 and make the pdf hard to read

Why is that a bug:
 It makes the PDF unreadable unless we know that we must click on that
 button, it really shouldn't be like that

opw-2499110