### PR TITLE
[FIX] point_of_sale: allow to download repo info

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -22,7 +22,7 @@ source ~/.bashrc
 
 apt-mark hold firmware-brcm80211
 # upgrade firmware-brcm80211 broke access point on rpi4
-apt-get update && apt-get -y upgrade
+apt-get update --allow-releaseinfo-change-suite && apt-get -y upgrade
 # Do not be too fast to upgrade to more recent firmware and kernel than 4.38
 # Firmware 4.44 seems to prevent the LED mechanism from working
 


### PR DESCRIPTION
if suite changed from stable to oldstable

closes #76224

Description of the issue/feature this PR addresses: while building pos image apt update command refuses to download repository image because suite change.

Current behavior before PR: unable to build pos image

Desired behavior after PR is merged: able to build pos image




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
