### PR TITLE
[FIX] account,mail: fix no depends not computing field

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -323,6 +323,7 @@ class AccountJournal(models.Model):
             else:
                 journal.suspense_account_id = False
 
+    @api.depends('name')
     def _compute_alias_domain(self):
         self.alias_domain = self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain")
 

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -93,6 +93,7 @@ class Alias(models.Model):
                     alias.alias_name,
                 ))
 
+    @api.depends('alias_name')
     def _compute_alias_domain(self):
         self.alias_domain = self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain")
 


### PR DESCRIPTION
Computed fields with no depends are not computed before record creation
rendering those fields empty instead of being computed on the first
request.
By adding a depends (the field does not actually depend on it) the field
is computed correctly and may be used directly.

TaskId-2647225
