### PR TITLE
[FIX] website: fix get_dynamic_filter controller method

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -310,7 +310,7 @@ class Website(Home):
         dynamic_filter = request.env['website.snippet.filter'].sudo().search(
             [('id', '=', filter_id)] + request.website.website_domain()
         )
-        return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample) or ''
+        return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample) or []
 
     @http.route('/website/snippet/options_filters', type='json', auth='user', website=True)
     def get_dynamic_snippet_filters(self, model_name=None, search_domain=None):


### PR DESCRIPTION
Before this commit when the method returned an empty string, the calling
method _fetchData couldn't processed map() on the result.
After this commit the result will be an empty array thus the map method
won't fail.

LINKS

Task-2489680


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
