### PR TITLE
[IMP] website: target popup as a link

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -108,6 +108,7 @@ function changeOption(optionName, weName = '', optionTooltipLabel = '', position
         trigger: `${option_block} ${weName}, ${option_block} [title='${weName}']`,
         content: Markup(sprintf(_t("<b>Click</b> on this option to change the %s of the block."), optionTooltipLabel)),
         position: position,
+        in_modal: false,
         run: "click",
     };
 }

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -22,7 +22,7 @@ function loadAnchors(url, body) {
             resolve();
         }
     }).then(function (response) {
-        const anchors = $(response).find('[id][data-anchor=true]').toArray().map((el) => {
+        const anchors = $(response).find('[id][data-anchor=true], .modal[id][data-display="onClick"]').toArray().map((el) => {
             return '#' + el.id;
         });
         // Always suggest the top and the bottom of the page as internal link

--- a/addons/website/static/src/snippets/s_popup/options.js
+++ b/addons/website/static/src/snippets/s_popup/options.js
@@ -31,6 +31,15 @@ options.registry.SnippetPopup = options.Class.extend({
         // sound). Stop the video, as the user can't do it (no button on video
         // in edit mode).
         this._removeIframeSrc();
+        if (!this.$target[0].parentElement.matches("#website_cookies_bar")) {
+            this.trigger_up("option_update", {
+                optionName: "anchor",
+                name: "modalAnchor",
+                data: {
+                    buttonEl: this._requestUserValueWidgets("onclick_opt")[0].el,
+                },
+            });
+        } 
         return this._super(...arguments);
     },
     /**

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -401,10 +401,18 @@
                             if (successPage.charAt(0) === "#") {
                                 const successAnchorEl = document.getElementById(successPage.substring(1));
                                 if (successAnchorEl) {
-                                    await dom.scrollTo(successAnchorEl, {
-                                        duration: 500,
-                                        extraOffset: 0,
-                                    });
+                                    // Check if the target of the link is a modal.
+                                    if (successAnchorEl.classList.contains("modal")) {
+                                        // Trigger a "hashChange" event to
+                                        // notify the popup widget to show the
+                                        // popup.
+                                        window.location.href = successPage;
+                                    } else {
+                                        await dom.scrollTo(successAnchorEl, {
+                                            duration: 500,
+                                            extraOffset: 0,
+                                        });
+                                    }
                                 }
                                 break;
                             }

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -1,0 +1,85 @@
+/** @odoo-module */
+
+import wTourUtils from "website.tour_utils";
+
+wTourUtils.registerWebsitePreviewTour("snippet_popup_display_on_click", {
+    test: true,
+    url: "/",
+    edition: true,
+}, [
+    wTourUtils.dragNDrop({id: "s_text_image", name: "Image - Text"}),
+    wTourUtils.dragNDrop({id: "s_popup", name: "Popup"}),
+    {
+        content: "Click inside the popup to access its options menu.",
+        in_modal: false,
+        trigger: "iframe .s_popup .s_banner",
+    },
+    wTourUtils.changeOption("SnippetPopup", 'we-select[data-attribute-name="display"] we-toggler'),
+    {
+        content: "Click on the display 'On Click' option",
+        trigger: "#oe_snippets we-button[data-name='onclick_opt']",
+        in_modal: false,
+        run() {
+            // The clipboard cannot be accessed from a script.
+            // https://w3c.github.io/editing/docs/execCommand/#dfn-the-copy-command
+            // The execCommand is patched for that step so that ClipboardJS still
+            // sends the "success" event.
+            const oldExecCommand = document.execCommand;
+            document.execCommand = () => true;
+            this.$anchor[0].click();
+            document.execCommand = oldExecCommand;
+        }
+    },
+    {
+        content: "Check the copied anchor from the notification toast",
+        trigger: ".o_notification_manager .o_notification_content",
+        run() {
+            const notificationContent = this.$anchor[0].innerText;
+            const anchor = notificationContent.substring(notificationContent.indexOf("#"));
+
+            if (anchor !== "#Win-%2420") {
+                console.error("The popup anchor is not '#Win-%2420' as expected.");
+            }
+        },
+    },
+    wTourUtils.clickOnElement("button to close the popup", "iframe .s_popup_close"),
+    wTourUtils.clickOnElement("text image snippet button", "iframe .s_text_image .btn-primary"),
+    {
+        content: "Paste the popup anchor in the URL input",
+        trigger: "#o_link_dialog_url_input",
+        run: "text #Win-%2420"
+    },
+    ...wTourUtils.clickOnSave(),
+    wTourUtils.clickOnElement("text image snippet button", "iframe .s_text_image .btn-primary"),
+    {
+        content: "Verify that the popup opens after clicked the button.",
+        in_modal: false,
+        trigger: "iframe .s_popup .modal[id='Win-%2420'].show",
+    },
+    wTourUtils.clickOnElement("button to close the popup", "iframe .s_popup_close"),
+    {
+        content: "Go to the 'contactus' page.",
+        trigger: "iframe a[href='/contactus']",
+    },
+    {
+        content: "wait for the page to be loaded",
+        trigger: ".o_website_preview[data-view-xmlid='website.contactus']",
+        run: () => null, // it"s a check
+    },
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    wTourUtils.dragNDrop({id: "s_text_image", name: "Image - Text"}),
+    wTourUtils.clickOnElement("text image snippet button", "iframe .s_text_image .btn-primary"),
+    {
+        content: "Add a link to the homepage popup in the URL input",
+        trigger: "#o_link_dialog_url_input",
+        run: "text /#Win-%2420"
+    },
+    ...wTourUtils.clickOnSave(),
+    wTourUtils.clickOnElement("text image snippet button", "iframe .s_text_image .btn-primary"),
+    {
+        content: "Verify that the popup opens when the homepage page loads.",
+        in_modal: false,
+        extra_trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
+        trigger: "iframe .s_popup .modal[id='Win-%2420'].show",
+    },
+]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -74,3 +74,6 @@ class TestSnippets(HttpCase):
 
     def test_10_parallax(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_parallax', login='admin')
+
+    def test_11_snippet_popup_display_on_click(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_display_on_click', login='admin')

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -53,10 +53,11 @@
             <we-select string="Display" data-attribute-name="display" data-attribute-default-value="always">
                 <we-button data-select-data-attribute="afterDelay" data-name="show_delay">Delay</we-button>
                 <we-button data-select-data-attribute="mouseExit">On Exit</we-button>
+                <we-button data-select-data-attribute="onClick" data-name="onclick_opt">On Click (via link)</we-button>
             </we-select>
             <we-input string="&#8985; Delay" title="Automatically opens the pop-up if the user stays on a page longer than the specified time." data-select-data-attribute="" data-attribute-name="showAfter" data-unit="s" data-save-unit="ms" data-dependencies="show_delay"/>
             <t t-set="unit_popup_duration">days</t>
-            <we-input string="Hide For" title="Once the user closes the popup, it won't be shown again for that period of time." t-attf-data-select-data-attribute="7#{unit_popup_duration}" data-attribute-name="consentsDuration" t-att-data-unit="unit_popup_duration"/>
+            <we-input string="Hide For" title="Once the user closes the popup, it won't be shown again for that period of time." t-attf-data-select-data-attribute="7#{unit_popup_duration}" data-attribute-name="consentsDuration" t-att-data-unit="unit_popup_duration" data-dependencies="!onclick_opt"/>
             <we-select string="Show on" data-no-preview="true">
                 <we-button data-move-block="currentPage">This page</we-button>
                 <we-button data-move-block="allPages">All pages</we-button>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1120,6 +1120,11 @@
                    data-no-preview="true"/>
     </div>
 
+    <div data-js="anchor"
+        data-selector=".s_popup"
+        data-target=".modal">
+    </div>
+
     <!-- Mega Menu settings -->
     <div data-js="MegaMenuLayout" data-selector=".o_mega_menu">
         <we-select string="Template" data-name="mega_menu_template_opt">


### PR DESCRIPTION
This commit introduces a new feature to the popup snippet.
Up until now, the popup could be displayed after a delay or on exit.
This commit enables the popup to be displayed on click.

To make use of this feature, the user will need to:

- Set the "Display" option of the popup to "On Click (via link)".
- Paste the anchor that has been copied to the clipboard into the
URL input of any link.

This commit also adds a test for this new feature.

task-2172312