### PR TITLE
[IMP] base: improve ir.mail_server form view readability

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -88,11 +88,11 @@ class IrMailServer(models.Model):
     NO_VALID_RECIPIENT = ("At least one valid recipient address should be "
                           "specified for outgoing emails (To/Cc/Bcc)")
 
-    name = fields.Char(string='Description', required=True, index=True)
+    name = fields.Char(string='Name', required=True, index=True)
     from_filter = fields.Char(
-      "From Filter",
-      help='Define for which email address or domain this server can be used.\n'
-      'e.g.: "notification@odoo.com" or "odoo.com"')
+        "FROM Filtering",
+        help='Define for which email address or domain this server can be used.\n'
+             'e.g.: "notification@odoo.com" or "odoo.com"')
     smtp_host = fields.Char(string='SMTP Server', required=True, help="Hostname or IP of SMTP server")
     smtp_port = fields.Integer(string='SMTP Port', required=True, default=25, help="SMTP Port. Usually 465 for SSL, and 25 or 587 for other cases.")
     smtp_authentication = fields.Selection([('login', 'Username'), ('certificate', 'SSL Certificate')], string='Authenticate with', required=True, default='login')
@@ -101,7 +101,7 @@ class IrMailServer(models.Model):
     smtp_encryption = fields.Selection([('none', 'None'),
                                         ('starttls', 'TLS (STARTTLS)'),
                                         ('ssl', 'SSL/TLS')],
-                                       string='Connection Security', required=True, default='none',
+                                       string='Connection Encryption', required=True, default='none',
                                        help="Choose the connection encryption scheme:\n"
                                             "- None: SMTP sessions are done in cleartext.\n"
                                             "- TLS (STARTTLS): TLS encryption is requested at start of SMTP session (Recommended)\n"
@@ -428,6 +428,7 @@ class IrMailServer(models.Model):
         domain = get_param('mail.catchall.domain')
         if postmaster and domain:
             return '%s@%s' % (postmaster, domain)
+        return
 
     @api.model
     def _get_default_from_address(self):

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -5,30 +5,33 @@
             <field name="model">ir.mail_server</field>
             <field name="arch" type="xml">
                 <form string="Outgoing Mail Servers">
-                  <sheet>
-                    <group col="4">
-                        <field name="name"/>
-                        <field name="from_filter"/>
-                        <field name="sequence"/>
-                        <field name="active" widget="boolean_toggle"/>
-                    </group>
-                    <group col="4" string="Connection Information">
-                        <field name="smtp_host"/>
-                        <field name="smtp_port" options="{'format': false}"/>
-                        <field name="smtp_debug" groups="base.group_no_one"/>
-                     </group>
-                     <group>
-                        <group string="Security and Authentication">
-                            <field name="smtp_authentication"/>
-                            <field name="smtp_encryption"/>
-                            <field name="smtp_user" attrs="{'invisible': [('smtp_authentication', '!=', 'login')]}" force_save="1"/>
-                            <field name="smtp_pass" attrs="{'invisible': [('smtp_authentication', '!=', 'login')]}" password="True" force_save="1"/>
-                            <field name="smtp_ssl_certificate" attrs="{'invisible': [('smtp_authentication', '!=', 'certificate')]}" force_save="1"/>
-                            <field name="smtp_ssl_private_key" attrs="{'invisible': [('smtp_authentication', '!=', 'certificate')]}" force_save="1"/>
-                            <button name="test_smtp_connection" type="object" string="Test Connection" icon="fa-television"/>
+                    <header>
+                        <button string="Test Connection" type="object"
+                            name="test_smtp_connection" class="btn-primary"/>
+                    </header>
+                    <sheet>
+                        <group col="4">
+                            <field name="name" placeholder="e.g. My Outgoing Server"/>
+                            <field name="from_filter"/>
+                            <field name="sequence"/>
+                            <field name="active" widget="boolean_toggle"/>
                         </group>
-                    </group>
-                  </sheet>
+                        <group>
+                            <group string="Authentication">
+                                <field name="smtp_authentication" widget="radio"/>
+                                <field name="smtp_user" attrs="{'invisible': [('smtp_authentication', '!=', 'login')]}" force_save="1"/>
+                                <field name="smtp_pass" attrs="{'invisible': [('smtp_authentication', '!=', 'login')]}" password="True" force_save="1"/>
+                                <field name="smtp_ssl_certificate" attrs="{'invisible': [('smtp_authentication', '!=', 'certificate')]}" force_save="1"/>
+                                <field name="smtp_ssl_private_key" attrs="{'invisible': [('smtp_authentication', '!=', 'certificate')]}" force_save="1"/>
+                            </group>
+                            <group string="Connection">
+                                <field name="smtp_encryption" widget="radio"/>
+                                <field name="smtp_host"/>
+                                <field name="smtp_port" options="{'format': false}"/>
+                                <field name="smtp_debug" groups="base.group_no_one"/>
+                            </group>
+                        </group>
+                    </sheet>
                 </form>
             </field>
         </record>
@@ -42,6 +45,7 @@
                     <field name="smtp_host"/>
                     <field name="smtp_user"/>
                     <field name="smtp_encryption"/>
+                    <field name="from_filter" optional="hide"/>
                 </tree>
             </field>
         </record>
@@ -51,9 +55,13 @@
             <field name="arch" type="xml">
                 <search string="Outgoing Mail Servers">
                     <field name="name"
-                        filter_domain="['|', '|', ('name','ilike',self), ('smtp_host','ilike',self), ('smtp_user','ilike',self)]"
+                        filter_domain="['|', '|',
+                                        ('name', 'ilike', self),
+                                        ('smtp_host', 'ilike', self),
+                                        ('smtp_user', 'ilike', self)]"
                         string="Outgoing Mail Server"/>
                     <field name="smtp_encryption"/>
+                    <field name="from_filter"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                 </search>


### PR DESCRIPTION
PURPOSE

Help people setuping their mail server with clear labels and form view.

SPECIFICATIONS

Rename Description to Name, as Description indicates a secondary text
field.

Relabel the field for filtering to FROM Filtering. Current From Filter
could lead to think it filters incoming emails which is not the case.

Move button in header as on all form views.

Task-2628092
