### PR TITLE
[FIX] mail: remove guest inaccessible features from the UI

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -70,6 +70,7 @@
             'web/static/src/legacy/scss/bootstrap_review.scss',
             'web/static/src/webclient/webclient.scss',
             'web/static/src/webclient/webclient_extra.scss',
+            'web/static/src/core/utils/*.scss',
             # Dependency of notification_group, notification_request, thread_needaction_preview and thread_preview
             'mail/static/src/components/notification_list/notification_list_item.scss',
             'mail/static/src/component_hooks/*/*.js',
@@ -90,7 +91,7 @@
             'bus/static/src/js/services/bus_service.js',
             'web/static/lib/luxon/luxon.js',
             'web/static/lib/py.js/lib/py.js',
-            'web/static/src/core/**/*.js',
+            'web/static/src/core/**/*',
             ('remove', 'web/static/src/core/debug/**/*.[js][scss]'),
             'web/static/src/env.js',
             'web/static/src/legacy/js/_deprecated/basic_fields.js',

--- a/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.xml
+++ b/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.xml
@@ -4,58 +4,60 @@
     <t t-name="mail.ChannelInvitationForm" owl="1">
         <div class="o_ChannelInvitationForm d-flex flex-column" t-ref="channelInvitationForm">
             <h3 class="mx-3 mt-3 mb-2">Invite people</h3>
