### PR TITLE
[FIX] product_margin: select 'in_payment' line when generating report

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -94,13 +94,13 @@ class ProductProduct(models.Model):
         payment_states = ()
         if invoice_state == 'paid':
             states = ('posted',)
-            payment_states = ('paid',)
+            payment_states = ('in_payment', 'paid',)
         elif invoice_state == 'open_paid':
             states = ('posted',)
-            payment_states = ('not_paid', 'paid')
+            payment_states = ('not_paid', 'in_payment', 'paid')
         elif invoice_state == 'draft_open_paid':
             states = ('posted', 'draft')
-            payment_states = ('not_paid', 'paid')
+            payment_states = ('not_paid', 'in_payment', 'paid')
         if "force_company" in self.env.context:
             company_id = self.env.context['force_company']
         else:


### PR DESCRIPTION
1. Define a product [TEST] with automated inventory valuation (AVCO)
2. Define a landed cost product in the same way
3. Create a RFQ for [TEST], Confirm and Receive product
4. Create Bill, add the landed cost on the bill
5. Confirm the Bill and create the landed cost (from transfer of point 3)
6. Create a SO for [TEST], confirm, delivery and create the invoice
7. Generate product margin analysis, [TEST] will be present
8. Register a payment for the invoice (it should have the status 'In
Payment')

Generate product margin analysis again, [TEST] entries will be missing
This occur because, when the invoice is in 'in_payment' state the
records are not taken into account

opw-2631974

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
