### PR TITLE
[FIX] google_calendar: send correct datetime for events in recurrences

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -16,6 +16,7 @@
     % set customer = object.event_id.find_partner_customer()
     % set target_responsible = object.partner_id == object.event_id.partner_id
     % set target_customer = object.partner_id == customer
+    % set recurrent = object.recurrence_id and not ctx.get('calendar_template_ignore_recurrence')
     <p>
         Hello ${object.common_name},<br/><br/>
 
@@ -142,6 +143,7 @@
     % set customer = object.event_id.find_partner_customer()
     % set target_responsible = object.partner_id == object.event_id.partner_id
     % set target_customer = object.partner_id == customer
+    % set recurrent = object.recurrence_id and not ctx.get('calendar_template_ignore_recurrence')
     <p>
         Hello ${object.common_name},<br/><br/>
         % if is_online and target_responsible:

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -203,9 +203,8 @@ class Meeting(models.Model):
             start = {'date': self.start_date.isoformat()}
             end = {'date': (self.stop_date + relativedelta(days=1)).isoformat()}
         else:
-            event_tz = self.event_tz or 'Etc/UTC'
-            start = {'dateTime': self.start.isoformat(), 'timeZone': event_tz}
-            end = {'dateTime': self.stop.isoformat(), 'timeZone': event_tz}
+            start = {'dateTime': pytz.utc.localize(self.start).isoformat()}
+            end = {'dateTime': pytz.utc.localize(self.stop).isoformat()}
         reminders = [{
             'method': "email" if alarm.alarm_type == "email" else "popup",
             'minutes': alarm.duration_minutes


### PR DESCRIPTION
Before this commit, when an recurrence was created in Odoo, the start and stop datetime were incorrectly set.
They were not properly localized. The UTC datetime were saved as local datetime. Therefore google would save the incorrect value and send them back to Odoo.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
