### PR TITLE
[FIX] website_sale_stock: Fix misaligned btn icon in cart

### DIFF
--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -13,11 +13,9 @@
         </xpath>
         <xpath expr="//div[hasclass('css_quantity')]//i[hasclass('fa-plus')]/.." position="replace">
           <t t-if="line._get_stock_warning(clear=False)">
-            <div class="input-group-append">
-                <a t-attf-href="#" class="btn btn-link">
-                  <i class='fa fa-warning text-warning' t-att-title="line._get_stock_warning()" role="img" aria-label="Warning"/>
-                </a>
-            </div>
+            <a t-attf-href="#" class="btn btn-link float_left js_add_cart_json d-none d-md-inline-block">
+              <i class='fa fa-warning text-warning' t-att-title="line._get_stock_warning()" role="img" aria-label="Warning"/>
+            </a>
           </t>
           <t t-else="1">
             <t>$0</t>


### PR DESCRIPTION
The fa-warning icon of the "Add one" on cart lines is missaligned when product is out of stock.

Current behavior before PR:
Steps to reproduce:
- Install website_sale_stock
- Set the "Availability" field on a product to "Sell inventory on website and prevent sales if not enough stock".
- Go to ecommerce and add product to cart
- Go to cart and try to increase the qty of products until the qty is higher than available in stock.
- A missaligned exlamation mark (fa-warning) is shown instead of the plus icon (fa-plus)

Desired behavior after PR is merged:
The icon is displayed correctly.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
