### PR TITLE
[REV] account: fix the switch to another company

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -10800,12 +10800,6 @@ msgid "You can not have an overlap between two fiscal years, please correct the 
 msgstr ""
 
 #. module: account
-#: code:addons/account/models/partner.py:441
-#, python-format
-msgid "You can't change the company of a partner if the latter already has some invoices."
-msgstr ""
-
-#. module: account
 #: code:addons/account/models/account_invoice.py:1784
 #, python-format
 msgid "You can only delete an invoice line if the invoice is in draft state."

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -434,22 +434,6 @@ class ResPartner(models.Model):
         for partner in self:
             partner.bank_account_count = mapped_data.get(partner.id, 0)
 
-    @api.constrains('company_id')
-    def _check_company_and_invoices(self):
-        partners_with_company = self.filtered(lambda p: p.company_id)
-        if partners_with_company:
-            query = """
-                SELECT partner.id
-                  FROM res_partner partner
-                  JOIN account_invoice invoice ON invoice.partner_id = partner.id
-                                              AND invoice.company_id != partner.company_id
-                 WHERE partner.id IN %s
-                 LIMIT 1
-             """
-            self.env.cr.execute(query, (tuple(partners_with_company.ids),))
-            if self.env.cr.fetchall():
-                raise ValidationError(_("You can't change the company of a partner if the latter already has some invoices."))
-
     def _find_accounting_partner(self, partner):
         ''' Find the partner for which the accounting entries will be created '''
         return partner.commercial_partner_id


### PR DESCRIPTION
This reverts the following commits: https://github.com/odoo/odoo/pull/72977/commits/acdc4547fb6f6128debc3ff1f4cbf5b2f772239f

The fix we initially made did not cover every possible scenario.

Steps to reproduce the bug:
- Install accounting
- Connect as admin in a multi-company environment, e.g: “Mitchell Admin”
- Go to the related partner form's view linked to “Mitchell Admin”
- in the “Sales & Purchase” tab > set this partner as a vendor and select the current company in the company field
- create a bill in accounting and choose “Mitchell Admin” as vendor > save
- Try to switch from a company to another
- Validation error is triggered

Problem:
When changing the current company of a user, the company of the partner linked to that user will also be changed.
So the constraint check “_check_company_and_invoices” will be triggered

OPW-2642942
OPW-2641402
OPW-2641399
OPW-2639942
OPW-2643541
OPW-2643399
OPW-2645467

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
