### PR TITLE
[FIX] web: mockServer should return original reason on reject

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -167,7 +167,7 @@ var MockServer = Class.extend({
             var event = result && result.event;
             var errorString = JSON.stringify(message || false);
             console.warn('%c[rpc] response (error) ' + route, 'color: orange; font-weight: bold;', JSON.parse(errorString));
-            return Promise.reject({message: errorString, event: event || $.Event()});
+            return Promise.reject({message, event: event || $.Event()});
         });
 
         def.abort = abort;

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -167,7 +167,7 @@ var MockServer = Class.extend({
             var event = result && result.event;
             var errorString = JSON.stringify(message || false);
             console.warn('%c[rpc] response (error) ' + route, 'color: orange; font-weight: bold;', JSON.parse(errorString));
-            return Promise.reject({message, event: event || $.Event()});
+            return Promise.reject({message: JSON.parse(errorString), event: event || $.Event()});
         });
 
         def.abort = abort;


### PR DESCRIPTION
For consistency, the reason of rejection should be propagated and not
partially stringified.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
