### PR TITLE
[FIX] fleet: clean service type demo data

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -46,66 +46,61 @@
       </record>
 
       <record id="type_service_service_7" model="fleet.service.type">
-          <field name="name">Summer tires</field>
-          <field name="category">service</field>
-      </record>
-
-      <record id="type_service_service_8" model="fleet.service.type">
           <field name="name">Repair and maintenance</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_9" model="fleet.service.type">
+      <record id="type_service_service_8" model="fleet.service.type">
           <field name="name">Assistance</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_10" model="fleet.service.type">
+      <record id="type_service_service_9" model="fleet.service.type">
           <field name="name">Replacement Vehicle</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_11" model="fleet.service.type">
+      <record id="type_service_service_10" model="fleet.service.type">
           <field name="name">Management Fee</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_12" model="fleet.service.type">
+      <record id="type_service_service_11" model="fleet.service.type">
           <field name="name">Rent (Excluding VAT)</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_13" model="fleet.service.type">
+      <record id="type_service_service_12" model="fleet.service.type">
           <field name="name">Entry into service tax</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_14" model="fleet.service.type">
+      <record id="type_service_service_13" model="fleet.service.type">
           <field name="name">Total expenses (Excluding VAT)</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_15" model="fleet.service.type">
+      <record id="type_service_service_14" model="fleet.service.type">
           <field name="name">Residual value (Excluding VAT)</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_16" model="fleet.service.type">
+      <record id="type_service_service_15" model="fleet.service.type">
           <field name="name">Options</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_17" model="fleet.service.type">
+      <record id="type_service_service_16" model="fleet.service.type">
           <field name="name">Emissions</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_18" model="fleet.service.type">
+      <record id="type_service_service_17" model="fleet.service.type">
           <field name="name">Touring Assistance</field>
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_19" model="fleet.service.type">
+      <record id="type_service_service_18" model="fleet.service.type">
           <field name="name">Residual value in %</field>
           <field name="category">service</field>
       </record>
@@ -145,7 +140,7 @@
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_8" model="fleet.service.type">
+      <record id="type_service_7" model="fleet.service.type">
           <field name="name">Ball Joint Replacement</field>
           <field name="category">service</field>
       </record>
@@ -683,7 +678,7 @@
       <record id="log_service_1" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_2" />
         <field name="amount">650</field>
-        <field name="service_type_id" ref="type_service_service_8"/>
+        <field name="service_type_id" ref="type_service_service_7"/>
         <field name="date" eval="(DateTime.now() - timedelta(days=60)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">4586</field>
@@ -695,7 +690,7 @@
       <record id="log_service_2" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_2" />
         <field name="amount">350</field>
-        <field name="service_type_id" ref="type_service_service_8"/>
+        <field name="service_type_id" ref="type_service_service_7"/>
         <field name="date" eval="(DateTime.now() - timedelta(days=30)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">4814</field>
@@ -707,7 +702,7 @@
       <record id="log_service_3" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_1" />
         <field name="amount">513</field>
-        <field name="service_type_id" ref="type_service_service_8"/>
+        <field name="service_type_id" ref="type_service_service_7"/>
         <field name="date" eval="(DateTime.now() - timedelta(days=15)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">124</field>
@@ -719,7 +714,7 @@
       <record id="log_service_4" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_3" />
         <field name="amount">412</field>
-        <field name="service_type_id" ref="type_service_service_8"/>
+        <field name="service_type_id" ref="type_service_service_7"/>
         <field name="date" eval="(DateTime.now() - timedelta(days=120)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">20984</field>
@@ -731,7 +726,7 @@
       <record id="log_service_5" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_4" />
         <field name="amount">275</field>
-        <field name="service_type_id" ref="type_service_service_8"/>
+        <field name="service_type_id" ref="type_service_service_7"/>
         <field name="date" eval="(DateTime.now() - timedelta(days=100)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">241</field>
@@ -743,7 +738,7 @@
       <record id="log_service_6" model="fleet.vehicle.log.services" >
         <field name="vehicle_id" ref="vehicle_5" />
         <field name="amount">302</field>
-        <field name="service_type_id" ref="type_service_service_8"/>
+        <field name="service_type_id" ref="type_service_service_7"/>
         <field name="date" eval="(DateTime.now() - timedelta(days=65)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">22513</field>

--- a/addons/fleet/models/fleet_service_type.py
+++ b/addons/fleet/models/fleet_service_type.py
@@ -7,6 +7,7 @@ from odoo import fields, models
 class FleetServiceType(models.Model):
     _name = 'fleet.service.type'
     _description = 'Fleet Service Type'
+    _order = 'name'
 
     name = fields.Char(required=True, translate=True)
     category = fields.Selection([

--- a/addons/fleet/models/fleet_vehicle_log_services.py
+++ b/addons/fleet/models/fleet_vehicle_log_services.py
@@ -29,7 +29,7 @@ class FleetVehicleLogServices(models.Model):
     notes = fields.Text()
     service_type_id = fields.Many2one(
         'fleet.service.type', 'Service Type', required=True,
-        default=lambda self: self.env.ref('fleet.type_service_service_8', raise_if_not_found=False),
+        default=lambda self: self.env.ref('fleet.type_service_service_7', raise_if_not_found=False),
     )
     state = fields.Selection([
         ('new', 'New'),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In fleet, the demo data for service type have two entries for summer tires
The service types are sorted by alphabetical orders instead of id

Current behavior before PR:
The summer tires service type is appearing twice in the demo data
The service types are sorted by id

Desired behavior after PR is merged:
The summer tires service type is unique in the list
The services types are sorted by alphabetical order

task-2641484

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
