### PR TITLE
[FIX] http: fix useless call in set_safe_image_headers

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1627,8 +1627,7 @@ def set_safe_image_headers(headers, content):
     safe_types = ['image/jpeg', 'image/png', 'image/gif', 'image/x-icon']
     if content_type in safe_types:
         headers = set_header_field(headers, 'Content-Type', content_type)
-    set_header_field(headers, 'Content-Length', len(content))
-    return headers
+    return set_header_field(headers, 'Content-Length', len(content))
 
 
 def set_header_field(headers, name, value):


### PR DESCRIPTION
Previously, set_safe_image_headers was supposed to set the correct
Content-length header according to the content, but the return value of
the call to set_header_field was ignored. This function doesn't modify
the original headers that are passed in, so this call was essentially
useless. This commit fixes that by returning the new headers correctly.