-            <div class="mx-3 my-2">
-                <input class="o_ChannelInvitationForm_searchInput" type="text" t-att-value="channelInvitationForm.searchTerm" placeholder="Type the name of a person" t-on-input="channelInvitationForm.onInputSearch" t-ref="searchInput"/>
-            </div>
-            <div class="d-flex flex-column flex-grow-1 mx-0 py-2 overflow-auto">
-                <t t-foreach="channelInvitationForm.selectablePartners" t-as="selectablePartner" t-key="selectablePartner.localId">
-                    <div class="o_ChannelInvitationForm_selectablePartner d-flex align-items-center px-3 py-1" t-on-click="channelInvitationForm.onClickSelectablePartner.bind(channelInvitationForm, selectablePartner)" t-att-data-partner-id="selectablePartner.id">
-                        <div class="o_ChannelInvitationForm_selectablePartnerAvatarContainer flex-shrink-0 position-relative">
-                            <img class="o_ChannelInvitationForm_selectablePartnerAvatar w-100 h-100 rounded-circle" t-att-src="selectablePartner.avatarUrl" alt="Avatar"/>
-                            <t t-if="selectablePartner.im_status and selectablePartner.im_status !== 'im_partner'">
-                                <PartnerImStatusIcon
-                                    class="o_ChannelInvitationForm_selectablePartnerImStatusIcon d-flex align-items-center justify-content-center text-white"
-                                    t-att-class="{
-                                        'o_ChannelInvitationForm_selectablePartnerImStatusIcon-mobile': messaging.device.isMobile,
-                                    }"
-                                    partnerLocalId="selectablePartner.localId"
-                                />
+            <t t-if="!messaging.isCurrentUserGuest">
+                <div class="mx-3 my-2">
+                    <input class="o_ChannelInvitationForm_searchInput" type="text" t-att-value="channelInvitationForm.searchTerm" placeholder="Type the name of a person" t-on-input="channelInvitationForm.onInputSearch" t-ref="searchInput"/>
+                </div>
+                <div class="d-flex flex-column flex-grow-1 mx-0 py-2 overflow-auto">
+                    <t t-foreach="channelInvitationForm.selectablePartners" t-as="selectablePartner" t-key="selectablePartner.localId">
+                        <div class="o_ChannelInvitationForm_selectablePartner d-flex align-items-center px-3 py-1" t-on-click="channelInvitationForm.onClickSelectablePartner.bind(channelInvitationForm, selectablePartner)" t-att-data-partner-id="selectablePartner.id">
+                            <div class="o_ChannelInvitationForm_selectablePartnerAvatarContainer flex-shrink-0 position-relative">
+                                <img class="o_ChannelInvitationForm_selectablePartnerAvatar w-100 h-100 rounded-circle" t-att-src="selectablePartner.avatarUrl" alt="Avatar"/>
+                                <t t-if="selectablePartner.im_status and selectablePartner.im_status !== 'im_partner'">
+                                    <PartnerImStatusIcon
+                                        class="o_ChannelInvitationForm_selectablePartnerImStatusIcon d-flex align-items-center justify-content-center text-white"
+                                        t-att-class="{
+                                            'o_ChannelInvitationForm_selectablePartnerImStatusIcon-mobile': messaging.device.isMobile,
+                                        }"
+                                        partnerLocalId="selectablePartner.localId"
+                                    />
+                                </t>
+                            </div>
+                            <div class="o_ChannelInvitationForm_selectablePartnerAvatarNameSeparator"/>
+                            <span class="o_ChannelInvitationForm_selectablePartnerName flex-grow-1 text-truncate">
+                                <t t-esc="selectablePartner.nameOrDisplayName"/>
+                            </span>
+                            <div class="o_ChannelInvitationForm_selectablePartnerNameSelectionSeparator flex-grow-1 flex-shrink-0"/>
+                            <input class="o_ChannelInvitationForm_selectablePartnerCheckbox flex-shrink-0" type="checkbox" t-att-checked="channelInvitationForm.selectedPartners.includes(selectablePartner) ? 'checked' : undefined" t-on-input="channelInvitationForm.onInputPartnerCheckbox.bind(channelInvitationForm, selectablePartner)" t-ref="selection-status"/>
+                        </div>
+                    </t>
+                    <t t-if="channelInvitationForm.selectablePartners.length === 0">
+                        <div class="mx-3">No user found that is not already a member of this channel.</div>
+                    </t>
+                    <t t-if="channelInvitationForm.searchResultCount > channelInvitationForm.selectablePartners.length">
+                        <div class="mx-3">
+                            Showing <t t-esc="channelInvitationForm.selectablePartners.length"/> results out of <t t-esc="channelInvitationForm.searchResultCount"/>. Narrow your search to see more choices.
+                        </div>
+                    </t>
+                </div>
+                <t t-if="channelInvitationForm.selectedPartners.length > 0">
+                    <div class="mx-3 mt-3">
+                        <h4>Selected users:</h4>
+                        <div class="o_ChannelInvitationForm_selectedPartners overflow-auto">
+                            <t t-foreach="channelInvitationForm.selectedPartners" t-as="selectedPartner" t-key="selectedPartner.localId">
+                                <button class="btn btn-secondary" t-on-click="channelInvitationForm.onClickSelectedPartner.bind(channelInvitationForm, selectedPartner)">
+                                    <t t-esc="selectedPartner.nameOrDisplayName"/> <i class="fa fa-times"/>
+                                </button>
                             </t>
                         </div>
-                        <div class="o_ChannelInvitationForm_selectablePartnerAvatarNameSeparator"/>
-                        <span class="o_ChannelInvitationForm_selectablePartnerName flex-grow-1 text-truncate">
-                            <t t-esc="selectablePartner.nameOrDisplayName"/>
-                        </span>
-                        <div class="o_ChannelInvitationForm_selectablePartnerNameSelectionSeparator flex-grow-1 flex-shrink-0"/>
-                        <input class="o_ChannelInvitationForm_selectablePartnerCheckbox flex-shrink-0" type="checkbox" t-att-checked="channelInvitationForm.selectedPartners.includes(selectablePartner) ? 'checked' : undefined" t-on-input="channelInvitationForm.onInputPartnerCheckbox.bind(channelInvitationForm, selectablePartner)" t-ref="selection-status"/>
                     </div>
                 </t>
