### PR TITLE
[IMP] hr_holidays: show conflicting time off in validation error message

### DIFF
--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -152,7 +152,9 @@ class TestCompanyLeave(TransactionCase):
             'name': 'Hol11',
             'employee_id': self.employee.id,
             'holiday_status_id': self.paid_time_off.id,
+            'date_from': date(2020, 1, 7),
             'request_date_from': date(2020, 1, 7),
+            'date_to': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 7),
             'number_of_days': 0.5,
             'request_unit_half': True,
@@ -196,7 +198,9 @@ class TestCompanyLeave(TransactionCase):
             'name': 'Hol11',
             'employee_id': self.employee.id,
             'holiday_status_id': self.paid_time_off.id,
+            'date_from': datetime.now(),
             'request_date_from': date(2020, 1, 9),
+            'date_to': datetime.now(),
             'request_date_to': date(2020, 1, 9),
             'number_of_days': 1,
 
@@ -247,7 +251,9 @@ class TestCompanyLeave(TransactionCase):
             'name': 'Hol11',
             'employee_id': self.employee.id,
             'holiday_status_id': self.paid_time_off.id,
+            'date_from': date(2020, 1, 6),
             'request_date_from': date(2020, 1, 6),
+            'date_to': date(2020, 1, 10),
             'request_date_to': date(2020, 1, 10),
             'number_of_days': 3,
         })
@@ -297,7 +303,9 @@ class TestCompanyLeave(TransactionCase):
             'employee_id': employee.id,
             'holiday_status_id': self.paid_time_off.id,
             'request_date_from': date(2020, 3, 29),
+            'date_from': date(2020, 3, 29),
             'request_date_to': date(2020, 4, 1),
+            'date_to': date(2020, 4, 1),
             'number_of_days': 3,
         } for employee in employees[0:15]])
         leaves._compute_date_from_to()

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -173,7 +173,7 @@
                 <button name="action_time_off_dashboard"
                         type="object"
                         class="oe_stat_button"
-                        context="{'search_default_employee_id': active_id}"
+                        context="{'search_default_employee_ids': active_id}"
                         attrs="{'invisible': [('is_absent', '=', False)]}">
                         <div attrs="{'invisible': [('hr_icon_display', '!=', 'presence_holiday_present')]}"
                               role="img" class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Off Till" title="Off Till"/>
@@ -193,7 +193,7 @@
                         class="oe_stat_button"
                         icon="fa-calendar"
                         attrs="{'invisible': [('show_leaves','=', False)]}"
-                        context="{'search_default_employee_id': active_id}"
+                        context="{'search_default_employee_ids': active_id}"
                         groups="base.group_user"
                         help="Remaining leaves">
                     <div class="o_field_widget o_stat_info" attrs="{'invisible': [('allocation_display', '=', '0')]}">

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -97,7 +97,9 @@ class TestWorkEntryHolidaysPerformancesBigData(TestWorkEntryHolidaysBase):
             'name': 'Holiday - %s' % employee.name,
             'employee_id': employee.id,
             'holiday_status_id': cls.paid_time_off.id,
+            'date_from': date(2020, 8, 3),
             'request_date_from': date(2020, 8, 3),
+            'date_to': date(2020, 8, 7),
             'request_date_to': date(2020, 8, 7),
             'number_of_days': 5,
         } for employee in cls.employees])

--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -181,7 +181,9 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
             'name': "Sick 1 that doesn't make sense, but it's the prod so YOLO",
             'employee_id': employee.id,
             'holiday_status_id': leave_type.id,
+            'date_from': date(2020, 9, 4),
             'request_date_from': date(2020, 9, 4),
+            'date_to': date(2020, 9, 4),
             'request_date_to': date(2020, 9, 4),
             'number_of_days': 1,
         })


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In hr_holidays, there is no information about the conflicting time off when a second time off is scheduled at the same time.
There is a validation error saying "You can not set 2 time off that overlaps on the same day for the same employee".
The validation error should display the conflicting time off

Current behavior before PR:
The validation error displays the following:
"You can not set 2 time off that overlaps on the same day for the same employee"

Desired behavior after PR is merged:
The validation error will display the following:
"You can not set 2 time off that overlaps on the same day for the same employee.
Existing time off: Mitchell Admin / Trip with Family : 24.00 hours / from 06/09/2021 to 08/09/2021 / To Approve"

task-2641682

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
