### PR TITLE
[FIX] point_of_sale: pos is launched with all companies

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -51,8 +51,10 @@ class PosController(http.Controller):
         if not pos_session:
             return werkzeug.utils.redirect('/web#action=point_of_sale.action_client_pos_menu')
         # The POS only work in one company, so we enforce the one of the session in the context
+        company = pos_session.company_id
         session_info = request.env['ir.http'].session_info()
-        session_info['user_context']['allowed_company_ids'] = pos_session.company_id.ids
+        session_info['user_context']['allowed_company_ids'] = company.ids
+        session_info['user_companies'] = {'current_company': (company.id, company.name), 'allowed_companies': [(company.id, company.name)]}
         context = {
             'session_info': session_info,
             'login_number': pos_session.login(),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Activate multicompany
- In the company switcher select all company
- Launch a pos session
--> Issue all rpc request are make in all companies (len(self.env.companies) != 1). It create some error with taxes, fiscale position, ...

In V14 `user_companies` in session info should be also modified to force 1 company.

It fix : https://github.com/odoo/odoo/pull/72987

@pimodoo @caburj 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
