### PR TITLE
[IMP] website_profile: clarify the sender of validation email

### DIFF
--- a/addons/website_profile/data/mail_template_data.xml
+++ b/addons/website_profile/data/mail_template_data.xml
@@ -7,7 +7,7 @@
             <field name="name">Profile: Email Verification</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">${object.company_id.name} Profile validation</field>
-            <field name="email_from">${user.email_formatted | safe}</field>
+            <field name="email_from">${(object.company_id.email_formatted or object.email_formatted) |safe}</field>
             <field name="email_to">${object.email_formatted | safe}</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">


### PR DESCRIPTION
PURPOSE

Currently the validation mail is send from you to you, but
the validation mail should be send from either company mail
or the fallback mail if the company mail is not available.

SPECIFICATION

For solving this we need to change the email from address in
validation mail template, we give first priority to
company mail, if not exist then automatically fallbacks to
company catchall address, else logged user mail id will be
set as email_from value.

LINKS
PR #76380
TaskID: 2634155
