### PR TITLE
[FIX] resource: planing use timezone context to display working hours

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -541,7 +541,8 @@ class ResourceCalendar(models.Model):
             resources_list = [resources]
         else:
             resources_list = list(resources)
-
+        if tz is None and 'tz' in self.env.context:
+            tz = timezone(self.env.context['tz'])
         resources_work_intervals = self._work_intervals_batch(start_dt, end_dt, resources, domain, tz)
         result = {}
         for resource in resources_list:


### PR DESCRIPTION
Issue: time offset when the server is not at the same timezone as the
user. The gantt view has the timezone in the context, however the method
does not use the context timezone as the default value.

opw-2557012