### PR TITLE
[FIX] web: control panel style

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -30,15 +30,9 @@
     }
 
     .o_cp_bottom_left {
-        // Bottom left holds only btn-groups
-        // they will handle pushing buttons on the relevant line
-        display: inline-block;
-
-        > .btn-group {
-            margin-bottom: map-get($spacers, 2);
-            // Before owl, the margin was handled by a real space!
-            margin-right: map-get($spacers, 3);
-        }
+        display: flex;
+        flex-wrap: wrap;
+        gap: map-get($spacers, 3) map-get($spacers, 2);
 
         > .o_cp_action_menus {
             padding-right: 10px;


### PR DESCRIPTION
The fix https://github.com/odoo/odoo/commit/18ea11c99a7e2bd58d7469927352587cb14c76c4 incorrectly set the rule
o_control_panel .o_cp_bottom_left { display: inline-block } to fix a
problem with the graph view buttons in mobile mode: the graph view has
many buttons and they were put on the same line pushing the view switcher
far too rigth. But the above rule had some other unexpected effects.
For example, an action menu button was put incorrectly on an different line
from the button line. Here we simply fix the css rules that regulate on witch line
the control panel buttons are put and their spacing.