### PR TITLE
[FIX] stock*, mrp: product as default type

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -51,9 +51,9 @@
                     <group>
                         <group>
                             <field name="active" invisible="1"/>
-                            <field name="product_tmpl_id" context="{'default_type': 'product'}"/>
+                            <field name="product_tmpl_id" context="{'default_detailed_type': 'product'}"/>
                             <field name="product_uom_category_id" invisible="1"/>
-                            <field name="product_id" groups="product.group_product_variant" context="{'default_type': 'product'}"/>
+                            <field name="product_id" groups="product.group_product_variant" context="{'default_detailed_type': 'product'}"/>
                             <label for="product_qty" string="Quantity"/>
                             <div class="o_row">
                                 <field name="product_qty"/>
@@ -83,7 +83,7 @@
                                 <tree string="Components" editable="bottom">
                                     <field name="company_id" invisible="1"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="product_id" context="{'default_type': 'product'}"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}"/>
                                     <field name="product_tmpl_id" invisible="1"/>
                                     <button name="action_see_attachments" type="object" icon="fa-files-o" aria-label="Product Attachments" title="Product Attachments" class="float-right oe_read_only"/>
                                     <field name="attachments_count" class="text-left oe_read_only"
@@ -117,7 +117,7 @@
                                     <field name="company_id" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="product_id" context="{'default_type': 'product'}"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}"/>
                                     <field name="product_qty"/>
                                     <field name="product_uom_id" groups="uom.group_uom"/>
                                     <field name="cost_share" optional="hide"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -162,7 +162,7 @@
                             <field name="use_create_components_lots" invisible="1"/>
                             <field name="show_lot_ids" invisible="1"/>
                             <field name="product_tracking" invisible="1"/>
-                            <field name="product_id" context="{'default_type': 'product'}" attrs="{'readonly': [('state', '!=', 'draft')]}" default_focus="1"/>
+                            <field name="product_id" context="{'default_detailed_type': 'product'}" attrs="{'readonly': [('state', '!=', 'draft')]}" default_focus="1"/>
                             <field name="product_tmpl_id" invisible="1"/>
                             <field name="forecasted_issue" invisible="1"/>
                             <field name="product_description_variants" attrs="{'invisible': [('product_description_variants', 'in', (False, ''))], 'readonly': [('state', '!=', 'draft')]}"/>
@@ -240,7 +240,7 @@
                                 context="{'default_date': date_planned_start, 'default_date_deadline': date_deadline, 'default_location_id': location_src_id, 'default_location_dest_id': production_location_id, 'default_state': 'draft', 'default_raw_material_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}"
                                 attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" editable="bottom">
-                                    <field name="product_id" force_save="1" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '|', ('move_lines_count', '&gt;', 0), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
+                                    <field name="product_id" force_save="1" required="1" context="{'default_detailed_type': 'product'}" attrs="{'readonly': ['|', '|', ('move_lines_count', '&gt;', 0), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
                                     <field name="location_id" string="From" readonly="1" groups="stock.group_stock_multi_locations" optional="show"/>
                                     <field name="move_line_ids" invisible="1">
                                         <tree>
@@ -319,7 +319,7 @@
                             <field name="move_byproduct_ids" context="{'default_date': date_planned_finished, 'default_date_deadline': date_deadline, 'default_location_id': production_location_id, 'default_location_dest_id': location_src_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" decoration-muted="is_done" editable="bottom">
                                     <field name="byproduct_id" invisible="1"/>
-                                    <field name="product_id" context="{'default_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
                                     <field name="location_dest_id" string="To" readonly="1" groups="stock.group_stock_multi_locations"/>
 
                                     <field name="move_line_ids" invisible="1">

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -52,7 +52,7 @@
             <field name="res_model">product.template</field>
             <field name="search_view_id" ref="mrp_product_template_search_view"/>
             <field name="view_mode">kanban,tree,form</field>
