### PR TITLE
[FIX] web: command palette

### DIFF
--- a/addons/web/static/src/webclient/commands/command_palette.js
+++ b/addons/web/static/src/webclient/commands/command_palette.js
@@ -5,7 +5,7 @@ import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { scrollTo } from "@web/core/utils/scrolling";
 import { fuzzyLookup } from "@web/core/utils/search";
-import { debouncePromise } from "@web/core/utils/timing";
+import { debounce } from "@web/core/utils/timing";
 import { _lt } from "@web/core/l10n/translation";
 
 const { Component, hooks } = owl;
@@ -69,7 +69,7 @@ export class CommandPalette extends Component {
         this.keepLast = new KeepLast();
         this.DefaultCommandItem = DefaultCommandItem;
         this.activeElement = useService("ui").activeElement;
-        const onDebouncedSearchInput = debouncePromise.apply(this, [this.onSearchInput, 250]);
+        const onDebouncedSearchInput = debounce.apply(this, [this.onSearchInput, 200]);
         this.onDebouncedSearchInput = (...args) => {
             this.inputPromise = onDebouncedSearchInput.apply(this, args).catch(() => {
                 this.inputPromise = null;
@@ -258,7 +258,7 @@ export class CommandPalette extends Component {
             namespace = searchValue[0];
             searchValue = searchValue.slice(1);
         }
-        this.setCommands(namespace, {
+        await this.setCommands(namespace, {
             searchValue,
             activeElement: this.activeElement,
         });

--- a/addons/web/static/src/webclient/commands/command_palette.js
+++ b/addons/web/static/src/webclient/commands/command_palette.js
@@ -212,7 +212,7 @@ export class CommandPalette extends Component {
 
         const listbox = this.el.querySelector(".o_command_palette_listbox");
         const command = listbox.querySelector(`#o_command_${nextIndex}`);
-        scrollTo(command.children[0], listbox);
+        scrollTo(command, listbox);
     }
 
     onCommandClicked(index) {

--- a/addons/web/static/src/webclient/commands/command_palette.xml
+++ b/addons/web/static/src/webclient/commands/command_palette.xml
@@ -16,9 +16,9 @@
             <div class="o_command_category" t-key="category.keyId">
               <t t-foreach="category.commands" t-as="command">
                 <t t-set="commandIndex" t-value="state.commands.indexOf(command)" />
-                <span t-attf-id="o_command_{{commandIndex}}" class="o_command" t-att-class="{ focused: state.selectedCommand === command }" t-on-click="onCommandClicked(commandIndex)" t-on-mouseenter="onCommandMouseEnter(commandIndex)" t-key="command.keyId">
+                <div t-attf-id="o_command_{{commandIndex}}" class="o_command" t-att-class="{ focused: state.selectedCommand === command }" t-on-click="onCommandClicked(commandIndex)" t-on-mouseenter="onCommandMouseEnter(commandIndex)" t-key="command.keyId">
                   <t t-component="command.Component || DefaultCommandItem" name="command.name" t-props="command.props" t-on-close="props.closeMe()" t-on-execute-command="executeCommand(command)"/>
-                </span>
+                </div>
               </t>
             </div>
 

--- a/addons/web/static/tests/core/utils/timing_tests.js
+++ b/addons/web/static/tests/core/utils/timing_tests.js
@@ -1,19 +1,86 @@
 /** @odoo-module **/
 
-import { debouncePromise } from "@web/core/utils/timing";
+import { browser } from "@web/core/browser/browser";
+import { debounce } from "@web/core/utils/timing";
+import { makeDeferred, patchWithCleanup } from "../../helpers/utils";
 
 QUnit.module("utils", () => {
     QUnit.module("timing");
 
-    QUnit.test("debouncePromise", async function (assert) {
+    QUnit.test("debounce on an async function", async function (assert) {
+        let callback;
+        patchWithCleanup(browser, {
+            setTimeout: (later) => {
+                callback = later;
+            },
+        });
+        const imSearchDef = makeDeferred();
         const myFunc = () => {
-            assert.step("exec");
+            assert.step("myFunc");
+            return imSearchDef;
         };
-        const myDebouncedFunc = debouncePromise(myFunc, 10);
-        let toAwait = myDebouncedFunc();
+        const myDebouncedFunc = debounce(myFunc, 3000);
+        myDebouncedFunc().then(() => {
+            throw new Error("Should never be resolved");
+        });
+        myDebouncedFunc().then((x) => {
+            assert.step("resolved " + x);
+        });
         assert.verifySteps([]);
-        toAwait = myDebouncedFunc();
-        await toAwait;
-        assert.verifySteps(["exec"]);
+        callback();
+        assert.verifySteps(["myFunc"]);
+        imSearchDef.resolve(42);
+        await Promise.resolve(); // wait for promise returned by myFunc
+        await Promise.resolve(); // wait for promise returned by debounce
+
+        assert.verifySteps(["resolved 42"]);
+    });
+
+    QUnit.test("debounce on a sync function", async function (assert) {
+        let callback;
+        patchWithCleanup(browser, {
+            setTimeout: (later) => {
+                callback = later;
+            },
+        });
+        const myFunc = () => {
+            assert.step("myFunc");
+            return 42;
+        };
+        const myDebouncedFunc = debounce(myFunc, 3000);
+        myDebouncedFunc().then(() => {
+            throw new Error("Should never be resolved");
+        });
+        myDebouncedFunc().then((x) => {
+            assert.step("resolved " + x);
+        });
+        assert.verifySteps([]);
+        callback();
+        assert.verifySteps(["myFunc"]);
+        await Promise.resolve(); // wait for promise returned by myFunc
+        await Promise.resolve(); // wait for promise returned by debounce
+
+        assert.verifySteps(["resolved 42"]);
+    });
+
+    QUnit.test("debounce with immediate", async function (assert) {
+        patchWithCleanup(browser, {
+            setTimeout: (later) => {
+                later();
+            },
+        });
+        const myFunc = () => {
+            assert.step("myFunc");
+            return 42;
+        };
+        const myDebouncedFunc = debounce(myFunc, 3000, true);
+        myDebouncedFunc().then((x) => {
+            assert.step("resolved " + x);
+        });
+        assert.verifySteps(["myFunc"]);
+        await Promise.resolve(); // wait for promise returned by myFunc
+        await Promise.resolve(); // wait for promise returned by debounce
+
+        assert.verifySteps(["resolved 42"]);
     });
 });


### PR DESCRIPTION
Before this commit, if a user does a search and press enter before the commands
are loaded, then the wrong command will be executed.
So we will wait for the commands to be loaded before executing the right command.

Solves the navigation problems with the arrows in the command palette on firefox.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
