### PR TITLE
fix no action helper in team member kanban view

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -745,11 +745,11 @@ var BasicModel = AbstractModel.extend({
     _isEmpty(dataPointID) {
         const dataPoint = this.localData[dataPointID];
         if (dataPoint.type === 'list') {
-            const hasRecords = dataPoint.count === 0;
-            if (dataPoint.groupedBy.length) {
-                return dataPoint.data.length > 0 && hasRecords;
+            const isEmpty = dataPoint.count === 0;
+            if (dataPoint.groupedBy.length && !dataPoint.openGroupByDefault) {
+                return dataPoint.data.length > 0 && isEmpty;
             } else {
-                return hasRecords;
+                return isEmpty;
             }
         }
         return false;

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -473,8 +473,7 @@ var KanbanRenderer = BasicRenderer.extend({
             !remove &&
             !this._hasContent() &&
             !!this.noContentHelp &&
-            !(this.quickCreate && !this.quickCreate.folded) &&
-            !this.state.isGroupedByM2ONoColumn;
+            !(this.quickCreate && !this.quickCreate.folded);
 
         var $noContentHelper = this.$('.o_view_nocontent');
 

--- a/addons/web/static/src/js/views/sample_server.js
+++ b/addons/web/static/src/js/views/sample_server.js
@@ -658,6 +658,7 @@
 
     SampleServer.MAIN_RECORDSET_SIZE = 16;
     SampleServer.SUB_RECORDSET_SIZE = 5;
+    SampleServer.SEARCH_READ_LIMIT = 7;
     SampleServer.SEARCH_READ_LIMIT = 10;
 
     SampleServer.MAX_FLOAT = 100;


### PR DESCRIPTION
PURPOSE
Display no content helper when there is no data in grouped kanban view of Team Member. 

SPEC
When there is no data in grouped kanban of Team Member, display no content helper.

Task id: 2583755



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
