### PR TITLE
[FIX] mrp: archive QC linked to archived operation 

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -176,6 +176,10 @@ class MrpBom(models.Model):
             raise UserError(_("You cannot create a new Bill of Material from here."))
         return super(MrpBom, self).name_create(name)
 
+    def toggle_active(self):
+        self.with_context({'active_test': False}).operation_ids.toggle_active()
+        return super().toggle_active()
+
     def name_get(self):
         return [(bom.id, '%s%s' % (bom.code and '%s: ' % bom.code or '', bom.product_tmpl_id.display_name)) for bom in self]
 

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -174,7 +174,7 @@
                                 </div>
                                 <field name="product_qty" class="oe_inline text-left" attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('state', 'not in', ('draft', 'done'))]}"/>
                                 <button type="action" name="%(mrp.action_change_production_qty)d"
-                                    context="{'default_mo_id': id}" class="oe_link oe_inline" attrs="{'invisible': ['|', ('state', 'in', ('draft', 'done','cancel')), ('id', '=', False)]}">
+                                    context="{'default_mo_id': id}" class="oe_link oe_inline" style="margin: 0px; padding: 0px;" attrs="{'invisible': ['|', ('state', 'in', ('draft', 'done','cancel')), ('id', '=', False)]}">
                                     <field name="product_qty" class="oe_inline" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 </button>
                                 <label for="product_uom_id" string="" class="oe_inline"/>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -27,6 +27,9 @@
             <field name="priority">1000</field>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
+                <xpath expr="//tree" position="attributes">
+                    <attribute name="delete">0</attribute>
+                </xpath>
                 <xpath expr="//field[@name='name']" position="before">
                     <field name="sequence" widget="handle"/>
                 </xpath>
@@ -36,6 +39,9 @@
                 </xpath>
                 <xpath expr="//field[@name='bom_product_template_attribute_value_ids']" position="attributes">
                     <attribute name="attrs">{'column_invisible': [('parent.product_id', '!=', False)]}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='bom_product_template_attribute_value_ids']" position="after">
+                    <button name="action_archive" class="btn-link" type="object" icon="fa-times"/>
                 </xpath>
             </field>
         </record>
@@ -129,6 +135,7 @@
                     <field name="name"/>
                     <field name="bom_id"/>
                     <field name="workcenter_id"/>
+                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group>
                         <filter string="Bill of Material" name="bom" context="{'group_by': 'bom_id'}"/>
                         <filter string="Workcenter" name="workcenter" context="{'group_by': 'workcenter_id'}"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -241,7 +241,6 @@
                 <filter string="Waiting" name="waiting" domain="[('state', '=', 'waiting')]"/>
                 <filter string="Pending" name="pending" domain="[('state', '=', 'pending')]"/>
                 <filter string="Finished" name="finish" domain="[('state', '=', 'done')]"/>
-                <filter string="Available" name="available" domain="[('production_availability', '=', 'assigned')]"/>
                 <separator/>
                 <filter string="Late" name="late" domain="['&amp;', ('date_planned_start', '&lt;', current_date), ('state', '=', 'ready')]"
                     help="Production started late"/>
@@ -471,7 +470,7 @@
         <field name="res_model">mrp.workorder</field>
         <field name="view_mode">tree,kanban,form,calendar,pivot,graph,gantt</field>
         <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
-        <field name="context">{'search_default_ready': True, 'search_default_waiting': True, 'search_default_progress': True, 'search_default_pending': True}</field>
+        <field name="context">{'search_default_ready': True, 'search_default_progress': True, 'search_default_pending': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             No work orders to do!


### PR DESCRIPTION
Instead of the delete icon next to the operations in a BoM, create a
button to archive the operation. Archiving an operation will also
archive the corresponding Quality Check.

Task-ID: 2619450
Enterprise-PR: https://github.com/odoo/enterprise/pull/20785


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
