### PR TITLE
[FIX] website_crm_partner_assign: hide activity types of other models

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -171,7 +171,7 @@ class WebsiteAccount(CustomerPortal):
                 'opportunity': opp,
                 'user_activity': opp.sudo().activity_ids.filtered(lambda activity: activity.user_id == request.env.user)[:1],
                 'stages': request.env['crm.stage'].search([('is_won', '!=', True)], order='sequence desc, name desc, id desc'),
-                'activity_types': request.env['mail.activity.type'].sudo().search([]),
+                'activity_types': request.env['mail.activity.type'].sudo().search(['|', ('res_model_id.model', '=', opp._name), ('res_model_id', '=', False)]),
                 'states': request.env['res.country.state'].sudo().search([]),
                 'countries': request.env['res.country'].sudo().search([]),
             })


### PR DESCRIPTION
PURPOSE

When editing the opportunity from font end , all the activity types are listed
in the drop-down, even those which are specific to other models.

SPECIFICATIONS

We should display only the activity types in drop-down which are either
specific for `crm.lead` or those which are not linked with
any models which are common for all.

LINKS
PR #76567
TaskID  2443894

