### PR TITLE
[FIX] mail: fix traceback in commands with body, commands don't linger

### DIFF
--- a/addons/mail/static/src/models/channel_command/channel_command.js
+++ b/addons/mail/static/src/models/channel_command/channel_command.js
@@ -96,14 +96,14 @@ function factory(dependencies) {
          * @static
          * @param {Object} param0
          * @param {mail.thread} param0.channel
-         * @param {Object} [param0.postData={}]
+         * @param {Object} [param0.body='']
          */
-        async execute({ channel, postData = {} }) {
+        async execute({ channel, body = '' }) {
             return this.env.services.rpc({
                 model: 'mail.channel',
                 method: this.methodName,
                 args: [[channel.id]],
-                kwargs: postData,
+                kwargs: { body },
             });
         }
 

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -206,7 +206,10 @@ function factory(dependencies) {
             if (this.thread.model === 'mail.channel') {
                 const command = this._getCommandFromText(this.textInputContent);
                 if (command) {
-                    command.execute({ channel: this.thread, body: this.textInputContent });
+                    await command.execute({ channel: this.thread, body: this.textInputContent });
+                    if (this.exists()) {
+                        this._reset();
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
Commands that were expecting a body were not receiving one, and sending
a command would not clear the text input. This commit fixes that.

task-2645395