### PR TITLE
Improve unaccent handling

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -600,7 +600,7 @@ class AccountGroup(models.Model):
     _order = 'code_prefix_start'
 
     parent_id = fields.Many2one('account.group', index=True, ondelete='cascade', readonly=True)
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     name = fields.Char(required=True)
     code_prefix_start = fields.Char()
     code_prefix_end = fields.Char()

--- a/addons/account/models/account_tax_report.py
+++ b/addons/account/models/account_tax_report.py
@@ -105,7 +105,7 @@ class AccountTaxReportLine(models.Model):
     parent_id = fields.Many2one(string="Parent Line", comodel_name='account.tax.report.line')
     sequence = fields.Integer(string='Sequence', required=True,
         help="Sequence determining the order of the lines in the report (smaller ones come first). This order is applied locally per section (so, children of the same line are always rendered one after the other).")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     report_id = fields.Many2one(string="Tax Report", required=True, comodel_name='account.tax.report', ondelete='cascade', help="The parent tax report of this line")
 
     # helper to create tags (positive and negative) on report line creation

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -41,7 +41,7 @@ class AccountAnalyticGroup(models.Model):
     name = fields.Char(required=True)
     description = fields.Text(string='Description')
     parent_id = fields.Many2one('account.analytic.group', string="Parent", ondelete='cascade', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     children_ids = fields.One2many('account.analytic.group', 'parent_id', string="Childrens")
     complete_name = fields.Char('Complete Name', compute='_compute_complete_name', recursive=True, store=True)
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -28,7 +28,7 @@ class ProductCategory(models.Model):
         'Complete Name', compute='_compute_complete_name', recursive=True,
         store=True)
     parent_id = fields.Many2one('product.category', 'Parent Category', index=True, ondelete='cascade')
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     child_id = fields.One2many('product.category', 'parent_id', 'Child Categories')
     product_count = fields.Integer(
         '# Products', compute='_compute_product_count',

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -62,7 +62,7 @@ class Location(models.Model):
     posx = fields.Integer('Corridor (X)', default=0, help="Optional localization details, for information purpose only")
     posy = fields.Integer('Shelves (Y)', default=0, help="Optional localization details, for information purpose only")
     posz = fields.Integer('Height (Z)', default=0, help="Optional localization details, for information purpose only")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     company_id = fields.Many2one(
         'res.company', 'Company',
         default=lambda self: self.env.company, index=True,

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -18,13 +18,13 @@ from werkzeug.exceptions import NotFound
 from odoo import api, fields, models, tools, http, release, registry
 from odoo.addons.http_routing.models.ir_http import slugify, _guess_mimetype, url_for
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
-from odoo.addons.website.tools import get_unaccent_sql_wrapper, similarity_score, text_from_html
+from odoo.addons.website.tools import similarity_score, text_from_html
 from odoo.addons.portal.controllers.portal import pager
 from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import UserError, AccessError
 from odoo.http import request
 from odoo.modules.module import get_resource_path
-from odoo.osv.expression import AND, OR, FALSE_DOMAIN
+from odoo.osv.expression import AND, OR, FALSE_DOMAIN, get_unaccent_wrapper
 from odoo.tools.translate import _
 from odoo.tools import escape_psql, pycompat
 
@@ -1614,7 +1614,7 @@ class Website(models.Model):
             domain = search_detail['base_domain'].copy()
             fields = set(fields).intersection(model._fields)
 
-            unaccent = get_unaccent_sql_wrapper(self.env.cr)
+            unaccent = get_unaccent_wrapper(self.env.cr)
             similarities = [sql.SQL("word_similarity({search}, {field})").format(
                 search=unaccent(sql.Placeholder('search')),
                 # Specific handling for website.page that inherits its arch_db and name fields

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -40,7 +40,7 @@ class Menu(models.Model):
     website_id = fields.Many2one('website', 'Website', ondelete='cascade')
     parent_id = fields.Many2one('website.menu', 'Parent Menu', index=True, ondelete="cascade")
     child_id = fields.One2many('website.menu', 'parent_id', string='Child Menus')
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     is_visible = fields.Boolean(compute='_compute_visible', string='Is Visible')
     group_ids = fields.Many2many('res.groups', string='Visible Groups',
                                  help="User need to be at least in one of these groups to see the menu")

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -186,16 +186,3 @@ def text_from_html(html_fragment):
     # lxml requires one single root element
     tree = etree.fromstring('<p>%s</p>' % html_fragment, etree.XMLParser(recover=True))
     return ' '.join(tree.itertext())
-
-def get_unaccent_sql_wrapper(cr):
-    """
-    Returns a function that wraps SQL within unaccent if available
-    TODO remove when this tool becomes globally available
-
-    :param cr: cursor on which the wrapping is done
-
-    :return: function that wraps SQL with unaccent if available
-    """
-    if odoo.registry(cr.dbname).has_unaccent:
-        return lambda x: sql.SQL("unaccent({wrapped_sql})").format(wrapped_sql=x)
-    return lambda x: x

--- a/addons/website_sale/models/product_misc.py
+++ b/addons/website_sale/models/product_misc.py
@@ -157,7 +157,7 @@ class ProductPublicCategory(models.Model):
 
     name = fields.Char(required=True, translate=True)
     parent_id = fields.Many2one('product.public.category', string='Parent Category', index=True, ondelete="cascade")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     child_id = fields.One2many('product.public.category', 'parent_id', string='Children Categories')
     parents_and_self = fields.Many2many('product.public.category', compute='_compute_parents_and_self')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.", index=True, default=_default_sequence)

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -30,7 +30,7 @@ class IrUiMenu(models.Model):
     sequence = fields.Integer(default=10)
     child_id = fields.One2many('ir.ui.menu', 'parent_id', string='Child IDs')
     parent_id = fields.Many2one('ir.ui.menu', string='Parent Menu', index=True, ondelete="restrict")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     groups_id = fields.Many2many('res.groups', 'ir_ui_menu_group_rel',
                                  'menu_id', 'gid', string='Groups',
                                  help="If you have groups, the visibility of this menu will be based on these groups. "\

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -80,7 +80,7 @@ class PartnerCategory(models.Model):
     parent_id = fields.Many2one('res.partner.category', string='Parent Category', index=True, ondelete='cascade')
     child_ids = fields.One2many('res.partner.category', 'parent_id', string='Child Tags')
     active = fields.Boolean(default=True, help="The active field allows you to hide the category without removing it.")
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     partner_ids = fields.Many2many('res.partner', column1='category_id', column2='partner_id', string='Partners')
 
     @api.constrains('parent_id')

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -17,7 +17,7 @@ class Category(models.Model):
     name = fields.Char(required=True)
     color = fields.Integer('Color Index')
     parent = fields.Many2one('test_new_api.category', ondelete='cascade')
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     root_categ = fields.Many2one(_name, compute='_compute_root_categ')
     display_name = fields.Char(compute='_compute_display_name', recursive=True,
                                inverse='_inverse_display_name')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1536,6 +1536,7 @@ class _String(Field):
     """ Abstract class for string fields. """
     translate = False                   # whether the field is translated
     prefetch = None
+    unaccent = True
 
     def __init__(self, string=Default, **kwargs):
         # translate is either True, False, or a callable

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -122,6 +122,9 @@ import traceback
 from functools import partial
 
 from datetime import date, datetime, time
+
+from psycopg2.sql import Composable, SQL
+
 import odoo.modules
 from odoo.osv.query import Query
 from odoo.tools import pycompat
@@ -401,9 +404,14 @@ def check_leaf(element, internal=False):
 # SQL utils
 # --------------------------------------------------
 
+def _unaccent_wrapper(x):
+    if isinstance(x, Composable):
+        return SQL('unaccent({})').format(x)
+    return 'unaccent({})'.format(x)
+
 def get_unaccent_wrapper(cr):
     if odoo.registry(cr.dbname).has_unaccent:
-        return lambda x: "unaccent(%s)" % (x,)
+        return _unaccent_wrapper
     return lambda x: x
 
 

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -449,10 +449,10 @@ class expression(object):
         # parse the domain expression
         self.parse()
 
-    def _unaccent(self, field, _id=lambda x: x):
+    def _unaccent(self, field):
         if getattr(field, 'unaccent', False):
             return self._unaccent_wrapper
-        return _id
+        return lambda x: x
 
     # ----------------------------------------
     # Leafs management


### PR DESCRIPTION
Covers tasks 2627454 (allow opting out of unaccent for indexing / performance reasons) and 2634851 (natively support `psycopg2.sql` in the unaccent wrapper).

Task 2551518 (unaccent indexes) is ignored, as it's not clear whether that should be handled in the ORM (with workarounds for `unaccent` not being `IMMUTABLE`) or just documented as a danger (generally speaking behaviour with respect to `unaccent` seems completely undocumented currently so...).