### PR TITLE
[FIX] mail, bus: move user unique index in bus

### DIFF
--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -30,6 +30,9 @@ class BusPresence(models.Model):
     last_presence = fields.Datetime('Last Presence', default=lambda self: fields.Datetime.now())
     status = fields.Selection([('online', 'Online'), ('away', 'Away'), ('offline', 'Offline')], 'IM Status', default='offline')
 
+    def init(self):
+        self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS bus_presence_user_unique ON %s (user_id) WHERE user_id IS NOT NULL" % self._table)
+
     @api.model
     def update(self, inactivity_period, identity_field, identity_value):
         """ Updates the last_poll and last_presence of the current user

--- a/addons/mail/models/bus_presence.py
+++ b/addons/mail/models/bus_presence.py
@@ -9,7 +9,6 @@ class BusPresence(models.Model):
     guest_id = fields.Many2one('mail.guest', 'Guest', ondelete='cascade')
 
     def init(self):
-        self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS bus_presence_user_unique ON %s (user_id) WHERE user_id IS NOT NULL" % self._table)
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS bus_presence_guest_unique ON %s (guest_id) WHERE guest_id IS NOT NULL" % self._table)
 
     _sql_constraints = [


### PR DESCRIPTION
Move user unique index back in bus module so that it is defined even
without mail module installed.
