### PR TITLE
[FIX] hr_holidays: fix the unavailibities in calendar

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1254,7 +1254,7 @@ class HolidaysRequest(models.Model):
     def get_unusual_days(self, date_from, date_to=None):
         # Checking the calendar directly allows to not grey out the leaves taken
         # by the employee
-        calendar = self.env.user.employee_id.resource_calendar_id
+        calendar = self.env.user.employee_id.resource_calendar_id or self.env.company.resource_calendar_id
         if not calendar:
             return {}
         dfrom = datetime.combine(fields.Date.from_string(date_from), time.min).replace(tzinfo=UTC)


### PR DESCRIPTION
If there is no employee link with the current login user then unavailabilities
do not appear in the calendar.

Example:
  - Install planning app
  - Current USER A ( no Employee link)
  - Open Calendar view (Month mode)
  - Unavailibities are not displayed
