### PR TITLE
[FIX] auth_totp, auth_totp_mail: fix misplaced test of 2FA invite button

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -242,6 +242,6 @@ trigger: 'div:contains("enter your password")',
     trigger: "a.nav-link:contains(Account Security)",
 }, {
     content: "check that demo user has been de-totp'd",
-    trigger: "button:contains(Invite to use 2FA)",
+    trigger: "button[name=action_totp_enable_wizard]",
 }])
 });

--- a/addons/auth_totp_mail/__manifest__.py
+++ b/addons/auth_totp_mail/__manifest__.py
@@ -16,6 +16,10 @@ by sending an email to the target user. This email redirect him to :
         'data/mail_template_data.xml',
         'views/res_users_views.xml',
     ],
-    'assets': {},
+    'assets': {
+        'web.assets_tests': [
+            'auth_totp_mail/static/tests/**/*',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -1,0 +1,92 @@
+odoo.define('auth_totp_mail.tours', function(require) {
+"use strict";
+
+const tour = require('web_tour.tour');
+
+function openUserProfileAtSecurityTab() {
+    return [{
+        content: 'Open user account menu',
+        trigger: '.o_user_menu .oe_topbar_name',
+        run: 'click',
+    }, {
+        content: "Open preferences / profile screen",
+        trigger: '[data-menu=settings]',
+        run: 'click',
+    }, {
+        content: "Switch to security tab",
+        trigger: 'a[role=tab]:contains("Account Security")',
+        run: 'click',
+    }];
+}
+
+function openAccountSettingsTab() {
+    return [{
+        content: 'Go to settings',
+        trigger: '[data-menu-xmlid="base.menu_administration"]'
+    }, {
+        content: 'Wait for page',
+        trigger: '.o_menu_brand:contains("Settings")',
+        run: () => {}
+    }, {
+        content: "Open Users menu",
+        trigger: '[data-menu-xmlid="base.menu_users"]'
+    }, {
+        content: "Open Users view",
+        trigger: '[data-menu-xmlid="base.menu_action_res_users"]',
+        run: function (helpers) {
+            // funny story: the users view we're trying to reach, sometimes we're
+            // already there, but if we re-click the next step executes before the
+            // action has the time to re-load, the one after that doesn't, and our
+            // selection get discarded by the action reloading, so here try to
+            // see if we're already on the users action through the breadcrumb and
+            // just close the menu if so
+            const $crumb = $('.breadcrumb');
+            if ($crumb.text().indexOf('Users') === -1) {
+                // on general settings page, click menu
+                helpers.click();
+            } else {
+                // else close menu
+                helpers.click($('[data-menu-xmlid="base.menu_users"]'));
+            }
+        }
+    }];
+}
+
+tour.register('totp_admin_self_invite', {
+    test: true,
+    url: '/web'
+}, [tour.stepUtils.showAppsMenuItem(), ...openAccountSettingsTab(), {
+    content: "open the user's form",
+    trigger: "td.o_data_cell:contains(admin)",
+}, {
+    content: "go to Account security Tab",
+    trigger: "a.nav-link:contains(Account Security)",
+}, {
+    content: "check that user cannot invite himself to use 2FA.",
+    trigger: "body",
+    run: function () {
+        var $inviteBtn = $('button:contains(Invite to use 2FA)');
+        if ($inviteBtn.hasClass('o_invisible_modifier')) {
+            $('body').addClass('CannotInviteYourself');
+        }
+    }
+}, {
+    content: "check that user cannot invite themself.",
+    trigger: "body.CannotInviteYourself"
+}]);
+
+tour.register('totp_admin_invite', {
+    test: true,
+    url: '/web'
+}, [tour.stepUtils.showAppsMenuItem(), ...openAccountSettingsTab(), {
+    content: "open the user's form",
+    trigger: "td.o_data_cell:contains(demo)",
+}, {
+    content: "go to Account security Tab",
+    trigger: "a.nav-link:contains(Account Security)",
+}, {
+    content: "check that demo user can be invited to use 2FA.",
+    trigger: "button:contains(Invite to use 2FA)",
+}]);
+
+});

--- a/addons/auth_totp_mail/tests/__init__.py
+++ b/addons/auth_totp_mail/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_totp

--- a/addons/auth_totp_mail/tests/test_totp.py
+++ b/addons/auth_totp_mail/tests/test_totp.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.auth_totp.tests.test_totp import TestTOTP
+
+
+@tagged('post_install', '-at_install')
+class TestTOTPInvite(TestTOTP):
+
+    def test_totp_administration(self):
+        self.start_tour('/web', 'totp_admin_invite', login='admin')
+        self.start_tour('/web', 'totp_admin_self_invite', login='admin')


### PR DESCRIPTION
Since mail dependancy has been extracted into a bridge module auth_totp_mail,
the test about "Invite to use 2FA" is misplaced in the wrong module.

This commit moves the test on 2FA invite button to the bridge module and fixes
the test on auth_totp module to use another indicator that 2FA has been disabled
for the currently tested user (see test file).

Task-2645206
Parent Task-2638538