### PR TITLE
[FIX] account: Don't generate pdf at all when trying to print a misc operation from the 'print invoices' actions

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2536,8 +2536,6 @@ class AccountMove(models.Model):
             move.write({'invoice_line_ids' : new_invoice_line_ids})
 
     def _get_report_base_filename(self):
-        if any(not move.is_invoice() for move in self):
-            raise UserError(_("Only invoices could be printed."))
         return self._get_move_display_name()
 
     def preview_invoice(self):

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -33,3 +33,15 @@ class IrActionsReport(models.Model):
             if attachment:
                 attachment.register_as_main_attachment(force=False)
         return res
+
+    def render_qweb_pdf(self, res_ids=None, data=None):
+        # Overridden so that the print > invoices actions raises an error
+        # when trying to print a miscellaneous operation instead of an invoice.
+        if self.model == 'account.move' and res_ids:
+            invoice_reports = (self.env.ref('account.account_invoices_without_payment'), self.env.ref('account.account_invoices'))
+            if self in invoice_reports:
+                moves = self.env['account.move'].browse(res_ids)
+                if any(not move.is_invoice(include_receipts=True) for move in moves):
+                    raise UserError(_("Only invoices could be printed."))
+
+        return super().render_qweb_pdf(res_ids=res_ids, data=None)


### PR DESCRIPTION
Before, clicking on 'print invoices' or 'print invoices without payment' on a posted misc operation raised an error message saying that only invoices could be printed. However, the pdf file still got generated and could be found as attachement on the move. With this commit, we don't generate the file anymore in this case.
