### PR TITLE
[FIX] sale,web: fix spread operator for old browsers

### DIFF
--- a/addons/sale/static/src/js/payment_form.js
+++ b/addons/sale/static/src/js/payment_form.js
@@ -22,11 +22,10 @@ odoo.define('sale.payment_form', require => {
          */
         _prepareTransactionRouteParams: function (provider, paymentOptionId, flow) {
             const transactionRouteParams = this._super(...arguments);
-            return {
-                ...transactionRouteParams,
+            return Object.assign({}, transactionRouteParams, {
                 'sale_order_id': this.txContext.saleOrderId
                     ? parseInt(this.txContext.saleOrderId) : undefined,
-            };
+            });
         },
 
     };

--- a/addons/web/static/lib/owl/owl.js
+++ b/addons/web/static/lib/owl/owl.js
@@ -384,7 +384,7 @@
                     if (groupType === "LEFT_BRACE" &&
                         isLeftSeparator(prevToken) &&
                         isRightSeparator(nextToken)) {
-                        tokens.splice(i + 1, 0, { type: "COLON", value: ":" }, { ...token });
+                        tokens.splice(i + 1, 0, { type: "COLON", value: ":" }, Object.assign({}, token));
                         nextToken = tokens[i + 1];
                     }
                     if (prevToken.type === "OPERATOR" && prevToken.value === ".") {


### PR DESCRIPTION
Older browsers such as Safari on iOS 11.1 (iPhone X) don't support the spread syntax in object literals, but are OK with the rest syntax or the spread syntax in array literals.

This commit fixes some occurrences of such syntax that break JavaScript on the public website.