### PR TITLE
[FIX] website: Fix top padding with sidebar header

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -141,7 +141,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
      * @private
      */
     _updateMainPaddingTop: function () {
-        this.headerHeight = this.$el.outerHeight();
+        this.headerHeight = this.el.classList.contains('o_header_sidebar') ? 0 : this.$el.outerHeight();
         this.topGap = this._computeTopGap();
 
         if (this.isOverlayHeader) {


### PR DESCRIPTION
Steps to follow

  - Install the treehouse theme
  - On the header, use the sidebar template
  - Put some content on the website in order to have a scrollbar
  -> A padding is added on top of the main element, even though the
  header is on the side

Solution

  If the header is a sidebar, don't add a top padding

opw-2511087