### PR TITLE
[FIX] website: prevent mega menu removal

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -451,9 +451,9 @@ var SnippetEditor = Widget.extend({
         await new Promise(resolve => {
             this.trigger_up('call_for_each_child_snippet', {
                 $snippet: this.$target,
-                callback: function (editor, $snippet) {
+                callback: async function (editor, $snippet) {
                     for (var i in editor.styles) {
-                        editor.styles[i].onRemove();
+                        await editor.styles[i].onRemove();
                     }
                 },
                 onSuccess: resolve,

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6693,6 +6693,31 @@ registry.SelectTemplate = SnippetOptionWidget.extend({
     },
 
     //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Retrieves a template either from cache or through RPC.
+     *
+     * @private
+     * @param {string} xmlid
+     * @returns {string}
+     */
+    async _getTemplate(xmlid) {
+        if (!this._templates[xmlid]) {
+            this._templates[xmlid] = await this._rpc({
+                model: 'ir.ui.view',
+                method: 'render_public_asset',
+                args: [`${xmlid}`, {}],
+                kwargs: {
+                    context: this.options.context,
+                },
+            });
+        }
+        return this._templates[xmlid];
+    },
+
+    //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
@@ -6712,14 +6737,7 @@ registry.SelectTemplate = SnippetOptionWidget.extend({
             // TODO should be better and retrieve all rendering in one RPC (but
             // those ~10 RPC are only done once per edit mode if the option is
             // opened, so I guess this is acceptable).
-            this._templates[xmlid] = await this._rpc({
-                model: 'ir.ui.view',
-                method: 'render_public_asset',
-                args: [`${xmlid}`, {}],
-                kwargs: {
-                    context: this.options.context,
-                },
-            });
+            await this._getTemplate(xmlid);
         });
         this._templatesLoading = Promise.all(proms);
     },

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2950,8 +2950,9 @@ const SnippetOptionWidget = Widget.extend({
      * Called when the associated snippet is about to be removed from the DOM.
      *
      * @abstract
+     * @returns {Promise|undefined}
      */
-    onRemove: function () {},
+    onRemove: async function () {},
     /**
      * Called when the target is shown, only meaningful if the target was hidden
      * at some point (typically used for 'invisible' snippets).

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3270,6 +3270,25 @@ options.registry.MegaMenuLayout = options.registry.SelectTemplate.extend({
     },
 
     //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    notify(name, data) {
+        if (name === 'reset_template') {
+            const xmlid = this._getCurrentTemplateXMLID();
+            this._getTemplate(xmlid).then(template => {
+                this.containerEl.insertAdjacentHTML('beforeend', template);
+                data.onSuccess();
+            });
+        } else {
+            this._super(...arguments);
+        }
+    },
+
+    //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
@@ -3278,11 +3297,40 @@ options.registry.MegaMenuLayout = options.registry.SelectTemplate.extend({
      */
     _computeWidgetState: function (methodName, params) {
         if (methodName === 'selectTemplate') {
-            const templateDefiningClass = this.containerEl.querySelector('section')
-                .classList.value.split(' ').filter(cl => cl.startsWith('s_mega_menu'))[0];
-            return `website.${templateDefiningClass}`;
+            return this._getCurrentTemplateXMLID();
         }
         return this._super(...arguments);
+    },
+    /**
+     * @private
+     * @returns {string} xmlid of the current template.
+     */
+    _getCurrentTemplateXMLID: function () {
+        const templateDefiningClass = this.containerEl.querySelector('section')
+            .classList.value.split(' ').filter(cl => cl.startsWith('s_mega_menu'))[0];
+        return `website.${templateDefiningClass}`;
+    },
+});
+
+/**
+ * Hides delete button for Mega Menu block.
+ */
+options.registry.MegaMenuNoDelete = options.Class.extend({
+    forceNoDeleteButton: true,
+
+    /**
+     * @override
+     */
+    async onRemove() {
+        await new Promise(resolve => {
+            this.trigger_up('option_update', {
+                optionName: 'MegaMenuLayout',
+                name: 'reset_template',
+                data: {
+                    onSuccess: () => resolve(),
+                }
+            });
+        });
     },
 });
 

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1030,6 +1030,8 @@
         </we-select>
     </div>
 
+    <div data-js="MegaMenuNoDelete" data-selector=".o_mega_menu > section"/>
+
     <div data-selector=".o_mega_menu .nav > .nav-link"
          data-drop-in=".o_mega_menu nav"
          data-drop-near=".o_mega_menu .nav-link"/>


### PR DESCRIPTION
The user was able to remove the mega menu snippet without removing
the corresponding link in the menu. To avoid this flow to happen
we removed the delete button for the mega menu snippet. We also
handle the case where the user remove the mega menu snippet columns
one by one. On last column removal we put back the original template.

task-2636545

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
