### PR TITLE
[FIX] point_of_sale: errer when accessing ir model

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -137,7 +137,19 @@ exports.PosModel = Backbone.Model.extend({
             searchTerm: '',
         };
     },
+    load_product_uom_unit: async function() {
+        const params = {
+            model: 'ir.model.data',
+            method:'check_object_reference',
+            args: ['uom', 'product_uom_unit'],
+        };
+
+        const uom_id = await this.rpc(params);
+        this.uom_unit_id = uom_id[1];
+    },
+
     after_load_server_data: async function(){
+        await this.load_product_uom_unit();
         await this.load_orders();
         this.set_start_order();
         if(this.config.use_proxy){
@@ -244,13 +256,6 @@ exports.PosModel = Backbone.Model.extend({
             _.each(units, function(unit){
                 self.units_by_id[unit.id] = unit;
             });
-        }
-    },{
-        model:  'ir.model.data',
-        fields: ['res_id'],
-        domain: function(){ return [['name', '=', 'product_uom_unit']]; },
-        loaded: function(self,unit){
-            self.uom_unit_id = unit[0].res_id;
         }
     },{
         model:  'res.country.state',


### PR DESCRIPTION
When the POS want to get the reference unit of measure "Unit", it search
on the ir.model.data model.

Due to recent changes, a normal user cannot have access to the
ir.model.data model.

So we are now calling the function 'check_object_reference' that will
retrun the model and id of record, and check the access rights on the
record returned.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
