### PR TITLE
[FIX] account: speed up account.invoice.report

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -168,7 +168,7 @@ class AccountInvoiceReport(models.Model):
         # self._table = account_invoice_report
         tools.drop_view_if_exists(self.env.cr, self._table)
         self.env.cr.execute("""CREATE or REPLACE VIEW %s as (
-            WITH currency_rate AS (%s)
+            WITH currency_rate AS {} (%s)
             %s
             FROM (
                 %s %s WHERE ail.account_id IS NOT NULL %s
@@ -178,7 +178,7 @@ class AccountInvoiceReport(models.Model):
                  cr.company_id = sub.company_id AND
                  cr.date_start <= COALESCE(sub.date, NOW()) AND
                  (cr.date_end IS NULL OR cr.date_end > COALESCE(sub.date, NOW())))
-        )""" % (
+        )""".format("MATERIALIZED" if self._cr._cnx.server_version >= 120000 else "") % (
                     self._table, self.env['res.currency']._select_companies_rates(),
                     self._select(), self._sub_select(), self._from(), self._group_by()))
 


### PR DESCRIPTION




Description of the issue/feature this PR addresses:
Very slow account.invoice.report

Current behavior before PR:
Before this patch, [this unoptimized filter][1] forced the subplan from `currency_rate` to be executed twice. And that's not a very optimized plan that, when joined with the `sub` table, slowed down the report *a lot*.

Desired behavior after PR is merged:
Now the `currency_rate` plan is forced to be materialized, which on one hand makes the plan execute just once, and on the other hand it is done outside of the join, which results in less records being used.

On a production database with big amount of records, [the old report took 2 minutes][2] to return, while [the new one takes "only" 19 seconds][3].

@Tecnativa TT31898

[1]: https://github.com/odoo/odoo/blob/8f6430359b347d3669a536eca0a297c66ce99163/addons/account/report/account_invoice_report.py#L179-L180
[2]: https://explain.dalibo.com/plan/3s1b
[3]: https://explain.dalibo.com/plan/A37



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
