### PR TITLE
[FIX] web: favorite domain is a string

### DIFF
--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1384,7 +1384,7 @@ export class SearchModel extends EventBus {
      * @param {boolean} [params.raw=false]
      * @param {boolean} [params.withSearchPanel=true]
      * @param {boolean} [params.withGlobal=true]
-     * @returns {DomainListRepr | string} AST domain if 'raw', else the evaluated list domain
+     * @returns {DomainListRepr | Domain} Domain instance if 'raw', else the evaluated list domain
      */
     _getDomain(params = {}) {
         const withSearchPanel = "withSearchPanel" in params ? params.withSearchPanel : true;
@@ -1734,7 +1734,7 @@ export class SearchModel extends EventBus {
                 delete context[key];
             }
         }
-        const rawDomain = this._getDomain({ raw: true, withGlobal: false });
+        const domain = this._getDomain({ raw: true, withGlobal: false }).toString();
         const groupBys = this._getGroupBy();
         const comparison = this._getComparison();
         const orderBy = saveParams.orderBy ? saveParams.orderBy : this._getOrderBy() || [];
@@ -1743,7 +1743,7 @@ export class SearchModel extends EventBus {
         const preFavorite = {
             description,
             isDefault,
-            domain: rawDomain.toList(userContext),
+            domain,
             context,
             groupBys,
             orderBy,
@@ -1753,7 +1753,7 @@ export class SearchModel extends EventBus {
             name: description,
             action_id: this.action.id,
             model_id: this.resModel,
-            domain: rawDomain.toString(),
+            domain,
             is_default: isDefault,
             sort: JSON.stringify(orderBy.map((o) => `${o.name}${o.asc === false ? " desc" : ""}`)),
             user_id: userId,


### PR DESCRIPTION
Since the refactoring of the search model aeb8e49,
the new favorite items were created with a domain with the wrong type:
Array instead of string. Thus it was impossible to share the search
state with a legacy view when a new favorite was created. We now set
correctly the domain key of a favorite.