### PR TITLE
[FIX] website_forum: prevent error when creating multi

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -186,7 +186,8 @@ class Forum(models.Model):
             forum.count_flagged_posts = self.env['forum.post'].search_count(domain)
 
     def _set_default_faq(self):
-        self.faq = self.env['ir.ui.view']._render_template('website_forum.faq_accordion', {"forum": self})
+        for forum in self:
+            forum.faq = self.env['ir.ui.view']._render_template('website_forum.faq_accordion', {"forum": forum})
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix a singleton error when passing a list of value dictionaries to forum.forum's create method that occurs because `_set_default_faq` is called on the result of the model's create-multi: https://github.com/odoo/odoo/blob/master/addons/website_forum/models/forum.py#L197.

Current behavior before PR:
Singleton error occurs when passing a list of value dictionaries to forum.forum's create method

Desired behavior after PR is merged:
No singleton error occurs when passing a list of value dictionaries to forum.forum's create method

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
