### PR TITLE
[IMP] mail: enable inheritance in the next activity values computation

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -532,19 +532,8 @@ class MailActivity(models.Model):
         for activity in self:
             # extract value to generate next activities
             if activity.chaining_type == 'trigger':
-                Activity = self.env['mail.activity'].with_context(activity_previous_deadline=activity.date_deadline)  # context key is required in the onchange to set deadline
-                vals = Activity.default_get(Activity.fields_get())
-
-                vals.update({
-                    'previous_activity_type_id': activity.activity_type_id.id,
-                    'res_id': activity.res_id,
-                    'res_model': activity.res_model,
-                    'res_model_id': self.env['ir.model']._get(activity.res_model).id,
-                })
-                virtual_activity = Activity.new(vals)
-                virtual_activity._onchange_previous_activity_type_id()
-                virtual_activity._onchange_activity_type_id()
-                next_activities_values.append(virtual_activity._convert_to_write(virtual_activity._cache))
+                vals = activity.with_context(activity_previous_deadline=activity.date_deadline)._prepare_next_activity_values()
+                next_activities_values.append(vals)
 
             # post message on activity, before deleting it
             record = self.env[activity.res_model].browse(activity.res_id)
@@ -633,3 +622,25 @@ class MailActivity(models.Model):
             'activity_res_ids': sorted(res_id_to_deadline, key=lambda item: res_id_to_deadline[item]),
             'grouped_activities': activity_data,
         }
+
+    # ----------------------------------------------------------------------
+    # TOOLS
+    # ----------------------------------------------------------------------
+
+    def _prepare_next_activity_values(self):
+        """ Prepare the next activity values based on the current activity record and applies _onchange methods
+        :returns a dict of values for the new activity
+        """
+        self.ensure_one()
+        vals = self.default_get(self.fields_get())
+
+        vals.update({
+            'previous_activity_type_id': self.activity_type_id.id,
+            'res_id': self.res_id,
+            'res_model': self.res_model,
+            'res_model_id': self.env['ir.model']._get(self.res_model).id,
+        })
+        virtual_activity = self.new(vals)
+        virtual_activity._onchange_previous_activity_type_id()
+        virtual_activity._onchange_activity_type_id()
+        return virtual_activity._convert_to_write(virtual_activity._cache)

--- a/addons/test_mail/data/data.xml
+++ b/addons/test_mail/data/data.xml
@@ -19,5 +19,21 @@
         <field name="category">default</field>
         <field name="res_model">mail.test.activity</field>
     </record>
+    <record id="mail_act_test_chained_2" model="mail.activity.type">
+        <field name="name">Step 2</field>
+        <field name="summary">Take the second step.</field>
+        <field name="category">default</field>
+        <field name="res_model">mail.test.activity</field>
+        <field name="delay_count">10</field>
+        <field name="delay_from">current_date</field>
+    </record>
+    <record id="mail_act_test_chained_1" model="mail.activity.type">
+        <field name="name">Step 1</field>
+        <field name="summary">Take the first step.</field>
+        <field name="category">default</field>
+        <field name="res_model">mail.test.activity</field>
+        <field name="chaining_type">trigger</field>
+        <field name="triggered_next_type_id" ref="test_mail.mail_act_test_chained_2"/>
+    </record>
 
 </odoo>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -266,6 +266,27 @@ class TestActivityFlow(TestActivityCommon):
             self.assertEqual(attachment.res_id, activity_message.id)
             self.assertEqual(attachment.res_model, activity_message._name)
 
+    def test_chained_activities(self):
+        Partner = self.env['ir.model']._get('res.partner')
+        partner = self.env['res.partner'].create({
+            'name': 'Tester',
+        })
+        chained_activity = self.env['mail.activity'].create({
+            'summary': 'Test',
+            'activity_type_id': self.env.ref('test_mail.mail_act_test_chained_1').id,
+            'res_model_id': Partner.id,
+            'res_id': partner.id,
+        })
+        chained_activity.action_feedback(feedback='Done')
+
+        self.assertFalse(chained_activity.exists())
+
+        next_activity = partner.activity_ids
+
+        self.assertNotEqual(chained_activity.id, next_activity.id)
+        self.assertEqual(next_activity.summary, 'Take the second step.')
+        self.assertEqual(next_activity.date_deadline, date.today() + relativedelta(days=10))
+
 
 @tests.tagged('mail_activity')
 class TestActivityMixin(TestActivityCommon):


### PR DESCRIPTION
 values for next activities are currently prepared inside the `mail_activity._action_done()` method which makes inheritance very difficult. This commit delegates the value computation to a sub-method and thereby improves the extensibility of the module.  

required to support changes to enterprise documents odoo/enterprise#20769 
task-2627837