### PR TITLE
[FIX] web: prevent the translate alert at the wizard

### DIFF
--- a/addons/web/static/src/legacy/js/views/form/form_renderer.js
+++ b/addons/web/static/src/legacy/js/views/form/form_renderer.js
@@ -130,8 +130,10 @@ var FormRenderer = BasicRenderer.extend({
      *  @param {Object} alertFields
      */
     updateAlertFields: function (alertFields) {
-        this.alertFields[this.state.res_id] = _.extend(this.alertFields[this.state.res_id] || {}, alertFields);
-        this.displayTranslationAlert();
+        if (this.state.res_id) {
+            this.alertFields[this.state.res_id] = _.extend(this.alertFields[this.state.res_id] || {}, alertFields);
+            this.displayTranslationAlert();
+        }
     },
     /**
      * Show a warning message if the user modified a translated field.  For each

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -14,6 +14,7 @@ var mixins = require('web.mixins');
 var pyUtils = require('web.py_utils');
 var RamStorage = require('web.RamStorage');
 var testUtils = require('web.test_utils');
+var ViewDialogs = require('web.view_dialogs');
 var widgetRegistry = require('web.widget_registry');
 const widgetRegistryOwl = require('web.widgetRegistry');
 var Widget = require('web.Widget');
@@ -7086,6 +7087,42 @@ QUnit.module('Views', {
         assert.strictEqual(nbTranslateCalls, 1, "should call_button translate once");
 
         form.destroy();
+        _t.database.multi_lang = multi_lang;
+    });
+
+    QUnit.test('check the translate alert in the wizard', async function (assert) {
+        assert.expect(1);
+
+        // Check whether it is alert before the dialog closes
+        testUtils.mock.patch(ViewDialogs.FormViewDialog, {
+            close() {
+                assert.containsNone(this.$el, '.o_notification_box');
+                this._super(...arguments);
+            },
+        });
+
+        this.data.product.fields.name.translate = true;
+
+        const multi_lang = _t.database.multi_lang;
+        _t.database.multi_lang = true;
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form><field name="product_id"/></form>`,
+            archs: {
+                'product,false,form': `<form><field name="name"/></form>`,
+            },
+            res_id: 1,
+        });
+
+        await testUtils.form.clickEdit(form);
+        await testUtils.fields.many2one.createAndEdit('product_id', "Ralts");
+        await testUtils.dom.click($('.modal-footer button.btn-primary'));
+
+        form.destroy();
+        testUtils.mock.unpatch(ViewDialogs.FormViewDialog);
         _t.database.multi_lang = multi_lang;
     });
 


### PR DESCRIPTION
The translation alert will now appear in the wizard, it will no longer appear.

Technical:
      res_id is undefined in the wizard
      Like :
	 {
           'undefined': {
             'displany_name / name': {
                 change_default: false
                 company_dependent: false
                 depends: []
                 id: null
                 manual: false
                 translate: true
                 --- }
            }
       }
