### PR TITLE
[FIX] mail: fileupload bug

### DIFF
--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -130,6 +130,7 @@
                                     <i class="fa fa-upload"/> Upload Document
                                 </button>
                                 <FileUploader
+                                    t-if="activity.thread"
                                     attachmentLocalIds="activity.attachments.map(attachment => attachment.localId)"
                                     threadLocalId="activity.thread.localId"
                                     t-on-o-attachment-created="_onAttachmentCreated"


### PR DESCRIPTION
Steps to reproduce (using documents app):
1. Create a new document request
2. Select the created document request, enable the chatter
3. Upload a document using the document request icon
4. Hide the chatter
5. Show the chatter
Odoo Client Error

OPW-2643331
