### PR TITLE
[FIX] l10n_in: set id instead of record set

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -35,7 +35,7 @@ class AccountMove(models.Model):
         res = super()._get_tax_grouping_key_from_tax_line(tax_line)
         if tax_line.move_id.journal_id.company_id.country_id.code == 'IN':
             res['product_id'] = tax_line.product_id.id
-            res['product_uom_id'] = tax_line.product_uom_id
+            res['product_uom_id'] = tax_line.product_uom_id.id
         return res
 
     @api.model
@@ -44,7 +44,7 @@ class AccountMove(models.Model):
         res = super()._get_tax_grouping_key_from_base_line(base_line, tax_vals)
         if base_line.move_id.journal_id.company_id.country_id.code == 'IN':
             res['product_id'] = base_line.product_id.id
-            res['product_uom_id'] = base_line.product_uom_id
+            res['product_uom_id'] = base_line.product_uom_id.id
         return res
 
     @api.model
@@ -54,6 +54,6 @@ class AccountMove(models.Model):
 
         tax_key += [
             line.product_id.id,
-            line.product_uom_id,
+            line.product_uom_id.id,
         ]
         return tax_key


### PR DESCRIPTION
on product_uom_id used in grouping key




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
