### PR TITLE
[IMP] web_editor, website: add options to upload documents on links

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/document_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/document_selector.js
@@ -49,7 +49,7 @@ export class DocumentSelector extends FileSelector {
     static async createElements(selectedMedia, { orm }) {
         return Promise.all(selectedMedia.map(async attachment => {
             const linkEl = document.createElement('a');
-            let href = `/web/content/${attachment.id}?unique=${attachment.checksum}&download=true`;
+            let href = `/web/content/${attachment.id}?unique=${attachment.checksum}`;
             if (!attachment.public) {
                 let accessToken = attachment.access_token;
                 if (!accessToken) {
@@ -64,11 +64,16 @@ export class DocumentSelector extends FileSelector {
             linkEl.href = href;
             linkEl.title = attachment.name;
             linkEl.dataset.mimetype = attachment.mimetype;
+            linkEl.dataset.fileName = attachment.name;
+            linkEl.textContent = attachment.name;
+            // The document behaviour is by default set to open in a new tab.
+            // This behaviour is configurable with an option in the Link Tools.
+            linkEl.target = '_blank';
             return linkEl;
         }));
     }
 }
-DocumentSelector.mediaSpecificClasses = ['o_image'];
+DocumentSelector.mediaSpecificClasses = [];
 DocumentSelector.mediaSpecificStyles = [];
 DocumentSelector.mediaExtraClasses = [];
 DocumentSelector.tagNames = ['A'];

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -198,6 +198,9 @@ export class MediaDialog extends Component {
                 element.classList.remove(...this.initialIconClasses);
                 element.classList.remove('o_modified_image_to_save');
                 element.classList.remove('oe_edited_link');
+                // The o_image class is not used anymore but it still needs to
+                // be removed for documents uploaded before 16.0.
+                element.classList.remove('o_image');
                 element.classList.add(...TABS[this.state.activeTab].Component.mediaSpecificClasses);
             });
             if (this.props.multiImages) {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -123,17 +123,7 @@ const Link = Widget.extend({
     start: function () {
         for (const option of this._getLinkOptions()) {
             const $option = $(option);
-            const value = $option.is('input') ? $option.val() : $option.data('value');
-            let active = true;
-            if (value) {
-                const subValues = value.split(',');
-                let subActive = true;
-                for (let subValue of subValues) {
-                    const classPrefix = new RegExp('(^|btn-| |btn-outline-|btn-fill-)' + subValue);
-                    subActive = subActive && classPrefix.test(this.data.iniClassName);
-                }
-                active = subActive;
-            }
+            const active = this._isOptionValueActive($option);
             this._setSelectOption($option, active);
         }
         if (this.data.url) {
@@ -461,6 +451,28 @@ const Link = Widget.extend({
      * @private
      */
     _updateOptionsUI: function () {},
+    /**
+     * Returns if an option value should be active or not, based
+     * on the initialization of the Link.
+     *
+     * @private
+     * @param $option
+     * @returns {boolean}
+     */
+    _isOptionValueActive($option) {
+        const value = $option.is('input') ? $option.val() : $option.data('value');
+        let active = true;
+        if (value) {
+            const subValues = value.split(',');
+            let subActive = true;
+            for (let subValue of subValues) {
+                const classPrefix = new RegExp('(^|btn-| |btn-outline-|btn-fill-)' + subValue);
+                subActive = subActive && classPrefix.test(this.data.iniClassName);
+            }
+            active = subActive;
+        }
+        return active;
+    },
 
     //--------------------------------------------------------------------------
     // Handlers

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -202,7 +202,7 @@ const LinkPopoverWidget = Widget.extend({
             }).removeClass('d-none');
             this.$previewFaviconFa.addClass('d-none');
         } else {
-            await this._dp.add($.get(this.target.href)).then(content => {
+            await this._dp.add($.get({url: this.target.href, dataType: 'html'})).then(content => {
                 const parser = new window.DOMParser();
                 const doc = parser.parseFromString(content, "text/html");
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -40,6 +40,7 @@ const LinkTools = Link.extend({
         this.customColors = {};
         this.colorpickers = {};
         this.colorpickersPromises = {};
+        this.fileName = this.linkEl.dataset.fileName;
     },
     /**
      * @override

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -11,6 +11,8 @@ const {
     getNumericAndUnit,
     isColorGradient,
 } = require('web_editor.utils');
+const { ComponentWrapper } = require('web.OwlCompatibility');
+const { MediaDialogWrapper, TABS } = require('@web_editor/components/media_dialog/media_dialog');
 
 /**
  * Allows to customize link content and style.
@@ -23,6 +25,8 @@ const LinkTools = Link.extend({
         'change .link-custom-color-border input': '_onChangeCustomBorderWidth',
         'keypress .link-custom-color-border input': '_onKeyPressCustomBorderWidth',
         'click we-select [name="link_border_style"] we-button': '_onBorderStyleSelectOption',
+        'click .o_we_upload_file': '_onUploadFileClick',
+        'click .o_we_remove_file': '_onRemoveFileClick',
     }),
 
     /**
@@ -41,6 +45,8 @@ const LinkTools = Link.extend({
         this.colorpickers = {};
         this.colorpickersPromises = {};
         this.fileName = this.linkEl.dataset.fileName;
+        this.mimetype = this.linkEl.dataset.mimetype;
+        this.download = this.linkEl.hasAttribute('download') || /download=true/.test(this.linkEl.href);
     },
     /**
      * @override
@@ -49,6 +55,9 @@ const LinkTools = Link.extend({
         this._addHintClasses();
         return this._super(...arguments);
     },
+    /**
+     * @override
+     */
     destroy: function () {
         if (!this.el) {
             return this._super(...arguments);
@@ -61,22 +70,52 @@ const LinkTools = Link.extend({
         this._super(...arguments);
         this._removeHintClasses();
     },
-    shouldUnlink: function () {
-        return !this.$link.attr('href') && !this.colorCombinationClass
-    },
-    applyLinkToDom() {
-        this._observer.disconnect();
-        this._removeHintClasses();
-        this._super(...arguments);
-        this.options.wysiwyg.odooEditor.historyStep();
-        this._addHintClasses();
-        this._observer.observe(this._link, {subtree: true, childList: true, characterData: true});
-    },
 
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
+    shouldUnlink: function () {
+        return !this.$link.attr('href') && !this.colorCombinationClass
+    },
+    /**
+     * @override
+     */
+    applyLinkToDom(data) {
+        this._observer.disconnect();
+        this._removeHintClasses();
+
+        // If a file was uploaded, we want to display its filename as the
+        // text content
+        if (!this.data.originalText && this.fileName) {
+            data.content = this.fileName;
+        }
+        this._super(data);
+
+        if (this.fileName) {
+            if (this.mimetype === 'application/octet-stream' || this._getFileAction() === 'download') {
+                this.linkEl.setAttribute('download', this.fileName);
+                if (this.linkEl.target === '_blank') {
+                    this.linkEl.removeAttribute('target');
+                }
+            } else {
+                this.linkEl.removeAttribute('download');
+                let href = data.url.replace(/[&?]+download=true/, '');
+                // Sets the document.title of the new tab in some browsers.
+                if (href.indexOf('#') < 0) {
+                    href += `#${this.fileName}`;
+                }
+                this.linkEl.setAttribute('href', href);
+            }
+        } else {
+            this.linkEl.removeAttribute('download');
+        }
+        this.linkEl.setAttribute('title', this.fileName);
+
+        this.options.wysiwyg.odooEditor.historyStep();
+        this._addHintClasses();
+        this._observer.observe(this._link, {subtree: true, childList: true, characterData: true});
+    },
     /**
      * @override
      */
@@ -113,6 +152,7 @@ const LinkTools = Link.extend({
             'we-selection-items[name="link_style_color"] > we-button',
             'we-selection-items[name="link_style_size"] > we-button',
             'we-selection-items[name="link_style_shape"] > we-button',
+            'we-selection-items[name="file_action"] > we-button',
         ];
         return this.$(options.join(','));
     },
@@ -133,6 +173,15 @@ const LinkTools = Link.extend({
      */
     _getLinkType: function () {
         return this.$('we-selection-items[name="link_style_color"] we-button.active').data('value') || '';
+    },
+    /**
+     * Returns the opening method for the file.
+     *
+     * @private
+     * @returns {string}
+     */
+    _getFileAction() {
+        return this.$('we-selection-items[name="file_action"] we-button.active').data('value') || '';
     },
     /**
      * @override
@@ -234,6 +283,31 @@ const LinkTools = Link.extend({
             const $activeBorderStyleToggler = $activeBorderStyleButton.closest('we-select').find('we-toggler');
             $activeBorderStyleToggler.empty();
             $activeBorderStyleButton.find('div').clone().appendTo($activeBorderStyleToggler);
+        }
+        if (!this.isButton) {
+            this.el.querySelector('.o_we_upload_file_wrapper').classList.toggle('d-none', !!this.fileName);
+            this.el.querySelector('.o_we_edit_file_wrapper').classList.toggle('d-none', !this.fileName);
+            // For binary data whose true type is unknown, the browser will
+            // interpret itself how to serve the data. The file actions
+            // should not be shown.
+            const genericBinaryData = this.mimetype === 'application/octet-stream';
+            const displayFileActions = this.fileName && !genericBinaryData;
+            const displayNewWindowSwitch = this._getFileAction() !== 'download' && !genericBinaryData || !this.fileName;
+            const newWindowSwitchEl = this.el.querySelector('we-checkbox[name="is_new_window"]').closest('we-button.o_we_checkbox_wrapper');
+            const fileActionsEl = this.el.querySelector('.o_we_file_action_wrapper');
+            fileActionsEl.classList.toggle('d-none', !displayFileActions);
+            newWindowSwitchEl.classList.toggle('d-none', !displayNewWindowSwitch);
+            if (displayNewWindowSwitch) {
+                const newWindowRow = newWindowSwitchEl.parentElement;
+                if (displayFileActions) {
+                    fileActionsEl.after(newWindowRow);
+                } else {
+                    this.el.append(newWindowRow);
+                }
+            }
+            this.el.querySelector('.o_we_filename').textContent = this.fileName;
+            this.el.querySelector('.o_we_filename').setAttribute('title', this.fileName);
+            this.el.querySelector('input[name="url"]').readOnly = !!this.fileName;
         }
     },
     /**
@@ -349,16 +423,35 @@ const LinkTools = Link.extend({
         this.$button.removeClass('active');
         this.options.wysiwyg.odooEditor.observerActive("hint_classes");
     },
+    /**
+     * @override
+     */
+   _isOptionValueActive($option) {
+       const optionEl = $option[0];
+       if (optionEl.closest('.o_we_file_action_wrapper')) {
+           const value = optionEl.dataset.value;
+           return value === 'download' ? this.download : !this.download;
+       }
+       return this._super(...arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
+    /**
+     * @private
+     * @param {Event} ev
+     */
     _onClickCheckbox: function (ev) {
         const $target = $(ev.target);
         $target.closest('we-button.o_we_checkbox_wrapper').toggleClass('active');
         this._adaptPreview();
     },
+    /**
+     * @private
+     * @param {Event} ev
+     */
     _onPickSelectOption: function (ev) {
         const $target = $(ev.target);
         if ($target.closest('[name="link_border_style"]').length) {
@@ -412,6 +505,48 @@ const LinkTools = Link.extend({
             $target.siblings('we-button').removeClass("active");
             this.options.wysiwyg.odooEditor.historyStep();
         }
+    },
+    /**
+     * @private
+     */
+    _onUploadFileClick() {
+        const dialog = new ComponentWrapper(this, MediaDialogWrapper, {
+            noIcons: true,
+            activeTab: TABS.DOCUMENTS.id,
+            save: this._onFileUploaded.bind(this),
+        });
+        dialog.mount(this.el);
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onRemoveFileClick(ev) {
+        this.el.querySelector('input[name="url"]').value = '';
+        this.el.querySelector('we-checkbox[name="is_new_window"]').closest('we-button.o_we_checkbox_wrapper').classList.remove('active');
+        delete this.fileName;
+        delete this.linkEl.dataset.fileName;
+        this._updateOptionsUI();
+        this._adaptPreview();
+    },
+    /**
+     * @private
+     * @param {Object} data
+     */
+    _onFileUploaded(data) {
+        if (data) {
+            const {src, href, title, dataset: {mimetype}} = data;
+            let url = href || src;
+            url = url.replace(window.location.origin, '');
+            this.el.querySelector('we-checkbox[name="is_new_window"]').closest('we-button.o_we_checkbox_wrapper').classList.add('active');
+            this.el.querySelector('input[name="url"]').value = url;
+            this.mimetype = mimetype;
+            this.linkEl.dataset.mimetype = this.mimetype;
+            this.fileName = title || url.split('/').slice(-1)[0];
+            this.linkEl.dataset.fileName = this.fileName;
+        }
+        this._updateOptionsUI();
+        this._adaptPreview();
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1178,7 +1178,7 @@ const Wysiwyg = Widget.extend({
                     if (
                         !ev.target.closest('#create-link') &&
                         (!ev.target.closest('.oe-toolbar') || !ev.target.closest('we-customizeblock-option')) &&
-                        !ev.target.closest('.ui-autocomplete') &&
+                        !ev.target.closest('.ui-autocomplete, .o_technical_modal') &&
                         (!this.linkTools || ![ev.target, ...wysiwygUtils.ancestors(ev.target)].includes(this.linkTools.$link[0]))
                     ) {
                         // Destroy the link tools on click anywhere outside the

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1387,6 +1387,8 @@ const Wysiwyg = Widget.extend({
             this.snippetsMenu.activateSnippet($(element)).then(() => {
                 if (element.tagName === 'IMG') {
                     $(element).trigger('image_changed');
+                } else if (element.tagName === 'A') {
+                    this.toggleLinkTools({ link: element });
                 }
             });
         }

--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -127,6 +127,7 @@ $o-we-sidebar-content-field-control-item-spacing: 0.5em !default;
 $o-we-sidebar-content-field-label-spacing: 6px !default;
 
 $o-we-sidebar-content-field-label-width: $o-we-sidebar-content-available-room * .4 !default;
+$o-we-sidebar-content-field-content-width: $o-we-sidebar-content-available-room - $o-we-sidebar-content-field-label-width;
 $o-we-sidebar-content-field-multi-spacing: $o-we-sidebar-content-field-label-spacing * .5 !default;
 $o-we-sidebar-content-field-height: 22px !default;
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1580,6 +1580,13 @@ body.editor_enable.editor_has_snippets {
                 flex: 0 1 auto;
                 min-width: 0;
                 margin-top: $o-we-sidebar-content-field-spacing;
+
+                &.o_we_truncated_content {
+                    max-width: $o-we-sidebar-content-field-content-width;
+                    > span {
+                        @include o-text-overflow();
+                    }
+                }
             }
 
             &:not(.o_we_fw) {

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -200,6 +200,37 @@
                 </div>
             </we-input>
         </we-row>
+        <we-row t-attf-class="#{widget.isButton ? ' d-none' : ''}" class="o_we_sublevel_1">
+            <we-title>Media</we-title>
+            <div class="o_we_edit_file_wrapper o_we_truncated_content">
+                <span class="o_we_filename"><t t-out="widget.fileName"/></span>
+                <we-button class="o_we_bg_success o_we_upload_file fa fa-fw fa-refresh" title="Replace file"/>
+                <we-button class="o_we_bg_danger o_we_remove_file fa fa-fw fa-trash" title="Remove file"/>
+            </div>
+            <div class="o_we_upload_file_wrapper">
+                <we-button class="o_we_bg_success o_we_upload_file" title="Upload file">Upload a file</we-button>
+            </div>
+        </we-row>
+        <we-row t-attf-class="o_we_file_action_wrapper #{widget.isButton ? ' d-none' : ''}">
+            <we-select class="o_we_user_value_widget o_we_sublevel_1">
+                <we-title>Action</we-title>
+                <div class="dropdown">
+                    <button class="dropdown-toggle"
+                        data-bs-toggle="dropdown" title="" tabindex="-1"
+                        data-original-title="File Action" aria-expanded="false">
+                        <we-toggler>Open</we-toggler>
+                    </button>
+                    <we-selection-items name="file_action" class="dropdown-menu">
+                        <we-button t-attf-class="dropdown-item" href="#" data-value="download">
+                            Download
+                        </we-button>
+                        <we-button t-attf-class="dropdown-item" href="#" data-value="">
+                            Open
+                        </we-button>
+                    </we-selection-items>
+                </div>
+            </we-select>
+        </we-row>
         <we-row class="o_strip_domain d-none" t-attf-class="#{widget.isButton ? ' d-none' : ''}">
             <we-button class="o_we_user_value_widget o_we_checkbox_wrapper o_we_sublevel_1 active">
                 <we-title class="o_long_title">Autoconvert to relative link</we-title>
@@ -331,12 +362,12 @@
                 </div>
             </we-select>
         </we-row>
-        <we-row  t-if="!widget.isButton &amp;&amp; !widget.options.forceNewWindow">
+        <we-row t-if="!widget.isButton &amp;&amp; !widget.options.forceNewWindow">
             <we-button t-attf-class="o_we_user_value_widget o_we_checkbox_wrapper o_we_sublevel_1 #{widget.data.isNewWindow ? 'active' : ''}">
                 <we-title class="o_long_title">Open in new window</we-title>
-                    <div class="o_switch">
-                        <we-checkbox name="is_new_window" t-att-checked="widget.data.isNewWindow ? 'checked' : undefined"/>
-                    </div>
+                <div class="o_switch">
+                    <we-checkbox name="is_new_window" t-att-checked="widget.data.isNewWindow ? 'checked' : undefined"/>
+                </div>
             </we-button>
         </we-row>
     </we-customizeblock-option>

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -331,7 +331,7 @@ export class WebsitePreview extends Component {
                 return;
             }
 
-            const { href, target, classList } = linkEl;
+            const { href, target, classList, download } = linkEl;
             if (classList.contains('o_add_language')) {
                 ev.preventDefault();
                 this.action.doAction('base.action_view_base_language_install', {
@@ -358,7 +358,7 @@ export class WebsitePreview extends Component {
                     },
                     reloadIframe: false,
                 });
-            } else if (href && target !== '_blank' && !isEditing && this._isTopWindowURL(linkEl)) {
+            } else if (href && target !== '_blank' && !isEditing && this._isTopWindowURL(linkEl) && !download) {
                 ev.preventDefault();
                 this.router.redirect(href);
             }

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -54,6 +54,11 @@ weWidgets.LinkTools.include({
         const isFromWebsite = urlInputValue[0] === '/';
         const $selectMenu = this.$('we-selection-items[name="link_anchor"]');
 
+        if (this.fileName) {
+            $pageAnchor[0].classList.add('d-none');
+            return;
+        }
+
         if ($selectMenu.data("anchor-for") !== urlInputValue) { // avoid useless query
             $pageAnchor.toggleClass('d-none', !isFromWebsite);
             $selectMenu.empty();

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -109,5 +109,19 @@ weWidgets.LinkTools.include({
         }
         this._super(...arguments);
     },
+    /**
+     * @override
+     */
+    _onRemoveFileClick() {
+        this._super(...arguments);
+        this._adaptPageAnchor();
+    },
+    /**
+     * @override
+     */
+    _onFileUploaded() {
+        this._super(...arguments);
+        this._adaptPageAnchor();
+    },
 });
 });


### PR DESCRIPTION
It is now possible to upload a file via the link tools, and link it to a
button.

An option was added when a link is used for serving a document to
specify how it should be served : either opening it in the browser or
downloading it.

As documents are handled through links, they won't be selectable via the
media dialog opened with "Insert media" or double clicking on an image.

task-2172311

Co-authored-by: Matthieu Stockbauer <tsm@odoo.com>



Spec validated are https://github.com/odoo/odoo/pull/69519#issuecomment-826977005