### PR TITLE
[FIX] base: use context_today as default rate name

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -245,7 +245,7 @@ class CurrencyRate(models.Model):
     _order = "name desc"
 
     name = fields.Date(string='Date', required=True, index=True,
-                           default=lambda self: fields.Date.today())
+                           default=fields.Date.context_today)
     rate = fields.Float(digits=(12, 6), default=1.0, help='The rate of the currency to the currency of rate 1')
     currency_id = fields.Many2one('res.currency', string='Currency', readonly=True)
     company_id = fields.Many2one('res.company', string='Company',


### PR DESCRIPTION
Suppose the TZ is UTC+12 and a user creates a new rate in the morning:
the date will be the day before

The default date should consider the user's timezone.

OPW-2590972