-                <t t-if="channelInvitationForm.selectablePartners.length === 0">
-                    <div class="mx-3">No user found that is not already a member of this channel.</div>
-                </t>
-                <t t-if="channelInvitationForm.searchResultCount > channelInvitationForm.selectablePartners.length">
-                    <div class="mx-3">
-                        Showing <t t-esc="channelInvitationForm.selectablePartners.length"/> results out of <t t-esc="channelInvitationForm.searchResultCount"/>. Narrow your search to see more choices.
-                    </div>
-                </t>
-            </div>
-            <t t-if="channelInvitationForm.selectedPartners.length > 0">
-                <div class="mx-3 mt-3">
-                    <h4>Selected users:</h4>
-                    <div class="o_ChannelInvitationForm_selectedPartners overflow-auto">
-                        <t t-foreach="channelInvitationForm.selectedPartners" t-as="selectedPartner" t-key="selectedPartner.localId">
-                            <button class="btn btn-secondary" t-on-click="channelInvitationForm.onClickSelectedPartner.bind(channelInvitationForm, selectedPartner)">
-                                <t t-esc="selectedPartner.nameOrDisplayName"/> <i class="fa fa-times"/>
-                            </button>
-                        </t>
-                    </div>
+                <div class="mx-3 mt-2 mb-3">
+                    <button class="o_ChannelInvitationForm_inviteButton btn btn-primary w-100" t-att-disabled="channelInvitationForm.selectedPartners.length === 0" t-on-click="channelInvitationForm.onClickInvite">
+                        <t t-esc="channelInvitationForm.inviteButtonText"/>
+                    </button>
                 </div>
             </t>
