### PR TITLE
[FIX] resource: timezone end before assigning search_range

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -950,6 +950,7 @@ class ResourceResource(models.Model):
             search_range = None
             tz = timezone(resource.tz)
             if calendar_start and start.astimezone(tz).date() == end.astimezone(tz).date():
+                end = end.astimezone(tz)
                 # Make sure to only search end after start
                 search_range = (
                     start,

--- a/addons/resource/tests/common.py
+++ b/addons/resource/tests/common.py
@@ -54,6 +54,8 @@ class TestResourceCommon(TransactionCase):
             (0, 0, 0, '1', 'line_section', 10), (8, 16, 0, '1', False, 11), (7, 15, 2, '1', False, 12),
             (8, 16, 3, '1', False, 13), (10, 16, 4, '1', False, 14)], 'Europe/Brussels')
 
+        self.calendar_paul = self._define_calendar('Morning and evening shifts', sum([((2, 7, i), (10, 16, i)) for i in range(5)], ()), 'Brazil/DeNoronha')
+
         # Employee is linked to a resource.resource via resource.mixin
         self.jean = self.env['resource.test'].create({
             'name': 'Jean',
@@ -70,4 +72,9 @@ class TestResourceCommon(TransactionCase):
         self.jules = self.env['resource.test'].create({
             'name': 'Jules',
             'resource_calendar_id': self.calendar_jules.id,
+        })
+
+        self.paul = self.env['resource.test'].create({
+            'name': 'Paul',
+            'resource_calendar_id': self.calendar_paul.id,
         })

--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -491,6 +491,17 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2020, 4, 3, 13, 0, 0, tzinfo=self.john.tz),
         ))
 
+        # It should find the start and end within the search range
+        result = self.paul._adjust_to_calendar(
+            datetime_tz(2020, 4, 2, 2, 0, 0, tzinfo='UTC'),
+            datetime_tz(2020, 4, 3, 1, 59, 59, tzinfo='UTC'),
+        )
+
+        self.assertEqual(result[self.paul], (
+            datetime_tz(2020, 4, 2, 4, 0, tzinfo='UTC'),
+            datetime_tz(2020, 4, 2, 18, 0, tzinfo='UTC')
+        ), "It should have found the start and end of the shift on the same day on April 2nd, 2020")
+
     def test_adjust_calendar_timezone_after(self):
         # Calendar:
         # Tuesdays 8-16


### PR DESCRIPTION
The end datetime is not timezoned in _adjust_to_calendar before defining the search_range and using the _get_closest_work_time method.
Since _get_closest_work_time will timezone the timestamp received to start searching, the search interval needs to refer to the same end timestamp to avoid erratic behaviors.

Task-2628876

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
