### PR TITLE
[FIX] mrp: qty for bom kits with multiple boms with same sequence

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -210,12 +210,12 @@ class MrpBom(models.Model):
             domain += [('type', '=', bom_type)]
 
         if len(products) == 1:
-            bom = self.search(domain, order='sequence, product_id', limit=1)
+            bom = self.search(domain, order='sequence, product_id, id', limit=1)
             if bom:
                 bom_by_product[products] = bom
             return bom_by_product
 
-        boms = self.search(domain, order='sequence, product_id')
+        boms = self.search(domain, order='sequence, product_id, id')
 
         products_ids = set(products.ids)
         for bom in boms:


### PR DESCRIPTION
When a product is configured with 2 different boms kit
using the same sequence,
the bom chosen could change randomly, therefore randomly
changing the available quantity.

This has been detected during an upgrade,
With the unit test checking the quantities
of the products doesn't change before and after the upgrade,
and in this case, the bom chosen before upgrade
was different than the bom chosen after upgrade,
therefore changing the available quantity of this product
before and after upgrade.

```
Traceback (most recent call last):
  File "/tmp/tmp659zn85u/migrations/testing.py", line 208, in test_check
    self.check(value)
  File "/tmp/tmp659zn85u/migrations/stock/tests/test_on_hand_quantity.py", line 20, in check
    self.assertEqual(before_results, self.convert_check(after_results), self.message)
AssertionError: Lists differ: [[262[3108 chars], '-107'], [3879, '-36'], [3983, '-39'], [3984[5666 chars]14']] != [[262[3108 chars], '-150'], [3879, '-36'], [3983, '-39'], [3984[5666 chars]14']]

First differing element 209:
[3878, '-107']
[3878, '-150']

Diff is 10670 characters long. Set self.maxDiff to None to see it. : Invariant check fail
```

upg-27353
