### PR TITLE
[FIX] base: completely wipe context in res.partner's display_name

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -275,8 +275,8 @@ class Partner(models.Model):
 
     @api.depends('is_company', 'name', 'parent_id.display_name', 'type', 'company_name')
     def _compute_display_name(self):
-        diff = dict(show_address=None, show_address_only=None, show_email=None, html_format=None, show_vat=None)
-        names = dict(self.with_context(**diff).name_get())
+        # retrieve name_get() without any fancy feature
+        names = dict(self.with_context({}).name_get())
         for partner in self:
             partner.display_name = names.get(partner.id)
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -146,4 +146,8 @@ class TestPartner(TransactionCase):
 
         partner_merge_wizard = self.env['base.partner.merge.automatic.wizard'].with_context(
             {'partner_show_db_id': True, 'default_dst_partner_id': test_partner}).new()
-        self.assertEqual(partner_merge_wizard.dst_partner_id.display_name, expected_partner_name, "'Destination Contact' name should contain db ID in brackets")
+        self.assertEqual(
+            partner_merge_wizard.dst_partner_id.name_get(),
+            [(test_partner.id, expected_partner_name)],
+            "'Destination Contact' name should contain db ID in brackets"
+        )

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1832,13 +1832,18 @@ class BaseModel(metaclass=MetaModel):
             record.display_name = names.get(record.id, False)
 
     def name_get(self):
-        """ name_get() -> [(id, name), ...]
+        """Returns a textual representation for the records in ``self``, with
+        one item output per input record, in the same order.
 
-        Returns a textual representation for the records in ``self``.
-        By default this is the value of the ``display_name`` field.
+        .. warning::
+
+            Although :meth:`~.name_get` can use context data for richer
+            contextual formatting, as it is the default implementation for
+            :attr:`~.display_name` it is important that it resets to the
+            "default" behaviour if the context keys are empty / missing.
 
         :return: list of pairs ``(id, text_repr)`` for each records
-        :rtype: list(tuple)
+        :rtype: list[(int, str)]
         """
         result = []
         name = self._rec_name


### PR DESCRIPTION
Because the field is stored it doesn't make much sense to have a
context dependency and that can cause significant issues. However
`name_get` looks pretty innocent and it's not necessarily insane to
have a context dependency *there* (or even in the average
`display_name` as they're normally non-stored computed fields).

`_compute_display_name` previously blanked (blacklisted) just a few
context values, but doing the opposite is probably the better idea.

See also: odoo/odoo#68946

OPW-2453956
Task 2500978
