### PR TITLE
[FIX] web_editor: avoid moving palette higher than top of screen

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1,5 +1,7 @@
 odoo.define('web_editor.wysiwyg', function (require) {
 'use strict';
+
+const dom = require('web.dom');
 const core = require('web.core');
 const Widget = require('web.Widget');
 const Dialog = require('web.Dialog');
@@ -879,17 +881,12 @@ const Wysiwyg = Widget.extend({
                         $dropdown.children('.dropdown-toggle').dropdown('show');
                         const $colorpickerMenu = $dropdown.find('.colorpicker-menu');
                         const $colorpicker = $dropdown.find('.colorpicker');
-                        const colorpickerHeight = $colorpicker.outerHeight();
-                        const toolbarPos = this.toolbar.$el.offset();
-                        let top;
-                        if (colorpickerHeight < toolbarPos.top) {
-                            top = 'auto';
-                        } else {
-                            const colorpickerBottom = toolbarPos.top + this.toolbar.$el.outerHeight() + colorpickerHeight;
-                            const clientHeight = this.odooEditor.document.documentElement.clientHeight;
-                            top = colorpickerBottom > clientHeight ? colorpickerHeight - clientHeight : '';
-                        }
-                        $colorpickerMenu.css({top, height: $colorpicker.outerHeight() + 2});
+                        const colorpickerHeight = $colorpicker.outerHeight() + 2;
+                        const toolbarContainerTop = dom.closestScrollable(this.toolbar.el).getBoundingClientRect().top;
+                        const toolbarColorButtonEl = this.toolbar.el.querySelector('#colorInputButtonGroup');
+                        const toolbarColorButtonTop = (toolbarColorButtonEl || this.toolbar.el).getBoundingClientRect().top;
+                        const top = colorpickerHeight + toolbarContainerTop <= toolbarColorButtonTop ? 'auto' : '';
+                        $colorpickerMenu.css({top, height: colorpickerHeight});
                         manualOpening = false;
                     });
                 });


### PR DESCRIPTION
Before this commit opening the color palette did not take the options
panel header height into account.
Because of this the popup sometimes opened higher than the top of the
screen making it unusable.
Also when opening below, if it would exceed the screen size, the popup
was repositioned at a position that could also be higher than the top of
the screen.

After this commit the options panel top position is taken into account
and the target position is adjusted to never be above the top of the
screen.

task-2599771

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
