### PR TITLE
[FIX] mrp production: Workorders of backorder are created cancelled

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1465,7 +1465,7 @@ class MrpProduction(models.Model):
                     wo.qty_producing = 1
                 else:
                     wo.qty_producing = wo.qty_remaining
-                if wo.qty_producing == 0:
+                if wo.qty_produced == 0:
                     wo.action_cancel()
 
             # We need to adapt `duration_expected` on both the original workorders and their

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1938,7 +1938,7 @@ class TestMrpOrder(TestMrpCommon):
         mo_2 = self.env['mrp.production'].browse(mo.id + 1)
         self.assertEqual(mo_2.state, 'progress')
         wo_4, wo_5, wo_6 = mo_2.workorder_ids
-        self.assertEqual(wo_4.state, 'cancel')
+        self.assertEqual(wo_4.state, 'ready')
 
         wo_5.button_start()
         self.assertEqual(mo_2.state, 'progress')
@@ -1946,7 +1946,7 @@ class TestMrpOrder(TestMrpCommon):
 
         wo_6.button_start()
         wo_6.button_finish()
-        self.assertEqual(mo_2.state, 'to_close')
+        self.assertEqual(mo_2.state, 'progress')
         mo_2.button_mark_done()
         self.assertEqual(mo_2.state, 'done')
 


### PR DESCRIPTION
Issue: When marking as done a MO for which the work orders have all
been done, but the quantity was reduced (from 0.2/0.2 to 1.0/2.0
for example), the workorder for the back order generated are cancelled

Steps to reproduce :
1) Install MRP, enable workcenters
2) Create a BoM for a new product with 2 operations
3) Create a Manufacturing Order for that BoM for 2 units
4) Plan it, finish the operations, then set the quantity produced to 1
5) Mark as done and create a back order
-> The operations of the back order are in canceled state

Side-note:
related to fix #63728
The real PR for the fix #76077 that was accidentally cancelled 
This time with the correct opw id

opw-2605862