### PR TITLE
[FIX] pos_adyen: Retry automatically to get last status

### DIFF
--- a/addons/pos_adyen/static/src/js/payment_adyen.js
+++ b/addons/pos_adyen/static/src/js/payment_adyen.js
@@ -28,7 +28,7 @@ var PaymentAdyen = PaymentInterface.extend({
     _reset_state: function () {
         this.was_cancelled = false;
         this.last_diagnosis_service_id = false;
-        this.remaining_polls = 2;
+        this.remaining_polls = 4;
         clearTimeout(this.polling);
     },
 
@@ -190,9 +190,13 @@ var PaymentAdyen = PaymentInterface.extend({
             timeout: 5000,
             shadow: true,
         }).catch(function (data) {
-            reject();
-            self.poll_error_order = self.pos.get_order();
-            return self._handle_odoo_connection_failure(data);
+            if (self.remaining_polls != 0) {
+                self.remaining_polls--;
+            } else {
+                reject();
+                self.poll_error_order = self.pos.get_order();
+                return self._handle_odoo_connection_failure(data);
+            }
         }).then(function (status) {
             var notification = status.latest_response;
             var last_diagnosis_service_id = status.last_received_diagnosis_id;


### PR DESCRIPTION
When making a payment intent from Adyen terminal with the POS, the payment intent was validated by Adyen
but Odoo stopped polling because a connection failure happened.

With this fix we use the remaining_polls already implemented to get the adyen status with a interval of 3 secondes.
If after 3 tries of 3 seconds each it still fails we can retry manually.
Related to dcb1e2b4823c917f4c547d2cad604187f893948d and f83d1b13a96f8df559918b5905b949009d2ece88

opw:2587625

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
