### PR TITLE
[FIX] website: prevent animations from restarting on a blank page

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -437,9 +437,6 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
      * @param {OdooEvent} ev
      */
     _onEditionWasStopped: function (ev) {
-        this.trigger_up('widgets_start_request', {
-            $target: this._targetForEdition(),
-        });
         this.editModeEnable = false;
     },
     /**


### PR DESCRIPTION
Commit [1] introduced `_onEditionWasStopped` which besides declaring the
edit mode as disabled, also restarted animations. Since the new editor
was introduced, this is triggered on save and cancel, which is indeed
needed in order to declare that edit mode is disabled, but also
generates a traceback due to the animations now restarting on an already
destroyed wysiwyg. That restarting of animations is unnecessary anyway
since the page will refresh when disabling the edit mode.

[1]: https://github.com/odoo/odoo/commit/f296992317e96562c66bd7ad59a5080d6c551ed5

task-2528814