### PR TITLE
[FIX] base: en_GB, week_start: Monday

### DIFF
--- a/doc/cla/individual/innovara.md
+++ b/doc/cla/individual/innovara.md
@@ -1,0 +1,11 @@
+United Kingdom, 2021-09-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Manuel Fombuena mfombuena@innovara.co.uk https://github.com/innovara

--- a/odoo/addons/base/data/res.lang.csv
+++ b/odoo/addons/base/data/res.lang.csv
@@ -18,7 +18,7 @@
 "base.lang_nl","Dutch / Nederlands","nl_NL","nl","Left-to-Right","[3,0]",",",".","%d-%m-%Y","%H:%M:%S","1"
 "base.lang_en_AU","English (AU)","en_AU","en_AU","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%H:%M:%S","7"
 "base.lang_en_CA","English (CA)","en_CA","en_CA","Left-to-Right","[3,0]",".",",","%Y-%m-%d","%H:%M:%S","7"
-"base.lang_en_GB","English (UK)","en_GB","en_GB","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%H:%M:%S","7"
+"base.lang_en_GB","English (UK)","en_GB","en_GB","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%H:%M:%S","1"
 "base.lang_en_IN","English (IN)","en_IN","en_IN","Left-to-Right","[3,2,0]",".",",","%d/%m/%Y","%H:%M:%S","7"
 "base.lang_et_EE","Estonian / Eesti keel","et_EE","et","Left-to-Right","[3,0]",","," ","%d.%m.%Y","%H:%M:%S","1"
 "base.lang_fi","Finnish / Suomi","fi_FI","fi","Left-to-Right","[3,0]",","," ","%d.%m.%Y","%H.%M.%S","1"


### PR DESCRIPTION
Monday is commonly accepted as the first day of the week in the UK.

Listed as first option on https://www.unicode.org/cldr/cldr-aux/charts/29/supplemental/territory_information.html#GB with Sunday as an alternative.
All mayor OS (Windows, Mac, iOS) use Monday as the first day of the week when the locale en_GB is used.

Description of the issue/feature this PR addresses: uncommon first day of the week for en_GB

Current behavior before PR: Sunday is selected as first day of the week

Desired behavior after PR is merged: Monday becomes first day of the week for en_GB