### PR TITLE
[FIX] l10n fr remove negative tax groups

### DIFF
--- a/addons/l10n_fr/data/account_data.xml
+++ b/addons/l10n_fr/data/account_data.xml
@@ -33,30 +33,5 @@
             <field name="country_id" ref="base.fr"/>
         </record>
 
-        <record id="tax_group_intra_20" model="account.tax.group">
-            <field name="name">TVA -20.0%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-
-        <record id="tax_group_intra_85" model="account.tax.group">
-            <field name="name">TVA -8.5%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-
-        <record id="tax_group_intra_55" model="account.tax.group">
-            <field name="name">TVA -5.5%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-
-        <record id="tax_group_intra_10" model="account.tax.group">
-            <field name="name">TVA -10.0%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-
-        <record id="tax_group_intra_21" model="account.tax.group">
-            <field name="name">TVA -2.1%</field>
-            <field name="country_id" ref="base.fr"/>
-        </record>
-
     </data>
 </odoo>

--- a/addons/l10n_fr/data/account_tax_data.xml
+++ b/addons/l10n_fr/data/account_tax_data.xml
@@ -1666,7 +1666,7 @@
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_intra_20"/>
+        <field name="tax_group_id" ref="tax_group_tva_20"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1719,7 +1719,7 @@
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_intra_85"/>
+        <field name="tax_group_id" ref="tax_group_tva_85"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1772,7 +1772,7 @@
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_intra_10"/>
+        <field name="tax_group_id" ref="tax_group_tva_10"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1825,7 +1825,7 @@
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_intra_55"/>
+        <field name="tax_group_id" ref="tax_group_tva_55"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1878,7 +1878,7 @@
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_group_id" ref="tax_group_intra_21"/>
+        <field name="tax_group_id" ref="tax_group_tva_21"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,


### PR DESCRIPTION
There exist negative tax groups defined in the account data. They appear to have no meaning.

This removes the negative tax groups from account data. and reassigns the taxes that were in the negative tax groups to their positive counterparts.