### PR TITLE
[FIX] sale_coupon: Coupon mail sent twice

### DIFF
--- a/addons/coupon/wizard/coupon_generate.py
+++ b/addons/coupon/wizard/coupon_generate.py
@@ -38,7 +38,7 @@ class CouponGenerate(models.TransientModel):
                 subject = _('%s, a coupon has been generated for you') % (partner.name)
                 del context
                 if self.template_id:
-                    email_values = {'email_to': partner.email, 'email_from': self.env.user.email or '', 'subject': subject}
+                    email_values = {'email_from': self.env.user.email or '', 'subject': subject}
                     self.template_id.send_mail(coupon.id, email_values=email_values, notif_layout='mail.mail_notification_light')
 
     @api.depends('partners_domain')


### PR DESCRIPTION
When generating coupons for customers, the email was sent twice due to the values
given on the email_values that is generating a TO (email_to) value
(plus using the one given on the template (recipients_ids))

opw-2574046

X-original-commit: 5cd985ce29822c832163e81c3c542c06bcbbc3af