-            <div class="mx-3 mt-2 mb-3">
-                <button class="o_ChannelInvitationForm_inviteButton btn btn-primary w-100" t-att-disabled="channelInvitationForm.selectedPartners.length === 0" t-on-click="channelInvitationForm.onClickInvite">
-                    <t t-esc="channelInvitationForm.inviteButtonText"/>
-                </button>
-            </div>
             <t t-if="channelInvitationForm.thread and channelInvitationForm.thread.invitationLink">
                 <h4 class="mx-3 mt-3 mb-2">Invitation Link</h4>
                 <div class="mx-3 my-2">

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.scss
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.scss
@@ -57,11 +57,11 @@
 .o_ThreadViewTopbar_threadName {
     max-width: map-get($sizes, 75);
 
-    &:not(.o-isMouseOverThreadName) {
+    &:not(.o-threadNameEditable) {
         border-color: transparent; // presence of border even if invisible to prevent flicker
     }
 
-    &.o-isMouseOverThreadName {
+    &.o-threadNameEditable {
         background-color: $white;
         border-color: $border-color;
     }
@@ -69,11 +69,11 @@
 
 .o_ThreadViewTopbar_threadDescription {
 
-    &:not(.o-isMouseOverThreadDescription) {
+    &:not(.o-threadDescriptionEditable) {
         border-color: transparent; // presence of border even if invisible to prevent flicker
     }
 
-    &.o-isMouseOverThreadDescription {
+    &.o-threadDescriptionEditable {
         background-color: $white;
         border-color: $border-color;
     }

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -67,7 +67,8 @@
                             </t>
                         </Popover>
                     </t>
-                    <t t-if="threadViewTopBar.thread and threadViewTopBar.thread.hasMemberListFeature and threadViewTopBar.threadView.hasMemberList and !threadViewTopBar.threadView.isMemberListOpened">
+                    <!-- FIXME: guests should be able to see members but there currently is no route for it, so hide it for now -->
+                    <t t-if="!messaging.isCurrentUserGuest and threadViewTopBar.thread and threadViewTopBar.thread.hasMemberListFeature and threadViewTopBar.threadView.hasMemberList and !threadViewTopBar.threadView.isMemberListOpened">
                         <button class="o_ThreadViewTopbar_showMemberListButton o_ThreadViewTopbar_button" title="Show Member List" t-on-click="threadViewTopBar.onClickShowMemberList">
                             <i class="fa fa-lg fa-users"/>
                         </button>

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -10,7 +10,7 @@
                 <div class="o_ThreadViewTopbar_title d-flex flex-grow-1 align-self-center align-items-center">
                     <t t-if="threadViewTopBar.thread">
                         <t t-if="!threadViewTopBar.isEditingThreadName">
-                            <div class="o_ThreadViewTopbar_threadName flex-shrink-0 px-1 text-truncate lead font-weight-bold" t-att-title="threadViewTopBar.thread.displayName" t-on-click="threadViewTopBar.onClickTopbarThreadName" t-on-mouseenter="threadViewTopBar.onMouseEnterTopBarThreadName" t-on-mouseleave="threadViewTopBar.onMouseLeaveTopBarThreadName" t-att-class="{ 'o-isMouseOverThreadName': threadViewTopBar.isMouseOverThreadName }">
+                            <div class="o_ThreadViewTopbar_threadName flex-shrink-0 px-1 text-truncate lead font-weight-bold" t-att-title="threadViewTopBar.thread.displayName" t-on-click="threadViewTopBar.onClickTopbarThreadName" t-on-mouseenter="threadViewTopBar.onMouseEnterTopBarThreadName" t-on-mouseleave="threadViewTopBar.onMouseLeaveTopBarThreadName" t-att-class="{ 'o-threadNameEditable': threadViewTopBar.isMouseOverThreadName and !messaging.isCurrentUserGuest }">
                                 <t t-esc="threadViewTopBar.thread.displayName"/>
                             </div>
                         </t>
@@ -27,7 +27,7 @@
                         <div class="o_ThreadViewTopbar_threadDescriptionSeparator flex-shrink-0 mx-2"/>
                         <t t-if="!threadViewTopBar.isEditingThreadDescription">
                             <t t-if="threadViewTopBar.thread.description">
-                                <div class="o_ThreadViewTopbar_threadDescription text-truncate px-1" t-att-title="threadViewTopBar.thread.description" t-on-click="threadViewTopBar.onClickTopbarThreadDescription" t-on-mouseenter="threadViewTopBar.onMouseEnterTopBarThreadDescription" t-on-mouseleave="threadViewTopBar.onMouseLeaveTopBarThreadDescription" t-att-class="{ 'o-isMouseOverThreadDescription': threadViewTopBar.isMouseOverThreadDescription }">
+                                <div class="o_ThreadViewTopbar_threadDescription text-truncate px-1" t-att-title="threadViewTopBar.thread.description" t-on-click="threadViewTopBar.onClickTopbarThreadDescription" t-on-mouseenter="threadViewTopBar.onMouseEnterTopBarThreadDescription" t-on-mouseleave="threadViewTopBar.onMouseLeaveTopBarThreadDescription" t-att-class="{ 'o-threadDescriptionEditable': threadViewTopBar.isMouseOverThreadDescription and !messaging.isCurrentUserGuest }">
                                     <t t-esc="threadViewTopBar.thread.description"/>
                                 </div>
                             </t>

--- a/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form/channel_invitation_form.js
@@ -103,7 +103,7 @@ function factory(dependencies) {
          * Handles OWL update on this channel invitation form component.
          */
         onComponentUpdate() {
-            if (this.doFocusOnSearchInput) {
+            if (this.doFocusOnSearchInput && this.searchInputRef.el) {
                 this.searchInputRef.el.focus();
                 this.searchInputRef.el.setSelectionRange(this.searchTerm.length, this.searchTerm.length);
                 this.update({ doFocusOnSearchInput: clear() });

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -365,7 +365,8 @@ function factory(dependencies) {
             if (!this.activeThread) {
                 return;
             }
-            if (!this.messaging.currentPartner) {
+            // not supported for guests
+            if (this.messaging.isCurrentUserGuest) {
                 return;
             }
             if (

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -361,7 +361,7 @@ function factory(dependencies) {
          * @returns {boolean}
          */
         _computeCanStarBeToggled() {
-            return !this.isTemporary && !this.isTransient;
+            return !this.messaging.isCurrentUserGuest && !this.isTemporary && !this.isTransient;
         }
 
         /**

--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -181,6 +181,14 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {boolean}
+         */
+        _computeIsCurrentUserGuest() {
+            return Boolean(!this.currentPartner && this.currentGuest);
+        }
+
+        /**
+         * @private
          * @returns {owl.EventBus}
          */
         _computeMessagingBus() {
@@ -309,6 +317,9 @@ function factory(dependencies) {
             default: create(),
             isCausal: true,
             readonly: true,
+        }),
+        isCurrentUserGuest: attr({
+            compute: '_computeIsCurrentUserGuest',
         }),
         isInitialized: attr({
             default: false,

--- a/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer/messaging_initializer.js
@@ -108,7 +108,10 @@ function factory(dependencies) {
             }
             // various suggestions in no particular order
             this._initCannedResponses(shortcodes);
-            this._initCommands();
+            // FIXME: guests should have (at least some) commands available
+            if (!this.messaging.isCurrentUserGuest) {
+                this._initCommands();
+            }
             // channels when the rest of messaging is ready
             await this.async(() => this._initChannels(channels));
             // failures after channels

--- a/addons/mail/static/src/models/notification_group_manager/notification_group_manager.js
+++ b/addons/mail/static/src/models/notification_group_manager/notification_group_manager.js
@@ -13,7 +13,8 @@ function factory(dependencies) {
         //----------------------------------------------------------------------
 
         computeGroups() {
-            if (!this.messaging.currentPartner) {
+            // not supported for guests
+            if (this.messaging.isCurrentUserGuest) {
                 return;
             }
             for (const group of this.groups) {

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -73,8 +73,10 @@ function factory(dependencies) {
             if (this.threadView.channelInvitationForm.component) {
                 return;
             }
-            this.threadView.channelInvitationForm.update({ doFocusOnSearchInput: true });
-            this.threadView.channelInvitationForm.searchPartnersToInvite();
+            if (!this.messaging.isCurrentUserGuest) {
+                this.threadView.channelInvitationForm.update({ doFocusOnSearchInput: true });
+                this.threadView.channelInvitationForm.searchPartnersToInvite();
+            }
         }
 
         /**

--- a/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar/thread_view_topbar.js
@@ -95,6 +95,10 @@ function factory(dependencies) {
             if (!this.thread || !this.thread.isChannelRenamable) {
                 return;
             }
+            // Guests cannot edit thread name
+            if (this.messaging.isCurrentUserGuest) {
+                return;
+            }
             const selection = window.getSelection();
             this.update({
                 doFocusOnThreadNameInput: true,
@@ -114,6 +118,10 @@ function factory(dependencies) {
          */
         onClickTopbarThreadDescription(ev) {
             if (!this.thread || !this.thread.isChannelDescriptionChangeable) {
+                return;
+            }
+            // Guests cannot edit description
+            if (this.messaging.isCurrentUserGuest) {
                 return;
             }
             const selection = window.getSelection();

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -5,6 +5,7 @@ import { MessagingService } from '@mail/services/messaging/messaging';
 import { getMessagingComponent } from '@mail/utils/messaging_component';
 
 import { processTemplates } from '@web/core/assets';
+import { MainComponentsContainer } from '@web/core/main_components_container';
 import { registry } from '@web/core/registry';
 import { makeEnv, startServices } from '@web/env';
 import { session } from '@web/session';
@@ -58,6 +59,7 @@ export async function boot() {
             autofetchPartnerImStatus: false,
         },
     }));
+    await owl.mount(MainComponentsContainer, { env, target: document.body });
 
     async function createThreadViewFromChannelData(channelData) {
         const messaging = await owl.Component.env.services.messaging.get();


### PR DESCRIPTION
Currently, a bunch of features are not supported for guests, some on purpose (eg modifying the channel name or description), while some are not yet implemented (eg /commands or the member list). This PR adapts the code so that these unsupported features no longer have a corresponding element in the UI, since these interacting with these UI elements only leads to a crash.

This PR also adds the main components container to guest pages so that guests now get error dialogs when errors occur.