### PR TITLE
[FIX] sale_mrp: MO link missing with 3steps manufacture

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -89,7 +89,11 @@ class StockRule(models.Model):
                 # Create now the procurement group that will be assigned to the new MO
                 # This ensure that the outgoing move PostProduction -> Stock is linked to its MO
                 # rather than the original record (MO or SO)
-                procurement.values['group_id'] = self.env["procurement.group"].create({'name': name})
+                group = procurement.values.get('group_id')
+                if group:
+                    procurement.values['group_id'] = group.copy({'name': name})
+                else:
+                    procurement.values['group_id'] = self.env["procurement.group"].create({'name': name})
         return super()._run_pull(procurements)
 
     def _get_custom_move_fields(self):


### PR DESCRIPTION
- Storable product with MTO and manufacture route;
- On your warehouse set 3 steps manufacture
- Create a SO for this product > Confirm

The smart button linking the Manufacturing order does not appear on
the MO.

opw-2634309

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
