### PR TITLE
[FIX] calendar : Server error when mark a scheduled activity as done

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -36,7 +36,7 @@ class MailActivity(models.Model):
                 description = event.description
                 description = '%s<br />%s' % (
                     description if not tools.is_html_empty(description) else '',
-                    _('Feedback: %(feedback)s', tools.plaintext2html(feedback)) if feedback else '',
+                    _('Feedback: %(feedback)s', feedback=tools.plaintext2html(feedback)) if feedback else '',
                 )
                 event.write({'description': description})
         return messages, activities


### PR DESCRIPTION
Reproduce :
- CRM.
- Go to a task and schedule next activity.
- Then mark this activity as done.
- Write a feedback.

Result :
- Server error traceback

Solution :
- The written feedback is given as a kwarg to translate.

opw-2641747

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
