### PR TITLE
[FIX] website_event: correctly display 'Event Sub-menu' customize menu

### DIFF
--- a/addons/website_event/static/src/js/website_event_set_customize_options.js
+++ b/addons/website_event/static/src/js/website_event_set_customize_options.js
@@ -109,6 +109,13 @@ CustomizeMenu.include({
             if (!self.__eventOptionsLoaded && self._getEventObject().model === 'event.event') {
                 self.__eventOptionsLoaded = true;
                 self.eventOptions = new EventSpecificOptions(self);
+                // If this is the first customize menu, add the divider at top
+                if (!self.$('.dropdown-divider').length) {
+                    self.$('.dropdown-menu').append($('<div/>', {
+                        class: 'dropdown-divider',
+                        role: 'separator',
+                    }));
+                }
                 self.eventOptions.insertAfter(self.$el.find('.dropdown-divider:first()'));
             }
         });


### PR DESCRIPTION
PURPOSE

The Event Sub-menu should be showing after installing the website_event module.
The purpose of this commit is to show the Event Sub-menu.

SPECIFICATIONS

Right now, when we only have the website_event installed and there are no
other regular(view-based) customize menus available, we won't have a
divider div tag. And the current code tries to push our menu after
the first divider and thus fails due to no divider available.

This fixes the issue simply by adding the div and push the menu after the divider.

This is the goal of this commit.

LINKS

PR #76633
Task-2616588


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr