### PR TITLE
[FIX] project,web: fix project status color in kanban progress bar

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -614,7 +614,7 @@
                     <field name="last_update_color"/>
                     <field name="last_update_status"/>
                     <field name="tag_ids"/>
-                    <progressbar field="last_update_status" colors='{"on_track": "success", "off_track": "danger", "on_hold": "muted", "at_risk": "warning"}'/>
+                    <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info"}'/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card">

--- a/addons/web/static/src/legacy/scss/kanban_column_progressbar.scss
+++ b/addons/web/static/src/legacy/scss/kanban_column_progressbar.scss
@@ -110,6 +110,7 @@
     @include o-kanban-css-filter(success, theme-color('success'));
     @include o-kanban-css-filter(warning, theme-color('warning'));
     @include o-kanban-css-filter(danger, theme-color('danger'));
+    @include o-kanban-css-filter(info, theme-color('info'));
     @include o-kanban-css-filter(muted, theme-color('dark'));
 
     &.o_kanban_group_show {


### PR DESCRIPTION
Currently, projects that are 'on hold'  stage are represented in grey in
the kanban progress bar while the colored dot on their card is in blue.

In this commit, we change the color of the 'on hold' stage into 'info'
instead of 'muted'. After this projects that are 'on hold' are display
blue in the kanban progress bar as well.

Task-Id:2633273
PR: #76355

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
