### PR TITLE
[FIX] hr_expense: reconcile expense residual

### DIFF
--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -14,7 +14,10 @@ class AccountMoveLine(models.Model):
         not_paid_expenses = self.expense_id.filtered(lambda expense: expense.state != 'done')
         not_paid_expense_sheets = not_paid_expenses.sheet_id
         res = super().reconcile()
-        paid_expenses = not_paid_expenses.filtered(lambda expense: expense.currency_id.is_zero(expense.amount_residual))
+        paid_expenses = not_paid_expenses.filtered(lambda expense:
+            expense.currency_id.is_zero(expense.amount_residual) and
+            expense.currency_id.is_zero(expense.sheet_id.amount_residual)
+        )        
         paid_expenses.write({'state': 'done'})
         not_paid_expense_sheets.filtered(lambda sheet: all(expense.state == 'done' for expense in sheet.expense_line_ids)).set_to_paid()
         return res


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fix state of expense report when we register payment partial reconciled,
Although there is still residual amount on expense report.

**Current behavior before PR:**
Case 1 - 1 Expense Report (2 line) register payment partial reconcile.
Case 2 - 2 Expense Report (each 1 line) register payment group by and partial reconcile

Both, it change state to paid.
1. we can't register payment residual on expense report form view.
2. user can't find document is not full payment because state is paid.


**Desired behavior after PR is merged:**
state will change to paid when residual amount on expense report and expense sheet  is equal 0.0


reference issue : https://github.com/odoo/odoo/issues/69804

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
