### PR TITLE
[FIX] crm: disable hazardous tests in lead assignment

### DIFF
--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -54,7 +54,7 @@ class TestLeadAssignCommon(TestLeadConvertCommon):
         self.assertEqual(self.sales_team_convert_m2.lead_month_count, 0)
 
 
-@tagged('lead_assign')
+@tagged('lead_assign', '-standard')
 class TestLeadAssign(TestLeadAssignCommon):
     """ Test lead assignment feature added in saas-14.2 """
 


### PR DESCRIPTION
Some tests in this test class are leading to uncertain results and fails
randomly.

With this commit, the whole test class is deactivated until a fix is found.

