### PR TITLE
[FIX] account: recompute the payment terms only if there is an invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1935,13 +1935,14 @@ class AccountMove(models.Model):
             default['date'] = self.company_id._get_user_fiscal_lock_date() + timedelta(days=1)
         if self.move_type == 'entry':
             default['partner_id'] = False
-        invoice = super().copy(default)
+        move = super().copy(default)
 
-        # Make sure to recompute payment terms. This could be necessary if the date is different for example.
-        # Also, this is necessary when creating a credit note because the current invoice is copied.
-        invoice._recompute_payment_terms_lines()
+        if move.is_invoice(include_receipts=True):
+            # Make sure to recompute payment terms. This could be necessary if the date is different for example.
+            # Also, this is necessary when creating a credit note because the current invoice is copied.
+            move._recompute_payment_terms_lines()
 
-        return invoice
+        return move
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Bug introduced by this commit: https://github.com/odoo/odoo/commit/f05db8b122140a9d0f124484ab22eb094b4e36e9

Steps to reproduce the bug:
- create a journal entry with 4 ”account.move.line”:
    - two `”account.move.line”` with accounts of type ('receivable' or 'payable') > with the amount of both in debit or both in credit
    - two `”account.move.line”` with accounts other than the type ('receivable' or 'payable')
- save
- duplicate the `“account.move”`
- validation error will be triggered: https:github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L3209-L3211

Problem:
The payment terms must be recomputed only if the `”account.move”` is an invoice

OPW-2642826

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
