### PR TITLE
[FIX] project: fix project updates colors in kanban list

### DIFF
--- a/addons/project/static/src/scss/project_widgets.scss
+++ b/addons/project/static/src/scss/project_widgets.scss
@@ -74,6 +74,31 @@
             }
         }
     }
+
+    .oe_kanban_color_20 {
+        border-left-color: $o-success;
+        &:after {
+            background-color: $o-success;
+        }
+    }
+    .oe_kanban_color_21 {
+        border-left-color: $o-info;
+        &:after {
+            background-color: $o-info;
+        }
+    }
+    .oe_kanban_color_22 {
+        border-left-color: $o-warning;
+        &:after {
+            background-color: $o-warning;
+        }
+    }
+    .oe_kanban_color_23 {
+        border-left-color: $o-danger;
+        &:after {
+            background-color: $o-danger;
+        }
+    }
 }
 
 .o_kanban_project_tasks .o_field_many2manytags, .o_kanban_tags{

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -58,7 +58,7 @@
                 <field name="color"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_global_click o_pupdate_kanban_card">
+                        <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + record.color.raw_value : ''}} oe_kanban_global_click o_pupdate_kanban_card">
                             <!-- Project Update Kanban View is always ungrouped - see js_class -->
                             <div class="o_kanban_detail_ungrouped row">
                                 <div class="col-lg-4 o_pupdate_name">


### PR DESCRIPTION
Purpose of this commit is to update the kanban card color
same as the state color of the project update.

TaskId: 2638993






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
