### PR TITLE
[FIX] website: fix invalid datetime format for Visitors graph view

### DIFF
--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -258,12 +258,12 @@
                 <field name="country_id"/>
                 <field name="visit_count"/>
                 <field name="page_ids"/>
-                <filter string="Last 7 Days" name="filter_last_7_days" domain="[('last_connection_datetime', '&gt;', datetime.datetime.now() - datetime.timedelta(days=7))]"/>
+                <filter string="Last 7 Days" name="filter_last_7_days" domain="[('last_connection_datetime', '&gt;', (datetime.datetime.now() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]"/>
                 <separator/>
                 <filter string="Unregistered" name="filter_type_visitor" domain="[('partner_id', '=', False)]"/>
                 <filter string="Contacts" name="filter_type_customer" domain="[('partner_id', '!=', False)]"/>
                 <separator/>
-                <filter string="Connected" name="filter_is_connected" domain="[('last_connection_datetime', '&gt;', datetime.datetime.now() - datetime.timedelta(minutes=5))]"/>
+                <filter string="Connected" name="filter_is_connected" domain="[('last_connection_datetime', '&gt;', (datetime.datetime.now() - datetime.timedelta(minutes=5)).strftime('%Y-%m-%d'))]"/>
                 <separator/>
                 <filter string="Archived" name="filter_is_archived" domain="[('active', '=', False)]"/>
                 <separator/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, the search filters of the graph view of the 'website.visitor' model contain datetime objects that are no longer supported. As a result, the system throws an exception when the user tries to open the graph view of the 'website.visitors' model.

How to reproduce?
1. Install the website module
2. Go on the website module > "Visitors" (in header) > "Visitors" (in sub-menu)
3. Open the graph view (near kanban and list view)
4. *Crash* (-> psycopg2.errors.InvalidDatetimeFormat)

Current behavior before PR:
The user can not open the graph view of the `website.visitor` model.

Desired behavior after PR is merged:
The user can open the graph view of the `website.vistor` model.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
