### PR TITLE
[FIX] stock: avoid breaking global scss for thead

### DIFF
--- a/addons/stock/static/src/scss/stock_traceability_report.scss
+++ b/addons/stock/static/src/scss/stock_traceability_report.scss
@@ -28,6 +28,9 @@
             @include o-stock-reports-lines($border-width: 1px, $font-weight: normal, $border-top-style: solid, $border-bottom-style: groove);
         }
         .o_stock_reports_table {
+            thead { 
+                display: table-row-group;
+            }
             white-space: nowrap;
             margin-top: 30px;
         }
@@ -81,4 +84,3 @@
         }
     }
 }
-thead { display: table-row-group; }


### PR DESCRIPTION
commit bc1a6faa51fef60bb64ea09f4e43f1120f9855bd add a rule to fix
tracability report but on a global level. However we won't this behavior
everywhere in odoo or at least if it's the case it shouldn't be specify
there
