### PR TITLE
[IMP] hr_org_chart: improve org chart widget

### DIFF
--- a/addons/hr_org_chart/static/src/js/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/js/hr_org_chart.js
@@ -178,6 +178,7 @@ var FieldOrgChart = AbstractField.extend({
                     args: [employee_id],
                 }).then(function(action) {
                     action = _.extend(action, {
+                        'name': _t('Team'),
                         'view_mode': 'kanban,list,form',
                         'views':  [[false, 'kanban'], [false, 'list'], [false, 'form']],
                         'domain': domain,

--- a/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
@@ -105,7 +105,7 @@
                     <a href="#"
                         t-att-data-employee-id="self.id"
                         t-att-data-employee-name="self.name"
-                        class="o_org_chart_show_more text-center o_employee_sub_redirect">&#8230;</a>
+                        class="o_org_chart_show_more text-center o_employee_sub_redirect">See All</a>
                 </div>
             </div>
         </t>


### PR DESCRIPTION
The display when too many employees where present wasn't very clear, 3
dots that were close to hidden because of the line right next to it, it
has been replaced by a `See All` button instead, and the action executed
upon clicking that button now has a name `Team` instead of `undefined`.

TaskId-2648133