### PR TITLE
[IMP] website_sale: add choice for default sort type in website editor

### DIFF
--- a/addons/website/views/snippets/s_searchbar.xml
+++ b/addons/website/views/snippets/s_searchbar.xml
@@ -36,7 +36,6 @@
             </we-select>
             <we-select string="Order by" data-name="order_opt" data-attribute-name="orderBy" data-apply-to=".search-query">
                 <we-button data-set-order-by="name asc" data-select-data-attribute="name asc" data-name="order_name_asc_opt">Name (A-Z)</we-button>
-                <we-button data-set-order-by="name desc" data-select-data-attribute="name desc" data-name="order_name_desc_opt">Name (Z-A)</we-button>
             </we-select>
             <t t-set="unit">results</t>
             <we-input string="Suggestions" data-name="limit_opt" data-attribute-name="limit"

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -48,6 +48,17 @@ class Website(models.Model):
     shop_ppg = fields.Integer(default=20, string="Number of products in the grid on the shop")
     shop_ppr = fields.Integer(default=4, string="Number of grid columns on the shop")
 
+    @staticmethod
+    def _get_product_sort_mapping():
+        return [
+            ('website_sequence asc', 'Featured'),
+            ('create_date desc', 'Newest Arrivals'),
+            ('name asc', 'Name (A-Z)'),
+            ('list_price asc', 'Price - Low to High'),
+            ('list_price desc', 'Price - High to Low'),
+        ]
+    shop_default_sort = fields.Selection(selection='_get_product_sort_mapping', default='website_sequence asc', required=True)
+
     shop_extra_field_ids = fields.One2many('website.sale.extra.field', 'website_id', string='E-Commerce Extra Fields')
 
     cart_add_on_page = fields.Boolean("Stay on page after adding to cart", default=True)

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -285,6 +285,7 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
     start: function () {
         this.ppg = parseInt(this.$target.closest('[data-ppg]').data('ppg'));
         this.ppr = parseInt(this.$target.closest('[data-ppr]').data('ppr'));
+        this.default_sort = this.$target.closest('[data-default-sort]').data('default-sort');
         return this._super.apply(this, arguments);
     },
     /**
@@ -309,7 +310,7 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
         }
         this.ppg = ppg;
         return this._rpc({
-            route: '/shop/change_ppg',
+            route: '/shop/config/website',
             params: {
                 'ppg': ppg,
             },
@@ -321,9 +322,21 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
     setPpr: function (previewMode, widgetValue, params) {
         this.ppr = parseInt(widgetValue);
         this._rpc({
-            route: '/shop/change_ppr',
+            route: '/shop/config/website',
             params: {
                 'ppr': this.ppr,
+            },
+        }).then(reload);
+    },
+    /**
+     * @see this.selectClass for params
+     */
+    setDefaultSort: function (previewMode, widgetValue, params) {
+        this.default_sort = widgetValue;
+        this._rpc({
+            route: '/shop/config/website',
+            params: {
+                'default_sort': this.default_sort,
             },
         }).then(reload);
     },
@@ -342,6 +355,9 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
             }
             case 'setPpr': {
                 return this.ppr;
+            }
+            case 'setDefaultSort': {
+                return this.default_sort;
             }
         }
         return this._super(...arguments);
