### PR TITLE
[IMP] account: simplify invoice payment status filters

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -368,7 +368,7 @@ class account_journal(models.Model):
                 company_id
             FROM account_move move
             WHERE journal_id = %(journal_id)s
-            AND invoice_date_due <= %(today)s
+            AND invoice_date_due < %(today)s
             AND state = 'posted'
             AND payment_state in ('not_paid', 'partial')
             AND move_type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt');

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1309,10 +1309,10 @@
                     <separator/>
                     <filter string="To Check" name="to_check" domain="[('to_check', '=', True)]"/>
                     <separator/>
-                    <!-- in_payment & not_paid & partial -->
-                    <filter name="open" string="Open" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('in_payment', 'not_paid', 'partial'))]"/>
-                    <!-- paid & reversed -->
-                    <filter name="closed" string="Closed" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('paid', 'reversed'))]"/>
+                    <!-- not_paid & partial -->
+                    <filter name="open" string="Unpaid" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial'))]"/>
+                    <!-- in_payment & paid -->
+                    <filter name="closed" string="Paid" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('in_payment', 'paid'))]"/>
                     <!-- overdue -->
                     <filter name="late" string="Overdue" domain="[
                         ('invoice_date_due', '&lt;', time.strftime('%%Y-%%m-%%d')),


### PR DESCRIPTION
Modify search filters on the invoice views:
Open -> Unpaid (not_paid & partial)
Closed -> Paid (in_payment & paid)
Overdue -> Overdue

[FIX] journal kanban view "late invoices/bills" should not include due date = today

Task 2635664