### PR TITLE
[FIX] website: keep configurator images on theme switch

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -450,13 +450,20 @@ class Website(models.Model):
                 except Exception as e:
                     logger.warning("Failed to download image: %s.\n%s", url, e)
                 else:
-                    self.env['ir.attachment'].create({
+                    attachment = self.env['ir.attachment'].create({
                         'name': name,
                         'website_id': website.id,
                         'key': name,
                         'type': 'binary',
                         'raw': response.content,
                         'public': True,
+                    })
+                    self.env['ir.model.data'].create({
+                        'name': 'configurator_%s_%s' % (website.id, name.split('.')[1]),
+                        'module': 'website',
+                        'model': 'ir.attachment',
+                        'res_id': attachment.id,
+                        'noupdate': True,
                     })
 
         website = self.get_current_website()


### PR DESCRIPTION
On theme switch default images of the previous theme are replaced
by the one of the new theme. For website where default images
come from the configurator we don't want them to be replaced by
the theme's images.

task-2614840

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
