### PR TITLE
[FIX]: point_of_sale: load products in the background

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -668,29 +668,39 @@ class PosConfig(models.Model):
             else:
                 pos_config.write({'module_account': False})
 
-    def get_limited_products_loading(self):
-        self.env.cr.execute("""
-            WITH pm AS
-            (
-                     SELECT   product_id,
-                              Max(write_date) date
-                     FROM     stock_quant
-                     GROUP BY product_id)
-            SELECT    p.id
-            FROM      product_product p
-            LEFT JOIN product_template t
-            ON        (
-                                product_tmpl_id=t.id)
-            LEFT JOIN pm
-            ON        (
-                                p.id=pm.product_id)
-            WHERE     p.active
-            AND       t.available_in_pos
-            ORDER BY  t.priority DESC,
+    def get_limited_products_loading(self, fields):
+        query = """
+            WITH pm AS (
+                  SELECT product_id,
+                         Max(write_date) date
+                    FROM stock_quant
+                GROUP BY product_id
+            )
+               SELECT p.id
+                 FROM product_product p
+            LEFT JOIN product_template t ON product_tmpl_id=t.id
+            LEFT JOIN pm ON p.id=pm.product_id
+                WHERE (
+                        t.available_in_pos
+                    AND t.sale_ok
+                    AND (t.company_id=%(company_id)s OR t.company_id IS NULL)
+                    AND %(available_categ_ids)s IS NULL OR t.pos_categ_id=ANY(%(available_categ_ids)s)
+                )    OR p.id=%(tip_product_id)s
+             ORDER BY t.priority DESC,
                       t.detailed_type DESC,
-                      COALESCE(pm.date,p.write_date) DESC limit %s
-        """, [str(self.limited_products_amount)])
-        return self.env.cr.fetchall()
+                      COALESCE(pm.date,p.write_date) DESC 
+                LIMIT %(limit)s
+        """
+        params = {
+            'company_id': self.company_id.id,
+            'available_categ_ids': self.iface_available_categ_ids.mapped('id') if self.iface_available_categ_ids else None,
+            'tip_product_id': self.tip_product_id.id if self.tip_product_id else None,
+            'limit': self.limited_products_amount
+        }
+        self.env.cr.execute(query, params)
+        product_ids = self.env.cr.fetchall()
+        products = self.env['product.product'].search_read([('id', 'in', product_ids)], fields=fields)
+        return products
 
     def get_limited_partners_loading(self):
         self.env.cr.execute("""


### PR DESCRIPTION
The limited products loading and the loading in the background did not follow the rule's order because the right method was never called. Also, the SQL query has been corrected to properly follow the rule of the loading order.

TODO: make the domain more generic instead of hard coded so that domains are only defined at one place (`product.product` loader of the `models.js` file)