### PR TITLE
[FIX] mail: load audio/video elements after changing the srcObject

### DIFF
--- a/addons/mail/static/src/components/rtc_video/rtc_video.js
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.js
@@ -50,9 +50,10 @@ export class RtcVideo extends Component {
         }
         if (!this.rtcSession || !this.rtcSession.videoStream) {
             this._videoRef.el.srcObject = undefined;
-            return;
+        } else {
+            this._videoRef.el.srcObject = this.rtcSession.videoStream;
         }
-        this._videoRef.el.srcObject = this.rtcSession.videoStream;
+        this._videoRef.el.load();
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/models/rtc_session/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session/rtc_session.js
@@ -108,6 +108,7 @@ function factory(dependencies) {
             this._removeAudio();
             const audioElement = this.audioElement || new window.Audio();
             audioElement.srcObject = audioStream;
+            audioElement.load();
             audioElement.volume = this.partner && this.partner.volumeSetting ? this.partner.volumeSetting.volume : this.volume;
             audioElement.muted = this.messaging.mailRtc.currentRtcSession.isDeaf;
             // Using both autoplay and play() as safari may prevent play() outside of user interactions


### PR DESCRIPTION
Before this commit, there could be tracebacks after changing the
srcObject of the audioElement of the rtcSession, this commit
fixes this issue by calling `load` on the element after changing
the srcObject.


