### PR TITLE
[FIX] website: correctly toggle the preview for the countdown snippet

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -207,6 +207,18 @@ body.editor_enable.editor_has_snippets {
     }
 }
 
+// s_countdown preview classes
+body.editor_enable {
+    .s_countdown {
+        .s_countdown_enable_preview {
+            display: initial !important;
+        }
+        .s_countdown_none {
+            display: none !important;
+        }
+    }
+}
+
 //s_dynamic_snippet
 body.editor_enable {
     .s_dynamic {

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -12,6 +12,16 @@ options.registry.countdown = options.Class.extend({
         'click .toggle-edit-message': '_onToggleEndMessageClick',
     }),
 
+    /**
+     * Remove any preview classes, if present.
+     *
+     * @override
+     */
+    cleanForSave: async function () {
+        this.$target.find('.s_countdown_canvas_wrapper').removeClass("s_countdown_none");
+        this.$target.find('.s_countdown_end_message').removeClass("s_countdown_enable_preview");
+    },
+
     //--------------------------------------------------------------------------
     // Options
     //--------------------------------------------------------------------------
@@ -86,9 +96,9 @@ options.registry.countdown = options.Class.extend({
      */
     updateUIEndMessage: function () {
         this.$target.find('.s_countdown_canvas_wrapper')
-            .toggleClass("d-none", this.showEndMessage === true && this.$target.hasClass("hide-countdown"));
+            .toggleClass("s_countdown_none", this.showEndMessage === true && this.$target.hasClass("hide-countdown"));
         this.$target.find('.s_countdown_end_message')
-            .toggleClass("d-none", !this.showEndMessage);
+            .toggleClass("s_countdown_enable_preview", this.showEndMessage === true);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -40,6 +40,9 @@ options.registry.countdown = options.Class.extend({
             }
         } else {
             const $message = this.$target.find('.s_countdown_end_message').detach();
+            if (this.showEndMessage) {
+                this._onToggleEndMessageClick();
+            }
             if ($message.length) {
                 this.endMessage = $message[0].outerHTML;
             }

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -1,0 +1,32 @@
+odoo.define("website.tour.snippet_countdown", function (require) {
+"use strict";
+
+const tour = require('web_tour.tour');
+const wTourUtils = require('website.tour_utils');
+
+tour.register('snippet_countdown', {
+    test: true,
+    url: '/?enable_editor=1',
+}, [
+    wTourUtils.dragNDrop({id: 's_countdown', name: 'Countdown'}),
+    wTourUtils.clickOnSnippet({id: 's_countdown', name: 'Countdown'}),
+    wTourUtils.changeOption('countdown', 'we-select:has([data-end-action]) we-toggler', 'end action'),
+    wTourUtils.changeOption('countdown', 'we-button[data-end-action="message"]', 'end action'),
+    wTourUtils.changeOption('countdown', 'we-button.toggle-edit-message', 'message preview'),
+    // The next two steps check that the end message does not disappear when a
+    // widgets_start_request is triggered.
+    {
+        content: "Hover the 'hide countdown at the end' button",
+        trigger: '[data-select-class="hide-countdown"]',
+        run: function (actions) {
+            this.$anchor.trigger('mouseover');
+            this.$anchor.trigger('mouseenter');
+        },
+    },
+    {
+        content: "Check that the countdown message is still displayed",
+        trigger: '.s_countdown .s_picture',
+        run: () => null, // Just a visibility check
+    },
+]);
+});

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -26,6 +26,43 @@ tour.register('snippet_countdown', {
     {
         content: "Check that the countdown message is still displayed",
         trigger: '.s_countdown .s_picture',
+        run: () => {
+            // Just a visibility check
+
+            // Also make sure the mouseout and mouseleave are triggered so that
+            // next steps make sense.
+            // TODO the next steps are not actually testing anything without
+            // it and the mouseout and mouseleave make sense but really it
+            // should not be *necessary* to simulate those for the editor flow
+            // to make some sense.
+            const $previousAnchor = $('[data-select-class="hide-countdown"]');
+            $previousAnchor.trigger('mouseout');
+            $previousAnchor.trigger('mouseleave');
+        },
+    },
+    // Next, we change the end action to redirect while the edit message toggle
+    // is still activated. Now, we can check if the countdown cannot be hidden
+    // by mistake.
+    wTourUtils.changeOption('countdown', 'we-select:has([data-end-action]) we-toggler', 'end action'),
+    wTourUtils.changeOption('countdown', 'we-button[data-end-action="redirect"]', 'end action'),
+    {
+        content: "Click on the 'hide countdown at the end' button",
+        trigger: '[data-select-class="hide-countdown"] we-checkbox',
+        run: function (actions) {
+            actions.auto();
+
+            // Needed since the bug this test is covering occured after a small
+            // delay.
+            // TODO should really be more robust
+            setTimeout(() => {
+                document.body.classList.add('o_countdown_tour_small_delay');
+            }, 100);
+        },
+    },
+    {
+        content: "Check that the countdown is still displayed",
+        trigger: '.s_countdown_canvas_wrapper',
+        extra_trigger: '.o_countdown_tour_small_delay',
         run: () => null, // Just a visibility check
     },
 ]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -10,3 +10,6 @@ class TestSnippets(odoo.tests.HttpCase):
 
     def test_01_empty_parents_autoremove(self):
         self.start_tour("/?enable_editor=1", "snippet_empty_parent_autoremove", login='admin')
+
+    def test_02_countdown_preview(self):
+        self.start_tour("/?enable_editor=1", "snippet_countdown", login='admin')

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -32,6 +32,7 @@
         <script type="text/javascript" src="/website/static/tests/tours/snippet_version.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/website_style_edition.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/snippet_empty_parent_autoremove.js"/>
+        <script type="text/javascript" src="/website/static/tests/tours/snippet_countdown.js"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
The countdown widget has an end action that can be configured to show a message when the countdown reaches zero. A button in the editor toggles a preview of this message. However, a bug currently makes the preview disappear whenever the widget is restarted. Such a restart is triggered whenever the editor emits a `widgets_start_request` event is emitted in the editor.

To solve the problem, the preview visibility is now controlled by a separate css class `s_countdown_enable_preview` overriding `d-none`. This way, the preview visibility no longer interacts with the widget's logic and is no longer affected by the widget restarting.

A second commit avoids content below a countdown snippet from jumping (perceived as a flicker) by setting a `min-height` on the countdown block in the html (so it is already there before it is rendered). 

task-2638366