### PR TITLE
[FIX] web_editor: restore lost selection when updating color

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -837,16 +837,31 @@ const Wysiwyg = Widget.extend({
                     const targetElement = targetNode && targetNode.nodeType === Node.ELEMENT_NODE
                         ? targetNode
                         : targetNode && targetNode.parentNode;
+                    const hadNonCollapsedSelection = range && !selection.isCollapsed;
+                    const isCurrentSelectionInEditable = () => {
+                        const selection = this.odooEditor.document.getSelection();
+                        const isSelectionInEditable =
+                            !selection.isCollapsed &&
+                            this.odooEditor.editable.contains(selection.anchorNode) &&
+                            this.odooEditor.editable.contains(selection.focusNode);
+                        return isSelectionInEditable;
+                    }
                     colorpicker = new ColorPaletteWidget(this, {
                         excluded: ['transparent_grayscale'],
                         $editable: $(this.odooEditor.editable), // Our parent is the root widget, we can't retrieve the editable section from it...
                         selectedColor: $(targetElement).css(eventName === "foreColor" ? 'color' : 'backgroundColor'),
                     });
                     colorpicker.on('custom_color_picked color_picked', null, ev => {
+                        if (hadNonCollapsedSelection && !isCurrentSelectionInEditable()) {
+                            this.odooEditor.resetCursorOnLastHistoryCursor();
+                        }
                         this._processAndApplyColor(eventName, ev.data.color);
                         this.odooEditor.historyStep();
                     });
                     colorpicker.on('color_hover color_leave', null, ev => {
+                        if (hadNonCollapsedSelection && !isCurrentSelectionInEditable()) {
+                            this.odooEditor.resetCursorOnLastHistoryCursor();
+                        }
                         this._processAndApplyColor(eventName, ev.data.color);
                     });
                     colorpicker.on('enter_key_color_colorpicker', null, () => {


### PR DESCRIPTION
Before this commit if the text selection was lost while the color
palette was used, the color selection was not applied on anything.

After this commit if the text selection was lost, it is restored to the
last selection known in history before applying (or previewing) the
color selection.

task-2599771

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
