### PR TITLE
[FIX] web: reintroduce RTL support

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -4,6 +4,7 @@ import { useBus, useEffect, useService } from "@web/core/utils/hooks";
 import { usePosition } from "../position/position_hook";
 import { useDropdownNavigation } from "./dropdown_navigation_hook";
 import { ParentClosingMode } from "./dropdown_item";
+import { localization } from "../l10n/localization";
 
 const { Component, core, hooks, useState, QWeb } = owl;
 const { EventBus } = core;
@@ -66,10 +67,21 @@ export class Dropdown extends Component {
         useDropdownNavigation();
 
         // Set up toggler and positioning --------------------------------------
+        /** @type {string} **/
+        let position =
+            this.props.position || (this.hasParentDropdown ? "right-start" : "bottom-start");
+        if (localization.direction === "rtl") {
+            let [direction, variant = "middle"] = position.split("-");
+            if (["bottom", "top"].includes(direction)) {
+                variant = variant === "start" ? "end" : "start";
+            } else {
+                direction = direction === "left" ? "right" : "left";
+            }
+            position = [direction, variant].join("-");
+        }
         const positioningOptions = {
             popper: "menuRef",
-            position:
-                this.props.position || (this.hasParentDropdown ? "right-start" : "bottom-start"),
+            position,
             directionFlipOrder: { right: "rl", bottom: "bt", top: "tb", left: "lr" },
         };
         if (this.props.toggler === "parent") {

--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -75,7 +75,7 @@
       & > .o_dropdown_toggler {
         &:after {
           @include o-position-absolute($right: 0, $top: 0);
-          transform: translate(-.6em, .6em);
+          transform: translate(-.6em, .6em) #{"/*rtl:translate(.6em, .6em) scaleX(-1)*/"};
           font: .9em/1em FontAwesome;
           content: "\f0da";
         }

--- a/addons/web/static/src/core/dropdown/dropdown_navigation_hook.js
+++ b/addons/web/static/src/core/dropdown/dropdown_navigation_hook.js
@@ -2,6 +2,7 @@
 
 import { useEffect, useService } from "@web/core/utils/hooks";
 import { browser } from "../browser/browser";
+import { localization } from "@web/core/l10n/localization";
 import { scrollTo } from "../utils/scrolling";
 
 /**
@@ -182,6 +183,14 @@ export function useDropdownNavigation() {
 
     // Set up keyboard navigation ----------------------------------------------
     const hotkeyService = useService("hotkey");
+    const closeSubDropdown = comp.hasParentDropdown ? comp.close : () => {};
+    const openSubDropdown = () => {
+        const menuElement = getActiveMenuElement();
+        // Active menu element is a sub dropdown
+        if (menuElement && menuElement.isSubDropdown) {
+            menuElement.openSubDropdown(true);
+        }
+    };
     let hotkeyRemoves = [];
     const hotkeyCallbacks = {
         home: () => setActiveMenuElement("FIRST"),
@@ -190,18 +199,8 @@ export function useDropdownNavigation() {
         "shift+tab": () => setActiveMenuElement("PREV"),
         arrowdown: () => setActiveMenuElement("NEXT"),
         arrowup: () => setActiveMenuElement("PREV"),
-        arrowleft: () => {
-            if (comp.hasParentDropdown) {
-                comp.close();
-            }
-        },
-        arrowright: () => {
-            const menuElement = getActiveMenuElement();
-            // Active menu element is a sub dropdown
-            if (menuElement && menuElement.isSubDropdown) {
-                menuElement.openSubDropdown(true);
-            }
-        },
+        arrowleft: localization.direction === "rtl" ? openSubDropdown : closeSubDropdown,
+        arrowright: localization.direction === "rtl" ? closeSubDropdown : openSubDropdown,
         enter: () => {
             const menuElement = getActiveMenuElement();
             if (menuElement) {

--- a/addons/web/static/src/core/popover/popover.scss
+++ b/addons/web/static/src/core/popover/popover.scss
@@ -1,3 +1,4 @@
+/*!rtl:begin:ignore*/
 @keyframes slide-top {
   0% {
     opacity: 0;
@@ -149,3 +150,4 @@
     }
   }
 }
+/*!rtl:end:ignore*/

--- a/addons/web/static/src/core/position/position.scss
+++ b/addons/web/static/src/core/position/position.scss
@@ -1,5 +1,7 @@
+/*!rtl:begin:ignore*/
 .o-popper-position {
   position: fixed;
   top: 0;
   left: 0;
 }
+/*!rtl:end:ignore*/

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -657,8 +657,7 @@
         t-attf-class="btn btn-secondary fa fa-lg o_switch_view o_{{ view.type }} {{ view.icon }}"
         t-att-class="{ active: env.view.type === view.type }"
         t-att-aria-label="sprintf(buttonLabel.toString(), view.type)"
-        t-att-title="sprintf(buttonLabel.toString(), view.type)"
-        data-toggle="tooltip"
+        t-att-data-tooltip="view.name"
         tabindex="-1"
         t-on-click="trigger('switch-view', { view_type: view.type })"
     />

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -9,6 +9,7 @@ import { MainComponentsContainer } from "../core/main_components_container";
 import { useOwnDebugContext } from "../core/debug/debug_context";
 import { registry } from "@web/core/registry";
 import { DebugMenu } from "@web/core/debug/debug_menu";
+import { localization } from "@web/core/l10n/localization";
 
 const { Component, hooks } = owl;
 const { useExternalListener } = hooks;
@@ -31,6 +32,7 @@ export class WebClient extends Component {
                 { sequence: 100 }
             );
         }
+        this.localization = localization;
         this.title.setParts({ zopenerp: "Odoo" }); // zopenerp is easy to grep
         useBus(this.env.bus, "ROUTE_CHANGE", this.loadRouterState);
         useBus(this.env.bus, "ACTION_MANAGER:UI-UPDATED", (mode) => {

--- a/addons/web/static/src/webclient/webclient.xml
+++ b/addons/web/static/src/webclient/webclient.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.WebClient" owl="1">
-        <body class="o_web_client" t-att-class="{'o_is_superuser': user.userId === 1}">
+        <body class="o_web_client" t-att-class="{'o_is_superuser': user.userId === 1, 'o_rtl': localization.direction === 'rtl' }">
             <NotUpdatable>
                 <NavBar/>
             </NotUpdatable>


### PR DESCRIPTION
With the new OWL view infrastructure introduced by 0134495, some parts of the right-to-left design was broken.

All the issues addressed in this commit are:
- subdropdowns are shown in the correct direction
- subdropdowns keyboard navigation with left/right arrows
- popovers' arrows point in the correct direction
- the document's `<body/>` will have the `o_rtl` CSS class

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
