### PR TITLE
[FIX] portal: preserve newlines from share note

### DIFF
--- a/addons/portal/data/mail_templates.xml
+++ b/addons/portal/data/mail_templates.xml
@@ -8,7 +8,7 @@
             <br/>
             <a t-attf-href="#{share_link}" style="background-color: #875A7B; padding: 10px; text-decoration: none; color: #fff; border-radius: 5px; font-size: 12px;"><strong>Open </strong><strong t-esc="record.display_name"/></a><br/>
             <br/>
-            <p t-if="note" t-esc="note"/>
+            <p t-if="note" style="white-space: pre-wrap;" t-esc="note"/>
         </div>
     </template>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this patch, if you wrote newlines or more than a single whitespace character while sharing any document, in the note, those'd get collapsed in the final email.

Current behavior before PR:

https://user-images.githubusercontent.com/973709/133422942-fb907f77-43ae-443b-b64b-14f23c07840d.mp4



Desired behavior after PR is merged:

https://user-images.githubusercontent.com/973709/133422949-76c8dd88-580d-4a97-a232-46c49bc1a020.mp4





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa TT31901