### PR TITLE
[FIX] sale_timesheet: fix the upsell activity creation

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -785,7 +785,7 @@
                     <field name="allow_task_dependencies" invisible="1" />
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : [('user_ids', '!=', False)]}" data-hotkey="q"/>
+                            attrs="{'invisible' : [('user_ids', '!=', [])]}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                     </header>
                     <div class="alert alert-info oe_edit_only mb-0" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}">

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -89,7 +89,7 @@ class SaleOrder(models.Model):
                 sol.qty_delivered,
                 sol.product_uom_qty * (sol.product_id.service_upsell_threshold or 1.0),
                 precision_digits=precision
-            ) >= 0
+            ) > 0
         )
 
     def action_view_timesheet(self):

--- a/addons/sale_timesheet/tests/test_upsell_warning.py
+++ b/addons/sale_timesheet/tests/test_upsell_warning.py
@@ -25,7 +25,7 @@ class TestUpsellWarning(TestCommonSaleTimesheet):
         """
         # 1) Configure the upsell warning in prepaid service product
         self.product_order_timesheet1.write({
-            'service_upsell_threshold': 0.6,
+            'service_upsell_threshold': 0.5,
         })
 
         # 2) Create SO with a SOL containing this updated product


### PR DESCRIPTION
Currently the 'upsell' activity generated when the delivered quantity
of the SOL is >= 100% instead of > 100%

so in this commit, if SOL is > 100% then only the upsell activity should
be generated.

TaskID: 2642872
