### PR TITLE
[FIX] stock: duplicate picking on push rules

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -15,7 +15,7 @@ from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools.float_utils import float_compare, float_is_zero, float_repr, float_round
-from odoo.tools.misc import format_date, OrderedSet
+from odoo.tools.misc import clean_context, format_date, OrderedSet
 
 PROCUREMENT_PRIORITIES = [('0', 'Normal'), ('1', 'Urgent')]
 
@@ -1148,7 +1148,8 @@ class StockMove(models.Model):
 
         # assign picking in batch for all confirmed move that share the same details
         for moves in to_assign.values():
-            moves._assign_picking()
+            moves.with_context(clean_context(
+                moves.env.context))._assign_picking()
         self._push_apply()
         self._check_company()
         moves = self


### PR DESCRIPTION
Usecase:
- 2 warehouses 1 and 2
- Create a route with a rule from inter-warehouse to WH2
- Create a picking type for WH1 for stock to inter-warehouse
- Create a planned transfer with 2 stock.move in the wH1 new picking
type
-* Go back to inventory overview
- Click on process on the picking type WH1 -> inter-warehouse
-* Process the picking created before
- Go to WH2 delivery

You see 2 pickings for each stock.move despite they share the same
data (procurement group, source and dest locations)
If you don't do the steps bewteen *, you only have 1 picking.

It's due to the context of the views that is propagate to the
new picking created by push rules.

opw-2533718

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
