### PR TITLE
[FIX] account, l10n_eu_oss: make OSS report work with cash basis OSS taxes

### DIFF
--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -8,7 +8,7 @@ class AccountAccountTag(models.Model):
     _description = 'Account Tag'
 
     name = fields.Char('Tag Name', required=True)
-    applicability = fields.Selection([('accounts', 'Accounts'), ('taxes', 'Taxes')], required=True, default='accounts')
+    applicability = fields.Selection([('accounts', 'Accounts'), ('taxes', 'Taxes'), ('products', 'Products')], required=True, default='accounts')
     color = fields.Integer('Color Index')
     active = fields.Boolean(default=True, help="Set active to false to hide the Account Tag without removing it.")
     tax_report_line_ids = fields.Many2many(string="Tax Report Lines", comodel_name='account.tax.report.line', relation='account_tax_report_line_tags_rel', help="The tax report lines using this tag")

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -39,7 +39,7 @@ class ProductTemplate(models.Model):
     account_tag_ids = fields.Many2many(
         string="Account Tags",
         comodel_name='account.account.tag',
-        domain="[('tax_report_line_ids', '=', False), ('applicability', '=', 'taxes')]",
+        domain="[('applicability', '=', 'products')]",
         help="Tags to be set on the base and tax journal items created for this product.")
 
     def _get_product_accounts(self):

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -61,7 +61,7 @@
                                     <group>
                                         <field name="user_type_id" widget="account_hierarchy_selection"/>
                                         <field name="tax_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]" attrs="{'invisible': [('internal_group', '=', 'off_balance')]}"/>
-                                        <field name="tag_ids" widget="many2many_tags" domain="[('applicability', '!=', 'taxes')]" context="{'default_applicability': 'accounts'}" options="{'no_create_edit': True}"/>
+                                        <field name="tag_ids" widget="many2many_tags" domain="[('applicability', '=', 'accounts')]" context="{'default_applicability': 'accounts'}" options="{'no_create_edit': True}"/>
                                         <field name="allowed_journal_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]" options="{'no_create_edit': True}"/>
                                     </group>
                                     <group>

--- a/addons/account/views/account_chart_template_views.xml
+++ b/addons/account/views/account_chart_template_views.xml
@@ -86,7 +86,7 @@
                         <newline/>
                         <field name="user_type_id" widget="account_hierarchy_selection"/>
                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
-                        <field name="tag_ids" domain="[('applicability', '!=', 'taxes')]" widget="many2many_tags" context="{'default_applicability': 'accounts'}"/>
+                        <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" widget="many2many_tags" context="{'default_applicability': 'accounts'}"/>
                         <field name="reconcile"/>
                         <field name="chart_template_id"/>
                     </group>

--- a/addons/l10n_eu_oss/data/account_account_tag.xml
+++ b/addons/l10n_eu_oss/data/account_account_tag.xml
@@ -9,7 +9,7 @@
 
         <record id="tag_eu_import" model="account.account.tag">
             <field name="name">non-EU origin</field>
-            <field name="applicability">taxes</field>
+            <field name="applicability">products</field>
         </record>
 
     </data>


### PR DESCRIPTION
Before this fix, a cash basis OSS tax used together with a product using the "non-EU origin" tag didn't appear properly in the OSS import report. This was due to the fact the product tag was not copied on the cash basis move: it only appeared on the invoice, on non exigible lines.

To fix that, we make the choice to keep the product tag as markup on the invoice, and to copy it to the cash basis lines created from move lines containing this tag. We therefore need a non-ambiguous way to identify account.account.tag objects that are used on products, since we don't want to copy tags used by taxes. Hence, we introduct a new value for the 'applicability' field of account.account.tag, limitating their use to products.
