### PR TITLE
[FIX] sale_timesheet: traceback dialog when removing uom_id in produc…

### DIFF
--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -35,7 +35,7 @@ class ProductTemplate(models.Model):
     def _compute_service_upsell_threshold_ratio(self):
         product_uom_hour = self.env.ref('uom.product_uom_hour')
         for record in self:
-            record.service_upsell_threshold_ratio = f"1 {record.uom_id.name} = {product_uom_hour.factor / record.uom_id.factor:.2f} Hours"
+            record.service_upsell_threshold_ratio = f"1 {record.uom_id.name} = {product_uom_hour.factor / record.uom_id.factor:.2f} Hours" if record.uom_id else ""
 
     def _compute_visible_expense_policy(self):
         visibility = self.user_has_groups('project.group_project_user')


### PR DESCRIPTION
…t form

Check if uom_id is not None when computing the service_upsell_threshold_ratio field.

If no check is done, the compute method raises an error whenever the uom_id becomes None (e.g. by removing it manually on the product form).

task-2647036

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
