### PR TITLE
[IMP] web: provide lazy_loaded bundle endpoint

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1022,6 +1022,18 @@ class WebClient(http.Controller):
     def benchmarks(self, mod=None, **kwargs):
         return request.render('web.benchmark_suite')
 
+    @http.route('/web/bundle/<string:bundle_name>', auth="user", methods=["GET"])
+    def bundle(self, bundle_name):
+        """
+        Request the definition of a bundle, including its javascript and css bundled assets
+        """
+        files = request.env["ir.qweb"]._get_asset_nodes(bundle_name, debug=request.session.debug, js=True, css=True)
+        data = json.dumps([{
+            "type": tag,
+            "src": attrs.get("src") or attrs.get('href'),
+        } for tag, attrs, _ in files])
+        return request.make_response(data, [('Content-Type', 'application/json')])
+
 
 class Proxy(http.Controller):
 


### PR DESCRIPTION
In this commit I provide a way for any part of the webclient to load a complete bundle of assets, JS and CSS.
The primary goal is to lazy load the complete o_spreadsheet package, including the library and all the custo that odoo includes
in it.

the endpoint /web/bundle/bundle_name will return a json structure describing the path to the JS and CSS files that have been generated by the client.
Those can then be loaded with the loadJS(...) function like any library.

The advantage of using a bundle, is that all the dependencies are respected inside that bundle.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
