### PR TITLE
[IMP] website_event_track_live: hide "YouTube replay" if no YouTube U…

### DIFF
--- a/addons/website_event_track_live/models/event_track.py
+++ b/addons/website_event_track_live/models/event_track.py
@@ -9,12 +9,12 @@ from odoo import api, fields, models
 class Track(models.Model):
     _inherit = 'event.track'
 
-    youtube_video_url = fields.Char('Youtube Video URL',
+    youtube_video_url = fields.Char('YouTube Video Link',
         help="Configure this URL so that event attendees can see your Track in video!")
-    youtube_video_id = fields.Char('Youtube video ID', compute='_compute_youtube_video_id',
+    youtube_video_id = fields.Char('YouTube video ID', compute='_compute_youtube_video_id',
         help="Extracted from the video URL and used to infer various links (embed/thumbnail/...)")
-    is_youtube_replay = fields.Boolean('Is Youtube Replay',
-        help="Check this option if the video is already available on Youtube to avoid showing 'Direct' options (Chat, ...)")
+    is_youtube_replay = fields.Boolean('Is YouTube Replay',
+        help="Check this option if the video is already available on YouTube to avoid showing 'Direct' options (Chat, ...)")
     is_youtube_chat_available = fields.Boolean('Is Chat Available', compute='_compute_is_youtube_chat_available')
 
     @api.depends('youtube_video_url')

--- a/addons/website_event_track_live/views/event_track_views.xml
+++ b/addons/website_event_track_live/views/event_track_views.xml
@@ -8,7 +8,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='active']" position="after">
                 <field name="youtube_video_url" widget="url" />
-                <field name="is_youtube_replay" attrs="{'invisible': [('youtube_video_url', '=', '')]}" />
+                <field name="is_youtube_replay"
+                    attrs="{'invisible': ['|', ('youtube_video_url', '=', False), ('youtube_video_url', '=', '')]}" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
…RL configured

This commit slightly adapts the invisible attrs domain of the is_youtube_replay
field to account for empty OR False youtube_video_url values.

So that the youtube replay field is always hidden if no youtube URL is
configured.

Side note: The web client should probably consider empty as a Falsy value so
that we can write simpler attrs domain based on empty/False Char values.

We also took this opportunity to tweak some youtube field labels.

Task-2643205
