### PR TITLE
[FIX] point_of_sale: type field should be stored

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -43,7 +43,7 @@ class PosPaymentMethod(models.Model):
     hide_use_payment_terminal = fields.Boolean(compute='_compute_hide_use_payment_terminal', help='Technical field which is used to '
                                                'hide use_payment_terminal when no payment interfaces are installed.')
     active = fields.Boolean(default=True)
-    type = fields.Selection(selection=[('cash', 'Cash'), ('bank', 'Bank'), ('pay_later', 'Customer Account')], compute="_compute_type")
+    type = fields.Selection(selection=[('cash', 'Cash'), ('bank', 'Bank'), ('pay_later', 'Customer Account')], compute="_compute_type", store=True)
 
     @api.depends('type')
     def _compute_hide_use_payment_terminal(self):


### PR DESCRIPTION
type field is introduced in https://github.com/odoo/odoo/pull/74870
and it's supposed to be stored.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
