### PR TITLE
reset value of custom filter on operator change

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -382,6 +382,7 @@
                         <option t-foreach="fields[condition.field].selection" t-as="option" t-key="option_index"
                             t-att-value="option[0]"
                             t-esc="option[1]"
+                            t-att-selected="condition.value and condition.value === option[0]"
                         />
                     </select>
                     <input t-elif="fieldType === 'float'"


### PR DESCRIPTION
PURPOSE
When selecting an operator from custom filter value is not reset, so while applying filter value show some other value but facet shows 0th option value, it is because internally value is changed but selection element is not changed.

SPEC
When changing operator value is reset to first option.

TASK 2646042



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
