### PR TITLE
[FIX] website: allow link popover test to continue when already hidden

### DIFF
--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -183,7 +183,7 @@ tour.register('edit_link_popover', {
     // FIXME this step shouldnt be needed but click not working as real click
     {
         content: "REMOVEME",
-        trigger: '.o_edit_menu_popover',
+        trigger: 'html', // Do not block if popover already hidden
         run: (actions) => {
             $('.o_edit_menu_popover').popover('hide');
         },


### PR DESCRIPTION
Before this commit the link popover test sometimes froze on a test that
was added to hide the popover in case it did not work automatically.
The popover is however automatically hidden before this step from time
to time, thus making this step blocking.

After this commit this step just hides the popover in case it was still
there.

Related to staging build https://runbot.odoo.com/runbot/build/9990797

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
