### PR TITLE
[FIX] link_tracker: use specific site url

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -68,12 +68,12 @@ class LinkTracker(models.Model):
     @api.depends('code')
     def _compute_short_url(self):
         for tracker in self:
-            base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
-            tracker.short_url = urls.url_join(base_url, '/r/%(code)s' % {'code': tracker.code})
+            tracker.short_url = urls.url_join(tracker.short_url_host, '%(code)s' % {'code': tracker.code})
 
     def _compute_short_url_host(self):
         for tracker in self:
-            tracker.short_url_host = self.env['ir.config_parameter'].sudo().get_param('web.base.url') + '/r/'
+            base_url = tracker.get_base_url()
+            tracker.short_url_host = urls.url_join(base_url, '/r/')
 
     def _compute_code(self):
         for tracker in self:

--- a/addons/website_links/models/link_tracker.py
+++ b/addons/website_links/models/link_tracker.py
@@ -3,6 +3,9 @@
 
 from odoo import models, _
 
+from werkzeug import urls
+
+
 class LinkTracker(models.Model):
     _inherit = ['link.tracker']
 
@@ -13,3 +16,8 @@ class LinkTracker(models.Model):
             'url': '%s+' % (self.short_url),
             'target': 'new',
         }
+
+    def _compute_short_url_host(self):
+        for tracker in self:
+            base_url = self.env['website'].get_current_website().get_base_url()
+            tracker.short_url_host = urls.url_join(base_url, '/r/')


### PR DESCRIPTION
- Create 3 websites and set a website domain for each
- Install the website_links module
- Go to Website > Configuration > Settings
- Select the website 3
- Go to website
- Menu Promote > Link tracking

The URL field uses the domain you are logged into the database
rather than the domain of the active website

opw-2638494

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
