### PR TITLE
[FIX] product: inherit last update from template

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -149,6 +149,16 @@ class ProductProduct(models.Model):
         for record in self:
             record.image_1920 = record.image_variant_1920 or record.product_tmpl_id.image_1920
 
+    @api.depends("create_date", "write_date", "product_tmpl_id.create_date", "product_tmpl_id.write_date")
+    def compute_concurrency_field_with_access(self):
+        super().compute_concurrency_field_with_access()
+        for record in self:
+            record[self.CONCURRENCY_CHECK_FIELD] = max(filter(None, (
+                record.product_tmpl_id.create_date,
+                record.product_tmpl_id.write_date,
+                record[self.CONCURRENCY_CHECK_FIELD],
+            )))
+
     def _set_image_1920(self):
         for record in self:
             if (


### PR DESCRIPTION
1. Open chrome.
2. Install `website_sale`.
3. Navigate to any product on eCommerce.
4. Press F5 a couple of times until the product image is cached.
5. Edit in backend.
6. Change the `product.template` image.
7. Go back to eCommerce product page.

Before this patch: Chrome still displays old image. This is because the `?unique=` paramater added by `ir.qweb.field.image` relies on `product.product`'s `__last_update`, which didn't update when the related `product.template` was updated.

After this patch: Chrome displays the new image, because the `__last_update` is propagated from `product.template` to its variants.

@Tecnativa TT31719

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
