### PR TITLE
[FIX] stock: Display only one table header in traceability report

### DIFF
--- a/addons/stock/static/src/scss/stock_traceability_report.scss
+++ b/addons/stock/static/src/scss/stock_traceability_report.scss
@@ -81,3 +81,4 @@
         }
     }
 }
+thead { display: table-row-group; }


### PR DESCRIPTION
Steps to reproduce:

  - Install Manufacturing module
  - Go to Manufacturing -> Operations -> Manufacturing Orders
  - Create a new one and add at least 10 product components
  - Move it to Done stage
  - Click on stat button Traceability
  - Unfold the components
  - Print report

Issue:

  Table header on 2nd page overlap table content.

Cause:

  Wkhtmltopdf does not handle well table on multiple pages.
  More info here: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2367

Solution:

  Do not duplicate table header on next pages.

opw-2634492