### PR TITLE
[FIX] mail: remove unnecessary disconnect broadcast after ending a call

### DIFF
--- a/addons/mail/static/src/models/rtc/rtc.js
+++ b/addons/mail/static/src/models/rtc/rtc.js
@@ -219,9 +219,6 @@ function factory(dependencies) {
         reset() {
             if (this._peerConnections) {
                 const peerTokens = Object.keys(this._peerConnections);
-                this._notifyPeers(peerTokens, {
-                    event: 'disconnect',
-                });
                 for (const token of peerTokens) {
                     this._removePeer(token);
                 }


### PR DESCRIPTION
Before this commit, we would attempt to notify peers that we are
disconnecting when resetting mailRtc, which was not necessary as peers
already close the peer connection when the server notifies them that the
call participation changed.

