### PR TITLE
[IMP] mail: speed up time of RTC peers connection

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 from odoo import http
@@ -374,25 +375,24 @@ class DiscussController(http.Controller):
     # --------------------------------------------------------------------------
 
     @http.route('/mail/rtc/session/notify_call_members', methods=['POST'], type="json", auth="public")
-    def session_call_notify(self, sender_session_id, target_session_ids=None, content=None):
+    def session_call_notify(self, peer_notifications):
         """ Sends content to other session of the same channel, only works if the user is the user of that session.
             This is used to send peer to peer information between sessions.
 
-            :param int sender_session_id: id of the session from which the content is sent
-            :param list target_session_ids: list of the ids of the sessions that should receive the content
-            :param content: the content to send to the other sessions
+            :param peer_notifications: list of tuple with the following elements:
+                - int sender_session_id: id of the session from which the content is sent
+                - list target_session_ids: list of the ids of the sessions that should receive the content
+                - string content: the content to send to the other sessions
         """
-        if request.env.user._is_public():
-            guest = request.env['mail.guest']._get_guest_from_request(request)
-            if guest:
-                session = guest.env['mail.channel.rtc.session'].sudo().browse(int(sender_session_id))
-                if session.exists() and session.guest_id == guest:
-                    session._notify_peers(target_session_ids, content)
-                    return
-            raise NotFound()
-        session = request.env['mail.channel.rtc.session'].sudo().browse(int(sender_session_id))
-        if session.exists() and session.partner_id == request.env.user.partner_id:
-            session._notify_peers(target_session_ids, content)
+        guest = request.env['mail.guest']._get_guest_from_request(request)
+        notifications_by_session = defaultdict(list)
+        for sender_session_id, target_session_ids, content in peer_notifications:
+            session_sudo = guest.env['mail.channel.rtc.session'].sudo().browse(int(sender_session_id)).exists()
+            if not session_sudo or (session_sudo.guest_id and session_sudo.guest_id != guest) or (session_sudo.partner_id and session_sudo.partner_id != request.env.user.partner_id):
+                continue
+            notifications_by_session[session_sudo].append(([int(sid) for sid in target_session_ids], content))
+        for session_sudo, notifications in notifications_by_session.items():
+            session_sudo._notify_peers(notifications)
 
     @http.route('/mail/rtc/session/update_and_broadcast', methods=['POST'], type="json", auth="public")
     def session_update_and_broadcast(self, session_id, values):

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -60,6 +60,11 @@
                                     <i class="fa fa-deaf"/>
                                 </span>
                             </t>
+                            <t t-if="callParticipantCard.rtcSession.channel.mailRtc and callParticipantCard.rtcSession.isAudioInError">
+                                <span class="o_RtcCallParticipantCard_overlayTop_element text-danger" title="Issue with audio">
+                                    <i class="fa fa-exclamation-triangle"/>
+                                </span>
+                            </t>
                             <t t-if="callParticipantCard.rtcSession.channel.mailRtc and !callParticipantCard.rtcSession.mailRtc and !['connected', 'completed'].includes(callParticipantCard.rtcSession.connectionState)">
                                 <span class="o_RtcCallParticipantCard_overlayTop_element" t-att-title="callParticipantCard.rtcSession.connectionState">
                                     <i class="fa fa-lg fa-signal o_RtcCallParticipantCard_connectionState"/>

--- a/addons/mail/static/src/components/rtc_video/rtc_video.js
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.js
@@ -69,7 +69,7 @@ export class RtcVideo extends Component {
     async _onVideoLoadedMetaData(ev) {
         try {
             await ev.target.play();
-        } catch (error)  {
+        } catch (error) {
             if (typeof error === 'object' && error.name === 'NotAllowedError') {
                 // Ignored as some browsers may reject play() calls that do not
                 // originate from a user input.

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -546,11 +546,13 @@ function factory(dependencies) {
         /**
          * @private
          * @param {Object} data
-         * @param {string} [data.sender]
-         * @param {string} [data.content]
+         * @param {string} data.sender
+         * @param {string[]} data.notifications
          */
-        _handleNotificationRtcPeerToPeer({ sender, content }) {
-            this.messaging.mailRtc.handleNotification(sender, content);
+        _handleNotificationRtcPeerToPeer({ sender, notifications }) {
+            for (const content of notifications) {
+                this.messaging.mailRtc.handleNotification(sender, content);
+            }
         }
 
         /**

--- a/addons/mail/static/src/models/rtc_peer_notification/rtc_peer_notification.js
+++ b/addons/mail/static/src/models/rtc_peer_notification/rtc_peer_notification.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import { registerNewModel } from '@mail/model/model_core';
+import { attr } from '@mail/model/model_field';
+
+function factory(dependencies) {
+
+    class RTCPeerNotification extends dependencies['mail.model'] {
+    }
+
+    RTCPeerNotification.fields = {
+        channelId: attr({
+            readonly: true,
+            required: true,
+        }),
+        event: attr({
+            readonly: true,
+            required: true,
+        }),
+        payload: attr({
+            readonly: true,
+        }),
+        senderId: attr({
+            readonly: true,
+            required: true,
+        }),
+        targetTokens: attr({
+            readonly: true,
+            required: true,
+        }),
+    };
+
+    RTCPeerNotification.modelName = 'mail.rtc_peer_notification';
+
+    return RTCPeerNotification;
+}
+
+registerNewModel('mail.rtc_peer_notification', factory);


### PR DESCRIPTION
Before this PR, the RPC to notify peers was called too much time too quickly.
Reducing request overload significantly improves the overall connection time.