@@ -518,9 +534,9 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
      */
     changeSequence: function (previewMode, widgetValue, params) {
         this._rpc({
-            route: '/shop/change_sequence',
+            route: '/shop/config/product',
             params: {
-                id: this.productTemplateID,
+                product_id: this.productTemplateID,
                 sequence: widgetValue,
             },
         }).then(reload);
@@ -690,9 +706,9 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         var x = $td.index() + 1;
         var y = $td.parent().index() + 1;
         this._rpc({
-            route: '/shop/change_size',
+            route: '/shop/config/product',
             params: {
-                id: this.productTemplateID,
+                product_id: this.productTemplateID,
                 x: x,
                 y: y,
             },

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -18,6 +18,11 @@
                 <we-button data-set-ppr="3">3</we-button>
                 <we-button data-set-ppr="4">4</we-button>
             </we-select>
+            <we-select string="Default Sort" class="o_wsale_sort_submenu" data-no-preview="true">
+                <t t-foreach="request.env['website']._get_product_sort_mapping()" t-as="query_and_label">
+                    <we-button t-att-data-set-default-sort="query_and_label[0]"><t t-esc="query_and_label[1]"/></we-button>
+                </t>
+            </we-select>
         </div>
 
         <div data-js="WebsiteSaleProductsItem"
@@ -96,9 +101,10 @@
         <we-button data-set-search-type="products" data-select-data-attribute="products" data-name="search_products_opt" data-form-action="/shop">Products</we-button>
     </xpath>
     <xpath expr="//div[@data-js='SearchBar']/we-select[@data-name='order_opt']" position="inside">
-        <we-button data-set-order-by="list_price asc" data-select-data-attribute="list_price asc" data-dependencies="search_products_opt" data-name="order_price_asc_opt">Price (low to high)</we-button>
-        <we-button data-set-order-by="list_price desc" data-select-data-attribute="list_price desc" data-dependencies="search_products_opt" data-name="order_price_desc_opt">Price (high to low)</we-button>
-        <we-button data-set-order-by="website_sequence asc" data-select-data-attribute="website_sequence asc" data-dependencies="search_products_opt" data-name="order_sequence_asc_opt">Sequence</we-button>
+        <t t-foreach="request.env['website']._get_product_sort_mapping()" t-as="query_and_label">
+            <!-- name asc is already part of the general sorting methods of this snippet. -->
+            <we-button t-if="query_and_label[0] != 'name asc'" t-att-data-set-order-by="query_and_label[0]" t-att-data-select-data-attribute="query_and_label[0]" data-dependencies="search_products_opt"><t t-out="query_and_label[1]"/></we-button>
+        </t>
     </xpath>
     <xpath expr="//div[@data-js='SearchBar']/div[@data-dependencies='limit_opt']" position="inside">
         <we-checkbox string="Description" data-dependencies="search_products_opt" data-select-data-attribute="true" data-attribute-name="displayDescription"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -281,7 +281,7 @@
                                 <div class="mb16" id="category_header" t-att-data-editor-message="editor_msg" t-field="category.website_description"/>
                             </t>
                             <div t-if="bins" class="o_wsale_products_grid_table_wrapper">
-                                <table class="table table-borderless m-0" t-att-data-ppg="ppg" t-att-data-ppr="ppr">
+                                <table class="table table-borderless m-0" t-att-data-ppg="ppg" t-att-data-ppr="ppr" t-att-data-default-sort="website.shop_default_sort">
                                     <colgroup t-ignore="true">
                                         <!-- Force the number of columns (useful when only one row of (x < ppr) products) -->
                                         <col t-foreach="ppr" t-as="p"/>
@@ -342,34 +342,25 @@
 
     <template id="sort" inherit_id="website_sale.products" customize_show="True" name="Show Sort by">
         <xpath expr="//div[hasclass('products_header')]/t[@t-call='website_sale.pricelist_list']" position="after">
-            <t t-set="list_price_asc_label">Price - Low to High</t>
-            <t t-set="list_price_desc_label">Price - High to Low</t>
-            <t t-set="newest_arrivals_desc_label">Newest arrivals</t>
-            <t t-set="name_asc_label">Name</t>
-            <t t-set="website_sale_sortable" t-value="[
-                (list_price_asc_label, 'list_price asc'),
-                (list_price_desc_label, 'list_price desc'),
-                (newest_arrivals_desc_label, 'create_date desc'),
-                (name_asc_label, 'name asc')
-            ]"/>
-            <t t-set="website_sale_sortable_current" t-value="[sort for sort in website_sale_sortable if sort[1]==request.params.get('order', '')]"/>
+            <t t-set="website_sale_sortable" t-value="website._get_product_sort_mapping()"/>
+            <t t-set="website_sale_sortable_current" t-value="[sort for sort in website_sale_sortable if sort[0]==request.params.get('order', '')]"/>
             <div class="o_sortby_dropdown dropdown dropdown_sorty_by ml-3 pb-2">
                 <span class="d-none d-lg-inline font-weight-bold text-muted">Sort By:</span>
                 <a role="button" href="#" class="dropdown-toggle btn btn-light border-0 px-0 text-muted align-baseline" data-toggle="dropdown">
                     <span class="d-none d-lg-inline">
                         <t t-if='website_sale_sortable_current'>
-                            <t t-esc="website_sale_sortable_current[0][0]"/>
+                            <t t-esc="website_sale_sortable_current[0][1]"/>
                         </t>
                         <t t-else='1'>
-                            Featured
+                            <span t-field="website.shop_default_sort"/>
                         </t>
                     </span>
                     <i class="fa fa-sort-amount-asc d-lg-none"/>
                 </a>
                 <div class="dropdown-menu dropdown-menu-right" role="menu">
                     <t t-foreach="website_sale_sortable" t-as="sortby">
-                        <a role="menuitem" rel="noindex,nofollow" t-att-href="keep('/shop', order=sortby[1])" class="dropdown-item">
-                            <span t-out="sortby[0]"/>
+                        <a role="menuitem" rel="noindex,nofollow" t-att-href="keep('/shop', order=sortby[0])" class="dropdown-item">
+                            <span t-out="sortby[1]"/>
                         </a>
                     </t>
                 </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
It is impossible to define the default order in which to display 
products in the shop page. The order can be changed through the
"Sort By" dropdown, but it is reset every time the page is refreshed.

**Desired behavior after PR is merged:**
There is now an option in the website editor that allows setting a
default sorting method that is applied when displaying products.
It is overridden by the setting from the "Sort By" dropdown if
there is a different sorting method selected.

task-2616245