### PR TITLE
[FIX] Allow setting group_expand for ir.model.fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1114,6 +1114,8 @@ class IrModelFields(models.Model):
                 attrs['size'] = field_data['size'] or None
         elif field_data['ttype'] in ('selection', 'reference'):
             attrs['selection'] = self.env['ir.model.fields.selection']._get_selection_data(field_data['id'])
+            if field_data['ttype'] == 'selection':
+                attrs['group_expand'] = field_data['group_expand']
         elif field_data['ttype'] == 'many2one':
             if not self.pool.loaded and field_data['relation'] not in self.env:
                 return

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -282,8 +282,8 @@
                                                     'readonly': [('ttype','not in',['many2one','one2many','many2many'])],
                                                     'invisible': [('ttype','not in',['many2one','one2many','many2many'])]}"/>
                                         <field name="group_expand" groups="base.group_no_one"
-                                            attrs="{'readonly': [('ttype','!=','many2one')],
-                                                    'invisible': [('ttype','!=','many2one')]}"/>
+                                            attrs="{'readonly': [('ttype','not in', ['many2one', 'selection'])],
+                                                    'invisible': [('ttype','not in', ['many2one', 'selection'])]}"/>
                                         <field name="on_delete" groups="base.group_no_one"
                                             attrs="{'readonly': [('ttype','!=','many2one')],
                                                     'invisible': [('ttype','!=','many2one')]}"/>


### PR DESCRIPTION
PR #75856 introduced a default implementation of group_expand for
Selection fields that set the value of group_expand to True.

However the PR lacked the necessary bits that allow the same behavior
for fields created on the fly instead of through code.

This commit allows the propagation of the group_expand attribute for
fields of type Selection, this commit also exposes the checkbox in the
UI to enable/disable the setting.