### PR TITLE
[FIX] mail: add isCausal to the volume setting of partners

### DIFF
--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -505,6 +505,7 @@ function factory(dependencies) {
         }),
         volumeSetting: one2one('mail.volume_setting', {
             inverse: 'partner',
+            isCausal: true,
         }),
     };
 


### PR DESCRIPTION
DRAFT, the volume setting should probably be causal, I had a traceback
in guest mode as a volume setting was missing its required partner.
not sure what caused this, it only happened once.
