### PR TITLE
[FIX] mail: disallow editing/deletion of tracking messages

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1900,6 +1900,8 @@ class MailThread(models.AbstractModel):
         note_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
         if not message.subtype_id.id == note_id:
             raise exceptions.UserError(_("Only logged notes can have their content updated on model '%s'", self._name))
+        if message.tracking_value_ids:
+            raise exceptions.UserError(_("Messages with tracking values cannot be modified"))
 
     # ------------------------------------------------------
     # MESSAGE POST TOOLS

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -328,6 +328,9 @@ function factory(dependencies) {
             if (!this.originThread) {
                 return false;
             }
+            if (this.tracking_value_ids.length > 0) {
+                return false;
+            }
             if (this.originThread.model === 'mail.channel') {
                 return this.message_type === 'comment';
             }


### PR DESCRIPTION
While only notes can be deleted on threads, some tracking messages are
created with the type "notification", some messages are created as
notes. This commit prevents deletion and editing of messages that have
tracking values, as they are invaluable for traceability and not
user-created.