-            <field name="context">{"search_default_consumable": 1, 'default_type': 'product'}</field>
+            <field name="context">{"search_default_consumable": 1, 'default_detailed_type': 'product'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 No product found. Let's create one!

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -457,7 +457,7 @@
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="search_view_id" ref="product_template_search_form_view_stock"/>
-        <field name="context">{"search_default_consumable": 1, 'default_type': 'product'}</field>
+        <field name="context">{"search_default_consumable": 1, 'default_detailed_type': 'product'}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No product found. Let's create one!

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -248,7 +248,7 @@
             <field name="priority">1000</field>
             <field name="arch" type="xml">
                 <tree editable="bottom" decoration-muted="(state == 'done' and is_locked == True)" decoration-danger="qty_done&gt;product_uom_qty and state!='done' and parent.picking_type_code != 'incoming'" decoration-success="qty_done==product_uom_qty and state!='done' and not result_package_id">
-                    <field name="product_id" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', ('state', '=', 'done'), ('move_id', '!=', False)]}"/>
+                    <field name="product_id" required="1" context="{'default_detailed_type': 'product'}" attrs="{'readonly': ['|', ('state', '=', 'done'), ('move_id', '!=', False)]}"/>
                     <field name="company_id" invisible="1"/>
                     <field name="move_id" invisible="1"/>
                     <field name="picking_id" invisible="1"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -372,7 +372,7 @@
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <field name="has_tracking" invisible="1"/>
                                     <field name="display_assign_serial" invisible="1"/>
-                                    <field name="product_id" required="1" context="{'default_type': 'product'}" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('move_lines_count', '&gt;', 0)]}"/>
+                                    <field name="product_id" required="1" context="{'default_detailed_type': 'product'}" attrs="{'readonly': ['|', '&amp;', ('state', '!=', 'draft'), ('additional', '=', False), ('move_lines_count', '&gt;', 0)]}"/>
                                     <field name="description_picking" string="Description" optional="hide"/>
                                     <field name="date" invisible="1"/>
                                     <field name="date_deadline" optional="hide"/>

--- a/addons/stock/views/stock_production_lot_views.xml
+++ b/addons/stock/views/stock_production_lot_views.xml
@@ -31,7 +31,7 @@
                 </div>
                 <group name="main_group">
                     <group>
-                        <field name="product_id" context="{'default_type': 'product', 'default_tracking': 'lot'}" readonly="context.get('set_product_readonly', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
+                        <field name="product_id" context="{'default_detailed_type': 'product', 'default_tracking': 'lot'}" readonly="context.get('set_product_readonly', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
                         <label for="product_qty" attrs="{'invisible': [('display_complete', '=', False)]}"/>
                         <div class="o_row" attrs="{'invisible': [('display_complete', '=', False)]}">
                             <field name="product_qty"/>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -46,7 +46,7 @@
                         </div>
                         <group>
                             <group>
-                                <field name="product_id" context="{'default_type': 'product'}"/>
+                                <field name="product_id" context="{'default_detailed_type': 'product'}"/>
                                 <label for="scrap_qty"/>
                                 <div class="o_row">
                                     <field name="scrap_qty"/>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -65,7 +65,7 @@
                                     <tree string="Cost Lines" editable="bottom">
                                         <field name="product_id"
                                             domain="[('landed_cost_ok', '=', True)]"
-                                            context="{'default_landed_cost_ok': True, 'default_type': 'service'}"/>
+                                            context="{'default_landed_cost_ok': True, 'default_detailed_type': 'service'}"/>
                                         <field name="name"/>
                                         <field name="account_id" options="{'no_create': True}"/>
                                         <field name="split_method"/>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -60,7 +60,7 @@
             <tree editable="top" decoration-muted="state == 'cancel'" string="Move Lines" default_order="location_id">
                 <field name="tracking" invisible="1"/>
                 <field name="state" invisible="1"/>
-                <field name="product_id" context="{'default_type': 'product'}" required="1" attrs="{'readonly': [('id', '!=', False)]}"/>
+                <field name="product_id" context="{'default_detailed_type': 'product'}" required="1" attrs="{'readonly': [('id', '!=', False)]}"/>
                 <field name="picking_id" required="1" attrs="{'readonly': [('id', '!=', False)]}"
                     options="{'no_create_edit': True}" domain="[('id', 'in', parent.picking_ids)]"/>
                 <field name="lot_id" groups="stock.group_production_lot" attrs="{'readonly': [('tracking', 'not in', ['lot', 'serial'])]}"/>


### PR DESCRIPTION
commit #fa034b2a646d9bc761246db62f9e96d565671ce8
added a new detailed_type instead of type on product.

default_type is now the basic field in the view so all the default_type
are not working anymore in the views

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
