### PR TITLE
[FIX] setting correct res_id when uploading file to ir.attachment

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1540,7 +1540,7 @@
             <t t-set="fileupload_action" t-translation="off">/web/binary/upload_attachment</t>
             <t t-set="multi_upload" t-value="true"/>
             <input type="hidden" name="model" t-att-value="widget.model"/>
-            <input type="hidden" name="id" value="0"/>
+            <input type="hidden" name="id" t-att-value="(!widget.res_id) ? 0 : widget.res_id"/>
         </t>
     </div>
 </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The many2many_binary widget did set the res_id hardcoded to "0". If a res_id is present - the id should be attached to the ir.attachment

Current behavior before PR:
Some assetes did not get found by the search, when you try to "read_search" attached documents to a model. Because there is no valid res_id ("0") saved within the ir.attachment. 

Desired behavior after PR is merged:
If a res_id is present - the id should be attached to the ir.attachment.
when you create a record and try to attach a document before saving the record - there is no valid res_id present. In this case the value shoul be "0" again. My Proposal: You can overwrite the "create" method of the specific model to check if the attached file has a res_id of "0" and then set it to the now existing one.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
