### PR TITLE
[IMP] core: allow nested declaration of xml for one2many fields

### DIFF
--- a/addons/l10n_ae/data/account_tax_report_data.xml
+++ b/addons/l10n_ae/data/account_tax_report_data.xml
@@ -1,426 +1,295 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.ae"/>
+        <field name="root_line_ids">
+            <record id="tax_report_line_base_all_sales" model="account.tax.report.line">
+                <field name="name">VAT on Sales and all other Outputs (Base)</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_supplies_base" model="account.tax.report.line">
+                        <field name="name">1. Standard Rated supplies (Base)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_standard_rated_supplies_base_abu_dhabi" model="account.tax.report.line">
+                                <field name="name">a. Abu Dhabi</field>
+                                <field name="tag_name">a. Abu Dhabi (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_AB</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_dubai" model="account.tax.report.line">
+                                <field name="name">b. Dubai</field>
+                                <field name="tag_name">b. Dubai (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_DB</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_sharjah" model="account.tax.report.line">
+                                <field name="name">c. Sharjah</field>
+                                <field name="tag_name">c. Sharjah (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_SJ</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_ajman" model="account.tax.report.line">
+                                <field name="name">d. Ajman</field>
+                                <field name="tag_name">d. Ajman (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_AJ</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_umm_al_quwain" model="account.tax.report.line">
+                                <field name="name">e. Umm Al Quwain</field>
+                                <field name="tag_name">e. Umm Al Quwain (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_UM</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_ras_al_khaima" model="account.tax.report.line">
+                                <field name="name">f. Ras Al-Khaima</field>
+                                <field name="tag_name">f. Ras Al-Khaima (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_RA</field>
+                                <field name="sequence" eval="6"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_fujairah" model="account.tax.report.line">
+                                <field name="name">g. Fujairah</field>
+                                <field name="tag_name">g. Fujairah (Base)</field>
+                                <field name="code">STD_RATE_SUPP_BASE_FU</field>
+                                <field name="sequence" eval="7"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_base_subtotal" model="account.tax.report.line">
+                                <field name="name">Sub Total</field>
+                                <field name="formula">STD_RATE_SUPP_BASE_AB + STD_RATE_SUPP_BASE_DB + STD_RATE_SUPP_BASE_SJ + STD_RATE_SUPP_BASE_AJ + STD_RATE_SUPP_BASE_UM + STD_RATE_SUPP_BASE_RA + STD_RATE_SUPP_BASE_FU</field>
+                                <field name="sequence" eval="8"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_tax_refund_tourist_base" model="account.tax.report.line">
+                        <field name="name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme</field>
+                        <field name="tag_name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme (Base)</field>
+                        <field name="code">TAX_REF_TOUR_SCHEME_BASE</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_supplies_reverse_charge_base" model="account.tax.report.line">
+                        <field name="name">3. Supplies subject to reverse charge provisions</field>
+                        <field name="tag_name">3. Supplies subject to reverse charge provisions (Base)</field>
+                        <field name="code">REVERSE_CHARGE_PRO_BASE</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_zero_rated_supplies_base" model="account.tax.report.line">
+                        <field name="name">4. Zero rated supplies</field>
+                        <field name="tag_name">4. Zero rated supplies (Base)</field>
+                        <field name="code">ZERO_RATE_SUPP_BASE</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_exempt_supplies_base" model="account.tax.report.line">
+                        <field name="name">5. Exempt supplies</field>
+                        <field name="tag_name">5. Exempt supplies (Base)</field>
+                        <field name="code">EXAMPT_SUPP_BASE</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_supplies_out_of_scope_base" model="account.tax.report.line">
+                        <field name="name">6. Out of scope</field>
+                        <field name="code">OUT_OF_SCOPE_BASE_0</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_line_import_uae_base" model="account.tax.report.line">
+                        <field name="name">7. Goods imported into the UAE</field>
+                        <field name="tag_name">7. Goods imported into the UAE (Base)</field>
+                        <field name="code">GOODS_IMPORT_IN_UAE_BASE</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_line_adjustment_import_uae_base" model="account.tax.report.line">
+                        <field name="name">8. Adjustments to goods imported into the UAE</field>
+                        <field name="code">ADJUST_GOODS_IMPORT_IN_UAE_BASE</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_line_base_all_sales_total" model="account.tax.report.line">
+                        <field name="name">9. Total</field>
+                        <field name="formula">ADJUST_GOODS_IMPORT_IN_UAE_BASE + GOODS_IMPORT_IN_UAE_BASE + OUT_OF_SCOPE_BASE_0 + EXAMPT_SUPP_BASE + ZERO_RATE_SUPP_BASE + REVERSE_CHARGE_PRO_BASE + TAX_REF_TOUR_SCHEME_BASE + (STD_RATE_SUPP_BASE_AB + STD_RATE_SUPP_BASE_DB + STD_RATE_SUPP_BASE_SJ + STD_RATE_SUPP_BASE_AJ + STD_RATE_SUPP_BASE_UM + STD_RATE_SUPP_BASE_RA + STD_RATE_SUPP_BASE_FU)</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_base_all_expense" model="account.tax.report.line">
+                <field name="name">VAT on Expenses and all other Inputs (Base)</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_expense_base" model="account.tax.report.line">
+                        <field name="name">10. Standard rated expenses</field>
+                        <field name="tag_name">10. Standard rated expenses (Base)</field>
+                        <field name="code">STD_RATE_EXPENSES_BASE</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_expense_supplies_reverse_base" model="account.tax.report.line">
+                        <field name="name">11. Supplies subject to the reverse charge provisions</field>
+                        <field name="tag_name">11. Supplies subject to the reverse charge provisions (Base)</field>
+                        <field name="code">SUPP_REV_CHARGE_PRO_BASE</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_expense_out_of_scope" model="account.tax.report.line">
+                        <field name="name">12. Out of scope</field>
+                        <field name="code">OUT_OF_SCOPE_1_BASE</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_base_all_expense_total" model="account.tax.report.line">
+                        <field name="name">13. Totals</field>
+                        <field name="formula">OUT_OF_SCOPE_1_BASE + SUPP_REV_CHARGE_PRO_BASE + STD_RATE_EXPENSES_BASE</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_vat_all_sales" model="account.tax.report.line">
+                <field name="name">VAT on Sales and all other Outputs (Tax)</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_supplies_vat" model="account.tax.report.line">
+                        <field name="name">1. Standard Rated supplies (Tax)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_standard_rated_supplies_vat_abu_dhabi" model="account.tax.report.line">
+                                <field name="name">a. Abu Dhabi</field>
+                                <field name="tag_name">a. Abu Dhabi (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_AB</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_dubai" model="account.tax.report.line">
+                                <field name="name">b. Dubai</field>
+                                <field name="tag_name">b. Dubai (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_DB</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_sharjah" model="account.tax.report.line">
+                                <field name="name">c. Sharjah</field>
+                                <field name="tag_name">c. Sharjah (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_SJ</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_ajman" model="account.tax.report.line">
+                                <field name="name">d. Ajman</field>
+                                <field name="tag_name">d. Ajman (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_AJ</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_umm_al_quwain" model="account.tax.report.line">
+                                <field name="name">e. Umm Al Quwain</field>
+                                <field name="tag_name">e. Umm Al Quwain (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_UM</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_ras_al_khaima" model="account.tax.report.line">
+                                <field name="name">f. Ras Al-Khaima</field>
+                                <field name="tag_name">f. Ras Al-Khaima (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_RA</field>
+                                <field name="sequence" eval="6"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_fujairah" model="account.tax.report.line">
+                                <field name="name">g. Fujairah</field>
+                                <field name="tag_name">g. Fujairah (Tax)</field>
+                                <field name="code">STD_RATE_SUPP_TAX_FU</field>
+                                <field name="sequence" eval="7"/>
+                            </record>
+                            <record id="tax_report_line_standard_rated_supplies_vat_subtotal" model="account.tax.report.line">
+                                <field name="name">Sub Total</field>
+                                <field name="formula">STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU</field>
+                                <field name="sequence" eval="8"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_tax_refund_tourist_vat" model="account.tax.report.line">
+                        <field name="name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme</field>
+                        <field name="tag_name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme (Tax)</field>
+                        <field name="code">TAX_REF_TOUR_SCHEME_TAX</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_supplies_reverse_charge_vat" model="account.tax.report.line">
+                        <field name="name">3. Supplies subject to reverse charge provisions</field>
+                        <field name="tag_name">3. Supplies subject to reverse charge provisions (Tax)</field>
+                        <field name="code">REVERSE_CHARGE_PRO_TAX</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_zero_rated_supplies_vat" model="account.tax.report.line">
+                        <field name="name">4. Zero rated supplies</field>
+                        <field name="tag_name">4. Zero rated supplies (Tax)</field>
+                        <field name="code">ZERO_RATE_SUPP_TAX</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_exempt_supplies_vat" model="account.tax.report.line">
+                        <field name="name">5. Exempt supplies</field>
+                        <field name="tag_name">5. Exempt supplies (Tax)</field>
+                        <field name="code">EXAMPT_SUPP_TAX</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_supplies_out_of_scope_vat" model="account.tax.report.line">
+                        <field name="name">6. Out of scope</field>
+                        <field name="code">OUT_OF_SCOPE_TAX_0</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_line_import_uae_vat" model="account.tax.report.line">
+                        <field name="name">7. Goods imported into the UAE</field>
+                        <field name="tag_name">7. Goods imported into the UAE (Tax)</field>
+                        <field name="code">GOODS_IMPORT_IN_UAE_TAX</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_line_adjustment_import_uae_vat" model="account.tax.report.line">
+                        <field name="name">8. Adjustments to goods imported into the UAE</field>
+                        <field name="code">ADJUST_GOODS_IMPORT_IN_UAE_TAX</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_line_vat_all_sales_total" model="account.tax.report.line">
+                        <field name="name">9. Total</field>
+                        <field name="formula">(STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_vat_all_expense" model="account.tax.report.line">
+                <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_expense_vat" model="account.tax.report.line">
+                        <field name="name">10. Standard rated expenses</field>
+                        <field name="tag_name">10. Standard rated expenses (Tax)</field>
+                        <field name="code">STD_RATE_EXPENSES_TAX</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_expense_supplies_reverse_vat" model="account.tax.report.line">
+                        <field name="name">11. Supplies subject to the reverse charge provisions</field>
+                        <field name="tag_name">11. Supplies subject to the reverse charge provisions (Tax)</field>
+                        <field name="code">SUPP_REV_CHARGE_PRO_TAX</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_expense_out_of_scope_vat" model="account.tax.report.line">
+                        <field name="name">12. Out of scope</field>
+                        <field name="code">OUT_OF_SCOPE_1_TAX</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_vat_all_expense_total" model="account.tax.report.line">
+                        <field name="name">13. Totals</field>
+                        <field name="formula">OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_net_vat_due" model="account.tax.report.line">
+                <field name="name">Net VAT Due</field>
+                <field name="sequence" eval="5"/>
+                <field name="formula">((STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX) - (OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX)</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_total_value_due_tax_period" model="account.tax.report.line">
+                        <field name="name">14. Total value of due tax for the period</field>
+                        <field name="formula">(STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_total_value_recoverable_tax_period" model="account.tax.report.line">
+                        <field name="name">15. Total value of recoverable tax for the period</field>
+                        <field name="formula">OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_net_vat_due_period" model="account.tax.report.line">
+                        <field name="name">16. Net VAT due (or reclaimed) for the period</field>
+                        <field name="formula">((STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX) - (OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX)</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_line_base_all_sales" model="account.tax.report.line">
-        <field name="name">VAT on Sales and all other Outputs (Base)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base" model="account.tax.report.line">
-        <field name="name">1. Standard Rated supplies (Base)</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_abu_dhabi" model="account.tax.report.line">
-        <field name="name">a. Abu Dhabi</field>
-        <field name="tag_name">a. Abu Dhabi (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_AB</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_dubai" model="account.tax.report.line">
-        <field name="name">b. Dubai</field>
-        <field name="tag_name">b. Dubai (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_DB</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_sharjah" model="account.tax.report.line">
-        <field name="name">c. Sharjah</field>
-        <field name="tag_name">c. Sharjah (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_SJ</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_ajman" model="account.tax.report.line">
-        <field name="name">d. Ajman</field>
-        <field name="tag_name">d. Ajman (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_AJ</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_umm_al_quwain" model="account.tax.report.line">
-        <field name="name">e. Umm Al Quwain</field>
-        <field name="tag_name">e. Umm Al Quwain (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_UM</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_ras_al_khaima" model="account.tax.report.line">
-        <field name="name">f. Ras Al-Khaima</field>
-        <field name="tag_name">f. Ras Al-Khaima (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_RA</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_fujairah" model="account.tax.report.line">
-        <field name="name">g. Fujairah</field>
-        <field name="tag_name">g. Fujairah (Base)</field>
-        <field name="code">STD_RATE_SUPP_BASE_FU</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_base_subtotal" model="account.tax.report.line">
-        <field name="name">Sub Total</field>
-        <field name="formula">STD_RATE_SUPP_BASE_AB + STD_RATE_SUPP_BASE_DB + STD_RATE_SUPP_BASE_SJ + STD_RATE_SUPP_BASE_AJ + STD_RATE_SUPP_BASE_UM + STD_RATE_SUPP_BASE_RA + STD_RATE_SUPP_BASE_FU</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_base"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_line_tax_refund_tourist_base" model="account.tax.report.line">
-        <field name="name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme</field>
-        <field name="tag_name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme (Base)</field>
-        <field name="code">TAX_REF_TOUR_SCHEME_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_supplies_reverse_charge_base" model="account.tax.report.line">
-        <field name="name">3. Supplies subject to reverse charge provisions</field>
-        <field name="tag_name">3. Supplies subject to reverse charge provisions (Base)</field>
-        <field name="code">REVERSE_CHARGE_PRO_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_zero_rated_supplies_base" model="account.tax.report.line">
-        <field name="name">4. Zero rated supplies</field>
-        <field name="tag_name">4. Zero rated supplies (Base)</field>
-        <field name="code">ZERO_RATE_SUPP_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_exempt_supplies_base" model="account.tax.report.line">
-        <field name="name">5. Exempt supplies</field>
-        <field name="tag_name">5. Exempt supplies (Base)</field>
-        <field name="code">EXAMPT_SUPP_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_line_supplies_out_of_scope_base" model="account.tax.report.line">
-        <field name="name">6. Out of scope</field>
-        <field name="code">OUT_OF_SCOPE_BASE_0</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_line_import_uae_base" model="account.tax.report.line">
-        <field name="name">7. Goods imported into the UAE</field>
-        <field name="tag_name">7. Goods imported into the UAE (Base)</field>
-        <field name="code">GOODS_IMPORT_IN_UAE_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_line_adjustment_import_uae_base" model="account.tax.report.line">
-        <field name="name">8. Adjustments to goods imported into the UAE</field>
-        <field name="code">ADJUST_GOODS_IMPORT_IN_UAE_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_line_base_all_sales_total" model="account.tax.report.line">
-        <field name="name">9. Total</field>
-        <field name="formula">ADJUST_GOODS_IMPORT_IN_UAE_BASE + GOODS_IMPORT_IN_UAE_BASE + OUT_OF_SCOPE_BASE_0 + EXAMPT_SUPP_BASE + ZERO_RATE_SUPP_BASE + REVERSE_CHARGE_PRO_BASE + TAX_REF_TOUR_SCHEME_BASE + (STD_RATE_SUPP_BASE_AB + STD_RATE_SUPP_BASE_DB + STD_RATE_SUPP_BASE_SJ + STD_RATE_SUPP_BASE_AJ + STD_RATE_SUPP_BASE_UM + STD_RATE_SUPP_BASE_RA + STD_RATE_SUPP_BASE_FU)</field>
-        <field name="parent_id" ref="tax_report_line_base_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-    </record>
-
-    <record id="tax_report_line_base_all_expense" model="account.tax.report.line">
-        <field name="name">VAT on Expenses and all other Inputs (Base)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_expense_base" model="account.tax.report.line">
-        <field name="name">10. Standard rated expenses</field>
-        <field name="tag_name">10. Standard rated expenses (Base)</field>
-        <field name="code">STD_RATE_EXPENSES_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_expense_supplies_reverse_base" model="account.tax.report.line">
-        <field name="name">11. Supplies subject to the reverse charge provisions</field>
-        <field name="tag_name">11. Supplies subject to the reverse charge provisions (Base)</field>
-        <field name="code">SUPP_REV_CHARGE_PRO_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_expense_out_of_scope" model="account.tax.report.line">
-        <field name="name">12. Out of scope</field>
-        <field name="code">OUT_OF_SCOPE_1_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_base_all_expense_total" model="account.tax.report.line">
-        <field name="name">13. Totals</field>
-        <field name="formula">OUT_OF_SCOPE_1_BASE + SUPP_REV_CHARGE_PRO_BASE + STD_RATE_EXPENSES_BASE</field>
-        <field name="parent_id" ref="tax_report_line_base_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_vat_all_sales" model="account.tax.report.line">
-        <field name="name">VAT on Sales and all other Outputs (Tax)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat" model="account.tax.report.line">
-        <field name="name">1. Standard Rated supplies (Tax)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_abu_dhabi" model="account.tax.report.line">
-        <field name="name">a. Abu Dhabi</field>
-        <field name="tag_name">a. Abu Dhabi (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_AB</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_dubai" model="account.tax.report.line">
-        <field name="name">b. Dubai</field>
-        <field name="tag_name">b. Dubai (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_DB</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_sharjah" model="account.tax.report.line">
-        <field name="name">c. Sharjah</field>
-        <field name="tag_name">c. Sharjah (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_SJ</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_ajman" model="account.tax.report.line">
-        <field name="name">d. Ajman</field>
-        <field name="tag_name">d. Ajman (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_AJ</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_umm_al_quwain" model="account.tax.report.line">
-        <field name="name">e. Umm Al Quwain</field>
-        <field name="tag_name">e. Umm Al Quwain (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_UM</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_ras_al_khaima" model="account.tax.report.line">
-        <field name="name">f. Ras Al-Khaima</field>
-        <field name="tag_name">f. Ras Al-Khaima (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_RA</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_fujairah" model="account.tax.report.line">
-        <field name="name">g. Fujairah</field>
-        <field name="tag_name">g. Fujairah (Tax)</field>
-        <field name="code">STD_RATE_SUPP_TAX_FU</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_supplies_vat_subtotal" model="account.tax.report.line">
-        <field name="name">Sub Total</field>
-        <field name="formula">STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU</field>
-        <field name="parent_id" ref="tax_report_line_standard_rated_supplies_vat"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_line_tax_refund_tourist_vat" model="account.tax.report.line">
-        <field name="name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme</field>
-        <field name="tag_name">2. Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme (Tax)</field>
-        <field name="code">TAX_REF_TOUR_SCHEME_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_supplies_reverse_charge_vat" model="account.tax.report.line">
-        <field name="name">3. Supplies subject to reverse charge provisions</field>
-        <field name="tag_name">3. Supplies subject to reverse charge provisions (Tax)</field>
-        <field name="code">REVERSE_CHARGE_PRO_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_zero_rated_supplies_vat" model="account.tax.report.line">
-        <field name="name">4. Zero rated supplies</field>
-        <field name="tag_name">4. Zero rated supplies (Tax)</field>
-        <field name="code">ZERO_RATE_SUPP_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_exempt_supplies_vat" model="account.tax.report.line">
-        <field name="name">5. Exempt supplies</field>
-        <field name="tag_name">5. Exempt supplies (Tax)</field>
-        <field name="code">EXAMPT_SUPP_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_line_supplies_out_of_scope_vat" model="account.tax.report.line">
-        <field name="name">6. Out of scope</field>
-        <field name="code">OUT_OF_SCOPE_TAX_0</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_line_import_uae_vat" model="account.tax.report.line">
-        <field name="name">7. Goods imported into the UAE</field>
-        <field name="tag_name">7. Goods imported into the UAE (Tax)</field>
-        <field name="code">GOODS_IMPORT_IN_UAE_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_line_adjustment_import_uae_vat" model="account.tax.report.line">
-        <field name="name">8. Adjustments to goods imported into the UAE</field>
-        <field name="code">ADJUST_GOODS_IMPORT_IN_UAE_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_line_vat_all_sales_total" model="account.tax.report.line">
-        <field name="name">9. Total</field>
-        <field name="formula">(STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-    </record>
-
-    <record id="tax_report_line_vat_all_expense" model="account.tax.report.line">
-        <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_standard_rated_expense_vat" model="account.tax.report.line">
-        <field name="name">10. Standard rated expenses</field>
-        <field name="tag_name">10. Standard rated expenses (Tax)</field>
-        <field name="code">STD_RATE_EXPENSES_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_expense_supplies_reverse_vat" model="account.tax.report.line">
-        <field name="name">11. Supplies subject to the reverse charge provisions</field>
-        <field name="tag_name">11. Supplies subject to the reverse charge provisions (Tax)</field>
-        <field name="code">SUPP_REV_CHARGE_PRO_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_expense_out_of_scope_vat" model="account.tax.report.line">
-        <field name="name">12. Out of scope</field>
-        <field name="code">OUT_OF_SCOPE_1_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_line_vat_all_expense_total" model="account.tax.report.line">
-        <field name="name">13. Totals</field>
-        <field name="formula">OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX</field>
-        <field name="parent_id" ref="tax_report_line_vat_all_expense"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_line_net_vat_due" model="account.tax.report.line">
-        <field name="name">Net VAT Due</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="formula">((STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX) - (OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX)</field>
-    </record>
-
-    <record id="tax_report_line_total_value_due_tax_period" model="account.tax.report.line">
-        <field name="name">14. Total value of due tax for the period</field>
-        <field name="formula">(STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX</field>
-        <field name="parent_id" ref="tax_report_line_net_vat_due"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_line_total_value_recoverable_tax_period" model="account.tax.report.line">
-        <field name="name">15. Total value of recoverable tax for the period</field>
-        <field name="formula">OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX</field>
-        <field name="parent_id" ref="tax_report_line_net_vat_due"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_line_net_vat_due_period" model="account.tax.report.line">
-        <field name="name">16. Net VAT due (or reclaimed) for the period</field>
-        <field name="formula">((STD_RATE_SUPP_TAX_AB + STD_RATE_SUPP_TAX_DB + STD_RATE_SUPP_TAX_SJ + STD_RATE_SUPP_TAX_AJ + STD_RATE_SUPP_TAX_UM + STD_RATE_SUPP_TAX_RA + STD_RATE_SUPP_TAX_FU) + OUT_OF_SCOPE_TAX_0 + ADJUST_GOODS_IMPORT_IN_UAE_TAX + GOODS_IMPORT_IN_UAE_TAX + EXAMPT_SUPP_TAX + ZERO_RATE_SUPP_TAX + REVERSE_CHARGE_PRO_TAX + TAX_REF_TOUR_SCHEME_TAX) - (OUT_OF_SCOPE_1_TAX + SUPP_REV_CHARGE_PRO_TAX + STD_RATE_EXPENSES_TAX)</field>
-        <field name="parent_id" ref="tax_report_line_net_vat_due"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_at/data/account_tax_report_data.xml
+++ b/addons/l10n_at/data/account_tax_report_data.xml
@@ -3,598 +3,425 @@
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.at"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_sale_report_title" model="account.tax.report.line">
-        <field name="name">4. Berechnung der Umsatzsteuer (U1/U30)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="formula">(AT_022_tax + AT_029_tax + AT_006_tax + AT_037_tax + AT_052_tax + AT_007_tax + AT_056 + AT_057 + AT_048 + AT_044 + AT_032 + AT_072_tax + AT_073_tax + AT_008_tax + AT_088_tax)</field>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_1" model="account.tax.report.line">
-        <field name="name">4.1 Gesamtbetrag der Bemessungsgrundlage für Lieferungen und sonstige Leistungen [000]</field>
-        <field name="tag_name">KZ 000</field>
-        <field name="code">AT_000</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="20"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_2" model="account.tax.report.line">
-        <field name="name">4.2 zuzüglich Eigenverbrauch (§ 1 Abs. 1 Z 2, § 3 Abs. 2 und § 3a Abs. 1a) [001]</field>
-        <field name="tag_name">KZ 001</field>
-        <field name="code">AT_001</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="30"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_3" model="account.tax.report.line">
-        <field name="name">4.3 abzüglich Umsätze, für die die Steuerschuld gemäß § 19 Abs. 1 (Leistungsempfänger) [021]</field>
-        <field name="tag_name">KZ 021</field>
-        <field name="code">AT_021</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="40"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_4" model="account.tax.report.line">
-        <field name="name">4.4 Summe</field>
-        <field name="formula">AT_000 + AT_001 - AT_021</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="50"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_sale_01_report_title" model="account.tax.report.line">
-        <field name="name">Davon steuerfrei MIT Vorsteuerabzug gemäß</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="60"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-    <record id="tax_report_line_l10n_at_tva_line_4_5" model="account.tax.report.line">
-        <field name="name">4.5 § 6 Abs. 1 Z 1 iVm § 7 (Ausfuhrlieferungen) [011]</field>
-        <field name="tag_name">KZ 011</field>
-        <field name="code">AT_011</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="70"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_01_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_6" model="account.tax.report.line">
-        <field name="name">4.6 § 6 Abs. 1 Z 1 iVm § 8 (Lohnveredelungen) [012]</field>
-        <field name="tag_name">KZ 012</field>
-        <field name="code">AT_012</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="80"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_01_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_7" model="account.tax.report.line">
-        <field name="name">4.7 § 6 Abs. 1 Z 2 bis 6 sowie § 23 Abs. 5 (Seeschifffahrt, Luftfahrt, ...) [015]</field>
-    <field name="tag_name">KZ 015</field>
-        <field name="code">AT_015</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="90"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_01_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_8" model="account.tax.report.line">
-        <field name="name">4.8 Art. 6 Abs. 1 (innergemeinschaftliche Lieferungen ohne die nachstehend gesondert anzuführenden Fahrzeuglieferungen) [017]</field>
-        <field name="tag_name">KZ 017</field>
-        <field name="code">AT_017</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="100"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_01_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_9" model="account.tax.report.line">
-        <field name="name">4.9 Art. 6 Abs. 1, sofern Lieferungen neuer Fahrzeuge an Abnehmer ohne UID-Nummer bzw. durch Fahrzeuglieferer gemäß
+        <field name="root_line_ids">
+            <record id="tax_report_line_l10n_at_tva_sale_report_title" model="account.tax.report.line">
+                <field name="name">4. Berechnung der Umsatzsteuer (U1/U30)</field>
+                <field name="sequence" eval="10"/>
+                <field name="formula">(AT_022_tax + AT_029_tax + AT_006_tax + AT_037_tax + AT_052_tax + AT_007_tax + AT_056 + AT_057 + AT_048 + AT_044 + AT_032 + AT_072_tax + AT_073_tax + AT_008_tax + AT_088_tax)</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_l10n_at_tva_line_4_1" model="account.tax.report.line">
+                        <field name="name">4.1 Gesamtbetrag der Bemessungsgrundlage für Lieferungen und sonstige Leistungen [000]</field>
+                        <field name="tag_name">KZ 000</field>
+                        <field name="code">AT_000</field>
+                        <field name="sequence" eval="20"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_2" model="account.tax.report.line">
+                        <field name="name">4.2 zuzüglich Eigenverbrauch (§ 1 Abs. 1 Z 2, § 3 Abs. 2 und § 3a Abs. 1a) [001]</field>
+                        <field name="tag_name">KZ 001</field>
+                        <field name="code">AT_001</field>
+                        <field name="sequence" eval="30"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_3" model="account.tax.report.line">
+                        <field name="name">4.3 abzüglich Umsätze, für die die Steuerschuld gemäß § 19 Abs. 1 (Leistungsempfänger) [021]</field>
+                        <field name="tag_name">KZ 021</field>
+                        <field name="code">AT_021</field>
+                        <field name="sequence" eval="40"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_4" model="account.tax.report.line">
+                        <field name="name">4.4 Summe</field>
+                        <field name="formula">AT_000 + AT_001 - AT_021</field>
+                        <field name="sequence" eval="50"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_sale_01_report_title" model="account.tax.report.line">
+                        <field name="name">Davon steuerfrei MIT Vorsteuerabzug gemäß</field>
+                        <field name="sequence" eval="60"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_4_5" model="account.tax.report.line">
+                                <field name="name">4.5 § 6 Abs. 1 Z 1 iVm § 7 (Ausfuhrlieferungen) [011]</field>
+                                <field name="tag_name">KZ 011</field>
+                                <field name="code">AT_011</field>
+                                <field name="sequence" eval="70"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_6" model="account.tax.report.line">
+                                <field name="name">4.6 § 6 Abs. 1 Z 1 iVm § 8 (Lohnveredelungen) [012]</field>
+                                <field name="tag_name">KZ 012</field>
+                                <field name="code">AT_012</field>
+                                <field name="sequence" eval="80"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_7" model="account.tax.report.line">
+                                <field name="name">4.7 § 6 Abs. 1 Z 2 bis 6 sowie § 23 Abs. 5 (Seeschifffahrt, Luftfahrt, ...) [015]</field>
+                                <field name="tag_name">KZ 015</field>
+                                <field name="code">AT_015</field>
+                                <field name="sequence" eval="90"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_8" model="account.tax.report.line">
+                                <field name="name">4.8 Art. 6 Abs. 1 (innergemeinschaftliche Lieferungen ohne die nachstehend gesondert anzuführenden Fahrzeuglieferungen) [017]</field>
+                                <field name="tag_name">KZ 017</field>
+                                <field name="code">AT_017</field>
+                                <field name="sequence" eval="100"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_9" model="account.tax.report.line">
+                                <field name="name">4.9 Art. 6 Abs. 1, sofern Lieferungen neuer Fahrzeuge an Abnehmer ohne UID-Nummer bzw. durch Fahrzeuglieferer gemäß
 Art. 2 erfolgten. [018]</field>
-    <field name="tag_name">KZ 018</field>
-        <field name="code">AT_018</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="110"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_01_report_title"/>
-    </record>
-    <record id="tax_report_line_l10n_at_tva_sale_02_report_title" model="account.tax.report.line">
-        <field name="name">Davon steuerfrei OHNE Vorsteuerabzug gemäß</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="120"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-    <record id="tax_report_line_l10n_at_tva_line_4_10" model="account.tax.report.line">
-        <field name="name">4.10 § 6 Abs. 1 Z 9 lit. a (Grundstücksumsätze) [019]</field>
-        <field name="tag_name">KZ 019</field>
-        <field name="code">AT_019</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="130"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_02_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_11" model="account.tax.report.line">
-        <field name="name">4.11 § 6 Abs. 1 Z 27 (Kleinunternehmer) [016]</field>
-        <field name="tag_name">KZ 016</field>
-        <field name="code">AT_016</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="140"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_02_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_12" model="account.tax.report.line">
-        <field name="name">4.12 § 6 Abs. 1 Z .. (übrige steuerfreie Umsätze ohne Vorsteuerabzug) [020]</field>
-        <field name="tag_name">KZ 020</field>
-        <field name="code">AT_020</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="150"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_02_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_13" model="account.tax.report.line">
-        <field name="name">4.13 Gesamtbetrag der steuerpflichtigen Lieferungen, sonstigen Leistungen und Eigenverbrauch (einschließlich steuerpflichtiger Anzahlungen)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="160"/>
-        <field name="formula">(AT_000 + AT_001 - AT_021) - AT_011 - AT_012 - AT_015 - AT_017 - AT_018 - AT_019 - AT_016 - AT_020</field>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_at_base_title_umsatz_base_4_14_19" model="account.tax.report.line">
-        <field name="name">Bemessungsgrundlage</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="170"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_14_base" model="account.tax.report.line">
-        <field name="name">4.14 20% Normalsteuersatz [022]</field>
-        <field name="tag_name">KZ 022 Bemessungsgrundlage</field>
-        <field name="code">AT_022_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="180"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_15_base" model="account.tax.report.line">
-        <field name="name">4.15 10% ermäßigter Steuersatz [029]</field>
-        <field name="tag_name">KZ 029 Bemessungsgrundlage</field>
-        <field name="code">AT_029_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="190"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_16_base" model="account.tax.report.line">
-        <field name="name">4.16 13% ermäßigter Steuersatz [006]</field>
-        <field name="tag_name">KZ 006 Bemessungsgrundlage</field>
-        <field name="code">AT_006_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="200"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_17_base" model="account.tax.report.line">
-        <field name="name">4.17 19% für Jungholz und Mittelberg [037]</field>
-        <field name="tag_name">KZ 037 Bemessungsgrundlage</field>
-        <field name="code">AT_037_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="210"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_18_base" model="account.tax.report.line">
-        <field name="name">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [052]</field>
-        <field name="tag_name">KZ 052 Bemessungsgrundlage</field>
-        <field name="code">AT_052_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="220"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_19_base" model="account.tax.report.line">
-        <field name="name">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [007]</field>
-        <field name="tag_name">KZ 007 Bemessungsgrundlage</field>
-        <field name="code">AT_007_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="230"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_at_tax_title_4_14_19" model="account.tax.report.line">
-        <field name="name">Umsatzsteuer</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="240"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_14_tax" model="account.tax.report.line">
-        <field name="name">4.14 20% Normalsteuersatz</field>
-        <field name="tag_name">KZ 022 Umsatzsteuer</field>
-        <field name="code">AT_022_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="250"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_15_tax" model="account.tax.report.line">
-        <field name="name">4.15 10% ermäßigter Steuersatz</field>
-        <field name="tag_name">KZ 029 Umsatzsteuer</field>
-        <field name="code">AT_029_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="260"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_16_tax" model="account.tax.report.line">
-        <field name="name">4.16 13% ermäßigter Steuersatz</field>
-        <field name="tag_name">KZ 006 Umsatzsteuer</field>
-        <field name="code">AT_006_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="270"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_17_tax" model="account.tax.report.line">
-        <field name="name">4.17 19% für Jungholz und Mittelberg</field>
-        <field name="tag_name">KZ 037 Umsatzsteuer</field>
-        <field name="code">AT_037_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="280"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_18_tax" model="account.tax.report.line">
-        <field name="name">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe</field>
-        <field name="tag_name">KZ 052 Umsatzsteuer</field>
-        <field name="code">AT_052_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="290"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_19_tax" model="account.tax.report.line">
-        <field name="name">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe</field>
-        <field name="tag_name">KZ 007 Umsatzsteuer</field>
-        <field name="code">AT_007_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="300"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_14_19"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_20" model="account.tax.report.line">
-        <field name="name">4.20 Steuerschuld gemäß § 11 Abs. 12 und 14, § 16 Abs. 2 sowie gemäß Art. 7 Abs. 4 [056]</field>
-        <field name="tag_name">KZ 056</field>
-        <field name="code">AT_056</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="310"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_21" model="account.tax.report.line">
-        <field name="name">4.21 Steuerschuld gemäß § 19 Abs. 1 zweiter Satz, § 19 Abs. 1c, 1e sowie gemäß Art. 25 Abs. 5 [057]</field>
-        <field name="tag_name">KZ 057</field>
-        <field name="code">AT_057</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="330"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_22" model="account.tax.report.line">
-        <field name="name">4.22 Steuerschuld gemäß § 19 Abs. 1a (Bauleistungen) [048]</field>
-        <field name="tag_name">KZ 048</field>
-        <field name="code">AT_048</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="340"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_23" model="account.tax.report.line">
-        <field name="name">4.23 Steuerschuld gemäß § 19 Abs. 1b (Sicherungseigentum, ...) [044]</field>
-        <field name="tag_name">KZ 044</field>
-        <field name="code">AT_044</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="350"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_24" model="account.tax.report.line">
-        <field name="name">4.24 Steuerschuld gemäß § 19 Abs. 1d (Schrott und Abfallstoffe) [032]</field>
-        <field name="tag_name">KZ 032</field>
-        <field name="code">AT_032</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="360"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_sale_03_report_title" model="account.tax.report.line">
-        <field name="name">Innergemeinschaftliche Erwerb</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="365"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-    <record id="tax_report_line_l10n_at_tva_line_4_25" model="account.tax.report.line">
-        <field name="name">4.25 Gesamtbetrag der Bemessungsgrundlagen für innergemeinschaftliche Erwerbe [070]</field>
-        <field name="tag_name">KZ 070</field>
-        <field name="code">AT_070</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="370"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_03_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_26" model="account.tax.report.line">
-        <field name="name">4.26 Davon steuerfrei gemäß Art. 6 Abs. 2 [071]</field>
-        <field name="tag_name">KZ 071</field>
-        <field name="code">AT_071</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="380"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_03_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_27" model="account.tax.report.line">
-        <field name="name">4.27 Gesamtbetrag der steuerpflichtigen innergemeinschaftlichen Erwerbe</field>
-        <field name="formula">AT_070 - AT_071</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="390"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_03_report_title"/>
-    </record>
-    <record id="tax_report_line_l10n_at_tva_sale_04_report_title" model="account.tax.report.line">
-        <field name="name">Davon sind zu versteuern mit</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="395"/>
-        <field name="formula">AT_072_base + AT_073_base + AT_008_base + AT_088_base</field>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-    <record id="tax_report_line_at_base_title_umsatz_base_4_28_31" model="account.tax.report.line">
-        <field name="name">Bemessungsgrundlage</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="400"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_04_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_28_base" model="account.tax.report.line">
-        <field name="name">4.28 20% Normalsteuersatz [072]</field>
-        <field name="tag_name">KZ 072 Bemessungsgrundlage</field>
-        <field name="code">AT_072_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="400"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_29_base" model="account.tax.report.line">
-        <field name="name">4.29 10% ermäßigter Steuersatz [073]</field>
-        <field name="tag_name">KZ 073 Bemessungsgrundlage</field>
-        <field name="code">AT_073_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="420"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_30_base" model="account.tax.report.line">
-        <field name="name">4.30 13% ermäßigter Steuersatz [008]</field>
-        <field name="tag_name">KZ 008 Bemessungsgrundlage</field>
-        <field name="code">AT_008_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="450"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_31_base" model="account.tax.report.line">
-        <field name="name">4.31 19% für Jungholz und Mittelberg [088]</field>
-        <field name="tag_name">KZ 088 Bemessungsgrundlage</field>
-        <field name="code">AT_088_base</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="550"/>
-        <field name="parent_id" ref="tax_report_line_at_base_title_umsatz_base_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_at_tax_title_4_28_31" model="account.tax.report.line">
-        <field name="name">Umsatzsteuer</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="410"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_04_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_28_tax" model="account.tax.report.line">
-        <field name="name">4.28 20% Normalsteuersatz</field>
-        <field name="tag_name">KZ 072 Umsatzsteuer</field>
-        <field name="code">AT_072_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="410"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_29_tax" model="account.tax.report.line">
-        <field name="name">4.29 10% ermäßigter Steuersatz</field>
-        <field name="tag_name">KZ 073 Umsatzsteuer</field>
-        <field name="code">AT_073_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="430"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_30_tax" model="account.tax.report.line">
-        <field name="name">4.30 13% ermäßigter Steuersatz</field>
-        <field name="tag_name">KZ 008 Umsatzsteuer</field>
-        <field name="code">AT_008_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="500"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_31_tax" model="account.tax.report.line">
-        <field name="name">4.31 19% für Jungholz und Mittelberg</field>
-        <field name="tag_name">KZ 088 Umsatzsteuer</field>
-        <field name="code">AT_088_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="600"/>
-        <field name="parent_id" ref="tax_report_line_at_tax_title_4_28_31"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_sale_05_report_title" model="account.tax.report.line">
-        <field name="name">Nicht zu versteuernde Erwerbe</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="610"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_report_title"/>
-    </record>
-    <record id="tax_report_line_l10n_at_tva_line_4_32" model="account.tax.report.line">
-        <field name="name">4.32 Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die im Mitgliedstaat des Bestimmungslandes besteuert worden sind [076]</field>
-        <field name="tag_name">KZ 076</field>
-        <field name="code">AT_076</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="650"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_05_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_4_33" model="account.tax.report.line">
-        <field name="name">4.33 Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die gemäß Art. 25 Abs. 2 im Inland als besteuert gelten [077]</field>
-        <field name="tag_name">KZ 077</field>
-        <field name="code">AT_077</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="700"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_sale_05_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_purchase_report_title" model="account.tax.report.line">
-    <field name="name">5. Berechnung der abziehbaren Vorsteuer</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="710"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_1" model="account.tax.report.line">
-        <field name="name">5.1 Gesamtbetrag der Vorsteuern (ohne die nachstehend gesondert anzuführenden Beträge) [060]</field>
-        <field name="tag_name">KZ 060</field>
-        <field name="code">AT_060</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="750"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_2" model="account.tax.report.line">
-        <field name="name">5.2 Vorsteuern betreffend die entrichtete Einfuhrumsatzsteuer (§ 12 Abs. 1 Z 2 lit. a) [061]</field>
-        <field name="tag_name">KZ 061</field>
-        <field name="code">AT_061</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="800"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_3" model="account.tax.report.line">
-        <field name="name">5.3 Vorsteuern betreffend die geschuldete, auf dem Abgabenkonto verbuchte Einfuhrumsatzsteuer (§ 12 Abs. 1 Z 2 lit. b) [083]</field>
-        <field name="tag_name">KZ 083</field>
-        <field name="code">AT_083</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="850"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_4" model="account.tax.report.line">
-        <field name="name">5.4 Vorsteuern aus dem innergemeinschaftlichen Erwerb [065]</field>
-        <field name="tag_name">KZ 065</field>
-        <field name="code">AT_065</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="900"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_5" model="account.tax.report.line">
-        <field name="name">5.5 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1 zweiter Satz, § 19 Abs. 1c, 1e sowie gemäß Art. 25 Abs. 5 [066]</field>
-        <field name="tag_name">KZ 066</field>
-        <field name="code">AT_066</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="950"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_6" model="account.tax.report.line">
-        <field name="name">5.6 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1a (Bauleistungen) [082]</field>
-        <field name="tag_name">KZ 082</field>
-        <field name="code">AT_082</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="960"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_7" model="account.tax.report.line">
-        <field name="name">5.7 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1b (Sicherungseigentum, ...) [087]</field>
-        <field name="tag_name">KZ 087</field>
-        <field name="code">AT_087</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="970"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_8" model="account.tax.report.line">
-        <field name="name">5.8 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1d (Schrott und Abfallstoffe) [089]</field>
-        <field name="tag_name">KZ 089</field>
-        <field name="code">AT_089</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="980"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_9" model="account.tax.report.line">
-        <field name="name">5.9 Vorsteuern für innergemeinschaftliche Lieferungen neuer Fahrzeuge von Fahrzeuglieferern gemäß Art. 2 [064]</field>
-        <field name="tag_name">KZ 064</field>
-        <field name="code">AT_064</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="990"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_10" model="account.tax.report.line">
-        <field name="name">5.10 Davon nicht abzugsfähig gemäß § 12 Abs. 3 iVm Abs. 4 und 5 [062]</field>
-        <field name="tag_name">KZ 062</field>
-        <field name="code">AT_062</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1000"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_11" model="account.tax.report.line">
-        <field name="name">5.11 Berichtigung gemäß § 12 Abs. 10 und 11 [063]</field>
-        <field name="tag_name">KZ 063</field>
-        <field name="code">AT_063</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1010"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_12" model="account.tax.report.line">
-        <field name="name">5.12 Berichtigung gemäß § 16 [067]</field>
-        <field name="tag_name">KZ 067</field>
-        <field name="code">AT_067</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1020"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_5_13" model="account.tax.report.line">
-        <field name="name">5.13 Gesamtbetrag der abziehbaren Vorsteuer</field>
-        <field name="formula">AT_060 + AT_061 + AT_083 + AT_065 + AT_066 + AT_082 + AT_087 + AT_089 + AT_064 + AT_062 + AT_063 + AT_067</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1030"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_purchase_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_final_report_title" model="account.tax.report.line">
-        <field name="name">6. Sonstige Berichtigungen</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1040"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_6" model="account.tax.report.line">
-        <field name="name">Sonstige Berichtigungen [090]</field>
-        <field name="tag_name">KZ 090</field>
-        <field name="code">AT_090</field>
-    <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1050"/>
-        <field name="parent_id" ref="tax_report_line_l10n_at_tva_final_report_title"/>
-    </record>
-
-    <record id="tax_report_line_l10n_at_tva_line_7" model="account.tax.report.line">
-        <field name="name">7. Zahllast (-) bzw. Gutschrift/Überschuss (+) [095]</field>
-        <field name="formula">(AT_022_tax + AT_029_tax + AT_006_tax + AT_037_tax + AT_052_tax + AT_007_tax + AT_056 + AT_057 + AT_048 + AT_044 + AT_032 + AT_072_tax + AT_073_tax + AT_008_tax + AT_088_tax + AT_060 + AT_061 + AT_083 + AT_065 + AT_066 + AT_082 + AT_087 + AT_089 + AT_064 + AT_062 + AT_063 + AT_067) + AT_090</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1060"/>
+                                <field name="tag_name">KZ 018</field>
+                                <field name="code">AT_018</field>
+                                <field name="sequence" eval="110"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_sale_02_report_title" model="account.tax.report.line">
+                        <field name="name">Davon steuerfrei OHNE Vorsteuerabzug gemäß</field>
+                        <field name="sequence" eval="120"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_4_10" model="account.tax.report.line">
+                                <field name="name">4.10 § 6 Abs. 1 Z 9 lit. a (Grundstücksumsätze) [019]</field>
+                                <field name="tag_name">KZ 019</field>
+                                <field name="code">AT_019</field>
+                                <field name="sequence" eval="130"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_11" model="account.tax.report.line">
+                                <field name="name">4.11 § 6 Abs. 1 Z 27 (Kleinunternehmer) [016]</field>
+                                <field name="tag_name">KZ 016</field>
+                                <field name="code">AT_016</field>
+                                <field name="sequence" eval="140"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_12" model="account.tax.report.line">
+                                <field name="name">4.12 § 6 Abs. 1 Z .. (übrige steuerfreie Umsätze ohne Vorsteuerabzug) [020]</field>
+                                <field name="tag_name">KZ 020</field>
+                                <field name="code">AT_020</field>
+                                <field name="sequence" eval="150"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_13" model="account.tax.report.line">
+                        <field name="name">4.13 Gesamtbetrag der steuerpflichtigen Lieferungen, sonstigen Leistungen und Eigenverbrauch (einschließlich steuerpflichtiger Anzahlungen)</field>
+                        <field name="sequence" eval="160"/>
+                        <field name="formula">(AT_000 + AT_001 - AT_021) - AT_011 - AT_012 - AT_015 - AT_017 - AT_018 - AT_019 - AT_016 - AT_020</field>
+                    </record>
+                    <record id="tax_report_line_at_base_title_umsatz_base_4_14_19" model="account.tax.report.line">
+                        <field name="name">Bemessungsgrundlage</field>
+                        <field name="sequence" eval="170"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_4_14_base" model="account.tax.report.line">
+                                <field name="name">4.14 20% Normalsteuersatz [022]</field>
+                                <field name="tag_name">KZ 022 Bemessungsgrundlage</field>
+                                <field name="code">AT_022_base</field>
+                                <field name="sequence" eval="180"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_15_base" model="account.tax.report.line">
+                                <field name="name">4.15 10% ermäßigter Steuersatz [029]</field>
+                                <field name="tag_name">KZ 029 Bemessungsgrundlage</field>
+                                <field name="code">AT_029_base</field>
+                                <field name="sequence" eval="190"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_16_base" model="account.tax.report.line">
+                                <field name="name">4.16 13% ermäßigter Steuersatz [006]</field>
+                                <field name="tag_name">KZ 006 Bemessungsgrundlage</field>
+                                <field name="code">AT_006_base</field>
+                                <field name="sequence" eval="200"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_17_base" model="account.tax.report.line">
+                                <field name="name">4.17 19% für Jungholz und Mittelberg [037]</field>
+                                <field name="tag_name">KZ 037 Bemessungsgrundlage</field>
+                                <field name="code">AT_037_base</field>
+                                <field name="sequence" eval="210"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_18_base" model="account.tax.report.line">
+                                <field name="name">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [052]</field>
+                                <field name="tag_name">KZ 052 Bemessungsgrundlage</field>
+                                <field name="code">AT_052_base</field>
+                                <field name="sequence" eval="220"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_19_base" model="account.tax.report.line">
+                                <field name="name">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [007]</field>
+                                <field name="tag_name">KZ 007 Bemessungsgrundlage</field>
+                                <field name="code">AT_007_base</field>
+                                <field name="sequence" eval="230"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_at_tax_title_4_14_19" model="account.tax.report.line">
+                        <field name="name">Umsatzsteuer</field>
+                        <field name="sequence" eval="240"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_4_14_tax" model="account.tax.report.line">
+                                <field name="name">4.14 20% Normalsteuersatz</field>
+                                <field name="tag_name">KZ 022 Umsatzsteuer</field>
+                                <field name="code">AT_022_tax</field>
+                                <field name="sequence" eval="250"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_15_tax" model="account.tax.report.line">
+                                <field name="name">4.15 10% ermäßigter Steuersatz</field>
+                                <field name="tag_name">KZ 029 Umsatzsteuer</field>
+                                <field name="code">AT_029_tax</field>
+                                <field name="sequence" eval="260"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_16_tax" model="account.tax.report.line">
+                                <field name="name">4.16 13% ermäßigter Steuersatz</field>
+                                <field name="tag_name">KZ 006 Umsatzsteuer</field>
+                                <field name="code">AT_006_tax</field>
+                                <field name="sequence" eval="270"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_17_tax" model="account.tax.report.line">
+                                <field name="name">4.17 19% für Jungholz und Mittelberg</field>
+                                <field name="tag_name">KZ 037 Umsatzsteuer</field>
+                                <field name="code">AT_037_tax</field>
+                                <field name="sequence" eval="280"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_18_tax" model="account.tax.report.line">
+                                <field name="name">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe</field>
+                                <field name="tag_name">KZ 052 Umsatzsteuer</field>
+                                <field name="code">AT_052_tax</field>
+                                <field name="sequence" eval="290"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_19_tax" model="account.tax.report.line">
+                                <field name="name">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe</field>
+                                <field name="tag_name">KZ 007 Umsatzsteuer</field>
+                                <field name="code">AT_007_tax</field>
+                                <field name="sequence" eval="300"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_20" model="account.tax.report.line">
+                        <field name="name">4.20 Steuerschuld gemäß § 11 Abs. 12 und 14, § 16 Abs. 2 sowie gemäß Art. 7 Abs. 4 [056]</field>
+                        <field name="tag_name">KZ 056</field>
+                        <field name="code">AT_056</field>
+                        <field name="sequence" eval="310"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_21" model="account.tax.report.line">
+                        <field name="name">4.21 Steuerschuld gemäß § 19 Abs. 1 zweiter Satz, § 19 Abs. 1c, 1e sowie gemäß Art. 25 Abs. 5 [057]</field>
+                        <field name="tag_name">KZ 057</field>
+                        <field name="code">AT_057</field>
+                        <field name="sequence" eval="330"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_22" model="account.tax.report.line">
+                        <field name="name">4.22 Steuerschuld gemäß § 19 Abs. 1a (Bauleistungen) [048]</field>
+                        <field name="tag_name">KZ 048</field>
+                        <field name="code">AT_048</field>
+                        <field name="sequence" eval="340"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_23" model="account.tax.report.line">
+                        <field name="name">4.23 Steuerschuld gemäß § 19 Abs. 1b (Sicherungseigentum, ...) [044]</field>
+                        <field name="tag_name">KZ 044</field>
+                        <field name="code">AT_044</field>
+                        <field name="sequence" eval="350"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_4_24" model="account.tax.report.line">
+                        <field name="name">4.24 Steuerschuld gemäß § 19 Abs. 1d (Schrott und Abfallstoffe) [032]</field>
+                        <field name="tag_name">KZ 032</field>
+                        <field name="code">AT_032</field>
+                        <field name="sequence" eval="360"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_sale_03_report_title" model="account.tax.report.line">
+                        <field name="name">Innergemeinschaftliche Erwerb</field>
+                        <field name="sequence" eval="365"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_4_25" model="account.tax.report.line">
+                                <field name="name">4.25 Gesamtbetrag der Bemessungsgrundlagen für innergemeinschaftliche Erwerbe [070]</field>
+                                <field name="tag_name">KZ 070</field>
+                                <field name="code">AT_070</field>
+                                <field name="sequence" eval="370"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_26" model="account.tax.report.line">
+                                <field name="name">4.26 Davon steuerfrei gemäß Art. 6 Abs. 2 [071]</field>
+                                <field name="tag_name">KZ 071</field>
+                                <field name="code">AT_071</field>
+                                <field name="sequence" eval="380"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_27" model="account.tax.report.line">
+                                <field name="name">4.27 Gesamtbetrag der steuerpflichtigen innergemeinschaftlichen Erwerbe</field>
+                                <field name="formula">AT_070 - AT_071</field>
+                                <field name="sequence" eval="390"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_sale_04_report_title" model="account.tax.report.line">
+                        <field name="name">Davon sind zu versteuern mit</field>
+                        <field name="sequence" eval="395"/>
+                        <field name="formula">AT_072_base + AT_073_base + AT_008_base + AT_088_base</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_at_base_title_umsatz_base_4_28_31" model="account.tax.report.line">
+                                <field name="name">Bemessungsgrundlage</field>
+                                <field name="sequence" eval="400"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_28_base" model="account.tax.report.line">
+                                        <field name="name">4.28 20% Normalsteuersatz [072]</field>
+                                        <field name="tag_name">KZ 072 Bemessungsgrundlage</field>
+                                        <field name="code">AT_072_base</field>
+                                        <field name="sequence" eval="400"/>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_29_base" model="account.tax.report.line">
+                                        <field name="name">4.29 10% ermäßigter Steuersatz [073]</field>
+                                        <field name="tag_name">KZ 073 Bemessungsgrundlage</field>
+                                        <field name="code">AT_073_base</field>
+                                        <field name="sequence" eval="420"/>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_30_base" model="account.tax.report.line">
+                                        <field name="name">4.30 13% ermäßigter Steuersatz [008]</field>
+                                        <field name="tag_name">KZ 008 Bemessungsgrundlage</field>
+                                        <field name="code">AT_008_base</field>
+                                        <field name="sequence" eval="450"/>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_31_base" model="account.tax.report.line">
+                                        <field name="name">4.31 19% für Jungholz und Mittelberg [088]</field>
+                                        <field name="tag_name">KZ 088 Bemessungsgrundlage</field>
+                                        <field name="code">AT_088_base</field>
+                                        <field name="sequence" eval="550"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_at_tax_title_4_28_31" model="account.tax.report.line">
+                                <field name="name">Umsatzsteuer</field>
+                                <field name="sequence" eval="410"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_28_tax" model="account.tax.report.line">
+                                        <field name="name">4.28 20% Normalsteuersatz</field>
+                                        <field name="tag_name">KZ 072 Umsatzsteuer</field>
+                                        <field name="code">AT_072_tax</field>
+                                        <field name="sequence" eval="410"/>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_29_tax" model="account.tax.report.line">
+                                        <field name="name">4.29 10% ermäßigter Steuersatz</field>
+                                        <field name="tag_name">KZ 073 Umsatzsteuer</field>
+                                        <field name="code">AT_073_tax</field>
+                                        <field name="sequence" eval="430"/>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_30_tax" model="account.tax.report.line">
+                                        <field name="name">4.30 13% ermäßigter Steuersatz</field>
+                                        <field name="tag_name">KZ 008 Umsatzsteuer</field>
+                                        <field name="code">AT_008_tax</field>
+                                        <field name="sequence" eval="500"/>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_31_tax" model="account.tax.report.line">
+                                        <field name="name">4.31 19% für Jungholz und Mittelberg</field>
+                                        <field name="tag_name">KZ 088 Umsatzsteuer</field>
+                                        <field name="code">AT_088_tax</field>
+                                        <field name="sequence" eval="600"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_sale_05_report_title" model="account.tax.report.line">
+                        <field name="name">Nicht zu versteuernde Erwerbe</field>
+                        <field name="sequence" eval="610"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_4_32" model="account.tax.report.line">
+                                <field name="name">4.32 Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die im Mitgliedstaat des Bestimmungslandes besteuert worden sind [076]</field>
+                                <field name="tag_name">KZ 076</field>
+                                <field name="code">AT_076</field>
+                                <field name="sequence" eval="650"/>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_33" model="account.tax.report.line">
+                                <field name="name">4.33 Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die gemäß Art. 25 Abs. 2 im Inland als besteuert gelten [077]</field>
+                                <field name="tag_name">KZ 077</field>
+                                <field name="code">AT_077</field>
+                                <field name="sequence" eval="700"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_l10n_at_tva_purchase_report_title" model="account.tax.report.line">
+                <field name="name">5. Berechnung der abziehbaren Vorsteuer</field>
+                <field name="sequence" eval="710"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_l10n_at_tva_line_5_1" model="account.tax.report.line">
+                        <field name="name">5.1 Gesamtbetrag der Vorsteuern (ohne die nachstehend gesondert anzuführenden Beträge) [060]</field>
+                        <field name="tag_name">KZ 060</field>
+                        <field name="code">AT_060</field>
+                        <field name="sequence" eval="750"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_2" model="account.tax.report.line">
+                        <field name="name">5.2 Vorsteuern betreffend die entrichtete Einfuhrumsatzsteuer (§ 12 Abs. 1 Z 2 lit. a) [061]</field>
+                        <field name="tag_name">KZ 061</field>
+                        <field name="code">AT_061</field>
+                        <field name="sequence" eval="800"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_3" model="account.tax.report.line">
+                        <field name="name">5.3 Vorsteuern betreffend die geschuldete, auf dem Abgabenkonto verbuchte Einfuhrumsatzsteuer (§ 12 Abs. 1 Z 2 lit. b) [083]</field>
+                        <field name="tag_name">KZ 083</field>
+                        <field name="code">AT_083</field>
+                        <field name="sequence" eval="850"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_4" model="account.tax.report.line">
+                        <field name="name">5.4 Vorsteuern aus dem innergemeinschaftlichen Erwerb [065]</field>
+                        <field name="tag_name">KZ 065</field>
+                        <field name="code">AT_065</field>
+                        <field name="sequence" eval="900"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_5" model="account.tax.report.line">
+                        <field name="name">5.5 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1 zweiter Satz, § 19 Abs. 1c, 1e sowie gemäß Art. 25 Abs. 5 [066]</field>
+                        <field name="tag_name">KZ 066</field>
+                        <field name="code">AT_066</field>
+                        <field name="sequence" eval="950"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_6" model="account.tax.report.line">
+                        <field name="name">5.6 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1a (Bauleistungen) [082]</field>
+                        <field name="tag_name">KZ 082</field>
+                        <field name="code">AT_082</field>
+                        <field name="sequence" eval="960"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_7" model="account.tax.report.line">
+                        <field name="name">5.7 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1b (Sicherungseigentum, ...) [087]</field>
+                        <field name="tag_name">KZ 087</field>
+                        <field name="code">AT_087</field>
+                        <field name="sequence" eval="970"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_8" model="account.tax.report.line">
+                        <field name="name">5.8 Vorsteuern betreffend die Steuerschuld gemäß § 19 Abs. 1d (Schrott und Abfallstoffe) [089]</field>
+                        <field name="tag_name">KZ 089</field>
+                        <field name="code">AT_089</field>
+                        <field name="sequence" eval="980"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_9" model="account.tax.report.line">
+                        <field name="name">5.9 Vorsteuern für innergemeinschaftliche Lieferungen neuer Fahrzeuge von Fahrzeuglieferern gemäß Art. 2 [064]</field>
+                        <field name="tag_name">KZ 064</field>
+                        <field name="code">AT_064</field>
+                        <field name="sequence" eval="990"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_10" model="account.tax.report.line">
+                        <field name="name">5.10 Davon nicht abzugsfähig gemäß § 12 Abs. 3 iVm Abs. 4 und 5 [062]</field>
+                        <field name="tag_name">KZ 062</field>
+                        <field name="code">AT_062</field>
+                        <field name="sequence" eval="1000"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_11" model="account.tax.report.line">
+                        <field name="name">5.11 Berichtigung gemäß § 12 Abs. 10 und 11 [063]</field>
+                        <field name="tag_name">KZ 063</field>
+                        <field name="code">AT_063</field>
+                        <field name="sequence" eval="1010"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_12" model="account.tax.report.line">
+                        <field name="name">5.12 Berichtigung gemäß § 16 [067]</field>
+                        <field name="tag_name">KZ 067</field>
+                        <field name="code">AT_067</field>
+                        <field name="sequence" eval="1020"/>
+                    </record>
+                    <record id="tax_report_line_l10n_at_tva_line_5_13" model="account.tax.report.line">
+                        <field name="name">5.13 Gesamtbetrag der abziehbaren Vorsteuer</field>
+                        <field name="formula">AT_060 + AT_061 + AT_083 + AT_065 + AT_066 + AT_082 + AT_087 + AT_089 + AT_064 + AT_062 + AT_063 + AT_067</field>
+                        <field name="sequence" eval="1030"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_l10n_at_tva_final_report_title" model="account.tax.report.line">
+                <field name="name">6. Sonstige Berichtigungen</field>
+                <field name="sequence" eval="1040"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_l10n_at_tva_line_6" model="account.tax.report.line">
+                        <field name="name">Sonstige Berichtigungen [090]</field>
+                        <field name="tag_name">KZ 090</field>
+                        <field name="code">AT_090</field>
+                        <field name="sequence" eval="1050"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_l10n_at_tva_line_7" model="account.tax.report.line">
+                <field name="name">7. Zahllast (-) bzw. Gutschrift/Überschuss (+) [095]</field>
+                <field name="formula">(AT_022_tax + AT_029_tax + AT_006_tax + AT_037_tax + AT_052_tax + AT_007_tax + AT_056 + AT_057 + AT_048 + AT_044 + AT_032 + AT_072_tax + AT_073_tax + AT_008_tax + AT_088_tax + AT_060 + AT_061 + AT_083 + AT_065 + AT_066 + AT_082 + AT_087 + AT_089 + AT_064 + AT_062 + AT_063 + AT_067) + AT_090</field>
+                <field name="sequence" eval="1060"/>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_au/data/account_tax_report_data.xml
+++ b/addons/l10n_au/data/account_tax_report_data.xml
@@ -1,233 +1,170 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.au"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_gstrpt_sale_total" model="account.tax.report.line">
+                <field name="name">GST amounts you owe the Tax Office from sales</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_gstrpt_g1" model="account.tax.report.line">
+                        <field name="name">G1: Total Sales (including any GST)</field>
+                        <field name="tag_name">G1</field>
+                        <field name="code">G1</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_gstrpt_g2" model="account.tax.report.line">
+                                <field name="name">G2: Export sales</field>
+                                <field name="tag_name">G2</field>
+                                <field name="code">G2</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g3" model="account.tax.report.line">
+                                <field name="name">G3: Other GST-free sales</field>
+                                <field name="tag_name">G3</field>
+                                <field name="code">G3</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g4" model="account.tax.report.line">
+                                <field name="name">G4: Input taxed sales</field>
+                                <field name="tag_name">G4</field>
+                                <field name="code">G4</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g5" model="account.tax.report.line">
+                        <field name="name">G5: G2 + G3 + G4</field>
+                        <field name="formula">G2+G3+G4</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g6" model="account.tax.report.line">
+                        <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
+                        <field name="sequence" eval="7"/>
+                        <field name="formula">G1-(G2+G3+G4)</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_gstrpt_g7" model="account.tax.report.line">
+                                <field name="name">G7: Adjustments (if applicable)</field>
+                                <field name="tag_name">G7</field>
+                                <field name="code">G7</field>
+                                <field name="sequence" eval="8"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g8" model="account.tax.report.line">
+                        <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
+                        <field name="sequence" eval="9"/>
+                        <field name="formula">(G1-(G2+G3+G4))+G7</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g9" model="account.tax.report.line">
+                        <field name="name">G9: GST on sales (G8 divided by eleven)</field>
+                        <field name="sequence" eval="10"/>
+                        <field name="formula">((G1-(G2+G3+G4))+G7)/11</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_gstrpt_purchase_total" model="account.tax.report.line">
+                <field name="name">GST amounts the Tax Office owes you from purchases</field>
+                <field name="sequence" eval="101"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_gstrpt_g10" model="account.tax.report.line">
+                        <field name="name">G10: Capital purchases (including any GST)</field>
+                        <field name="tag_name">G10</field>
+                        <field name="code">G10</field>
+                        <field name="sequence" eval="102"/>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g11" model="account.tax.report.line">
+                        <field name="name">G11: Non-capital purchases (including GST)</field>
+                        <field name="tag_name">G11</field>
+                        <field name="code">G11</field>
+                        <field name="sequence" eval="103"/>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g12" model="account.tax.report.line">
+                        <field name="name">G12: G10 + G11</field>
+                        <field name="sequence" eval="104"/>
+                        <field name="formula">G10+G11</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_gstrpt_g13" model="account.tax.report.line">
+                                <field name="name">G13: Purchases for making input taxed sales</field>
+                                <field name="tag_name">G13</field>
+                                <field name="code">G13</field>
+                                <field name="sequence" eval="105"/>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g14" model="account.tax.report.line">
+                                <field name="name">G14: Purchases without GST in the price</field>
+                                <field name="tag_name">G14</field>
+                                <field name="code">G14</field>
+                                <field name="sequence" eval="106"/>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g15" model="account.tax.report.line">
+                                <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
+                                <field name="tag_name">G15</field>
+                                <field name="code">G15</field>
+                                <field name="sequence" eval="107"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g16" model="account.tax.report.line">
+                        <field name="name">G16: G13 + G14 + G15</field>
+                        <field name="sequence" eval="108"/>
+                        <field name="formula">G13+G14+G15</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g17" model="account.tax.report.line">
+                        <field name="name">G17: Total purchases subject to GST (G12 minus G16) </field>
+                        <field name="sequence" eval="109"/>
+                        <field name="formula">(G10+G11)-(G13+G14+G15)</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_gstrpt_g18" model="account.tax.report.line">
+                                <field name="name">G18: Adjustments (if applicable)</field>
+                                <field name="tag_name">G18</field>
+                                <field name="code">G18</field>
+                                <field name="sequence" eval="110"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g19" model="account.tax.report.line">
+                        <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18) </field>
+                        <field name="sequence" eval="111"/>
+                        <field name="formula">(G10+G11)-(G13+G14+G15)+G18</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g20a" model="account.tax.report.line">
+                        <field name="name">GST on purchases (G19 divided by eleven)</field>
+                        <field name="formula">((G10+G11)-(G13+G14+G15)+G18)/11</field>
+                        <field name="sequence" eval="112"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_gstrpt_gstonly" model="account.tax.report.line">
+                                <field name="name">GST only purchases</field>
+                                <field name="tag_name">ONLY</field>
+                                <field name="code">ONLY</field>
+                                <field name="sequence" eval="113"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_gstrpt_g20b" model="account.tax.report.line">
+                <field name="name">G20: GST on purchases</field>
+                <field name="formula">(((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY</field>
+                <field name="sequence" eval="114"/>
+            </record>
+            <record id="account_tax_report_gstrpt_comparison" model="account.tax.report.line">
+                <field name="name">Comparison</field>
+                <field name="tag_name">Comparison</field>
+                <field name="sequence" eval="201"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_gstrpt_comparison_worksheet" model="account.tax.report.line">
+                        <field name="name">GST from worksheet (G20-G9)</field>
+                        <field name="formula">((((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY)-(((G1-(G2+G3+G4))+G7)/11)</field>
+                        <field name="sequence" eval="202"/>
+                    </record>
+                    <record id="account_tax_report_gstrpt_comparison_gl" model="account.tax.report.line">
+                        <field name="name">GST from General Ledger</field>
+                        <field name="tag_name">GST from General Ledger</field>
+                        <field name="sequence" eval="203"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_gstrpt_sale_total" model="account.tax.report.line">
-        <field name="name">GST amounts you owe the Tax Office from sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g1" model="account.tax.report.line">
-        <field name="name">G1: Total Sales (including any GST)</field>
-        <field name="tag_name">G1</field>
-        <field name="code">G1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_sale_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g2" model="account.tax.report.line">
-        <field name="name">G2: Export sales</field>
-        <field name="tag_name">G2</field>
-        <field name="code">G2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g1"/>
-        </record>
-
-    <record id="account_tax_report_gstrpt_g3" model="account.tax.report.line">
-        <field name="name">G3: Other GST-free sales</field>
-        <field name="tag_name">G3</field>
-        <field name="code">G3</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g1"/>
-        </record>
-
-    <record id="account_tax_report_gstrpt_g4" model="account.tax.report.line">
-        <field name="name">G4: Input taxed sales</field>
-        <field name="tag_name">G4</field>
-        <field name="code">G4</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g1"/>
-        </record>
-
-    <record id="account_tax_report_gstrpt_g5" model="account.tax.report.line">
-        <field name="name">G5: G2 + G3 + G4</field>
-        <field name="formula">G2+G3+G4</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_sale_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g6" model="account.tax.report.line">
-        <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="formula">G1-(G2+G3+G4)</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_sale_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g7" model="account.tax.report.line">
-        <field name="name">G7: Adjustments (if applicable)</field>
-        <field name="tag_name">G7</field>
-        <field name="code">G7</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g6"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g8" model="account.tax.report.line">
-        <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="formula">(G1-(G2+G3+G4))+G7</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_sale_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g9" model="account.tax.report.line">
-        <field name="name">G9: GST on sales (G8 divided by eleven)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="formula">((G1-(G2+G3+G4))+G7)/11</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_sale_total"/>
-    </record>
-
-    <!-- Purchase Report -->
-    <record id="account_tax_report_gstrpt_purchase_total" model="account.tax.report.line">
-        <field name="name">GST amounts the Tax Office owes you from purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="101"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g10" model="account.tax.report.line">
-        <field name="name">G10: Capital purchases (including any GST)</field>
-        <field name="tag_name">G10</field>
-        <field name="code">G10</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="102"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g11" model="account.tax.report.line">
-        <field name="name">G11: Non-capital purchases (including GST)</field>
-        <field name="tag_name">G11</field>
-        <field name="code">G11</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="103"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g12" model="account.tax.report.line">
-        <field name="name">G12: G10 + G11</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="104"/>
-        <field name="formula">G10+G11</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g13" model="account.tax.report.line">
-        <field name="name">G13: Purchases for making input taxed sales</field>
-        <field name="tag_name">G13</field>
-        <field name="code">G13</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="105"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g12"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g14" model="account.tax.report.line">
-        <field name="name">G14: Purchases without GST in the price</field>
-        <field name="tag_name">G14</field>
-        <field name="code">G14</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="106"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g12"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g15" model="account.tax.report.line">
-        <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
-        <field name="tag_name">G15</field>
-        <field name="code">G15</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="107"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g12"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g16" model="account.tax.report.line">
-        <field name="name">G16: G13 + G14 + G15</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="108"/>
-        <field name="formula">G13+G14+G15</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g17" model="account.tax.report.line">
-        <field name="name">G17: Total purchases subject to GST (G12 minus G16) </field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="109"/>
-        <field name="formula">(G10+G11)-(G13+G14+G15)</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g18" model="account.tax.report.line">
-        <field name="name">G18: Adjustments (if applicable)</field>
-        <field name="tag_name">G18</field>
-        <field name="code">G18</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="110"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g17"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g19" model="account.tax.report.line">
-        <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18) </field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="111"/>
-        <field name="formula">(G10+G11)-(G13+G14+G15)+G18</field>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g20a" model="account.tax.report.line">
-        <field name="name">GST on purchases (G19 divided by eleven)</field>
-        <field name="formula">((G10+G11)-(G13+G14+G15)+G18)/11</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="112"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_purchase_total"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_gstonly" model="account.tax.report.line">
-        <field name="name">GST only purchases</field>
-        <field name="tag_name">ONLY</field>
-        <field name="code">ONLY</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="113"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_g20a"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_g20b" model="account.tax.report.line">
-        <field name="name">G20: GST on purchases</field>
-        <field name="formula">(((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="114"/>
-    </record>
-
-    <!-- Comparison -->
-    <record id="account_tax_report_gstrpt_comparison" model="account.tax.report.line">
-        <field name="name">Comparison</field>
-        <field name="tag_name">Comparison</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="201"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_comparison_worksheet" model="account.tax.report.line">
-        <field name="name">GST from worksheet (G20-G9)</field>
-        <field name="formula">((((G10+G11)-(G13+G14+G15)+G18)/11)+ONLY)-(((G1-(G2+G3+G4))+G7)/11)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="202"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_comparison"/>
-    </record>
-
-    <record id="account_tax_report_gstrpt_comparison_gl" model="account.tax.report.line">
-        <field name="name">GST from General Ledger</field>
-        <field name="tag_name">GST from General Ledger</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="203"/>
-        <field name="parent_id" ref="account_tax_report_gstrpt_comparison"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -3,370 +3,268 @@
     <record id="tax_report_vat" model="account.tax.report">
         <field name="name">VAT Report</field>
         <field name="country_id" ref="base.be"/>
+        <field name="root_line_ids">
+            <record id="tax_report_title_operations" model="account.tax.report.line">
+                <field name="name">Opérations</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_title_operations_sortie" model="account.tax.report.line">
+                        <field name="name">II A la sortie</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_00" model="account.tax.report.line">
+                                <field name="name">00 - Opérations soumises à un régime particulier</field>
+                                <field name="code">c00</field>
+                                <field name="tag_name">00</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_01" model="account.tax.report.line">
+                                <field name="name">01 - Opérations avec TVA à 6%</field>
+                                <field name="code">c01</field>
+                                <field name="tag_name">01</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_line_02" model="account.tax.report.line">
+                                <field name="name">02 - Opérations avec TVA à 12%</field>
+                                <field name="code">c02</field>
+                                <field name="tag_name">02</field>
+                                <field name="sequence">3</field>
+                            </record>
+                            <record id="tax_report_line_03" model="account.tax.report.line">
+                                <field name="name">03 - Opérations avec TVA à 21%</field>
+                                <field name="code">c03</field>
+                                <field name="tag_name">03</field>
+                                <field name="sequence">4</field>
+                            </record>
+                            <record id="tax_report_line_44" model="account.tax.report.line">
+                                <field name="name">44 - Services intra-communautaires</field>
+                                <field name="code">c44</field>
+                                <field name="tag_name">44</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_line_45" model="account.tax.report.line">
+                                <field name="name">45 - Opérations avec TVA due par le cocontractant</field>
+                                <field name="code">c45</field>
+                                <field name="tag_name">45</field>
+                                <field name="sequence">6</field>
+                            </record>
+                            <record id="tax_report_title_operations_sortie_46" model="account.tax.report.line">
+                                <field name="name">46 - Livraisons intra-communautaires exemptées</field>
+                                <field name="code">c46</field>
+                                <field name="sequence">7</field>
+                                <field name="formula"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_46L" model="account.tax.report.line">
+                                        <field name="name">46L - Livraisons biens intra-communautaires exemptées</field>
+                                        <field name="code">c46L</field>
+                                        <field name="tag_name">46L</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_46T" model="account.tax.report.line">
+                                        <field name="name">46T - Livraisons biens intra-communautaire exemptées</field>
+                                        <field name="code">c46T</field>
+                                        <field name="tag_name">46T</field>
+                                        <field name="sequence">2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_47" model="account.tax.report.line">
+                                <field name="name">47 - Autres opérations exemptées</field>
+                                <field name="code">c47</field>
+                                <field name="tag_name">47</field>
+                                <field name="sequence">8</field>
+                            </record>
+                            <record id="tax_report_title_operations_sortie_48" model="account.tax.report.line">
+                                <field name="name">48 - Notes de crédit aux opérations grilles [44] et [46]</field>
+                                <field name="code">c48</field>
+                                <field name="sequence">9</field>
+                                <field name="formula"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_48s44" model="account.tax.report.line">
+                                        <field name="name">48s44 - Notes de crédit aux opérations grilles [44]</field>
+                                        <field name="code">c48s44</field>
+                                        <field name="tag_name">48s44</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_48s46L" model="account.tax.report.line">
+                                        <field name="name">48s46L - Notes de crédit aux opérations grilles [46L]</field>
+                                        <field name="code">c48s46L</field>
+                                        <field name="tag_name">48s46L</field>
+                                        <field name="sequence">2</field>
+                                    </record>
+                                    <record id="tax_report_line_48s46T" model="account.tax.report.line">
+                                        <field name="name">48s46T - Notes de crédit aux opérations grilles [46T]</field>
+                                        <field name="code">c48s46T</field>
+                                        <field name="tag_name">48s46T</field>
+                                        <field name="sequence">3</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_49" model="account.tax.report.line">
+                                <field name="name">49 - Notes de crédit aux opérations du point II</field>
+                                <field name="code">c49</field>
+                                <field name="tag_name">49</field>
+                                <field name="sequence">10</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_title_operations_entree" model="account.tax.report.line">
+                        <field name="name">III A l'entrée</field>
+                        <field name="sequence">2</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_81" model="account.tax.report.line">
+                                <field name="name">81 - Marchandises, matières premières et auxiliaires</field>
+                                <field name="code">c81</field>
+                                <field name="tag_name">81</field>
+                                <field name="sequence">1</field>
+                                <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
+                            </record>
+                            <record id="tax_report_line_82" model="account.tax.report.line">
+                                <field name="name">82 - Services et biens divers</field>
+                                <field name="code">c82</field>
+                                <field name="tag_name">82</field>
+                                <field name="sequence">2</field>
+                                <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
+                            </record>
+                            <record id="tax_report_line_83" model="account.tax.report.line">
+                                <field name="name">83 - Biens d'investissement</field>
+                                <field name="code">c83</field>
+                                <field name="tag_name">83</field>
+                                <field name="sequence">3</field>
+                                <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
+                            </record>
+                            <record id="tax_report_line_84" model="account.tax.report.line">
+                                <field name="name">84 - Notes de crédits sur opérations case [86] et [88]</field>
+                                <field name="code">c84</field>
+                                <field name="tag_name">84</field>
+                                <field name="sequence">4</field>
+                            </record>
+                            <record id="tax_report_line_85" model="account.tax.report.line">
+                                <field name="name">85 - Notes de crédits autres opérations</field>
+                                <field name="code">c85</field>
+                                <field name="tag_name">85</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_line_86" model="account.tax.report.line">
+                                <field name="name">86 - Acquisition intra-communautaires et ventes ABC</field>
+                                <field name="code">c86</field>
+                                <field name="tag_name">86</field>
+                                <field name="sequence">6</field>
+                                <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
+                            </record>
+                            <record id="tax_report_line_87" model="account.tax.report.line">
+                                <field name="name">87 - Autres opérations</field>
+                                <field name="code">c87</field>
+                                <field name="tag_name">87</field>
+                                <field name="sequence">7</field>
+                                <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
+                            </record>
+                            <record id="tax_report_line_88" model="account.tax.report.line">
+                                <field name="name">88 - Acquisition services intra-communautaires</field>
+                                <field name="code">c88</field>
+                                <field name="tag_name">88</field>
+                                <field name="sequence">8</field>
+                                <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_taxes" model="account.tax.report.line">
+                <field name="name">Taxes</field>
+                <field name="sequence">2</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_title_taxes_dues" model="account.tax.report.line">
+                        <field name="name">IV Dues</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_54" model="account.tax.report.line">
+                                <field name="name">54 - TVA sur opérations des grilles [01], [02], [03]</field>
+                                <field name="code">c54</field>
+                                <field name="tag_name">54</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_55" model="account.tax.report.line">
+                                <field name="name">55 - TVA sur opérations des grilles [86] et [88]</field>
+                                <field name="code">c55</field>
+                                <field name="tag_name">55</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_line_56" model="account.tax.report.line">
+                                <field name="name">56 - TVA sur opérations de la grille [87]</field>
+                                <field name="code">c56</field>
+                                <field name="tag_name">56</field>
+                                <field name="sequence">3</field>
+                            </record>
+                            <record id="tax_report_line_57" model="account.tax.report.line">
+                                <field name="name">57 - TVA relatives aux importations</field>
+                                <field name="code">c57</field>
+                                <field name="tag_name">57</field>
+                                <field name="sequence">4</field>
+                            </record>
+                            <record id="tax_report_line_61" model="account.tax.report.line">
+                                <field name="name">61 - Diverses régularisations en faveur de l'Etat</field>
+                                <field name="code">c61</field>
+                                <field name="tag_name">61</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_line_63" model="account.tax.report.line">
+                                <field name="name">63 - TVA à reverser sur notes de crédit recues</field>
+                                <field name="code">c63</field>
+                                <field name="tag_name">63</field>
+                                <field name="sequence">6</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_title_taxes_deductibles" model="account.tax.report.line">
+                        <field name="name">V Déductibles</field>
+                        <field name="sequence">2</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_59" model="account.tax.report.line">
+                                <field name="name">59 - TVA déductible</field>
+                                <field name="code">c59</field>
+                                <field name="tag_name">59</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_62" model="account.tax.report.line">
+                                <field name="name">62 - Diverses régularisations en faveur du déclarant</field>
+                                <field name="code">c62</field>
+                                <field name="tag_name">62</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_line_64" model="account.tax.report.line">
+                                <field name="name">64 - TVA à récupérer sur notes de crédit delivrées</field>
+                                <field name="code">c64</field>
+                                <field name="tag_name">64</field>
+                                <field name="sequence">3</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_title_taxes_soldes" model="account.tax.report.line">
+                        <field name="name">VI Soldes</field>
+                        <field name="sequence">3</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_71" model="account.tax.report.line">
+                                <field name="name">71 - Taxes dues à l'état</field>
+                                <field name="formula">(c54 + c55 + c56 + c57 + c61 + c63)&gt;(c59 + c62 + c64) and (c54 + c55 + c56 + c57 + c61 + c63)-(c59 + c62 + c64) or 0</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_72" model="account.tax.report.line">
+                                <field name="name">72 - Somme due par l'état</field>
+                                <field name="formula">(c54 + c55 + c56 + c57 + c61 + c63)&lt;(c59 + c62 + c64) and (c59 + c62 + c64)-(c54 + c55 + c56 + c57 + c61 + c63) or 0</field>
+                                <field name="sequence">2</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_title_operations" model="account.tax.report.line">
-        <field name="name">Opérations</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_title_operations_sortie" model="account.tax.report.line">
-        <field name="name">II A la sortie</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_line_00" model="account.tax.report.line">
-        <field name="name">00 - Opérations soumises à un régime particulier</field>
-        <field name="code">c00</field>
-        <field name="tag_name">00</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_line_01" model="account.tax.report.line">
-        <field name="name">01 - Opérations avec TVA à 6%</field>
-        <field name="code">c01</field>
-        <field name="tag_name">01</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_line_02" model="account.tax.report.line">
-        <field name="name">02 - Opérations avec TVA à 12%</field>
-        <field name="code">c02</field>
-        <field name="tag_name">02</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_line_03" model="account.tax.report.line">
-        <field name="name">03 - Opérations avec TVA à 21%</field>
-        <field name="code">c03</field>
-        <field name="tag_name">03</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_line_44" model="account.tax.report.line">
-        <field name="name">44 - Services intra-communautaires</field>
-        <field name="code">c44</field>
-        <field name="tag_name">44</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_line_45" model="account.tax.report.line">
-        <field name="name">45 - Opérations avec TVA due par le cocontractant</field>
-        <field name="code">c45</field>
-        <field name="tag_name">45</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">6</field>
-    </record>
-
-    <record id="tax_report_title_operations_sortie_46" model="account.tax.report.line">
-        <field name="name">46 - Livraisons intra-communautaires exemptées</field>
-        <field name="code">c46</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">7</field>
-        <field name="formula"></field>
-    </record>
-
-    <record id="tax_report_line_46L" model="account.tax.report.line">
-        <field name="name">46L - Livraisons biens intra-communautaires exemptées</field>
-        <field name="code">c46L</field>
-        <field name="tag_name">46L</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie_46"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_line_46T" model="account.tax.report.line">
-        <field name="name">46T - Livraisons biens intra-communautaire exemptées</field>
-        <field name="code">c46T</field>
-        <field name="tag_name">46T</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie_46"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_line_47" model="account.tax.report.line">
-        <field name="name">47 - Autres opérations exemptées</field>
-        <field name="code">c47</field>
-        <field name="tag_name">47</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">8</field>
-    </record>
-
-    <record id="tax_report_title_operations_sortie_48" model="account.tax.report.line">
-        <field name="name">48 - Notes de crédit aux opérations grilles [44] et [46]</field>
-        <field name="code">c48</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">9</field>
-        <field name="formula"></field>
-    </record>
-
-    <record id="tax_report_line_48s44" model="account.tax.report.line">
-        <field name="name">48s44 - Notes de crédit aux opérations grilles [44]</field>
-        <field name="code">c48s44</field>
-        <field name="tag_name">48s44</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie_48"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_line_48s46L" model="account.tax.report.line">
-        <field name="name">48s46L - Notes de crédit aux opérations grilles [46L]</field>
-        <field name="code">c48s46L</field>
-        <field name="tag_name">48s46L</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie_48"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_line_48s46T" model="account.tax.report.line">
-        <field name="name">48s46T - Notes de crédit aux opérations grilles [46T]</field>
-        <field name="code">c48s46T</field>
-        <field name="tag_name">48s46T</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie_48"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_line_49" model="account.tax.report.line">
-        <field name="name">49 - Notes de crédit aux opérations du point II</field>
-        <field name="code">c49</field>
-        <field name="tag_name">49</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_sortie"/>
-        <field name="sequence">10</field>
-    </record>
-
-    <record id="tax_report_title_operations_entree" model="account.tax.report.line">
-        <field name="name">III A l'entrée</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_line_81" model="account.tax.report.line">
-        <field name="name">81 - Marchandises, matières premières et auxiliaires</field>
-        <field name="code">c81</field>
-        <field name="tag_name">81</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">1</field>
-        <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
-    </record>
-
-    <record id="tax_report_line_82" model="account.tax.report.line">
-        <field name="name">82 - Services et biens divers</field>
-        <field name="code">c82</field>
-        <field name="tag_name">82</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">2</field>
-        <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
-    </record>
-
-    <record id="tax_report_line_83" model="account.tax.report.line">
-        <field name="name">83 - Biens d'investissement</field>
-        <field name="code">c83</field>
-        <field name="tag_name">83</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">3</field>
-        <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
-    </record>
-
-    <record id="tax_report_line_84" model="account.tax.report.line">
-        <field name="name">84 - Notes de crédits sur opérations case [86] et [88]</field>
-        <field name="code">c84</field>
-        <field name="tag_name">84</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_line_85" model="account.tax.report.line">
-        <field name="name">85 - Notes de crédits autres opérations</field>
-        <field name="code">c85</field>
-        <field name="tag_name">85</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_line_86" model="account.tax.report.line">
-        <field name="name">86 - Acquisition intra-communautaires et ventes ABC</field>
-        <field name="code">c86</field>
-        <field name="tag_name">86</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">6</field>
-        <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
-    </record>
-
-    <record id="tax_report_line_87" model="account.tax.report.line">
-        <field name="name">87 - Autres opérations</field>
-        <field name="code">c87</field>
-        <field name="tag_name">87</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">7</field>
-        <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
-    </record>
-
-    <record id="tax_report_line_88" model="account.tax.report.line">
-        <field name="name">88 - Acquisition services intra-communautaires</field>
-        <field name="code">c88</field>
-        <field name="tag_name">88</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_operations_entree"/>
-        <field name="sequence">8</field>
-        <field name="carry_over_condition_method">no_negative_amount_carry_over_condition</field>
-    </record>
-
-    <record id="tax_report_title_taxes" model="account.tax.report.line">
-        <field name="name">Taxes</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_title_taxes_dues" model="account.tax.report.line">
-        <field name="name">IV Dues</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_line_54" model="account.tax.report.line">
-        <field name="name">54 - TVA sur opérations des grilles [01], [02], [03]</field>
-        <field name="code">c54</field>
-        <field name="tag_name">54</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_dues"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_line_55" model="account.tax.report.line">
-        <field name="name">55 - TVA sur opérations des grilles [86] et [88]</field>
-        <field name="code">c55</field>
-        <field name="tag_name">55</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_dues"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_line_56" model="account.tax.report.line">
-        <field name="name">56 - TVA sur opérations de la grille [87]</field>
-        <field name="code">c56</field>
-        <field name="tag_name">56</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_dues"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_line_57" model="account.tax.report.line">
-        <field name="name">57 - TVA relatives aux importations</field>
-        <field name="code">c57</field>
-        <field name="tag_name">57</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_dues"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_line_61" model="account.tax.report.line">
-        <field name="name">61 - Diverses régularisations en faveur de l'Etat</field>
-        <field name="code">c61</field>
-        <field name="tag_name">61</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_dues"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_line_63" model="account.tax.report.line">
-        <field name="name">63 - TVA à reverser sur notes de crédit recues</field>
-        <field name="code">c63</field>
-        <field name="tag_name">63</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_dues"/>
-        <field name="sequence">6</field>
-    </record>
-
-    <record id="tax_report_title_taxes_deductibles" model="account.tax.report.line">
-        <field name="name">V Déductibles</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_line_59" model="account.tax.report.line">
-        <field name="name">59 - TVA déductible</field>
-        <field name="code">c59</field>
-        <field name="tag_name">59</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_deductibles"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_line_62" model="account.tax.report.line">
-        <field name="name">62 - Diverses régularisations en faveur du déclarant</field>
-        <field name="code">c62</field>
-        <field name="tag_name">62</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_deductibles"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_line_64" model="account.tax.report.line">
-        <field name="name">64 - TVA à récupérer sur notes de crédit delivrées</field>
-        <field name="code">c64</field>
-        <field name="tag_name">64</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_deductibles"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_title_taxes_soldes" model="account.tax.report.line">
-        <field name="name">VI Soldes</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes"/>
-        <field name="sequence">3</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_line_71" model="account.tax.report.line">
-        <field name="name">71 - Taxes dues à l'état</field>
-        <field name="formula">(c54 + c55 + c56 + c57 + c61 + c63)&gt;(c59 + c62 + c64) and (c54 + c55 + c56 + c57 + c61 + c63)-(c59 + c62 + c64) or 0</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_soldes"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_line_72" model="account.tax.report.line">
-        <field name="name">72 - Somme due par l'état</field>
-        <field name="formula">(c54 + c55 + c56 + c57 + c61 + c63)&lt;(c59 + c62 + c64) and (c59 + c62 + c64)-(c54 + c55 + c56 + c57 + c61 + c63) or 0</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="parent_id" ref="tax_report_title_taxes_soldes"/>
-        <field name="sequence">2</field>
-    </record>
-
 </odoo>

--- a/addons/l10n_bo/data/account_tax_report_data.xml
+++ b/addons/l10n_bo/data/account_tax_report_data.xml
@@ -1,157 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.bo"/>
+        <field name="root_line_ids">
+            <record id="tax_report_impuesto_25" model="account.tax.report.line">
+                <field name="name">Impuesto a las Utilidades de la Empresa IUE (25%)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_impuesto_trans" model="account.tax.report.line">
+                <field name="name">Impuesto a las Transacciones IT (3%)</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_impuesto_trans_3" model="account.tax.report.line">
+                        <field name="name">Impuesto a las Transacciones IT (3%)</field>
+                        <field name="tag_name">Impuesto a las Transacciones IT (3%)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_impuesto_ttl" model="account.tax.report.line">
+                <field name="name">Impuesto al Valor Agregado (IVA) Total a Pagar</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_impuesto_ttl_cob" model="account.tax.report.line">
+                        <field name="name">Impuesto Cobrado</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_impuesto_ttl_cob_fuera" model="account.tax.report.line">
+                                <field name="name">Impuesto Cobrado Fuera de Ámbito</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_impuesto_ttl_cob_exon" model="account.tax.report.line">
+                                <field name="name">Impuesto Cobrado de Exonerados al IVA</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_impuesto_ttl_cob_iva" model="account.tax.report.line">
+                                <field name="name">Impuesto Cobrado IVA</field>
+                                <field name="tag_name">Impuesto Cobrado IVA</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_impuesto_ttl_pag" model="account.tax.report.line">
+                        <field name="name">Impuesto Pagado</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_impuesto_ttl_pag_fuera" model="account.tax.report.line">
+                                <field name="name">Impuesto Pagado Fuera de Ámbito</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_impuesto_ttl_pag_exon" model="account.tax.report.line">
+                                <field name="name">Impuesto Pagado de Exonerados al IVA</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_impuesto_ttl_pag_iva" model="account.tax.report.line">
+                                <field name="name">Impuesto Pagado IVA</field>
+                                <field name="tag_name">Impuesto Pagado IVA</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_base_imponible" model="account.tax.report.line">
+                <field name="name">Base Imponible</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_base_imponible_compras" model="account.tax.report.line">
+                        <field name="name">Base Imponible - Compras</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_base_imponible_compras_fuera" model="account.tax.report.line">
+                                <field name="name">Compras Gravadas Fuera de Ámbito</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_base_imponible_compras_gravadas" model="account.tax.report.line">
+                                <field name="name">Compras NO Gravadas (Exoneradas)</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_base_imponible_compras_iva" model="account.tax.report.line">
+                                <field name="name">Compras Gravadas con IVA</field>
+                                <field name="tag_name">Compras Gravadas con IVA</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_base_imponible_venras" model="account.tax.report.line">
+                        <field name="name">Base Imponible - Ventas</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_base_imponible_venras_fuera" model="account.tax.report.line">
+                                <field name="name">Ventas Gravadas Fuera de Ámbito</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_base_imponible_venras_exon" model="account.tax.report.line">
+                                <field name="name">Ventas NO Gravadas (Exoneradas)</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_base_imponible_venras_iva" model="account.tax.report.line">
+                                <field name="name">Impuesto al Valor Agregado con IVA</field>
+                                <field name="tag_name">Impuesto al Valor Agregado con IVA</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-	<record id="tax_report_impuesto_25" model="account.tax.report.line">
-        <field name="name">Impuesto a las Utilidades de la Empresa IUE (25%)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_impuesto_trans" model="account.tax.report.line">
-        <field name="name">Impuesto a las Transacciones IT (3%)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_impuesto_trans_3" model="account.tax.report.line">
-        <field name="name">Impuesto a las Transacciones IT (3%)</field>
-        <field name="tag_name">Impuesto a las Transacciones IT (3%)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_impuesto_trans"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl" model="account.tax.report.line">
-        <field name="name">Impuesto al Valor Agregado (IVA) Total a Pagar</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_cob" model="account.tax.report.line">
-        <field name="name">Impuesto Cobrado</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_cob_fuera" model="account.tax.report.line">
-        <field name="name">Impuesto Cobrado Fuera de Ámbito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl_cob"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_cob_exon" model="account.tax.report.line">
-        <field name="name">Impuesto Cobrado de Exonerados al IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl_cob"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_cob_iva" model="account.tax.report.line">
-        <field name="name">Impuesto Cobrado IVA</field>
-        <field name="tag_name">Impuesto Cobrado IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl_cob"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_pag" model="account.tax.report.line">
-        <field name="name">Impuesto Pagado</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_pag_fuera" model="account.tax.report.line">
-        <field name="name">Impuesto Pagado Fuera de Ámbito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl_pag"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_pag_exon" model="account.tax.report.line">
-        <field name="name">Impuesto Pagado de Exonerados al IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl_pag"/>
-    </record>
-
-    <record id="tax_report_impuesto_ttl_pag_iva" model="account.tax.report.line">
-        <field name="name">Impuesto Pagado IVA</field>
-        <field name="tag_name">Impuesto Pagado IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_impuesto_ttl_pag"/>
-    </record>
-
-    <record id="tax_report_base_imponible" model="account.tax.report.line">
-        <field name="name">Base Imponible</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_base_imponible_compras" model="account.tax.report.line">
-        <field name="name">Base Imponible - Compras</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_base_imponible"/>
-    </record>
-
-    <record id="tax_report_base_imponible_compras_fuera" model="account.tax.report.line">
-        <field name="name">Compras Gravadas Fuera de Ámbito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_base_imponible_compras"/>
-    </record>
-
-    <record id="tax_report_base_imponible_compras_gravadas" model="account.tax.report.line">
-        <field name="name">Compras NO Gravadas (Exoneradas)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_base_imponible_compras"/>
-    </record>
-
-    <record id="tax_report_base_imponible_compras_iva" model="account.tax.report.line">
-        <field name="name">Compras Gravadas con IVA</field>
-        <field name="tag_name">Compras Gravadas con IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_base_imponible_compras"/>
-    </record>
-
-    <record id="tax_report_base_imponible_venras" model="account.tax.report.line">
-        <field name="name">Base Imponible - Ventas</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_base_imponible"/>
-    </record>
-
-    <record id="tax_report_base_imponible_venras_fuera" model="account.tax.report.line">
-        <field name="name">Ventas Gravadas Fuera de Ámbito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_base_imponible_venras"/>
-    </record>
-
-    <record id="tax_report_base_imponible_venras_exon" model="account.tax.report.line">
-        <field name="name">Ventas NO Gravadas (Exoneradas)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_base_imponible_venras"/>
-    </record>
-
-    <record id="tax_report_base_imponible_venras_iva" model="account.tax.report.line">
-        <field name="name">Impuesto al Valor Agregado con IVA</field>
-        <field name="tag_name">Impuesto al Valor Agregado con IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_base_imponible_venras"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_br/data/account_tax_report_data.xml
+++ b/addons/l10n_br/data/account_tax_report_data.xml
@@ -1,916 +1,571 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.br"/>
-    </record>
-
-    <record id="tax_report_icmsst" model="account.tax.report.line">
-        <field name="name">ICMSST</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_icmsst_1" model="account.tax.report.line">
-        <field name="name">ICMSST_1</field>
-        <field name="tag_name">ICMSST_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_icmsst"/>
-    </record>
-
-    <record id="tax_report_icmsst_2" model="account.tax.report.line">
-        <field name="name">ICMSST_2</field>
-        <field name="tag_name">ICMSST_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_icmsst"/>
-    </record>
-
-    <record id="tax_report_irpj" model="account.tax.report.line">
-        <field name="name">IRPJ</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_irpj_1" model="account.tax.report.line">
-        <field name="name">IRPJ_1</field>
-        <field name="tag_name">IRPJ_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_irpj"/>
-    </record>
-
-    <record id="tax_report_irpj_2" model="account.tax.report.line">
-        <field name="name">IRPJ_2</field>
-        <field name="tag_name">IRPJ_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_irpj"/>
-    </record>
-
-    <record id="tax_report_ir" model="account.tax.report.line">
-        <field name="name">IR</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_ir_1" model="account.tax.report.line">
-        <field name="name">IR_1</field>
-        <field name="tag_name">IR_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_ir"/>
-    </record>
-
-    <record id="tax_report_ir_2" model="account.tax.report.line">
-        <field name="name">IR_2</field>
-        <field name="tag_name">IR_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_ir"/>
-    </record>
-
-    <record id="tax_report_issqn" model="account.tax.report.line">
-        <field name="name">ISSQN</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_issqn_1" model="account.tax.report.line">
-        <field name="name">ISSQN_1</field>
-        <field name="tag_name">ISSQN_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_issqn"/>
-    </record>
-
-    <record id="tax_report_issqn_2" model="account.tax.report.line">
-        <field name="name">ISSQN_2</field>
-        <field name="tag_name">ISSQN_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_issqn"/>
-    </record>
-
-
-    <record id="tax_report_csll" model="account.tax.report.line">
-        <field name="name">CSLL</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_csll_1" model="account.tax.report.line">
-        <field name="name">CSLL_1</field>
-        <field name="tag_name">CSLL_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_csll"/>
-    </record>
-
-    <record id="tax_report_csll_2" model="account.tax.report.line">
-        <field name="name">CSLL_2</field>
-        <field name="tag_name">CSLL_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_csll"/>
-    </record>
-
-    <record id="tax_report_cofins" model="account.tax.report.line">
-        <field name="name">COFINS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_bas" model="account.tax.report.line">
-        <field name="name">Operação Tributável com Alíquota Básica</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_1" model="account.tax.report.line">
-        <field name="name">COFINS_1</field>
-        <field name="tag_name">COFINS_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_cofins_oper_bas"/>
-    </record>
-
-    <record id="tax_report_cofins_2" model="account.tax.report.line">
-        <field name="name">COFINS_2</field>
-        <field name="tag_name">COFINS_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_cofins_oper_bas"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_dif" model="account.tax.report.line">
-        <field name="name">Operação Tributável com Alíquota Diferenciada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_uni" model="account.tax.report.line">
-        <field name="name">Operação Tributável com Alíquota por Unidade de Medida de Produto</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_line12" model="account.tax.report.line">
-        <field name="name">Operação Tributável Monofásica - Revenda a Alíquota Zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_sub" model="account.tax.report.line">
-        <field name="name">Operação Tributável por Substituição Tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_tri" model="account.tax.report.line">
-        <field name="name">Operação Tributável a Alíquota zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_isenta" model="account.tax.report.line">
-        <field name="name">Operação Isenta da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_sem" model="account.tax.report.line">
-        <field name="name">Operação sem Incidência da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_com" model="account.tax.report.line">
-        <field name="name">Operação com Suspensão da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_outras_oper_saida" model="account.tax.report.line">
-        <field name="name">Outras Operações de Saída</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_mercado" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_no_mercado" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_receita" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="13"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_nao_tri" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="14"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_oper_export" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação </field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="15"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_interno_export" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="16"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_no_marcado_interno_export" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="17"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_oper_no_marcado" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="18"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_oper_tri" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="19"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_oper_export" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="20"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_oper_nao_tributadas" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="21"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_oper_tributadas" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="22"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_nao_oper_tributadas" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="23"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_oper_receitas" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="24"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_credito_outras_oper" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Outras Operações</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="25"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_aqui_sem" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição sem Direito a Crédito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="26"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_aqui_com" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição com Isenção</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="27"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_aqui_com_sus" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição com Suspensão</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="28"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_aqui_zero" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição a Alíquota Zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="29"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_aqui_contri" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição sem Incidência da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="30"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_oper_aqui_sub" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição por Substituição Tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="31"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_outras_oper_entrada" model="account.tax.report.line">
-        <field name="name">Outras Operações de Entrada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="32"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_cofins_outras_oper" model="account.tax.report.line">
-        <field name="name">Outras Operações</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="33"/>
-        <field name="parent_id" ref="tax_report_cofins"/>
-    </record>
-
-    <record id="tax_report_pis" model="account.tax.report.line">
-        <field name="name">PIS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_pis_oper_tri_basica" model="account.tax.report.line">
-        <field name="name">Operação Tributável com Alíquota Básica</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_1" model="account.tax.report.line">
-        <field name="name">PIS_1</field>
-        <field name="tag_name">PIS_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_pis_oper_tri_basica"/>
-    </record>
-
-    <record id="tax_report_pis_2" model="account.tax.report.line">
-        <field name="name">PIS_2</field>
-        <field name="tag_name">PIS_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_pis_oper_tri_basica"/>
-    </record>
-
-    <record id="tax_report_pis_oper_tri_diferenciada" model="account.tax.report.line">
-        <field name="name">Operação Tributável com Alíquota Diferenciada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_tri_produto" model="account.tax.report.line">
-        <field name="name">Operação Tributável com Alíquota por Unidade de Medida de Produto</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_tri_zero" model="account.tax.report.line">
-        <field name="name">Operação Tributável Monofásica - Revenda a Alíquota Zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_tri_sub" model="account.tax.report.line">
-        <field name="name">Operação Tributável por Substituição Tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_tri_ali_zero" model="account.tax.report.line">
-        <field name="name">Operação Tributável a Alíquota Zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_isenta" model="account.tax.report.line">
-        <field name="name">Operação Isenta da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_sem" model="account.tax.report.line">
-        <field name="name">Operação sem Incidência da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com" model="account.tax.report.line">
-        <field name="name">Operação com Suspensão da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_outras_oper_saida" model="account.tax.report.line">
-        <field name="name">Outras Operações de Saída</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_direito" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_credito" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_vinculada_ex" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="13"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_vinculada_rec" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="14"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_export" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="15"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_nao_tri" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="16"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_tri_" model="account.tax.report.line">
-        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="17"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_tributada" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="18"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_nao_tributada" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="19"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_export" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="20"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_interno" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="21"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_interno_export" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="22"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_oper_nao_tri" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="23"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_oper_tri" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="24"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_credito_presumido_outras_oper" model="account.tax.report.line">
-        <field name="name">Crédito Presumido - Outras Operações</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="25"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_aqui_sem" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição sem Direito a Crédito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="26"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_com_ise" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição com Isenção</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="27"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_aqui_com" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição com Suspensão</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="28"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_aqui_zero" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição a Alíquota Zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="29"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_aqui_inc" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição sem Incidência da Contribuição</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="30"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_oper_aqui_sub" model="account.tax.report.line">
-        <field name="name">Operação de Aquisição por Substituição Tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="31"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_outras_oper_entrada" model="account.tax.report.line">
-        <field name="name">Outras Operações de Entrada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="32"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_pis_outras_oper" model="account.tax.report.line">
-        <field name="name">Outras Operações</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="33"/>
-        <field name="parent_id" ref="tax_report_pis"/>
-    </record>
-
-    <record id="tax_report_ipi" model="account.tax.report.line">
-        <field name="name">IPI</field>
-        <field name="code">BRTAX07</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_ipi_extrada_com" model="account.tax.report.line">
-        <field name="name">Entrada com recuperação de crédito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_1" model="account.tax.report.line">
-        <field name="name">IPI_1</field>
-        <field name="tag_name">IPI_1</field>
-        <field name="code">BRTAX07_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_ipi_extrada_com"/>
-    </record>
-
-    <record id="tax_report_ipi_extrada_tributada" model="account.tax.report.line">
-        <field name="name">Entrada tributada com alíquota zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_2" model="account.tax.report.line">
-        <field name="name">IPI_2</field>
-        <field name="tag_name">IPI_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_ipi_extrada_tributada"/>
-    </record>
-
-    <record id="tax_report_ipi_entrada_isenta" model="account.tax.report.line">
-        <field name="name">Entrada isenta</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_entrada_nao_tributada" model="account.tax.report.line">
-        <field name="name">EEntrada não-tributada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_entrada_imune" model="account.tax.report.line">
-        <field name="name">Entrada imune</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_entrada_com_suspensao" model="account.tax.report.line">
-        <field name="name">Entrada com suspensão</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_outras_entradas" model="account.tax.report.line">
-        <field name="name">Outras entradas</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_saida_tributada" model="account.tax.report.line">
-        <field name="name">Saída tributada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_saida_tributada_com" model="account.tax.report.line">
-        <field name="name">Saída tributada com alíquota zero</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_saida_isenta" model="account.tax.report.line">
-        <field name="name">Saída isenta</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_saida_nao_tributada" model="account.tax.report.line">
-        <field name="name">Saída não-tributada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_saida_imune" model="account.tax.report.line">
-        <field name="name">Saída imune</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_saida_com" model="account.tax.report.line">
-        <field name="name">Saída com suspensão</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="13"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_ipi_outras_saidas" model="account.tax.report.line">
-        <field name="name">Outras saídas</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="14"/>
-        <field name="parent_id" ref="tax_report_ipi"/>
-    </record>
-
-    <record id="tax_report_icms" model="account.tax.report.line">
-        <field name="name">ICMS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-    </record>
-
-    <record id="tax_report_icms_tributada" model="account.tax.report.line">
-        <field name="name">Tributada integralmente</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_1" model="account.tax.report.line">
-        <field name="name">ICMS_1</field>
-        <field name="tag_name">ICMS_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_icms_tributada"/>
-    </record>
-
-    <record id="tax_report_icms_tributada_com" model="account.tax.report.line">
-        <field name="name">Tributada e com cobrança do ICMS por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_2" model="account.tax.report.line">
-        <field name="name">ICMS_2</field>
-        <field name="tag_name">ICMS_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_icms_tributada_com"/>
-    </record>
-
-    <record id="tax_report_icms_com_red" model="account.tax.report.line">
-        <field name="name">Com redução de base de cálculo</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_isenta_tributada" model="account.tax.report.line">
-        <field name="name">Isenta ou não tributada e com cobrança do ICMS por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_isenta" model="account.tax.report.line">
-        <field name="name">Isenta</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-     <record id="tax_report_icms_nao_tributada" model="account.tax.report.line">
-        <field name="name">Não tributada</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_suspensao" model="account.tax.report.line">
-        <field name="name">Suspensão</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-     <record id="tax_report_icms_diferimento" model="account.tax.report.line">
-        <field name="name">Diferimento</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_cobrado" model="account.tax.report.line">
-        <field name="name">ICMS cobrado anteriormente por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_reducao" model="account.tax.report.line">
-        <field name="name">Com redução de base de cálculo e cobrança do ICMS por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_outras" model="account.tax.report.line">
-        <field name="name">Outras</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_com" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Tributada pelo Simples Nacional com permissão de crédito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_sem" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Tributada pelo Simples Nacional sem permissão de crédito</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="13"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_isencao" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Isenção do ICMS no Simples Nacional para faixa de receita bruta</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="14"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_tributada" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="15"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_tributada_pelo" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="16"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_isencao_icms" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Isenção do ICMS no Simples Nacional para faixa de receita bruta e com cobrança do ICMS por substituição tributária</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="17"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_imune" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Imune</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="18"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_nao_tributada" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Não tributada pelo Simples Nacional</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="19"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_icms" model="account.tax.report.line">
-        <field name="name">Simples Nacional - ICMS cobrado anteriormente por substituição tributária (substituído) ou por antecipação</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="20"/>
-        <field name="parent_id" ref="tax_report_icms"/>
-    </record>
-
-    <record id="tax_report_icms_simples_nacional_outras" model="account.tax.report.line">
-        <field name="name">Simples Nacional - Outros</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="21"/>
-        <field name="parent_id" ref="tax_report_icms"/>
+        <field name="root_line_ids">
+            <record id="tax_report_icmsst" model="account.tax.report.line">
+                <field name="name">ICMSST</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_icmsst_1" model="account.tax.report.line">
+                        <field name="name">ICMSST_1</field>
+                        <field name="tag_name">ICMSST_1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_icmsst_2" model="account.tax.report.line">
+                        <field name="name">ICMSST_2</field>
+                        <field name="tag_name">ICMSST_2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_irpj" model="account.tax.report.line">
+                <field name="name">IRPJ</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_irpj_1" model="account.tax.report.line">
+                        <field name="name">IRPJ_1</field>
+                        <field name="tag_name">IRPJ_1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_irpj_2" model="account.tax.report.line">
+                        <field name="name">IRPJ_2</field>
+                        <field name="tag_name">IRPJ_2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_ir" model="account.tax.report.line">
+                <field name="name">IR</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_ir_1" model="account.tax.report.line">
+                        <field name="name">IR_1</field>
+                        <field name="tag_name">IR_1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_ir_2" model="account.tax.report.line">
+                        <field name="name">IR_2</field>
+                        <field name="tag_name">IR_2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_issqn" model="account.tax.report.line">
+                <field name="name">ISSQN</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_issqn_1" model="account.tax.report.line">
+                        <field name="name">ISSQN_1</field>
+                        <field name="tag_name">ISSQN_1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_issqn_2" model="account.tax.report.line">
+                        <field name="name">ISSQN_2</field>
+                        <field name="tag_name">ISSQN_2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_csll" model="account.tax.report.line">
+                <field name="name">CSLL</field>
+                <field name="sequence" eval="5"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_csll_1" model="account.tax.report.line">
+                        <field name="name">CSLL_1</field>
+                        <field name="tag_name">CSLL_1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_csll_2" model="account.tax.report.line">
+                        <field name="name">CSLL_2</field>
+                        <field name="tag_name">CSLL_2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_cofins" model="account.tax.report.line">
+                <field name="name">COFINS</field>
+                <field name="sequence" eval="6"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_cofins_oper_bas" model="account.tax.report.line">
+                        <field name="name">Operação Tributável com Alíquota Básica</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_cofins_1" model="account.tax.report.line">
+                                <field name="name">COFINS_1</field>
+                                <field name="tag_name">COFINS_1</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_cofins_2" model="account.tax.report.line">
+                                <field name="name">COFINS_2</field>
+                                <field name="tag_name">COFINS_2</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_cofins_oper_dif" model="account.tax.report.line">
+                        <field name="name">Operação Tributável com Alíquota Diferenciada</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_uni" model="account.tax.report.line">
+                        <field name="name">Operação Tributável com Alíquota por Unidade de Medida de Produto</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_cofins_line12" model="account.tax.report.line">
+                        <field name="name">Operação Tributável Monofásica - Revenda a Alíquota Zero</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_sub" model="account.tax.report.line">
+                        <field name="name">Operação Tributável por Substituição Tributária</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_tri" model="account.tax.report.line">
+                        <field name="name">Operação Tributável a Alíquota zero</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_isenta" model="account.tax.report.line">
+                        <field name="name">Operação Isenta da Contribuição</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_sem" model="account.tax.report.line">
+                        <field name="name">Operação sem Incidência da Contribuição</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_com" model="account.tax.report.line">
+                        <field name="name">Operação com Suspensão da Contribuição</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_cofins_outras_oper_saida" model="account.tax.report.line">
+                        <field name="name">Outras Operações de Saída</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_mercado" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_no_mercado" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_receita" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_nao_tri" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                    <record id="tax_report_cofins_oper_export" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação </field>
+                        <field name="sequence" eval="15"/>
+                    </record>
+                    <record id="tax_report_oper_interno_export" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="16"/>
+                    </record>
+                    <record id="tax_report_oper_no_marcado_interno_export" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="17"/>
+                    </record>
+                    <record id="tax_report_credito_oper_no_marcado" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="18"/>
+                    </record>
+                    <record id="tax_report_credito_oper_tri" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="19"/>
+                    </record>
+                    <record id="tax_report_credito_oper_export" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação</field>
+                        <field name="sequence" eval="20"/>
+                    </record>
+                    <record id="tax_report_credito_oper_nao_tributadas" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
+                        <field name="sequence" eval="21"/>
+                    </record>
+                    <record id="tax_report_credito_oper_tributadas" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="22"/>
+                    </record>
+                    <record id="tax_report_credito_nao_oper_tributadas" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="23"/>
+                    </record>
+                    <record id="tax_report_credito_oper_receitas" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="24"/>
+                    </record>
+                    <record id="tax_report_credito_outras_oper" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Outras Operações</field>
+                        <field name="sequence" eval="25"/>
+                    </record>
+                    <record id="tax_report_oper_aqui_sem" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição sem Direito a Crédito</field>
+                        <field name="sequence" eval="26"/>
+                    </record>
+                    <record id="tax_report_oper_aqui_com" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição com Isenção</field>
+                        <field name="sequence" eval="27"/>
+                    </record>
+                    <record id="tax_report_oper_aqui_com_sus" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição com Suspensão</field>
+                        <field name="sequence" eval="28"/>
+                    </record>
+                    <record id="tax_report_oper_aqui_zero" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição a Alíquota Zero</field>
+                        <field name="sequence" eval="29"/>
+                    </record>
+                    <record id="tax_report_oper_aqui_contri" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição sem Incidência da Contribuição</field>
+                        <field name="sequence" eval="30"/>
+                    </record>
+                    <record id="tax_report_oper_aqui_sub" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição por Substituição Tributária</field>
+                        <field name="sequence" eval="31"/>
+                    </record>
+                    <record id="tax_report_outras_oper_entrada" model="account.tax.report.line">
+                        <field name="name">Outras Operações de Entrada</field>
+                        <field name="sequence" eval="32"/>
+                    </record>
+                    <record id="tax_report_cofins_outras_oper" model="account.tax.report.line">
+                        <field name="name">Outras Operações</field>
+                        <field name="sequence" eval="33"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_pis" model="account.tax.report.line">
+                <field name="name">PIS</field>
+                <field name="sequence" eval="7"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_pis_oper_tri_basica" model="account.tax.report.line">
+                        <field name="name">Operação Tributável com Alíquota Básica</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_pis_1" model="account.tax.report.line">
+                                <field name="name">PIS_1</field>
+                                <field name="tag_name">PIS_1</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_pis_2" model="account.tax.report.line">
+                                <field name="name">PIS_2</field>
+                                <field name="tag_name">PIS_2</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_pis_oper_tri_diferenciada" model="account.tax.report.line">
+                        <field name="name">Operação Tributável com Alíquota Diferenciada</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_pis_oper_tri_produto" model="account.tax.report.line">
+                        <field name="name">Operação Tributável com Alíquota por Unidade de Medida de Produto</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_pis_oper_tri_zero" model="account.tax.report.line">
+                        <field name="name">Operação Tributável Monofásica - Revenda a Alíquota Zero</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_pis_oper_tri_sub" model="account.tax.report.line">
+                        <field name="name">Operação Tributável por Substituição Tributária</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_pis_oper_tri_ali_zero" model="account.tax.report.line">
+                        <field name="name">Operação Tributável a Alíquota Zero</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_pis_oper_isenta" model="account.tax.report.line">
+                        <field name="name">Operação Isenta da Contribuição</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_pis_oper_sem" model="account.tax.report.line">
+                        <field name="name">Operação sem Incidência da Contribuição</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com" model="account.tax.report.line">
+                        <field name="name">Operação com Suspensão da Contribuição</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_pis_outras_oper_saida" model="account.tax.report.line">
+                        <field name="name">Outras Operações de Saída</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_direito" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_credito" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_vinculada_ex" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_vinculada_rec" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_export" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="15"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_nao_tri" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="16"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_tri_" model="account.tax.report.line">
+                        <field name="name">Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação</field>
+                        <field name="sequence" eval="17"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_tributada" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="18"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_nao_tributada" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno</field>
+                        <field name="sequence" eval="19"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_export" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação</field>
+                        <field name="sequence" eval="20"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_interno" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno</field>
+                        <field name="sequence" eval="21"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_interno_export" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="22"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_oper_nao_tri" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação</field>
+                        <field name="sequence" eval="23"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_oper_tri" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação</field>
+                        <field name="sequence" eval="24"/>
+                    </record>
+                    <record id="tax_report_pis_credito_presumido_outras_oper" model="account.tax.report.line">
+                        <field name="name">Crédito Presumido - Outras Operações</field>
+                        <field name="sequence" eval="25"/>
+                    </record>
+                    <record id="tax_report_pis_oper_aqui_sem" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição sem Direito a Crédito</field>
+                        <field name="sequence" eval="26"/>
+                    </record>
+                    <record id="tax_report_pis_oper_com_ise" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição com Isenção</field>
+                        <field name="sequence" eval="27"/>
+                    </record>
+                    <record id="tax_report_pis_oper_aqui_com" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição com Suspensão</field>
+                        <field name="sequence" eval="28"/>
+                    </record>
+                    <record id="tax_report_pis_oper_aqui_zero" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição a Alíquota Zero</field>
+                        <field name="sequence" eval="29"/>
+                    </record>
+                    <record id="tax_report_pis_oper_aqui_inc" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição sem Incidência da Contribuição</field>
+                        <field name="sequence" eval="30"/>
+                    </record>
+                    <record id="tax_report_pis_oper_aqui_sub" model="account.tax.report.line">
+                        <field name="name">Operação de Aquisição por Substituição Tributária</field>
+                        <field name="sequence" eval="31"/>
+                    </record>
+                    <record id="tax_report_pis_outras_oper_entrada" model="account.tax.report.line">
+                        <field name="name">Outras Operações de Entrada</field>
+                        <field name="sequence" eval="32"/>
+                    </record>
+                    <record id="tax_report_pis_outras_oper" model="account.tax.report.line">
+                        <field name="name">Outras Operações</field>
+                        <field name="sequence" eval="33"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_ipi" model="account.tax.report.line">
+                <field name="name">IPI</field>
+                <field name="code">BRTAX07</field>
+                <field name="sequence" eval="8"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_ipi_extrada_com" model="account.tax.report.line">
+                        <field name="name">Entrada com recuperação de crédito</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_ipi_1" model="account.tax.report.line">
+                                <field name="name">IPI_1</field>
+                                <field name="tag_name">IPI_1</field>
+                                <field name="code">BRTAX07_1</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_ipi_extrada_tributada" model="account.tax.report.line">
+                        <field name="name">Entrada tributada com alíquota zero</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_ipi_2" model="account.tax.report.line">
+                                <field name="name">IPI_2</field>
+                                <field name="tag_name">IPI_2</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_ipi_entrada_isenta" model="account.tax.report.line">
+                        <field name="name">Entrada isenta</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_ipi_entrada_nao_tributada" model="account.tax.report.line">
+                        <field name="name">EEntrada não-tributada</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_ipi_entrada_imune" model="account.tax.report.line">
+                        <field name="name">Entrada imune</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_ipi_entrada_com_suspensao" model="account.tax.report.line">
+                        <field name="name">Entrada com suspensão</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_ipi_outras_entradas" model="account.tax.report.line">
+                        <field name="name">Outras entradas</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_ipi_saida_tributada" model="account.tax.report.line">
+                        <field name="name">Saída tributada</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_ipi_saida_tributada_com" model="account.tax.report.line">
+                        <field name="name">Saída tributada com alíquota zero</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_ipi_saida_isenta" model="account.tax.report.line">
+                        <field name="name">Saída isenta</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_ipi_saida_nao_tributada" model="account.tax.report.line">
+                        <field name="name">Saída não-tributada</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_ipi_saida_imune" model="account.tax.report.line">
+                        <field name="name">Saída imune</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_ipi_saida_com" model="account.tax.report.line">
+                        <field name="name">Saída com suspensão</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_ipi_outras_saidas" model="account.tax.report.line">
+                        <field name="name">Outras saídas</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_icms" model="account.tax.report.line">
+                <field name="name">ICMS</field>
+                <field name="sequence" eval="9"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_icms_tributada" model="account.tax.report.line">
+                        <field name="name">Tributada integralmente</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_icms_1" model="account.tax.report.line">
+                                <field name="name">ICMS_1</field>
+                                <field name="tag_name">ICMS_1</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_icms_tributada_com" model="account.tax.report.line">
+                        <field name="name">Tributada e com cobrança do ICMS por substituição tributária</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_icms_2" model="account.tax.report.line">
+                                <field name="name">ICMS_2</field>
+                                <field name="tag_name">ICMS_2</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_icms_com_red" model="account.tax.report.line">
+                        <field name="name">Com redução de base de cálculo</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_icms_isenta_tributada" model="account.tax.report.line">
+                        <field name="name">Isenta ou não tributada e com cobrança do ICMS por substituição tributária</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_icms_isenta" model="account.tax.report.line">
+                        <field name="name">Isenta</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_icms_nao_tributada" model="account.tax.report.line">
+                        <field name="name">Não tributada</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_icms_suspensao" model="account.tax.report.line">
+                        <field name="name">Suspensão</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_icms_diferimento" model="account.tax.report.line">
+                        <field name="name">Diferimento</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_icms_cobrado" model="account.tax.report.line">
+                        <field name="name">ICMS cobrado anteriormente por substituição tributária</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_icms_reducao" model="account.tax.report.line">
+                        <field name="name">Com redução de base de cálculo e cobrança do ICMS por substituição tributária</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_icms_outras" model="account.tax.report.line">
+                        <field name="name">Outras</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_com" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Tributada pelo Simples Nacional com permissão de crédito</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_sem" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Tributada pelo Simples Nacional sem permissão de crédito</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_isencao" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Isenção do ICMS no Simples Nacional para faixa de receita bruta</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_tributada" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por substituição tributária</field>
+                        <field name="sequence" eval="15"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_tributada_pelo" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por substituição tributária</field>
+                        <field name="sequence" eval="16"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_isencao_icms" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Isenção do ICMS no Simples Nacional para faixa de receita bruta e com cobrança do ICMS por substituição tributária</field>
+                        <field name="sequence" eval="17"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_imune" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Imune</field>
+                        <field name="sequence" eval="18"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_nao_tributada" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Não tributada pelo Simples Nacional</field>
+                        <field name="sequence" eval="19"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_icms" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - ICMS cobrado anteriormente por substituição tributária (substituído) ou por antecipação</field>
+                        <field name="sequence" eval="20"/>
+                    </record>
+                    <record id="tax_report_icms_simples_nacional_outras" model="account.tax.report.line">
+                        <field name="name">Simples Nacional - Outros</field>
+                        <field name="sequence" eval="21"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_ch/data/account_tax_report_data.xml
+++ b/addons/l10n_ch/data/account_tax_report_data.xml
@@ -1,289 +1,206 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.ch"/>
-    </record>
-
-    <record id="account_tax_report_line_chiffre_af" model="account.tax.report.line">
-        <field name="name">I – TURNOVER</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="formula">None</field>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_200" model="account.tax.report.line">
-        <field name="name">200 Total amount of agreed or collected consideration incl. from supplies opted for taxation, transfer of supplies acc. to the notification procedure and supplies provided abroad (worldwide turnover)</field>
-        <field name="formula">tax_ch_302a + tax_ch_312a + tax_ch_342a + tax_ch_289</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_chiffre_af"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_289" model="account.tax.report.line">
-        <field name="name">289 Consideration reported in Ref. 200 from supplies exempt from the tax without credit (art. 21) where the option for their taxation according to art. 22 has been exercised</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="code">tax_ch_289</field>
-        <field name="parent_id" ref="account_tax_report_line_chiffre_af"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_220_289" model="account.tax.report.line">
-        <field name="name">220 Supplies exempt from the tax (e.g. export, art. 23) and supplies provided to institutional and individual beneficiaries that are exempt from liability for tax (art. 107 para. 1 lit. a)</field>
-        <field name="tag_name">220</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_289"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_221" model="account.tax.report.line">
-        <field name="name">221 Supplies provided abroad (place of supply is abroad)</field>
-        <field name="tag_name">221</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_289"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_225" model="account.tax.report.line">
-        <field name="name">225 Transfer of supplies according to the notification procedure (art. 38, please submit Form 764)</field>
-        <field name="tag_name">225</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_289"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_230" model="account.tax.report.line">
-        <field name="name">230 Supplies provided on Swiss territory exempt from the tax without credit (art. 21) and where the option for their taxation according to art. 22 has not been exercised</field>
-        <field name="tag_name">230</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_289"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_235" model="account.tax.report.line">
-        <field name="name">235 Reduction of consideration (discounts, rebates etc.)</field>
-        <field name="tag_name">235</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_289"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_280" model="account.tax.report.line">
-        <field name="name">280 Miscellaneous (e.g. land value, purchase prices in case of margin taxation)</field>
-        <field name="tag_name">280</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_289"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_299" model="account.tax.report.line">
-        <field name="name">299 Taxable turnover (Ref. 200 minus Ref. 289)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="formula">tax_ch_302a + tax_ch_312a + tax_ch_342a</field>
-    </record>
-
-    <record id="account_tax_report_line_calc_impot" model="account.tax.report.line">
-        <field name="name">II - TAX CALCULATION</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="formula">None</field>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="account_tax_report_line_calc_impot_chiffre" model="account.tax.report.line">
-        <field name="name">Taxable turnover</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_302a" model="account.tax.report.line">
-        <field name="name">302a Taxable turnover at 7.7% (TS)</field>
-        <field name="tag_name">302a</field>
-        <field name="code">tax_ch_302a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot_chiffre"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_312a" model="account.tax.report.line">
-        <field name="name">312a Taxable turnover at 2.5% (TR)</field>
-        <field name="tag_name">312a</field>
-        <field name="code">tax_ch_312a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot_chiffre"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_342a" model="account.tax.report.line">
-        <field name="name">342a Taxable turnover at 3.7% (TS)</field>
-        <field name="tag_name">342a</field>
-        <field name="code">tax_ch_342a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot_chiffre"/>
-    </record>
-
-    <record id="account_tax_report_line_calc_impot_base" model="account.tax.report.line">
-        <field name="name">Tax base on service acquisitions</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_381a" model="account.tax.report.line">
-        <field name="name">381a Acquisition tax</field>
-        <field name="tag_name">381a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot_base"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_382a" model="account.tax.report.line">
-        <field name="name">382a Acquisition tax</field>
-        <field name="tag_name">382a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot_base"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_399" model="account.tax.report.line">
-        <field name="name">399 Total amount of tax due</field>
-        <field name="code">tax_ch_399</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_calc_impot"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_302b" model="account.tax.report.line">
-        <field name="name">302b Tax due at 7.7% (TS)</field>
-        <field name="tag_name">302b</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_399"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_312b" model="account.tax.report.line">
-        <field name="name">312b Tax due at 2.5% (TR)</field>
-        <field name="tag_name">312b</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_399"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_342b" model="account.tax.report.line">
-        <field name="name">342b Tax due at 3.7% (TS)</field>
-        <field name="tag_name">342b</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_399"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_381b" model="account.tax.report.line">
-        <field name="name">381b Acquisition tax</field>
-        <field name="tag_name">381b</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_399"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_382b" model="account.tax.report.line">
-        <field name="name">382b Acquisition tax</field>
-        <field name="tag_name">382b</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_399"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_479" model="account.tax.report.line">
-        <field name="name">479 TVA préalable</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="code">tax_ch_479</field>
-    </record>
-
-    <record id="account_tax_report_line_chtax_400" model="account.tax.report.line">
-        <field name="name">400 Input tax on cost of materials and supplies of services</field>
-        <field name="tag_name">400</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_479"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_405" model="account.tax.report.line">
-        <field name="name">405 Input tax on investments and other operating costs</field>
-        <field name="tag_name">405</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_479"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_410" model="account.tax.report.line">
-        <field name="name">410 De-taxation (art. 32, please enclose a detailed list)</field>
-        <field name="tag_name">410</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_479"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_415" model="account.tax.report.line">
-        <field name="name">415 Correction of the input tax deduction: mixed use (art. 30), own use (art. 31)</field>
-        <field name="tag_name">415</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_479"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_420" model="account.tax.report.line">
-        <field name="name">420 Reduction of the input tax deduction: Flow of funds, which are not deemed to be consideration, such as subsidies, tourist charges (art. 33 para. 2)</field>
-        <field name="tag_name">420</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_479"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_solde" model="account.tax.report.line">
-        <field name="name">AMOUNT PAYABLE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_500" model="account.tax.report.line">
-        <field name="name">500 Amount of VAT payable to AFC</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">tax_ch_399 - tax_ch_479 &gt; 0 and tax_ch_399 - tax_ch_479 or 0.0</field>
-        <field name="parent_id" ref="account_tax_report_line_chtax_solde"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_510" model="account.tax.report.line">
-        <field name="name">510 Credit in favour of the taxable person</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="formula">tax_ch_479 - tax_ch_399 &gt; 0 and tax_ch_479 - tax_ch_399 or 0.0</field>
-        <field name="parent_id" ref="account_tax_report_line_chtax_solde"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_autres_mouv" model="account.tax.report.line">
-        <field name="name">OTHER CASH FLOWS (art. 18 para. 2)</field>
-        <field name="sequence" eval="6"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_900" model="account.tax.report.line">
-        <field name="name">900 Subsidies, tourist funds collected by tourist offices, contributions from cantonal water, sewage or waste funds (art. 18 para. 2 lit. a to c)</field>
-        <field name="tag_name">900</field>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_autres_mouv"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_chtax_910" model="account.tax.report.line">
-        <field name="name">910 Donations, dividends, payments of damages etc. (art. 18 para. 2 lit. d to l)</field>
-        <field name="tag_name">910</field>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_chtax_autres_mouv"/>
-        <field name="report_id" ref="tax_report"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_chiffre_af" model="account.tax.report.line">
+                <field name="name">I – TURNOVER</field>
+                <field name="formula">None</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_chtax_200" model="account.tax.report.line">
+                        <field name="name">200 Total amount of agreed or collected consideration incl. from supplies opted for taxation, transfer of supplies acc. to the notification procedure and supplies provided abroad (worldwide turnover)</field>
+                        <field name="formula">tax_ch_302a + tax_ch_312a + tax_ch_342a + tax_ch_289</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_chtax_289" model="account.tax.report.line">
+                        <field name="name">289 Consideration reported in Ref. 200 from supplies exempt from the tax without credit (art. 21) where the option for their taxation according to art. 22 has been exercised</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="code">tax_ch_289</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_chtax_220_289" model="account.tax.report.line">
+                                <field name="name">220 Supplies exempt from the tax (e.g. export, art. 23) and supplies provided to institutional and individual beneficiaries that are exempt from liability for tax (art. 107 para. 1 lit. a)</field>
+                                <field name="tag_name">220</field>
+                                <field name="sequence" eval="0"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_221" model="account.tax.report.line">
+                                <field name="name">221 Supplies provided abroad (place of supply is abroad)</field>
+                                <field name="tag_name">221</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_225" model="account.tax.report.line">
+                                <field name="name">225 Transfer of supplies according to the notification procedure (art. 38, please submit Form 764)</field>
+                                <field name="tag_name">225</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_230" model="account.tax.report.line">
+                                <field name="name">230 Supplies provided on Swiss territory exempt from the tax without credit (art. 21) and where the option for their taxation according to art. 22 has not been exercised</field>
+                                <field name="tag_name">230</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_235" model="account.tax.report.line">
+                                <field name="name">235 Reduction of consideration (discounts, rebates etc.)</field>
+                                <field name="tag_name">235</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_280" model="account.tax.report.line">
+                                <field name="name">280 Miscellaneous (e.g. land value, purchase prices in case of margin taxation)</field>
+                                <field name="tag_name">280</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_chtax_299" model="account.tax.report.line">
+                <field name="name">299 Taxable turnover (Ref. 200 minus Ref. 289)</field>
+                <field name="sequence" eval="2"/>
+                <field name="formula">tax_ch_302a + tax_ch_312a + tax_ch_342a</field>
+            </record>
+            <record id="account_tax_report_line_calc_impot" model="account.tax.report.line">
+                <field name="name">II - TAX CALCULATION</field>
+                <field name="formula">None</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_calc_impot_chiffre" model="account.tax.report.line">
+                        <field name="name">Taxable turnover</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_chtax_302a" model="account.tax.report.line">
+                                <field name="name">302a Taxable turnover at 7.7% (TS)</field>
+                                <field name="tag_name">302a</field>
+                                <field name="code">tax_ch_302a</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_312a" model="account.tax.report.line">
+                                <field name="name">312a Taxable turnover at 2.5% (TR)</field>
+                                <field name="tag_name">312a</field>
+                                <field name="code">tax_ch_312a</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_342a" model="account.tax.report.line">
+                                <field name="name">342a Taxable turnover at 3.7% (TS)</field>
+                                <field name="tag_name">342a</field>
+                                <field name="code">tax_ch_342a</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_calc_impot_base" model="account.tax.report.line">
+                        <field name="name">Tax base on service acquisitions</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_chtax_381a" model="account.tax.report.line">
+                                <field name="name">381a Acquisition tax</field>
+                                <field name="tag_name">381a</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_382a" model="account.tax.report.line">
+                                <field name="name">382a Acquisition tax</field>
+                                <field name="tag_name">382a</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_chtax_399" model="account.tax.report.line">
+                        <field name="name">399 Total amount of tax due</field>
+                        <field name="code">tax_ch_399</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_chtax_302b" model="account.tax.report.line">
+                                <field name="name">302b Tax due at 7.7% (TS)</field>
+                                <field name="tag_name">302b</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_312b" model="account.tax.report.line">
+                                <field name="name">312b Tax due at 2.5% (TR)</field>
+                                <field name="tag_name">312b</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_342b" model="account.tax.report.line">
+                                <field name="name">342b Tax due at 3.7% (TS)</field>
+                                <field name="tag_name">342b</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_381b" model="account.tax.report.line">
+                                <field name="name">381b Acquisition tax</field>
+                                <field name="tag_name">381b</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                            <record id="account_tax_report_line_chtax_382b" model="account.tax.report.line">
+                                <field name="name">382b Acquisition tax</field>
+                                <field name="tag_name">382b</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_chtax_479" model="account.tax.report.line">
+                <field name="name">479 TVA préalable</field>
+                <field name="sequence" eval="4"/>
+                <field name="code">tax_ch_479</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_chtax_400" model="account.tax.report.line">
+                        <field name="name">400 Input tax on cost of materials and supplies of services</field>
+                        <field name="tag_name">400</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_chtax_405" model="account.tax.report.line">
+                        <field name="name">405 Input tax on investments and other operating costs</field>
+                        <field name="tag_name">405</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_line_chtax_410" model="account.tax.report.line">
+                        <field name="name">410 De-taxation (art. 32, please enclose a detailed list)</field>
+                        <field name="tag_name">410</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="account_tax_report_line_chtax_415" model="account.tax.report.line">
+                        <field name="name">415 Correction of the input tax deduction: mixed use (art. 30), own use (art. 31)</field>
+                        <field name="tag_name">415</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="account_tax_report_line_chtax_420" model="account.tax.report.line">
+                        <field name="name">420 Reduction of the input tax deduction: Flow of funds, which are not deemed to be consideration, such as subsidies, tourist charges (art. 33 para. 2)</field>
+                        <field name="tag_name">420</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_chtax_solde" model="account.tax.report.line">
+                <field name="name">AMOUNT PAYABLE</field>
+                <field name="sequence" eval="5"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_chtax_500" model="account.tax.report.line">
+                        <field name="name">500 Amount of VAT payable to AFC</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">tax_ch_399 - tax_ch_479 &gt; 0 and tax_ch_399 - tax_ch_479 or 0.0</field>
+                    </record>
+                    <record id="account_tax_report_line_chtax_510" model="account.tax.report.line">
+                        <field name="name">510 Credit in favour of the taxable person</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="formula">tax_ch_479 - tax_ch_399 &gt; 0 and tax_ch_479 - tax_ch_399 or 0.0</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_chtax_autres_mouv" model="account.tax.report.line">
+                <field name="name">OTHER CASH FLOWS (art. 18 para. 2)</field>
+                <field name="sequence" eval="6"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_chtax_900" model="account.tax.report.line">
+                        <field name="name">900 Subsidies, tourist funds collected by tourist offices, contributions from cantonal water, sewage or waste funds (art. 18 para. 2 lit. a to c)</field>
+                        <field name="tag_name">900</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_chtax_910" model="account.tax.report.line">
+                        <field name="name">910 Donations, dividends, payments of damages etc. (art. 18 para. 2 lit. d to l)</field>
+                        <field name="tag_name">910</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_cl/data/account_tax_report_data.xml
+++ b/addons/l10n_cl/data/account_tax_report_data.xml
@@ -1,221 +1,161 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.cl"/>
+        <field name="root_line_ids">
+            <record id="tax_report_base_imponible_ventas" model="account.tax.report.line">
+                <field name="name">Base Imponible Ventas</field>
+                <field name="tag_name">Base Imponible Ventas</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_ventas_exentas" model="account.tax.report.line">
+                        <field name="name">Ventas Exentas</field>
+                        <field name="tag_name">Ventas Exentas</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_impuestos_renta" model="account.tax.report.line">
+                        <field name="name">Impuesto a la Renta Primera Categoría a Pagar</field>
+                        <field name="tag_name">Impuesto a la Renta Primera Categoría a Pagar</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_retencion_total_compras" model="account.tax.report.line">
+                <field name="name">Retención Total (compras)</field>
+                <field name="tag_name">Retención Total (compras)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_ventas_netas_gravadas_c_iva" model="account.tax.report.line">
+                <field name="name">Ventas Netas Gravadas con IVA</field>
+                <field name="tag_name">Ventas Netas Gravadas con IVA</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_impuestos_originados_venta" model="account.tax.report.line">
+                <field name="name">Impuesto Originado por la Venta</field>
+                <field name="tag_name">Impuesto Originado por la Venta</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_iva_debito_fiscal" model="account.tax.report.line">
+                <field name="name">IVA Debito Fiscal</field>
+                <field name="tag_name">IVA Debito Fiscal</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_ppm" model="account.tax.report.line">
+                <field name="name">PPM</field>
+                <field name="tag_name">PPM</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_netas_gr_iva_recup" model="account.tax.report.line">
+                <field name="name">Compras Netas Gravadas Con IVA (recuperable)</field>
+                <field name="tag_name">Compras Netas Gravadas Con IVA (recuperable)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_netas_gr_iva_uso_comun" model="account.tax.report.line">
+                <field name="name">Compra Netas Gravadas Con IVA Uso Comun</field>
+                <field name="tag_name">Compra Netas Gravadas Con IVA Uso Comun</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_netas_gr_iva_no_recuperable" model="account.tax.report.line">
+                <field name="name">Compras IVA No Recuperable</field>
+                <field name="tag_name">Compras IVA No Recuperable</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_supermercado" model="account.tax.report.line">
+                <field name="name">Compras De Supermercado</field>
+                <field name="tag_name">Compras De Supermercado</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_activo_fijo" model="account.tax.report.line">
+                <field name="name">Compras de Activo Fijo</field>
+                <field name="tag_name">Compras de Activo Fijo</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_activo_fijo_uso_comun" model="account.tax.report.line">
+                <field name="name">Compras de Activo Fijo Uso Común</field>
+                <field name="tag_name">Compras de Activo Fijo Uso Común</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_activo_fijo_no_recup" model="account.tax.report.line">
+                <field name="name">Compras de Activo Fijo No Recuperable</field>
+                <field name="tag_name">Compras de Activo Fijo No Recuperable</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_no_gravadas_iva" model="account.tax.report.line">
+                <field name="name">Compras No Gravadas Con IVA</field>
+                <field name="tag_name">Compras No Gravadas Con IVA</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_impuestos_pagados_compra" model="account.tax.report.line">
+                <field name="name">Impuestos Pagados en la Compra</field>
+                <field name="tag_name">Impuestos Pagados en la Compra</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_recup" model="account.tax.report.line">
+                <field name="name">IVA Pagado Compras Recuperables</field>
+                <field name="tag_name">IVA Pagado Compras Recuperables</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_uso_comun" model="account.tax.report.line">
+                <field name="name">IVA Pagado Compras Uso Común</field>
+                <field name="tag_name">IVA Pagado Compras Uso Común</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_no_recup" model="account.tax.report.line">
+                <field name="name">IVA Pagado No Recuperable</field>
+                <field name="tag_name">IVA Pagado No Recuperable</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_supermercado" model="account.tax.report.line">
+                <field name="name">IVA Pagado Compras Supermercado</field>
+                <field name="tag_name">IVA Pagado Compras Supermercado</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_activo_fijo" model="account.tax.report.line">
+                <field name="name">Compras Activo Fijo</field>
+                <field name="tag_name">Compras Activo Fijo</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_activo_fijo_uso_comun" model="account.tax.report.line">
+                <field name="name">Compras Activo Fijo Uso Común</field>
+                <field name="tag_name">Compras Activo Fijo Uso Común</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_compras_iva_activo_fijo_no_recup" model="account.tax.report.line">
+                <field name="name">Compras Activo Fijo No Recuperables</field>
+                <field name="tag_name">Compras Activo Fijo No Recuperables</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_retencion_segunda_categ" model="account.tax.report.line">
+                <field name="name">Retención Segunda Categoría</field>
+                <field name="tag_name">Retención Segunda Categoría</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_base_retencion_segunda_categ" model="account.tax.report.line">
+                <field name="name">Base Retención Segunda Categoría</field>
+                <field name="tag_name">Base Retención Segunda Categoría</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_base_ila_compras" model="account.tax.report.line">
+                <field name="name">Base Retenciones ILA (compras)</field>
+                <field name="tag_name">Base Retenciones ILA (compras)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_tax_ila_compras" model="account.tax.report.line">
+                <field name="name">Impuesto Ret Sufrida ILA (compras)</field>
+                <field name="tag_name">Retenciones ILA (compras)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_base_ila_ventas" model="account.tax.report.line">
+                <field name="name">Base Retenciones ILA (ventas)</field>
+                <field name="tag_name">Base Retenciones ILA (ventas)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+            <record id="tax_report_tax_ila_ventas" model="account.tax.report.line">
+                <field name="name">Impuesto Ret Practicadas ILA (ventas)</field>
+                <field name="tag_name">Retenciones ILA (ventas)</field>
+                <field name="sequence" eval="1"/>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_base_imponible_ventas" model="account.tax.report.line">
-        <field name="name">Base Imponible Ventas</field>
-        <field name="tag_name">Base Imponible Ventas</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_ventas_netas_gravadas_c_iva" model="account.tax.report.line">
-        <field name="name">Ventas Netas Gravadas con IVA</field>
-        <field name="tag_name">Ventas Netas Gravadas con IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_ventas_exentas" model="account.tax.report.line">
-        <field name="name">Ventas Exentas</field>
-        <field name="tag_name">Ventas Exentas</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_base_imponible_ventas"/>
-    </record>
-
-    <record id="tax_report_impuestos_renta" model="account.tax.report.line">
-        <field name="name">Impuesto a la Renta Primera Categoría a Pagar</field>
-        <field name="tag_name">Impuesto a la Renta Primera Categoría a Pagar</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_base_imponible_ventas"/>
-    </record>
-
-    <record id="tax_report_retencion_total_compras" model="account.tax.report.line">
-        <field name="name">Retención Total (compras)</field>
-        <field name="tag_name">Retención Total (compras)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_impuestos_originados_venta" model="account.tax.report.line">
-        <field name="name">Impuesto Originado por la Venta</field>
-        <field name="tag_name">Impuesto Originado por la Venta</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_iva_debito_fiscal" model="account.tax.report.line">
-        <field name="name">IVA Debito Fiscal</field>
-        <field name="tag_name">IVA Debito Fiscal</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_ppm" model="account.tax.report.line">
-        <field name="name">PPM</field>
-        <field name="tag_name">PPM</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_netas_gr_iva_recup" model="account.tax.report.line">
-        <field name="name">Compras Netas Gravadas Con IVA (recuperable)</field>
-        <field name="tag_name">Compras Netas Gravadas Con IVA (recuperable)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_netas_gr_iva_uso_comun" model="account.tax.report.line">
-        <field name="name">Compra Netas Gravadas Con IVA Uso Comun</field>
-        <field name="tag_name">Compra Netas Gravadas Con IVA Uso Comun</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_netas_gr_iva_no_recuperable" model="account.tax.report.line">
-        <field name="name">Compras IVA No Recuperable</field>
-        <field name="tag_name">Compras IVA No Recuperable</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_supermercado" model="account.tax.report.line">
-        <field name="name">Compras De Supermercado</field>
-        <field name="tag_name">Compras De Supermercado</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_activo_fijo" model="account.tax.report.line">
-        <field name="name">Compras de Activo Fijo</field>
-        <field name="tag_name">Compras de Activo Fijo</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_activo_fijo_uso_comun" model="account.tax.report.line">
-        <field name="name">Compras de Activo Fijo Uso Común</field>
-        <field name="tag_name">Compras de Activo Fijo Uso Común</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_activo_fijo_no_recup" model="account.tax.report.line">
-        <field name="name">Compras de Activo Fijo No Recuperable</field>
-        <field name="tag_name">Compras de Activo Fijo No Recuperable</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_no_gravadas_iva" model="account.tax.report.line">
-        <field name="name">Compras No Gravadas Con IVA</field>
-        <field name="tag_name">Compras No Gravadas Con IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_impuestos_pagados_compra" model="account.tax.report.line">
-        <field name="name">Impuestos Pagados en la Compra</field>
-        <field name="tag_name">Impuestos Pagados en la Compra</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_recup" model="account.tax.report.line">
-        <field name="name">IVA Pagado Compras Recuperables</field>
-        <field name="tag_name">IVA Pagado Compras Recuperables</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_uso_comun" model="account.tax.report.line">
-        <field name="name">IVA Pagado Compras Uso Común</field>
-        <field name="tag_name">IVA Pagado Compras Uso Común</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_no_recup" model="account.tax.report.line">
-        <field name="name">IVA Pagado No Recuperable</field>
-        <field name="tag_name">IVA Pagado No Recuperable</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_supermercado" model="account.tax.report.line">
-        <field name="name">IVA Pagado Compras Supermercado</field>
-        <field name="tag_name">IVA Pagado Compras Supermercado</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_activo_fijo" model="account.tax.report.line">
-        <field name="name">Compras Activo Fijo</field>
-        <field name="tag_name">Compras Activo Fijo</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_activo_fijo_uso_comun" model="account.tax.report.line">
-        <field name="name">Compras Activo Fijo Uso Común</field>
-        <field name="tag_name">Compras Activo Fijo Uso Común</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_compras_iva_activo_fijo_no_recup" model="account.tax.report.line">
-        <field name="name">Compras Activo Fijo No Recuperables</field>
-        <field name="tag_name">Compras Activo Fijo No Recuperables</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_retencion_segunda_categ" model="account.tax.report.line">
-        <field name="name">Retención Segunda Categoría</field>
-        <field name="tag_name">Retención Segunda Categoría</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_base_retencion_segunda_categ" model="account.tax.report.line">
-        <field name="name">Base Retención Segunda Categoría</field>
-        <field name="tag_name">Base Retención Segunda Categoría</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_base_ila_compras" model="account.tax.report.line">
-        <field name="name">Base Retenciones ILA (compras)</field>
-        <field name="tag_name">Base Retenciones ILA (compras)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_tax_ila_compras" model="account.tax.report.line">
-        <field name="name">Impuesto Ret Sufrida ILA (compras)</field>
-        <field name="tag_name">Retenciones ILA (compras)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_base_ila_ventas" model="account.tax.report.line">
-        <field name="name">Base Retenciones ILA (ventas)</field>
-        <field name="tag_name">Base Retenciones ILA (ventas)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_tax_ila_ventas" model="account.tax.report.line">
-        <field name="name">Impuesto Ret Practicadas ILA (ventas)</field>
-        <field name="tag_name">Retenciones ILA (ventas)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_de/data/account_account_tags_data.xml
+++ b/addons/l10n_de/data/account_account_tags_data.xml
@@ -1,547 +1,408 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.de"/>
+        <field name="root_line_ids">
+            <record id="tax_report_de_tag_01" model="account.tax.report.line">
+                <field name="name">Bemessungsgrundlage</field>
+                <field name="sequence">1</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_de_tag_17" model="account.tax.report.line">
+                        <field name="name">I. Anmeldung der Umsatzsteuer-Vorauszahlung (zeile 17)</field>
+                        <field name="sequence">1</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_de_tag_18" model="account.tax.report.line">
+                                <field name="name">Lieferungen und sonstige Leistungen (zeile 18)</field>
+                                <field name="sequence">1</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_19" model="account.tax.report.line">
+                                        <field name="name">Steuerfreie Umsätze mit Vorsteuerabzug (zeile 19)</field>
+                                        <field name="sequence">1</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_de_tag_41" model="account.tax.report.line">
+                                                <field name="name">41. an Abnehmer mit USt-IdNr (zeile 20)</field>
+                                                <field name="tag_name">41</field>
+                                                <field name="sequence">1</field>
+                                                <field name="code">41</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_44" model="account.tax.report.line">
+                                                <field name="name">44. neuer Fahrzeuge an Abnehmer ohne USt-IdNr (zeile 21)</field>
+                                                <field name="tag_name">44</field>
+                                                <field name="sequence">2</field>
+                                                <field name="code">44</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_49" model="account.tax.report.line">
+                                                <field name="name">49. neuer Fahrzeuge außerhalb eines Unternehmens (zeile 22)</field>
+                                                <field name="tag_name">49</field>
+                                                <field name="sequence">3</field>
+                                                <field name="code">49</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_43" model="account.tax.report.line">
+                                                <field name="name">43. Weitere steuerfreie Umsätze mit Vorsteuerabzug (zeile 23)</field>
+                                                <field name="tag_name">43</field>
+                                                <field name="sequence">4</field>
+                                                <field name="code">43</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_de_tag_24" model="account.tax.report.line">
+                                        <field name="name">48. Steuerfreie Umsätze ohne Vorsteuerabzug (zeile 24)</field>
+                                        <field name="tag_name">48</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">48</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_25" model="account.tax.report.line">
+                                        <field name="name">Steuerpflichtige Umsätze (zeile 25)</field>
+                                        <field name="sequence">3</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_de_tag_81" model="account.tax.report.line">
+                                                <field name="name">81. zum Steuersatz von 19 % (zeile 26)</field>
+                                                <field name="tag_name">81_BASE</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_86" model="account.tax.report.line">
+                                                <field name="name">86. zum Steuersatz von 7 % (zeile 27)</field>
+                                                <field name="tag_name">86_BASE</field>
+                                                <field name="sequence">2</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_35" model="account.tax.report.line">
+                                                <field name="name">35. zu anderen Steuersätzen (zeile 28)</field>
+                                                <field name="tag_name">35</field>
+                                                <field name="sequence">2</field>
+                                                <field name="code">35</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_77" model="account.tax.report.line">
+                                                <field name="name">77. Lieferungen land- und forstwirtschaftlicher Betriebe nach § 24 UStG an Abnehmer mit USt-IdNr. (zeile 29)</field>
+                                                <field name="tag_name">77</field>
+                                                <field name="sequence">4</field>
+                                                <field name="code">77</field>
+                                            </record>
+                                            <record id="tax_report_de_tag_76" model="account.tax.report.line">
+                                                <field name="name">76. Umsätze, für die eine Steuer nach § 24 UStG zu entrichten ist (zeile 30)</field>
+                                                <field name="tag_name">76</field>
+                                                <field name="sequence">5</field>
+                                                <field name="code">76</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tag_31" model="account.tax.report.line">
+                                <field name="name">Innergemeinschaftliche Erwerbe (zeile 31)</field>
+                                <field name="sequence">2</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_91" model="account.tax.report.line">
+                                        <field name="name">91. Steuerfreie innergemeinschaftliche Erwerbe (zeile 32)</field>
+                                        <field name="tag_name">91</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">91</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_89" model="account.tax.report.line">
+                                        <field name="name">89. Steuerpflichtige innergemeinschaftliche Erwerbe zum Steuersatz von 19 % (zeile 33)</field>
+                                        <field name="tag_name">89_BASE</field>
+                                        <field name="sequence">2</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_93" model="account.tax.report.line">
+                                        <field name="name">93. zum Steuersatz von 7 % (zeile 34)</field>
+                                        <field name="tag_name">93_BASE</field>
+                                        <field name="sequence">3</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_95" model="account.tax.report.line">
+                                        <field name="name">95. zu anderen Steuersätzen (zeile 35)</field>
+                                        <field name="tag_name">95</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">95</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_94" model="account.tax.report.line">
+                                        <field name="name">94. neuer Fahrzeuge von Lieferern ohne (zeile 36)</field>
+                                        <field name="tag_name">94</field>
+                                        <field name="sequence">5</field>
+                                        <field name="code">94</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tag_37" model="account.tax.report.line">
+                                <field name="name">Ergänzende Angaben zu Umsätzen (zeile 37)</field>
+                                <field name="sequence">3</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_42" model="account.tax.report.line">
+                                        <field name="name">42. Dreiecksgeschäften (zeile 38)</field>
+                                        <field name="tag_name">42</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">42</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_68" model="account.tax.report.line">
+                                        <field name="name">68. Steuerpflichtige Umsätze, für die der Leistungsempfänger die Steuer nach § 13b Abs. 5 Satz 1 i.V.m. Abs. 2 Nr. 10 UStG schuldet (zeile 39)</field>
+                                        <field name="tag_name">68</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">68</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_60" model="account.tax.report.line">
+                                        <field name="name">60. Übrige steuerpflichtige Umsätze, für die der Leistungsempfänger die Steuer nach § 13b Abs. 5 UStG schuldet (zeile 40)</field>
+                                        <field name="tag_name">60</field>
+                                        <field name="sequence">3</field>
+                                        <field name="code">60</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_21" model="account.tax.report.line">
+                                        <field name="name">21. Nicht steuerbare sonstige Leistungen (zeile 41)</field>
+                                        <field name="tag_name">21</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">21</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_45" model="account.tax.report.line">
+                                        <field name="name">45. Übrige nicht steuerbare Umsätze (zeile 42)</field>
+                                        <field name="tag_name">45_BASE</field>
+                                        <field name="sequence">5</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tag_46" model="account.tax.report.line">
+                                <field name="name">Leistungsempfänger als Steuerschuldner (zeile 46)</field>
+                                <field name="sequence">4</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_48" model="account.tax.report.line">
+                                        <field name="name">46. Steuerpflichtige sonstige Leistungen eines im übrigen Gemeinschaftsgebiet ansässigen Unternehmers (zeile 48)</field>
+                                        <field name="tag_name">46</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">46</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_52" model="account.tax.report.line">
+                                        <field name="name">52. Andere Leistungen eines im Ausland ansässigen Unternehmers (zeile 49)</field>
+                                        <field name="tag_name">52</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">52</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_73" model="account.tax.report.line">
+                                        <field name="name">73. Lieferungen sicherungsübereigneter Gegenstände und Umsätze, die unter das GrEStG fallen (zeile 50)</field>
+                                        <field name="tag_name">73</field>
+                                        <field name="sequence">3</field>
+                                        <field name="code">73</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_78" model="account.tax.report.line">
+                                        <field name="name">78. Lieferungen von Mobilfunkgeräten, Tablet-Computern, Spielekonsolen und integrierten Schaltkreisen (zeile 51)</field>
+                                        <field name="tag_name">78</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">78</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_84" model="account.tax.report.line">
+                                        <field name="name">84. Andere Leistungen (zeile 52)</field>
+                                        <field name="tag_name">84</field>
+                                        <field name="sequence">5</field>
+                                        <field name="code">84</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_de_tag_02" model="account.tax.report.line">
+                <field name="name">Steuer</field>
+                <field name="sequence">2</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_de_tax_tag_17" model="account.tax.report.line">
+                        <field name="name">I. Anmeldung der Umsatzsteuer-Vorauszahlung (zeile 17)</field>
+                        <field name="sequence">1</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_de_tax_tag_18" model="account.tax.report.line">
+                                <field name="name">Lieferungen und sonstige Leistungen (zeile 18)</field>
+                                <field name="sequence">1</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_26" model="account.tax.report.line">
+                                        <field name="name">81. zum Steuersatz von 19 % (zeile 26)</field>
+                                        <field name="tag_name">81_TAX</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">81</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_27" model="account.tax.report.line">
+                                        <field name="name">86. zum Steuersatz von 7 % (zeile 27)</field>
+                                        <field name="tag_name">86_TAX</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">86</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_36" model="account.tax.report.line">
+                                        <field name="name">36. zu anderen Steuersatzen (zeile 28)</field>
+                                        <field name="tag_name">36</field>
+                                        <field name="sequence">3</field>
+                                        <field name="code">36</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_80" model="account.tax.report.line">
+                                        <field name="name">80. Umsatze, fur die eine Steuer nach § 24 UStG zu entrichten ist (zeile 30)</field>
+                                        <field name="tag_name">80</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">80</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tax_tag_31" model="account.tax.report.line">
+                                <field name="name">Innergemeinschaftliche Erwerbe (zeile 31)</field>
+                                <field name="sequence">2</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_33" model="account.tax.report.line">
+                                        <field name="name">89. zum Steuersatz von 19 % (zeile 33)</field>
+                                        <field name="tag_name">89_TAX</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">89</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_34" model="account.tax.report.line">
+                                        <field name="name">93. zum Steuersatz von 7 % (zeile 34)</field>
+                                        <field name="tag_name">93_TAX</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">93</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_98" model="account.tax.report.line">
+                                        <field name="name">98. zu anderen Steuersatzen (zeile 35)</field>
+                                        <field name="tag_name">98</field>
+                                        <field name="sequence">3</field>
+                                        <field name="code">98</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_96" model="account.tax.report.line">
+                                        <field name="name">96. neuer Fahrzeuge von Lieferern ohne USt-IdNr. zum allgemeinen Steuersatz (zeile 36)</field>
+                                        <field name="tag_name">96</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">96</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tax_tag_37" model="account.tax.report.line">
+                                <field name="name">Erganzende Angaben zu Umsatzen (zeile 37)</field>
+                                <field name="sequence">3</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tax_tag_45" model="account.tax.report.line">
+                                        <field name="name">45. Ubertrag (zeile 45)</field>
+                                        <field name="tag_name">45_TAX</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">45</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tax_tag_46" model="account.tax.report.line">
+                                <field name="name">Leistungsempfanger als Steuerschuldner (zeile 46)</field>
+                                <field name="sequence">4</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_47" model="account.tax.report.line">
+                                        <field name="name">47. Steuerpflichtige sonstige Leistungen eines im übrigen Gemeinschaftsgebietansässigen Unternehmers (zeile 48)</field>
+                                        <field name="tag_name">47</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">47</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_53" model="account.tax.report.line">
+                                        <field name="name">53. Andere Leistungen eines im Ausland ansässigen Unternehmers (zeile 49)</field>
+                                        <field name="tag_name">53</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">53</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_74" model="account.tax.report.line">
+                                        <field name="name">74. Lieferungen sicherungsübereigneter Gegenstände und Umsätze, die unter das GrEStG fallen (zeile 50)</field>
+                                        <field name="tag_name">74</field>
+                                        <field name="sequence">3</field>
+                                        <field name="code">74</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_79" model="account.tax.report.line">
+                                        <field name="name">79. Lieferungen von Mobilfunkgeräten, Tablet-Computern, Spielekonsolen und integrierten Schaltkreisen (zeile 51)</field>
+                                        <field name="tag_name">79</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">79</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_85" model="account.tax.report.line">
+                                        <field name="name">85. Andere Leistungen (zeile 52)</field>
+                                        <field name="tag_name">85</field>
+                                        <field name="sequence">5</field>
+                                        <field name="code">85</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_65" model="account.tax.report.line">
+                                        <field name="name">65. Steuer infolge Wechsels der Besteuerungsform sowie Nachsteuer auf versteuerte Anzahlungen u. ä. wegen Steuersatzänderung (zeile 53)</field>
+                                        <field name="tag_name">65</field>
+                                        <field name="sequence">6</field>
+                                        <field name="code">65</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tax_tag_55" model="account.tax.report.line">
+                                <field name="name">Abziehbare Vorsteuerbetrage (zeile 55)</field>
+                                <field name="sequence">5</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_66" model="account.tax.report.line">
+                                        <field name="name">66. Vorsteuerbeträge aus Rechnungen von anderen Unternehmern (zeile 56)</field>
+                                        <field name="tag_name">66</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">66</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_61" model="account.tax.report.line">
+                                        <field name="name">61. Vorsteuerbeträge aus dem innergemeinschaftlichen Erwerb von Gegenständen (zeile 57)</field>
+                                        <field name="tag_name">61</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">61</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_62" model="account.tax.report.line">
+                                        <field name="name">62. Entstandene Einfuhrumsatzsteuer (zeile 58)</field>
+                                        <field name="tag_name">62</field>
+                                        <field name="sequence">3</field>
+                                        <field name="code">62</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_67" model="account.tax.report.line">
+                                        <field name="name">67. Vorsteuerbeträge aus Leistungen im Sinne des § 13b UStG (zeile 59)</field>
+                                        <field name="tag_name">67</field>
+                                        <field name="sequence">4</field>
+                                        <field name="code">67</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_63" model="account.tax.report.line">
+                                        <field name="name">63. Vorsteuerbeträge, die nach allgemeinen Durchschnittssätzen berechnet sind (zeile 60)</field>
+                                        <field name="tag_name">63</field>
+                                        <field name="sequence">5</field>
+                                        <field name="code">63</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_64" model="account.tax.report.line">
+                                        <field name="name">64. Berichtigung des Vorsteuerabzugs (zeile 61)</field>
+                                        <field name="tag_name">64</field>
+                                        <field name="sequence">6</field>
+                                        <field name="code">64</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_59" model="account.tax.report.line">
+                                        <field name="name">59. Vorsteuerabzug für innergemeinschaftliche Lieferungen neuer Fahrzeuge außerhalb eines Unternehmens (zeile 62)</field>
+                                        <field name="tag_name">59</field>
+                                        <field name="sequence">7</field>
+                                        <field name="code">59</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tax_tag_64" model="account.tax.report.line">
+                                <field name="name">Andere Steuerbetrage (zeile 64)</field>
+                                <field name="sequence">6</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_69" model="account.tax.report.line">
+                                        <field name="name">69. In Rechnungen unrichtig oder unberechtigt ausgewiesene Steuerbeträge (zeile 65)</field>
+                                        <field name="tag_name">69</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">69</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_de_tax_tag_66" model="account.tax.report.line">
+                                <field name="name">Umsatzsteuer-Vorauszahlung/Uberschuss (zeile 66)</field>
+                                <field name="sequence">7</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_de_tag_39" model="account.tax.report.line">
+                                        <field name="name">39. Abzug der festgesetzten Sondervorauszahlung für Dauerfristverlängerung (zeile 67)</field>
+                                        <field name="tag_name">39</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">39</field>
+                                    </record>
+                                    <record id="tax_report_de_tag_83" model="account.tax.report.line">
+                                        <field name="name">83. Verbleibende Umsatzsteuer-Vorauszahlung (zeile 68)</field>
+                                        <field name="tag_name">83</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">83</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <!-- First level, one for base, one for tax -->
-    <record id="tax_report_de_tag_01" model="account.tax.report.line">
-        <field name="name">Bemessungsgrundlage</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-    <record id="tax_report_de_tag_02" model="account.tax.report.line">
-        <field name="name">Steuer</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-
-    <!-- BASE -->
-    <record id="tax_report_de_tag_17" model="account.tax.report.line">
-        <field name="name">I. Anmeldung der Umsatzsteuer-Vorauszahlung (zeile 17)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_01"/>
-    </record>
-
-    <!-- Row 18 - 31 - 37 - 46 -->
-
-    <record id="tax_report_de_tag_18" model="account.tax.report.line">
-        <field name="name">Lieferungen und sonstige Leistungen (zeile 18)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_17"/>
-    </record>
-    <record id="tax_report_de_tag_31" model="account.tax.report.line">
-        <field name="name">Innergemeinschaftliche Erwerbe (zeile 31)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_17"/>
-    </record>
-    <record id="tax_report_de_tag_37" model="account.tax.report.line">
-        <field name="name">Ergänzende Angaben zu Umsätzen (zeile 37)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tag_17"/>
-    </record>
-    <record id="tax_report_de_tag_46" model="account.tax.report.line">
-        <field name="name">Leistungsempfänger als Steuerschuldner (zeile 46)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tag_17"/>
-    </record>
-
-    <!-- Row 19 - 24 - 25 -->
-
-    <record id="tax_report_de_tag_19" model="account.tax.report.line">
-        <field name="name">Steuerfreie Umsätze mit Vorsteuerabzug (zeile 19)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_18"/>
-    </record>
-    <record id="tax_report_de_tag_24" model="account.tax.report.line">
-        <field name="name">48. Steuerfreie Umsätze ohne Vorsteuerabzug (zeile 24)</field>
-        <field name="tag_name">48</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_18"/>
-        <field name="code">48</field>
-    </record>
-    <record id="tax_report_de_tag_25" model="account.tax.report.line">
-        <field name="name">Steuerpflichtige Umsätze (zeile 25)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tag_18"/>
-    </record>
-
-
-    <record id="tax_report_de_tag_41" model="account.tax.report.line">
-        <field name="name">41. an Abnehmer mit USt-IdNr (zeile 20)</field>
-        <field name="tag_name">41</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_19"/>
-        <field name="code">41</field>
-    </record>
-    <record id="tax_report_de_tag_44" model="account.tax.report.line">
-        <field name="name">44. neuer Fahrzeuge an Abnehmer ohne USt-IdNr (zeile 21)</field>
-        <field name="tag_name">44</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_19"/>
-        <field name="code">44</field>
-    </record>
-    <record id="tax_report_de_tag_49" model="account.tax.report.line">
-        <field name="name">49. neuer Fahrzeuge außerhalb eines Unternehmens (zeile 22)</field>
-        <field name="tag_name">49</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tag_19"/>
-        <field name="code">49</field>
-    </record>
-    <record id="tax_report_de_tag_43" model="account.tax.report.line">
-        <field name="name">43. Weitere steuerfreie Umsätze mit Vorsteuerabzug (zeile 23)</field>
-        <field name="tag_name">43</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tag_19"/>
-        <field name="code">43</field>
-    </record>
-
-    <record id="tax_report_de_tag_81" model="account.tax.report.line">
-        <field name="name">81. zum Steuersatz von 19 % (zeile 26)</field>
-        <field name="tag_name">81_BASE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_25"/>
-    </record>
-    <record id="tax_report_de_tag_86" model="account.tax.report.line">
-        <field name="name">86. zum Steuersatz von 7 % (zeile 27)</field>
-        <field name="tag_name">86_BASE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_25"/>
-    </record>
-    <record id="tax_report_de_tag_35" model="account.tax.report.line">
-        <field name="name">35. zu anderen Steuersätzen (zeile 28)</field>
-        <field name="tag_name">35</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_25"/>
-        <field name="code">35</field>
-    </record>
-    <record id="tax_report_de_tag_77" model="account.tax.report.line">
-        <field name="name">77. Lieferungen land- und forstwirtschaftlicher Betriebe nach § 24 UStG an Abnehmer mit USt-IdNr. (zeile 29)</field>
-        <field name="tag_name">77</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tag_25"/>
-        <field name="code">77</field>
-    </record>
-    <record id="tax_report_de_tag_76" model="account.tax.report.line">
-        <field name="name">76. Umsätze, für die eine Steuer nach § 24 UStG zu entrichten ist (zeile 30)</field>
-        <field name="tag_name">76</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tag_25"/>
-        <field name="code">76</field>
-    </record>
-
-
-    <record id="tax_report_de_tag_91" model="account.tax.report.line">
-        <field name="name">91. Steuerfreie innergemeinschaftliche Erwerbe (zeile 32)</field>
-        <field name="tag_name">91</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_31"/>
-        <field name="code">91</field>
-    </record>
-    <record id="tax_report_de_tag_89" model="account.tax.report.line">
-        <field name="name">89. Steuerpflichtige innergemeinschaftliche Erwerbe zum Steuersatz von 19 % (zeile 33)</field>
-        <field name="tag_name">89_BASE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_31"/>
-    </record>
-    <record id="tax_report_de_tag_93" model="account.tax.report.line">
-        <field name="name">93. zum Steuersatz von 7 % (zeile 34)</field>
-        <field name="tag_name">93_BASE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tag_31"/>
-    </record>
-    <record id="tax_report_de_tag_95" model="account.tax.report.line">
-        <field name="name">95. zu anderen Steuersätzen (zeile 35)</field>
-        <field name="tag_name">95</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tag_31"/>
-        <field name="code">95</field>
-    </record>
-    <record id="tax_report_de_tag_94" model="account.tax.report.line">
-        <field name="name">94. neuer Fahrzeuge von Lieferern ohne (zeile 36)</field>
-        <field name="tag_name">94</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tag_31"/>
-        <field name="code">94</field>
-    </record>
-
-
-    <record id="tax_report_de_tag_42" model="account.tax.report.line">
-        <field name="name">42. Dreiecksgeschäften (zeile 38)</field>
-        <field name="tag_name">42</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_37"/>
-        <field name="code">42</field>
-    </record>
-    <record id="tax_report_de_tag_68" model="account.tax.report.line">
-        <field name="name">68. Steuerpflichtige Umsätze, für die der Leistungsempfänger die Steuer nach § 13b Abs. 5 Satz 1 i.V.m. Abs. 2 Nr. 10 UStG schuldet (zeile 39)</field>
-        <field name="tag_name">68</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_37"/>
-        <field name="code">68</field>
-    </record>
-    <record id="tax_report_de_tag_60" model="account.tax.report.line">
-        <field name="name">60. Übrige steuerpflichtige Umsätze, für die der Leistungsempfänger die Steuer nach § 13b Abs. 5 UStG schuldet (zeile 40)</field>
-        <field name="tag_name">60</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tag_37"/>
-        <field name="code">60</field>
-    </record>
-    <record id="tax_report_de_tag_21" model="account.tax.report.line">
-        <field name="name">21. Nicht steuerbare sonstige Leistungen (zeile 41)</field>
-        <field name="tag_name">21</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tag_37"/>
-        <field name="code">21</field>
-    </record>
-    <record id="tax_report_de_tag_45" model="account.tax.report.line">
-        <field name="name">45. Übrige nicht steuerbare Umsätze (zeile 42)</field>
-        <field name="tag_name">45_BASE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tag_37"/>
-    </record>
-
-
-    <record id="tax_report_de_tag_48" model="account.tax.report.line">
-        <field name="name">46. Steuerpflichtige sonstige Leistungen eines im übrigen Gemeinschaftsgebiet ansässigen Unternehmers (zeile 48)</field>
-        <field name="tag_name">46</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_46"/>
-        <field name="code">46</field>
-    </record>
-    <record id="tax_report_de_tag_52" model="account.tax.report.line">
-        <field name="name">52. Andere Leistungen eines im Ausland ansässigen Unternehmers (zeile 49)</field>
-        <field name="tag_name">52</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tag_46"/>
-        <field name="code">52</field>
-    </record>
-    <record id="tax_report_de_tag_73" model="account.tax.report.line">
-        <field name="name">73. Lieferungen sicherungsübereigneter Gegenstände und Umsätze, die unter das GrEStG fallen (zeile 50)</field>
-        <field name="tag_name">73</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tag_46"/>
-        <field name="code">73</field>
-    </record>
-    <record id="tax_report_de_tag_78" model="account.tax.report.line">
-        <field name="name">78. Lieferungen von Mobilfunkgeräten, Tablet-Computern, Spielekonsolen und integrierten Schaltkreisen (zeile 51)</field>
-        <field name="tag_name">78</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tag_46"/>
-        <field name="code">78</field>
-    </record>
-    <record id="tax_report_de_tag_84" model="account.tax.report.line">
-        <field name="name">84. Andere Leistungen (zeile 52)</field>
-        <field name="tag_name">84</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tag_46"/>
-        <field name="code">84</field>
-    </record>
-
-
-    <!-- TAX -->
-
-    <record id="tax_report_de_tax_tag_17" model="account.tax.report.line">
-        <field name="name">I. Anmeldung der Umsatzsteuer-Vorauszahlung (zeile 17)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tag_02"/>
-    </record>
-
-
-    <!-- Row 18 - 31 - 37 - 46 - 55 - 64 - 66 -->
-    <record id="tax_report_de_tax_tag_18" model="account.tax.report.line">
-        <field name="name">Lieferungen und sonstige Leistungen (zeile 18)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-    <record id="tax_report_de_tax_tag_31" model="account.tax.report.line">
-        <field name="name">Innergemeinschaftliche Erwerbe (zeile 31)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-    <record id="tax_report_de_tax_tag_37" model="account.tax.report.line">
-        <field name="name">Erganzende Angaben zu Umsatzen (zeile 37)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-    <record id="tax_report_de_tax_tag_46" model="account.tax.report.line">
-        <field name="name">Leistungsempfanger als Steuerschuldner (zeile 46)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-    <record id="tax_report_de_tax_tag_55" model="account.tax.report.line">
-        <field name="name">Abziehbare Vorsteuerbetrage (zeile 55)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-    <record id="tax_report_de_tax_tag_64" model="account.tax.report.line">
-        <field name="name">Andere Steuerbetrage (zeile 64)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-    <record id="tax_report_de_tax_tag_66" model="account.tax.report.line">
-        <field name="name">Umsatzsteuer-Vorauszahlung/Uberschuss (zeile 66)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">7</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_17"/>
-    </record>
-
-    <!-- Row 26 - 27 - 28 - 30 -->
-    <record id="tax_report_de_tag_26" model="account.tax.report.line">
-        <field name="name">81. zum Steuersatz von 19 % (zeile 26)</field>
-        <field name="tag_name">81_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_18"/>
-        <field name="code">81</field>
-    </record>
-    <record id="tax_report_de_tag_27" model="account.tax.report.line">
-        <field name="name">86. zum Steuersatz von 7 % (zeile 27)</field>
-        <field name="tag_name">86_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_18"/>
-        <field name="code">86</field>
-    </record>
-    <record id="tax_report_de_tag_36" model="account.tax.report.line">
-        <field name="name">36. zu anderen Steuersatzen (zeile 28)</field>
-        <field name="tag_name">36</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_18"/>
-        <field name="code">36</field>
-    </record>
-    <record id="tax_report_de_tag_80" model="account.tax.report.line">
-        <field name="name">80. Umsatze, fur die eine Steuer nach § 24 UStG zu entrichten ist (zeile 30)</field>
-        <field name="tag_name">80</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_18"/>
-        <field name="code">80</field>
-    </record>
-
-     <!-- Row 33 - 34 - 35 - 36 -->
-    <record id="tax_report_de_tag_33" model="account.tax.report.line">
-        <field name="name">89. zum Steuersatz von 19 % (zeile 33)</field>
-        <field name="tag_name">89_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_31"/>
-        <field name="code">89</field>
-    </record>
-    <record id="tax_report_de_tag_34" model="account.tax.report.line">
-        <field name="name">93. zum Steuersatz von 7 % (zeile 34)</field>
-        <field name="tag_name">93_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_31"/>
-        <field name="code">93</field>
-    </record>
-    <record id="tax_report_de_tag_98" model="account.tax.report.line">
-        <field name="name">98. zu anderen Steuersatzen (zeile 35)</field>
-        <field name="tag_name">98</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_31"/>
-        <field name="code">98</field>
-    </record>
-    <record id="tax_report_de_tag_96" model="account.tax.report.line">
-        <field name="name">96. neuer Fahrzeuge von Lieferern ohne USt-IdNr. zum allgemeinen Steuersatz (zeile 36)</field>
-        <field name="tag_name">96</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_31"/>
-        <field name="code">96</field>
-    </record>
-
-    <!-- Row 45 -->
-    <record id="tax_report_de_tax_tag_45" model="account.tax.report.line">
-        <field name="name">45. Ubertrag (zeile 45)</field>
-        <field name="tag_name">45_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_37"/>
-        <field name="code">45</field>
-    </record>
-
-    <!-- Row 48 - 49 - 50 - 51 - 52 - 53 -->
-    <record id="tax_report_de_tag_47" model="account.tax.report.line">
-        <field name="name">47. Steuerpflichtige sonstige Leistungen eines im übrigen Gemeinschaftsgebietansässigen Unternehmers (zeile 48)</field>
-        <field name="tag_name">47</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_46"/>
-        <field name="code">47</field>
-    </record>
-    <record id="tax_report_de_tag_53" model="account.tax.report.line">
-        <field name="name">53. Andere Leistungen eines im Ausland ansässigen Unternehmers (zeile 49)</field>
-        <field name="tag_name">53</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_46"/>
-        <field name="code">53</field>
-    </record>
-    <record id="tax_report_de_tag_74" model="account.tax.report.line">
-        <field name="name">74. Lieferungen sicherungsübereigneter Gegenstände und Umsätze, die unter das GrEStG fallen (zeile 50)</field>
-        <field name="tag_name">74</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_46"/>
-        <field name="code">74</field>
-    </record>
-    <record id="tax_report_de_tag_79" model="account.tax.report.line">
-        <field name="name">79. Lieferungen von Mobilfunkgeräten, Tablet-Computern, Spielekonsolen und integrierten Schaltkreisen (zeile 51)</field>
-        <field name="tag_name">79</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_46"/>
-        <field name="code">79</field>
-    </record>
-    <record id="tax_report_de_tag_85" model="account.tax.report.line">
-        <field name="name">85. Andere Leistungen (zeile 52)</field>
-        <field name="tag_name">85</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_46"/>
-        <field name="code">85</field>
-    </record>
-    <record id="tax_report_de_tag_65" model="account.tax.report.line">
-        <field name="name">65. Steuer infolge Wechsels der Besteuerungsform sowie Nachsteuer auf versteuerte Anzahlungen u. ä. wegen Steuersatzänderung (zeile 53)</field>
-        <field name="tag_name">65</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_46"/>
-        <field name="code">65</field>
-    </record>
-
-    <!-- Row 56 - 57 - 58 - 59 - 60 - 61 - 62 -->
-    <record id="tax_report_de_tag_66" model="account.tax.report.line">
-        <field name="name">66. Vorsteuerbeträge aus Rechnungen von anderen Unternehmern (zeile 56)</field>
-        <field name="tag_name">66</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">66</field>
-    </record>
-    <record id="tax_report_de_tag_61" model="account.tax.report.line">
-        <field name="name">61. Vorsteuerbeträge aus dem innergemeinschaftlichen Erwerb von Gegenständen (zeile 57)</field>
-        <field name="tag_name">61</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">61</field>
-    </record>
-    <record id="tax_report_de_tag_62" model="account.tax.report.line">
-        <field name="name">62. Entstandene Einfuhrumsatzsteuer (zeile 58)</field>
-        <field name="tag_name">62</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">62</field>
-    </record>
-    <record id="tax_report_de_tag_67" model="account.tax.report.line">
-        <field name="name">67. Vorsteuerbeträge aus Leistungen im Sinne des § 13b UStG (zeile 59)</field>
-        <field name="tag_name">67</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">67</field>
-    </record>
-    <record id="tax_report_de_tag_63" model="account.tax.report.line">
-        <field name="name">63. Vorsteuerbeträge, die nach allgemeinen Durchschnittssätzen berechnet sind (zeile 60)</field>
-        <field name="tag_name">63</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">63</field>
-    </record>
-    <record id="tax_report_de_tag_64" model="account.tax.report.line">
-        <field name="name">64. Berichtigung des Vorsteuerabzugs (zeile 61)</field>
-        <field name="tag_name">64</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">64</field>
-    </record>
-    <record id="tax_report_de_tag_59" model="account.tax.report.line">
-        <field name="name">59. Vorsteuerabzug für innergemeinschaftliche Lieferungen neuer Fahrzeuge außerhalb eines Unternehmens (zeile 62)</field>
-        <field name="tag_name">59</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">7</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_55"/>
-        <field name="code">59</field>
-    </record>
-
-    <!-- Row 65 -->
-    <record id="tax_report_de_tag_69" model="account.tax.report.line">
-        <field name="name">69. In Rechnungen unrichtig oder unberechtigt ausgewiesene Steuerbeträge (zeile 65)</field>
-        <field name="tag_name">69</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_64"/>
-        <field name="code">69</field>
-    </record>
-
-    <!-- Row 67 - 68 -->
-    <record id="tax_report_de_tag_39" model="account.tax.report.line">
-        <field name="name">39. Abzug der festgesetzten Sondervorauszahlung für Dauerfristverlängerung (zeile 67)</field>
-        <field name="tag_name">39</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_66"/>
-        <field name="code">39</field>
-    </record>
-    <record id="tax_report_de_tag_83" model="account.tax.report.line">
-        <field name="name">83. Verbleibende Umsatzsteuer-Vorauszahlung (zeile 68)</field>
-        <field name="tag_name">83</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="parent_id" ref="tax_report_de_tax_tag_66"/>
-        <field name="code">83</field>
-    </record>
-
     <record id="tag_de_intracom_community_delivery" model="account.account.tag">
         <field name="name">Innergemeinschaftliche Lieferung</field>
         <field name="applicability">taxes</field>
@@ -557,8 +418,6 @@
         <field name="applicability">taxes</field>
         <field name="country_id" ref="base.de"/>
     </record>
-
-    <!-- Profit and loss tags -->
     <record id="tag_de_pl_01" model="account.account.tag">
         <field name="name">G&amp;V: 1-Umsatzerlöse</field>
         <field name="applicability">accounts</field>
@@ -643,8 +502,6 @@
         <field name="name">G&amp;V: 15-Sonstige Steuern</field>
         <field name="applicability">accounts</field>
     </record>
-
-    <!-- Balance sheet tags -->
     <record id="tag_de_asset_bs_A_I_1" model="account.account.tag">
         <field name="name">Bilanz-Aktiva: A I 1-Selbst geschaffene gewerbliche Schutzrechte und ähnliche Rechte und Werte</field>
         <field name="applicability">accounts</field>
@@ -757,7 +614,6 @@
         <field name="name">Bilanz-Aktiva: E-Aktiver Unterschiedsbetrag aus der Vermögensverrechnung</field>
         <field name="applicability">accounts</field>
     </record>
-
     <record id="tag_de_liabilities_bs_A_I" model="account.account.tag">
         <field name="name">Bilanz-Passiva: A I-Gezeichnetes Kapital</field>
         <field name="applicability">accounts</field>
@@ -846,5 +702,4 @@
         <field name="name">Bilanz-Passiva: F-Passive latente Steuern</field>
         <field name="applicability">accounts</field>
     </record>
-
 </odoo>

--- a/addons/l10n_do/data/account_tax_report_data.xml
+++ b/addons/l10n_do/data/account_tax_report_data.xml
@@ -1,148 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.do"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_total_operaciones" model="account.tax.report.line">
+                <field name="name">II-1 Total de Operaciones</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_2A_ingrs_exprt" model="account.tax.report.line">
+                        <field name="name">II.A INGRESOS POR EXPORTACIONES DE BIENES O SERVICIOS EXENTOS</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_2A2_ingrs_exprt" model="account.tax.report.line">
+                                <field name="name">II.A.2 INGRESOS POR EXPORTACIONES DE BIENES O SERVICIOS EXENTOS</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_2A3_ingrs_local_vnts" model="account.tax.report.line">
+                                <field name="name">II.A.3 INGRESOS POR VENTAS LOCALES DE BIENES O SERVICIOS EXENTOS</field>
+                                <field name="tag_name">II.A.3</field>
+                                <field name="code">DOTAX010102</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_2b_grvd" model="account.tax.report.line">
+                        <field name="name">II.B GRAVADAS</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_2b6_grvd" model="account.tax.report.line">
+                                <field name="name">II.B.6 OPERACIONES GRAVADAS AL 18%</field>
+                                <field name="tag_name">II.B.6</field>
+                                <field name="code">DOTAX010201</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_2b7_grvd" model="account.tax.report.line">
+                                <field name="name">II.B.7 OPERACIONES GRAVADAS AL 11%</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_3_liquidacion" model="account.tax.report.line">
+                <field name="name">III LIQUIDACION</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_financial_report_line_02_01_do_account_tax_report_total_itbs" model="account.tax.report.line">
+                        <field name="name">III.10 TOTAL ITBIS COBRADO (Sumar casillas 8+9)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_itbs_18_casilla" model="account.tax.report.line">
+                                <field name="name">III.8 ITBIS COBRADO (18% de la casilla 6)</field>
+                                <field name="tag_name">III.8</field>
+                                <field name="code">DOTAX020101</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_tbs_11_casilla" model="account.tax.report.line">
+                                <field name="name">III.9 TBIS COBRADO (11% de la casilla 7)</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_total_itbs_pgdo" model="account.tax.report.line">
+                        <field name="name">III.14 TOTAL ITBIS PAGADO (Sumar casillas 11+12+13)</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_itbs_pgdo_locales" model="account.tax.report.line">
+                                <field name="name">III.11 ITBIS PAGADO EN COMPRAS LOCALES</field>
+                                <field name="tag_name">III.11</field>
+                                <field name="code">DOTAX020201</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_itbs_pgdo_dedubl" model="account.tax.report.line">
+                                <field name="name">III.12 ITBIS PAGADO POR SERVICIOS DEDUCIBLES</field>
+                                <field name="tag_name">III.12</field>
+                                <field name="code">DOTAX020202</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_itbs_pgdo_imptcn" model="account.tax.report.line">
+                                <field name="name">III.13 ITBIS PAGADO EN IMPORTACIONES</field>
+                                <field name="tag_name">III.13</field>
+                                <field name="code">DOTAX020203</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_itbs_rntnd" model="account.tax.report.line">
+                <field name="name">A,1 ITBIS RETENIDO</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_retcn_prsn" model="account.tax.report.line">
+                        <field name="name">A.25 Servicios Sujetos a Retención Personas = Físicas y Entidad</field>
+                        <field name="tag_name">A.25</field>
+                        <field name="code">DOTAX0301</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_itbs_retcn_prsn" model="account.tax.report.line">
+                        <field name="name">A.30 Itbis Por Servicios Sujetos A Retencion Personas Físicas</field>
+                        <field name="tag_name">A.30</field>
+                        <field name="code">DOTAX0302</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_total_operaciones" model="account.tax.report.line">
-        <field name="name">II-1 Total de Operaciones</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_2A_ingrs_exprt" model="account.tax.report.line">
-        <field name="name">II.A INGRESOS POR EXPORTACIONES DE BIENES O SERVICIOS EXENTOS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_total_operaciones"/>
-    </record>
-
-    <record id="account_tax_report_2A2_ingrs_exprt" model="account.tax.report.line">
-        <field name="name">II.A.2 INGRESOS POR EXPORTACIONES DE BIENES O SERVICIOS EXENTOS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_2A_ingrs_exprt"/>
-    </record>
-
-    <record id="account_tax_report_2A3_ingrs_local_vnts" model="account.tax.report.line">
-        <field name="name">II.A.3 INGRESOS POR VENTAS LOCALES DE BIENES O SERVICIOS EXENTOS</field>
-        <field name="tag_name">II.A.3</field>
-        <field name="code">DOTAX010102</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_2A_ingrs_exprt"/>
-    </record>
-
-    <record id="account_tax_report_2b_grvd" model="account.tax.report.line">
-        <field name="name">II.B GRAVADAS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_total_operaciones"/>
-    </record>
-
-    <record id="account_tax_report_2b6_grvd" model="account.tax.report.line">
-        <field name="name">II.B.6 OPERACIONES GRAVADAS AL 18%</field>
-        <field name="tag_name">II.B.6</field>
-        <field name="code">DOTAX010201</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_2b_grvd"/>
-    </record>
-
-    <record id="account_tax_report_2b7_grvd" model="account.tax.report.line">
-        <field name="name">II.B.7 OPERACIONES GRAVADAS AL 11%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_2b_grvd"/>
-    </record>
-
-    <record id="account_tax_report_3_liquidacion" model="account.tax.report.line">
-        <field name="name">III LIQUIDACION</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_financial_report_line_02_01_do_account_tax_report_total_itbs" model="account.tax.report.line">
-        <field name="name">III.10 TOTAL ITBIS COBRADO (Sumar casillas 8+9)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_3_liquidacion"/>
-    </record>
-
-    <record id="account_tax_report_itbs_18_casilla" model="account.tax.report.line">
-        <field name="name">III.8 ITBIS COBRADO (18% de la casilla 6)</field>
-        <field name="tag_name">III.8</field>
-        <field name="code">DOTAX020101</field>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_financial_report_line_02_01_do_account_tax_report_total_itbs"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_tbs_11_casilla" model="account.tax.report.line">
-        <field name="name">III.9 TBIS COBRADO (11% de la casilla 7)</field>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_financial_report_line_02_01_do_account_tax_report_total_itbs"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_total_itbs_pgdo" model="account.tax.report.line">
-        <field name="name">III.14 TOTAL ITBIS PAGADO (Sumar casillas 11+12+13)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_3_liquidacion"/>
-    </record>
-
-    <record id="account_tax_report_itbs_pgdo_locales" model="account.tax.report.line">
-        <field name="name">III.11 ITBIS PAGADO EN COMPRAS LOCALES</field>
-        <field name="tag_name">III.11</field>
-        <field name="code">DOTAX020201</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_total_itbs_pgdo"/>
-    </record>
-
-    <record id="account_tax_report_itbs_pgdo_dedubl" model="account.tax.report.line">
-        <field name="name">III.12 ITBIS PAGADO POR SERVICIOS DEDUCIBLES</field>
-        <field name="tag_name">III.12</field>
-        <field name="code">DOTAX020202</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_total_itbs_pgdo"/>
-    </record>
-
-    <record id="account_tax_report_itbs_pgdo_imptcn" model="account.tax.report.line">
-        <field name="name">III.13 ITBIS PAGADO EN IMPORTACIONES</field>
-        <field name="tag_name">III.13</field>
-        <field name="code">DOTAX020203</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_total_itbs_pgdo"/>
-    </record>
-
-    <record id="account_tax_report_itbs_rntnd" model="account.tax.report.line">
-        <field name="name">A,1 ITBIS RETENIDO</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="account_tax_report_retcn_prsn" model="account.tax.report.line">
-        <field name="name">A.25 Servicios Sujetos a Retención Personas = Físicas y Entidad</field>
-        <field name="tag_name">A.25</field>
-        <field name="code">DOTAX0301</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_itbs_rntnd"/>
-    </record>
-
-    <record id="account_tax_report_itbs_retcn_prsn" model="account.tax.report.line">
-        <field name="name">A.30 Itbis Por Servicios Sujetos A Retencion Personas Físicas</field>
-        <field name="tag_name">A.30</field>
-        <field name="code">DOTAX0302</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_itbs_rntnd"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_ec/data/account_tax_report_data.xml
+++ b/addons/l10n_ec/data/account_tax_report_data.xml
@@ -1,3116 +1,2399 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <record id="tax_report_104" model="account.tax.report">
-            <field name="name">104</field>
-            <field name="country_id" ref="base.ec"/>
-        </record>
-        <record id="tax_report_line_parent_line_report_1" model="account.tax.report.line">
-            <field name="name">RESUMEN DE VENTAS Y OTRAS OPERACIONES DEL PERÍODO QUE DECLARA</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_2" model="account.tax.report.line">
-            <field name="name">Ventas locales (excluye activos fijos) gravadas tarifa diferente de cero</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_401" model="account.tax.report.line">
-            <field name="name">Valor bruto(401)</field>
-            <field name="code">c401</field>
-            <field name="tag_name">401 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_2"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_411" model="account.tax.report.line">
-            <field name="name">Valor neto(411)</field>
-            <field name="code">c411</field>
-            <field name="tag_name">411 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_2"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_421" model="account.tax.report.line">
-            <field name="name">Impuesto generado(421)</field>
-            <field name="code">c421</field>
-            <field name="tag_name">421 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_2"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_6" model="account.tax.report.line">
-            <field name="name">Ventas de activos fijos gravadas tarifa diferente de cero</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_402" model="account.tax.report.line">
-            <field name="name">Valor bruto(402)</field>
-            <field name="code">c402</field>
-            <field name="tag_name">402 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_6"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_412" model="account.tax.report.line">
-            <field name="name">Valor neto(412)</field>
-            <field name="code">c412</field>
-            <field name="tag_name">412 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_6"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_422" model="account.tax.report.line">
-            <field name="name">Impuesto generado(422)</field>
-            <field name="code">c422</field>
-            <field name="tag_name">422 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_6"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_10" model="account.tax.report.line">
-            <field name="name">IVA generado en la diferencia entre ventas y notas de crédito con distinta tarifa (ajuste
+    <record id="tax_report_104" model="account.tax.report">
+        <field name="name">104</field>
+        <field name="country_id" ref="base.ec"/>
+        <field name="root_line_ids">
+            <record id="tax_report_line_parent_line_report_1" model="account.tax.report.line">
+                <field name="name">RESUMEN DE VENTAS Y OTRAS OPERACIONES DEL PERÍODO QUE DECLARA</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_parent_line_report_2" model="account.tax.report.line">
+                        <field name="name">Ventas locales (excluye activos fijos) gravadas tarifa diferente de cero</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_401" model="account.tax.report.line">
+                                <field name="name">Valor bruto(401)</field>
+                                <field name="code">c401</field>
+                                <field name="tag_name">401 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_411" model="account.tax.report.line">
+                                <field name="name">Valor neto(411)</field>
+                                <field name="code">c411</field>
+                                <field name="tag_name">411 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_421" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(421)</field>
+                                <field name="code">c421</field>
+                                <field name="tag_name">421 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_6" model="account.tax.report.line">
+                        <field name="name">Ventas de activos fijos gravadas tarifa diferente de cero</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_402" model="account.tax.report.line">
+                                <field name="name">Valor bruto(402)</field>
+                                <field name="code">c402</field>
+                                <field name="tag_name">402 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_412" model="account.tax.report.line">
+                                <field name="name">Valor neto(412)</field>
+                                <field name="code">c412</field>
+                                <field name="tag_name">412 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_422" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(422)</field>
+                                <field name="code">c422</field>
+                                <field name="tag_name">422 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_10" model="account.tax.report.line">
+                        <field name="name">IVA generado en la diferencia entre ventas y notas de crédito con distinta tarifa (ajuste
                 a pagar)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_423" model="account.tax.report.line">
-            <field name="name">Impuesto generado(423)</field>
-            <field name="code">c423</field>
-            <field name="tag_name">423 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_10"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_12" model="account.tax.report.line">
-            <field name="name">IVA generado en la diferencia entre ventas y notas de crédito con distinta tarifa (ajuste
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_423" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(423)</field>
+                                <field name="code">c423</field>
+                                <field name="tag_name">423 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_12" model="account.tax.report.line">
+                        <field name="name">IVA generado en la diferencia entre ventas y notas de crédito con distinta tarifa (ajuste
                 a favor)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_424" model="account.tax.report.line">
-            <field name="name">Impuesto generado(424)</field>
-            <field name="code">c424</field>
-            <field name="tag_name">424 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_12"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_14" model="account.tax.report.line">
-            <field name="name">Ventas locales (excluye activos fijos) gravadas tarifa 0% que no dan derecho a crédito
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_424" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(424)</field>
+                                <field name="code">c424</field>
+                                <field name="tag_name">424 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_14" model="account.tax.report.line">
+                        <field name="name">Ventas locales (excluye activos fijos) gravadas tarifa 0% que no dan derecho a crédito
                 tributario
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_403" model="account.tax.report.line">
-            <field name="name">Valor bruto(403)</field>
-            <field name="code">c403</field>
-            <field name="tag_name">403 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_14"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_413" model="account.tax.report.line">
-            <field name="name">Valor neto(413)</field>
-            <field name="code">c413</field>
-            <field name="tag_name">413 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_14"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_17" model="account.tax.report.line">
-            <field name="name">Ventas de activos fijos gravadas tarifa 0% que no dan derecho a crédito tributario
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_403" model="account.tax.report.line">
+                                <field name="name">Valor bruto(403)</field>
+                                <field name="code">c403</field>
+                                <field name="tag_name">403 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_413" model="account.tax.report.line">
+                                <field name="name">Valor neto(413)</field>
+                                <field name="code">c413</field>
+                                <field name="tag_name">413 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_17" model="account.tax.report.line">
+                        <field name="name">Ventas de activos fijos gravadas tarifa 0% que no dan derecho a crédito tributario
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_404" model="account.tax.report.line">
-            <field name="name">Valor bruto(404)</field>
-            <field name="code">c404</field>
-            <field name="tag_name">404 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_17"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_414" model="account.tax.report.line">
-            <field name="name">Valor neto(414)</field>
-            <field name="code">c414</field>
-            <field name="tag_name">414 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_17"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_20" model="account.tax.report.line">
-            <field name="name">Ventas locales (excluye activos fijos) gravadas tarifa 0% que dan derecho a crédito
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_404" model="account.tax.report.line">
+                                <field name="name">Valor bruto(404)</field>
+                                <field name="code">c404</field>
+                                <field name="tag_name">404 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_414" model="account.tax.report.line">
+                                <field name="name">Valor neto(414)</field>
+                                <field name="code">c414</field>
+                                <field name="tag_name">414 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_20" model="account.tax.report.line">
+                        <field name="name">Ventas locales (excluye activos fijos) gravadas tarifa 0% que dan derecho a crédito
                 tributario
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_405" model="account.tax.report.line">
-            <field name="name">Valor bruto(405)</field>
-            <field name="code">c405</field>
-            <field name="tag_name">405 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_20"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_415" model="account.tax.report.line">
-            <field name="name">Valor neto(415)</field>
-            <field name="code">c415</field>
-            <field name="tag_name">415 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_20"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_23" model="account.tax.report.line">
-            <field name="name">Ventas de activos fijos gravadas tarifa 0% que dan derecho a crédito tributario</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_406" model="account.tax.report.line">
-            <field name="name">Valor bruto(406)</field>
-            <field name="code">c406</field>
-            <field name="tag_name">406 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_23"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_416" model="account.tax.report.line">
-            <field name="name">Valor neto(416)</field>
-            <field name="code">c416</field>
-            <field name="tag_name">416 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_23"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_26" model="account.tax.report.line">
-            <field name="name">Exportaciones de bienes</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_407" model="account.tax.report.line">
-            <field name="name">Valor bruto(407)</field>
-            <field name="code">c407</field>
-            <field name="tag_name">407 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_26"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_417" model="account.tax.report.line">
-            <field name="name">Valor neto(417)</field>
-            <field name="code">c417</field>
-            <field name="tag_name">417 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_26"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_29" model="account.tax.report.line">
-            <field name="name">Exportaciones de servicios y/o derechos</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_408" model="account.tax.report.line">
-            <field name="name">Valor bruto(408)</field>
-            <field name="code">c408</field>
-            <field name="tag_name">408 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_29"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_418" model="account.tax.report.line">
-            <field name="name">Valor neto(418)</field>
-            <field name="code">c418</field>
-            <field name="tag_name">418 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_29"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_32" model="account.tax.report.line">
-            <field name="name">TOTAL VENTAS Y OTRAS OPERACIONES</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_409" model="account.tax.report.line">
-            <field name="name">Valor bruto(409)</field>
-            <field name="code">c409</field>
-            <field name="tag_name">409 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_32"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_419" model="account.tax.report.line">
-            <field name="name">Valor neto(419)</field>
-            <field name="code">c419</field>
-            <field name="tag_name">419 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_32"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_429" model="account.tax.report.line">
-            <field name="name">Impuesto generado(429)</field>
-            <field name="code">c429</field>
-            <field name="tag_name">429 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_32"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_36" model="account.tax.report.line">
-            <field name="name">Transferencias no objeto o exentas de IVA</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_431" model="account.tax.report.line">
-            <field name="name">Valor bruto(431)</field>
-            <field name="code">c431</field>
-            <field name="tag_name">431 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_36"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_441" model="account.tax.report.line">
-            <field name="name">Valor neto(441)</field>
-            <field name="code">c441</field>
-            <field name="tag_name">441 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_36"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_39" model="account.tax.report.line">
-            <field name="name">Notas de crédito tarifa 0% por compensar próximo mes</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_442" model="account.tax.report.line">
-            <field name="name">Valor neto(442)</field>
-            <field name="code">c442</field>
-            <field name="tag_name">442 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_39"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_41" model="account.tax.report.line">
-            <field name="name">Notas de crédito tarifa diferente de cero por compensar próximo mes</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_443" model="account.tax.report.line">
-            <field name="name">Valor neto(443)</field>
-            <field name="code">c443</field>
-            <field name="tag_name">443 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_41"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_453" model="account.tax.report.line">
-            <field name="name">Impuesto generado(453)</field>
-            <field name="code">c453</field>
-            <field name="tag_name">453 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_41"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_44" model="account.tax.report.line">
-            <field name="name">Ingresos por reembolso como intermediario / valores facturados por operadoras de
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_405" model="account.tax.report.line">
+                                <field name="name">Valor bruto(405)</field>
+                                <field name="code">c405</field>
+                                <field name="tag_name">405 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_415" model="account.tax.report.line">
+                                <field name="name">Valor neto(415)</field>
+                                <field name="code">c415</field>
+                                <field name="tag_name">415 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_23" model="account.tax.report.line">
+                        <field name="name">Ventas de activos fijos gravadas tarifa 0% que dan derecho a crédito tributario</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_406" model="account.tax.report.line">
+                                <field name="name">Valor bruto(406)</field>
+                                <field name="code">c406</field>
+                                <field name="tag_name">406 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_416" model="account.tax.report.line">
+                                <field name="name">Valor neto(416)</field>
+                                <field name="code">c416</field>
+                                <field name="tag_name">416 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_26" model="account.tax.report.line">
+                        <field name="name">Exportaciones de bienes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_407" model="account.tax.report.line">
+                                <field name="name">Valor bruto(407)</field>
+                                <field name="code">c407</field>
+                                <field name="tag_name">407 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_417" model="account.tax.report.line">
+                                <field name="name">Valor neto(417)</field>
+                                <field name="code">c417</field>
+                                <field name="tag_name">417 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_29" model="account.tax.report.line">
+                        <field name="name">Exportaciones de servicios y/o derechos</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_408" model="account.tax.report.line">
+                                <field name="name">Valor bruto(408)</field>
+                                <field name="code">c408</field>
+                                <field name="tag_name">408 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_418" model="account.tax.report.line">
+                                <field name="name">Valor neto(418)</field>
+                                <field name="code">c418</field>
+                                <field name="tag_name">418 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_32" model="account.tax.report.line">
+                        <field name="name">TOTAL VENTAS Y OTRAS OPERACIONES</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_409" model="account.tax.report.line">
+                                <field name="name">Valor bruto(409)</field>
+                                <field name="code">c409</field>
+                                <field name="tag_name">409 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_419" model="account.tax.report.line">
+                                <field name="name">Valor neto(419)</field>
+                                <field name="code">c419</field>
+                                <field name="tag_name">419 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_429" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(429)</field>
+                                <field name="code">c429</field>
+                                <field name="tag_name">429 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_36" model="account.tax.report.line">
+                        <field name="name">Transferencias no objeto o exentas de IVA</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_431" model="account.tax.report.line">
+                                <field name="name">Valor bruto(431)</field>
+                                <field name="code">c431</field>
+                                <field name="tag_name">431 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_441" model="account.tax.report.line">
+                                <field name="name">Valor neto(441)</field>
+                                <field name="code">c441</field>
+                                <field name="tag_name">441 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_39" model="account.tax.report.line">
+                        <field name="name">Notas de crédito tarifa 0% por compensar próximo mes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_442" model="account.tax.report.line">
+                                <field name="name">Valor neto(442)</field>
+                                <field name="code">c442</field>
+                                <field name="tag_name">442 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_41" model="account.tax.report.line">
+                        <field name="name">Notas de crédito tarifa diferente de cero por compensar próximo mes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_443" model="account.tax.report.line">
+                                <field name="name">Valor neto(443)</field>
+                                <field name="code">c443</field>
+                                <field name="tag_name">443 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_453" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(453)</field>
+                                <field name="code">c453</field>
+                                <field name="tag_name">453 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_44" model="account.tax.report.line">
+                        <field name="name">Ingresos por reembolso como intermediario / valores facturados por operadoras de
                 transporte (informativo)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_1"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_434" model="account.tax.report.line">
-            <field name="name">Valor bruto(434)</field>
-            <field name="code">c434</field>
-            <field name="tag_name">434 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_44"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_444" model="account.tax.report.line">
-            <field name="name">Valor neto(444)</field>
-            <field name="code">c444</field>
-            <field name="tag_name">444 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_44"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_454" model="account.tax.report.line">
-            <field name="name">Impuesto generado(454)</field>
-            <field name="code">c454</field>
-            <field name="tag_name">454 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_44"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_48" model="account.tax.report.line">
-            <field name="name">LIQUIDACIÓN DEL IVA EN EL MES</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_480" model="account.tax.report.line">
-            <field name="name">Total transferencias gravadas tarifa diferente de cero a contado este mes(480)</field>
-            <field name="code">c480</field>
-            <field name="tag_name">480 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_481" model="account.tax.report.line">
-            <field name="name">Total transferencias gravadas tarifa diferente de cero a crédito este mes(481)</field>
-            <field name="code">c481</field>
-            <field name="tag_name">481 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_482" model="account.tax.report.line">
-            <field name="name">Total impuesto generado(482)</field>
-            <field name="code">c482</field>
-            <field name="tag_name">482 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_483" model="account.tax.report.line">
-            <field name="name">Impuesto a liquidar del mes anterior(483)</field>
-            <field name="code">c483</field>
-            <field name="tag_name">483 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_484" model="account.tax.report.line">
-            <field name="name">Impuesto a liquidar en este mes(484)</field>
-            <field name="code">c484</field>
-            <field name="tag_name">484 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_495" model="account.tax.report.line">
-            <field name="name">Impuesto a liquidar en el próximo mes(495)</field>
-            <field name="code">c495</field>
-            <field name="tag_name">495 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_499" model="account.tax.report.line">
-            <field name="name">TOTAL IMPUESTO A LIQUIDAR EN ESTE MES(499)</field>
-            <field name="code">c499</field>
-            <field name="tag_name">499 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_48"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_56" model="account.tax.report.line">
-            <field name="name">RESUMEN DE ADQUISICIONES Y PAGOS DEL PERÍODO QUE DECLARA</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_57" model="account.tax.report.line">
-            <field name="name">Adquisiciones y pagos (excluye activos fijos) gravados tarifa diferente de cero (con
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_434" model="account.tax.report.line">
+                                <field name="name">Valor bruto(434)</field>
+                                <field name="code">c434</field>
+                                <field name="tag_name">434 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_444" model="account.tax.report.line">
+                                <field name="name">Valor neto(444)</field>
+                                <field name="code">c444</field>
+                                <field name="tag_name">444 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_454" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(454)</field>
+                                <field name="code">c454</field>
+                                <field name="tag_name">454 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_48" model="account.tax.report.line">
+                <field name="name">LIQUIDACIÓN DEL IVA EN EL MES</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_104_480" model="account.tax.report.line">
+                        <field name="name">Total transferencias gravadas tarifa diferente de cero a contado este mes(480)</field>
+                        <field name="code">c480</field>
+                        <field name="tag_name">480 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_481" model="account.tax.report.line">
+                        <field name="name">Total transferencias gravadas tarifa diferente de cero a crédito este mes(481)</field>
+                        <field name="code">c481</field>
+                        <field name="tag_name">481 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_482" model="account.tax.report.line">
+                        <field name="name">Total impuesto generado(482)</field>
+                        <field name="code">c482</field>
+                        <field name="tag_name">482 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_483" model="account.tax.report.line">
+                        <field name="name">Impuesto a liquidar del mes anterior(483)</field>
+                        <field name="code">c483</field>
+                        <field name="tag_name">483 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_484" model="account.tax.report.line">
+                        <field name="name">Impuesto a liquidar en este mes(484)</field>
+                        <field name="code">c484</field>
+                        <field name="tag_name">484 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_495" model="account.tax.report.line">
+                        <field name="name">Impuesto a liquidar en el próximo mes(495)</field>
+                        <field name="code">c495</field>
+                        <field name="tag_name">495 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_499" model="account.tax.report.line">
+                        <field name="name">TOTAL IMPUESTO A LIQUIDAR EN ESTE MES(499)</field>
+                        <field name="code">c499</field>
+                        <field name="tag_name">499 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_56" model="account.tax.report.line">
+                <field name="name">RESUMEN DE ADQUISICIONES Y PAGOS DEL PERÍODO QUE DECLARA</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_parent_line_report_57" model="account.tax.report.line">
+                        <field name="name">Adquisiciones y pagos (excluye activos fijos) gravados tarifa diferente de cero (con
                 derecho a crédito tributario)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_500" model="account.tax.report.line">
-            <field name="name">Valor bruto(500)</field>
-            <field name="code">c500</field>
-            <field name="tag_name">500 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_57"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_510" model="account.tax.report.line">
-            <field name="name">Valor neto(510)</field>
-            <field name="code">c510</field>
-            <field name="tag_name">510 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_57"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_520" model="account.tax.report.line">
-            <field name="name">Impuesto generado(520)</field>
-            <field name="code">c520</field>
-            <field name="tag_name">520 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_57"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_61" model="account.tax.report.line">
-            <field name="name">Adquisiciones locales de activos fijos gravados tarifa diferente de cero (con derecho a
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_500" model="account.tax.report.line">
+                                <field name="name">Valor bruto(500)</field>
+                                <field name="code">c500</field>
+                                <field name="tag_name">500 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_510" model="account.tax.report.line">
+                                <field name="name">Valor neto(510)</field>
+                                <field name="code">c510</field>
+                                <field name="tag_name">510 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_520" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(520)</field>
+                                <field name="code">c520</field>
+                                <field name="tag_name">520 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_61" model="account.tax.report.line">
+                        <field name="name">Adquisiciones locales de activos fijos gravados tarifa diferente de cero (con derecho a
                 crédito tributario)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_501" model="account.tax.report.line">
-            <field name="name">Valor bruto(501)</field>
-            <field name="code">c501</field>
-            <field name="tag_name">501 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_61"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_511" model="account.tax.report.line">
-            <field name="name">Valor neto(511)</field>
-            <field name="code">c511</field>
-            <field name="tag_name">511 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_61"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_521" model="account.tax.report.line">
-            <field name="name">Impuesto generado(521)</field>
-            <field name="code">c521</field>
-            <field name="tag_name">521 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_61"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_65" model="account.tax.report.line">
-            <field name="name">Otras adquisiciones y pagos gravados tarifa diferente de cero (sin derecho a crédito
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_501" model="account.tax.report.line">
+                                <field name="name">Valor bruto(501)</field>
+                                <field name="code">c501</field>
+                                <field name="tag_name">501 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_511" model="account.tax.report.line">
+                                <field name="name">Valor neto(511)</field>
+                                <field name="code">c511</field>
+                                <field name="tag_name">511 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_521" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(521)</field>
+                                <field name="code">c521</field>
+                                <field name="tag_name">521 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_65" model="account.tax.report.line">
+                        <field name="name">Otras adquisiciones y pagos gravados tarifa diferente de cero (sin derecho a crédito
                 tributario)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_502" model="account.tax.report.line">
-            <field name="name">Valor bruto(502)</field>
-            <field name="code">c502</field>
-            <field name="tag_name">502 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_65"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_512" model="account.tax.report.line">
-            <field name="name">Valor neto(512)</field>
-            <field name="code">c512</field>
-            <field name="tag_name">512 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_65"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_522" model="account.tax.report.line">
-            <field name="name">Impuesto generado(522)</field>
-            <field name="code">c522</field>
-            <field name="tag_name">522 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_65"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_69" model="account.tax.report.line">
-            <field name="name">Importaciones de servicios y/o derechos gravados tarifa diferente de cero</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_503" model="account.tax.report.line">
-            <field name="name">Valor bruto(503)</field>
-            <field name="code">c503</field>
-            <field name="tag_name">503 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_69"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_513" model="account.tax.report.line">
-            <field name="name">Valor neto(513)</field>
-            <field name="code">c513</field>
-            <field name="tag_name">513 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_69"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_523" model="account.tax.report.line">
-            <field name="name">Impuesto generado(523)</field>
-            <field name="code">c523</field>
-            <field name="tag_name">523 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_69"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_73" model="account.tax.report.line">
-            <field name="name">Importaciones de bienes (excluye activos fijos) gravados tarifa diferente de cero</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_504" model="account.tax.report.line">
-            <field name="name">Valor bruto(504)</field>
-            <field name="code">c504</field>
-            <field name="tag_name">504 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_73"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_514" model="account.tax.report.line">
-            <field name="name">Valor neto(514)</field>
-            <field name="code">c514</field>
-            <field name="tag_name">514 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_73"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_524" model="account.tax.report.line">
-            <field name="name">Impuesto generado(524)</field>
-            <field name="code">c524</field>
-            <field name="tag_name">524 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_73"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_77" model="account.tax.report.line">
-            <field name="name">Importaciones de activos fijos gravados tarifa diferente de cero</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_505" model="account.tax.report.line">
-            <field name="name">Valor bruto(505)</field>
-            <field name="code">c505</field>
-            <field name="tag_name">505 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_77"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_515" model="account.tax.report.line">
-            <field name="name">Valor neto(515)</field>
-            <field name="code">c515</field>
-            <field name="tag_name">515 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_77"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_525" model="account.tax.report.line">
-            <field name="name">Impuesto generado(525)</field>
-            <field name="code">c525</field>
-            <field name="tag_name">525 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_77"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_81" model="account.tax.report.line">
-            <field name="name">IVA generado en la diferencia entre adquisiciones y notas de crédito con distinta tarifa
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_502" model="account.tax.report.line">
+                                <field name="name">Valor bruto(502)</field>
+                                <field name="code">c502</field>
+                                <field name="tag_name">502 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_512" model="account.tax.report.line">
+                                <field name="name">Valor neto(512)</field>
+                                <field name="code">c512</field>
+                                <field name="tag_name">512 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_522" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(522)</field>
+                                <field name="code">c522</field>
+                                <field name="tag_name">522 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_69" model="account.tax.report.line">
+                        <field name="name">Importaciones de servicios y/o derechos gravados tarifa diferente de cero</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_503" model="account.tax.report.line">
+                                <field name="name">Valor bruto(503)</field>
+                                <field name="code">c503</field>
+                                <field name="tag_name">503 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_513" model="account.tax.report.line">
+                                <field name="name">Valor neto(513)</field>
+                                <field name="code">c513</field>
+                                <field name="tag_name">513 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_523" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(523)</field>
+                                <field name="code">c523</field>
+                                <field name="tag_name">523 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_73" model="account.tax.report.line">
+                        <field name="name">Importaciones de bienes (excluye activos fijos) gravados tarifa diferente de cero</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_504" model="account.tax.report.line">
+                                <field name="name">Valor bruto(504)</field>
+                                <field name="code">c504</field>
+                                <field name="tag_name">504 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_514" model="account.tax.report.line">
+                                <field name="name">Valor neto(514)</field>
+                                <field name="code">c514</field>
+                                <field name="tag_name">514 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_524" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(524)</field>
+                                <field name="code">c524</field>
+                                <field name="tag_name">524 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_77" model="account.tax.report.line">
+                        <field name="name">Importaciones de activos fijos gravados tarifa diferente de cero</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_505" model="account.tax.report.line">
+                                <field name="name">Valor bruto(505)</field>
+                                <field name="code">c505</field>
+                                <field name="tag_name">505 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_515" model="account.tax.report.line">
+                                <field name="name">Valor neto(515)</field>
+                                <field name="code">c515</field>
+                                <field name="tag_name">515 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_525" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(525)</field>
+                                <field name="code">c525</field>
+                                <field name="tag_name">525 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_81" model="account.tax.report.line">
+                        <field name="name">IVA generado en la diferencia entre adquisiciones y notas de crédito con distinta tarifa
                 (ajuste en positivo al crédito tributario)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_526" model="account.tax.report.line">
-            <field name="name">Impuesto generado(526)</field>
-            <field name="code">c526</field>
-            <field name="tag_name">526 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_81"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_83" model="account.tax.report.line">
-            <field name="name">IVA generado en la diferencia entre adquisiciones y notas de crédito con distinta tarifa
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_526" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(526)</field>
+                                <field name="code">c526</field>
+                                <field name="tag_name">526 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_83" model="account.tax.report.line">
+                        <field name="name">IVA generado en la diferencia entre adquisiciones y notas de crédito con distinta tarifa
                 (ajuste en negativo al crédito tributario)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_527" model="account.tax.report.line">
-            <field name="name">Impuesto generado(527)</field>
-            <field name="code">c527</field>
-            <field name="tag_name">527 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_83"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_85" model="account.tax.report.line">
-            <field name="name">Importaciones de bienes (incluye activos fijos) gravados tarifa 0%</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_506" model="account.tax.report.line">
-            <field name="name">Valor bruto(506)</field>
-            <field name="code">c506</field>
-            <field name="tag_name">506 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_85"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_516" model="account.tax.report.line">
-            <field name="name">Valor neto(516)</field>
-            <field name="code">c516</field>
-            <field name="tag_name">516 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_85"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_88" model="account.tax.report.line">
-            <field name="name">Adquisiciones y pagos (incluye activos fijos) gravados tarifa 0%</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_507" model="account.tax.report.line">
-            <field name="name">Valor bruto(507)</field>
-            <field name="code">c507</field>
-            <field name="tag_name">507 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_88"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_517" model="account.tax.report.line">
-            <field name="name">Valor neto(517)</field>
-            <field name="code">c517</field>
-            <field name="tag_name">517 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_88"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_91" model="account.tax.report.line">
-            <field name="name">Adquisiciones realizadas a contribuyentes RISE</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_508" model="account.tax.report.line">
-            <field name="name">Valor bruto(508)</field>
-            <field name="code">c508</field>
-            <field name="tag_name">508 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_91"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_518" model="account.tax.report.line">
-            <field name="name">Valor neto(518)</field>
-            <field name="code">c518</field>
-            <field name="tag_name">518 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_91"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_94" model="account.tax.report.line">
-            <field name="name">TOTAL ADQUISICIONES Y PAGOS</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_509" model="account.tax.report.line">
-            <field name="name">Valor bruto(509)</field>
-            <field name="code">c509</field>
-            <field name="tag_name">509 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_94"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_519" model="account.tax.report.line">
-            <field name="name">Valor neto(519)</field>
-            <field name="code">c519</field>
-            <field name="tag_name">519 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_94"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_529" model="account.tax.report.line">
-            <field name="name">Impuesto generado(529)</field>
-            <field name="code">c529</field>
-            <field name="tag_name">529 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_94"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_98" model="account.tax.report.line">
-            <field name="name">Adquisiciones no objeto de IVA</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_531" model="account.tax.report.line">
-            <field name="name">Valor bruto(531)</field>
-            <field name="code">c531</field>
-            <field name="tag_name">531 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_98"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_541" model="account.tax.report.line">
-            <field name="name">Valor neto(541)</field>
-            <field name="code">c541</field>
-            <field name="tag_name">541 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_98"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_101" model="account.tax.report.line">
-            <field name="name">Adquisiciones exentas del pago de IVA</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_532" model="account.tax.report.line">
-            <field name="name">Valor bruto(532)</field>
-            <field name="code">c532</field>
-            <field name="tag_name">532 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_101"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_542" model="account.tax.report.line">
-            <field name="name">Valor neto(542)</field>
-            <field name="code">c542</field>
-            <field name="tag_name">542 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_101"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_104" model="account.tax.report.line">
-            <field name="name">Notas de crédito tarifa 0% por compensar próximo mes</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_543" model="account.tax.report.line">
-            <field name="name">Valor neto(543)</field>
-            <field name="code">c543</field>
-            <field name="tag_name">543 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_104"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_106" model="account.tax.report.line">
-            <field name="name">Notas de crédito tarifa diferente de cero por compensar próximo mes</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_544" model="account.tax.report.line">
-            <field name="name">Valor neto(544)</field>
-            <field name="code">c544</field>
-            <field name="tag_name">544 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_106"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_554" model="account.tax.report.line">
-            <field name="name">Impuesto generado(554)</field>
-            <field name="code">c554</field>
-            <field name="tag_name">554 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_106"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_109" model="account.tax.report.line">
-            <field name="name">Pagos netos por reembolso como intermediario / valores facturados por socios a operadoras
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_527" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(527)</field>
+                                <field name="code">c527</field>
+                                <field name="tag_name">527 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_85" model="account.tax.report.line">
+                        <field name="name">Importaciones de bienes (incluye activos fijos) gravados tarifa 0%</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_506" model="account.tax.report.line">
+                                <field name="name">Valor bruto(506)</field>
+                                <field name="code">c506</field>
+                                <field name="tag_name">506 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_516" model="account.tax.report.line">
+                                <field name="name">Valor neto(516)</field>
+                                <field name="code">c516</field>
+                                <field name="tag_name">516 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_88" model="account.tax.report.line">
+                        <field name="name">Adquisiciones y pagos (incluye activos fijos) gravados tarifa 0%</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_507" model="account.tax.report.line">
+                                <field name="name">Valor bruto(507)</field>
+                                <field name="code">c507</field>
+                                <field name="tag_name">507 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_517" model="account.tax.report.line">
+                                <field name="name">Valor neto(517)</field>
+                                <field name="code">c517</field>
+                                <field name="tag_name">517 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_91" model="account.tax.report.line">
+                        <field name="name">Adquisiciones realizadas a contribuyentes RISE</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_508" model="account.tax.report.line">
+                                <field name="name">Valor bruto(508)</field>
+                                <field name="code">c508</field>
+                                <field name="tag_name">508 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_518" model="account.tax.report.line">
+                                <field name="name">Valor neto(518)</field>
+                                <field name="code">c518</field>
+                                <field name="tag_name">518 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_94" model="account.tax.report.line">
+                        <field name="name">TOTAL ADQUISICIONES Y PAGOS</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_509" model="account.tax.report.line">
+                                <field name="name">Valor bruto(509)</field>
+                                <field name="code">c509</field>
+                                <field name="tag_name">509 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_519" model="account.tax.report.line">
+                                <field name="name">Valor neto(519)</field>
+                                <field name="code">c519</field>
+                                <field name="tag_name">519 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_529" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(529)</field>
+                                <field name="code">c529</field>
+                                <field name="tag_name">529 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_98" model="account.tax.report.line">
+                        <field name="name">Adquisiciones no objeto de IVA</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_531" model="account.tax.report.line">
+                                <field name="name">Valor bruto(531)</field>
+                                <field name="code">c531</field>
+                                <field name="tag_name">531 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_541" model="account.tax.report.line">
+                                <field name="name">Valor neto(541)</field>
+                                <field name="code">c541</field>
+                                <field name="tag_name">541 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_101" model="account.tax.report.line">
+                        <field name="name">Adquisiciones exentas del pago de IVA</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_532" model="account.tax.report.line">
+                                <field name="name">Valor bruto(532)</field>
+                                <field name="code">c532</field>
+                                <field name="tag_name">532 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_542" model="account.tax.report.line">
+                                <field name="name">Valor neto(542)</field>
+                                <field name="code">c542</field>
+                                <field name="tag_name">542 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_104" model="account.tax.report.line">
+                        <field name="name">Notas de crédito tarifa 0% por compensar próximo mes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_543" model="account.tax.report.line">
+                                <field name="name">Valor neto(543)</field>
+                                <field name="code">c543</field>
+                                <field name="tag_name">543 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_106" model="account.tax.report.line">
+                        <field name="name">Notas de crédito tarifa diferente de cero por compensar próximo mes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_544" model="account.tax.report.line">
+                                <field name="name">Valor neto(544)</field>
+                                <field name="code">c544</field>
+                                <field name="tag_name">544 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_554" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(554)</field>
+                                <field name="code">c554</field>
+                                <field name="tag_name">554 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_109" model="account.tax.report.line">
+                        <field name="name">Pagos netos por reembolso como intermediario / valores facturados por socios a operadoras
                 de transporte (informativo)
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_56"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_535" model="account.tax.report.line">
-            <field name="name">Valor bruto(535)</field>
-            <field name="code">c535</field>
-            <field name="tag_name">535 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_109"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_545" model="account.tax.report.line">
-            <field name="name">Valor neto(545)</field>
-            <field name="code">c545</field>
-            <field name="tag_name">545 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_109"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_555" model="account.tax.report.line">
-            <field name="name">Impuesto generado(555)</field>
-            <field name="code">c555</field>
-            <field name="tag_name">555 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_109"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_113" model="account.tax.report.line">
-            <field name="name">RESUMEN IMPOSITIVO: AGENTE DE PERCEPCIÓN DEL IMPUESTO AL VALOR AGREGADO</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_601" model="account.tax.report.line">
-            <field name="name">Impuesto causado (si la diferencia de los campos 499-564 es mayor que cero)(601)</field>
-            <field name="code">c601</field>
-            <field name="tag_name">601 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_602" model="account.tax.report.line">
-            <field name="name">Crédito tributario aplicable en este período (si la diferencia de los campos 499-564 es
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_535" model="account.tax.report.line">
+                                <field name="name">Valor bruto(535)</field>
+                                <field name="code">c535</field>
+                                <field name="tag_name">535 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_545" model="account.tax.report.line">
+                                <field name="name">Valor neto(545)</field>
+                                <field name="code">c545</field>
+                                <field name="tag_name">545 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_555" model="account.tax.report.line">
+                                <field name="name">Impuesto generado(555)</field>
+                                <field name="code">c555</field>
+                                <field name="tag_name">555 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_113" model="account.tax.report.line">
+                <field name="name">RESUMEN IMPOSITIVO: AGENTE DE PERCEPCIÓN DEL IMPUESTO AL VALOR AGREGADO</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_104_601" model="account.tax.report.line">
+                        <field name="name">Impuesto causado (si la diferencia de los campos 499-564 es mayor que cero)(601)</field>
+                        <field name="code">c601</field>
+                        <field name="tag_name">601 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_602" model="account.tax.report.line">
+                        <field name="name">Crédito tributario aplicable en este período (si la diferencia de los campos 499-564 es
                 menor que cero)(602)
             </field>
-            <field name="code">c602</field>
-            <field name="tag_name">602 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_604" model="account.tax.report.line">
-            <field name="name">(-) Compensación de IVA por ventas efectuadas en zonas afectadas - Ley de solidaridad,
+                        <field name="code">c602</field>
+                        <field name="tag_name">602 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_604" model="account.tax.report.line">
+                        <field name="name">(-) Compensación de IVA por ventas efectuadas en zonas afectadas - Ley de solidaridad,
                 restitución de crédito tributario en resoluciones(604)
             </field>
-            <field name="code">c604</field>
-            <field name="tag_name">604 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_117" model="account.tax.report.line">
-            <field name="name">(-) Saldo crédito tributario del mes anterior</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_605" model="account.tax.report.line">
-            <field name="name">Por adquisiciones e importaciones (trasládese el campo 615 de la declaración del período
+                        <field name="code">c604</field>
+                        <field name="tag_name">604 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_117" model="account.tax.report.line">
+                        <field name="name">(-) Saldo crédito tributario del mes anterior</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_605" model="account.tax.report.line">
+                                <field name="name">Por adquisiciones e importaciones (trasládese el campo 615 de la declaración del período
                 anterior)(605)
             </field>
-            <field name="code">c605</field>
-            <field name="tag_name">605 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_117"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_606" model="account.tax.report.line">
-            <field name="name">Por retenciones en la fuente de IVA que le han sido efectuadas (trasládese el campo 617
+                                <field name="code">c605</field>
+                                <field name="tag_name">605 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_606" model="account.tax.report.line">
+                                <field name="name">Por retenciones en la fuente de IVA que le han sido efectuadas (trasládese el campo 617
                 de la declaración del período anterior)(606)
             </field>
-            <field name="code">c606</field>
-            <field name="tag_name">606 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_117"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_608" model="account.tax.report.line">
-            <field name="name">Por compensación de IVA por ventas efectuadas en zonas afectadas - Ley de solidaridad
+                                <field name="code">c606</field>
+                                <field name="tag_name">606 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_608" model="account.tax.report.line">
+                                <field name="name">Por compensación de IVA por ventas efectuadas en zonas afectadas - Ley de solidaridad
                 (trasládese el campo 619 de la declaración del período anterior)(608)
             </field>
-            <field name="code">c608</field>
-            <field name="tag_name">608 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_117"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_609" model="account.tax.report.line">
-            <field name="name">(-) Retenciones en la fuente de IVA que le han sido efectuadas en este período(609)
+                                <field name="code">c608</field>
+                                <field name="tag_name">608 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_104_609" model="account.tax.report.line">
+                        <field name="name">(-) Retenciones en la fuente de IVA que le han sido efectuadas en este período(609)
             </field>
-            <field name="code">c609</field>
-            <field name="tag_name">609 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_610" model="account.tax.report.line">
-            <field name="name">(+) Ajuste por IVA devuelto o descontado por adquisiciones efectuadas con medio
+                        <field name="code">c609</field>
+                        <field name="tag_name">609 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_610" model="account.tax.report.line">
+                        <field name="name">(+) Ajuste por IVA devuelto o descontado por adquisiciones efectuadas con medio
                 electrónico(610)
             </field>
-            <field name="code">c610</field>
-            <field name="tag_name">610 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_612" model="account.tax.report.line">
-            <field name="name">(+) Ajuste por IVA devuelto e IVA rechazado (por concepto de devoluciones de IVA), ajuste
+                        <field name="code">c610</field>
+                        <field name="tag_name">610 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_612" model="account.tax.report.line">
+                        <field name="name">(+) Ajuste por IVA devuelto e IVA rechazado (por concepto de devoluciones de IVA), ajuste
                 de IVA por procesos de control y otros (adquisiciones en importaciones), imputables al crédito
                 tributario(612)
             </field>
-            <field name="code">c612</field>
-            <field name="tag_name">612 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_613" model="account.tax.report.line">
-            <field name="name">(+) Ajuste por IVA devuelto e IVA rechazado, ajuste de IVA por procesos de control y
+                        <field name="code">c612</field>
+                        <field name="tag_name">612 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_613" model="account.tax.report.line">
+                        <field name="name">(+) Ajuste por IVA devuelto e IVA rechazado, ajuste de IVA por procesos de control y
                 otros (por concepto retenciones en la fuente de IVA), imputables al crédito tributario(613)
             </field>
-            <field name="code">c613</field>
-            <field name="tag_name">613 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_614" model="account.tax.report.line">
-            <field name="name">(+) Ajuste por IVA devuelto por otras instituciones del sector público imputable al
+                        <field name="code">c613</field>
+                        <field name="tag_name">613 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_614" model="account.tax.report.line">
+                        <field name="name">(+) Ajuste por IVA devuelto por otras instituciones del sector público imputable al
                 crédito tributario en el mes(614)
             </field>
-            <field name="code">c614</field>
-            <field name="tag_name">614 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_126" model="account.tax.report.line">
-            <field name="name">Saldo crédito tributario para el próximo mes</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_615" model="account.tax.report.line">
-            <field name="name">Por adquisiciones e Importaciones(615)</field>
-            <field name="code">c615</field>
-            <field name="tag_name">615 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_126"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_617" model="account.tax.report.line">
-            <field name="name">Por retenciones en la fuente de IVA que le han sido efectuadas(617)</field>
-            <field name="code">c617</field>
-            <field name="tag_name">617 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_126"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_619" model="account.tax.report.line">
-            <field name="name">Por compensación de IVA por ventas efectuadas en zonas afectadas - Ley de solidaridad,
+                        <field name="code">c614</field>
+                        <field name="tag_name">614 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_126" model="account.tax.report.line">
+                        <field name="name">Saldo crédito tributario para el próximo mes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_615" model="account.tax.report.line">
+                                <field name="name">Por adquisiciones e Importaciones(615)</field>
+                                <field name="code">c615</field>
+                                <field name="tag_name">615 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_617" model="account.tax.report.line">
+                                <field name="name">Por retenciones en la fuente de IVA que le han sido efectuadas(617)</field>
+                                <field name="code">c617</field>
+                                <field name="tag_name">617 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_619" model="account.tax.report.line">
+                                <field name="name">Por compensación de IVA por ventas efectuadas en zonas afectadas - Ley de solidaridad,
                 restitución de crédito tributario en resoluciones(619)
             </field>
-            <field name="code">c619</field>
-            <field name="tag_name">619 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_126"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_620" model="account.tax.report.line">
-            <field name="name">SUBTOTAL A PAGAR Si (601-602-603-604-605-606-607-608-609+610+611+612+613+614) > 0(620)
+                                <field name="code">c619</field>
+                                <field name="tag_name">619 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_104_620" model="account.tax.report.line">
+                        <field name="name">SUBTOTAL A PAGAR Si (601-602-603-604-605-606-607-608-609+610+611+612+613+614) &gt; 0(620)
             </field>
-            <field name="code">c620</field>
-            <field name="tag_name">620 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_621" model="account.tax.report.line">
-            <field name="name">IVA presuntivo de salas de juego (bingo mecánicos) y otros juegos de azar (aplica para
+                        <field name="code">c620</field>
+                        <field name="tag_name">620 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_621" model="account.tax.report.line">
+                        <field name="name">IVA presuntivo de salas de juego (bingo mecánicos) y otros juegos de azar (aplica para
                 ejercicios anteriores al 2013)(621)
             </field>
-            <field name="code">c621</field>
-            <field name="tag_name">621 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_699" model="account.tax.report.line">
-            <field name="name">TOTAL IMPUESTO A PAGAR POR PERCEPCIÓN(699)</field>
-            <field name="code">c699</field>
-            <field name="tag_name">699 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_113"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_133" model="account.tax.report.line">
-            <field name="name">IMPUESTO A LA SALIDA DE DIVISAS A EFECTOS DE DEVOLUCIÓN A EXPORTADORES HABITUALES DE
+                        <field name="code">c621</field>
+                        <field name="tag_name">621 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_699" model="account.tax.report.line">
+                        <field name="name">TOTAL IMPUESTO A PAGAR POR PERCEPCIÓN(699)</field>
+                        <field name="code">c699</field>
+                        <field name="tag_name">699 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_133" model="account.tax.report.line">
+                <field name="name">IMPUESTO A LA SALIDA DE DIVISAS A EFECTOS DE DEVOLUCIÓN A EXPORTADORES HABITUALES DE
                 BIENES
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_134" model="account.tax.report.line">
-            <field name="name">Importaciones liquidadas de materias primas, insumos y bienes de capital que sean
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_parent_line_report_134" model="account.tax.report.line">
+                        <field name="name">Importaciones liquidadas de materias primas, insumos y bienes de capital que sean
                 incorporadas en procesos productivos de bienes que se exporten
             </field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_133"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_700" model="account.tax.report.line">
-            <field name="name">Valor(700)</field>
-            <field name="code">c700</field>
-            <field name="tag_name">700 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_134"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_701" model="account.tax.report.line">
-            <field name="name">ISD pagado(701)</field>
-            <field name="code">c701</field>
-            <field name="tag_name">701 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_134"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_137" model="account.tax.report.line">
-            <field name="name">AGENTE DE RETENCIÓN DEL IMPUESTO AL VALOR AGREGADO</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_721" model="account.tax.report.line">
-            <field name="name">Retención del 10%(721)</field>
-            <field name="code">c721</field>
-            <field name="tag_name">721 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_723" model="account.tax.report.line">
-            <field name="name">Retención del 20%(723)</field>
-            <field name="code">c723</field>
-            <field name="tag_name">723 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_725" model="account.tax.report.line">
-            <field name="name">Retención del 30%(725)</field>
-            <field name="code">c725</field>
-            <field name="tag_name">725 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_727" model="account.tax.report.line">
-            <field name="name">Retención del 50%(727)</field>
-            <field name="code">c727</field>
-            <field name="tag_name">727 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_729" model="account.tax.report.line">
-            <field name="name">Retención del 70%(729)</field>
-            <field name="code">c729</field>
-            <field name="tag_name">729 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_104_731" model="account.tax.report.line">
-            <field name="name">Retención del 100%(731)</field>
-            <field name="code">c731</field>
-            <field name="tag_name">731 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_144" model="account.tax.report.line">
-            <field name="name">TOTAL IMPUESTO RETENIDO</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_799" model="account.tax.report.line">
-            <field name="name">(799)</field>
-            <field name="code">c799</field>
-            <field name="tag_name">799 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_144"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_146" model="account.tax.report.line">
-            <field name="name">Devolución provisional de IVA mediante compensación con retenciones efectuadas</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_800" model="account.tax.report.line">
-            <field name="name">(800)</field>
-            <field name="code">c800</field>
-            <field name="tag_name">800 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_146"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_148" model="account.tax.report.line">
-            <field name="name">TOTAL IMPUESTO A PAGAR POR RETENCIÓN</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_137"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_104_801" model="account.tax.report.line">
-            <field name="name">(801)</field>
-            <field name="code">c801</field>
-            <field name="tag_name">801 (Reporte 104)</field>
-            <field name="report_id" ref="tax_report_104"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_148"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_103" model="account.tax.report">
-            <field name="name">103</field>
-            <field name="country_id" ref="base.ec"/>
-        </record>
-        <record id="tax_report_line_parent_line_report_150" model="account.tax.report.line">
-            <field name="name">POR PAGOS EFECTUADOS A RESIDENTES Y ESTABLECIMIENTOS PERMANENTES</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_151" model="account.tax.report.line">
-            <field name="name">En relación de dependencia que supera o no la base desgravada</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_302" model="account.tax.report.line">
-            <field name="name">Base imponible(302)</field>
-            <field name="code">c302</field>
-            <field name="tag_name">302 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_352" model="account.tax.report.line">
-            <field name="name">Valor retenido(352)</field>
-            <field name="code">c352</field>
-            <field name="tag_name">352 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_154" model="account.tax.report.line">
-            <field name="name">Servicios</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_155" model="account.tax.report.line">
-            <field name="name">Honorarios profesionales</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_154"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_303" model="account.tax.report.line">
-            <field name="name">Base imponible(303)</field>
-            <field name="code">c303</field>
-            <field name="tag_name">303 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_155"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_353" model="account.tax.report.line">
-            <field name="name">Valor retenido(353)</field>
-            <field name="code">c353</field>
-            <field name="tag_name">353 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_155"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_158" model="account.tax.report.line">
-            <field name="name">Predomina el intelecto</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_154"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_304" model="account.tax.report.line">
-            <field name="name">Base imponible(304)</field>
-            <field name="code">c304</field>
-            <field name="tag_name">304 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_158"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_354" model="account.tax.report.line">
-            <field name="name">Valor retenido(354)</field>
-            <field name="code">c354</field>
-            <field name="tag_name">354 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_158"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_161" model="account.tax.report.line">
-            <field name="name">Predomina la mano de obra</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_154"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_307" model="account.tax.report.line">
-            <field name="name">Base imponible(307)</field>
-            <field name="code">c307</field>
-            <field name="tag_name">307 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_161"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_357" model="account.tax.report.line">
-            <field name="name">Valor retenido(357)</field>
-            <field name="code">c357</field>
-            <field name="tag_name">357 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_161"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_164" model="account.tax.report.line">
-            <field name="name">Utilización o aprovechamiento de la imagen o renombre</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_154"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_308" model="account.tax.report.line">
-            <field name="name">Base imponible(308)</field>
-            <field name="code">c308</field>
-            <field name="tag_name">308 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_164"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_358" model="account.tax.report.line">
-            <field name="name">Valor retenido(358)</field>
-            <field name="code">c358</field>
-            <field name="tag_name">358 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_164"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_167" model="account.tax.report.line">
-            <field name="name">Publicidad y comunicación</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_154"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_309" model="account.tax.report.line">
-            <field name="name">Base imponible(309)</field>
-            <field name="code">c309</field>
-            <field name="tag_name">309 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_167"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_359" model="account.tax.report.line">
-            <field name="name">Valor retenido(359)</field>
-            <field name="code">c359</field>
-            <field name="tag_name">359 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_167"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_170" model="account.tax.report.line">
-            <field name="name">Transporte privado de pasajeros o servicio público o privado de carga</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_154"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_310" model="account.tax.report.line">
-            <field name="name">Base imponible(310)</field>
-            <field name="code">c310</field>
-            <field name="tag_name">310 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_170"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_360" model="account.tax.report.line">
-            <field name="name">Valor retenido(360)</field>
-            <field name="code">c360</field>
-            <field name="tag_name">360 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_170"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_173" model="account.tax.report.line">
-            <field name="name">A través de liquidaciones de compra (nivel cultural o rusticidad)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_311" model="account.tax.report.line">
-            <field name="name">Base imponible(311)</field>
-            <field name="code">c311</field>
-            <field name="tag_name">311 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_173"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_361" model="account.tax.report.line">
-            <field name="name">Valor retenido(361)</field>
-            <field name="code">c361</field>
-            <field name="tag_name">361 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_173"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_176" model="account.tax.report.line">
-            <field name="name">Transferencia de bienes muebles de naturaleza corporal</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_312" model="account.tax.report.line">
-            <field name="name">Base imponible(312)</field>
-            <field name="code">c312</field>
-            <field name="tag_name">312 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_176"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_362" model="account.tax.report.line">
-            <field name="name">Valor retenido(362)</field>
-            <field name="code">c362</field>
-            <field name="tag_name">362 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_176"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_179" model="account.tax.report.line">
-            <field name="name">Compra de bienes de origen agrícola, avícola, pecuario, apícola, cunícula, bioacuático,
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_700" model="account.tax.report.line">
+                                <field name="name">Valor(700)</field>
+                                <field name="code">c700</field>
+                                <field name="tag_name">700 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_104_701" model="account.tax.report.line">
+                                <field name="name">ISD pagado(701)</field>
+                                <field name="code">c701</field>
+                                <field name="tag_name">701 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_137" model="account.tax.report.line">
+                <field name="name">AGENTE DE RETENCIÓN DEL IMPUESTO AL VALOR AGREGADO</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_104_721" model="account.tax.report.line">
+                        <field name="name">Retención del 10%(721)</field>
+                        <field name="code">c721</field>
+                        <field name="tag_name">721 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_723" model="account.tax.report.line">
+                        <field name="name">Retención del 20%(723)</field>
+                        <field name="code">c723</field>
+                        <field name="tag_name">723 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_725" model="account.tax.report.line">
+                        <field name="name">Retención del 30%(725)</field>
+                        <field name="code">c725</field>
+                        <field name="tag_name">725 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_727" model="account.tax.report.line">
+                        <field name="name">Retención del 50%(727)</field>
+                        <field name="code">c727</field>
+                        <field name="tag_name">727 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_729" model="account.tax.report.line">
+                        <field name="name">Retención del 70%(729)</field>
+                        <field name="code">c729</field>
+                        <field name="tag_name">729 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_104_731" model="account.tax.report.line">
+                        <field name="name">Retención del 100%(731)</field>
+                        <field name="code">c731</field>
+                        <field name="tag_name">731 (Reporte 104)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_144" model="account.tax.report.line">
+                        <field name="name">TOTAL IMPUESTO RETENIDO</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_799" model="account.tax.report.line">
+                                <field name="name">(799)</field>
+                                <field name="code">c799</field>
+                                <field name="tag_name">799 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_146" model="account.tax.report.line">
+                        <field name="name">Devolución provisional de IVA mediante compensación con retenciones efectuadas</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_800" model="account.tax.report.line">
+                                <field name="name">(800)</field>
+                                <field name="code">c800</field>
+                                <field name="tag_name">800 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_148" model="account.tax.report.line">
+                        <field name="name">TOTAL IMPUESTO A PAGAR POR RETENCIÓN</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_104_801" model="account.tax.report.line">
+                                <field name="name">(801)</field>
+                                <field name="code">c801</field>
+                                <field name="tag_name">801 (Reporte 104)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+    <record id="tax_report_103" model="account.tax.report">
+        <field name="name">103</field>
+        <field name="country_id" ref="base.ec"/>
+        <field name="root_line_ids">
+            <record id="tax_report_line_parent_line_report_150" model="account.tax.report.line">
+                <field name="name">POR PAGOS EFECTUADOS A RESIDENTES Y ESTABLECIMIENTOS PERMANENTES</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_parent_line_report_151" model="account.tax.report.line">
+                        <field name="name">En relación de dependencia que supera o no la base desgravada</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_103_302" model="account.tax.report.line">
+                                <field name="name">Base imponible(302)</field>
+                                <field name="code">c302</field>
+                                <field name="tag_name">302 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_103_352" model="account.tax.report.line">
+                                <field name="name">Valor retenido(352)</field>
+                                <field name="code">c352</field>
+                                <field name="tag_name">352 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_154" model="account.tax.report.line">
+                                <field name="name">Servicios</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_parent_line_report_155" model="account.tax.report.line">
+                                        <field name="name">Honorarios profesionales</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_303" model="account.tax.report.line">
+                                                <field name="name">Base imponible(303)</field>
+                                                <field name="code">c303</field>
+                                                <field name="tag_name">303 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_353" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(353)</field>
+                                                <field name="code">c353</field>
+                                                <field name="tag_name">353 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_parent_line_report_158" model="account.tax.report.line">
+                                        <field name="name">Predomina el intelecto</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_304" model="account.tax.report.line">
+                                                <field name="name">Base imponible(304)</field>
+                                                <field name="code">c304</field>
+                                                <field name="tag_name">304 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_354" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(354)</field>
+                                                <field name="code">c354</field>
+                                                <field name="tag_name">354 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_parent_line_report_161" model="account.tax.report.line">
+                                        <field name="name">Predomina la mano de obra</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_307" model="account.tax.report.line">
+                                                <field name="name">Base imponible(307)</field>
+                                                <field name="code">c307</field>
+                                                <field name="tag_name">307 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_357" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(357)</field>
+                                                <field name="code">c357</field>
+                                                <field name="tag_name">357 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_parent_line_report_164" model="account.tax.report.line">
+                                        <field name="name">Utilización o aprovechamiento de la imagen o renombre</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_308" model="account.tax.report.line">
+                                                <field name="name">Base imponible(308)</field>
+                                                <field name="code">c308</field>
+                                                <field name="tag_name">308 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_358" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(358)</field>
+                                                <field name="code">c358</field>
+                                                <field name="tag_name">358 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_parent_line_report_167" model="account.tax.report.line">
+                                        <field name="name">Publicidad y comunicación</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_309" model="account.tax.report.line">
+                                                <field name="name">Base imponible(309)</field>
+                                                <field name="code">c309</field>
+                                                <field name="tag_name">309 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_359" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(359)</field>
+                                                <field name="code">c359</field>
+                                                <field name="tag_name">359 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_parent_line_report_170" model="account.tax.report.line">
+                                        <field name="name">Transporte privado de pasajeros o servicio público o privado de carga</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_310" model="account.tax.report.line">
+                                                <field name="name">Base imponible(310)</field>
+                                                <field name="code">c310</field>
+                                                <field name="tag_name">310 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_360" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(360)</field>
+                                                <field name="code">c360</field>
+                                                <field name="tag_name">360 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_173" model="account.tax.report.line">
+                                <field name="name">A través de liquidaciones de compra (nivel cultural o rusticidad)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_311" model="account.tax.report.line">
+                                        <field name="name">Base imponible(311)</field>
+                                        <field name="code">c311</field>
+                                        <field name="tag_name">311 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_361" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(361)</field>
+                                        <field name="code">c361</field>
+                                        <field name="tag_name">361 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_176" model="account.tax.report.line">
+                                <field name="name">Transferencia de bienes muebles de naturaleza corporal</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_312" model="account.tax.report.line">
+                                        <field name="name">Base imponible(312)</field>
+                                        <field name="code">c312</field>
+                                        <field name="tag_name">312 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_362" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(362)</field>
+                                        <field name="code">c362</field>
+                                        <field name="tag_name">362 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_179" model="account.tax.report.line">
+                                <field name="name">Compra de bienes de origen agrícola, avícola, pecuario, apícola, cunícula, bioacuático,
                 forestal y carnes en estado natural
             </field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_3210" model="account.tax.report.line">
-            <field name="name">Base imponible(3210)</field>
-            <field name="code">c3210</field>
-            <field name="tag_name">3210 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_179"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_3620" model="account.tax.report.line">
-            <field name="name">Valor retenido(3620)</field>
-            <field name="code">c3620</field>
-            <field name="tag_name">3620 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_179"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_182" model="account.tax.report.line">
-            <field name="name">Por regalías, derechos de autor, marcas, patentes y similares</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_314" model="account.tax.report.line">
-            <field name="name">Base imponible(314)</field>
-            <field name="code">c314</field>
-            <field name="tag_name">314 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_182"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_364" model="account.tax.report.line">
-            <field name="name">Valor retenido(364)</field>
-            <field name="code">c364</field>
-            <field name="tag_name">364 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_182"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_185" model="account.tax.report.line">
-            <field name="name">Arrendamiento</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_186" model="account.tax.report.line">
-            <field name="name">Mercantil</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_185"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_319" model="account.tax.report.line">
-            <field name="name">Base imponible(319)</field>
-            <field name="code">c319</field>
-            <field name="tag_name">319 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_186"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_369" model="account.tax.report.line">
-            <field name="name">Valor retenido(369)</field>
-            <field name="code">c369</field>
-            <field name="tag_name">369 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_186"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_189" model="account.tax.report.line">
-            <field name="name">Bienes inmuebles</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_185"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_320" model="account.tax.report.line">
-            <field name="name">Base imponible(320)</field>
-            <field name="code">c320</field>
-            <field name="tag_name">320 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_189"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_370" model="account.tax.report.line">
-            <field name="name">Valor retenido(370)</field>
-            <field name="code">c370</field>
-            <field name="tag_name">370 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_189"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_192" model="account.tax.report.line">
-            <field name="name">Seguros y reaseguros (primas y cesiones)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_322" model="account.tax.report.line">
-            <field name="name">Base imponible(322)</field>
-            <field name="code">c322</field>
-            <field name="tag_name">322 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_192"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_372" model="account.tax.report.line">
-            <field name="name">Valor retenido(372)</field>
-            <field name="code">c372</field>
-            <field name="tag_name">372 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_192"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_195" model="account.tax.report.line">
-            <field name="name">Rendimientos financieros</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_323" model="account.tax.report.line">
-            <field name="name">Base imponible(323)</field>
-            <field name="code">c323</field>
-            <field name="tag_name">323 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_195"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_373" model="account.tax.report.line">
-            <field name="name">Valor retenido(373)</field>
-            <field name="code">c373</field>
-            <field name="tag_name">373 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_195"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_198" model="account.tax.report.line">
-            <field name="name">Rendimientos financieros entre instituciones del sistema financiero y entidades economía
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_3210" model="account.tax.report.line">
+                                        <field name="name">Base imponible(3210)</field>
+                                        <field name="code">c3210</field>
+                                        <field name="tag_name">3210 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_3620" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(3620)</field>
+                                        <field name="code">c3620</field>
+                                        <field name="tag_name">3620 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_182" model="account.tax.report.line">
+                                <field name="name">Por regalías, derechos de autor, marcas, patentes y similares</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_314" model="account.tax.report.line">
+                                        <field name="name">Base imponible(314)</field>
+                                        <field name="code">c314</field>
+                                        <field name="tag_name">314 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_364" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(364)</field>
+                                        <field name="code">c364</field>
+                                        <field name="tag_name">364 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_185" model="account.tax.report.line">
+                                <field name="name">Arrendamiento</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_parent_line_report_186" model="account.tax.report.line">
+                                        <field name="name">Mercantil</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_319" model="account.tax.report.line">
+                                                <field name="name">Base imponible(319)</field>
+                                                <field name="code">c319</field>
+                                                <field name="tag_name">319 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_369" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(369)</field>
+                                                <field name="code">c369</field>
+                                                <field name="tag_name">369 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_parent_line_report_189" model="account.tax.report.line">
+                                        <field name="name">Bienes inmuebles</field>
+                                        <field name="sequence">1</field>
+                                        <field name="formula">None</field>
+                                        <field name="children_line_ids">
+                                            <record id="tax_report_line_103_320" model="account.tax.report.line">
+                                                <field name="name">Base imponible(320)</field>
+                                                <field name="code">c320</field>
+                                                <field name="tag_name">320 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                            <record id="tax_report_line_103_370" model="account.tax.report.line">
+                                                <field name="name">Valor retenido(370)</field>
+                                                <field name="code">c370</field>
+                                                <field name="tag_name">370 (Reporte 103)</field>
+                                                <field name="sequence">1</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_192" model="account.tax.report.line">
+                                <field name="name">Seguros y reaseguros (primas y cesiones)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_322" model="account.tax.report.line">
+                                        <field name="name">Base imponible(322)</field>
+                                        <field name="code">c322</field>
+                                        <field name="tag_name">322 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_372" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(372)</field>
+                                        <field name="code">c372</field>
+                                        <field name="tag_name">372 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_195" model="account.tax.report.line">
+                                <field name="name">Rendimientos financieros</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_323" model="account.tax.report.line">
+                                        <field name="name">Base imponible(323)</field>
+                                        <field name="code">c323</field>
+                                        <field name="tag_name">323 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_373" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(373)</field>
+                                        <field name="code">c373</field>
+                                        <field name="tag_name">373 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_198" model="account.tax.report.line">
+                                <field name="name">Rendimientos financieros entre instituciones del sistema financiero y entidades economía
                 popular y solidaria
             </field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_324" model="account.tax.report.line">
-            <field name="name">Base imponible(324)</field>
-            <field name="code">c324</field>
-            <field name="tag_name">324 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_198"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_374" model="account.tax.report.line">
-            <field name="name">Valor retenido(374)</field>
-            <field name="code">c374</field>
-            <field name="tag_name">374 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_198"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_201" model="account.tax.report.line">
-            <field name="name">Anticipo dividendos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_325" model="account.tax.report.line">
-            <field name="name">Base imponible(325)</field>
-            <field name="code">c325</field>
-            <field name="tag_name">325 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_201"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_375" model="account.tax.report.line">
-            <field name="name">Valor retenido(375)</field>
-            <field name="code">c375</field>
-            <field name="tag_name">375 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_201"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_204" model="account.tax.report.line">
-            <field name="name">Dividendos distribuidos que correspondan al impuesto a la renta único establecido en el
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_324" model="account.tax.report.line">
+                                        <field name="name">Base imponible(324)</field>
+                                        <field name="code">c324</field>
+                                        <field name="tag_name">324 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_374" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(374)</field>
+                                        <field name="code">c374</field>
+                                        <field name="tag_name">374 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_201" model="account.tax.report.line">
+                                <field name="name">Anticipo dividendos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_325" model="account.tax.report.line">
+                                        <field name="name">Base imponible(325)</field>
+                                        <field name="code">c325</field>
+                                        <field name="tag_name">325 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_375" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(375)</field>
+                                        <field name="code">c375</field>
+                                        <field name="tag_name">375 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_204" model="account.tax.report.line">
+                                <field name="name">Dividendos distribuidos que correspondan al impuesto a la renta único establecido en el
                 art. 27 de la LRTI
             </field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_326" model="account.tax.report.line">
-            <field name="name">Base imponible(326)</field>
-            <field name="code">c326</field>
-            <field name="tag_name">326 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_204"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_376" model="account.tax.report.line">
-            <field name="name">Valor retenido(376)</field>
-            <field name="code">c376</field>
-            <field name="tag_name">376 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_204"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_207" model="account.tax.report.line">
-            <field name="name">Dividendos distribuidos a personas naturales residentes</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_327" model="account.tax.report.line">
-            <field name="name">Base imponible(327)</field>
-            <field name="code">c327</field>
-            <field name="tag_name">327 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_207"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_377" model="account.tax.report.line">
-            <field name="name">Valor retenido(377)</field>
-            <field name="code">c377</field>
-            <field name="tag_name">377 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_207"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_210" model="account.tax.report.line">
-            <field name="name">Dividendos distribuidos a sociedades residentes</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_328" model="account.tax.report.line">
-            <field name="name">Base imponible(328)</field>
-            <field name="code">c328</field>
-            <field name="tag_name">328 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_210"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_378" model="account.tax.report.line">
-            <field name="name">Valor retenido(378)</field>
-            <field name="code">c378</field>
-            <field name="tag_name">378 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_210"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_213" model="account.tax.report.line">
-            <field name="name">Dividendos distribuidos a fideicomisos residentes</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_329" model="account.tax.report.line">
-            <field name="name">Base imponible(329)</field>
-            <field name="code">c329</field>
-            <field name="tag_name">329 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_213"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_379" model="account.tax.report.line">
-            <field name="name">Valor retenido(379)</field>
-            <field name="code">c379</field>
-            <field name="tag_name">379 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_213"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_216" model="account.tax.report.line">
-            <field name="name">Dividendos en acciones (capitalización de utilidades)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_331" model="account.tax.report.line">
-            <field name="name">Base imponible(331)</field>
-            <field name="code">c331</field>
-            <field name="tag_name">331 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_216"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_218" model="account.tax.report.line">
-            <field name="name">Pagos de bienes y servicios no sujetos a retención</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_332" model="account.tax.report.line">
-            <field name="name">Base imponible(332)</field>
-            <field name="code">c332</field>
-            <field name="tag_name">332 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_218"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_220" model="account.tax.report.line">
-            <field name="name">Enajenación de derechos representativos de capital y otros derechos cotizados en bolsa
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_326" model="account.tax.report.line">
+                                        <field name="name">Base imponible(326)</field>
+                                        <field name="code">c326</field>
+                                        <field name="tag_name">326 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_376" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(376)</field>
+                                        <field name="code">c376</field>
+                                        <field name="tag_name">376 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_207" model="account.tax.report.line">
+                                <field name="name">Dividendos distribuidos a personas naturales residentes</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_327" model="account.tax.report.line">
+                                        <field name="name">Base imponible(327)</field>
+                                        <field name="code">c327</field>
+                                        <field name="tag_name">327 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_377" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(377)</field>
+                                        <field name="code">c377</field>
+                                        <field name="tag_name">377 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_210" model="account.tax.report.line">
+                                <field name="name">Dividendos distribuidos a sociedades residentes</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_328" model="account.tax.report.line">
+                                        <field name="name">Base imponible(328)</field>
+                                        <field name="code">c328</field>
+                                        <field name="tag_name">328 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_378" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(378)</field>
+                                        <field name="code">c378</field>
+                                        <field name="tag_name">378 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_213" model="account.tax.report.line">
+                                <field name="name">Dividendos distribuidos a fideicomisos residentes</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_329" model="account.tax.report.line">
+                                        <field name="name">Base imponible(329)</field>
+                                        <field name="code">c329</field>
+                                        <field name="tag_name">329 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_379" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(379)</field>
+                                        <field name="code">c379</field>
+                                        <field name="tag_name">379 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_216" model="account.tax.report.line">
+                                <field name="name">Dividendos en acciones (capitalización de utilidades)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_331" model="account.tax.report.line">
+                                        <field name="name">Base imponible(331)</field>
+                                        <field name="code">c331</field>
+                                        <field name="tag_name">331 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_218" model="account.tax.report.line">
+                                <field name="name">Pagos de bienes y servicios no sujetos a retención</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_332" model="account.tax.report.line">
+                                        <field name="name">Base imponible(332)</field>
+                                        <field name="code">c332</field>
+                                        <field name="tag_name">332 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_220" model="account.tax.report.line">
+                                <field name="name">Enajenación de derechos representativos de capital y otros derechos cotizados en bolsa
                 ecuatoriana
             </field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_333" model="account.tax.report.line">
-            <field name="name">Base imponible(333)</field>
-            <field name="code">c333</field>
-            <field name="tag_name">333 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_220"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_383" model="account.tax.report.line">
-            <field name="name">Valor retenido(383)</field>
-            <field name="code">c383</field>
-            <field name="tag_name">383 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_220"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_223" model="account.tax.report.line">
-            <field name="name">Enajenación de derechos representativos de capital y otros derechos no cotizados en bolsa
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_333" model="account.tax.report.line">
+                                        <field name="name">Base imponible(333)</field>
+                                        <field name="code">c333</field>
+                                        <field name="tag_name">333 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_383" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(383)</field>
+                                        <field name="code">c383</field>
+                                        <field name="tag_name">383 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_223" model="account.tax.report.line">
+                                <field name="name">Enajenación de derechos representativos de capital y otros derechos no cotizados en bolsa
                 ecuatoriana
             </field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_334" model="account.tax.report.line">
-            <field name="name">Base imponible(334)</field>
-            <field name="code">c334</field>
-            <field name="tag_name">334 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_223"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_384" model="account.tax.report.line">
-            <field name="name">Valor retenido(384)</field>
-            <field name="code">c384</field>
-            <field name="tag_name">384 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_223"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_226" model="account.tax.report.line">
-            <field name="name">Loterías, rifas, apuestas y similares</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_151"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_335" model="account.tax.report.line">
-            <field name="name">Base imponible(335)</field>
-            <field name="code">c335</field>
-            <field name="tag_name">335 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_226"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_385" model="account.tax.report.line">
-            <field name="name">Valor retenido(385)</field>
-            <field name="code">c385</field>
-            <field name="tag_name">385 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_226"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_229" model="account.tax.report.line">
-            <field name="name">Venta de combustibles</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_230" model="account.tax.report.line">
-            <field name="name">A comercializadoras</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_229"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_336" model="account.tax.report.line">
-            <field name="name">Base imponible(336)</field>
-            <field name="code">c336</field>
-            <field name="tag_name">336 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_230"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_386" model="account.tax.report.line">
-            <field name="name">Valor retenido(386)</field>
-            <field name="code">c386</field>
-            <field name="tag_name">386 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_230"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_233" model="account.tax.report.line">
-            <field name="name">A distribuidores</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_229"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_337" model="account.tax.report.line">
-            <field name="name">Base imponible(337)</field>
-            <field name="code">c337</field>
-            <field name="tag_name">337 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_233"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_387" model="account.tax.report.line">
-            <field name="name">Valor retenido(387)</field>
-            <field name="code">c387</field>
-            <field name="tag_name">387 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_233"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_236" model="account.tax.report.line">
-            <field name="name">Producción y venta local de banano producido o no por el mismo sujeto pasivo</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_3380" model="account.tax.report.line">
-            <field name="name">Base imponible(3380)</field>
-            <field name="code">c3380</field>
-            <field name="tag_name">3380 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_236"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_3880" model="account.tax.report.line">
-            <field name="name">Valor retenido(3880)</field>
-            <field name="code">c3880</field>
-            <field name="tag_name">3880 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_236"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_239" model="account.tax.report.line">
-            <field name="name">Impuesto único a la exportación de banano</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_3400" model="account.tax.report.line">
-            <field name="name">Base imponible(3400)</field>
-            <field name="code">c3400</field>
-            <field name="tag_name">3400 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_239"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_3900" model="account.tax.report.line">
-            <field name="name">Valor retenido(3900)</field>
-            <field name="code">c3900</field>
-            <field name="tag_name">3900 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_239"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_242" model="account.tax.report.line">
-            <field name="name">Otras retenciones</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_243" model="account.tax.report.line">
-            <field name="name">Aplicables el 1%</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_242"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_343" model="account.tax.report.line">
-            <field name="name">Base imponible(343)</field>
-            <field name="code">c343</field>
-            <field name="tag_name">343 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_243"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_393" model="account.tax.report.line">
-            <field name="name">Valor retenido(393)</field>
-            <field name="code">c393</field>
-            <field name="tag_name">393 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_243"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_246" model="account.tax.report.line">
-            <field name="name">Aplicables el 2%</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_242"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_344" model="account.tax.report.line">
-            <field name="name">Base imponible(344)</field>
-            <field name="code">c344</field>
-            <field name="tag_name">344 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_246"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_394" model="account.tax.report.line">
-            <field name="name">Valor retenido(394)</field>
-            <field name="code">c394</field>
-            <field name="tag_name">394 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_246"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_249" model="account.tax.report.line">
-            <field name="name">Aplicables el 2,75%</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_242"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_3440" model="account.tax.report.line">
-            <field name="name">Base imponible(3440)</field>
-            <field name="code">c3440</field>
-            <field name="tag_name">3440 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_249"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_3940" model="account.tax.report.line">
-            <field name="name">Valor retenido(3940)</field>
-            <field name="code">c3940</field>
-            <field name="tag_name">3940 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_249"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_252" model="account.tax.report.line">
-            <field name="name">Aplicables el 8%</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_242"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_345" model="account.tax.report.line">
-            <field name="name">Base imponible(345)</field>
-            <field name="code">c345</field>
-            <field name="tag_name">345 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_252"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_395" model="account.tax.report.line">
-            <field name="name">Valor retenido(395)</field>
-            <field name="code">c395</field>
-            <field name="tag_name">395 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_252"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_255" model="account.tax.report.line">
-            <field name="name">Aplicables a otros porcentajes (incluye régimen Microempresarial)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_242"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_346" model="account.tax.report.line">
-            <field name="name">Base imponible(346)</field>
-            <field name="code">c346</field>
-            <field name="tag_name">346 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_255"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_396" model="account.tax.report.line">
-            <field name="name">Valor retenido(396)</field>
-            <field name="code">c396</field>
-            <field name="tag_name">396 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_255"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_258" model="account.tax.report.line">
-            <field name="name">Impuesto único a ingresos provenientes de actividades agropecuarias en etapa de
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_334" model="account.tax.report.line">
+                                        <field name="name">Base imponible(334)</field>
+                                        <field name="code">c334</field>
+                                        <field name="tag_name">334 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_384" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(384)</field>
+                                        <field name="code">c384</field>
+                                        <field name="tag_name">384 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_226" model="account.tax.report.line">
+                                <field name="name">Loterías, rifas, apuestas y similares</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_335" model="account.tax.report.line">
+                                        <field name="name">Base imponible(335)</field>
+                                        <field name="code">c335</field>
+                                        <field name="tag_name">335 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_385" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(385)</field>
+                                        <field name="code">c385</field>
+                                        <field name="tag_name">385 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_229" model="account.tax.report.line">
+                        <field name="name">Venta de combustibles</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_parent_line_report_230" model="account.tax.report.line">
+                                <field name="name">A comercializadoras</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_336" model="account.tax.report.line">
+                                        <field name="name">Base imponible(336)</field>
+                                        <field name="code">c336</field>
+                                        <field name="tag_name">336 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_386" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(386)</field>
+                                        <field name="code">c386</field>
+                                        <field name="tag_name">386 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_233" model="account.tax.report.line">
+                                <field name="name">A distribuidores</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_337" model="account.tax.report.line">
+                                        <field name="name">Base imponible(337)</field>
+                                        <field name="code">c337</field>
+                                        <field name="tag_name">337 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_387" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(387)</field>
+                                        <field name="code">c387</field>
+                                        <field name="tag_name">387 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_236" model="account.tax.report.line">
+                        <field name="name">Producción y venta local de banano producido o no por el mismo sujeto pasivo</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_103_3380" model="account.tax.report.line">
+                                <field name="name">Base imponible(3380)</field>
+                                <field name="code">c3380</field>
+                                <field name="tag_name">3380 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_103_3880" model="account.tax.report.line">
+                                <field name="name">Valor retenido(3880)</field>
+                                <field name="code">c3880</field>
+                                <field name="tag_name">3880 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_239" model="account.tax.report.line">
+                        <field name="name">Impuesto único a la exportación de banano</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_103_3400" model="account.tax.report.line">
+                                <field name="name">Base imponible(3400)</field>
+                                <field name="code">c3400</field>
+                                <field name="tag_name">3400 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_103_3900" model="account.tax.report.line">
+                                <field name="name">Valor retenido(3900)</field>
+                                <field name="code">c3900</field>
+                                <field name="tag_name">3900 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_242" model="account.tax.report.line">
+                        <field name="name">Otras retenciones</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_parent_line_report_243" model="account.tax.report.line">
+                                <field name="name">Aplicables el 1%</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_343" model="account.tax.report.line">
+                                        <field name="name">Base imponible(343)</field>
+                                        <field name="code">c343</field>
+                                        <field name="tag_name">343 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_393" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(393)</field>
+                                        <field name="code">c393</field>
+                                        <field name="tag_name">393 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_246" model="account.tax.report.line">
+                                <field name="name">Aplicables el 2%</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_344" model="account.tax.report.line">
+                                        <field name="name">Base imponible(344)</field>
+                                        <field name="code">c344</field>
+                                        <field name="tag_name">344 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_394" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(394)</field>
+                                        <field name="code">c394</field>
+                                        <field name="tag_name">394 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_249" model="account.tax.report.line">
+                                <field name="name">Aplicables el 2,75%</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_3440" model="account.tax.report.line">
+                                        <field name="name">Base imponible(3440)</field>
+                                        <field name="code">c3440</field>
+                                        <field name="tag_name">3440 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_3940" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(3940)</field>
+                                        <field name="code">c3940</field>
+                                        <field name="tag_name">3940 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_252" model="account.tax.report.line">
+                                <field name="name">Aplicables el 8%</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_345" model="account.tax.report.line">
+                                        <field name="name">Base imponible(345)</field>
+                                        <field name="code">c345</field>
+                                        <field name="tag_name">345 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_395" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(395)</field>
+                                        <field name="code">c395</field>
+                                        <field name="tag_name">395 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_255" model="account.tax.report.line">
+                                <field name="name">Aplicables a otros porcentajes (incluye régimen Microempresarial)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_346" model="account.tax.report.line">
+                                        <field name="name">Base imponible(346)</field>
+                                        <field name="code">c346</field>
+                                        <field name="tag_name">346 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_396" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(396)</field>
+                                        <field name="code">c396</field>
+                                        <field name="tag_name">396 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_258" model="account.tax.report.line">
+                        <field name="name">Impuesto único a ingresos provenientes de actividades agropecuarias en etapa de
                 producción / comercialización local o exportación
             </field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_348" model="account.tax.report.line">
-            <field name="name">Base imponible(348)</field>
-            <field name="code">c348</field>
-            <field name="tag_name">348 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_258"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_398" model="account.tax.report.line">
-            <field name="name">Valor retenido(398)</field>
-            <field name="code">c398</field>
-            <field name="tag_name">398 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_258"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_261" model="account.tax.report.line">
-            <field name="name">Otras autoretenciones</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_350" model="account.tax.report.line">
-            <field name="name">Base imponible(350)</field>
-            <field name="code">c350</field>
-            <field name="tag_name">350 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_261"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_400" model="account.tax.report.line">
-            <field name="name">Valor retenido(400)</field>
-            <field name="code">c400</field>
-            <field name="tag_name">400 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_261"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_264" model="account.tax.report.line">
-            <field name="name">SUBTOTAL OPERACIONES EFECTUADAS EN EL PAÍS</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_150"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_349" model="account.tax.report.line">
-            <field name="name">Base imponible(349)</field>
-            <field name="code">c349</field>
-            <field name="tag_name">349 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_264"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_399" model="account.tax.report.line">
-            <field name="name">Valor retenido(399)</field>
-            <field name="code">c399</field>
-            <field name="tag_name">399 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_264"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_267" model="account.tax.report.line">
-            <field name="name">POR PAGOS A NO RESIDENTES</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_268" model="account.tax.report.line">
-            <field name="name">Con convenio de doble tributación</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_267"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_269" model="account.tax.report.line">
-            <field name="name">Intereses por financiamiento de proveedores</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_402" model="account.tax.report.line">
-            <field name="name">Base imponible(402)</field>
-            <field name="code">c402</field>
-            <field name="tag_name">402 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_269"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_452" model="account.tax.report.line">
-            <field name="name">Valor retenido(452)</field>
-            <field name="code">c452</field>
-            <field name="tag_name">452 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_269"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_272" model="account.tax.report.line">
-            <field name="name">Intereses de créditos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_403" model="account.tax.report.line">
-            <field name="name">Base imponible(403)</field>
-            <field name="code">c403</field>
-            <field name="tag_name">403 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_272"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_453" model="account.tax.report.line">
-            <field name="name">Valor retenido(453)</field>
-            <field name="code">c453</field>
-            <field name="tag_name">453 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_272"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_275" model="account.tax.report.line">
-            <field name="name">Anticipo de dividendos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_404" model="account.tax.report.line">
-            <field name="name">Base imponible(404)</field>
-            <field name="code">c404</field>
-            <field name="tag_name">404 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_275"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_454" model="account.tax.report.line">
-            <field name="name">Valor retenido(454)</field>
-            <field name="code">c454</field>
-            <field name="tag_name">454 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_275"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_278" model="account.tax.report.line">
-            <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4050" model="account.tax.report.line">
-            <field name="name">Base imponible(4050)</field>
-            <field name="code">c4050</field>
-            <field name="tag_name">4050 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_278"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4550" model="account.tax.report.line">
-            <field name="name">Valor retenido(4550)</field>
-            <field name="code">c4550</field>
-            <field name="tag_name">4550 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_278"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_281" model="account.tax.report.line">
-            <field name="name">Dividendos con beneficiario efectivo persona natural residente en Ecuador</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4060" model="account.tax.report.line">
-            <field name="name">Base imponible(4060)</field>
-            <field name="code">c4060</field>
-            <field name="tag_name">4060 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_281"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4560" model="account.tax.report.line">
-            <field name="name">Valor retenido(4560)</field>
-            <field name="code">c4560</field>
-            <field name="tag_name">4560 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_281"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_284" model="account.tax.report.line">
-            <field name="name">Dividendos incumpliendo el deber de informar la composición societaria</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4070" model="account.tax.report.line">
-            <field name="name">Base imponible(4070)</field>
-            <field name="code">c4070</field>
-            <field name="tag_name">4070 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_284"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4570" model="account.tax.report.line">
-            <field name="name">Valor retenido(4570)</field>
-            <field name="code">c4570</field>
-            <field name="tag_name">4570 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_284"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_287" model="account.tax.report.line">
-            <field name="name">Enajenación de derechos representativos de capital y otros derechos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_408" model="account.tax.report.line">
-            <field name="name">Base imponible(408)</field>
-            <field name="code">c408</field>
-            <field name="tag_name">408 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_287"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_458" model="account.tax.report.line">
-            <field name="name">Valor retenido(458)</field>
-            <field name="code">c458</field>
-            <field name="tag_name">458 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_287"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_290" model="account.tax.report.line">
-            <field name="name">Seguros y reaseguros (primas y cesiones)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_409" model="account.tax.report.line">
-            <field name="name">Base imponible(409)</field>
-            <field name="code">c409</field>
-            <field name="tag_name">409 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_290"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_459" model="account.tax.report.line">
-            <field name="name">Valor retenido(459)</field>
-            <field name="code">c459</field>
-            <field name="tag_name">459 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_290"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_293" model="account.tax.report.line">
-            <field name="name">Servicios técnicos, administrativos o de consultoría y regalías</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_410" model="account.tax.report.line">
-            <field name="name">Base imponible(410)</field>
-            <field name="code">c410</field>
-            <field name="tag_name">410 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_293"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_460" model="account.tax.report.line">
-            <field name="name">Valor retenido(460)</field>
-            <field name="code">c460</field>
-            <field name="tag_name">460 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_293"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_296" model="account.tax.report.line">
-            <field name="name">Otros conceptos de ingresos gravados</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_411" model="account.tax.report.line">
-            <field name="name">Base imponible(411)</field>
-            <field name="code">c411</field>
-            <field name="tag_name">411 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_296"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_461" model="account.tax.report.line">
-            <field name="name">Valor retenido(461)</field>
-            <field name="code">c461</field>
-            <field name="tag_name">461 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_296"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_299" model="account.tax.report.line">
-            <field name="name">Otros pagos al exterior no sujetos a retención</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_268"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_412" model="account.tax.report.line">
-            <field name="name">Base imponible(412)</field>
-            <field name="code">c412</field>
-            <field name="tag_name">412 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_299"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_301" model="account.tax.report.line">
-            <field name="name">Sin convenio de doble tributación</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_267"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_302" model="account.tax.report.line">
-            <field name="name">Intereses por financiamiento de proveedores</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_413" model="account.tax.report.line">
-            <field name="name">Base imponible(413)</field>
-            <field name="code">c413</field>
-            <field name="tag_name">413 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_302"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_463" model="account.tax.report.line">
-            <field name="name">Valor retenido(463)</field>
-            <field name="code">c463</field>
-            <field name="tag_name">463 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_302"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_305" model="account.tax.report.line">
-            <field name="name">Intereses de créditos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_414" model="account.tax.report.line">
-            <field name="name">Base imponible(414)</field>
-            <field name="code">c414</field>
-            <field name="tag_name">414 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_305"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_464" model="account.tax.report.line">
-            <field name="name">Valor retenido(464)</field>
-            <field name="code">c464</field>
-            <field name="tag_name">464 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_305"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_308" model="account.tax.report.line">
-            <field name="name">Anticipo de dividendos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_415" model="account.tax.report.line">
-            <field name="name">Base imponible(415)</field>
-            <field name="code">c415</field>
-            <field name="tag_name">415 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_308"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_465" model="account.tax.report.line">
-            <field name="name">Valor retenido(465)</field>
-            <field name="code">c465</field>
-            <field name="tag_name">465 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_308"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_311" model="account.tax.report.line">
-            <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4160" model="account.tax.report.line">
-            <field name="name">Base imponible(4160)</field>
-            <field name="code">c4160</field>
-            <field name="tag_name">4160 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_311"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4660" model="account.tax.report.line">
-            <field name="name">Valor retenido(4660)</field>
-            <field name="code">c4660</field>
-            <field name="tag_name">4660 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_311"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_314" model="account.tax.report.line">
-            <field name="name">Dividendos con beneficiario efectivo persona natural residente en Ecuador</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4170" model="account.tax.report.line">
-            <field name="name">Base imponible(4170)</field>
-            <field name="code">c4170</field>
-            <field name="tag_name">4170 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_314"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4670" model="account.tax.report.line">
-            <field name="name">Valor retenido(4670)</field>
-            <field name="code">c4670</field>
-            <field name="tag_name">4670 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_314"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_317" model="account.tax.report.line">
-            <field name="name">Dividendos incumpliendo el deber de informar la composición societaria</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4180" model="account.tax.report.line">
-            <field name="name">Base imponible(4180)</field>
-            <field name="code">c4180</field>
-            <field name="tag_name">4180 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_317"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4680" model="account.tax.report.line">
-            <field name="name">Valor retenido(4680)</field>
-            <field name="code">c4680</field>
-            <field name="tag_name">4680 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_317"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_320" model="account.tax.report.line">
-            <field name="name">Enajenación de derechos representativos de capital y otros derechos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_419" model="account.tax.report.line">
-            <field name="name">Base imponible(419)</field>
-            <field name="code">c419</field>
-            <field name="tag_name">419 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_320"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_469" model="account.tax.report.line">
-            <field name="name">Valor retenido(469)</field>
-            <field name="code">c469</field>
-            <field name="tag_name">469 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_320"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_323" model="account.tax.report.line">
-            <field name="name">Seguros y reaseguros (primas y cesiones)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_420" model="account.tax.report.line">
-            <field name="name">Base imponible(420)</field>
-            <field name="code">c420</field>
-            <field name="tag_name">420 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_323"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_470" model="account.tax.report.line">
-            <field name="name">Valor retenido(470)</field>
-            <field name="code">c470</field>
-            <field name="tag_name">470 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_323"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_326" model="account.tax.report.line">
-            <field name="name">Servicios técnicos, administrativos o de consultoría y regalías</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_421" model="account.tax.report.line">
-            <field name="name">Base imponible(421)</field>
-            <field name="code">c421</field>
-            <field name="tag_name">421 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_326"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_471" model="account.tax.report.line">
-            <field name="name">Valor retenido(471)</field>
-            <field name="code">c471</field>
-            <field name="tag_name">471 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_326"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_329" model="account.tax.report.line">
-            <field name="name">Otros conceptos de ingresos gravados</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_422" model="account.tax.report.line">
-            <field name="name">Base imponible(422)</field>
-            <field name="code">c422</field>
-            <field name="tag_name">422 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_329"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_472" model="account.tax.report.line">
-            <field name="name">Valor retenido(472)</field>
-            <field name="code">c472</field>
-            <field name="tag_name">472 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_329"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_332" model="account.tax.report.line">
-            <field name="name">Otros pagos al exterior no sujetos a retención</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_301"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_423" model="account.tax.report.line">
-            <field name="name">Base imponible(423)</field>
-            <field name="code">c423</field>
-            <field name="tag_name">423 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_332"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_334" model="account.tax.report.line">
-            <field name="name">En paraísos fiscales o regímenes fiscales preferentes</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_267"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_335" model="account.tax.report.line">
-            <field name="name">Intereses</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_424" model="account.tax.report.line">
-            <field name="name">Base imponible(424)</field>
-            <field name="code">c424</field>
-            <field name="tag_name">424 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_335"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_474" model="account.tax.report.line">
-            <field name="name">Valor retenido(474)</field>
-            <field name="code">c474</field>
-            <field name="tag_name">474 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_335"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_338" model="account.tax.report.line">
-            <field name="name">Anticipo de dividendos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_425" model="account.tax.report.line">
-            <field name="name">Base imponible(425)</field>
-            <field name="code">c425</field>
-            <field name="tag_name">425 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_338"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_475" model="account.tax.report.line">
-            <field name="name">Valor retenido(475)</field>
-            <field name="code">c475</field>
-            <field name="tag_name">475 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_338"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_341" model="account.tax.report.line">
-            <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4260" model="account.tax.report.line">
-            <field name="name">Base imponible(4260)</field>
-            <field name="code">c4260</field>
-            <field name="tag_name">4260 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_341"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4760" model="account.tax.report.line">
-            <field name="name">Valor retenido(4760)</field>
-            <field name="code">c4760</field>
-            <field name="tag_name">4760 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_341"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_344" model="account.tax.report.line">
-            <field name="name">Dividendos con beneficiario efectivo persona natural residente en Ecuador</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4270" model="account.tax.report.line">
-            <field name="name">Base imponible(4270)</field>
-            <field name="code">c4270</field>
-            <field name="tag_name">4270 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_344"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4770" model="account.tax.report.line">
-            <field name="name">Valor retenido(4770)</field>
-            <field name="code">c4770</field>
-            <field name="tag_name">4770 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_344"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_347" model="account.tax.report.line">
-            <field name="name">Dividendos incumpliendo el deber de informar la composición societaria</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_4280" model="account.tax.report.line">
-            <field name="name">Base imponible(4280)</field>
-            <field name="code">c4280</field>
-            <field name="tag_name">4280 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_347"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_4780" model="account.tax.report.line">
-            <field name="name">Valor retenido(4780)</field>
-            <field name="code">c4780</field>
-            <field name="tag_name">4780 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_347"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_350" model="account.tax.report.line">
-            <field name="name">Enajenación de derechos representativos de capital y otros derechos</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_429" model="account.tax.report.line">
-            <field name="name">Base imponible(429)</field>
-            <field name="code">c429</field>
-            <field name="tag_name">429 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_350"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_479" model="account.tax.report.line">
-            <field name="name">Valor retenido(479)</field>
-            <field name="code">c479</field>
-            <field name="tag_name">479 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_350"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_353" model="account.tax.report.line">
-            <field name="name">Seguros y reaseguros (primas y cesiones)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_430" model="account.tax.report.line">
-            <field name="name">Base imponible(430)</field>
-            <field name="code">c430</field>
-            <field name="tag_name">430 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_353"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_480" model="account.tax.report.line">
-            <field name="name">Valor retenido(480)</field>
-            <field name="code">c480</field>
-            <field name="tag_name">480 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_353"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_356" model="account.tax.report.line">
-            <field name="name">Servicios técnicos, administrativos o de consultoría y regalías</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_431" model="account.tax.report.line">
-            <field name="name">Base imponible(431)</field>
-            <field name="code">c431</field>
-            <field name="tag_name">431 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_356"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_481" model="account.tax.report.line">
-            <field name="name">Valor retenido(481)</field>
-            <field name="code">c481</field>
-            <field name="tag_name">481 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_356"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_359" model="account.tax.report.line">
-            <field name="name">Otros conceptos de ingresos gravados</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_432" model="account.tax.report.line">
-            <field name="name">Base imponible(432)</field>
-            <field name="code">c432</field>
-            <field name="tag_name">432 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_359"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_482" model="account.tax.report.line">
-            <field name="name">Valor retenido(482)</field>
-            <field name="code">c482</field>
-            <field name="tag_name">482 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_359"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_362" model="account.tax.report.line">
-            <field name="name">Otros pagos al exterior no sujetos a retención</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_334"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_433" model="account.tax.report.line">
-            <field name="name">Base imponible(433)</field>
-            <field name="code">c433</field>
-            <field name="tag_name">433 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_362"/>
-            <field name="sequence">1</field>
-        </record>
-        <record id="tax_report_line_parent_line_report_364" model="account.tax.report.line">
-            <field name="name">SUBTOTAL OPERACIONES EFECTUADAS CON EL EXTERIOR</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="sequence">1</field>
-            <field name="formula">None</field>
-        </record>
-
-        <record id="tax_report_line_103_487" model="account.tax.report.line">
-            <field name="name">Base imponible(487)</field>
-            <field name="code">c487</field>
-            <field name="tag_name">487 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_364"/>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="tax_report_line_103_498" model="account.tax.report.line">
-            <field name="name">Valor retenido(498)</field>
-            <field name="code">c498</field>
-            <field name="tag_name">498 (Reporte 103)</field>
-            <field name="report_id" ref="tax_report_103"/>
-            <field name="parent_id" ref="tax_report_line_parent_line_report_364"/>
-            <field name="sequence">1</field>
-        </record>
-
-    </data>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_103_348" model="account.tax.report.line">
+                                <field name="name">Base imponible(348)</field>
+                                <field name="code">c348</field>
+                                <field name="tag_name">348 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_103_398" model="account.tax.report.line">
+                                <field name="name">Valor retenido(398)</field>
+                                <field name="code">c398</field>
+                                <field name="tag_name">398 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_261" model="account.tax.report.line">
+                        <field name="name">Otras autoretenciones</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_103_350" model="account.tax.report.line">
+                                <field name="name">Base imponible(350)</field>
+                                <field name="code">c350</field>
+                                <field name="tag_name">350 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_103_400" model="account.tax.report.line">
+                                <field name="name">Valor retenido(400)</field>
+                                <field name="code">c400</field>
+                                <field name="tag_name">400 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_264" model="account.tax.report.line">
+                        <field name="name">SUBTOTAL OPERACIONES EFECTUADAS EN EL PAÍS</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_103_349" model="account.tax.report.line">
+                                <field name="name">Base imponible(349)</field>
+                                <field name="code">c349</field>
+                                <field name="tag_name">349 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_103_399" model="account.tax.report.line">
+                                <field name="name">Valor retenido(399)</field>
+                                <field name="code">c399</field>
+                                <field name="tag_name">399 (Reporte 103)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_267" model="account.tax.report.line">
+                <field name="name">POR PAGOS A NO RESIDENTES</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_parent_line_report_268" model="account.tax.report.line">
+                        <field name="name">Con convenio de doble tributación</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_parent_line_report_269" model="account.tax.report.line">
+                                <field name="name">Intereses por financiamiento de proveedores</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_402" model="account.tax.report.line">
+                                        <field name="name">Base imponible(402)</field>
+                                        <field name="code">c402</field>
+                                        <field name="tag_name">402 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_452" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(452)</field>
+                                        <field name="code">c452</field>
+                                        <field name="tag_name">452 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_272" model="account.tax.report.line">
+                                <field name="name">Intereses de créditos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_403" model="account.tax.report.line">
+                                        <field name="name">Base imponible(403)</field>
+                                        <field name="code">c403</field>
+                                        <field name="tag_name">403 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_453" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(453)</field>
+                                        <field name="code">c453</field>
+                                        <field name="tag_name">453 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_275" model="account.tax.report.line">
+                                <field name="name">Anticipo de dividendos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_404" model="account.tax.report.line">
+                                        <field name="name">Base imponible(404)</field>
+                                        <field name="code">c404</field>
+                                        <field name="tag_name">404 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_454" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(454)</field>
+                                        <field name="code">c454</field>
+                                        <field name="tag_name">454 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_278" model="account.tax.report.line">
+                                <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4050" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4050)</field>
+                                        <field name="code">c4050</field>
+                                        <field name="tag_name">4050 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4550" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4550)</field>
+                                        <field name="code">c4550</field>
+                                        <field name="tag_name">4550 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_281" model="account.tax.report.line">
+                                <field name="name">Dividendos con beneficiario efectivo persona natural residente en Ecuador</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4060" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4060)</field>
+                                        <field name="code">c4060</field>
+                                        <field name="tag_name">4060 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4560" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4560)</field>
+                                        <field name="code">c4560</field>
+                                        <field name="tag_name">4560 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_284" model="account.tax.report.line">
+                                <field name="name">Dividendos incumpliendo el deber de informar la composición societaria</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4070" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4070)</field>
+                                        <field name="code">c4070</field>
+                                        <field name="tag_name">4070 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4570" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4570)</field>
+                                        <field name="code">c4570</field>
+                                        <field name="tag_name">4570 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_287" model="account.tax.report.line">
+                                <field name="name">Enajenación de derechos representativos de capital y otros derechos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_408" model="account.tax.report.line">
+                                        <field name="name">Base imponible(408)</field>
+                                        <field name="code">c408</field>
+                                        <field name="tag_name">408 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_458" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(458)</field>
+                                        <field name="code">c458</field>
+                                        <field name="tag_name">458 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_290" model="account.tax.report.line">
+                                <field name="name">Seguros y reaseguros (primas y cesiones)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_409" model="account.tax.report.line">
+                                        <field name="name">Base imponible(409)</field>
+                                        <field name="code">c409</field>
+                                        <field name="tag_name">409 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_459" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(459)</field>
+                                        <field name="code">c459</field>
+                                        <field name="tag_name">459 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_293" model="account.tax.report.line">
+                                <field name="name">Servicios técnicos, administrativos o de consultoría y regalías</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_410" model="account.tax.report.line">
+                                        <field name="name">Base imponible(410)</field>
+                                        <field name="code">c410</field>
+                                        <field name="tag_name">410 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_460" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(460)</field>
+                                        <field name="code">c460</field>
+                                        <field name="tag_name">460 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_296" model="account.tax.report.line">
+                                <field name="name">Otros conceptos de ingresos gravados</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_411" model="account.tax.report.line">
+                                        <field name="name">Base imponible(411)</field>
+                                        <field name="code">c411</field>
+                                        <field name="tag_name">411 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_461" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(461)</field>
+                                        <field name="code">c461</field>
+                                        <field name="tag_name">461 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_299" model="account.tax.report.line">
+                                <field name="name">Otros pagos al exterior no sujetos a retención</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_412" model="account.tax.report.line">
+                                        <field name="name">Base imponible(412)</field>
+                                        <field name="code">c412</field>
+                                        <field name="tag_name">412 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_301" model="account.tax.report.line">
+                        <field name="name">Sin convenio de doble tributación</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_parent_line_report_302" model="account.tax.report.line">
+                                <field name="name">Intereses por financiamiento de proveedores</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_413" model="account.tax.report.line">
+                                        <field name="name">Base imponible(413)</field>
+                                        <field name="code">c413</field>
+                                        <field name="tag_name">413 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_463" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(463)</field>
+                                        <field name="code">c463</field>
+                                        <field name="tag_name">463 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_305" model="account.tax.report.line">
+                                <field name="name">Intereses de créditos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_414" model="account.tax.report.line">
+                                        <field name="name">Base imponible(414)</field>
+                                        <field name="code">c414</field>
+                                        <field name="tag_name">414 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_464" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(464)</field>
+                                        <field name="code">c464</field>
+                                        <field name="tag_name">464 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_308" model="account.tax.report.line">
+                                <field name="name">Anticipo de dividendos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_415" model="account.tax.report.line">
+                                        <field name="name">Base imponible(415)</field>
+                                        <field name="code">c415</field>
+                                        <field name="tag_name">415 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_465" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(465)</field>
+                                        <field name="code">c465</field>
+                                        <field name="tag_name">465 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_311" model="account.tax.report.line">
+                                <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4160" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4160)</field>
+                                        <field name="code">c4160</field>
+                                        <field name="tag_name">4160 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4660" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4660)</field>
+                                        <field name="code">c4660</field>
+                                        <field name="tag_name">4660 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_314" model="account.tax.report.line">
+                                <field name="name">Dividendos con beneficiario efectivo persona natural residente en Ecuador</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4170" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4170)</field>
+                                        <field name="code">c4170</field>
+                                        <field name="tag_name">4170 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4670" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4670)</field>
+                                        <field name="code">c4670</field>
+                                        <field name="tag_name">4670 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_317" model="account.tax.report.line">
+                                <field name="name">Dividendos incumpliendo el deber de informar la composición societaria</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4180" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4180)</field>
+                                        <field name="code">c4180</field>
+                                        <field name="tag_name">4180 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4680" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4680)</field>
+                                        <field name="code">c4680</field>
+                                        <field name="tag_name">4680 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_320" model="account.tax.report.line">
+                                <field name="name">Enajenación de derechos representativos de capital y otros derechos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_419" model="account.tax.report.line">
+                                        <field name="name">Base imponible(419)</field>
+                                        <field name="code">c419</field>
+                                        <field name="tag_name">419 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_469" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(469)</field>
+                                        <field name="code">c469</field>
+                                        <field name="tag_name">469 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_323" model="account.tax.report.line">
+                                <field name="name">Seguros y reaseguros (primas y cesiones)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_420" model="account.tax.report.line">
+                                        <field name="name">Base imponible(420)</field>
+                                        <field name="code">c420</field>
+                                        <field name="tag_name">420 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_470" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(470)</field>
+                                        <field name="code">c470</field>
+                                        <field name="tag_name">470 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_326" model="account.tax.report.line">
+                                <field name="name">Servicios técnicos, administrativos o de consultoría y regalías</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_421" model="account.tax.report.line">
+                                        <field name="name">Base imponible(421)</field>
+                                        <field name="code">c421</field>
+                                        <field name="tag_name">421 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_471" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(471)</field>
+                                        <field name="code">c471</field>
+                                        <field name="tag_name">471 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_329" model="account.tax.report.line">
+                                <field name="name">Otros conceptos de ingresos gravados</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_422" model="account.tax.report.line">
+                                        <field name="name">Base imponible(422)</field>
+                                        <field name="code">c422</field>
+                                        <field name="tag_name">422 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_472" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(472)</field>
+                                        <field name="code">c472</field>
+                                        <field name="tag_name">472 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_332" model="account.tax.report.line">
+                                <field name="name">Otros pagos al exterior no sujetos a retención</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_423" model="account.tax.report.line">
+                                        <field name="name">Base imponible(423)</field>
+                                        <field name="code">c423</field>
+                                        <field name="tag_name">423 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_parent_line_report_334" model="account.tax.report.line">
+                        <field name="name">En paraísos fiscales o regímenes fiscales preferentes</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_parent_line_report_335" model="account.tax.report.line">
+                                <field name="name">Intereses</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_424" model="account.tax.report.line">
+                                        <field name="name">Base imponible(424)</field>
+                                        <field name="code">c424</field>
+                                        <field name="tag_name">424 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_474" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(474)</field>
+                                        <field name="code">c474</field>
+                                        <field name="tag_name">474 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_338" model="account.tax.report.line">
+                                <field name="name">Anticipo de dividendos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_425" model="account.tax.report.line">
+                                        <field name="name">Base imponible(425)</field>
+                                        <field name="code">c425</field>
+                                        <field name="tag_name">425 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_475" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(475)</field>
+                                        <field name="code">c475</field>
+                                        <field name="tag_name">475 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_341" model="account.tax.report.line">
+                                <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4260" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4260)</field>
+                                        <field name="code">c4260</field>
+                                        <field name="tag_name">4260 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4760" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4760)</field>
+                                        <field name="code">c4760</field>
+                                        <field name="tag_name">4760 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_344" model="account.tax.report.line">
+                                <field name="name">Dividendos con beneficiario efectivo persona natural residente en Ecuador</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4270" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4270)</field>
+                                        <field name="code">c4270</field>
+                                        <field name="tag_name">4270 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4770" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4770)</field>
+                                        <field name="code">c4770</field>
+                                        <field name="tag_name">4770 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_347" model="account.tax.report.line">
+                                <field name="name">Dividendos incumpliendo el deber de informar la composición societaria</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_4280" model="account.tax.report.line">
+                                        <field name="name">Base imponible(4280)</field>
+                                        <field name="code">c4280</field>
+                                        <field name="tag_name">4280 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_4780" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(4780)</field>
+                                        <field name="code">c4780</field>
+                                        <field name="tag_name">4780 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_350" model="account.tax.report.line">
+                                <field name="name">Enajenación de derechos representativos de capital y otros derechos</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_429" model="account.tax.report.line">
+                                        <field name="name">Base imponible(429)</field>
+                                        <field name="code">c429</field>
+                                        <field name="tag_name">429 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_479" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(479)</field>
+                                        <field name="code">c479</field>
+                                        <field name="tag_name">479 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_353" model="account.tax.report.line">
+                                <field name="name">Seguros y reaseguros (primas y cesiones)</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_430" model="account.tax.report.line">
+                                        <field name="name">Base imponible(430)</field>
+                                        <field name="code">c430</field>
+                                        <field name="tag_name">430 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_480" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(480)</field>
+                                        <field name="code">c480</field>
+                                        <field name="tag_name">480 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_356" model="account.tax.report.line">
+                                <field name="name">Servicios técnicos, administrativos o de consultoría y regalías</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_431" model="account.tax.report.line">
+                                        <field name="name">Base imponible(431)</field>
+                                        <field name="code">c431</field>
+                                        <field name="tag_name">431 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_481" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(481)</field>
+                                        <field name="code">c481</field>
+                                        <field name="tag_name">481 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_359" model="account.tax.report.line">
+                                <field name="name">Otros conceptos de ingresos gravados</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_432" model="account.tax.report.line">
+                                        <field name="name">Base imponible(432)</field>
+                                        <field name="code">c432</field>
+                                        <field name="tag_name">432 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                    <record id="tax_report_line_103_482" model="account.tax.report.line">
+                                        <field name="name">Valor retenido(482)</field>
+                                        <field name="code">c482</field>
+                                        <field name="tag_name">482 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_362" model="account.tax.report.line">
+                                <field name="name">Otros pagos al exterior no sujetos a retención</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">None</field>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_line_103_433" model="account.tax.report.line">
+                                        <field name="name">Base imponible(433)</field>
+                                        <field name="code">c433</field>
+                                        <field name="tag_name">433 (Reporte 103)</field>
+                                        <field name="sequence">1</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_parent_line_report_364" model="account.tax.report.line">
+                <field name="name">SUBTOTAL OPERACIONES EFECTUADAS CON EL EXTERIOR</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_103_487" model="account.tax.report.line">
+                        <field name="name">Base imponible(487)</field>
+                        <field name="code">c487</field>
+                        <field name="tag_name">487 (Reporte 103)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_103_498" model="account.tax.report.line">
+                        <field name="name">Valor retenido(498)</field>
+                        <field name="code">c498</field>
+                        <field name="tag_name">498 (Reporte 103)</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
 </odoo>

--- a/addons/l10n_et/data/account_tax_report_data.xml
+++ b/addons/l10n_et/data/account_tax_report_data.xml
@@ -1,225 +1,163 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.et"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_purch_vt" model="account.tax.report.line">
+                <field name="name">Taxable Purchases - VAT</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_purch_vt_out_scope" model="account.tax.report.line">
+                        <field name="name">Taxable Purchase VAT Out of Scope</field>
+                        <field name="tag_name">Taxable Purchase VAT Out of Scope</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_purch_vt_exmpt" model="account.tax.report.line">
+                        <field name="name">Taxable Purchase VAT Exempt</field>
+                        <field name="tag_name">Taxable Purchase VAT Exempt</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_purch_vt_ratd_0" model="account.tax.report.line">
+                        <field name="name">Taxable Purchase VAT Rated 0%</field>
+                        <field name="tag_name">Taxable Purchase VAT Rated 0%</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="account_tax_report_purch_vt_ratd_15" model="account.tax.report.line">
+                        <field name="name">Taxable Purchase VAT Rated 15%</field>
+                        <field name="tag_name">Taxable Purchase VAT Rated 15%</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_purch_withholding" model="account.tax.report.line">
+                <field name="name">Taxable Purchases - Witholding</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_purch_withholding_2" model="account.tax.report.line">
+                        <field name="name">Taxable 2% Withholding on Purchases</field>
+                        <field name="tag_name">Taxable 2% Withholding on Purchases</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_purch_withholding_35" model="account.tax.report.line">
+                        <field name="name">Taxable 35% Withholding on Purchases</field>
+                        <field name="tag_name">Taxable 35% Withholding on Purchases</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_sale_vat" model="account.tax.report.line">
+                <field name="name">Taxable Sales - VAT</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_sale_vat_out_scope" model="account.tax.report.line">
+                        <field name="name">Taxable Sales VAT Out of Scope (Sales)</field>
+                        <field name="tag_name">Taxable Sales VAT Out of Scope (Sales)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_sale_vat_exmpt" model="account.tax.report.line">
+                        <field name="name">Taxable Sales VAT Exempt</field>
+                        <field name="tag_name">Taxable Sales VAT Exempt</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_sale_vat_rated_0" model="account.tax.report.line">
+                        <field name="name">Taxable Sales VAT Rated 0%</field>
+                        <field name="tag_name">Taxable Sales VAT Rated 0%</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="account_tax_report_sale_vat_rated_15" model="account.tax.report.line">
+                        <field name="name">Taxable Sales VAT Rated 15%</field>
+                        <field name="tag_name">Taxable Sales VAT Rated 15%</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_sale_withholding" model="account.tax.report.line">
+                <field name="name">Taxable Sales - Withholding</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_sale_withholding_2" model="account.tax.report.line">
+                        <field name="name">Taxable 2% Withholding on Sales</field>
+                        <field name="tag_name">Taxable 2% Withholding on Sales</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_sale_withholding_35" model="account.tax.report.line">
+                        <field name="name">Taxable 35% Withholding on Sales</field>
+                        <field name="tag_name">Taxable 35% Withholding on Sales</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_sale_vat_withholding" model="account.tax.report.line">
+                        <field name="name">Taxable VAT Withholding on Sales</field>
+                        <field name="tag_name">Taxable VAT Withholding on Sales</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_net_vat" model="account.tax.report.line">
+                <field name="name">Net VAT to be Paid/Reclaimed</field>
+                <field name="sequence" eval="5"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_purch_vat" model="account.tax.report.line">
+                        <field name="name">Purchase VAT</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_purch_vat_rated_15" model="account.tax.report.line">
+                                <field name="name">Purchase VAT Rated 15%</field>
+                                <field name="tag_name">Purchase VAT Rated 15%</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_net_sale_vat" model="account.tax.report.line">
+                        <field name="name">Sales VAT</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_net_sale_vat_15" model="account.tax.report.line">
+                                <field name="name">Sales VAT Rated 15%</field>
+                                <field name="tag_name">Sales VAT Rated 15%</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_net_purch_witholding" model="account.tax.report.line">
+                <field name="name">Withholding on Purchases</field>
+                <field name="sequence" eval="6"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_net_purch_witholding_2" model="account.tax.report.line">
+                        <field name="name">2% Withholding on Purchases</field>
+                        <field name="tag_name">2% Withholding on Purchases</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_net_purch_witholding_35" model="account.tax.report.line">
+                        <field name="name">35% Withholding on Purchases</field>
+                        <field name="tag_name">35% Withholding on Purchases</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_net_sale_witholding" model="account.tax.report.line">
+                <field name="name">Withholding on Sales</field>
+                <field name="sequence" eval="7"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_net_sale_witheld_2" model="account.tax.report.line">
+                        <field name="name">2% Withheld on Sales</field>
+                        <field name="tag_name">2% Withheld on Sales</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_net_sale_witheld_35" model="account.tax.report.line">
+                        <field name="name">35% Withheld on Sales</field>
+                        <field name="tag_name">35% Withheld on Sales</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_net_sale_vat_witheld" model="account.tax.report.line">
+                        <field name="name">VAT Withheld on Sales</field>
+                        <field name="tag_name">VAT Withheld on Sales</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_purch_vt" model="account.tax.report.line">
-        <field name="name">Taxable Purchases - VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_purch_vt_out_scope" model="account.tax.report.line">
-        <field name="name">Taxable Purchase VAT Out of Scope</field>
-        <field name="tag_name">Taxable Purchase VAT Out of Scope</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_purch_vt"/>
-    </record>
-
-    <record id="account_tax_report_purch_vt_exmpt" model="account.tax.report.line">
-        <field name="name">Taxable Purchase VAT Exempt</field>
-        <field name="tag_name">Taxable Purchase VAT Exempt</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_purch_vt"/>
-    </record>
-
-    <record id="account_tax_report_purch_vt_ratd_0" model="account.tax.report.line">
-        <field name="name">Taxable Purchase VAT Rated 0%</field>
-        <field name="tag_name">Taxable Purchase VAT Rated 0%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_purch_vt"/>
-    </record>
-
-    <record id="account_tax_report_purch_vt_ratd_15" model="account.tax.report.line">
-        <field name="name">Taxable Purchase VAT Rated 15%</field>
-        <field name="tag_name">Taxable Purchase VAT Rated 15%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_purch_vt"/>
-    </record>
-
-    <record id="account_tax_report_purch_withholding" model="account.tax.report.line">
-        <field name="name">Taxable Purchases - Witholding</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_purch_withholding_2" model="account.tax.report.line">
-        <field name="name">Taxable 2% Withholding on Purchases</field>
-        <field name="tag_name">Taxable 2% Withholding on Purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_purch_withholding"/>
-    </record>
-
-    <record id="account_tax_report_purch_withholding_35" model="account.tax.report.line">
-        <field name="name">Taxable 35% Withholding on Purchases</field>
-        <field name="tag_name">Taxable 35% Withholding on Purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_purch_withholding"/>
-    </record>
-
-    <record id="account_tax_report_sale_vat" model="account.tax.report.line">
-        <field name="name">Taxable Sales - VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="account_tax_report_sale_vat_out_scope" model="account.tax.report.line">
-        <field name="name">Taxable Sales VAT Out of Scope (Sales)</field>
-        <field name="tag_name">Taxable Sales VAT Out of Scope (Sales)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_sale_vat"/>
-    </record>
-
-    <record id="account_tax_report_sale_vat_exmpt" model="account.tax.report.line">
-        <field name="name">Taxable Sales VAT Exempt</field>
-        <field name="tag_name">Taxable Sales VAT Exempt</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_sale_vat"/>
-    </record>
-
-    <record id="account_tax_report_sale_vat_rated_0" model="account.tax.report.line">
-        <field name="name">Taxable Sales VAT Rated 0%</field>
-        <field name="tag_name">Taxable Sales VAT Rated 0%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_sale_vat"/>
-    </record>
-
-    <record id="account_tax_report_sale_vat_rated_15" model="account.tax.report.line">
-        <field name="name">Taxable Sales VAT Rated 15%</field>
-        <field name="tag_name">Taxable Sales VAT Rated 15%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_sale_vat"/>
-    </record>
-
-    <record id="account_tax_report_sale_withholding" model="account.tax.report.line">
-        <field name="name">Taxable Sales - Withholding</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="account_tax_report_sale_withholding_2" model="account.tax.report.line">
-        <field name="name">Taxable 2% Withholding on Sales</field>
-        <field name="tag_name">Taxable 2% Withholding on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_sale_withholding"/>
-    </record>
-
-    <record id="account_tax_report_sale_withholding_35" model="account.tax.report.line">
-        <field name="name">Taxable 35% Withholding on Sales</field>
-        <field name="tag_name">Taxable 35% Withholding on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_sale_withholding"/>
-    </record>
-
-    <record id="account_tax_report_sale_vat_withholding" model="account.tax.report.line">
-        <field name="name">Taxable VAT Withholding on Sales</field>
-        <field name="tag_name">Taxable VAT Withholding on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_sale_withholding"/>
-    </record>
-
-    <record id="account_tax_report_net_vat" model="account.tax.report.line">
-        <field name="name">Net VAT to be Paid/Reclaimed</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="account_tax_report_purch_vat" model="account.tax.report.line">
-        <field name="name">Purchase VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_net_vat"/>
-    </record>
-
-    <record id="account_tax_report_purch_vat_rated_15" model="account.tax.report.line">
-        <field name="name">Purchase VAT Rated 15%</field>
-        <field name="tag_name">Purchase VAT Rated 15%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_purch_vat"/>
-    </record>
-
-    <record id="account_tax_report_net_sale_vat" model="account.tax.report.line">
-        <field name="name">Sales VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_net_vat"/>
-    </record>
-
-    <record id="account_tax_report_net_sale_vat_15" model="account.tax.report.line">
-        <field name="name">Sales VAT Rated 15%</field>
-        <field name="tag_name">Sales VAT Rated 15%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_net_sale_vat"/>
-    </record>
-
-    <record id="account_tax_report_net_purch_witholding" model="account.tax.report.line">
-        <field name="name">Withholding on Purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="account_tax_report_net_purch_witholding_2" model="account.tax.report.line">
-        <field name="name">2% Withholding on Purchases</field>
-        <field name="tag_name">2% Withholding on Purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_net_purch_witholding"/>
-    </record>
-
-    <record id="account_tax_report_net_purch_witholding_35" model="account.tax.report.line">
-        <field name="name">35% Withholding on Purchases</field>
-        <field name="tag_name">35% Withholding on Purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_net_purch_witholding"/>
-    </record>
-
-    <record id="account_tax_report_net_sale_witholding" model="account.tax.report.line">
-        <field name="name">Withholding on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="account_tax_report_net_sale_witheld_2" model="account.tax.report.line">
-        <field name="name">2% Withheld on Sales</field>
-        <field name="tag_name">2% Withheld on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_net_sale_witholding"/>
-    </record>
-
-    <record id="account_tax_report_net_sale_witheld_35" model="account.tax.report.line">
-        <field name="name">35% Withheld on Sales</field>
-        <field name="tag_name">35% Withheld on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_net_sale_witholding"/>
-    </record>
-
-    <record id="account_tax_report_net_sale_vat_witheld" model="account.tax.report.line">
-        <field name="name">VAT Withheld on Sales</field>
-        <field name="tag_name">VAT Withheld on Sales</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_net_sale_witholding"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_fi/data/account_tax_report_line.xml
+++ b/addons/l10n_fi/data/account_tax_report_line.xml
@@ -3,131 +3,111 @@
     <record id="vat_report" model="account.tax.report">
         <field name="name">VAT Report</field>
         <field name="country_id" ref="base.fi"/>
-    </record>
-
-    <record id="tax_report_sales_title" model="account.tax.report.line">
-        <field name="name">Vero kotimaan myynneistä verokannoittain</field>
-        <field name="sequence">0</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_sales_24" model="account.tax.report.line">
-        <field name="name">24 %:n vero</field>
-        <field name="code">sale_24</field>
-        <field name="tag_name">fi_301</field>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="vat_report"/>
-        <field name="parent_id" ref="tax_report_sales_title"/>
-    </record>
-    <record id="tax_report_sales_14" model="account.tax.report.line">
-        <field name="name">14 %:n vero</field>
-        <field name="code">sale_14</field>
-        <field name="tag_name">fi_302</field>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="vat_report"/>
-        <field name="parent_id" ref="tax_report_sales_title"/>
-    </record>
-    <record id="tax_report_sales_10" model="account.tax.report.line">
-        <field name="name">10 %:n vero</field>
-        <field name="code">sale_10</field>
-        <field name="tag_name">fi_303</field>
-        <field name="sequence">3</field>
-        <field name="report_id" ref="vat_report"/>
-        <field name="parent_id" ref="tax_report_sales_title"/>
-    </record>
-    <record id="tax_report_tax_purchase_goods_eu" model="account.tax.report.line">
-        <field name="name">Vero tavaraostoista muista EU-maista</field>
-        <field name="code">goods_eu</field>
-        <field name="tag_name">fi_305</field>
-        <field name="sequence">4</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_tax_purchase_service_eu" model="account.tax.report.line">
-        <field name="name">Vero palveluostoista muista EU-maista</field>
-        <field name="code">service_eu</field>
-        <field name="tag_name">fi_tax_306</field>
-        <field name="sequence">5</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_tax_import_goods_no_eu" model="account.tax.report.line">
-        <field name="name">Vero tavaroiden maahantuonneista EU:n ulkopuolelta</field>
-        <field name="code">goods_no_eu</field>
-        <field name="tag_name">fi_340</field>
-        <field name="sequence">6</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_tax_purchase_construct_service" model="account.tax.report.line">
-        <field name="name">Vero rakentamispalvelun ja metalliromun ostoista (käännetty verovelvollisuus)</field>
-        <field name="code">construct</field>
-        <field name="tag_name">fi_318</field>
-        <field name="sequence">7</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_deductible" model="account.tax.report.line">
-        <field name="name">Verokauden vähennettävä vero</field>
-        <field name="code">deductible</field>
-        <field name="tag_name">fi_307</field>
-        <field name="sequence">8</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="vat_report_relief" model="account.tax.report.line">
-        <field name="name">Alarajahuojennuksen määrä</field>
-        <field name="tag_name">fi_vat_relief</field>
-        <field name="sequence">9</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_tax_payable" model="account.tax.report.line">
-        <field name="name">Maksettava vero / Palautukseen oikeuttava vero (-)</field>
-        <field name="formula">sale_24 + sale_14 + sale_10 + goods_eu + service_eu + goods_no_eu + construct - deductible</field>
-        <field name="sequence">10</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="tax_report_base_turnover_0_vat" model="account.tax.report.line">
-        <field name="name">0-verokannan alainen liikevaihto</field>
-        <field name="tag_name">fi_304</field>
-        <field name="sequence">11</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_sales_goods_eu" model="account.tax.report.line">
-        <field name="name">Tavaroiden myynnit muihin EU-maihin</field>
-        <field name="tag_name">fi_311</field>
-        <field name="sequence">12</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_sales_service_eu" model="account.tax.report.line">
-        <field name="name">Palvelujen myynnit muihin EU-maihin</field>
-        <field name="tag_name">fi_312</field>
-        <field name="sequence">13</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_purchase_goods_eu" model="account.tax.report.line">
-        <field name="name">Tavaraostot muista EU-maista</field>
-        <field name="tag_name">fi_base_purchase_goods_eu</field>
-        <field name="sequence">14</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_purchase_service_eu" model="account.tax.report.line">
-        <field name="name">Palveluostot muista EU-maista</field>
-        <field name="tag_name">fi_base_306</field>
-        <field name="sequence">15</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_import_goods_no_eu" model="account.tax.report.line">
-        <field name="name">Tavaroiden maahantuonnit EU:n ulkopuolelta</field>
-        <field name="tag_name">fi_base_340</field>
-        <field name="sequence">16</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_sales_construct_service" model="account.tax.report.line">
-        <field name="name">Rakentamispalvelun ja metalliromun myynnit (käännetty verovelvollisuus)</field>
-        <field name="tag_name">fi_319</field>
-        <field name="sequence">17</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-    <record id="tax_report_base_purchase_construct_service" model="account.tax.report.line">
-        <field name="name">Rakentamispalvelun ja metalliromun ostot (käännetty verovelvollisuus)</field>
-        <field name="tag_name">fi_base_318</field>
-        <field name="sequence">18</field>
-        <field name="report_id" ref="vat_report"/>
+        <field name="root_line_ids">
+            <record id="tax_report_sales_title" model="account.tax.report.line">
+                <field name="name">Vero kotimaan myynneistä verokannoittain</field>
+                <field name="sequence">0</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_sales_24" model="account.tax.report.line">
+                        <field name="name">24 %:n vero</field>
+                        <field name="code">sale_24</field>
+                        <field name="tag_name">fi_301</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_sales_14" model="account.tax.report.line">
+                        <field name="name">14 %:n vero</field>
+                        <field name="code">sale_14</field>
+                        <field name="tag_name">fi_302</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_sales_10" model="account.tax.report.line">
+                        <field name="name">10 %:n vero</field>
+                        <field name="code">sale_10</field>
+                        <field name="tag_name">fi_303</field>
+                        <field name="sequence">3</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_tax_purchase_goods_eu" model="account.tax.report.line">
+                <field name="name">Vero tavaraostoista muista EU-maista</field>
+                <field name="code">goods_eu</field>
+                <field name="tag_name">fi_305</field>
+                <field name="sequence">4</field>
+            </record>
+            <record id="tax_report_tax_purchase_service_eu" model="account.tax.report.line">
+                <field name="name">Vero palveluostoista muista EU-maista</field>
+                <field name="code">service_eu</field>
+                <field name="tag_name">fi_tax_306</field>
+                <field name="sequence">5</field>
+            </record>
+            <record id="tax_report_tax_import_goods_no_eu" model="account.tax.report.line">
+                <field name="name">Vero tavaroiden maahantuonneista EU:n ulkopuolelta</field>
+                <field name="code">goods_no_eu</field>
+                <field name="tag_name">fi_340</field>
+                <field name="sequence">6</field>
+            </record>
+            <record id="tax_report_tax_purchase_construct_service" model="account.tax.report.line">
+                <field name="name">Vero rakentamispalvelun ja metalliromun ostoista (käännetty verovelvollisuus)</field>
+                <field name="code">construct</field>
+                <field name="tag_name">fi_318</field>
+                <field name="sequence">7</field>
+            </record>
+            <record id="tax_report_deductible" model="account.tax.report.line">
+                <field name="name">Verokauden vähennettävä vero</field>
+                <field name="code">deductible</field>
+                <field name="tag_name">fi_307</field>
+                <field name="sequence">8</field>
+            </record>
+            <record id="vat_report_relief" model="account.tax.report.line">
+                <field name="name">Alarajahuojennuksen määrä</field>
+                <field name="tag_name">fi_vat_relief</field>
+                <field name="sequence">9</field>
+            </record>
+            <record id="tax_report_tax_payable" model="account.tax.report.line">
+                <field name="name">Maksettava vero / Palautukseen oikeuttava vero (-)</field>
+                <field name="formula">sale_24 + sale_14 + sale_10 + goods_eu + service_eu + goods_no_eu + construct - deductible</field>
+                <field name="sequence">10</field>
+            </record>
+            <record id="tax_report_base_turnover_0_vat" model="account.tax.report.line">
+                <field name="name">0-verokannan alainen liikevaihto</field>
+                <field name="tag_name">fi_304</field>
+                <field name="sequence">11</field>
+            </record>
+            <record id="tax_report_base_sales_goods_eu" model="account.tax.report.line">
+                <field name="name">Tavaroiden myynnit muihin EU-maihin</field>
+                <field name="tag_name">fi_311</field>
+                <field name="sequence">12</field>
+            </record>
+            <record id="tax_report_base_sales_service_eu" model="account.tax.report.line">
+                <field name="name">Palvelujen myynnit muihin EU-maihin</field>
+                <field name="tag_name">fi_312</field>
+                <field name="sequence">13</field>
+            </record>
+            <record id="tax_report_base_purchase_goods_eu" model="account.tax.report.line">
+                <field name="name">Tavaraostot muista EU-maista</field>
+                <field name="tag_name">fi_base_purchase_goods_eu</field>
+                <field name="sequence">14</field>
+            </record>
+            <record id="tax_report_base_purchase_service_eu" model="account.tax.report.line">
+                <field name="name">Palveluostot muista EU-maista</field>
+                <field name="tag_name">fi_base_306</field>
+                <field name="sequence">15</field>
+            </record>
+            <record id="tax_report_base_import_goods_no_eu" model="account.tax.report.line">
+                <field name="name">Tavaroiden maahantuonnit EU:n ulkopuolelta</field>
+                <field name="tag_name">fi_base_340</field>
+                <field name="sequence">16</field>
+            </record>
+            <record id="tax_report_base_sales_construct_service" model="account.tax.report.line">
+                <field name="name">Rakentamispalvelun ja metalliromun myynnit (käännetty verovelvollisuus)</field>
+                <field name="tag_name">fi_319</field>
+                <field name="sequence">17</field>
+            </record>
+            <record id="tax_report_base_purchase_construct_service" model="account.tax.report.line">
+                <field name="name">Rakentamispalvelun ja metalliromun ostot (käännetty verovelvollisuus)</field>
+                <field name="tag_name">fi_base_318</field>
+                <field name="sequence">18</field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -1,542 +1,390 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.fr"/>
-    </record>
-
-    <record id="tax_report_montant_op_realisees" model="account.tax.report.line">
-        <field name="name">A. Montant des opérations réalisées</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_op_imposables_ht" model="account.tax.report.line">
-        <field name="name">Opérations imposables (H.T.)</field>
-        <field name="parent_id" ref="tax_report_montant_op_realisees"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_01" model="account.tax.report.line">
-        <field name="name">01 - Ventes, prestations de services</field>
-        <field name="tag_name">01</field>
-        <field name="code">box_01</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_02" model="account.tax.report.line">
-        <field name="name">02 - Autres opérations imposables</field>
-        <field name="tag_name">02</field>
-        <field name="code">box_02</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_2A" model="account.tax.report.line">
-        <field name="name">2A - Achats de prestations de services intracommunautaires</field>
-        <field name="tag_name">2A</field>
-        <field name="code">box_2A</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_2B" model="account.tax.report.line">
-        <field name="name">2B - Importations</field>
-        <field name="tag_name">2B</field>
-        <field name="code">box_2B</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_03" model="account.tax.report.line">
-        <field name="name">03 - Acquisitions intracommunautaires</field>
-        <field name="tag_name">03</field>
-        <field name="code">box_03</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_3A" model="account.tax.report.line">
-        <field name="name">3A - Livraisons d'électricité, de gaz naturel, de chaleur ou de froid imposables en France
+        <field name="root_line_ids">
+            <record id="tax_report_montant_op_realisees" model="account.tax.report.line">
+                <field name="name">A. Montant des opérations réalisées</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_op_imposables_ht" model="account.tax.report.line">
+                        <field name="name">Opérations imposables (H.T.)</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_01" model="account.tax.report.line">
+                                <field name="name">01 - Ventes, prestations de services</field>
+                                <field name="tag_name">01</field>
+                                <field name="code">box_01</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_02" model="account.tax.report.line">
+                                <field name="name">02 - Autres opérations imposables</field>
+                                <field name="tag_name">02</field>
+                                <field name="code">box_02</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_2A" model="account.tax.report.line">
+                                <field name="name">2A - Achats de prestations de services intracommunautaires</field>
+                                <field name="tag_name">2A</field>
+                                <field name="code">box_2A</field>
+                                <field name="sequence">3</field>
+                            </record>
+                            <record id="tax_report_2B" model="account.tax.report.line">
+                                <field name="name">2B - Importations</field>
+                                <field name="tag_name">2B</field>
+                                <field name="code">box_2B</field>
+                                <field name="sequence">4</field>
+                            </record>
+                            <record id="tax_report_03" model="account.tax.report.line">
+                                <field name="name">03 - Acquisitions intracommunautaires</field>
+                                <field name="tag_name">03</field>
+                                <field name="code">box_03</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_3A" model="account.tax.report.line">
+                                <field name="name">3A - Livraisons d'électricité, de gaz naturel, de chaleur ou de froid imposables en France
         </field>
-        <field name="tag_name">3A</field>
-        <field name="code">box_3A</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-    </record>
-
-    <record id="tax_report_3B" model="account.tax.report.line">
-        <field name="name">3B - Achats de bien ou de prestations de services réalisés auprès d'un assujetti non établi
+                                <field name="tag_name">3A</field>
+                                <field name="code">box_3A</field>
+                                <field name="sequence">6</field>
+                            </record>
+                            <record id="tax_report_3B" model="account.tax.report.line">
+                                <field name="name">3B - Achats de bien ou de prestations de services réalisés auprès d'un assujetti non établi
             en
             France
         </field>
-        <field name="tag_name">3B</field>
-        <field name="code">box_3B</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">7</field>
-    </record>
-
-    <record id="tax_report_3C" model="account.tax.report.line">
-        <field name="name">3C - Régularisations</field>
-        <field name="tag_name">3C</field>
-        <field name="code">box_3C</field>
-        <field name="parent_id" ref="tax_report_op_imposables_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">8</field>
-    </record>
-
-    <record id="tax_report_op_non_imposables" model="account.tax.report.line">
-        <field name="name">Opérations Non Imposables</field>
-        <field name="parent_id" ref="tax_report_montant_op_realisees"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_04" model="account.tax.report.line">
-        <field name="name">04 - Exportations hors UE</field>
-        <field name="tag_name">04</field>
-        <field name="code">box_04</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_05" model="account.tax.report.line">
-        <field name="name">05 - Autres opérations non imposables</field>
-        <field name="tag_name">05</field>
-        <field name="code">box_05</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_5A" model="account.tax.report.line">
-        <field name="name">5A - Ventes à distance taxables dans un autre État membre au profit des personnes non
+                                <field name="tag_name">3B</field>
+                                <field name="code">box_3B</field>
+                                <field name="sequence">7</field>
+                            </record>
+                            <record id="tax_report_3C" model="account.tax.report.line">
+                                <field name="name">3C - Régularisations</field>
+                                <field name="tag_name">3C</field>
+                                <field name="code">box_3C</field>
+                                <field name="sequence">8</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_op_non_imposables" model="account.tax.report.line">
+                        <field name="name">Opérations Non Imposables</field>
+                        <field name="sequence">2</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_04" model="account.tax.report.line">
+                                <field name="name">04 - Exportations hors UE</field>
+                                <field name="tag_name">04</field>
+                                <field name="code">box_04</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_05" model="account.tax.report.line">
+                                <field name="name">05 - Autres opérations non imposables</field>
+                                <field name="tag_name">05</field>
+                                <field name="code">box_05</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_5A" model="account.tax.report.line">
+                                <field name="name">5A - Ventes à distance taxables dans un autre État membre au profit des personnes non
             assujetties - Ventes BtoC
         </field>
-        <field name="tag_name">5A</field>
-        <field name="code">box_5A</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_06" model="account.tax.report.line">
-        <field name="name">06 - Livraisons intracommunautaires à destination d'une personne assujettie - Ventes BtoB
+                                <field name="tag_name">5A</field>
+                                <field name="code">box_5A</field>
+                                <field name="sequence">3</field>
+                            </record>
+                            <record id="tax_report_06" model="account.tax.report.line">
+                                <field name="name">06 - Livraisons intracommunautaires à destination d'une personne assujettie - Ventes BtoB
         </field>
-        <field name="tag_name">06</field>
-        <field name="code">box_06</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_07" model="account.tax.report.line">
-        <field name="name">07 - Achats en franchise</field>
-        <field name="tag_name">07</field>
-        <field name="code">box_07</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_7A" model="account.tax.report.line">
-        <field name="name">7A - Ventes de biens ou prestations de services réalisées par un assujetti non établi en
+                                <field name="tag_name">06</field>
+                                <field name="code">box_06</field>
+                                <field name="sequence">4</field>
+                            </record>
+                            <record id="tax_report_07" model="account.tax.report.line">
+                                <field name="name">07 - Achats en franchise</field>
+                                <field name="tag_name">07</field>
+                                <field name="code">box_07</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_7A" model="account.tax.report.line">
+                                <field name="name">7A - Ventes de biens ou prestations de services réalisées par un assujetti non établi en
             France
         </field>
-        <field name="tag_name">7A</field>
-        <field name="code">box_7A</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-    </record>
-
-    <record id="tax_report_7B" model="account.tax.report.line">
-        <field name="name">7B - Régularisations</field>
-        <field name="tag_name">7B</field>
-        <field name="code">box_7B</field>
-        <field name="parent_id" ref="tax_report_op_non_imposables"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">7</field>
-    </record>
-
-    <record id="tax_report_decompte_tva" model="account.tax.report.line">
-        <field name="name">B. Décompte de la TVA à payer</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_tva_brute" model="account.tax.report.line">
-        <field name="name">TVA Brute</field>
-        <field name="parent_id" ref="tax_report_decompte_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_08_base" model="account.tax.report.line">
-        <field name="name">08 - Taux normal 20 % (base)</field>
-        <field name="tag_name">08_base</field>
-        <field name="code">box_08_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-    <record id="tax_report_08_taxe" model="account.tax.report.line">
-        <field name="name">08 - Taux normal 20 % (taxe)</field>
-        <field name="tag_name">08_taxe</field>
-        <field name="code">box_08_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_09_base" model="account.tax.report.line">
-        <field name="name">09 - Taux réduit 5,5 % (base)</field>
-        <field name="tag_name">09_base</field>
-        <field name="code">box_09_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-    <record id="tax_report_09_taxe" model="account.tax.report.line">
-        <field name="name">09 - Taux réduit 5,5 % (taxe)</field>
-        <field name="tag_name">09_taxe</field>
-        <field name="code">box_09_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_9B_base" model="account.tax.report.line">
-        <field name="name">9B - Taux réduit 10 % (base)</field>
-        <field name="tag_name">9B_base</field>
-        <field name="code">box_9B_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-    </record>
-    <record id="tax_report_9B_taxe" model="account.tax.report.line">
-        <field name="name">9B - Taux réduit 10 % (taxe)</field>
-        <field name="tag_name">9B_taxe</field>
-        <field name="code">box_9B_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-    </record>
-
-    <record id="tax_report_10_base" model="account.tax.report.line">
-        <field name="name">10 - Taux normal 8,5 % (base)</field>
-        <field name="tag_name">10_base</field>
-        <field name="code">box_10_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">7</field>
-    </record>
-    <record id="tax_report_10_taxe" model="account.tax.report.line">
-        <field name="name">10 - Taux normal 8,5 % (taxe)</field>
-        <field name="tag_name">10_taxe</field>
-        <field name="code">box_10_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">8</field>
-    </record>
-
-    <record id="tax_report_11_base" model="account.tax.report.line">
-        <field name="name">11 - Taux normal 2,1 % (base)</field>
-        <field name="tag_name">11_base</field>
-        <field name="code">box_11_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">9</field>
-    </record>
-    <record id="tax_report_11_taxe" model="account.tax.report.line">
-        <field name="name">11 - Taux normal 2,1 % (taxe)</field>
-        <field name="tag_name">11_taxe</field>
-        <field name="code">box_11_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">10</field>
-    </record>
-
-    <record id="tax_report_13_base" model="account.tax.report.line">
-        <field name="name">13 - Anciens taux (base)</field>
-        <field name="tag_name">13_base</field>
-        <field name="code">box_13_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">11</field>
-    </record>
-    <record id="tax_report_13_taxe" model="account.tax.report.line">
-        <field name="name">13 - Anciens taux (taxe)</field>
-        <field name="tag_name">13_taxe</field>
-        <field name="code">box_13_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">12</field>
-    </record>
-
-    <record id="tax_report_14_base" model="account.tax.report.line">
-        <field name="name">14 - Opérations imposables à un taux particulier (base)</field>
-        <field name="tag_name">14_base</field>
-        <field name="code">box_14_base</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">13</field>
-    </record>
-    <record id="tax_report_14_taxe" model="account.tax.report.line">
-        <field name="name">14 - Opérations imposables à un taux particulier (taxe)</field>
-        <field name="tag_name">14_taxe</field>
-        <field name="code">box_14_taxe</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">14</field>
-    </record>
-
-    <record id="tax_report_15" model="account.tax.report.line">
-        <field name="name">15 - TVA antérieurement déduite à reverser</field>
-        <field name="tag_name">15</field>
-        <field name="code">box_15</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">15</field>
-    </record>
-
-    <record id="tax_report_5B" model="account.tax.report.line">
-        <field name="name">5B - Sommes à ajouter, y compris acompte congés</field>
-        <field name="tag_name">5B</field>
-        <field name="code">box_5B</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">16</field>
-    </record>
-
-    <record id="tax_report_16" model="account.tax.report.line">
-        <field name="name">16 - Total de la TVA brute due</field>
-        <field name="code">box_16</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">17</field>
-        <field name="formula">box_08_taxe + box_09_taxe + box_9B_taxe + box_10_taxe + box_11_taxe + box_13_taxe + box_14_taxe + box_15 + box_5B</field>
-    </record>
-
-    <record id="tax_report_7C" model="account.tax.report.line">
-        <field name="name">7C - Dont TVA sur importations bénéficiant du dispositif d'autoliquidation</field>
-        <field name="tag_name">7C</field>
-        <field name="code">box_7C</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">18</field>
-    </record>
-
-    <record id="tax_report_17" model="account.tax.report.line">
-        <field name="name">17 - Dont TVA sur acquisitions intracommunautaires</field>
-        <field name="tag_name">17</field>
-        <field name="code">box_17</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">19</field>
-    </record>
-
-    <record id="tax_report_18" model="account.tax.report.line">
-        <field name="name">18 - Dont TVA sur opérations à destination de Monaco</field>
-        <field name="tag_name">18</field>
-        <field name="code">box_18</field>
-        <field name="parent_id" ref="tax_report_tva_brute"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">20</field>
-    </record>
-
-    <record id="tax_report_tva_deductible" model="account.tax.report.line">
-        <field name="name">TVA Déductible</field>
-        <field name="parent_id" ref="tax_report_decompte_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_19" model="account.tax.report.line">
-        <field name="name">19 - Biens constituant des immobilisations</field>
-        <field name="tag_name">19</field>
-        <field name="code">box_19</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_20" model="account.tax.report.line">
-        <field name="name">20 - Autres bien et services</field>
-        <field name="tag_name">20</field>
-        <field name="code">box_20</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_21" model="account.tax.report.line">
-        <field name="name">21 - Autre TVA à déduire</field>
-        <field name="tag_name">21</field>
-        <field name="code">box_21</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_22" model="account.tax.report.line">
-        <field name="name">22 - Report du crédit apparaissant ligne 27 de la précédente déclaration</field>
-        <field name="tag_name">22</field>
-        <field name="code">box_22</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="is_carryover_used_in_balance">True</field>
-    </record>
-
-    <record id="tax_report_2C" model="account.tax.report.line">
-        <field name="name">2C - Sommes à imputer, y compris acompte congés</field>
-        <field name="tag_name">2C</field>
-        <field name="code">box_2C</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_22A" model="account.tax.report.line">
-        <field name="name">22A - Indiquer le coefficient de taxation unique applicable pour la période s'il est
+                                <field name="tag_name">7A</field>
+                                <field name="code">box_7A</field>
+                                <field name="sequence">6</field>
+                            </record>
+                            <record id="tax_report_7B" model="account.tax.report.line">
+                                <field name="name">7B - Régularisations</field>
+                                <field name="tag_name">7B</field>
+                                <field name="code">box_7B</field>
+                                <field name="sequence">7</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_decompte_tva" model="account.tax.report.line">
+                <field name="name">B. Décompte de la TVA à payer</field>
+                <field name="sequence">2</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_tva_brute" model="account.tax.report.line">
+                        <field name="name">TVA Brute</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_08_base" model="account.tax.report.line">
+                                <field name="name">08 - Taux normal 20 % (base)</field>
+                                <field name="tag_name">08_base</field>
+                                <field name="code">box_08_base</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_08_taxe" model="account.tax.report.line">
+                                <field name="name">08 - Taux normal 20 % (taxe)</field>
+                                <field name="tag_name">08_taxe</field>
+                                <field name="code">box_08_taxe</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_09_base" model="account.tax.report.line">
+                                <field name="name">09 - Taux réduit 5,5 % (base)</field>
+                                <field name="tag_name">09_base</field>
+                                <field name="code">box_09_base</field>
+                                <field name="sequence">3</field>
+                            </record>
+                            <record id="tax_report_09_taxe" model="account.tax.report.line">
+                                <field name="name">09 - Taux réduit 5,5 % (taxe)</field>
+                                <field name="tag_name">09_taxe</field>
+                                <field name="code">box_09_taxe</field>
+                                <field name="sequence">4</field>
+                            </record>
+                            <record id="tax_report_9B_base" model="account.tax.report.line">
+                                <field name="name">9B - Taux réduit 10 % (base)</field>
+                                <field name="tag_name">9B_base</field>
+                                <field name="code">box_9B_base</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_9B_taxe" model="account.tax.report.line">
+                                <field name="name">9B - Taux réduit 10 % (taxe)</field>
+                                <field name="tag_name">9B_taxe</field>
+                                <field name="code">box_9B_taxe</field>
+                                <field name="sequence">6</field>
+                            </record>
+                            <record id="tax_report_10_base" model="account.tax.report.line">
+                                <field name="name">10 - Taux normal 8,5 % (base)</field>
+                                <field name="tag_name">10_base</field>
+                                <field name="code">box_10_base</field>
+                                <field name="sequence">7</field>
+                            </record>
+                            <record id="tax_report_10_taxe" model="account.tax.report.line">
+                                <field name="name">10 - Taux normal 8,5 % (taxe)</field>
+                                <field name="tag_name">10_taxe</field>
+                                <field name="code">box_10_taxe</field>
+                                <field name="sequence">8</field>
+                            </record>
+                            <record id="tax_report_11_base" model="account.tax.report.line">
+                                <field name="name">11 - Taux normal 2,1 % (base)</field>
+                                <field name="tag_name">11_base</field>
+                                <field name="code">box_11_base</field>
+                                <field name="sequence">9</field>
+                            </record>
+                            <record id="tax_report_11_taxe" model="account.tax.report.line">
+                                <field name="name">11 - Taux normal 2,1 % (taxe)</field>
+                                <field name="tag_name">11_taxe</field>
+                                <field name="code">box_11_taxe</field>
+                                <field name="sequence">10</field>
+                            </record>
+                            <record id="tax_report_13_base" model="account.tax.report.line">
+                                <field name="name">13 - Anciens taux (base)</field>
+                                <field name="tag_name">13_base</field>
+                                <field name="code">box_13_base</field>
+                                <field name="sequence">11</field>
+                            </record>
+                            <record id="tax_report_13_taxe" model="account.tax.report.line">
+                                <field name="name">13 - Anciens taux (taxe)</field>
+                                <field name="tag_name">13_taxe</field>
+                                <field name="code">box_13_taxe</field>
+                                <field name="sequence">12</field>
+                            </record>
+                            <record id="tax_report_14_base" model="account.tax.report.line">
+                                <field name="name">14 - Opérations imposables à un taux particulier (base)</field>
+                                <field name="tag_name">14_base</field>
+                                <field name="code">box_14_base</field>
+                                <field name="sequence">13</field>
+                            </record>
+                            <record id="tax_report_14_taxe" model="account.tax.report.line">
+                                <field name="name">14 - Opérations imposables à un taux particulier (taxe)</field>
+                                <field name="tag_name">14_taxe</field>
+                                <field name="code">box_14_taxe</field>
+                                <field name="sequence">14</field>
+                            </record>
+                            <record id="tax_report_15" model="account.tax.report.line">
+                                <field name="name">15 - TVA antérieurement déduite à reverser</field>
+                                <field name="tag_name">15</field>
+                                <field name="code">box_15</field>
+                                <field name="sequence">15</field>
+                            </record>
+                            <record id="tax_report_5B" model="account.tax.report.line">
+                                <field name="name">5B - Sommes à ajouter, y compris acompte congés</field>
+                                <field name="tag_name">5B</field>
+                                <field name="code">box_5B</field>
+                                <field name="sequence">16</field>
+                            </record>
+                            <record id="tax_report_16" model="account.tax.report.line">
+                                <field name="name">16 - Total de la TVA brute due</field>
+                                <field name="code">box_16</field>
+                                <field name="sequence">17</field>
+                                <field name="formula">box_08_taxe + box_09_taxe + box_9B_taxe + box_10_taxe + box_11_taxe + box_13_taxe + box_14_taxe + box_15 + box_5B</field>
+                            </record>
+                            <record id="tax_report_7C" model="account.tax.report.line">
+                                <field name="name">7C - Dont TVA sur importations bénéficiant du dispositif d'autoliquidation</field>
+                                <field name="tag_name">7C</field>
+                                <field name="code">box_7C</field>
+                                <field name="sequence">18</field>
+                            </record>
+                            <record id="tax_report_17" model="account.tax.report.line">
+                                <field name="name">17 - Dont TVA sur acquisitions intracommunautaires</field>
+                                <field name="tag_name">17</field>
+                                <field name="code">box_17</field>
+                                <field name="sequence">19</field>
+                            </record>
+                            <record id="tax_report_18" model="account.tax.report.line">
+                                <field name="name">18 - Dont TVA sur opérations à destination de Monaco</field>
+                                <field name="tag_name">18</field>
+                                <field name="code">box_18</field>
+                                <field name="sequence">20</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_tva_deductible" model="account.tax.report.line">
+                        <field name="name">TVA Déductible</field>
+                        <field name="sequence">2</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_19" model="account.tax.report.line">
+                                <field name="name">19 - Biens constituant des immobilisations</field>
+                                <field name="tag_name">19</field>
+                                <field name="code">box_19</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_20" model="account.tax.report.line">
+                                <field name="name">20 - Autres bien et services</field>
+                                <field name="tag_name">20</field>
+                                <field name="code">box_20</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_21" model="account.tax.report.line">
+                                <field name="name">21 - Autre TVA à déduire</field>
+                                <field name="tag_name">21</field>
+                                <field name="code">box_21</field>
+                                <field name="sequence">3</field>
+                            </record>
+                            <record id="tax_report_22" model="account.tax.report.line">
+                                <field name="name">22 - Report du crédit apparaissant ligne 27 de la précédente déclaration</field>
+                                <field name="tag_name">22</field>
+                                <field name="code">box_22</field>
+                                <field name="sequence">4</field>
+                                <field name="is_carryover_used_in_balance">True</field>
+                            </record>
+                            <record id="tax_report_2C" model="account.tax.report.line">
+                                <field name="name">2C - Sommes à imputer, y compris acompte congés</field>
+                                <field name="tag_name">2C</field>
+                                <field name="code">box_2C</field>
+                                <field name="sequence">5</field>
+                            </record>
+                            <record id="tax_report_22A" model="account.tax.report.line">
+                                <field name="name">22A - Indiquer le coefficient de taxation unique applicable pour la période s'il est
             différent de 100 %
         </field>
-        <field name="tag_name">22A</field>
-        <field name="code">box_22A</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">6</field>
-    </record>
-
-    <record id="tax_report_23" model="account.tax.report.line">
-        <field name="name">23 - Total TVA déductible</field>
-        <field name="code">box_23</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">7</field>
-        <field name="formula">box_19 + box_20 + box_21 + box_22 + box_2C</field>
-    </record>
-
-    <record id="tax_report_24" model="account.tax.report.line">
-        <field name="name">24 - Dont TVA déductible sur importations</field>
-        <field name="tag_name">24</field>
-        <field name="code">box_24</field>
-        <field name="parent_id" ref="tax_report_tva_deductible"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">8</field>
-    </record>
-
-    <record id="tax_report_credit" model="account.tax.report.line">
-        <field name="name">Crédit</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_25" model="account.tax.report.line">
-        <field name="name">25 - Crédit de TVA</field>
-        <field name="code">box_25</field>
-        <field name="parent_id" ref="tax_report_credit"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="formula">box_23 - box_16 if box_23 - box_16 > 0 else 0</field>
-    </record>
-
-    <record id="tax_report_26" model="account.tax.report.line">
-        <field name="name">26 - Remboursement de crédit demandé sur formulaire n°3519 joint</field>
-        <field name="tag_name">26</field>
-        <field name="code">box_26</field>
-        <field name="parent_id" ref="tax_report_credit"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_AA" model="account.tax.report.line">
-        <field name="name">AA - Crédit de TVA transféré à la société tête de groupe sur la déclaration récapitulative
+                                <field name="tag_name">22A</field>
+                                <field name="code">box_22A</field>
+                                <field name="sequence">6</field>
+                            </record>
+                            <record id="tax_report_23" model="account.tax.report.line">
+                                <field name="name">23 - Total TVA déductible</field>
+                                <field name="code">box_23</field>
+                                <field name="sequence">7</field>
+                                <field name="formula">box_19 + box_20 + box_21 + box_22 + box_2C</field>
+                            </record>
+                            <record id="tax_report_24" model="account.tax.report.line">
+                                <field name="name">24 - Dont TVA déductible sur importations</field>
+                                <field name="tag_name">24</field>
+                                <field name="code">box_24</field>
+                                <field name="sequence">8</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_credit" model="account.tax.report.line">
+                <field name="name">Crédit</field>
+                <field name="sequence">3</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_25" model="account.tax.report.line">
+                        <field name="name">25 - Crédit de TVA</field>
+                        <field name="code">box_25</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">box_23 - box_16 if box_23 - box_16 &gt; 0 else 0</field>
+                    </record>
+                    <record id="tax_report_26" model="account.tax.report.line">
+                        <field name="name">26 - Remboursement de crédit demandé sur formulaire n°3519 joint</field>
+                        <field name="tag_name">26</field>
+                        <field name="code">box_26</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_AA" model="account.tax.report.line">
+                        <field name="name">AA - Crédit de TVA transféré à la société tête de groupe sur la déclaration récapitulative
             3310-CA3G
         </field>
-        <field name="tag_name">AA</field>
-        <field name="code">box_AA</field>
-        <field name="parent_id" ref="tax_report_credit"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_27" model="account.tax.report.line">
-        <field name="name">27 - Crédit à reporter</field>
-        <field name="code">box_27</field>
-        <field name="parent_id" ref="tax_report_credit"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="formula">box_25 - box_26 - box_AA if box_25 - box_26 - box_AA > 0 else 0</field>
-        <field name="carry_over_condition_method">always_carry_over_and_set_to_0</field>
-        <field name="carry_over_destination_line_id" ref="tax_report_22"/>
-        <field name="is_carryover_persistent">False</field>
-    </record>
-
-    <record id="tax_report_taxes_a_payer" model="account.tax.report.line">
-        <field name="name">Taxe à Payer</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="formula">None</field>
-    </record>
-
-    <record id="tax_report_28" model="account.tax.report.line">
-        <field name="name">28 - TVA nette due</field>
-        <field name="code">box_28</field>
-        <field name="parent_id" ref="tax_report_taxes_a_payer"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-        <field name="formula">box_16 - box_23 if box_16 - box_23 > 0 else 0</field>
-    </record>
-
-    <record id="tax_report_29" model="account.tax.report.line">
-        <field name="name">29 - Taxes assimilées calculées sur annexe n°3310-A-SD</field>
-        <field name="tag_name">29</field>
-        <field name="code">box_29</field>
-        <field name="parent_id" ref="tax_report_taxes_a_payer"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_AB" model="account.tax.report.line">
-        <field name="name">AB - Total à payer acquitté par la société tête de groupe sur la déclaration récapitulative
+                        <field name="tag_name">AA</field>
+                        <field name="code">box_AA</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_27" model="account.tax.report.line">
+                        <field name="name">27 - Crédit à reporter</field>
+                        <field name="code">box_27</field>
+                        <field name="sequence">4</field>
+                        <field name="formula">box_25 - box_26 - box_AA if box_25 - box_26 - box_AA &gt; 0 else 0</field>
+                        <field name="carry_over_condition_method">always_carry_over_and_set_to_0</field>
+                        <field name="carry_over_destination_line_id" ref="tax_report_22"/>
+                        <field name="is_carryover_persistent">False</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_taxes_a_payer" model="account.tax.report.line">
+                <field name="name">Taxe à Payer</field>
+                <field name="sequence">4</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_28" model="account.tax.report.line">
+                        <field name="name">28 - TVA nette due</field>
+                        <field name="code">box_28</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">box_16 - box_23 if box_16 - box_23 &gt; 0 else 0</field>
+                    </record>
+                    <record id="tax_report_29" model="account.tax.report.line">
+                        <field name="name">29 - Taxes assimilées calculées sur annexe n°3310-A-SD</field>
+                        <field name="tag_name">29</field>
+                        <field name="code">box_29</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_AB" model="account.tax.report.line">
+                        <field name="name">AB - Total à payer acquitté par la société tête de groupe sur la déclaration récapitulative
             3310-CA3G
         </field>
-        <field name="code">box_AB</field>
-        <field name="parent_id" ref="tax_report_taxes_a_payer"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <!--According to the trustee, it's very rare that a company fill this box-->
-        <field name="formula">None</field>
+                        <field name="code">box_AB</field>
+                        <field name="sequence">3</field>
+                        <field name="formula">None</field>
+                    </record>
+                    <record id="tax_report_32" model="account.tax.report.line">
+                        <field name="name">32 - Total à payer</field>
+                        <field name="code">box_32</field>
+                        <field name="sequence">4</field>
+                        <field name="formula">box_28 + box_29</field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_32" model="account.tax.report.line">
-        <field name="name">32 - Total à payer</field>
-        <field name="code">box_32</field>
-        <field name="parent_id" ref="tax_report_taxes_a_payer"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <!--The real formula is "box_28 + box_29 - box_AB" but box_AB not zero is a rare edge case -->
-        <field name="formula">box_28 + box_29</field>
-    </record>
-
 </odoo>

--- a/addons/l10n_gr/data/account_tax_report_data.xml
+++ b/addons/l10n_gr/data/account_tax_report_data.xml
@@ -1,106 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.gr"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_311" model="account.tax.report.line">
+                <field name="name">311 Σύνολο Εκροών</field>
+                <field name="code">GRTAX_311</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_307" model="account.tax.report.line">
+                        <field name="name">307 Σύνολο φορολ. Εκροών</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">GRTAX_303</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_303" model="account.tax.report.line">
+                                <field name="name">303 Πωλήσεις 19-23%f</field>
+                                <field name="tag_name">303 Πωλήσεις 19-23%</field>
+                                <field name="code">GRTAX_303</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_358" model="account.tax.report.line">
+                <field name="name">358 Σύνολο φορολ. Εισροών</field>
+                <field name="code">GRTAX_358</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_353" model="account.tax.report.line">
+                        <field name="name">353 Αγορές ΦΠΑ 19-23%</field>
+                        <field name="tag_name">353 Αγορές ΦΠΑ 19-23%</field>
+                        <field name="code">GRTAX_353</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_357" model="account.tax.report.line">
+                        <field name="name">357 Δαπάνες/Έξοδα φορολ.</field>
+                        <field name="tag_name">357 Δαπάνες/Έξοδα φορολ.</field>
+                        <field name="code">GRTAX_357</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_501-511" model="account.tax.report.line">
+                <field name="name">501-511 Υπόλοιπο ΦΠΑ</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_337" model="account.tax.report.line">
+                        <field name="name">337 ΦΠΑ Πωλήσεων</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">GRTAX_333</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_333" model="account.tax.report.line">
+                                <field name="name">333 ΦΠΑ 19-23%</field>
+                                <field name="tag_name">333 ΦΠΑ 19-23%</field>
+                                <field name="code">GRTAX_333</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_420" model="account.tax.report.line">
+                        <field name="name">420 ΦΠΑ Αγορών</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="formula">GRTAX_373+GRTAX_377</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_378" model="account.tax.report.line">
+                                <field name="name">378 Σύνολο Φορ. Αγορών</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="formula">GRTAX_373+GRTAX_377</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_373" model="account.tax.report.line">
+                                        <field name="name">373 ΦΠΑ Αγορών 19-23%</field>
+                                        <field name="tag_name">373 ΦΠΑ Αγορών 19-23%</field>
+                                        <field name="code">GRTAX_373</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="account_tax_report_line_377" model="account.tax.report.line">
+                                        <field name="name">377 ΦΠΑ Δαπανών</field>
+                                        <field name="tag_name">377 ΦΠΑ Δαπανών</field>
+                                        <field name="code">GRTAX_377</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_line_311" model="account.tax.report.line">
-        <field name="name">311 Σύνολο Εκροών</field>
-        <field name="code">GRTAX_311</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_line_307" model="account.tax.report.line">
-        <field name="name">307 Σύνολο φορολ. Εκροών</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_311"/>
-        <field name="formula">GRTAX_303</field>
-    </record>
-
-    <record id="account_tax_report_line_303" model="account.tax.report.line">
-        <field name="name">303 Πωλήσεις 19-23%f</field>
-        <field name="tag_name">303 Πωλήσεις 19-23%</field>
-        <field name="code">GRTAX_303</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_307"/>
-    </record>
-
-    <record id="account_tax_report_line_358" model="account.tax.report.line">
-        <field name="name">358 Σύνολο φορολ. Εισροών</field>
-        <field name="code">GRTAX_358</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-    <record id="account_tax_report_line_353" model="account.tax.report.line">
-        <field name="name">353 Αγορές ΦΠΑ 19-23%</field>
-        <field name="tag_name">353 Αγορές ΦΠΑ 19-23%</field>
-        <field name="code">GRTAX_353</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_358"/>
-    </record>
-    <record id="account_tax_report_line_357" model="account.tax.report.line">
-        <field name="name">357 Δαπάνες/Έξοδα φορολ.</field>
-        <field name="tag_name">357 Δαπάνες/Έξοδα φορολ.</field>
-        <field name="code">GRTAX_357</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_358"/>
-    </record>
-    <record id="account_tax_report_line_501-511" model="account.tax.report.line">
-        <field name="name">501-511 Υπόλοιπο ΦΠΑ</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-    <record id="account_tax_report_line_337" model="account.tax.report.line">
-        <field name="name">337 ΦΠΑ Πωλήσεων</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_501-511"/>
-        <field name="formula">GRTAX_333</field>
-    </record>
-    <record id="account_tax_report_line_333" model="account.tax.report.line">
-        <field name="name">333 ΦΠΑ 19-23%</field>
-        <field name="tag_name">333 ΦΠΑ 19-23%</field>
-        <field name="code">GRTAX_333</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_337"/>
-    </record>
-    <record id="account_tax_report_line_420" model="account.tax.report.line">
-        <field name="name">420 ΦΠΑ Αγορών</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_501-511"/>
-        <field name="formula">GRTAX_373+GRTAX_377</field>
-    </record>
-    <record id="account_tax_report_line_378" model="account.tax.report.line">
-        <field name="name">378 Σύνολο Φορ. Αγορών</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_420"/>
-        <field name="formula">GRTAX_373+GRTAX_377</field>
-    </record>
-    <record id="account_tax_report_line_373" model="account.tax.report.line">
-        <field name="name">373 ΦΠΑ Αγορών 19-23%</field>
-        <field name="tag_name">373 ΦΠΑ Αγορών 19-23%</field>
-        <field name="code">GRTAX_373</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_378"/>
-    </record>
-    <record id="account_tax_report_line_377" model="account.tax.report.line">
-        <field name="name">377 ΦΠΑ Δαπανών</field>
-        <field name="tag_name">377 ΦΠΑ Δαπανών</field>
-        <field name="code">GRTAX_377</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_378"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_hr/data/account_tax_report_data.xml
+++ b/addons/l10n_hr/data/account_tax_report_data.xml
@@ -1,645 +1,450 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.hr"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_ostali_porezi" model="account.tax.report.line">
+                <field name="name">Ostali porezi, carine, trošarine i sl.</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_porez" model="account.tax.report.line">
+                        <field name="name">Porez na potrošnju</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_pdv" model="account.tax.report.line">
+                <field name="name">PDV</field>
+                <field name="formula">(((koje + (izvozne + isporuke + tuzemne + ostale) + isporuke_po) + (izdani_10 + izdani_25)) + (pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0)) + (((izdani_racuni + izdani_racuni_25) + (pretporez_10_tax + pretporez_25_tax + placeni_uvozu_tax + placeni_usluge_10_tax + placeni_usluge_25_ta))) + ((nepriznati_pretporez_25_other + (0.3 * nepriznati_pretporez_25_30) + (0.7 * nepriznati_pretporez_25_70)) + pretporez_koji + (nepriznati_pretporez_25_tax) + (pretporez_koji_neplaceni + pretporez_koji_neplaceni_25 + pretporez_koji_neplaceni_usluge_25))</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_obrazac_pdv" model="account.tax.report.line">
+                        <field name="name">OBRAZAC PDV</field>
+                        <field name="formula">(((koje + (izvozne + isporuke + tuzemne + ostale) + isporuke_po) + (izdani_10 + izdani_25)) + (pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0)) + (((izdani_racuni + izdani_racuni_25) + (pretporez_10_tax + pretporez_25_tax + placeni_uvozu_tax + placeni_usluge_10_tax + placeni_usluge_25_ta)))</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_osnovica" model="account.tax.report.line">
+                                <field name="name">O S N O V I C A</field>
+                                <field name="formula">((koje + (izvozne + isporuke + tuzemne + ostale) + isporuke_po) + (izdani_10 + izdani_25)) + (pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0)</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_obracun" model="account.tax.report.line">
+                                        <field name="name">Obračun isporuka (I+II)</field>
+                                        <field name="sequence" eval="1"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_obracun_isporuke" model="account.tax.report.line">
+                                                <field name="name">I. Isporuke ne podliježu / oslobođene</field>
+                                                <field name="sequence" eval="1"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_koje" model="account.tax.report.line">
+                                                        <field name="name">I.1. Koje ne podliježu oporezivanju</field>
+                                                        <field name="tag_name">I.1. Koje ne podliježu oporezivanju</field>
+                                                        <field name="code">koje</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_oslobodene" model="account.tax.report.line">
+                                                        <field name="name">I.2. Oslobođene ukupno</field>
+                                                        <field name="sequence" eval="2"/>
+                                                        <field name="children_line_ids">
+                                                            <record id="account_tax_report_line_izvozne" model="account.tax.report.line">
+                                                                <field name="name">I.2.1. Izvozne</field>
+                                                                <field name="tag_name">I.2.1. Izvozne</field>
+                                                                <field name="code">izvozne</field>
+                                                                <field name="sequence" eval="1"/>
+                                                            </record>
+                                                            <record id="account_tax_report_line_isporuke" model="account.tax.report.line">
+                                                                <field name="name">I.2.2. Isporuke dobara</field>
+                                                                <field name="tag_name">I.2.2. Isporuke dobara</field>
+                                                                <field name="code">isporuke</field>
+                                                                <field name="sequence" eval="2"/>
+                                                            </record>
+                                                            <record id="account_tax_report_line_tuzemne" model="account.tax.report.line">
+                                                                <field name="name">I.2.3. Tuzemne  - bez prava odbitka</field>
+                                                                <field name="tag_name">I.2.3. Tuzemne  - bez prava odbitka</field>
+                                                                <field name="code">tuzemne</field>
+                                                                <field name="sequence" eval="3"/>
+                                                            </record>
+                                                            <record id="account_tax_report_line_ostale" model="account.tax.report.line">
+                                                                <field name="name">I.2.4. Ostale – s pravom odbitka</field>
+                                                                <field name="tag_name">I.2.4. Ostale – s pravom odbitka</field>
+                                                                <field name="code">ostale</field>
+                                                                <field name="sequence" eval="4"/>
+                                                            </record>
+                                                        </field>
+                                                    </record>
+                                                    <record id="account_tax_report_line_isporuke_po" model="account.tax.report.line">
+                                                        <field name="name">I.3. Isporuke po stopi od 0%</field>
+                                                        <field name="tag_name">I.3. Isporuke po stopi od 0%</field>
+                                                        <field name="code">isporuke_po</field>
+                                                        <field name="sequence" eval="3"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                            <record id="account_tax_report_line_oporezive" model="account.tax.report.line">
+                                                <field name="name">II. Oporezive isporuke</field>
+                                                <field name="sequence" eval="2"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_izdani_10" model="account.tax.report.line">
+                                                        <field name="name">II.1 Izdani računi po stopi 10%</field>
+                                                        <field name="tag_name">II.1 Izdani računi po stopi 10% (osnovica)</field>
+                                                        <field name="code">izdani_10</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_izdani_22_i_23" model="account.tax.report.line">
+                                                        <field name="name">II.2 Izdani računi po stopi 22% i 23%</field>
+                                                        <field name="sequence" eval="2"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_izdani_25" model="account.tax.report.line">
+                                                        <field name="name">II.3 Izdani računi po stopi 25%</field>
+                                                        <field name="tag_name">II.3 Izdani računi po stopi 25% (osnovica)</field>
+                                                        <field name="code">izdani_25</field>
+                                                        <field name="sequence" eval="3"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_nenaplaceni" model="account.tax.report.line">
+                                                        <field name="name">II.4 Nenaplaćeni izvoz</field>
+                                                        <field name="sequence" eval="4"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_oslobodenje" model="account.tax.report.line">
+                                                        <field name="name">II.5 Oslobođenje izvoza – putnički promet</field>
+                                                        <field name="sequence" eval="5"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_obracunani" model="account.tax.report.line">
+                                        <field name="name">III. OBRAČUNANI PRETPOREZ</field>
+                                        <field name="formula">pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0</field>
+                                        <field name="sequence" eval="2"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_pretporez_10" model="account.tax.report.line">
+                                                <field name="name">III.1. Pretporez 10%</field>
+                                                <field name="tag_name">III.1. Pretporez 10% (osnovica)</field>
+                                                <field name="code">pretporez_10</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pretporez_22_i_23" model="account.tax.report.line">
+                                                <field name="name">III.2. Pretporez 22% i23%</field>
+                                                <field name="tag_name">III.2. Pretporez 22% i23%</field>
+                                                <field name="sequence" eval="2"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pretporez_25" model="account.tax.report.line">
+                                                <field name="name">III.3. Pretporez 25%</field>
+                                                <field name="sequence" eval="3"/>
+                                                <field name="formula">0.3 * pretporez_25_30 + 0.7 * pretporez_25_70</field>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_pretporez_25_30" model="account.tax.report.line">
+                                                        <field name="name">III.3. Pretporez 25% (30%)</field>
+                                                        <field name="tag_name">III.3. Pretporez 25% (30%)</field>
+                                                        <field name="code">pretporez_25_30</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_pretporez_25_70" model="account.tax.report.line">
+                                                        <field name="name">III.3. Pretporez 25% (70%)</field>
+                                                        <field name="tag_name">III.3. Pretporez 25% (70%)</field>
+                                                        <field name="code">pretporez_25_70</field>
+                                                        <field name="sequence" eval="2"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                            <record id="account_tax_report_line_placeni_uvozu" model="account.tax.report.line">
+                                                <field name="name">III.4. Plaćeni PP pri uvozu</field>
+                                                <field name="tag_name">III.4. Plaćeni PP pri uvozu (osnovica)</field>
+                                                <field name="code">placeni_uvozu</field>
+                                                <field name="sequence" eval="4"/>
+                                            </record>
+                                            <record id="account_tax_report_line_placeni_usluge_10" model="account.tax.report.line">
+                                                <field name="name">III.5. Plaćeni PP na ino usluge 10%</field>
+                                                <field name="tag_name">III.5. Plaćeni PP na ino usluge 10% (osnovica)</field>
+                                                <field name="code">placeni_usluge_10</field>
+                                                <field name="sequence" eval="5"/>
+                                            </record>
+                                            <record id="account_tax_report_line_placeni_usluge_22_i_23" model="account.tax.report.line">
+                                                <field name="name">III.6. Plaćeni PP na ino usluge 22% i 23%</field>
+                                                <field name="tag_name">III.6. Plaćeni PP na ino usluge 22% i 23%</field>
+                                                <field name="sequence" eval="6"/>
+                                            </record>
+                                            <record id="account_tax_report_line_placeni_usluge_25" model="account.tax.report.line">
+                                                <field name="name">III.7. Plaćeni PP na ino usluge 25%</field>
+                                                <field name="tag_name">III.7. Plaćeni PP na ino usluge 25% (osnovica)</field>
+                                                <field name="code">placeni_usluge_25</field>
+                                                <field name="sequence" eval="7"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pretporez_0" model="account.tax.report.line">
+                                                <field name="name">III.0. Pretporez 0%</field>
+                                                <field name="tag_name">III.0. Pretporez 0%</field>
+                                                <field name="code">pretporez_0</field>
+                                                <field name="sequence" eval="8"/>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_pdv_porez" model="account.tax.report.line">
+                                <field name="name">PDV – POREZ – razlika za uplatu/preplata</field>
+                                <field name="sequence" eval="2"/>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_porezna" model="account.tax.report.line">
+                                        <field name="name">VI. POREZNA OBVEZA U RAZDOBLJU</field>
+                                        <field name="sequence" eval="1"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_isporuke_ne" model="account.tax.report.line">
+                                                <field name="name">I. Isporuke ne podliježu / oslobođene</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_oporezive_isporuke" model="account.tax.report.line">
+                                                <field name="name">II. Oporezive isporuke</field>
+                                                <field name="sequence" eval="2"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_izdani_racuni" model="account.tax.report.line">
+                                                        <field name="name">II.1 Izdani računi po stopi 10%</field>
+                                                        <field name="tag_name">II.1 Izdani računi po stopi 10% (porez)</field>
+                                                        <field name="code">izdani_racuni</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_izdani_racuni_22_i_23" model="account.tax.report.line">
+                                                        <field name="name">II.2 Izdani računi po stopi 22% i 23%</field>
+                                                        <field name="sequence" eval="2"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_izdani_racuni_25" model="account.tax.report.line">
+                                                        <field name="name">II.3 Izdani računi po stopi 25%</field>
+                                                        <field name="tag_name">II.3 Izdani računi po stopi 25% (porez)</field>
+                                                        <field name="code">izdani_racuni_25</field>
+                                                        <field name="sequence" eval="3"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_oslobodenje_izvoza" model="account.tax.report.line">
+                                                        <field name="name">II.4 Oslobođenje izvoza – putnički promet</field>
+                                                        <field name="sequence" eval="4"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                            <record id="account_tax_report_line_obracunani_pretporez" model="account.tax.report.line">
+                                                <field name="name">III. OBRAČUNANI PRETPOREZ</field>
+                                                <field name="sequence" eval="3"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_pretporez_10_tax" model="account.tax.report.line">
+                                                        <field name="name">III.1. Pretporez 10%</field>
+                                                        <field name="tag_name">III.1. Pretporez 10% (porez)</field>
+                                                        <field name="code">pretporez_10_tax</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_pretporez_22_i_23_tax" model="account.tax.report.line">
+                                                        <field name="name">III.2. Pretporez 22% i 23%</field>
+                                                        <field name="sequence" eval="2"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_pretporez_25_tax" model="account.tax.report.line">
+                                                        <field name="name">III.3. Pretporez 25%</field>
+                                                        <field name="tag_name">III.3. Pretporez 25%</field>
+                                                        <field name="code">pretporez_25_tax</field>
+                                                        <field name="sequence" eval="3"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_placeni_uvozu_tax" model="account.tax.report.line">
+                                                        <field name="name">III.4. Plaćeni PP pri uvozu</field>
+                                                        <field name="tag_name">III.4. Plaćeni PP pri uvozu (porez)</field>
+                                                        <field name="code">placeni_uvozu_tax</field>
+                                                        <field name="sequence" eval="4"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_placeni_usluge_10_tax" model="account.tax.report.line">
+                                                        <field name="name">III.5. Plaćeni PP na ino usluge 10%</field>
+                                                        <field name="tag_name">III.5. Plaćeni PP na ino usluge 10% (porez)</field>
+                                                        <field name="code">placeni_usluge_10_tax</field>
+                                                        <field name="sequence" eval="5"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_placeni_usluge_22_i_23_tax" model="account.tax.report.line">
+                                                        <field name="name">III.6. Plaćeni PP na ino usluge 22% i 23%</field>
+                                                        <field name="sequence" eval="6"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_placeni_usluge_25_tax" model="account.tax.report.line">
+                                                        <field name="name">III.7. Plaćeni PP na ino usluge 25%</field>
+                                                        <field name="tag_name">III.7. Plaćeni PP na ino usluge 25% (porez)</field>
+                                                        <field name="code">placeni_usluge_25_ta</field>
+                                                        <field name="sequence" eval="7"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_ispravci" model="account.tax.report.line">
+                                                        <field name="name">III.8. Ispravci pretporeza</field>
+                                                        <field name="sequence" eval="8"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_uplaceno" model="account.tax.report.line">
+                                        <field name="name">Uplaćeno u razdoblju</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_pdv_ostalo" model="account.tax.report.line">
+                        <field name="name">PDV - OSTALO</field>
+                        <field name="formula">(nepriznati_pretporez_25_other + (0.3 * nepriznati_pretporez_25_30) + (0.7 * nepriznati_pretporez_25_70)) + pretporez_koji + (nepriznati_pretporez_25_tax) + (pretporez_koji_neplaceni + pretporez_koji_neplaceni_25 + pretporez_koji_neplaceni_usluge_25)</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_ostali_podaci" model="account.tax.report.line">
+                                <field name="name">Ostali podaci</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_ispravak" model="account.tax.report.line">
+                                        <field name="name">1. ZA ISPRAVAK PRETPOREZA</field>
+                                        <field name="sequence" eval="1"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_nabava" model="account.tax.report.line">
+                                                <field name="name">1.1. NABAVA NEKRETNINA</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_prodaja" model="account.tax.report.line">
+                                                <field name="name">1.2. PRODAJA NEKRETNINA</field>
+                                                <field name="sequence" eval="2"/>
+                                            </record>
+                                            <record id="account_tax_report_line_nabava_osobnih" model="account.tax.report.line">
+                                                <field name="name">1.3. NABAVA OSOBNIH VOZILA</field>
+                                                <field name="sequence" eval="3"/>
+                                            </record>
+                                            <record id="account_tax_report_line_prodaja_osobnih" model="account.tax.report.line">
+                                                <field name="name">1.4. PRODAJA OSOBNIH VOZILA</field>
+                                                <field name="sequence" eval="4"/>
+                                            </record>
+                                            <record id="account_tax_report_line_nabava_dugotrajne" model="account.tax.report.line">
+                                                <field name="name">1.5. NABAVA DUGOTRAJNE IMOVINE</field>
+                                                <field name="sequence" eval="5"/>
+                                            </record>
+                                            <record id="account_tax_report_line_prodaja_dugotrajne" model="account.tax.report.line">
+                                                <field name="name">1.6. PRODAJA DUGOTRAJNE IMOVINE</field>
+                                                <field name="sequence" eval="6"/>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_otudenje" model="account.tax.report.line">
+                                        <field name="name">2. OTUĐENJE/STJECANJE GOSPODARSKE CJELINE ILI POGONA</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="account_tax_report_line_nabava_dobara" model="account.tax.report.line">
+                                        <field name="name">3. NABAVA DOBARA I USLUGA ZA REPREZENTACIJU</field>
+                                        <field name="sequence" eval="3"/>
+                                    </record>
+                                    <record id="account_tax_report_line_nabava_osobnih_vozila" model="account.tax.report.line">
+                                        <field name="name">4. NABAVA OSOBNIH VOZILA I DRUGIH SREDSTAVA ZA OSOBNI PRIJEVOZ</field>
+                                        <field name="sequence" eval="4"/>
+                                    </record>
+                                    <record id="account_tax_report_line_osnovica_za_obracun" model="account.tax.report.line">
+                                        <field name="name">5. OSNOVICA ZA OBRAČUN VLASTITE POTROŠNJE ZA OSOBNA VOZILA NABAV</field>
+                                        <field name="sequence" eval="5"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_nepriznati_pretporez" model="account.tax.report.line">
+                                <field name="name">NEPRIZNATI PRETPOREZ</field>
+                                <field name="sequence" eval="2"/>
+                                <field name="formula">0.3 * nepriznati_pretporez_25_30 + 0.7 * nepriznati_pretporez_25_70 + nepriznati_pretporez_25_other + pretporez_koji</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_nepriznati_pretporez_osnovica_3070" model="account.tax.report.line">
+                                        <field name="name">NEPRIZNATI PRETPOREZ (osnovica 30 ili 70%)</field>
+                                        <field name="sequence" eval="1"/>
+                                        <field name="formula">0.3 * nepriznati_pretporez_25_30 + 0.7 * nepriznati_pretporez_25_70 + nepriznati_pretporez_25_other</field>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_nepriznati_pretporez_10" model="account.tax.report.line">
+                                                <field name="name">Nepriznati pretporez 10% (o)</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_nepriznati_pretporez_22_i_23" model="account.tax.report.line">
+                                                <field name="name">Nepriznati pretporez 22% i 23% (o)</field>
+                                                <field name="sequence" eval="2"/>
+                                            </record>
+                                            <record id="account_tax_report_line_nepriznati_pretporez_25" model="account.tax.report.line">
+                                                <field name="name">Nepriznati pretporez 25% (o)</field>
+                                                <field name="formula">0.3 * nepriznati_pretporez_25_30 + 0.7 * nepriznati_pretporez_25_70 + nepriznati_pretporez_25_other</field>
+                                                <field name="sequence" eval="3"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_nepriznati_pretporez_25_30" model="account.tax.report.line">
+                                                        <field name="name">Nepriznati pretporez 25% (o) (30%)</field>
+                                                        <field name="tag_name">Nepriznati pretporez 25% (o) (30%)</field>
+                                                        <field name="code">nepriznati_pretporez_25_30</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_nepriznati_pretporez_25_70" model="account.tax.report.line">
+                                                        <field name="name">Nepriznati pretporez 25% (o) (70%)</field>
+                                                        <field name="tag_name">Nepriznati pretporez 25% (o) (70%)</field>
+                                                        <field name="code">nepriznati_pretporez_25_70</field>
+                                                        <field name="sequence" eval="2"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_nepriznati_pretporez_25_other" model="account.tax.report.line">
+                                                        <field name="name">Nepriznati pretporez 25% (o)</field>
+                                                        <field name="tag_name">Nepriznati pretporez 25% (o)</field>
+                                                        <field name="code">nepriznati_pretporez_25_other</field>
+                                                        <field name="sequence" eval="3"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_pretporez_koji" model="account.tax.report.line">
+                                        <field name="name">Pretporez koji još nije priznan (uključivo i neplaćeni R-2)</field>
+                                        <field name="tag_name">Pretporez koji još nije priznan (uključivo i neplaćeni R-2)</field>
+                                        <field name="code">pretporez_koji</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="account_tax_report_line_nepriznati_pretporez_porez" model="account.tax.report.line">
+                                        <field name="name">NEPRIZNATI PRETPOREZ (porez)</field>
+                                        <field name="sequence" eval="3"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_nepriznati_pretporez_3070" model="account.tax.report.line">
+                                                <field name="name">NEPRIZNATI PRETPOREZ (30 ili 70%)</field>
+                                                <field name="sequence" eval="1"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_nepriznati_pretporez_10_tax" model="account.tax.report.line">
+                                                        <field name="name">Nepriznati pretporez 10% (p)</field>
+                                                        <field name="sequence" eval="1"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_nepriznati_pretporez_22_i_23_tax" model="account.tax.report.line">
+                                                        <field name="name">Nepriznati pretporez 22% i 23% (p)</field>
+                                                        <field name="sequence" eval="2"/>
+                                                    </record>
+                                                    <record id="account_tax_report_line_nepriznati_pretporez_25_tax" model="account.tax.report.line">
+                                                        <field name="name">Nepriznati pretporez 25% (p)</field>
+                                                        <field name="tag_name">Nepriznati pretporez 25% (p)</field>
+                                                        <field name="code">nepriznati_pretporez_25_tax</field>
+                                                        <field name="sequence" eval="3"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_pretporez_koji_ukupno" model="account.tax.report.line">
+                                        <field name="name">Pretporez koji još nije priznan (ukupno)</field>
+                                        <field name="sequence" eval="4"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_pretporez_koji_neplaceni" model="account.tax.report.line">
+                                                <field name="name">Pretporez koji još nije priznan (neplaćeni R2)</field>
+                                                <field name="tag_name">Pretporez koji još nije priznan (neplaćeni R2)</field>
+                                                <field name="code">pretporez_koji_neplaceni</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pretporez_koji_neplaceni_25" model="account.tax.report.line">
+                                                <field name="name">Pretporez koji još nije priznan (neplaćeni UVOZ dobara 25%)</field>
+                                                <field name="tag_name">Pretporez koji još nije priznan (neplaćeni UVOZ dobara 25%)</field>
+                                                <field name="code">pretporez_koji_neplaceni_25</field>
+                                                <field name="sequence" eval="2"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pretporez_koji_neplaceni_usluge_25" model="account.tax.report.line">
+                                                <field name="name">Pretporez koji još nije priznan (neplaćene INO usluge 25%)</field>
+                                                <field name="tag_name">Pretporez koji još nije priznan (neplaćene INO usluge 25%)</field>
+                                                <field name="code">pretporez_koji_neplaceni_usluge_25</field>
+                                                <field name="sequence" eval="3"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pretporez_koji_neplaceni_usluge_10" model="account.tax.report.line">
+                                                <field name="name">Pretporez koji još nije priznan (neplaćene INO usluge 10%)</field>
+                                                <field name="sequence" eval="4"/>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_line_ostali_porezi" model="account.tax.report.line">
-        <field name="name">Ostali porezi, carine, trošarine i sl.</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_line_porez" model="account.tax.report.line">
-        <field name="name">Porez na potrošnju</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_ostali_porezi"/>
-    </record>
-
-    <record id="account_tax_report_line_pdv" model="account.tax.report.line">
-        <field name="name">PDV</field>
-        <field name="formula">(((koje + (izvozne + isporuke + tuzemne + ostale) + isporuke_po) + (izdani_10 + izdani_25)) + (pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0)) + (((izdani_racuni + izdani_racuni_25) + (pretporez_10_tax + pretporez_25_tax + placeni_uvozu_tax + placeni_usluge_10_tax + placeni_usluge_25_ta))) + ((nepriznati_pretporez_25_other + (0.3 * nepriznati_pretporez_25_30) + (0.7 * nepriznati_pretporez_25_70)) + pretporez_koji + (nepriznati_pretporez_25_tax) + (pretporez_koji_neplaceni + pretporez_koji_neplaceni_25 + pretporez_koji_neplaceni_usluge_25))</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_line_obrazac_pdv" model="account.tax.report.line">
-        <field name="name">OBRAZAC PDV</field>
-        <field name="formula">(((koje + (izvozne + isporuke + tuzemne + ostale) + isporuke_po) + (izdani_10 + izdani_25)) + (pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0)) + (((izdani_racuni + izdani_racuni_25) + (pretporez_10_tax + pretporez_25_tax + placeni_uvozu_tax + placeni_usluge_10_tax + placeni_usluge_25_ta)))</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_pdv"/>
-    </record>
-
-    <record id="account_tax_report_line_osnovica" model="account.tax.report.line">
-        <field name="name">O S N O V I C A</field>
-        <field name="formula">((koje + (izvozne + isporuke + tuzemne + ostale) + isporuke_po) + (izdani_10 + izdani_25)) + (pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_obrazac_pdv"/>
-    </record>
-
-    <record id="account_tax_report_line_obracun" model="account.tax.report.line">
-        <field name="name">Obračun isporuka (I+II)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_osnovica"/>
-    </record>
-
-    <record id="account_tax_report_line_obracun_isporuke" model="account.tax.report.line">
-        <field name="name">I. Isporuke ne podliježu / oslobođene</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_obracun"/>
-    </record>
-
-    <record id="account_tax_report_line_koje" model="account.tax.report.line">
-        <field name="name">I.1. Koje ne podliježu oporezivanju</field>
-        <field name="tag_name">I.1. Koje ne podliježu oporezivanju</field>
-        <field name="code">koje</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_obracun_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_oslobodene" model="account.tax.report.line">
-        <field name="name">I.2. Oslobođene ukupno</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_obracun_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_izvozne" model="account.tax.report.line">
-        <field name="name">I.2.1. Izvozne</field>
-        <field name="tag_name">I.2.1. Izvozne</field>
-        <field name="code">izvozne</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_oslobodene"/>
-    </record>
-
-    <record id="account_tax_report_line_isporuke" model="account.tax.report.line">
-        <field name="name">I.2.2. Isporuke dobara</field>
-        <field name="tag_name">I.2.2. Isporuke dobara</field>
-        <field name="code">isporuke</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_oslobodene"/>
-    </record>
-
-    <record id="account_tax_report_line_tuzemne" model="account.tax.report.line">
-        <field name="name">I.2.3. Tuzemne  - bez prava odbitka</field>
-        <field name="tag_name">I.2.3. Tuzemne  - bez prava odbitka</field>
-        <field name="code">tuzemne</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_oslobodene"/>
-    </record>
-
-    <record id="account_tax_report_line_ostale" model="account.tax.report.line">
-        <field name="name">I.2.4. Ostale – s pravom odbitka</field>
-        <field name="tag_name">I.2.4. Ostale – s pravom odbitka</field>
-        <field name="code">ostale</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_oslobodene"/>
-    </record>
-
-    <record id="account_tax_report_line_isporuke_po" model="account.tax.report.line">
-        <field name="name">I.3. Isporuke po stopi od 0%</field>
-        <field name="tag_name">I.3. Isporuke po stopi od 0%</field>
-        <field name="code">isporuke_po</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_obracun_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_oporezive" model="account.tax.report.line">
-        <field name="name">II. Oporezive isporuke</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_obracun"/>
-    </record>
-
-    <record id="account_tax_report_line_izdani_10" model="account.tax.report.line">
-        <field name="name">II.1 Izdani računi po stopi 10%</field>
-        <field name="tag_name">II.1 Izdani računi po stopi 10% (osnovica)</field>
-        <field name="code">izdani_10</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive"/>
-    </record>
-
-    <record id="account_tax_report_line_izdani_22_i_23" model="account.tax.report.line">
-        <field name="name">II.2 Izdani računi po stopi 22% i 23%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive"/>
-    </record>
-
-    <record id="account_tax_report_line_izdani_25" model="account.tax.report.line">
-        <field name="name">II.3 Izdani računi po stopi 25%</field>
-        <field name="tag_name">II.3 Izdani računi po stopi 25% (osnovica)</field>
-        <field name="code">izdani_25</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive"/>
-    </record>
-
-    <record id="account_tax_report_line_nenaplaceni" model="account.tax.report.line">
-        <field name="name">II.4 Nenaplaćeni izvoz</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive"/>
-    </record>
-
-    <record id="account_tax_report_line_oslobodenje" model="account.tax.report.line">
-        <field name="name">II.5 Oslobođenje izvoza – putnički promet</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive"/>
-    </record>
-
-    <record id="account_tax_report_line_obracunani" model="account.tax.report.line">
-        <field name="name">III. OBRAČUNANI PRETPOREZ</field>
-        <field name="formula">pretporez_10 + (0.7 * pretporez_25_70 + 0.3 * pretporez_25_30) + placeni_uvozu + placeni_usluge_10 + placeni_usluge_25 + pretporez_0</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_osnovica"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_10" model="account.tax.report.line">
-        <field name="name">III.1. Pretporez 10%</field>
-        <field name="tag_name">III.1. Pretporez 10% (osnovica)</field>
-        <field name="code">pretporez_10</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_22_i_23" model="account.tax.report.line">
-        <field name="name">III.2. Pretporez 22% i23%</field>
-        <field name="tag_name">III.2. Pretporez 22% i23%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_25" model="account.tax.report.line">
-        <field name="name">III.3. Pretporez 25%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">0.3 * pretporez_25_30 + 0.7 * pretporez_25_70</field>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_25_30" model="account.tax.report.line">
-        <field name="name">III.3. Pretporez 25% (30%)</field>
-        <field name="tag_name">III.3. Pretporez 25% (30%)</field>
-        <field name="code">pretporez_25_30</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_pretporez_25"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_25_70" model="account.tax.report.line">
-        <field name="name">III.3. Pretporez 25% (70%)</field>
-        <field name="tag_name">III.3. Pretporez 25% (70%)</field>
-        <field name="code">pretporez_25_70</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_pretporez_25"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_uvozu" model="account.tax.report.line">
-        <field name="name">III.4. Plaćeni PP pri uvozu</field>
-        <field name="tag_name">III.4. Plaćeni PP pri uvozu (osnovica)</field>
-        <field name="code">placeni_uvozu</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_usluge_10" model="account.tax.report.line">
-        <field name="name">III.5. Plaćeni PP na ino usluge 10%</field>
-        <field name="tag_name">III.5. Plaćeni PP na ino usluge 10% (osnovica)</field>
-        <field name="code">placeni_usluge_10</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_usluge_22_i_23" model="account.tax.report.line">
-        <field name="name">III.6. Plaćeni PP na ino usluge 22% i 23%</field>
-        <field name="tag_name">III.6. Plaćeni PP na ino usluge 22% i 23%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_usluge_25" model="account.tax.report.line">
-        <field name="name">III.7. Plaćeni PP na ino usluge 25%</field>
-        <field name="tag_name">III.7. Plaćeni PP na ino usluge 25% (osnovica)</field>
-        <field name="code">placeni_usluge_25</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_0" model="account.tax.report.line">
-        <field name="name">III.0. Pretporez 0%</field>
-        <field name="tag_name">III.0. Pretporez 0%</field>
-        <field name="code">pretporez_0</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani"/>
-    </record>
-
-    <record id="account_tax_report_line_pdv_porez" model="account.tax.report.line">
-        <field name="name">PDV – POREZ – razlika za uplatu/preplata</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_obrazac_pdv"/>
-    </record>
-
-    <record id="account_tax_report_line_porezna" model="account.tax.report.line">
-        <field name="name">VI. POREZNA OBVEZA U RAZDOBLJU</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_pdv_porez"/>
-    </record>
-
-    <record id="account_tax_report_line_isporuke_ne" model="account.tax.report.line">
-        <field name="name">I. Isporuke ne podliježu / oslobođene</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_porezna"/>
-    </record>
-
-    <record id="account_tax_report_line_oporezive_isporuke" model="account.tax.report.line">
-        <field name="name">II. Oporezive isporuke</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_porezna"/>
-    </record>
-
-    <record id="account_tax_report_line_izdani_racuni" model="account.tax.report.line">
-        <field name="name">II.1 Izdani računi po stopi 10%</field>
-        <field name="tag_name">II.1 Izdani računi po stopi 10% (porez)</field>
-        <field name="code">izdani_racuni</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_izdani_racuni_22_i_23" model="account.tax.report.line">
-        <field name="name">II.2 Izdani računi po stopi 22% i 23%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_izdani_racuni_25" model="account.tax.report.line">
-        <field name="name">II.3 Izdani računi po stopi 25%</field>
-        <field name="tag_name">II.3 Izdani računi po stopi 25% (porez)</field>
-        <field name="code">izdani_racuni_25</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_oslobodenje_izvoza" model="account.tax.report.line">
-        <field name="name">II.4 Oslobođenje izvoza – putnički promet</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_oporezive_isporuke"/>
-    </record>
-
-    <record id="account_tax_report_line_obracunani_pretporez" model="account.tax.report.line">
-        <field name="name">III. OBRAČUNANI PRETPOREZ</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_porezna"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_10_tax" model="account.tax.report.line">
-        <field name="name">III.1. Pretporez 10%</field>
-        <field name="tag_name">III.1. Pretporez 10% (porez)</field>
-        <field name="code">pretporez_10_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_22_i_23_tax" model="account.tax.report.line">
-        <field name="name">III.2. Pretporez 22% i 23%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_25_tax" model="account.tax.report.line">
-        <field name="name">III.3. Pretporez 25%</field>
-        <field name="tag_name">III.3. Pretporez 25%</field>
-        <field name="code">pretporez_25_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_uvozu_tax" model="account.tax.report.line">
-        <field name="name">III.4. Plaćeni PP pri uvozu</field>
-        <field name="tag_name">III.4. Plaćeni PP pri uvozu (porez)</field>
-        <field name="code">placeni_uvozu_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_usluge_10_tax" model="account.tax.report.line">
-        <field name="name">III.5. Plaćeni PP na ino usluge 10%</field>
-        <field name="tag_name">III.5. Plaćeni PP na ino usluge 10% (porez)</field>
-        <field name="code">placeni_usluge_10_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_usluge_22_i_23_tax" model="account.tax.report.line">
-        <field name="name">III.6. Plaćeni PP na ino usluge 22% i 23%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_placeni_usluge_25_tax" model="account.tax.report.line">
-        <field name="name">III.7. Plaćeni PP na ino usluge 25%</field>
-        <field name="tag_name">III.7. Plaćeni PP na ino usluge 25% (porez)</field>
-        <field name="code">placeni_usluge_25_ta</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_ispravci" model="account.tax.report.line">
-        <field name="name">III.8. Ispravci pretporeza</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="account_tax_report_line_obracunani_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_uplaceno" model="account.tax.report.line">
-        <field name="name">Uplaćeno u razdoblju</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_pdv_porez"/>
-    </record>
-
-    <record id="account_tax_report_line_pdv_ostalo" model="account.tax.report.line">
-        <field name="name">PDV - OSTALO</field>
-        <field name="formula">(nepriznati_pretporez_25_other + (0.3 * nepriznati_pretporez_25_30) + (0.7 * nepriznati_pretporez_25_70)) + pretporez_koji + (nepriznati_pretporez_25_tax) + (pretporez_koji_neplaceni + pretporez_koji_neplaceni_25 + pretporez_koji_neplaceni_usluge_25)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_pdv"/>
-    </record>
-
-    <record id="account_tax_report_line_ostali_podaci" model="account.tax.report.line">
-        <field name="name">Ostali podaci</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_pdv_ostalo"/>
-    </record>
-
-    <record id="account_tax_report_line_ispravak" model="account.tax.report.line">
-        <field name="name">1. ZA ISPRAVAK PRETPOREZA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_ostali_podaci"/>
-    </record>
-
-    <record id="account_tax_report_line_nabava" model="account.tax.report.line">
-        <field name="name">1.1. NABAVA NEKRETNINA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_ispravak"/>
-    </record>
-
-    <record id="account_tax_report_line_prodaja" model="account.tax.report.line">
-        <field name="name">1.2. PRODAJA NEKRETNINA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_ispravak"/>
-    </record>
-
-    <record id="account_tax_report_line_nabava_osobnih" model="account.tax.report.line">
-        <field name="name">1.3. NABAVA OSOBNIH VOZILA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_ispravak"/>
-    </record>
-
-    <record id="account_tax_report_line_prodaja_osobnih" model="account.tax.report.line">
-        <field name="name">1.4. PRODAJA OSOBNIH VOZILA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_ispravak"/>
-    </record>
-
-    <record id="account_tax_report_line_nabava_dugotrajne" model="account.tax.report.line">
-        <field name="name">1.5. NABAVA DUGOTRAJNE IMOVINE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_ispravak"/>
-    </record>
-
-    <record id="account_tax_report_line_prodaja_dugotrajne" model="account.tax.report.line">
-        <field name="name">1.6. PRODAJA DUGOTRAJNE IMOVINE</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_ispravak"/>
-    </record>
-
-    <record id="account_tax_report_line_otudenje" model="account.tax.report.line">
-        <field name="name">2. OTUĐENJE/STJECANJE GOSPODARSKE CJELINE ILI POGONA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_ostali_podaci"/>
-    </record>
-
-    <record id="account_tax_report_line_nabava_dobara" model="account.tax.report.line">
-        <field name="name">3. NABAVA DOBARA I USLUGA ZA REPREZENTACIJU</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_ostali_podaci"/>
-    </record>
-
-    <record id="account_tax_report_line_nabava_osobnih_vozila" model="account.tax.report.line">
-        <field name="name">4. NABAVA OSOBNIH VOZILA I DRUGIH SREDSTAVA ZA OSOBNI PRIJEVOZ</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_ostali_podaci"/>
-    </record>
-
-    <record id="account_tax_report_line_osnovica_za_obracun" model="account.tax.report.line">
-        <field name="name">5. OSNOVICA ZA OBRAČUN VLASTITE POTROŠNJE ZA OSOBNA VOZILA NABAV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_ostali_podaci"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez" model="account.tax.report.line">
-        <field name="name">NEPRIZNATI PRETPOREZ</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="formula">0.3 * nepriznati_pretporez_25_30 + 0.7 * nepriznati_pretporez_25_70 + nepriznati_pretporez_25_other + pretporez_koji</field>
-        <field name="parent_id" ref="account_tax_report_line_pdv_ostalo"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_osnovica_3070" model="account.tax.report.line">
-        <field name="name">NEPRIZNATI PRETPOREZ (osnovica 30 ili 70%)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">0.3 * nepriznati_pretporez_25_30 + 0.7 * nepriznati_pretporez_25_70 + nepriznati_pretporez_25_other</field>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_10" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 10% (o)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_osnovica_3070"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_22_i_23" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 22% i 23% (o)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_osnovica_3070"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_25" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 25% (o)</field>
-        <field name="formula">0.3 * nepriznati_pretporez_25_30 + 0.7 * nepriznati_pretporez_25_70 + nepriznati_pretporez_25_other</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_osnovica_3070"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_25_30" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 25% (o) (30%)</field>
-        <field name="tag_name">Nepriznati pretporez 25% (o) (30%)</field>
-        <field name="code">nepriznati_pretporez_25_30</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_25"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_25_70" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 25% (o) (70%)</field>
-        <field name="tag_name">Nepriznati pretporez 25% (o) (70%)</field>
-        <field name="code">nepriznati_pretporez_25_70</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_25"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_25_other" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 25% (o)</field>
-        <field name="tag_name">Nepriznati pretporez 25% (o)</field>
-        <field name="code">nepriznati_pretporez_25_other</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_25"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_koji" model="account.tax.report.line">
-        <field name="name">Pretporez koji još nije priznan (uključivo i neplaćeni R-2)</field>
-        <field name="tag_name">Pretporez koji još nije priznan (uključivo i neplaćeni R-2)</field>
-        <field name="code">pretporez_koji</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_porez" model="account.tax.report.line">
-        <field name="name">NEPRIZNATI PRETPOREZ (porez)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_3070" model="account.tax.report.line">
-        <field name="name">NEPRIZNATI PRETPOREZ (30 ili 70%)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_porez"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_10_tax" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 10% (p)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_3070"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_22_i_23_tax" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 22% i 23% (p)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_3070"/>
-    </record>
-
-    <record id="account_tax_report_line_nepriznati_pretporez_25_tax" model="account.tax.report.line">
-        <field name="name">Nepriznati pretporez 25% (p)</field>
-        <field name="tag_name">Nepriznati pretporez 25% (p)</field>
-        <field name="code">nepriznati_pretporez_25_tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez_3070"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_koji_ukupno" model="account.tax.report.line">
-        <field name="name">Pretporez koji još nije priznan (ukupno)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_nepriznati_pretporez"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_koji_neplaceni" model="account.tax.report.line">
-        <field name="name">Pretporez koji još nije priznan (neplaćeni R2)</field>
-        <field name="tag_name">Pretporez koji još nije priznan (neplaćeni R2)</field>
-        <field name="code">pretporez_koji_neplaceni</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_pretporez_koji_ukupno"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_koji_neplaceni_25" model="account.tax.report.line">
-        <field name="name">Pretporez koji još nije priznan (neplaćeni UVOZ dobara 25%)</field>
-        <field name="tag_name">Pretporez koji još nije priznan (neplaćeni UVOZ dobara 25%)</field>
-        <field name="code">pretporez_koji_neplaceni_25</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_pretporez_koji_ukupno"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_koji_neplaceni_usluge_25" model="account.tax.report.line">
-        <field name="name">Pretporez koji još nije priznan (neplaćene INO usluge 25%)</field>
-        <field name="tag_name">Pretporez koji još nije priznan (neplaćene INO usluge 25%)</field>
-        <field name="code">pretporez_koji_neplaceni_usluge_25</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_pretporez_koji_ukupno"/>
-    </record>
-
-    <record id="account_tax_report_line_pretporez_koji_neplaceni_usluge_10" model="account.tax.report.line">
-        <field name="name">Pretporez koji još nije priznan (neplaćene INO usluge 10%)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_pretporez_koji_ukupno"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_hu/data/account_tax_report_data.xml
+++ b/addons/l10n_hu/data/account_tax_report_data.xml
@@ -1,189 +1,126 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.hu"/>
+        <field name="root_line_ids">
+            <record id="tax_report_alap" model="account.tax.report.line">
+                <field name="name">ÁFA alap</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_alap_fiz_export" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA Export</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA Export</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_alap_fiz_eu" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA EU</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA EU</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_alap_fiz_targyi" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA tárgyi adómentes</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA tárgyi adómentes</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_alap_fiz_alanyi" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA alanyi adómentes</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA alanyi adómentes</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_alap_fiz_afa_5" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA 5%</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA 5%</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_alap_fiz_afa_18" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA 18%</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA 18%</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_alap_fiz_afa_27" model="account.tax.report.line">
+                        <field name="name">Adóalap - Fizetendő ÁFA 27%</field>
+                        <field name="tag_name">Adóalap - Fizetendő ÁFA 27%</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_alap_viss" model="account.tax.report.line">
+                        <field name="name">Adóalap - Visszaigényelhető ÁFA EU</field>
+                        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA EU</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_alap_import" model="account.tax.report.line">
+                        <field name="name">Adóalap – Import ÁFA</field>
+                        <field name="tag_name">Adóalap – Import ÁFA</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_alap_forditott" model="account.tax.report.line">
+                        <field name="name">Adóalap – Fordított ÁFA</field>
+                        <field name="tag_name">Adóalap – Fordított ÁFA</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_alap_viss_alanyi" model="account.tax.report.line">
+                        <field name="name">Adóalap - Visszaigényelhető ÁFA alanyi adómentes</field>
+                        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA alanyi adómentes</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_alap_viss_targyi" model="account.tax.report.line">
+                        <field name="name">Adóalap - Visszaigényelhető ÁFA tárgyi adómentes</field>
+                        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA tárgyi adómentes</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_alap_viss_5" model="account.tax.report.line">
+                        <field name="name">Adóalap - Visszaigényelhető ÁFA 5%</field>
+                        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA 5%</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_alap_viss_18" model="account.tax.report.line">
+                        <field name="name">Adóalap - Visszaigényelhető ÁFA 18%</field>
+                        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA 18%</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                    <record id="tax_report_alap_viss_27" model="account.tax.report.line">
+                        <field name="name">Adóalap - Visszaigényelhető ÁFA 27%</field>
+                        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA 27%</field>
+                        <field name="sequence" eval="15"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_fizetndo" model="account.tax.report.line">
+                <field name="name">ÁFA fizetndő / visszaigényelhető</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_fizetndo_5" model="account.tax.report.line">
+                        <field name="name">Fizetendő ÁFA 5%</field>
+                        <field name="tag_name">Fizetendő ÁFA 5%</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_fizetndo_18" model="account.tax.report.line">
+                        <field name="name">Fizetendő ÁFA 18%</field>
+                        <field name="tag_name">Fizetendő ÁFA 18%</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_fizetndo_27" model="account.tax.report.line">
+                        <field name="name">Fizetendő ÁFA 27%</field>
+                        <field name="tag_name">Fizetendő ÁFA 27%</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_fizetndo_viss_5" model="account.tax.report.line">
+                        <field name="name">Visszaigényelhető ÁFA 5%</field>
+                        <field name="tag_name">Visszaigényelhető ÁFA 5%</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_fizetndo_viss_18" model="account.tax.report.line">
+                        <field name="name">Visszaigényelhető ÁFA 18%</field>
+                        <field name="tag_name">Visszaigényelhető ÁFA 18%</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_fizetndo_viss_27" model="account.tax.report.line">
+                        <field name="name">Visszaigényelhető ÁFA 27%</field>
+                        <field name="tag_name">Visszaigényelhető ÁFA 27%</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_alap" model="account.tax.report.line">
-        <field name="name">ÁFA alap</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_export" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA Export</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA Export</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_eu" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA EU</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA EU</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_targyi" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA tárgyi adómentes</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA tárgyi adómentes</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_alanyi" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA alanyi adómentes</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA alanyi adómentes</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_afa_5" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA 5%</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_afa_18" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA 18%</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA 18%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_fiz_afa_27" model="account.tax.report.line">
-        <field name="name">Adóalap - Fizetendő ÁFA 27%</field>
-        <field name="tag_name">Adóalap - Fizetendő ÁFA 27%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_viss" model="account.tax.report.line">
-        <field name="name">Adóalap - Visszaigényelhető ÁFA EU</field>
-        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA EU</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_import" model="account.tax.report.line">
-        <field name="name">Adóalap – Import ÁFA</field>
-        <field name="tag_name">Adóalap – Import ÁFA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_forditott" model="account.tax.report.line">
-        <field name="name">Adóalap – Fordított ÁFA</field>
-        <field name="tag_name">Adóalap – Fordított ÁFA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_viss_alanyi" model="account.tax.report.line">
-        <field name="name">Adóalap - Visszaigényelhető ÁFA alanyi adómentes</field>
-        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA alanyi adómentes</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_viss_targyi" model="account.tax.report.line">
-        <field name="name">Adóalap - Visszaigényelhető ÁFA tárgyi adómentes</field>
-        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA tárgyi adómentes</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_viss_5" model="account.tax.report.line">
-        <field name="name">Adóalap - Visszaigényelhető ÁFA 5%</field>
-        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="13"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_viss_18" model="account.tax.report.line">
-        <field name="name">Adóalap - Visszaigényelhető ÁFA 18%</field>
-        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA 18%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="14"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_alap_viss_27" model="account.tax.report.line">
-        <field name="name">Adóalap - Visszaigényelhető ÁFA 27%</field>
-        <field name="tag_name">Adóalap - Visszaigényelhető ÁFA 27%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="15"/>
-        <field name="parent_id" ref="tax_report_alap"/>
-    </record>
-
-    <record id="tax_report_fizetndo" model="account.tax.report.line">
-        <field name="name">ÁFA fizetndő / visszaigényelhető</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_fizetndo_5" model="account.tax.report.line">
-        <field name="name">Fizetendő ÁFA 5%</field>
-        <field name="tag_name">Fizetendő ÁFA 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_fizetndo"/>
-    </record>
-
-    <record id="tax_report_fizetndo_18" model="account.tax.report.line">
-        <field name="name">Fizetendő ÁFA 18%</field>
-        <field name="tag_name">Fizetendő ÁFA 18%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_fizetndo"/>
-    </record>
-
-    <record id="tax_report_fizetndo_27" model="account.tax.report.line">
-        <field name="name">Fizetendő ÁFA 27%</field>
-        <field name="tag_name">Fizetendő ÁFA 27%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_fizetndo"/>
-    </record>
-
-    <record id="tax_report_fizetndo_viss_5" model="account.tax.report.line">
-        <field name="name">Visszaigényelhető ÁFA 5%</field>
-        <field name="tag_name">Visszaigényelhető ÁFA 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_fizetndo"/>
-    </record>
-
-    <record id="tax_report_fizetndo_viss_18" model="account.tax.report.line">
-        <field name="name">Visszaigényelhető ÁFA 18%</field>
-        <field name="tag_name">Visszaigényelhető ÁFA 18%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_fizetndo"/>
-    </record>
-
-    <record id="tax_report_fizetndo_viss_27" model="account.tax.report.line">
-        <field name="name">Visszaigényelhető ÁFA 27%</field>
-        <field name="tag_name">Visszaigényelhető ÁFA 27%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_fizetndo"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_il/data/account_tax_report_data.xml
+++ b/addons/l10n_il/data/account_tax_report_data.xml
@@ -3,131 +3,101 @@
     <record id="vat_report" model="account.tax.report">
         <field name="name">VAT Report (PCN874)</field>
         <field name="country_id" ref="base.il"/>
-    </record>
-
-    <!-- SALES lines -->
-
-    <record id="account_tax_report_line_out_base_title" model="account.tax.report.line">
-        <field name="name">VAT SALES (BASE)</field>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_out_base" model="account.tax.report.line">
-        <field name="name">VAT SALES (BASE)</field>
-        <field name="tag_name">VAT SALES (BASE)</field>
-        <field name="code">ILTAX_OUT_BASE</field>
-        <field name="sequence">1</field>
-        <field name="parent_id" ref="account_tax_report_line_out_base_title"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-	<record id="account_tax_report_line_vat_sales_tax" model="account.tax.report.line">
-        <field name="name">VAT SALES (TAX)</field>
-        <field name="formula">ILTAX_OUT_BALANCE_00+ILTAX_OUT_BALANCE_PA</field>
-        <field name="code">ILTAX_OUT_BALANCE</field>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_out_balance" model="account.tax.report.line">
-        <field name="name">VAT Sales</field>
-        <field name="tag_name">VAT Sales</field>
-        <field name="code">ILTAX_OUT_BALANCE_00</field>
-        <field name="sequence">21</field>
-        <field name="parent_id" ref="account_tax_report_line_vat_sales_tax"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_out_balance_pa" model="account.tax.report.line">
-        <field name="name">VAT PA Sales</field>
-        <field name="tag_name">VAT PA Sales</field>
-        <field name="code">ILTAX_OUT_BALANCE_PA</field>
-        <field name="sequence">22</field>
-        <field name="parent_id" ref="account_tax_report_line_vat_sales_tax"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_out_base_exempt_title" model="account.tax.report.line">
-        <field name="name">VAT Exempt Sales (BASE)</field>
-        <field name="sequence">3</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_out_base_exempt" model="account.tax.report.line">
-        <field name="name">VAT Exempt Sales (BASE)</field>
-        <field name="tag_name">VAT Exempt Sales (BASE)</field>
-        <field name="code">ILTAX_OUT_BASE_exempt</field>
-        <field name="sequence">3</field>
-        <field name="parent_id" ref="account_tax_report_line_out_base_exempt_title"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <!-- PURCHASE lines -->
-    <record id="account_tax_report_line_in_balance" model="account.tax.report.line">
-        <field name="name">VAT INPUTS (TAX)</field>
-        <field name="formula">ILTAX_IN_BALANCE_17+ILTAX_IN_BALANCE_2_3+ILTAX_IN_BALANCE_1_4+ILTAX_IN_BALANCE_PA</field>
-        <field name="code">ILTAX_IN_BALANCE</field>
-        <field name="sequence">5</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-	<record id="account_tax_report_line_in_balance_17" model="account.tax.report.line">
-        <field name="name">VAT Inputs 17%</field>
-        <field name="tag_name">VAT Inputs 17%</field>
-        <field name="code">ILTAX_IN_BALANCE_17</field>
-        <field name="sequence">51</field>
-        <field name="parent_id" ref="account_tax_report_line_in_balance"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_in_balance_pa_16" model="account.tax.report.line">
-        <field name="name">VAT Inputs PA 16%</field>
-        <field name="tag_name">VAT Inputs PA 16%</field>
-        <field name="code">ILTAX_IN_BALANCE_PA</field>
-        <field name="sequence">52</field>
-        <field name="parent_id" ref="account_tax_report_line_in_balance"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_in_balance_2_3" model="account.tax.report.line">
-        <field name="name">VAT Inputs 2/3</field>
-        <field name="tag_name">VAT Inputs 2/3</field>
-        <field name="code">ILTAX_IN_BALANCE_2_3</field>
-        <field name="sequence">53</field>
-        <field name="parent_id" ref="account_tax_report_line_in_balance"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_in_balance_1_4" model="account.tax.report.line">
-        <field name="name">VAT Inputs 1/4</field>
-        <field name="tag_name">VAT Inputs 1/4</field>
-        <field name="code">ILTAX_IN_BALANCE_1_4</field>
-        <field name="sequence">54</field>
-        <field name="parent_id" ref="account_tax_report_line_in_balance"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_in_fa_title" model="account.tax.report.line">
-        <field name="name">VAT INPUTS (fixed assets)</field>
-        <field name="sequence">6</field>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_in_fa" model="account.tax.report.line">
-        <field name="name">VAT INPUTS (fixed assets)</field>
-        <field name="tag_name">VAT INPUTS (fixed assets)</field>
-        <field name="code">ILTAX_VAT_IN_FA</field>
-        <field name="sequence">6</field>
-        <field name="parent_id" ref="account_tax_report_line_vat_in_fa_title"/>
-        <field name="report_id" ref="vat_report"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_due" model="account.tax.report.line">
-        <field name="name">VAT DUE</field>
-        <field name="code">ILTAX_VAT_DUE</field>
-        <field name="formula">(ILTAX_OUT_BALANCE_00 + ILTAX_OUT_BALANCE_PA) - (ILTAX_IN_BALANCE_17 + ILTAX_IN_BALANCE_2_3 + ILTAX_IN_BALANCE_1_4 + ILTAX_IN_BALANCE_PA) - ILTAX_VAT_IN_FA</field>
-        <field name="sequence">7</field>
-        <field name="report_id" ref="vat_report"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_out_base_title" model="account.tax.report.line">
+                <field name="name">VAT SALES (BASE)</field>
+                <field name="sequence">1</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_out_base" model="account.tax.report.line">
+                        <field name="name">VAT SALES (BASE)</field>
+                        <field name="tag_name">VAT SALES (BASE)</field>
+                        <field name="code">ILTAX_OUT_BASE</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_vat_sales_tax" model="account.tax.report.line">
+                <field name="name">VAT SALES (TAX)</field>
+                <field name="formula">ILTAX_OUT_BALANCE_00+ILTAX_OUT_BALANCE_PA</field>
+                <field name="code">ILTAX_OUT_BALANCE</field>
+                <field name="sequence">2</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_out_balance" model="account.tax.report.line">
+                        <field name="name">VAT Sales</field>
+                        <field name="tag_name">VAT Sales</field>
+                        <field name="code">ILTAX_OUT_BALANCE_00</field>
+                        <field name="sequence">21</field>
+                    </record>
+                    <record id="account_tax_report_line_out_balance_pa" model="account.tax.report.line">
+                        <field name="name">VAT PA Sales</field>
+                        <field name="tag_name">VAT PA Sales</field>
+                        <field name="code">ILTAX_OUT_BALANCE_PA</field>
+                        <field name="sequence">22</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_out_base_exempt_title" model="account.tax.report.line">
+                <field name="name">VAT Exempt Sales (BASE)</field>
+                <field name="sequence">3</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_out_base_exempt" model="account.tax.report.line">
+                        <field name="name">VAT Exempt Sales (BASE)</field>
+                        <field name="tag_name">VAT Exempt Sales (BASE)</field>
+                        <field name="code">ILTAX_OUT_BASE_exempt</field>
+                        <field name="sequence">3</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_in_balance" model="account.tax.report.line">
+                <field name="name">VAT INPUTS (TAX)</field>
+                <field name="formula">ILTAX_IN_BALANCE_17+ILTAX_IN_BALANCE_2_3+ILTAX_IN_BALANCE_1_4+ILTAX_IN_BALANCE_PA</field>
+                <field name="code">ILTAX_IN_BALANCE</field>
+                <field name="sequence">5</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_in_balance_17" model="account.tax.report.line">
+                        <field name="name">VAT Inputs 17%</field>
+                        <field name="tag_name">VAT Inputs 17%</field>
+                        <field name="code">ILTAX_IN_BALANCE_17</field>
+                        <field name="sequence">51</field>
+                    </record>
+                    <record id="account_tax_report_line_in_balance_pa_16" model="account.tax.report.line">
+                        <field name="name">VAT Inputs PA 16%</field>
+                        <field name="tag_name">VAT Inputs PA 16%</field>
+                        <field name="code">ILTAX_IN_BALANCE_PA</field>
+                        <field name="sequence">52</field>
+                    </record>
+                    <record id="account_tax_report_line_in_balance_2_3" model="account.tax.report.line">
+                        <field name="name">VAT Inputs 2/3</field>
+                        <field name="tag_name">VAT Inputs 2/3</field>
+                        <field name="code">ILTAX_IN_BALANCE_2_3</field>
+                        <field name="sequence">53</field>
+                    </record>
+                    <record id="account_tax_report_line_in_balance_1_4" model="account.tax.report.line">
+                        <field name="name">VAT Inputs 1/4</field>
+                        <field name="tag_name">VAT Inputs 1/4</field>
+                        <field name="code">ILTAX_IN_BALANCE_1_4</field>
+                        <field name="sequence">54</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_vat_in_fa_title" model="account.tax.report.line">
+                <field name="name">VAT INPUTS (fixed assets)</field>
+                <field name="sequence">6</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_vat_in_fa" model="account.tax.report.line">
+                        <field name="name">VAT INPUTS (fixed assets)</field>
+                        <field name="tag_name">VAT INPUTS (fixed assets)</field>
+                        <field name="code">ILTAX_VAT_IN_FA</field>
+                        <field name="sequence">6</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_vat_due" model="account.tax.report.line">
+                <field name="name">VAT DUE</field>
+                <field name="code">ILTAX_VAT_DUE</field>
+                <field name="formula">(ILTAX_OUT_BALANCE_00 + ILTAX_OUT_BALANCE_PA) - (ILTAX_IN_BALANCE_17 + ILTAX_IN_BALANCE_2_3 + ILTAX_IN_BALANCE_1_4 + ILTAX_IN_BALANCE_PA) - ILTAX_VAT_IN_FA</field>
+                <field name="sequence">7</field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_in/data/account_tax_template_data.xml
+++ b/addons/l10n_in/data/account_tax_template_data.xml
@@ -1,114 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.in"/>
+        <field name="root_line_ids">
+            <record id="tax_report_line_gst" model="account.tax.report.line">
+                <field name="name">GST</field>
+                <field name="sequence">1</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_sgst" model="account.tax.report.line">
+                        <field name="name">SGST</field>
+                        <field name="tag_name">SGST</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_cgst" model="account.tax.report.line">
+                        <field name="name">CGST</field>
+                        <field name="tag_name">CGST</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_sgst_rc" model="account.tax.report.line">
+                        <field name="name">SGST Reverse Charge</field>
+                        <field name="tag_name">SGST (RC)</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_line_cgst_rc" model="account.tax.report.line">
+                        <field name="name">CGST Reverse Charge</field>
+                        <field name="tag_name">CGST (RC)</field>
+                        <field name="sequence">4</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_igst_root" model="account.tax.report.line">
+                <field name="name">IGST</field>
+                <field name="sequence">2</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_igst" model="account.tax.report.line">
+                        <field name="name">IGST</field>
+                        <field name="tag_name">IGST</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_line_igst_rc" model="account.tax.report.line">
+                        <field name="name">IGST Reverse Charge</field>
+                        <field name="tag_name">IGST (RC)</field>
+                        <field name="sequence">4</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_gst_others" model="account.tax.report.line">
+                <field name="name">Others</field>
+                <field name="sequence">3</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_cess" model="account.tax.report.line">
+                        <field name="name">CESS</field>
+                        <field name="tag_name">CESS</field>
+                        <field name="sequence">4</field>
+                    </record>
+                    <record id="tax_report_line_cess_rc" model="account.tax.report.line">
+                        <field name="name">CESS Reverse Charge</field>
+                        <field name="tag_name">CESS (RC)</field>
+                        <field name="sequence">5</field>
+                    </record>
+                    <record id="tax_report_line_exempt" model="account.tax.report.line">
+                        <field name="name">Exempt</field>
+                        <field name="tag_name">Exempt</field>
+                        <field name="sequence">5</field>
+                    </record>
+                    <record id="tax_report_line_nil_rated" model="account.tax.report.line">
+                        <field name="name">Nil Rated</field>
+                        <field name="tag_name">Nil Rated</field>
+                        <field name="sequence">6</field>
+                    </record>
+                    <record id="tax_report_line_zero_rated" model="account.tax.report.line">
+                        <field name="name">Zero Rated</field>
+                        <field name="tag_name">Zero Rated</field>
+                        <field name="sequence">7</field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_line_gst" model="account.tax.report.line">
-        <field name="name">GST</field>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="tax_report_line_igst_root" model="account.tax.report.line">
-        <field name="name">IGST</field>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="tax_report_line_gst_others" model="account.tax.report.line">
-        <field name="name">Others</field>
-        <field name="sequence">3</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_line_sgst" model="account.tax.report.line">
-        <field name="name">SGST</field>
-        <field name="tag_name">SGST</field>
-        <field name="parent_id" ref="tax_report_line_gst"/>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="tax_report_line_cgst" model="account.tax.report.line">
-        <field name="name">CGST</field>
-        <field name="tag_name">CGST</field>
-        <field name="parent_id" ref="tax_report_line_gst"/>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_line_igst" model="account.tax.report.line">
-        <field name="name">IGST</field>
-        <field name="tag_name">IGST</field>
-        <field name="parent_id" ref="tax_report_line_igst_root"/>
-        <field name="sequence">3</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="tax_report_line_cess" model="account.tax.report.line">
-        <field name="name">CESS</field>
-        <field name="tag_name">CESS</field>
-        <field name="parent_id" ref="tax_report_line_gst_others"/>
-        <field name="sequence">4</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_line_sgst_rc" model="account.tax.report.line">
-        <field name="name">SGST Reverse Charge</field>
-        <field name="tag_name">SGST (RC)</field>
-        <field name="parent_id" ref="tax_report_line_gst"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-    <record id="tax_report_line_cgst_rc" model="account.tax.report.line">
-        <field name="name">CGST Reverse Charge</field>
-        <field name="tag_name">CGST (RC)</field>
-        <field name="parent_id" ref="tax_report_line_gst"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_line_igst_rc" model="account.tax.report.line">
-        <field name="name">IGST Reverse Charge</field>
-        <field name="tag_name">IGST (RC)</field>
-        <field name="parent_id" ref="tax_report_line_igst_root"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-    <record id="tax_report_line_cess_rc" model="account.tax.report.line">
-        <field name="name">CESS Reverse Charge</field>
-        <field name="tag_name">CESS (RC)</field>
-        <field name="parent_id" ref="tax_report_line_gst_others"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">5</field>
-    </record>
-
-    <record id="tax_report_line_exempt" model="account.tax.report.line">
-        <field name="name">Exempt</field>
-        <field name="tag_name">Exempt</field>
-        <field name="parent_id" ref="tax_report_line_gst_others"/>
-        <field name="sequence">5</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="tax_report_line_nil_rated" model="account.tax.report.line">
-        <field name="name">Nil Rated</field>
-        <field name="tag_name">Nil Rated</field>
-        <field name="parent_id" ref="tax_report_line_gst_others"/>
-        <field name="sequence">6</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="tax_report_line_zero_rated" model="account.tax.report.line">
-        <field name="name">Zero Rated</field>
-        <field name="tag_name">Zero Rated</field>
-        <field name="parent_id" ref="tax_report_line_gst_others"/>
-        <field name="sequence">7</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-
-    <!-- GST TAXES-->
-
-    <!-- CESS Tax -->
-
     <record id="cess_sale_5" model="account.tax.template">
         <field name="name">CESS Sale 5%</field>
         <field name="description">CESS 5%</field>
@@ -117,34 +87,9 @@
         <field name="amount">5</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'plus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'minus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'plus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'minus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
     </record>
-
     <record id="cess_sale_1591" model="account.tax.template">
         <field name="name">CESS Sale 1591 Per Thousand</field>
         <field name="description">1591 PER THOUSAND</field>
@@ -153,34 +98,9 @@
         <field name="amount">1.591</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'plus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'minus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'plus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'minus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
     </record>
-
     <record id="cess_5_plus_1591_sale" model="account.tax.template">
         <field name="name">CESS 5% + RS.1591/THOUSAND</field>
         <field name="description">CESS 5% + RS.1591/THOUSAND</field>
@@ -191,7 +111,6 @@
         <field name="children_tax_ids" eval="[(6, 0, [ref('cess_sale_5'),ref('cess_sale_1591'),])]"/>
         <field name="tax_group_id" ref="cess_group"/>
     </record>
-
     <record id="cess_21_4170_higer_sale" model="account.tax.template">
         <field name="name">CESS 21% or RS.4170/THOUSAND</field>
         <field name="description">CESS 21% or RS.4170/THOUSAND</field>
@@ -200,39 +119,12 @@
         <field name="amount">0</field>
         <field name="python_compute">result=base_amount * 0.21
 tax=quantity * 4.17
-if tax > result:result=tax</field>
+if tax &gt; result:result=tax</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'plus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'minus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'plus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'minus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
     </record>
-
-    <!-- Exempt -->
-
     <record id="exempt_sale" model="account.tax.template">
         <field name="name">Exempt Sale</field>
         <field name="description">Exempt</field>
@@ -241,35 +133,9 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="exempt_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_exempt')],
-
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_exempt')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_exempt')],              }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_exempt')],             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
     </record>
-
-    <!-- Nil Rated -->
-
     <record id="nil_rated_sale" model="account.tax.template">
         <field name="name">Nil Rated</field>
         <field name="description">Nil Rated</field>
@@ -278,35 +144,9 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="nil_rated_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_nil_rated')],
-
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_nil_rated')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_nil_rated')],              }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_nil_rated')],             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
     </record>
-
-    <!-- IGST -->
-
     <record id="igst_sale_0" model="account.tax.template">
         <field name="name">IGST 0%</field>
         <field name="description">IGST 0%</field>
@@ -315,32 +155,9 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_zero_rated')],
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_zero_rated')],
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_zero_rated')],             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_zero_rated')],             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',             }),         ]"/>
     </record>
-
     <record id="igst_sale_1" model="account.tax.template">
         <field name="name">IGST 1%</field>
         <field name="description">IGST 1%</field>
@@ -349,34 +166,9 @@ if tax > result:result=tax</field>
         <field name="amount">1</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_sale_2" model="account.tax.template">
         <field name="name">IGST 2%</field>
         <field name="description">IGST 2%</field>
@@ -385,34 +177,9 @@ if tax > result:result=tax</field>
         <field name="amount">2</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_sale_28" model="account.tax.template">
         <field name="name">IGST 28%</field>
         <field name="description">IGST 28%</field>
@@ -421,34 +188,9 @@ if tax > result:result=tax</field>
         <field name="amount">28</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_sale_18" model="account.tax.template">
         <field name="name">IGST 18%</field>
         <field name="description">IGST 18%</field>
@@ -457,34 +199,9 @@ if tax > result:result=tax</field>
         <field name="amount">18</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_sale_12" model="account.tax.template">
         <field name="name">IGST 12%</field>
         <field name="description">IGST 12%</field>
@@ -493,34 +210,9 @@ if tax > result:result=tax</field>
         <field name="amount">12</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_sale_5" model="account.tax.template">
         <field name="name">IGST 5%</field>
         <field name="description">IGST 5%</field>
@@ -529,36 +221,9 @@ if tax > result:result=tax</field>
         <field name="amount">5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
-    <!-- SGST & CGST Sales Group Tax -->
-
     <record id="sgst_sale_0_5" model="account.tax.template">
         <field name="name">SGST Sale 0.5%</field>
         <field name="description">SGST 0.5%</field>
@@ -567,34 +232,9 @@ if tax > result:result=tax</field>
         <field name="amount">0.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_sale_0_5" model="account.tax.template">
         <field name="name">CGST Sale 0.5%</field>
         <field name="description">CGST 0.5%</field>
@@ -603,32 +243,9 @@ if tax > result:result=tax</field>
         <field name="amount">0.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_sale_1" model="account.tax.template">
         <field name="name">GST 1%</field>
         <field name="description">GST 1%</field>
@@ -639,7 +256,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_sale_0_5'), ref('cgst_sale_0_5'),])]"/>
     </record>
-
     <record id="sgst_sale_1_2" model="account.tax.template">
         <field name="name">SGST Sale 1%</field>
         <field name="description">SGST 1%</field>
@@ -648,34 +264,9 @@ if tax > result:result=tax</field>
         <field name="amount">1</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_sale_1_2" model="account.tax.template">
         <field name="name">CGST Sale 1%</field>
         <field name="description">CGST 1%</field>
@@ -684,32 +275,9 @@ if tax > result:result=tax</field>
         <field name="amount">1</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_sale_2" model="account.tax.template">
         <field name="name">GST 2%</field>
         <field name="description">GST 2%</field>
@@ -720,7 +288,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_sale_1_2'), ref('cgst_sale_1_2'),])]"/>
     </record>
-
     <record id="sgst_sale_14" model="account.tax.template">
         <field name="name">SGST Sale 14%</field>
         <field name="description">SGST 14%</field>
@@ -729,34 +296,9 @@ if tax > result:result=tax</field>
         <field name="amount">14</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_sale_14" model="account.tax.template">
         <field name="name">CGST Sale 14%</field>
         <field name="description">CGST 14%</field>
@@ -765,32 +307,9 @@ if tax > result:result=tax</field>
         <field name="amount">14</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_sale_28" model="account.tax.template">
         <field name="name">GST 28%</field>
         <field name="description">GST 28%</field>
@@ -801,7 +320,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_sale_14'),ref('cgst_sale_14'),])]"/>
     </record>
-
     <record id="sgst_sale_9" model="account.tax.template">
         <field name="name">SGST Sale 9%</field>
         <field name="description">SGST 9%</field>
@@ -810,34 +328,9 @@ if tax > result:result=tax</field>
         <field name="amount">9</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_sale_9" model="account.tax.template">
         <field name="name">CGST Sale 9%</field>
         <field name="description">CGST 9%</field>
@@ -846,32 +339,9 @@ if tax > result:result=tax</field>
         <field name="amount">9</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_sale_18" model="account.tax.template">
         <field name="name">GST 18%</field>
         <field name="description">GST 18%</field>
@@ -882,8 +352,7 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_sale_9'),ref('cgst_sale_9'),])]"/>
     </record>
-
-     <record id="sgst_sale_6" model="account.tax.template">
+    <record id="sgst_sale_6" model="account.tax.template">
         <field name="name">SGST Sale 6%</field>
         <field name="description">SGST 6%</field>
         <field name="type_tax_use">none</field>
@@ -891,32 +360,9 @@ if tax > result:result=tax</field>
         <field name="amount">6</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_sale_6" model="account.tax.template">
         <field name="name">CGST Sale 6%</field>
         <field name="description">CGST 6%</field>
@@ -925,32 +371,9 @@ if tax > result:result=tax</field>
         <field name="amount">6</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             }),         ]"/>
     </record>
-
     <record id="sgst_sale_12" model="account.tax.template">
         <field name="name">GST 12%</field>
         <field name="description">GST 12%</field>
@@ -961,7 +384,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_sale_6'),ref('cgst_sale_6'),])]"/>
     </record>
-
     <record id="sgst_sale_2_5" model="account.tax.template">
         <field name="name">SGST Sale 2.5%</field>
         <field name="description">SGST 2.5%</field>
@@ -970,34 +392,9 @@ if tax > result:result=tax</field>
         <field name="amount">2.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_sale_2_5" model="account.tax.template">
         <field name="name">CGST Sale 2.5%</field>
         <field name="description">CGST 2.5%</field>
@@ -1006,32 +403,9 @@ if tax > result:result=tax</field>
         <field name="amount">2.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_sale_5" model="account.tax.template">
         <field name="name">GST 5%</field>
         <field name="description">GST 5%</field>
@@ -1043,11 +417,6 @@ if tax > result:result=tax</field>
         <field name="sequence">0</field>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_sale_2_5'), ref('cgst_sale_2_5'),])]"/>
     </record>
-
-    <!-- Purchase Taxes-->
-
-    <!-- CESS Taxes -->
-
     <record id="cess_purchase_5" model="account.tax.template">
         <field name="name">CESS Purchase 5%</field>
         <field name="description">CESS 5%</field>
@@ -1056,34 +425,9 @@ if tax > result:result=tax</field>
         <field name="amount">5</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'minus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'plus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'minus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'plus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
     </record>
-
     <record id="cess_purchase_1591" model="account.tax.template">
         <field name="name">CESS Purchase 1591 Per Thousand</field>
         <field name="description">1591 PER THOUSAND</field>
@@ -1092,34 +436,9 @@ if tax > result:result=tax</field>
         <field name="amount">1.591</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'minus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'plus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'minus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'plus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
     </record>
-
     <record id="cess_5_plus_1591_purchase" model="account.tax.template">
         <field name="name">CESS 5% + RS.1591/THOUSAND</field>
         <field name="description">CESS 5% + RS.1591/THOUSAND</field>
@@ -1130,7 +449,6 @@ if tax > result:result=tax</field>
         <field name="children_tax_ids" eval="[(6, 0, [ref('cess_purchase_5'),ref('cess_purchase_1591'),])]"/>
         <field name="tax_group_id" ref="cess_group"/>
     </record>
-
     <record id="cess_21_4170_higer_purchase" model="account.tax.template">
         <field name="name">CESS 21% or RS.4170/THOUSAND</field>
         <field name="description">CESS 21% or RS.4170/THOUSAND</field>
@@ -1139,39 +457,12 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="python_compute">result=base_amount * 0.21
 tax=quantity * 4.17
-if tax > result:result=tax</field>
+if tax &gt; result:result=tax</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'minus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'plus_report_line_ids': [ref('tax_report_line_cess')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'minus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'plus_report_line_ids': [ref('tax_report_line_cess')],             }),         ]"/>
     </record>
-
-    <!-- Exempt -->
-
     <record id="exempt_purchase" model="account.tax.template">
         <field name="name">Exempt purchase</field>
         <field name="description">Exempt</field>
@@ -1180,33 +471,9 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="exempt_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_exempt')],
-
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_exempt')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_exempt')],              }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_exempt')],             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',             }),         ]"/>
     </record>
-
-    <!-- Nil Rated -->
-
     <record id="nil_rated_purchase" model="account.tax.template">
         <field name="name">Nil Rated</field>
         <field name="description">Nil Rat</field>
@@ -1215,35 +482,9 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="nil_rated_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_nil_rated')],
-
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_nil_rated')],
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_nil_rated')],              }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_nil_rated')],             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',              }),         ]"/>
     </record>
-
-    <!-- IGST -->
-
     <record id="igst_purchase_0" model="account.tax.template">
         <field name="name">IGST 0%</field>
         <field name="description">IGST 0%</field>
@@ -1252,32 +493,9 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'minus_report_line_ids': [ref('tax_report_line_zero_rated')],
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-                'plus_report_line_ids': [ref('tax_report_line_zero_rated')],
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'minus_report_line_ids': [ref('tax_report_line_zero_rated')],             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',                 'plus_report_line_ids': [ref('tax_report_line_zero_rated')],             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',             }),         ]"/>
     </record>
-
     <record id="igst_purchase_1" model="account.tax.template">
         <field name="name">IGST 1%</field>
         <field name="description">IGST 1%</field>
@@ -1286,34 +504,9 @@ if tax > result:result=tax</field>
         <field name="amount">1</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_2" model="account.tax.template">
         <field name="name">IGST 2%</field>
         <field name="description">IGST 2%</field>
@@ -1322,34 +515,9 @@ if tax > result:result=tax</field>
         <field name="amount">2</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_28" model="account.tax.template">
         <field name="name">IGST 28%</field>
         <field name="description">IGST 28%</field>
@@ -1358,34 +526,9 @@ if tax > result:result=tax</field>
         <field name="amount">28</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_18" model="account.tax.template">
         <field name="name">IGST 18%</field>
         <field name="description">IGST 18%</field>
@@ -1394,34 +537,9 @@ if tax > result:result=tax</field>
         <field name="amount">18</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_12" model="account.tax.template">
         <field name="name">IGST 12%</field>
         <field name="description">IGST 12%</field>
@@ -1430,34 +548,9 @@ if tax > result:result=tax</field>
         <field name="amount">12</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_5" model="account.tax.template">
         <field name="name">IGST 5%</field>
         <field name="description">IGST 5%</field>
@@ -1466,36 +559,9 @@ if tax > result:result=tax</field>
         <field name="amount">5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'minus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'plus_report_line_ids': [ref('tax_report_line_igst')],             }),         ]"/>
     </record>
-
-    <!-- SGST & CGST -->
-
     <record id="sgst_purchase_0_5" model="account.tax.template">
         <field name="name">SGST Purchase 0.5%</field>
         <field name="description">SGST 0.5%</field>
@@ -1504,32 +570,9 @@ if tax > result:result=tax</field>
         <field name="amount">0.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_0_5" model="account.tax.template">
         <field name="name">CGST Purchase 0.5%</field>
         <field name="description">CGST 0.5%</field>
@@ -1538,32 +581,9 @@ if tax > result:result=tax</field>
         <field name="amount">0.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_1" model="account.tax.template">
         <field name="name">GST 1%</field>
         <field name="description">GST 1%</field>
@@ -1574,7 +594,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_0_5'),ref('cgst_purchase_0_5'),])]"/>
     </record>
-
     <record id="sgst_purchase_1_2" model="account.tax.template">
         <field name="name">SGST Purchase 1%</field>
         <field name="description">SGST 1%</field>
@@ -1583,34 +602,9 @@ if tax > result:result=tax</field>
         <field name="amount">1</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_1_2" model="account.tax.template">
         <field name="name">CGST Purchase 1%</field>
         <field name="description">CGST 1%</field>
@@ -1619,33 +613,9 @@ if tax > result:result=tax</field>
         <field name="amount">1</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_2" model="account.tax.template">
         <field name="name">GST 2%</field>
         <field name="description">GST 2%</field>
@@ -1656,7 +626,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_1_2'),ref('cgst_purchase_1_2'),])]"/>
     </record>
-
     <record id="sgst_purchase_14" model="account.tax.template">
         <field name="name">SGST Purchase 14%</field>
         <field name="description">SGST 14%</field>
@@ -1665,32 +634,9 @@ if tax > result:result=tax</field>
         <field name="amount">14</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_14" model="account.tax.template">
         <field name="name">CGST Purchase 14%</field>
         <field name="description">CGST 14%</field>
@@ -1699,32 +645,9 @@ if tax > result:result=tax</field>
         <field name="amount">14</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_28" model="account.tax.template">
         <field name="name">GST 28%</field>
         <field name="description">GST 28%</field>
@@ -1735,7 +658,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_14'),ref('cgst_purchase_14'),])]"/>
     </record>
-
     <record id="sgst_purchase_9" model="account.tax.template">
         <field name="name">SGST Purchase 9%</field>
         <field name="description">SGST 9%</field>
@@ -1744,34 +666,9 @@ if tax > result:result=tax</field>
         <field name="amount">9</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_9" model="account.tax.template">
         <field name="name">CGST Purchase 9%</field>
         <field name="description">CGST 9%</field>
@@ -1780,32 +677,9 @@ if tax > result:result=tax</field>
         <field name="amount">9</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_18" model="account.tax.template">
         <field name="name">GST 18%</field>
         <field name="description">GST 18%</field>
@@ -1816,7 +690,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_9'),ref('cgst_purchase_9'),])]"/>
     </record>
-
     <record id="sgst_purchase_6" model="account.tax.template">
         <field name="name">SGST Purchase 6%</field>
         <field name="description">SGST 6%</field>
@@ -1825,34 +698,9 @@ if tax > result:result=tax</field>
         <field name="amount">6</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_6" model="account.tax.template">
         <field name="name">CGST Purchase 6%</field>
         <field name="description">CGST 6%</field>
@@ -1861,32 +709,9 @@ if tax > result:result=tax</field>
         <field name="amount">6</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_12" model="account.tax.template">
         <field name="name">GST 12%</field>
         <field name="description">GST 12%</field>
@@ -1897,7 +722,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="gst_group"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_6'),ref('cgst_purchase_6'),])]"/>
     </record>
-
     <record id="sgst_purchase_2_5" model="account.tax.template">
         <field name="name">SGST Purchase 2.5%</field>
         <field name="description">SGST 2.5%</field>
@@ -1906,34 +730,9 @@ if tax > result:result=tax</field>
         <field name="amount">2.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'minus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'plus_report_line_ids': [ref('tax_report_line_sgst')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_2_5" model="account.tax.template">
         <field name="name">CGST Purchase 2.5%</field>
         <field name="description">CGST 2.5%</field>
@@ -1942,32 +741,9 @@ if tax > result:result=tax</field>
         <field name="amount">2.5</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'minus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'plus_report_line_ids': [ref('tax_report_line_cgst')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_5" model="account.tax.template">
         <field name="name">GST 5%</field>
         <field name="description">GST 5%</field>
@@ -1979,11 +755,6 @@ if tax > result:result=tax</field>
         <field name="sequence">0</field>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_2_5'),ref('cgst_purchase_2_5'),])]"/>
     </record>
-
-    <!-- Purchase Reverse Charge Taxes-->
-
-    <!-- CESS Taxes -->
-
     <record id="cess_purchase_5_rc" model="account.tax.template">
         <field name="name">CESS Purchase 5% (RC)</field>
         <field name="description">CESS 5%</field>
@@ -1993,44 +764,9 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'minus_report_line_ids': [ref('tax_report_line_cess_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'plus_report_line_ids': [ref('tax_report_line_cess_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'minus_report_line_ids': [ref('tax_report_line_cess_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'plus_report_line_ids': [ref('tax_report_line_cess_rc')],             }),         ]"/>
     </record>
-
     <record id="cess_purchase_1591_rc" model="account.tax.template">
         <field name="name">CESS Purchase 1591 Per Thousand (RC)</field>
         <field name="description">1591 PER THOUSAND</field>
@@ -2040,43 +776,9 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'minus_report_line_ids': [ref('tax_report_line_cess_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'plus_report_line_ids': [ref('tax_report_line_cess_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'minus_report_line_ids': [ref('tax_report_line_cess_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'plus_report_line_ids': [ref('tax_report_line_cess_rc')],             }),         ]"/>
     </record>
-
     <record id="cess_5_plus_1591_purchase_rc" model="account.tax.template">
         <field name="name">CESS 5% + RS.1591/THOUSAND (RC)</field>
         <field name="description">CESS 5% + RS.1591/THOUSAND</field>
@@ -2088,7 +790,6 @@ if tax > result:result=tax</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
     </record>
-
     <record id="cess_21_4170_higer_purchase_rc" model="account.tax.template">
         <field name="name">CESS 21% or RS.4170/THOUSAND (RC)</field>
         <field name="description">CESS 21% or RS.4170/THOUSAND</field>
@@ -2097,50 +798,13 @@ if tax > result:result=tax</field>
         <field name="amount">0</field>
         <field name="python_compute">result=base_amount * 0.21
 tax=quantity * 4.17
-if tax > result:result=tax</field>
+if tax &gt; result:result=tax</field>
         <field name="tax_group_id" ref="cess_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11235'),
-                'minus_report_line_ids': [ref('tax_report_line_cess_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10055'),
-                'plus_report_line_ids': [ref('tax_report_line_cess_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11235'),                 'minus_report_line_ids': [ref('tax_report_line_cess_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10055'),                 'plus_report_line_ids': [ref('tax_report_line_cess_rc')],             }),         ]"/>
     </record>
-
-
-    <!-- IGST -->
-
     <record id="igst_purchase_1_rc" model="account.tax.template">
         <field name="name">IGST 1% (RC)</field>
         <field name="description">IGST 1%</field>
@@ -2150,44 +814,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst'), ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'minus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'plus_report_line_ids': [ref('tax_report_line_igst'), ref('tax_report_line_igst_rc')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_2_rc" model="account.tax.template">
         <field name="name">IGST 2% (RC)</field>
         <field name="description">IGST 2%</field>
@@ -2197,43 +826,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'minus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'plus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_28_rc" model="account.tax.template">
         <field name="name">IGST 28% (RC)</field>
         <field name="description">IGST 28%</field>
@@ -2243,44 +838,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst'), ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'minus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'plus_report_line_ids': [ref('tax_report_line_igst'), ref('tax_report_line_igst_rc')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_18_rc" model="account.tax.template">
         <field name="name">IGST 18% (RC)</field>
         <field name="description">IGST 18%</field>
@@ -2290,44 +850,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'minus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'plus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_12_rc" model="account.tax.template">
         <field name="name">IGST 12% (RC)</field>
         <field name="description">IGST 12%</field>
@@ -2337,44 +862,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'minus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'plus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
     </record>
-
     <record id="igst_purchase_5_rc" model="account.tax.template">
         <field name="name">IGST 5% (RC)</field>
         <field name="description">IGST 5%</field>
@@ -2384,46 +874,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="igst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11234'),                 'minus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10053'),                 'plus_report_line_ids': [ref('tax_report_line_igst_rc')],             }),         ]"/>
     </record>
-
-    <!-- SGST & CGST -->
-
     <record id="sgst_purchase_0_5_rc" model="account.tax.template">
         <field name="name">SGST Purchase 0.5% (RC)</field>
         <field name="description">SGST 0.5%</field>
@@ -2433,42 +886,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_0_5_rc" model="account.tax.template">
         <field name="name">CGST Purchase 0.5% (RC)</field>
         <field name="description">CGST 0.5%</field>
@@ -2478,42 +898,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_1_rc" model="account.tax.template">
         <field name="name">GST 1% (RC)</field>
         <field name="description">GST 1%</field>
@@ -2525,7 +912,6 @@ if tax > result:result=tax</field>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_0_5_rc'),ref('cgst_purchase_0_5_rc'),])]"/>
     </record>
-
     <record id="sgst_purchase_1_2_rc" model="account.tax.template">
         <field name="name">SGST Purchase 1% (RC)</field>
         <field name="description">SGST 1%</field>
@@ -2535,44 +921,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_1_2_rc" model="account.tax.template">
         <field name="name">CGST Purchase 1% (RC)</field>
         <field name="description">CGST 1%</field>
@@ -2582,43 +933,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            })
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            })
-        ]"/>
-
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],             })         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],             })         ]"/>
     </record>
-
     <record id="sgst_purchase_2_rc" model="account.tax.template">
         <field name="name">GST 2% (RC)</field>
         <field name="description">GST 2%</field>
@@ -2630,7 +947,6 @@ if tax > result:result=tax</field>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_1_2_rc'),ref('cgst_purchase_1_2_rc'),])]"/>
     </record>
-
     <record id="sgst_purchase_14_rc" model="account.tax.template">
         <field name="name">SGST Purchase 14% (RC)</field>
         <field name="description">SGST 14%</field>
@@ -2640,43 +956,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),          ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),         ]"/>
     </record>
-
     <record id="cgst_purchase_14_rc" model="account.tax.template">
         <field name="name">CGST Purchase 14% (RC)</field>
         <field name="description">CGST 14%</field>
@@ -2686,42 +968,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
     </record>
-
     <record id="sgst_purchase_28_rc" model="account.tax.template">
         <field name="name">GST 28% (RC)</field>
         <field name="description">GST 28%</field>
@@ -2733,7 +982,6 @@ if tax > result:result=tax</field>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_14_rc'),ref('cgst_purchase_14_rc'),])]"/>
     </record>
-
     <record id="sgst_purchase_9_rc" model="account.tax.template">
         <field name="name">SGST Purchase 9% (RC)</field>
         <field name="description">SGST 9%</field>
@@ -2743,44 +991,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),         ]"/>
     </record>
-
     <record id="cgst_purchase_9_rc" model="account.tax.template">
         <field name="name">CGST Purchase 9% (RC)</field>
         <field name="description">CGST 9%</field>
@@ -2790,42 +1003,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
     </record>
-
     <record id="sgst_purchase_18_rc" model="account.tax.template">
         <field name="name">GST 18% (RC)</field>
         <field name="description">GST 18%</field>
@@ -2837,7 +1017,6 @@ if tax > result:result=tax</field>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_9_rc'),ref('cgst_purchase_9_rc'),])]"/>
     </record>
-
     <record id="sgst_purchase_6_rc" model="account.tax.template">
         <field name="name">SGST Purchase 6% (RC)</field>
         <field name="description">SGST 6%</field>
@@ -2847,44 +1026,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),         ]"/>
     </record>
-
     <record id="cgst_purchase_6_rc" model="account.tax.template">
         <field name="name">CGST Purchase 6% (RC)</field>
         <field name="description">CGST 6%</field>
@@ -2894,42 +1038,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
     </record>
-
     <record id="sgst_purchase_12_rc" model="account.tax.template">
         <field name="name">GST 12% (RC)</field>
         <field name="description">GST 12%</field>
@@ -2941,7 +1052,6 @@ if tax > result:result=tax</field>
         <field name="l10n_in_reverse_charge" eval="True"/>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_6_rc'),ref('cgst_purchase_6_rc'),])]"/>
     </record>
-
     <record id="sgst_purchase_2_5_rc" model="account.tax.template">
         <field name="name">SGST Purchase 2.5% (RC)</field>
         <field name="description">SGST 2.5%</field>
@@ -2951,44 +1061,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="sgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],
-            })
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11232'),                 'minus_report_line_ids': [ref('tax_report_line_sgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),              (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10051'),                 'plus_report_line_ids': [ref('tax_report_line_sgst_rc')],             })         ]"/>
     </record>
-
     <record id="cgst_purchase_2_5_rc" model="account.tax.template">
         <field name="name">CGST Purchase 2.5% (RC)</field>
         <field name="description">CGST 2.5%</field>
@@ -2998,42 +1073,9 @@ if tax > result:result=tax</field>
         <field name="chart_template_id" ref="indian_chart_template_standard"/>
         <field name="tax_group_id" ref="cgst_group"/>
         <field name="l10n_in_reverse_charge" eval="True"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p11233'),
-                'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'base',
-            }),
-            (0,0, {
-                'factor_percent': 100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10057'),
-            }),
-            (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],
-            }),
-        ]"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p11233'),                 'minus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'base',             }),             (0,0, {                 'factor_percent': 100,                 'repartition_type': 'tax',                 'account_id': ref('p10057'),             }),             (0,0, {                 'factor_percent': -100,                 'repartition_type': 'tax',                 'account_id': ref('p10052'),                 'plus_report_line_ids': [ref('tax_report_line_cgst_rc')],             }),         ]"/>
     </record>
-
     <record id="sgst_purchase_5_rc" model="account.tax.template">
         <field name="name">GST 5% (RC)</field>
         <field name="description">GST 5%</field>
@@ -3046,5 +1088,4 @@ if tax > result:result=tax</field>
         <field name="sequence">0</field>
         <field name="children_tax_ids" eval="[(6, 0, [ref('sgst_purchase_2_5_rc'),ref('cgst_purchase_2_5_rc'),])]"/>
     </record>
-
 </odoo>

--- a/addons/l10n_it/data/account_tax_report_data.xml
+++ b/addons/l10n_it/data/account_tax_report_data.xml
@@ -1,202 +1,160 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report_vat" model="account.tax.report">
         <field name="name">VAT Report</field>
         <field name="country_id" ref="base.it"/>
-    </record>
-
-    <record id="tax_report_line_operazione_imponibile" model="account.tax.report.line">
-        <field name="name">Operazione Imponibile</field>
-        <field name="code">h1</field>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp2" model="account.tax.report.line">
-        <field name="name">VP2 - Totale operazioni attive</field>
-        <field name="code">VP2</field>
-        <field name="parent_id" ref="tax_report_line_operazione_imponibile"/>
-        <field name="tag_name">02</field>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp3" model="account.tax.report.line">
-        <field name="name">VP3 - Totale operazioni passive</field>
-        <field name="code">VP3</field>
-        <field name="parent_id" ref="tax_report_line_operazione_imponibile"/>
-        <field name="tag_name">03</field>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_iva" model="account.tax.report.line">
-        <field name="name">IVA</field>
-        <field name="code">h2</field>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp4" model="account.tax.report.line">
-        <field name="name">VP4 - IVA esigibile</field>
-        <field name="code">VP4</field>
-        <field name="parent_id" ref="tax_report_line_iva"/>
-        <field name="tag_name">4v</field>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp5" model="account.tax.report.line">
-        <field name="name">VP5 - IVA detraibile</field>
-        <field name="code">VP5</field>
-        <field name="parent_id" ref="tax_report_line_iva"/>
-        <field name="tag_name">5v</field>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_saldi_riporti_e_interessi" model="account.tax.report.line">
-        <field name="name">Saldi, riporti e interessi</field>
-        <field name="code">h3</field>
-        <field name="sequence">3</field>
-        <field name="formula">None</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp6" model="account.tax.report.line">
-        <field name="name">VP6 - IVA dovuta</field>
-        <field name="code">VP6</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-    <record id="tax_report_line_vp6a" model="account.tax.report.line">
-        <field name="name">VP6a - IVA dovuta (debito)</field>
-        <field name="code">VP6a</field>
-        <field name="parent_id" ref="tax_report_line_vp6"/>
-        <field name="formula">VP4&gt;VP5 and VP4-VP5 or 0</field>
-        <field name="sequence">1</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-    <record id="tax_report_line_vp6b" model="account.tax.report.line">
-        <field name="name">VP6b - IVA dovuta (credito)</field>
-        <field name="code">VP6b</field>
-        <field name="parent_id" ref="tax_report_line_vp6"/>
-        <field name="formula">VP5&gt;VP4 and VP5-VP4 or 0</field>
-        <field name="sequence">2</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp7" model="account.tax.report.line">
-        <field name="name">VP7 - Debito periodo precedente non superiore 25,82</field>
-        <field name="code">VP7</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">2</field>
-        <field name="tag_name">vp7</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="is_carryover_used_in_balance">True</field>
-    </record>
-
-    <record id="tax_report_line_vp8" model="account.tax.report.line">
-        <field name="name">VP8 - Credito periodo precedente</field>
-        <field name="code">VP8</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">3</field>
-        <field name="tag_name">vp8</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="is_carryover_used_in_balance">True</field>
-    </record>
-
-    <record id="tax_report_line_vp9" model="account.tax.report.line">
-        <field name="name">VP9 - Credito anno precedente</field>
-        <field name="code">VP9</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">4</field>
-        <field name="tag_name">vp9</field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="is_carryover_used_in_balance">True</field>
-    </record>
-
-    <record id="tax_report_line_vp10" model="account.tax.report.line">
-        <field name="name">VP10 - Versamenti auto UE</field>
-        <field name="code">VP10</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">5</field>
-        <field name="tag_name">vp10</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp11" model="account.tax.report.line">
-        <field name="name">VP11 - Credito d'imposta</field>
-        <field name="code">VP11</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">6</field>
-        <field name="tag_name">vp11</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp12" model="account.tax.report.line">
-        <field name="name">VP12 - Interessi dovuti per liquidazioni trimestrali</field>
-        <field name="code">VP12</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">7</field>
-        <field name="tag_name">vp12</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_vp13" model="account.tax.report.line">
-        <field name="name">VP13 - Acconto dovuto</field>
-        <field name="code">VP13</field>
-        <field name="parent_id" ref="tax_report_line_saldi_riporti_e_interessi"/>
-        <field name="sequence">8</field>
-        <field name="tag_name">vp13</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_line_conto_corrente_iva" model="account.tax.report.line">
-        <field name="name">Conto corrente IVA</field>
-        <field name="code">h4</field>
-        <field name="sequence">4</field>
-        <field name="formula">None</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-    <record id="tax_report_line_vp14" model="account.tax.report.line">
-        <field name="name">VP14 - IVA da versare</field>
-        <field name="code">VP14</field>
-        <field name="parent_id" ref="tax_report_line_conto_corrente_iva"/>
-        <field name="sequence">1</field>
-        <field name="formula">None</field>
-        <field name="report_id" ref="tax_report_vat"/>
-    </record>
-    <record id="tax_report_line_vp14a" model="account.tax.report.line">
-        <field name="name">VP14a - IVA da versare (debito)</field>
-        <field name="code">VP14a</field>
-        <field name="parent_id" ref="tax_report_line_vp14"/>
-        <field name="sequence">1</field>
-        <field name="formula">max(((VP4&gt;VP5 and VP4-VP5 or 0) + VP7 + VP12) - ((VP5&gt;VP4 and VP5-VP4 or 0) + VP8 +
+        <field name="root_line_ids">
+            <record id="tax_report_line_operazione_imponibile" model="account.tax.report.line">
+                <field name="name">Operazione Imponibile</field>
+                <field name="code">h1</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_vp2" model="account.tax.report.line">
+                        <field name="name">VP2 - Totale operazioni attive</field>
+                        <field name="code">VP2</field>
+                        <field name="tag_name">02</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_vp3" model="account.tax.report.line">
+                        <field name="name">VP3 - Totale operazioni passive</field>
+                        <field name="code">VP3</field>
+                        <field name="tag_name">03</field>
+                        <field name="sequence">2</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_iva" model="account.tax.report.line">
+                <field name="name">IVA</field>
+                <field name="code">h2</field>
+                <field name="sequence">2</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_vp4" model="account.tax.report.line">
+                        <field name="name">VP4 - IVA esigibile</field>
+                        <field name="code">VP4</field>
+                        <field name="tag_name">4v</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_vp5" model="account.tax.report.line">
+                        <field name="name">VP5 - IVA detraibile</field>
+                        <field name="code">VP5</field>
+                        <field name="tag_name">5v</field>
+                        <field name="sequence">2</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_saldi_riporti_e_interessi" model="account.tax.report.line">
+                <field name="name">Saldi, riporti e interessi</field>
+                <field name="code">h3</field>
+                <field name="sequence">3</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_vp6" model="account.tax.report.line">
+                        <field name="name">VP6 - IVA dovuta</field>
+                        <field name="code">VP6</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_vp6a" model="account.tax.report.line">
+                                <field name="name">VP6a - IVA dovuta (debito)</field>
+                                <field name="code">VP6a</field>
+                                <field name="formula">VP4&gt;VP5 and VP4-VP5 or 0</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_line_vp6b" model="account.tax.report.line">
+                                <field name="name">VP6b - IVA dovuta (credito)</field>
+                                <field name="code">VP6b</field>
+                                <field name="formula">VP5&gt;VP4 and VP5-VP4 or 0</field>
+                                <field name="sequence">2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_vp7" model="account.tax.report.line">
+                        <field name="name">VP7 - Debito periodo precedente non superiore 25,82</field>
+                        <field name="code">VP7</field>
+                        <field name="sequence">2</field>
+                        <field name="tag_name">vp7</field>
+                        <field name="is_carryover_used_in_balance">True</field>
+                    </record>
+                    <record id="tax_report_line_vp8" model="account.tax.report.line">
+                        <field name="name">VP8 - Credito periodo precedente</field>
+                        <field name="code">VP8</field>
+                        <field name="sequence">3</field>
+                        <field name="tag_name">vp8</field>
+                        <field name="is_carryover_used_in_balance">True</field>
+                    </record>
+                    <record id="tax_report_line_vp9" model="account.tax.report.line">
+                        <field name="name">VP9 - Credito anno precedente</field>
+                        <field name="code">VP9</field>
+                        <field name="sequence">4</field>
+                        <field name="tag_name">vp9</field>
+                        <field name="is_carryover_used_in_balance">True</field>
+                    </record>
+                    <record id="tax_report_line_vp10" model="account.tax.report.line">
+                        <field name="name">VP10 - Versamenti auto UE</field>
+                        <field name="code">VP10</field>
+                        <field name="sequence">5</field>
+                        <field name="tag_name">vp10</field>
+                    </record>
+                    <record id="tax_report_line_vp11" model="account.tax.report.line">
+                        <field name="name">VP11 - Credito d'imposta</field>
+                        <field name="code">VP11</field>
+                        <field name="sequence">6</field>
+                        <field name="tag_name">vp11</field>
+                    </record>
+                    <record id="tax_report_line_vp12" model="account.tax.report.line">
+                        <field name="name">VP12 - Interessi dovuti per liquidazioni trimestrali</field>
+                        <field name="code">VP12</field>
+                        <field name="sequence">7</field>
+                        <field name="tag_name">vp12</field>
+                    </record>
+                    <record id="tax_report_line_vp13" model="account.tax.report.line">
+                        <field name="name">VP13 - Acconto dovuto</field>
+                        <field name="code">VP13</field>
+                        <field name="sequence">8</field>
+                        <field name="tag_name">vp13</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_conto_corrente_iva" model="account.tax.report.line">
+                <field name="name">Conto corrente IVA</field>
+                <field name="code">h4</field>
+                <field name="sequence">4</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_vp14" model="account.tax.report.line">
+                        <field name="name">VP14 - IVA da versare</field>
+                        <field name="code">VP14</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">None</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_line_vp14a" model="account.tax.report.line">
+                                <field name="name">VP14a - IVA da versare (debito)</field>
+                                <field name="code">VP14a</field>
+                                <field name="sequence">1</field>
+                                <field name="formula">max(((VP4&gt;VP5 and VP4-VP5 or 0) + VP7 + VP12) - ((VP5&gt;VP4 and VP5-VP4 or 0) + VP8 +
             VP9 + VP10 + VP11 + VP13), 0)
         </field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="carry_over_condition_method">vp14_debt_carryover_condition</field>
-        <field name="carry_over_destination_line_id" ref="tax_report_line_vp7"/>
-        <field name="is_carryover_persistent">False</field>
-    </record>
-    <record id="tax_report_line_vp14b" model="account.tax.report.line">
-        <field name="name">VP14b - IVA da versare (credito)</field>
-        <field name="code">VP14b</field>
-        <field name="parent_id" ref="tax_report_line_vp14"/>
-        <field name="sequence">2</field>
-        <field name="formula">max(((VP5&gt;VP4 and VP5-VP4 or 0) + VP8 + VP9 + VP10 + VP11 + VP13) - ((VP4&gt;VP5 and
+                                <field name="carry_over_condition_method">vp14_debt_carryover_condition</field>
+                                <field name="carry_over_destination_line_id" ref="tax_report_line_vp7"/>
+                                <field name="is_carryover_persistent">False</field>
+                            </record>
+                            <record id="tax_report_line_vp14b" model="account.tax.report.line">
+                                <field name="name">VP14b - IVA da versare (credito)</field>
+                                <field name="code">VP14b</field>
+                                <field name="sequence">2</field>
+                                <field name="formula">max(((VP5&gt;VP4 and VP5-VP4 or 0) + VP8 + VP9 + VP10 + VP11 + VP13) - ((VP4&gt;VP5 and
             VP4-VP5 or 0) + VP7 + VP12), 0)
         </field>
-        <field name="report_id" ref="tax_report_vat"/>
-        <field name="carry_over_condition_method">vp14_credit_carryover_condition</field>
-        <field name="carry_over_destination_line_id" ref="tax_report_line_vp8"/>
-        <field name="is_carryover_persistent">False</field>
+                                <field name="carry_over_condition_method">vp14_credit_carryover_condition</field>
+                                <field name="carry_over_destination_line_id" ref="tax_report_line_vp8"/>
+                                <field name="is_carryover_persistent">False</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
 </odoo>

--- a/addons/l10n_jp/data/account_tax_report_data.xml
+++ b/addons/l10n_jp/data/account_tax_report_data.xml
@@ -1,177 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.jp"/>
+        <field name="root_line_ids">
+            <record id="tax_report_to_pay" model="account.tax.report.line">
+                <field name="name">支払対象税額</field>
+                <field name="sequence">1</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_to_pay_temp_tx" model="account.tax.report.line">
+                        <field name="name">仮受税額</field>
+                        <field name="sequence">1</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_to_pay_temp_tx_output_8" model="account.tax.report.line">
+                                <field name="name">仮受消費税(8%)</field>
+                                <field name="tag_name">仮受消費税(8%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_to_pay_temp_tx_output_10" model="account.tax.report.line">
+                                <field name="name">仮受消費税(10%)</field>
+                                <field name="tag_name">仮受消費税(10%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_to_pay_temp_tx_duty_free" model="account.tax.report.line">
+                                <field name="name">免税</field>
+                                <field name="tag_name">免税</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_to_pay_temp_tx_tax_free" model="account.tax.report.line">
+                                <field name="name">不課税</field>
+                                <field name="tag_name">不課税 (仮受税額)</field>
+                                <field name="sequence">3</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_to_pay_temp_pmt" model="account.tax.report.line">
+                        <field name="name">仮払税額</field>
+                        <field name="sequence">2</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_to_pay_temp_pmt_susp_cons_8" model="account.tax.report.line">
+                                <field name="name">仮払消費税(8%)</field>
+                                <field name="tag_name">仮払消費税(8%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_to_pay_temp_pmt_susp_cons_10" model="account.tax.report.line">
+                                <field name="name">仮払消費税(10%)</field>
+                                <field name="tag_name">仮払消費税(10%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_to_pay_temp_pmt_import_8" model="account.tax.report.line">
+                                <field name="name">輸入</field>
+                                <field name="tag_name">輸入</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_to_pay_temp_pmt_tax_free" model="account.tax.report.line">
+                                <field name="name">不課税</field>
+                                <field name="tag_name">不課税 (仮払税額)</field>
+                                <field name="sequence">3</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_comp_basis" model="account.tax.report.line">
+                <field name="name">税計算基準額</field>
+                <field name="sequence">2</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_comp_basis_sales" model="account.tax.report.line">
+                        <field name="name">販売基準額</field>
+                        <field name="sequence">1</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_comp_basis_sales_taxable_8" model="account.tax.report.line">
+                                <field name="name">課税対象売上(8%)</field>
+                                <field name="tag_name">課税対象売上(8%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_comp_basis_sales_taxable_10" model="account.tax.report.line">
+                                <field name="name">課税対象売上(10%)</field>
+                                <field name="tag_name">課税対象売上(10%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_comp_basis_sales_duty_free" model="account.tax.report.line">
+                                <field name="name">免税売上</field>
+                                <field name="tag_name">免税売上</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_comp_basis_sales_tax_free" model="account.tax.report.line">
+                                <field name="name">不課税売上</field>
+                                <field name="tag_name">不課税売上</field>
+                                <field name="sequence">3</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_comp_basis_purchases" model="account.tax.report.line">
+                        <field name="name">購買基準額</field>
+                        <field name="sequence">2</field>
+                        <field name="children_line_ids">
+                            <record id="tax_report_comp_basis_purchases_taxable_8" model="account.tax.report.line">
+                                <field name="name">課税対象仕入(8%)</field>
+                                <field name="tag_name">課税対象仕入(8%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_comp_basis_purchases_taxable_10" model="account.tax.report.line">
+                                <field name="name">課税対象仕入(10%)</field>
+                                <field name="tag_name">課税対象仕入(10%)</field>
+                                <field name="sequence">1</field>
+                            </record>
+                            <record id="tax_report_comp_basis_purchases_import" model="account.tax.report.line">
+                                <field name="name">輸入仕入</field>
+                                <field name="tag_name">輸入仕入</field>
+                                <field name="sequence">2</field>
+                            </record>
+                            <record id="tax_report_comp_basis_purchases_tax_free" model="account.tax.report.line">
+                                <field name="name">不課税仕入</field>
+                                <field name="tag_name">不課税仕入</field>
+                                <field name="sequence">3</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_to_pay" model="account.tax.report.line">
-        <field name="name">支払対象税額</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_tx" model="account.tax.report.line">
-        <field name="name">仮受税額</field>
-        <field name="parent_id" ref="tax_report_to_pay"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_tx_output_8" model="account.tax.report.line">
-        <field name="name">仮受消費税(8%)</field>
-        <field name="tag_name">仮受消費税(8%)</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_tx"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_tx_output_10" model="account.tax.report.line">
-        <field name="name">仮受消費税(10%)</field>
-        <field name="tag_name">仮受消費税(10%)</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_tx"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_tx_duty_free" model="account.tax.report.line">
-        <field name="name">免税</field>
-        <field name="tag_name">免税</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_tx"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_tx_tax_free" model="account.tax.report.line">
-        <field name="name">不課税</field>
-        <field name="tag_name">不課税 (仮受税額)</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_tx"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_pmt" model="account.tax.report.line">
-        <field name="name">仮払税額</field>
-        <field name="parent_id" ref="tax_report_to_pay"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_pmt_susp_cons_8" model="account.tax.report.line">
-        <field name="name">仮払消費税(8%)</field>
-        <field name="tag_name">仮払消費税(8%)</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_pmt"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_pmt_susp_cons_10" model="account.tax.report.line">
-        <field name="name">仮払消費税(10%)</field>
-        <field name="tag_name">仮払消費税(10%)</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_pmt"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_pmt_import_8" model="account.tax.report.line">
-        <field name="name">輸入</field>
-        <field name="tag_name">輸入</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_pmt"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_to_pay_temp_pmt_tax_free" model="account.tax.report.line">
-        <field name="name">不課税</field>
-        <field name="tag_name">不課税 (仮払税額)</field>
-        <field name="parent_id" ref="tax_report_to_pay_temp_pmt"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_comp_basis" model="account.tax.report.line">
-        <field name="name">税計算基準額</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_comp_basis_sales" model="account.tax.report.line">
-        <field name="name">販売基準額</field>
-        <field name="parent_id" ref="tax_report_comp_basis"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_comp_basis_sales_taxable_8" model="account.tax.report.line">
-        <field name="name">課税対象売上(8%)</field>
-        <field name="tag_name">課税対象売上(8%)</field>
-        <field name="parent_id" ref="tax_report_comp_basis_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_comp_basis_sales_taxable_10" model="account.tax.report.line">
-        <field name="name">課税対象売上(10%)</field>
-        <field name="tag_name">課税対象売上(10%)</field>
-        <field name="parent_id" ref="tax_report_comp_basis_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_comp_basis_sales_duty_free" model="account.tax.report.line">
-        <field name="name">免税売上</field>
-        <field name="tag_name">免税売上</field>
-        <field name="parent_id" ref="tax_report_comp_basis_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_comp_basis_sales_tax_free" model="account.tax.report.line">
-        <field name="name">不課税売上</field>
-        <field name="tag_name">不課税売上</field>
-        <field name="parent_id" ref="tax_report_comp_basis_sales"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_comp_basis_purchases" model="account.tax.report.line">
-        <field name="name">購買基準額</field>
-        <field name="parent_id" ref="tax_report_comp_basis"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_comp_basis_purchases_taxable_8" model="account.tax.report.line">
-        <field name="name">課税対象仕入(8%)</field>
-        <field name="tag_name">課税対象仕入(8%)</field>
-        <field name="parent_id" ref="tax_report_comp_basis_purchases"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_comp_basis_purchases_taxable_10" model="account.tax.report.line">
-        <field name="name">課税対象仕入(10%)</field>
-        <field name="tag_name">課税対象仕入(10%)</field>
-        <field name="parent_id" ref="tax_report_comp_basis_purchases"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_comp_basis_purchases_import" model="account.tax.report.line">
-        <field name="name">輸入仕入</field>
-        <field name="tag_name">輸入仕入</field>
-        <field name="parent_id" ref="tax_report_comp_basis_purchases"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_comp_basis_purchases_tax_free" model="account.tax.report.line">
-        <field name="name">不課税仕入</field>
-        <field name="tag_name">不課税仕入</field>
-        <field name="parent_id" ref="tax_report_comp_basis_purchases"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
 </odoo>

--- a/addons/l10n_lu/data/account_tax_report_line.xml
+++ b/addons/l10n_lu/data/account_tax_report_line.xml
@@ -1,1017 +1,724 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.lu"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_2_assesment_of_tax_due" model="account.tax.report.line">
+                <field name="name">II. ASSESSMENT OF TAX DUE (output tax)</field>
+                <field name="sequence">2</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_2b_intra_community_acqui_of_goods_base" model="account.tax.report.line">
+                        <field name="name">051 - Intra-Community acquisitions of goods – base</field>
+                        <field name="sequence">3</field>
+                        <field name="code">LUTAX_051</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2b_base_3" model="account.tax.report.line">
+                                <field name="name">049 - base 3%</field>
+                                <field name="tag_name">049</field>
+                                <field name="sequence">9</field>
+                                <field name="code">LUTAX_049</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_base_exempt" model="account.tax.report.line">
+                                <field name="name">194 - base exempt</field>
+                                <field name="tag_name">194</field>
+                                <field name="sequence">10</field>
+                                <field name="code">LUTAX_194</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_base_17" model="account.tax.report.line">
+                                <field name="name">711 - base 17%</field>
+                                <field name="tag_name">711</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_711</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_base_14" model="account.tax.report.line">
+                                <field name="name">713 - base 14%</field>
+                                <field name="tag_name">713</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_713</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_base_8" model="account.tax.report.line">
+                                <field name="name">715 - base 8%</field>
+                                <field name="tag_name">715</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_715</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2d_importation_of_goods_base" model="account.tax.report.line">
+                        <field name="name">065 - Importation of goods – base</field>
+                        <field name="sequence">6</field>
+                        <field name="code">LUTAX_065</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2d_2_base_exempt" model="account.tax.report.line">
+                                <field name="name">196 - for non-business purposes: base exempt</field>
+                                <field name="tag_name">196</field>
+                                <field name="sequence">12</field>
+                                <field name="code">LUTAX_196</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_base_17" model="account.tax.report.line">
+                                <field name="name">721 - for business purposes: base 17%</field>
+                                <field name="tag_name">721</field>
+                                <field name="sequence">3</field>
+                                <field name="code">LUTAX_721</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_base_14" model="account.tax.report.line">
+                                <field name="name">723 - for business purposes: base 14%</field>
+                                <field name="tag_name">723</field>
+                                <field name="sequence">4</field>
+                                <field name="code">LUTAX_723</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_base_8" model="account.tax.report.line">
+                                <field name="name">725 - for business purposes: base 8%</field>
+                                <field name="tag_name">725</field>
+                                <field name="sequence">5</field>
+                                <field name="code">LUTAX_725</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_base_17" model="account.tax.report.line">
+                                <field name="name">731 - for non-business purposes: base 17%</field>
+                                <field name="tag_name">731</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_731</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_base_14" model="account.tax.report.line">
+                                <field name="name">733 - for non-business purposes: base 14%</field>
+                                <field name="tag_name">733</field>
+                                <field name="sequence">9</field>
+                                <field name="code">LUTAX_733</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_base_8" model="account.tax.report.line">
+                                <field name="name">735 - for non-business purposes: base 8%</field>
+                                <field name="tag_name">735</field>
+                                <field name="sequence">10</field>
+                                <field name="code">LUTAX_735</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_base_3" model="account.tax.report.line">
+                                <field name="name">059 - for business purposes: base 3%</field>
+                                <field name="tag_name">059</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_059</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_base_3" model="account.tax.report.line">
+                                <field name="name">063 - for non-business purposes: base 3%</field>
+                                <field name="tag_name">063</field>
+                                <field name="sequence">11</field>
+                                <field name="code">LUTAX_063</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_base_exempt" model="account.tax.report.line">
+                                <field name="name">195 - for business purposes: base exempt</field>
+                                <field name="tag_name">195</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_195</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2c_acquisitions_triangular_transactions_base" model="account.tax.report.line">
+                        <field name="name">152 - Acquisitions, in the context of triangular transactions – base</field>
+                        <field name="tag_name">152</field>
+                        <field name="sequence">5</field>
+                        <field name="code">LUTAX_152</field>
+                    </record>
+                    <record id="account_tax_report_line_2e_supply_of_service_for_customer" model="account.tax.report.line">
+                        <field name="name">409 - Supply of services for which the customer is liable for the payment of VAT – base</field>
+                        <field name="sequence">8</field>
+                        <field name="code">LUTAX_409</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2e_1_base" model="account.tax.report.line">
+                                <field name="name">436 - base</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_436</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_2e_1_a_base_3" model="account.tax.report.line">
+                                        <field name="name">431 - not exempt within the territory: base 3%</field>
+                                        <field name="tag_name">431</field>
+                                        <field name="sequence">9</field>
+                                        <field name="code">LUTAX_431</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_1_a_base_17" model="account.tax.report.line">
+                                        <field name="name">741 - not exempt within the territory: base 17%</field>
+                                        <field name="tag_name">741</field>
+                                        <field name="sequence">6</field>
+                                        <field name="code">LUTAX_741</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_1_a_base_14" model="account.tax.report.line">
+                                        <field name="name">743 - not exempt within the territory: base 14%</field>
+                                        <field name="tag_name">743</field>
+                                        <field name="sequence">7</field>
+                                        <field name="code">LUTAX_743</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_1_a_base_8" model="account.tax.report.line">
+                                        <field name="name">745 - not exempt within the territory: base 8%</field>
+                                        <field name="tag_name">745</field>
+                                        <field name="sequence">8</field>
+                                        <field name="code">LUTAX_745</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_2e_1_b_exempt" model="account.tax.report.line">
+                                <field name="name">435 - exempt within the territory: exempt</field>
+                                <field name="tag_name">435</field>
+                                <field name="sequence">2</field>
+                                <field name="code">LUTAX_435</field>
+                            </record>
+                            <record id="account_tax_report_line_2e_2_base" model="account.tax.report.line">
+                                <field name="name">463 - base</field>
+                                <field name="sequence">3</field>
+                                <field name="code">LUTAX_463</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_2e_2_base_3" model="account.tax.report.line">
+                                        <field name="name">441 - not established or residing within the Community: base 3%</field>
+                                        <field name="tag_name">441</field>
+                                        <field name="sequence">9</field>
+                                        <field name="code">LUTAX_441</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_exempt" model="account.tax.report.line">
+                                        <field name="name">445 - not established or residing within the Community: exempt</field>
+                                        <field name="tag_name">445</field>
+                                        <field name="sequence">10</field>
+                                        <field name="code">LUTAX_445</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_base_17" model="account.tax.report.line">
+                                        <field name="name">751 - not established or residing within the Community: base 17%</field>
+                                        <field name="tag_name">751</field>
+                                        <field name="sequence">6</field>
+                                        <field name="code">LUTAX_751</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_base_14" model="account.tax.report.line">
+                                        <field name="name">753 - not established or residing within the Community: base 14%</field>
+                                        <field name="tag_name">753</field>
+                                        <field name="sequence">7</field>
+                                        <field name="code">LUTAX_753</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_base_8" model="account.tax.report.line">
+                                        <field name="name">755 - not established or residing within the Community: base 8%</field>
+                                        <field name="tag_name">755</field>
+                                        <field name="sequence">8</field>
+                                        <field name="code">LUTAX_755</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_2e_3_base" model="account.tax.report.line">
+                                <field name="name">765 - base</field>
+                                <field name="sequence">4</field>
+                                <field name="code">LUTAX_765</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_2e_3_base_17" model="account.tax.report.line">
+                                        <field name="name">761 - suppliers established within the territory: base 17%</field>
+                                        <field name="tag_name">761</field>
+                                        <field name="sequence">1</field>
+                                        <field name="code">LUTAX_761</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2a_breakdown_taxable_turnover_base" model="account.tax.report.line">
+                        <field name="name">037 - Breakdown of taxable turnover – base</field>
+                        <field name="sequence">1</field>
+                        <field name="code">LUTAX_037</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2a_base_3" model="account.tax.report.line">
+                                <field name="name">031 - base 3%</field>
+                                <field name="tag_name">031</field>
+                                <field name="sequence">9</field>
+                                <field name="code">LUTAX_031</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_base_0" model="account.tax.report.line">
+                                <field name="name">033 - base 0%</field>
+                                <field name="tag_name">033</field>
+                                <field name="sequence">10</field>
+                                <field name="code">LUTAX_033</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_base_17" model="account.tax.report.line">
+                                <field name="name">701 - base 17%</field>
+                                <field name="tag_name">701</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_701</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_base_14" model="account.tax.report.line">
+                                <field name="name">703 - base 14%</field>
+                                <field name="tag_name">703</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_703</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_base_8" model="account.tax.report.line">
+                                <field name="name">705 - base 8%</field>
+                                <field name="tag_name">705</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_705</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2f_supply_goods_base" model="account.tax.report.line">
+                        <field name="name">767 - Supply of goods for which the purchaser is liable for the payment of VAT - base</field>
+                        <field name="sequence">10</field>
+                        <field name="code">LUTAX_767</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2f_supply_goods_base_8" model="account.tax.report.line">
+                                <field name="name">763 - base 8%</field>
+                                <field name="tag_name">763</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_763</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2f_supply_goods_tax" model="account.tax.report.line">
+                        <field name="name">768 - Supply of goods for which the purchaser is liable for the payment of VAT - tax</field>
+                        <field name="sequence">11</field>
+                        <field name="code">LUTAX_768</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2f_supply_goods_tax_8" model="account.tax.report.line">
+                                <field name="name">764 - tax 8%</field>
+                                <field name="tag_name">764</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_764</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2g_special_arrangement" model="account.tax.report.line">
+                        <field name="name">227 - Special arrangement for tax suspension: adjustment</field>
+                        <field name="tag_name">227</field>
+                        <field name="sequence">12</field>
+                        <field name="code">LUTAX_227</field>
+                    </record>
+                    <record id="account_tax_report_line_2h_total_tax_due" model="account.tax.report.line">
+                        <field name="name">076 - Total tax due</field>
+                        <field name="sequence">13</field>
+                        <field name="code">LUTAX_076</field>
+                        <field name="formula">LUTAX_103</field>
+                    </record>
+                    <record id="account_tax_report_line_2a_breakdown_taxable_turnover_tax" model="account.tax.report.line">
+                        <field name="name">046 - Breakdown of taxable turnover – tax</field>
+                        <field name="sequence">2</field>
+                        <field name="code">LUTAX_046</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2a_tax_3" model="account.tax.report.line">
+                                <field name="name">040 - tax 3%</field>
+                                <field name="tag_name">040</field>
+                                <field name="sequence">9</field>
+                                <field name="code">LUTAX_040</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_tax_17" model="account.tax.report.line">
+                                <field name="name">702 - tax 17%</field>
+                                <field name="tag_name">702</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_702</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_tax_14" model="account.tax.report.line">
+                                <field name="name">704 - tax 14%</field>
+                                <field name="tag_name">704</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_704</field>
+                            </record>
+                            <record id="account_tax_report_line_2a_tax_8" model="account.tax.report.line">
+                                <field name="name">706 - tax 8%</field>
+                                <field name="tag_name">706</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_706</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2b_intra_community_acquisitions_goods_tax" model="account.tax.report.line">
+                        <field name="name">056 - Intra-Community acquisitions of goods – tax</field>
+                        <field name="sequence">4</field>
+                        <field name="code">LUTAX_056</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2b_tax_3" model="account.tax.report.line">
+                                <field name="name">054 - tax 3%</field>
+                                <field name="tag_name">054</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_054</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_tax_17" model="account.tax.report.line">
+                                <field name="name">712 - tax 17%</field>
+                                <field name="tag_name">712</field>
+                                <field name="sequence">5</field>
+                                <field name="code">LUTAX_712</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_tax_14" model="account.tax.report.line">
+                                <field name="name">714 - tax 14%</field>
+                                <field name="tag_name">714</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_714</field>
+                            </record>
+                            <record id="account_tax_report_line_2b_tax_8" model="account.tax.report.line">
+                                <field name="name">716 - tax 8%</field>
+                                <field name="tag_name">716</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_716</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2d_importation_of_goods_tax" model="account.tax.report.line">
+                        <field name="name">407 - Importation of goods – tax</field>
+                        <field name="sequence">7</field>
+                        <field name="code">LUTAX_407</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2d_1_tax_14" model="account.tax.report.line">
+                                <field name="name">724 - for business purposes: tax 14%</field>
+                                <field name="tag_name">724</field>
+                                <field name="sequence">2</field>
+                                <field name="code">LUTAX_724</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_tax_8" model="account.tax.report.line">
+                                <field name="name">726 - for business purposes: tax 8%</field>
+                                <field name="tag_name">726</field>
+                                <field name="sequence">3</field>
+                                <field name="code">LUTAX_726</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_tax_17" model="account.tax.report.line">
+                                <field name="name">732 - for non-business purposes: tax 17%</field>
+                                <field name="tag_name">732</field>
+                                <field name="sequence">5</field>
+                                <field name="code">LUTAX_732</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_tax_14" model="account.tax.report.line">
+                                <field name="name">734 - for non-business purposes: tax 14%</field>
+                                <field name="tag_name">734</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_734</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_tax_8" model="account.tax.report.line">
+                                <field name="name">736 - for non-business purposes: tax 8%</field>
+                                <field name="tag_name">736</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_736</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_tax_3" model="account.tax.report.line">
+                                <field name="name">068 - for business purposes: tax 3%</field>
+                                <field name="tag_name">068</field>
+                                <field name="sequence">4</field>
+                                <field name="code">LUTAX_068</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_2_tax_3" model="account.tax.report.line">
+                                <field name="name">073 - for non-business purposes: tax 3%</field>
+                                <field name="tag_name">073</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_073</field>
+                            </record>
+                            <record id="account_tax_report_line_2d_1_tax_17" model="account.tax.report.line">
+                                <field name="name">722 - for business purposes: tax 17%</field>
+                                <field name="tag_name">722</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_722</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax" model="account.tax.report.line">
+                        <field name="name">410 - Supply of services for which the customer is liable for the payment of VAT – tax</field>
+                        <field name="sequence">9</field>
+                        <field name="code">LUTAX_410</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_2e_1_a_tax" model="account.tax.report.line">
+                                <field name="name">462 - tax</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_462</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_2e_1_a_tax_3" model="account.tax.report.line">
+                                        <field name="name">432 - not exempt within the territory: tax 3%</field>
+                                        <field name="tag_name">432</field>
+                                        <field name="sequence">8</field>
+                                        <field name="code">LUTAX_432</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_1_a_tax_17" model="account.tax.report.line">
+                                        <field name="name">742 - not exempt within the territory: tax 17%</field>
+                                        <field name="tag_name">742</field>
+                                        <field name="sequence">5</field>
+                                        <field name="code">LUTAX_742</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_1_a_tax_14" model="account.tax.report.line">
+                                        <field name="name">744 - not exempt within the territory: tax 14%</field>
+                                        <field name="tag_name">744</field>
+                                        <field name="sequence">6</field>
+                                        <field name="code">LUTAX_744</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_1_a_tax_8" model="account.tax.report.line">
+                                        <field name="name">746 - not exempt within the territory: tax 8%</field>
+                                        <field name="tag_name">746</field>
+                                        <field name="sequence">7</field>
+                                        <field name="code">LUTAX_746</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_2e_2_tax" model="account.tax.report.line">
+                                <field name="name">464 - tax</field>
+                                <field name="sequence">2</field>
+                                <field name="code">LUTAX_464</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_2e_2_tax_3" model="account.tax.report.line">
+                                        <field name="name">442 - not established or residing within the Community: tax 3%</field>
+                                        <field name="tag_name">442</field>
+                                        <field name="sequence">8</field>
+                                        <field name="code">LUTAX_442</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_tax_17" model="account.tax.report.line">
+                                        <field name="name">752 - not established or residing within the Community: tax 17%</field>
+                                        <field name="tag_name">752</field>
+                                        <field name="sequence">5</field>
+                                        <field name="code">LUTAX_752</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_tax_14" model="account.tax.report.line">
+                                        <field name="name">754 - not established or residing within the Community: tax 14%</field>
+                                        <field name="tag_name">754</field>
+                                        <field name="sequence">6</field>
+                                        <field name="code">LUTAX_754</field>
+                                    </record>
+                                    <record id="account_tax_report_line_2e_2_tax_8" model="account.tax.report.line">
+                                        <field name="name">756 - not established or residing within the Community: tax 8%</field>
+                                        <field name="tag_name">756</field>
+                                        <field name="sequence">7</field>
+                                        <field name="code">LUTAX_756</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_2e_3_tax" model="account.tax.report.line">
+                                <field name="name">766 - tax</field>
+                                <field name="sequence">3</field>
+                                <field name="code">LUTAX_766</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_2e_3_tax_17" model="account.tax.report.line">
+                                        <field name="name">762 - suppliers established within the territory: tax 17%</field>
+                                        <field name="tag_name">762</field>
+                                        <field name="sequence">2</field>
+                                        <field name="code">LUTAX_762</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_1_assessment_taxable_turnover" model="account.tax.report.line">
+                <field name="name">I. ASSESSMENT OF TAXABLE TURNOVER</field>
+                <field name="sequence">1</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_1a_overall_turnover" model="account.tax.report.line">
+                        <field name="name">012 - Overall turnover</field>
+                        <field name="sequence">1</field>
+                        <field name="formula">LUTAX_454 + LUTAX_455 + LUTAX_456</field>
+                        <field name="code">LUTAX_012</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_1a_total_sale" model="account.tax.report.line">
+                                <field name="name">454 - Total Sales / Receipts</field>
+                                <field name="sequence" eval="2"/>
+                                <field name="code">LUTAX_454</field>
+                                <field name="formula">LUTAX_471 + LUTAX_472</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_1a_telecom_service" model="account.tax.report.line">
+                                        <field name="name">471 - Telecommunications services, radio and television broadcasting services...</field>
+                                        <field name="tag_name">471</field>
+                                        <field name="sequence" eval="1"/>
+                                        <field name="code">LUTAX_471</field>
+                                    </record>
+                                    <record id="account_tax_report_line_1a_other_sales" model="account.tax.report.line">
+                                        <field name="name">472 - Other sales / receipts</field>
+                                        <field name="sequence" eval="2"/>
+                                        <field name="code">LUTAX_472</field>
+                                        <field name="formula">LUTAX_021 + LUTAX_037 - LUTAX_456</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1a_app_goods_non_bus" model="account.tax.report.line">
+                                <field name="name">455 - Application of goods for non-business use and for business purposes</field>
+                                <field name="tag_name">455</field>
+                                <field name="sequence" eval="3"/>
+                                <field name="code">LUTAX_455</field>
+                            </record>
+                            <record id="account_tax_report_line_1a_non_bus_gs" model="account.tax.report.line">
+                                <field name="name">456 - Non-business use of goods and supply of services free of charge</field>
+                                <field name="tag_name">456</field>
+                                <field name="sequence" eval="4"/>
+                                <field name="code">LUTAX_456</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_1b_exemptions_deductible_amounts" model="account.tax.report.line">
+                        <field name="name">021 - Exemptions and deductible amounts</field>
+                        <field name="sequence">2</field>
+                        <field name="code">LUTAX_021</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_1b_2_export" model="account.tax.report.line">
+                                <field name="name">014 - Exports</field>
+                                <field name="tag_name">014</field>
+                                <field name="sequence">2</field>
+                                <field name="code">LUTAX_014</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat" model="account.tax.report.line">
+                                <field name="name">457 - Intra-Community supply of goods to persons identified for VAT purposes in another Member State (MS)</field>
+                                <field name="tag_name">457</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_457</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_3_other_exemptions_art_43" model="account.tax.report.line">
+                                <field name="name">015 - Other exemptions</field>
+                                <field name="tag_name">015</field>
+                                <field name="sequence">3</field>
+                                <field name="code">LUTAX_015</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater" model="account.tax.report.line">
+                                <field name="name">016 - Other exemptions</field>
+                                <field name="tag_name">016</field>
+                                <field name="sequence">4</field>
+                                <field name="code">LUTAX_016</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_5_manufactured_tobacco_vat_collected" model="account.tax.report.line">
+                                <field name="name">017 - Manufactured tobacco whose VAT was collected at the source or at the exit of the tax...</field>
+                                <field name="tag_name">017</field>
+                                <field name="sequence">5</field>
+                                <field name="code">LUTAX_017</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_a_subsequent_to_intra_community" model="account.tax.report.line">
+                                <field name="name">018 - Supply, subsequent to intra-Community acquisitions of goods, in the context of triangular transactions, when the customer identified,...</field>
+                                <field name="tag_name">018</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_018</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_b1_non_exempt_customer_vat" model="account.tax.report.line">
+                                <field name="name">423 - not exempt in the MS where the customer is liable for payment of VAT</field>
+                                <field name="tag_name">423</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_423</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_b2_exempt_ms_customer" model="account.tax.report.line">
+                                <field name="name">424 - exempt in the MS where the customer is identified</field>
+                                <field name="tag_name">424</field>
+                                <field name="sequence">8</field>
+                                <field name="code">LUTAX_424</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement" model="account.tax.report.line">
+                                <field name="name">226 - Supplies carried out within the scope of the special arrangement of art. 56sexies</field>
+                                <field name="tag_name">226</field>
+                                <field name="sequence">9</field>
+                                <field name="code">LUTAX_226</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_d_supplies_other_referred" model="account.tax.report.line">
+                                <field name="name">019 - Supplies other than referred to in 018 and 423 or 424</field>
+                                <field name="tag_name">019</field>
+                                <field name="sequence">10</field>
+                                <field name="code">LUTAX_019</field>
+                            </record>
+                            <record id="account_tax_report_line_1b_7_inland_supplies_for_customer" model="account.tax.report.line">
+                                <field name="name">419 - Inland supplies for which the customer is liable for the payment of VAT</field>
+                                <field name="tag_name">419</field>
+                                <field name="sequence">11</field>
+                                <field name="code">LUTAX_419</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_1c_taxable_turnover" model="account.tax.report.line">
+                        <field name="name">022 - Taxable turnover</field>
+                        <field name="sequence">3</field>
+                        <field name="code">LUTAX_022</field>
+                        <field name="formula">LUTAX_037</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_4_tax_tobe_paid_or_reclaimed" model="account.tax.report.line">
+                <field name="name">IV. TAX TO BE PAID OR TO BE RECLAIMED</field>
+                <field name="sequence">4</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_4c_exceeding_amount" model="account.tax.report.line">
+                        <field name="name">105 - Exceeding amount</field>
+                        <field name="sequence">3</field>
+                        <field name="formula">LUTAX_103 - LUTAX_102</field>
+                        <field name="code">LUTAX_105</field>
+                    </record>
+                    <record id="account_tax_report_line_4a_total_tax_due" model="account.tax.report.line">
+                        <field name="name">103 - Total tax due</field>
+                        <field name="sequence">1</field>
+                        <field name="code">LUTAX_103</field>
+                        <field name="formula">LUTAX_702+LUTAX_704+LUTAX_706+LUTAX_040+LUTAX_712+LUTAX_714+LUTAX_716+LUTAX_054+LUTAX_722+LUTAX_724+LUTAX_726+LUTAX_068+LUTAX_732+LUTAX_734+LUTAX_736+LUTAX_073+LUTAX_742+LUTAX_744+LUTAX_746+LUTAX_432+LUTAX_752+LUTAX_754+LUTAX_756+LUTAX_442+LUTAX_762+LUTAX_764+LUTAX_227</field>
+                    </record>
+                    <record id="account_tax_report_line_4a_total_input_tax_deductible" model="account.tax.report.line">
+                        <field name="name">104 - Total input tax deductible</field>
+                        <field name="sequence">2</field>
+                        <field name="formula">LUTAX_102</field>
+                        <field name="code">LUTAX_104</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_3_assessment_deducible_tax" model="account.tax.report.line">
+                <field name="name">III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)</field>
+                <field name="sequence">3</field>
+                <field name="formula">None</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_3a_total_input_tax" model="account.tax.report.line">
+                        <field name="name">093 - Total input tax</field>
+                        <field name="sequence">1</field>
+                        <field name="code">LUTAX_093</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_3a_4_due_respect_application_goods" model="account.tax.report.line">
+                                <field name="name">090 - Due in respect of the application of goods for business purposes</field>
+                                <field name="tag_name">090</field>
+                                <field name="sequence">4</field>
+                                <field name="code">LUTAX_090</field>
+                            </record>
+                            <record id="account_tax_report_line_3a_6_paid_joint_several_guarantee" model="account.tax.report.line">
+                                <field name="name">092 - Paid as joint and several guarantee</field>
+                                <field name="tag_name">092</field>
+                                <field name="sequence">6</field>
+                                <field name="code">LUTAX_092</field>
+                            </record>
+                            <record id="account_tax_report_line_3a_7_adjusted_tax_special_arrangement" model="account.tax.report.line">
+                                <field name="name">228 - Adjusted tax - special arrangement for tax suspension</field>
+                                <field name="tag_name">228</field>
+                                <field name="sequence">7</field>
+                                <field name="code">LUTAX_228</field>
+                            </record>
+                            <record id="account_tax_report_line_3a_1_invoiced_by_other_taxable_person" model="account.tax.report.line">
+                                <field name="name">458 - Invoiced by other taxable persons for goods or services supplied</field>
+                                <field name="tag_name">458</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_458</field>
+                            </record>
+                            <record id="account_tax_report_line_3a_2_due_respect_intra_comm_goods" model="account.tax.report.line">
+                                <field name="name">459 - Due in respect of intra-Community acquisitions of goods</field>
+                                <field name="tag_name">459</field>
+                                <field name="sequence">2</field>
+                                <field name="code">LUTAX_459</field>
+                            </record>
+                            <record id="account_tax_report_line_3a_3_due_paid_respect_importation_goods" model="account.tax.report.line">
+                                <field name="name">460 - Due or paid in respect of importation of goods</field>
+                                <field name="tag_name">460</field>
+                                <field name="sequence">3</field>
+                                <field name="code">LUTAX_460</field>
+                            </record>
+                            <record id="account_tax_report_line_3a_5_due_under_reverse_charge" model="account.tax.report.line">
+                                <field name="name">461 - Due under the reverse charge (see points II.E and F)</field>
+                                <field name="tag_name">461</field>
+                                <field name="sequence">5</field>
+                                <field name="code">LUTAX_461</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_3b_total_input_tax_nd" model="account.tax.report.line">
+                        <field name="name">097 - Total input tax non-deductible</field>
+                        <field name="sequence">2</field>
+                        <field name="code">LUTAX_097</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_3b1_rel_trans" model="account.tax.report.line">
+                                <field name="name">094 - relating to transactions which are exempt pursuant to articles 44 and 56quater</field>
+                                <field name="sequence">1</field>
+                                <field name="code">LUTAX_094</field>
+                            </record>
+                            <record id="account_tax_report_line_3b2_ded_prop" model="account.tax.report.line">
+                                <field name="name">095 - where the deductible proportion determined in accordance to article 50 is applied</field>
+                                <field name="sequence">2</field>
+                                <field name="code">LUTAX_095</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_3c_total_input_tax_deductible" model="account.tax.report.line">
+                        <field name="name">102 - Total input tax deductible</field>
+                        <field name="sequence">3</field>
+                        <field name="code">LUTAX_102</field>
+                        <field name="formula">LUTAX_458+LUTAX_459+LUTAX_460+LUTAX_090+LUTAX_461+LUTAX_092+LUTAX_228+LUTAX_094+LUTAX_095</field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_line_2_assesment_of_tax_due" model="account.tax.report.line">
-      <field name="name">II. ASSESSMENT OF TAX DUE (output tax)</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="formula">None</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_intra_community_acqui_of_goods_base" model="account.tax.report.line">
-      <field name="name">051 - Intra-Community acquisitions of goods – base</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_051</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_base_3" model="account.tax.report.line">
-      <field name="name">049 - base 3%</field>
-      <field name="tag_name">049</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acqui_of_goods_base"/>
-      <field name="code">LUTAX_049</field>
-    </record>
-
-
-    <record id="account_tax_report_line_2b_base_exempt" model="account.tax.report.line">
-      <field name="name">194 - base exempt</field>
-      <field name="tag_name">194</field>
-      <field name="sequence">10</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acqui_of_goods_base"/>
-      <field name="code">LUTAX_194</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_base_17" model="account.tax.report.line">
-      <field name="name">711 - base 17%</field>
-      <field name="tag_name">711</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acqui_of_goods_base"/>
-      <field name="code">LUTAX_711</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_base_14" model="account.tax.report.line">
-      <field name="name">713 - base 14%</field>
-      <field name="tag_name">713</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acqui_of_goods_base"/>
-      <field name="code">LUTAX_713</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_base_8" model="account.tax.report.line">
-      <field name="name">715 - base 8%</field>
-      <field name="tag_name">715</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acqui_of_goods_base"/>
-      <field name="code">LUTAX_715</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_importation_of_goods_base" model="account.tax.report.line">
-      <field name="name">065 - Importation of goods – base</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_065</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_base_exempt" model="account.tax.report.line">
-      <field name="name">196 - for non-business purposes: base exempt</field>
-      <field name="tag_name">196</field>
-      <field name="sequence">12</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_196</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_base_17" model="account.tax.report.line">
-      <field name="name">721 - for business purposes: base 17%</field>
-      <field name="tag_name">721</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_721</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_base_14" model="account.tax.report.line">
-      <field name="name">723 - for business purposes: base 14%</field>
-      <field name="tag_name">723</field>
-      <field name="sequence">4</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_723</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_base_8" model="account.tax.report.line">
-      <field name="name">725 - for business purposes: base 8%</field>
-      <field name="tag_name">725</field>
-      <field name="sequence">5</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_725</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_base_17" model="account.tax.report.line">
-      <field name="name">731 - for non-business purposes: base 17%</field>
-      <field name="tag_name">731</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_731</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_base_14" model="account.tax.report.line">
-      <field name="name">733 - for non-business purposes: base 14%</field>
-      <field name="tag_name">733</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_733</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_base_8" model="account.tax.report.line">
-      <field name="name">735 - for non-business purposes: base 8%</field>
-      <field name="tag_name">735</field>
-      <field name="sequence">10</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_735</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_base_3" model="account.tax.report.line">
-      <field name="name">059 - for business purposes: base 3%</field>
-      <field name="tag_name">059</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_059</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_base_3" model="account.tax.report.line">
-      <field name="name">063 - for non-business purposes: base 3%</field>
-      <field name="tag_name">063</field>
-      <field name="sequence">11</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_063</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_base_exempt" model="account.tax.report.line">
-      <field name="name">195 - for business purposes: base exempt</field>
-      <field name="tag_name">195</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_base"/>
-      <field name="code">LUTAX_195</field>
-    </record>
-
-    <record id="account_tax_report_line_2c_acquisitions_triangular_transactions_base" model="account.tax.report.line">
-      <field name="name">152 - Acquisitions, in the context of triangular transactions – base</field>
-      <field name="tag_name">152</field>
-      <field name="sequence">5</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_152</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_supply_of_service_for_customer" model="account.tax.report.line">
-      <field name="name">409 - Supply of services for which the customer is liable for the payment of VAT – base</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_409</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_base" model="account.tax.report.line">
-      <field name="name">436 - base</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer"/>
-      <field name="code">LUTAX_436</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_base_3" model="account.tax.report.line">
-      <field name="name">431 - not exempt within the territory: base 3%</field>
-      <field name="tag_name">431</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_1_base"/>
-      <field name="code">LUTAX_431</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_b_exempt" model="account.tax.report.line">
-      <field name="name">435 - exempt within the territory: exempt</field>
-      <field name="tag_name">435</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer"/>
-      <field name="code">LUTAX_435</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_base_17" model="account.tax.report.line">
-      <field name="name">741 - not exempt within the territory: base 17%</field>
-      <field name="tag_name">741</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_1_base"/>
-      <field name="code">LUTAX_741</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_base_14" model="account.tax.report.line">
-      <field name="name">743 - not exempt within the territory: base 14%</field>
-      <field name="tag_name">743</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_1_base"/>
-      <field name="code">LUTAX_743</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_base_8" model="account.tax.report.line">
-      <field name="name">745 - not exempt within the territory: base 8%</field>
-      <field name="tag_name">745</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_1_base"/>
-      <field name="code">LUTAX_745</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_base" model="account.tax.report.line">
-      <field name="name">463 - base</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer"/>
-      <field name="code">LUTAX_463</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_base_3" model="account.tax.report.line">
-      <field name="name">441 - not established or residing within the Community: base 3%</field>
-      <field name="tag_name">441</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_2_base"/>
-      <field name="code">LUTAX_441</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_exempt" model="account.tax.report.line">
-      <field name="name">445 - not established or residing within the Community: exempt</field>
-      <field name="tag_name">445</field>
-      <field name="sequence">10</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_2_base"/>
-      <field name="code">LUTAX_445</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_base_17" model="account.tax.report.line">
-      <field name="name">751 - not established or residing within the Community: base 17%</field>
-      <field name="tag_name">751</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_2_base"/>
-      <field name="code">LUTAX_751</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_base_14" model="account.tax.report.line">
-      <field name="name">753 - not established or residing within the Community: base 14%</field>
-      <field name="tag_name">753</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_2_base"/>
-      <field name="code">LUTAX_753</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_base_8" model="account.tax.report.line">
-      <field name="name">755 - not established or residing within the Community: base 8%</field>
-      <field name="tag_name">755</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_2_base"/>
-      <field name="code">LUTAX_755</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_3_base" model="account.tax.report.line">
-      <field name="name">765 - base</field>
-      <field name="sequence">4</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer"/>
-      <field name="code">LUTAX_765</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_3_base_17" model="account.tax.report.line">
-      <field name="name">761 - suppliers established within the territory: base 17%</field>
-      <field name="tag_name">761</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2e_3_base"/>
-      <field name="code">LUTAX_761</field>
-    </record>
-
-    <record id="account_tax_report_line_1_assessment_taxable_turnover" model="account.tax.report.line">
-      <field name="name">I. ASSESSMENT OF TAXABLE TURNOVER</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="formula">None</field>
-    </record>
-
-    <record id="account_tax_report_line_1a_overall_turnover" model="account.tax.report.line">
-      <field name="name">012 - Overall turnover</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_1_assessment_taxable_turnover"/>
-      <field name="formula">LUTAX_454 + LUTAX_455 + LUTAX_456</field>
-      <field name="code">LUTAX_012</field>
-    </record>
-
-    <record id="account_tax_report_line_1a_total_sale" model="account.tax.report.line">
-        <field name="name">454 - Total Sales / Receipts</field>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_1a_overall_turnover"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="code">LUTAX_454</field>
-        <field name="formula">LUTAX_471 + LUTAX_472</field>
-    </record>
-
-    <!-- 471 not managed, only 472 is filled in -->
-    <record id="account_tax_report_line_1a_telecom_service" model="account.tax.report.line">
-        <field name="name">471 - Telecommunications services, radio and television broadcasting services...</field>
-        <field name="tag_name">471</field>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_1a_total_sale"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="code">LUTAX_471</field>
-    </record>
-
-    <record id="account_tax_report_line_1a_other_sales" model="account.tax.report.line">
-        <field name="name">472 - Other sales / receipts</field>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_1a_total_sale"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="code">LUTAX_472</field>
-        <field name="formula">LUTAX_021 + LUTAX_037 - LUTAX_456</field>
-    </record>
-
-    <record id="account_tax_report_line_1a_app_goods_non_bus" model="account.tax.report.line">
-        <field name="name">455 - Application of goods for non-business use and for business purposes</field>
-        <field name="tag_name">455</field>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_1a_overall_turnover"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="code">LUTAX_455</field>
-    </record>
-
-    <record id="account_tax_report_line_1a_non_bus_gs" model="account.tax.report.line">
-        <field name="name">456 - Non-business use of goods and supply of services free of charge</field>
-        <field name="tag_name">456</field>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_1a_overall_turnover"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="code">LUTAX_456</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_exemptions_deductible_amounts" model="account.tax.report.line">
-      <field name="name">021 - Exemptions and deductible amounts</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_1_assessment_taxable_turnover"/>
-      <field name="code">LUTAX_021</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_2_export" model="account.tax.report.line">
-      <field name="name">014 - Exports</field>
-      <field name="tag_name">014</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_014</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat" model="account.tax.report.line">
-      <field name="name">457 - Intra-Community supply of goods to persons identified for VAT purposes in another Member State (MS)</field>
-      <field name="tag_name">457</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_457</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_3_other_exemptions_art_43" model="account.tax.report.line">
-      <field name="name">015 - Other exemptions</field>
-      <field name="tag_name">015</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_015</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater" model="account.tax.report.line">
-      <field name="name">016 - Other exemptions</field>
-      <field name="tag_name">016</field>
-      <field name="sequence">4</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_016</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_5_manufactured_tobacco_vat_collected" model="account.tax.report.line">
-      <field name="name">017 - Manufactured tobacco whose VAT was collected at the source or at the exit of the tax...</field>
-      <field name="tag_name">017</field>
-      <field name="sequence">5</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_017</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_6_a_subsequent_to_intra_community" model="account.tax.report.line">
-      <field name="name">018 - Supply, subsequent to intra-Community acquisitions of goods, in the context of triangular transactions, when the customer identified,...</field>
-      <field name="tag_name">018</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_018</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_6_b1_non_exempt_customer_vat" model="account.tax.report.line">
-      <field name="name">423 - not exempt in the MS where the customer is liable for payment of VAT</field>
-      <field name="tag_name">423</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_423</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_6_b2_exempt_ms_customer" model="account.tax.report.line">
-      <field name="name">424 - exempt in the MS where the customer is identified</field>
-      <field name="tag_name">424</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_424</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement" model="account.tax.report.line">
-      <field name="name">226 - Supplies carried out within the scope of the special arrangement of art. 56sexies</field>
-      <field name="tag_name">226</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_226</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_6_d_supplies_other_referred" model="account.tax.report.line">
-      <field name="name">019 - Supplies other than referred to in 018 and 423 or 424</field>
-      <field name="tag_name">019</field>
-      <field name="sequence">10</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_019</field>
-    </record>
-
-    <record id="account_tax_report_line_1b_7_inland_supplies_for_customer" model="account.tax.report.line">
-      <field name="name">419 - Inland supplies for which the customer is liable for the payment of VAT</field>
-      <field name="tag_name">419</field>
-      <field name="sequence">11</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_1b_exemptions_deductible_amounts"/>
-      <field name="code">LUTAX_419</field>
-    </record>
-
-    <record id="account_tax_report_line_1c_taxable_turnover" model="account.tax.report.line">
-      <field name="name">022 - Taxable turnover</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_1_assessment_taxable_turnover"/>
-      <field name="code">LUTAX_022</field>
-      <field name="formula">LUTAX_037</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_breakdown_taxable_turnover_base" model="account.tax.report.line">
-      <field name="name">037 - Breakdown of taxable turnover – base</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_037</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_base_3" model="account.tax.report.line">
-      <field name="name">031 - base 3%</field>
-      <field name="tag_name">031</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_base"/>
-      <field name="code">LUTAX_031</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_base_0" model="account.tax.report.line">
-      <field name="name">033 - base 0%</field>
-      <field name="tag_name">033</field>
-      <field name="sequence">10</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_base"/>
-      <field name="code">LUTAX_033</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_base_17" model="account.tax.report.line">
-      <field name="name">701 - base 17%</field>
-      <field name="tag_name">701</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_base"/>
-      <field name="code">LUTAX_701</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_base_14" model="account.tax.report.line">
-      <field name="name">703 - base 14%</field>
-      <field name="tag_name">703</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_base"/>
-      <field name="code">LUTAX_703</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_base_8" model="account.tax.report.line">
-      <field name="name">705 - base 8%</field>
-      <field name="tag_name">705</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_base"/>
-      <field name="code">LUTAX_705</field>
-    </record>
-
-    <record id="account_tax_report_line_4_tax_tobe_paid_or_reclaimed" model="account.tax.report.line">
-      <field name="name">IV. TAX TO BE PAID OR TO BE RECLAIMED</field>
-      <field name="sequence">4</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="formula">None</field>
-    </record>
-
-    <record id="account_tax_report_line_4c_exceeding_amount" model="account.tax.report.line">
-      <field name="name">105 - Exceeding amount</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_4_tax_tobe_paid_or_reclaimed"/>
-      <field name="formula">LUTAX_103 - LUTAX_102</field>
-      <field name="code">LUTAX_105</field>
-  </record>
-
-    <record id="account_tax_report_line_4a_total_tax_due" model="account.tax.report.line">
-      <field name="name">103 - Total tax due</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_4_tax_tobe_paid_or_reclaimed"/>
-      <field name="code">LUTAX_103</field>
-      <field name="formula">LUTAX_702+LUTAX_704+LUTAX_706+LUTAX_040+LUTAX_712+LUTAX_714+LUTAX_716+LUTAX_054+LUTAX_722+LUTAX_724+LUTAX_726+LUTAX_068+LUTAX_732+LUTAX_734+LUTAX_736+LUTAX_073+LUTAX_742+LUTAX_744+LUTAX_746+LUTAX_432+LUTAX_752+LUTAX_754+LUTAX_756+LUTAX_442+LUTAX_762+LUTAX_764+LUTAX_227</field>
-  </record>
-
-    <record id="account_tax_report_line_2f_supply_goods_base" model="account.tax.report.line">
-      <field name="name">767 - Supply of goods for which the purchaser is liable for the payment of VAT - base</field>
-      <field name="sequence">10</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_767</field>
-    </record>
-
-    <record id="account_tax_report_line_2f_supply_goods_base_8" model="account.tax.report.line">
-      <field name="name">763 - base 8%</field>
-      <field name="tag_name">763</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2f_supply_goods_base"/>
-      <field name="code">LUTAX_763</field>
-    </record>
-
-    <record id="account_tax_report_line_2f_supply_goods_tax" model="account.tax.report.line">
-      <field name="name">768 - Supply of goods for which the purchaser is liable for the payment of VAT - tax</field>
-      <field name="sequence">11</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_768</field>
-    </record>
-
-    <record id="account_tax_report_line_2f_supply_goods_tax_8" model="account.tax.report.line">
-      <field name="name">764 - tax 8%</field>
-      <field name="tag_name">764</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2f_supply_goods_tax"/>
-      <field name="code">LUTAX_764</field>
-  </record>
-
-    <record id="account_tax_report_line_2g_special_arrangement" model="account.tax.report.line">
-      <field name="name">227 - Special arrangement for tax suspension: adjustment</field>
-      <field name="tag_name">227</field>
-      <field name="sequence">12</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_227</field>
-    </record>
-
-    <record id="account_tax_report_line_2h_total_tax_due" model="account.tax.report.line">
-      <field name="name">076 - Total tax due</field>
-      <field name="sequence">13</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_076</field>
-      <field name="formula">LUTAX_103</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_breakdown_taxable_turnover_tax" model="account.tax.report.line">
-      <field name="name">046 - Breakdown of taxable turnover – tax</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_046</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_tax_3" model="account.tax.report.line">
-      <field name="name">040 - tax 3%</field>
-      <field name="tag_name">040</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_tax"/>
-      <field name="code">LUTAX_040</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_tax_17" model="account.tax.report.line">
-      <field name="name">702 - tax 17%</field>
-      <field name="tag_name">702</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_tax"/>
-      <field name="code">LUTAX_702</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_tax_14" model="account.tax.report.line">
-      <field name="name">704 - tax 14%</field>
-      <field name="tag_name">704</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_tax"/>
-      <field name="code">LUTAX_704</field>
-    </record>
-
-    <record id="account_tax_report_line_2a_tax_8" model="account.tax.report.line">
-      <field name="name">706 - tax 8%</field>
-      <field name="tag_name">706</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2a_breakdown_taxable_turnover_tax"/>
-      <field name="code">LUTAX_706</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_intra_community_acquisitions_goods_tax" model="account.tax.report.line">
-      <field name="name">056 - Intra-Community acquisitions of goods – tax</field>
-      <field name="sequence">4</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_056</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_tax_3" model="account.tax.report.line">
-      <field name="name">054 - tax 3%</field>
-      <field name="tag_name">054</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acquisitions_goods_tax"/>
-      <field name="code">LUTAX_054</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_tax_17" model="account.tax.report.line">
-      <field name="name">712 - tax 17%</field>
-      <field name="tag_name">712</field>
-      <field name="sequence">5</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acquisitions_goods_tax"/>
-      <field name="code">LUTAX_712</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_tax_14" model="account.tax.report.line">
-      <field name="name">714 - tax 14%</field>
-      <field name="tag_name">714</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acquisitions_goods_tax"/>
-      <field name="code">LUTAX_714</field>
-    </record>
-
-    <record id="account_tax_report_line_2b_tax_8" model="account.tax.report.line">
-      <field name="name">716 - tax 8%</field>
-      <field name="tag_name">716</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2b_intra_community_acquisitions_goods_tax"/>
-      <field name="code">LUTAX_716</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_importation_of_goods_tax" model="account.tax.report.line">
-      <field name="name">407 - Importation of goods – tax</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-        <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_407</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_tax_14" model="account.tax.report.line">
-      <field name="name">724 - for business purposes: tax 14%</field>
-      <field name="tag_name">724</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_724</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_tax_8" model="account.tax.report.line">
-      <field name="name">726 - for business purposes: tax 8%</field>
-      <field name="tag_name">726</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_726</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_tax_17" model="account.tax.report.line">
-      <field name="name">732 - for non-business purposes: tax 17%</field>
-      <field name="tag_name">732</field>
-      <field name="sequence">5</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_732</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_tax_14" model="account.tax.report.line">
-      <field name="name">734 - for non-business purposes: tax 14%</field>
-      <field name="tag_name">734</field>
-      <field name="sequence">6</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_734</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_tax_8" model="account.tax.report.line">
-      <field name="name">736 - for non-business purposes: tax 8%</field>
-      <field name="tag_name">736</field>
-      <field name="sequence">7</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_736</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_tax_3" model="account.tax.report.line">
-      <field name="name">068 - for business purposes: tax 3%</field>
-      <field name="tag_name">068</field>
-      <field name="sequence">4</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_068</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_2_tax_3" model="account.tax.report.line">
-      <field name="name">073 - for non-business purposes: tax 3%</field>
-      <field name="tag_name">073</field>
-      <field name="sequence">8</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_073</field>
-    </record>
-
-    <record id="account_tax_report_line_2d_1_tax_17" model="account.tax.report.line">
-      <field name="name">722 - for business purposes: tax 17%</field>
-      <field name="tag_name">722</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2d_importation_of_goods_tax"/>
-      <field name="code">LUTAX_722</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax" model="account.tax.report.line">
-      <field name="name">410 - Supply of services for which the customer is liable for the payment of VAT – tax</field>
-      <field name="sequence">9</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2_assesment_of_tax_due"/>
-      <field name="code">LUTAX_410</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_tax" model="account.tax.report.line">
-      <field name="name">462 - tax</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax"/>
-      <field name="code">LUTAX_462</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_tax_3" model="account.tax.report.line">
-      <field name="name">432 - not exempt within the territory: tax 3%</field>
-      <field name="tag_name">432</field>
-      <field name="sequence">8</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_1_a_tax"/>
-      <field name="code">LUTAX_432</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_tax_17" model="account.tax.report.line">
-      <field name="name">742 - not exempt within the territory: tax 17%</field>
-      <field name="tag_name">742</field>
-      <field name="sequence">5</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_1_a_tax"/>
-      <field name="code">LUTAX_742</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_tax_14" model="account.tax.report.line">
-      <field name="name">744 - not exempt within the territory: tax 14%</field>
-      <field name="tag_name">744</field>
-      <field name="sequence">6</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_1_a_tax"/>
-      <field name="code">LUTAX_744</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_1_a_tax_8" model="account.tax.report.line">
-      <field name="name">746 - not exempt within the territory: tax 8%</field>
-      <field name="tag_name">746</field>
-      <field name="sequence">7</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_1_a_tax"/>
-      <field name="code">LUTAX_746</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_tax" model="account.tax.report.line">
-      <field name="name">464 - tax</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax"/>
-      <field name="code">LUTAX_464</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_tax_3" model="account.tax.report.line">
-      <field name="name">442 - not established or residing within the Community: tax 3%</field>
-      <field name="tag_name">442</field>
-      <field name="sequence">8</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_2_tax"/>
-      <field name="code">LUTAX_442</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_tax_17" model="account.tax.report.line">
-      <field name="name">752 - not established or residing within the Community: tax 17%</field>
-      <field name="tag_name">752</field>
-      <field name="sequence">5</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_2_tax"/>
-      <field name="code">LUTAX_752</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_tax_14" model="account.tax.report.line">
-      <field name="name">754 - not established or residing within the Community: tax 14%</field>
-      <field name="tag_name">754</field>
-      <field name="sequence">6</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_2_tax"/>
-      <field name="code">LUTAX_754</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_2_tax_8" model="account.tax.report.line">
-      <field name="name">756 - not established or residing within the Community: tax 8%</field>
-      <field name="tag_name">756</field>
-      <field name="sequence">7</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_2_tax"/>
-      <field name="code">LUTAX_756</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_2e_3_tax" model="account.tax.report.line">
-      <field name="name">766 - tax</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax"/>
-      <field name="code">LUTAX_766</field>
-    </record>
-
-    <record id="account_tax_report_line_2e_3_tax_17" model="account.tax.report.line">
-      <field name="name">762 - suppliers established within the territory: tax 17%</field>
-      <field name="tag_name">762</field>
-      <field name="sequence">2</field>
-      <field name="parent_id" ref="account_tax_report_line_2e_3_tax"/>
-      <field name="code">LUTAX_762</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_4a_total_input_tax_deductible" model="account.tax.report.line">
-      <field name="name">104 - Total input tax deductible</field>
-      <field name="sequence">2</field>
-      <field name="parent_id" ref="account_tax_report_line_4_tax_tobe_paid_or_reclaimed"/>
-      <field name="formula">LUTAX_102</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="code">LUTAX_104</field>
-    </record>
-
-    <record id="account_tax_report_line_3_assessment_deducible_tax" model="account.tax.report.line">
-      <field name="name">III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)</field>
-      <field name="sequence">3</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="formula">None</field>
-    </record>
-
-    <record id="account_tax_report_line_3a_total_input_tax" model="account.tax.report.line">
-      <field name="name">093 - Total input tax</field>
-      <field name="sequence">1</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_3_assessment_deducible_tax"/>
-      <field name="code">LUTAX_093</field>
-    </record>
-
-    <record id="account_tax_report_line_3b_total_input_tax_nd" model="account.tax.report.line">
-      <field name="name">097 - Total input tax non-deductible</field>
-      <field name="sequence">2</field>
-      <field name="report_id" ref="tax_report"/>
-      <field name="parent_id" ref="account_tax_report_line_3_assessment_deducible_tax"/>
-      <field name="code">LUTAX_097</field>
-    </record>
-
-    <record id="account_tax_report_line_3b1_rel_trans" model="account.tax.report.line">
-      <field name="name">094 - relating to transactions which are exempt pursuant to articles 44 and 56quater</field>
-      <field name="sequence">1</field>
-      <field name="parent_id" ref="account_tax_report_line_3b_total_input_tax_nd"/>
-      <field name="code">LUTAX_094</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3b2_ded_prop" model="account.tax.report.line">
-      <field name="name">095 - where the deductible proportion determined in accordance to article 50 is applied</field>
-      <field name="sequence">2</field>
-      <field name="parent_id" ref="account_tax_report_line_3b_total_input_tax_nd"/>
-      <field name="code">LUTAX_095</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3c_total_input_tax_deductible" model="account.tax.report.line">
-      <field name="name">102 - Total input tax deductible</field>
-      <field name="sequence">3</field>
-      <field name="parent_id" ref="account_tax_report_line_3_assessment_deducible_tax"/>
-      <field name="code">LUTAX_102</field>
-      <field name="formula">LUTAX_458+LUTAX_459+LUTAX_460+LUTAX_090+LUTAX_461+LUTAX_092+LUTAX_228+LUTAX_094+LUTAX_095</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_4_due_respect_application_goods" model="account.tax.report.line">
-      <field name="name">090 - Due in respect of the application of goods for business purposes</field>
-      <field name="tag_name">090</field>
-      <field name="sequence">4</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_090</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_6_paid_joint_several_guarantee" model="account.tax.report.line">
-      <field name="name">092 - Paid as joint and several guarantee</field>
-      <field name="tag_name">092</field>
-      <field name="sequence">6</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_092</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_7_adjusted_tax_special_arrangement" model="account.tax.report.line">
-      <field name="name">228 - Adjusted tax - special arrangement for tax suspension</field>
-      <field name="tag_name">228</field>
-      <field name="sequence">7</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_228</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_1_invoiced_by_other_taxable_person" model="account.tax.report.line">
-      <field name="name">458 - Invoiced by other taxable persons for goods or services supplied</field>
-      <field name="tag_name">458</field>
-      <field name="sequence">1</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_458</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_2_due_respect_intra_comm_goods" model="account.tax.report.line">
-      <field name="name">459 - Due in respect of intra-Community acquisitions of goods</field>
-      <field name="tag_name">459</field>
-      <field name="sequence">2</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_459</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_3_due_paid_respect_importation_goods" model="account.tax.report.line">
-      <field name="name">460 - Due or paid in respect of importation of goods</field>
-      <field name="tag_name">460</field>
-      <field name="sequence">3</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_460</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_3a_5_due_under_reverse_charge" model="account.tax.report.line">
-      <field name="name">461 - Due under the reverse charge (see points II.E and F)</field>
-      <field name="tag_name">461</field>
-      <field name="sequence">5</field>
-      <field name="parent_id" ref="account_tax_report_line_3a_total_input_tax"/>
-      <field name="code">LUTAX_461</field>
-      <field name="report_id" ref="tax_report"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_ma/data/account_tax_report_data.xml
+++ b/addons/l10n_ma/data/account_tax_report_data.xml
@@ -1,306 +1,207 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.ma"/>
-    </record>
-
-    <record id="tax_report_ventilation_chiffre_affaires_imposable" model="account.tax.report.line">
-        <field name="name">Ventilation du chiffre d’affaires imposable</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_taux_normal_20" model="account.tax.report.line">
-        <field name="name">TAUX NORMAL DE 20% (Base HT)</field>
-        <field name="tag_name">TAUX NORMAL DE 20% (Base HT)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="code">MATAXB_1</field>
-    </record>
-
-    <record id="tax_report_taux_normal_tva_20" model="account.tax.report.line">
-        <field name="name">TAUX NORMAL DE 20% (TVA exigible)</field>
-        <field name="tag_name">TAUX NORMAL DE 20% (TVA exigible)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="code">MATAXB_2</field>
-    </record>
-
-     <record id="tax_report_tauz_reduit_ht_14" model="account.tax.report.line">
-        <field name="name">TAUX REDUIT DE 14% (Base HT)</field>
-        <field name="tag_name">TAUX REDUIT DE 14% (Base HT)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="code">MATAXB_3</field>
-    </record>
-
-    <record id="tax_report_taux_rediut_tva_14" model="account.tax.report.line">
-        <field name="name">TAUX REDUIT DE 14% (TVA exigible)</field>
-        <field name="tag_name">TAUX REDUIT DE 14% (TVA exigible)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="code">MATAXB_4</field>
-    </record>
-
-    <record id="account_report_taux_reduit_base_ht_10" model="account.tax.report.line">
-        <field name="name">TAUX REDUIT DE 1O% (Base HT)</field>
-        <field name="tag_name">TAUX REDUIT DE 1O% (Base HT)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="code">MATAXB_5</field>
-    </record>
-
-    <record id="tax_report_taux_reduit_tva_10" model="account.tax.report.line">
-        <field name="name">TAUX REDUIT DE 1O% (TVA exigible)</field>
-        <field name="tag_name">TAUX REDUIT DE 1O% (TVA exigible)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="code">MATAXB_6</field>
-    </record>
-
-    <record id="tax_report_taux_reduit_ht_7" model="account.tax.report.line">
-        <field name="name">TAUX REDUIT DE 7% (Base HT)</field>
-        <field name="tag_name">TAUX REDUIT DE 7% (Base HT)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="code">MATAXB_7</field>
-    </record>
-
-    <record id="tax_report_taux_reduit_tva_7" model="account.tax.report.line">
-        <field name="name">TAUX REDUIT DE 7% (TVA exigible)</field>
-        <field name="tag_name">TAUX REDUIT DE 7% (TVA exigible)</field>
-        <field name="parent_id" ref="tax_report_ventilation_chiffre_affaires_imposable"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="code">MATAXB_8</field>
-    </record>
-
-    <record id="tax_report_ventilation_des_deductions" model="account.tax.report.line">
-        <field name="name">Ventilation des déductions</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_achats_non_immobilises_ht" model="account.tax.report.line">
-        <field name="name">1-ACHATS NON IMMOBILISES (Base HT)</field>
-        <field name="parent_id" ref="tax_report_ventilation_des_deductions"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_travaux_facons_ht" model="account.tax.report.line">
-        <field name="name">Travaux à façons (HT)</field>
-        <field name="parent_id" ref="tax_report_achats_non_immobilises_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_sous_traitance_immobiliers_ht" model="account.tax.report.line">
-        <field name="name">Sous-traitance (travaux immobiliers) (HT)</field>
-        <field name="parent_id" ref="tax_report_achats_non_immobilises_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_biens_materiels_ht" model="account.tax.report.line">
-        <field name="name">Biens matériels (Base HT)</field>
-        <field name="parent_id" ref="tax_report_achats_non_immobilises_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_achats_importation_ht_20" model="account.tax.report.line">
-        <field name="name">Achats à l'importation (20%) (HT)</field>
-        <field name="tag_name">Achats à l'importation (20%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_ht_20" model="account.tax.report.line">
-        <field name="name">Achats à l'intérieur (20%) (HT)</field>
-        <field name="tag_name">Achats à l'intérieur (20%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_achats_importation_ht_14" model="account.tax.report.line">
-        <field name="name">Achats à l'importation (14%) (HT)</field>
-        <field name="tag_name">Achats à l'importation (14%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_ht_14" model="account.tax.report.line">
-        <field name="name">Achats à l'intérieur (14%) (HT)</field>
-        <field name="tag_name">Achats à l'intérieur (14%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_achats_importation_ht_10" model="account.tax.report.line">
-        <field name="name">Achats à l'importation (10%) (HT)</field>
-        <field name="tag_name">Achats à l'importation (10%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_ht_10" model="account.tax.report.line">
-        <field name="name">Achats à l'intérieur (10%) (HT)</field>
-        <field name="tag_name">Achats à l'intérieur (10%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_achat_importation_ht_7" model="account.tax.report.line">
-        <field name="name">Achat à l'importation (7%) (HT)</field>
-        <field name="tag_name">Achat à l'importation (7%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_ht_7" model="account.tax.report.line">
-        <field name="name">Achat à l'intérieur (7%) (HT)</field>
-        <field name="tag_name">Achat à l'intérieur (7%) (HT)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_prestations_services_ht_1" model="account.tax.report.line">
-        <field name="name">Prestations de services (Base HT)</field>
-        <field name="parent_id" ref="tax_report_achats_non_immobilises_ht"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_achats_immobilises_deductible_tva" model="account.tax.report.line">
-        <field name="name">1-ACHATS NON IMMOBILISES (TVA déductible)</field>
-        <field name="parent_id" ref="tax_report_ventilation_des_deductions"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_travaux_facons_tva" model="account.tax.report.line">
-        <field name="name">Travaux à façons (TVA déductible)</field>
-        <field name="parent_id" ref="tax_report_achats_immobilises_deductible_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_sous_traitance_immobiliers_tva" model="account.tax.report.line">
-        <field name="name">Sous-traitance (travaux immobiliers) (TVA déductible)</field>
-        <field name="parent_id" ref="tax_report_achats_immobilises_deductible_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_biens_materiels_tva" model="account.tax.report.line">
-        <field name="name">Biens matériels (TVA déductible)</field>
-        <field name="parent_id" ref="tax_report_achats_immobilises_deductible_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_achats_importation_tva_20" model="account.tax.report.line">
-        <field name="name">Achats à l'importation (20%) (TVA)</field>
-        <field name="tag_name">Achats à l'importation (20%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_tva_20" model="account.tax.report.line">
-        <field name="name">Achats à l'intérieur (20%) (TVA)</field>
-        <field name="tag_name">Achats à l'intérieur (20%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_achats_importation_tva_14" model="account.tax.report.line">
-        <field name="name">Achats à l'importation (14%) (TVA)</field>
-        <field name="tag_name">Achats à l'importation (14%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_tva_14" model="account.tax.report.line">
-        <field name="name">Achats à l'intérieur (14%) (TVA)</field>
-        <field name="tag_name">Achats à l'intérieur (14%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_achats_importation_tva_10" model="account.tax.report.line">
-        <field name="name">Achats à l'importation (10%) (TVA)</field>
-        <field name="tag_name">Achats à l'importation (10%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_tva_10" model="account.tax.report.line">
-        <field name="name">Achats à l'intérieur (10%) (TVA)</field>
-        <field name="tag_name">Achats à l'intérieur (10%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_achats_importation_tva_7" model="account.tax.report.line">
-        <field name="name">Achat à l'importation (7%) (TVA)</field>
-        <field name="tag_name">Achat à l'importation (7%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_achats_interieur_tva_7" model="account.tax.report.line">
-        <field name="name">Achat à l'intérieur (7%) (TVA)</field>
-        <field name="tag_name">Achat à l'intérieur (7%) (TVA)</field>
-        <field name="parent_id" ref="tax_report_biens_materiels_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_prestations_service_deductible_tva" model="account.tax.report.line">
-        <field name="name">Prestations de services (TVA déductible)</field>
-        <field name="parent_id" ref="tax_report_achats_immobilises_deductible_tva"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_immobilisations_base_ht" model="account.tax.report.line">
-        <field name="name">2-IMMOBILISATIONS (Base HT)</field>
-        <field name="tag_name">Immobilisations (Base HT)</field>
-        <field name="parent_id" ref="tax_report_ventilation_des_deductions"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_immobilisations_deductible_tva" model="account.tax.report.line">
-        <field name="name">2-IMMOBILISATIONS (TVA déductible)</field>
-        <field name="tag_name">Immobilisations (TVA déductible)</field>
-        <field name="parent_id" ref="tax_report_ventilation_des_deductions"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
+        <field name="root_line_ids">
+            <record id="tax_report_ventilation_chiffre_affaires_imposable" model="account.tax.report.line">
+                <field name="name">Ventilation du chiffre d’affaires imposable</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_taux_normal_20" model="account.tax.report.line">
+                        <field name="name">TAUX NORMAL DE 20% (Base HT)</field>
+                        <field name="tag_name">TAUX NORMAL DE 20% (Base HT)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="code">MATAXB_1</field>
+                    </record>
+                    <record id="tax_report_taux_normal_tva_20" model="account.tax.report.line">
+                        <field name="name">TAUX NORMAL DE 20% (TVA exigible)</field>
+                        <field name="tag_name">TAUX NORMAL DE 20% (TVA exigible)</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="code">MATAXB_2</field>
+                    </record>
+                    <record id="tax_report_tauz_reduit_ht_14" model="account.tax.report.line">
+                        <field name="name">TAUX REDUIT DE 14% (Base HT)</field>
+                        <field name="tag_name">TAUX REDUIT DE 14% (Base HT)</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="code">MATAXB_3</field>
+                    </record>
+                    <record id="tax_report_taux_rediut_tva_14" model="account.tax.report.line">
+                        <field name="name">TAUX REDUIT DE 14% (TVA exigible)</field>
+                        <field name="tag_name">TAUX REDUIT DE 14% (TVA exigible)</field>
+                        <field name="sequence" eval="4"/>
+                        <field name="code">MATAXB_4</field>
+                    </record>
+                    <record id="account_report_taux_reduit_base_ht_10" model="account.tax.report.line">
+                        <field name="name">TAUX REDUIT DE 1O% (Base HT)</field>
+                        <field name="tag_name">TAUX REDUIT DE 1O% (Base HT)</field>
+                        <field name="sequence" eval="5"/>
+                        <field name="code">MATAXB_5</field>
+                    </record>
+                    <record id="tax_report_taux_reduit_tva_10" model="account.tax.report.line">
+                        <field name="name">TAUX REDUIT DE 1O% (TVA exigible)</field>
+                        <field name="tag_name">TAUX REDUIT DE 1O% (TVA exigible)</field>
+                        <field name="sequence" eval="6"/>
+                        <field name="code">MATAXB_6</field>
+                    </record>
+                    <record id="tax_report_taux_reduit_ht_7" model="account.tax.report.line">
+                        <field name="name">TAUX REDUIT DE 7% (Base HT)</field>
+                        <field name="tag_name">TAUX REDUIT DE 7% (Base HT)</field>
+                        <field name="sequence" eval="7"/>
+                        <field name="code">MATAXB_7</field>
+                    </record>
+                    <record id="tax_report_taux_reduit_tva_7" model="account.tax.report.line">
+                        <field name="name">TAUX REDUIT DE 7% (TVA exigible)</field>
+                        <field name="tag_name">TAUX REDUIT DE 7% (TVA exigible)</field>
+                        <field name="sequence" eval="8"/>
+                        <field name="code">MATAXB_8</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_ventilation_des_deductions" model="account.tax.report.line">
+                <field name="name">Ventilation des déductions</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_achats_non_immobilises_ht" model="account.tax.report.line">
+                        <field name="name">1-ACHATS NON IMMOBILISES (Base HT)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_travaux_facons_ht" model="account.tax.report.line">
+                                <field name="name">Travaux à façons (HT)</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_sous_traitance_immobiliers_ht" model="account.tax.report.line">
+                                <field name="name">Sous-traitance (travaux immobiliers) (HT)</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_biens_materiels_ht" model="account.tax.report.line">
+                                <field name="name">Biens matériels (Base HT)</field>
+                                <field name="sequence" eval="3"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_achats_importation_ht_20" model="account.tax.report.line">
+                                        <field name="name">Achats à l'importation (20%) (HT)</field>
+                                        <field name="tag_name">Achats à l'importation (20%) (HT)</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_ht_20" model="account.tax.report.line">
+                                        <field name="name">Achats à l'intérieur (20%) (HT)</field>
+                                        <field name="tag_name">Achats à l'intérieur (20%) (HT)</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="tax_report_achats_importation_ht_14" model="account.tax.report.line">
+                                        <field name="name">Achats à l'importation (14%) (HT)</field>
+                                        <field name="tag_name">Achats à l'importation (14%) (HT)</field>
+                                        <field name="sequence" eval="3"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_ht_14" model="account.tax.report.line">
+                                        <field name="name">Achats à l'intérieur (14%) (HT)</field>
+                                        <field name="tag_name">Achats à l'intérieur (14%) (HT)</field>
+                                        <field name="sequence" eval="4"/>
+                                    </record>
+                                    <record id="tax_report_achats_importation_ht_10" model="account.tax.report.line">
+                                        <field name="name">Achats à l'importation (10%) (HT)</field>
+                                        <field name="tag_name">Achats à l'importation (10%) (HT)</field>
+                                        <field name="sequence" eval="5"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_ht_10" model="account.tax.report.line">
+                                        <field name="name">Achats à l'intérieur (10%) (HT)</field>
+                                        <field name="tag_name">Achats à l'intérieur (10%) (HT)</field>
+                                        <field name="sequence" eval="6"/>
+                                    </record>
+                                    <record id="tax_report_achat_importation_ht_7" model="account.tax.report.line">
+                                        <field name="name">Achat à l'importation (7%) (HT)</field>
+                                        <field name="tag_name">Achat à l'importation (7%) (HT)</field>
+                                        <field name="sequence" eval="7"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_ht_7" model="account.tax.report.line">
+                                        <field name="name">Achat à l'intérieur (7%) (HT)</field>
+                                        <field name="tag_name">Achat à l'intérieur (7%) (HT)</field>
+                                        <field name="sequence" eval="8"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_prestations_services_ht_1" model="account.tax.report.line">
+                                <field name="name">Prestations de services (Base HT)</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_achats_immobilises_deductible_tva" model="account.tax.report.line">
+                        <field name="name">1-ACHATS NON IMMOBILISES (TVA déductible)</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_travaux_facons_tva" model="account.tax.report.line">
+                                <field name="name">Travaux à façons (TVA déductible)</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="tax_report_sous_traitance_immobiliers_tva" model="account.tax.report.line">
+                                <field name="name">Sous-traitance (travaux immobiliers) (TVA déductible)</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="tax_report_biens_materiels_tva" model="account.tax.report.line">
+                                <field name="name">Biens matériels (TVA déductible)</field>
+                                <field name="sequence" eval="3"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_achats_importation_tva_20" model="account.tax.report.line">
+                                        <field name="name">Achats à l'importation (20%) (TVA)</field>
+                                        <field name="tag_name">Achats à l'importation (20%) (TVA)</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_tva_20" model="account.tax.report.line">
+                                        <field name="name">Achats à l'intérieur (20%) (TVA)</field>
+                                        <field name="tag_name">Achats à l'intérieur (20%) (TVA)</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="tax_report_achats_importation_tva_14" model="account.tax.report.line">
+                                        <field name="name">Achats à l'importation (14%) (TVA)</field>
+                                        <field name="tag_name">Achats à l'importation (14%) (TVA)</field>
+                                        <field name="sequence" eval="3"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_tva_14" model="account.tax.report.line">
+                                        <field name="name">Achats à l'intérieur (14%) (TVA)</field>
+                                        <field name="tag_name">Achats à l'intérieur (14%) (TVA)</field>
+                                        <field name="sequence" eval="4"/>
+                                    </record>
+                                    <record id="tax_report_achats_importation_tva_10" model="account.tax.report.line">
+                                        <field name="name">Achats à l'importation (10%) (TVA)</field>
+                                        <field name="tag_name">Achats à l'importation (10%) (TVA)</field>
+                                        <field name="sequence" eval="5"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_tva_10" model="account.tax.report.line">
+                                        <field name="name">Achats à l'intérieur (10%) (TVA)</field>
+                                        <field name="tag_name">Achats à l'intérieur (10%) (TVA)</field>
+                                        <field name="sequence" eval="6"/>
+                                    </record>
+                                    <record id="tax_report_achats_importation_tva_7" model="account.tax.report.line">
+                                        <field name="name">Achat à l'importation (7%) (TVA)</field>
+                                        <field name="tag_name">Achat à l'importation (7%) (TVA)</field>
+                                        <field name="sequence" eval="7"/>
+                                    </record>
+                                    <record id="tax_report_achats_interieur_tva_7" model="account.tax.report.line">
+                                        <field name="name">Achat à l'intérieur (7%) (TVA)</field>
+                                        <field name="tag_name">Achat à l'intérieur (7%) (TVA)</field>
+                                        <field name="sequence" eval="8"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_prestations_service_deductible_tva" model="account.tax.report.line">
+                                <field name="name">Prestations de services (TVA déductible)</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_immobilisations_base_ht" model="account.tax.report.line">
+                        <field name="name">2-IMMOBILISATIONS (Base HT)</field>
+                        <field name="tag_name">Immobilisations (Base HT)</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_immobilisations_deductible_tva" model="account.tax.report.line">
+                        <field name="name">2-IMMOBILISATIONS (TVA déductible)</field>
+                        <field name="tag_name">Immobilisations (TVA déductible)</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_nl/data/account_tax_report_data.xml
+++ b/addons/l10n_nl/data/account_tax_report_data.xml
@@ -1,275 +1,197 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.nl"/>
+        <field name="root_line_ids">
+            <record id="tax_report_rub_1" model="account.tax.report.line">
+                <field name="name">Rubriek 1: Prestaties binnenland</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_1a" model="account.tax.report.line">
+                        <field name="name">1a. Leveringen/diensten belast met hoog tarief (omzet)</field>
+                        <field name="tag_name">1a (omzet)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_rub_1b" model="account.tax.report.line">
+                        <field name="name">1b. Leveringen/diensten belast met laag tarief (omzet)</field>
+                        <field name="tag_name">1b (omzet)</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_rub_1c" model="account.tax.report.line">
+                        <field name="name">1c. Leveringen/diensten belast met overige tarieven behalve 0% (omzet)</field>
+                        <field name="tag_name">1c (omzet)</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_rub_1d" model="account.tax.report.line">
+                        <field name="name">1d. Privégebruik (omzet)</field>
+                        <field name="tag_name">1d (omzet)</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_rub_1e" model="account.tax.report.line">
+                        <field name="name">1e. Leveringen/diensten belast met 0% of niet bij u belast (omzet)</field>
+                        <field name="tag_name">1e (omzet)</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_2" model="account.tax.report.line">
+                <field name="name">Rubriek 2: Verleggingsregelingen binnenland (omzet)</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_2a" model="account.tax.report.line">
+                        <field name="name">2a. Leveringen/diensten waarbij de heffing van omzetbelasting naar u is verlegd (omzet)</field>
+                        <field name="tag_name">2a (omzet)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_3" model="account.tax.report.line">
+                <field name="name">Rubriek 3: Prestaties naar of in het buitenland (omzet)</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_3a" model="account.tax.report.line">
+                        <field name="name">3a. Leveringen naar landen buiten de EU (uitvoer) (omzet)</field>
+                        <field name="tag_name">3a (omzet)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_rub_3b" model="account.tax.report.line">
+                        <field name="name">3b. Leveringen naar/diensten in landen binnen de EU (omzet)</field>
+                        <field name="tag_name">3b (omzet)</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_rub_3c" model="account.tax.report.line">
+                        <field name="name">3c. Installatie/afstandsverkopen binnen de EU (omzet)</field>
+                        <field name="tag_name">3c (omzet)</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_4" model="account.tax.report.line">
+                <field name="name">Rubriek 4: Prestaties vanuit het buitenland aan u verricht (omzet)</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_4a" model="account.tax.report.line">
+                        <field name="name">4a. Leveringen/diensten uit landen buiten de EU (invoer) (omzet)</field>
+                        <field name="tag_name">4a (omzet)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_rub_4b" model="account.tax.report.line">
+                        <field name="name">4b. Leveringen/diensten uit landen binnen de EU (omzet)</field>
+                        <field name="tag_name">4b (omzet)</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_btw_1" model="account.tax.report.line">
+                <field name="code">NLTAX_B1</field>
+                <field name="name">Rubriek 1: Prestaties binnenland (BTW)</field>
+                <field name="sequence" eval="5"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_btw_1a" model="account.tax.report.line">
+                        <field name="name">1a. Leveringen/diensten belast met 21% (BTW)</field>
+                        <field name="tag_name">1a (BTW)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_rub_btw_1b" model="account.tax.report.line">
+                        <field name="name">1b. Leveringen/diensten belast met laag tarief (BTW)</field>
+                        <field name="tag_name">1b (BTW)</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_rub_btw_1c" model="account.tax.report.line">
+                        <field name="name">1c. Leveringen/diensten belast met overige tarieven behalve 0% (BTW)</field>
+                        <field name="tag_name">1c (BTW)</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_rub_btw_1d" model="account.tax.report.line">
+                        <field name="name">1d. Privégebruik (BTW)</field>
+                        <field name="tag_name">1d (BTW)</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_rub_btw_1e" model="account.tax.report.line">
+                        <field name="name">1e. Leveringen/diensten belast met 0% of niet bij u belast (BTW)</field>
+                        <field name="tag_name">1e (BTW)</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_btw_2" model="account.tax.report.line">
+                <field name="name">Rubriek 2: Verleggingsregelingen binnenland (BTW)</field>
+                <field name="sequence" eval="6"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_btw_2a" model="account.tax.report.line">
+                        <field name="name">2a. Leveringen/diensten waarbij de heffing van Heffing van omzetbelasting naar u is verlegd (BTW)</field>
+                        <field name="code">NLTAX_B2</field>
+                        <field name="tag_name">2a (BTW)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_btw_4" model="account.tax.report.line">
+                <field name="name">Rubriek 4: Prestaties vanuit het buitenland aan u verricht (BTW)</field>
+                <field name="sequence" eval="7"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_btw_4a" model="account.tax.report.line">
+                        <field name="name">4a. Leveringen/diensten uit landen buiten de EU (BTW)</field>
+                        <field name="tag_name">4a (BTW)</field>
+                        <field name="code">NLTAX_B4a</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_rub_btw_4b" model="account.tax.report.line">
+                        <field name="name">4b. Leveringen/diensten uit landen binnen de EU (BTW)</field>
+                        <field name="tag_name">4b (BTW)</field>
+                        <field name="code">NLTAX_B4b</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_rub_btw_5" model="account.tax.report.line">
+                <field name="name">Rubriek 5: Voorbelasting, kleineondernemersregeling en totaal (BTW)</field>
+                <field name="sequence" eval="8"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_rub_btw_5a" model="account.tax.report.line">
+                        <field name="name">5a. Verschuldigde omzetbelasting (rubrieken 1a t/m 4b) (BTW)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">NLTAX_B1 + NLTAX_B2 + NLTAX_B4a + NLTAX_B4b</field>
+                    </record>
+                    <record id="tax_report_rub_btw_5b" model="account.tax.report.line">
+                        <field name="code">NLTAX_B5b</field>
+                        <field name="name">5b. Voorbelasting (BTW)</field>
+                        <field name="tag_name">5b (BTW)</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_rub_btw_5c" model="account.tax.report.line">
+                        <field name="code"/>
+                        <field name="name">5c. Subtotaal (rubriek 5a min 5b) (BTW)</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="formula">NLTAX_B1 + NLTAX_B2 + NLTAX_B4a + NLTAX_B4b - NLTAX_B5b</field>
+                    </record>
+                    <record id="tax_report_rub_btw_5d" model="account.tax.report.line">
+                        <field name="code">NLTAX_B5d</field>
+                        <field name="name">5d. Vermindering volgens de kleineondernemersregeling (BTW)</field>
+                        <field name="tag_name">5d. (BTW)</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_rub_btw_5e" model="account.tax.report.line">
+                        <field name="code">NLTAX_B5e</field>
+                        <field name="name">5e. Schatting vorige aangifte(n) (BTW)</field>
+                        <field name="tag_name">5e. (BTW)</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_rub_btw_5f" model="account.tax.report.line">
+                        <field name="code">NLTAX_B5f</field>
+                        <field name="name">5f. Schatting deze aangifte (BTW)</field>
+                        <field name="tag_name">5f. (BTW)</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_rub_btw_5g" model="account.tax.report.line">
+                        <field name="code">NLTAX_B5g</field>
+                        <field name="name">5g. Totaal te betalen/terug te vragen (BTW)</field>
+                        <field name="sequence" eval="7"/>
+                        <field name="formula">NLTAX_B1 + NLTAX_B2 + NLTAX_B4a + NLTAX_B4b - NLTAX_B5b - NLTAX_B5d - NLTAX_B5e - NLTAX_B5f</field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_rub_1" model="account.tax.report.line">
-        <field name="name">Rubriek 1: Prestaties binnenland</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_rub_1a" model="account.tax.report.line">
-        <field name="name">1a. Leveringen/diensten belast met hoog tarief (omzet)</field>
-        <field name="tag_name">1a (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_1"/>
-    </record>
-
-    <record id="tax_report_rub_1b" model="account.tax.report.line">
-        <field name="name">1b. Leveringen/diensten belast met laag tarief (omzet)</field>
-        <field name="tag_name">1b (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_rub_1"/>
-    </record>
-
-    <record id="tax_report_rub_1c" model="account.tax.report.line">
-        <field name="name">1c. Leveringen/diensten belast met overige tarieven behalve 0% (omzet)</field>
-        <field name="tag_name">1c (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_rub_1"/>
-    </record>
-
-    <record id="tax_report_rub_1d" model="account.tax.report.line">
-        <field name="name">1d. Privégebruik (omzet)</field>
-        <field name="tag_name">1d (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_rub_1"/>
-    </record>
-
-    <record id="tax_report_rub_1e" model="account.tax.report.line">
-        <field name="name">1e. Leveringen/diensten belast met 0% of niet bij u belast (omzet)</field>
-        <field name="tag_name">1e (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_rub_1"/>
-    </record>
-
-    <record id="tax_report_rub_2" model="account.tax.report.line">
-        <field name="name">Rubriek 2: Verleggingsregelingen binnenland (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_rub_2a" model="account.tax.report.line">
-        <field name="name">2a. Leveringen/diensten waarbij de heffing van omzetbelasting naar u is verlegd (omzet)</field>
-        <field name="tag_name">2a (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_2"/>
-    </record>
-
-    <record id="tax_report_rub_3" model="account.tax.report.line">
-        <field name="name">Rubriek 3: Prestaties naar of in het buitenland (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_rub_3a" model="account.tax.report.line">
-        <field name="name">3a. Leveringen naar landen buiten de EU (uitvoer) (omzet)</field>
-        <field name="tag_name">3a (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_3"/>
-    </record>
-
-    <record id="tax_report_rub_3b" model="account.tax.report.line">
-        <field name="name">3b. Leveringen naar/diensten in landen binnen de EU (omzet)</field>
-        <field name="tag_name">3b (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_rub_3"/>
-    </record>
-
-    <record id="tax_report_rub_3c" model="account.tax.report.line">
-        <field name="name">3c. Installatie/afstandsverkopen binnen de EU (omzet)</field>
-        <field name="tag_name">3c (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_rub_3"/>
-    </record>
-
-    <record id="tax_report_rub_4" model="account.tax.report.line">
-        <field name="name">Rubriek 4: Prestaties vanuit het buitenland aan u verricht (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_rub_4a" model="account.tax.report.line">
-        <field name="name">4a. Leveringen/diensten uit landen buiten de EU (invoer) (omzet)</field>
-        <field name="tag_name">4a (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_4"/>
-    </record>
-
-    <record id="tax_report_rub_4b" model="account.tax.report.line">
-        <field name="name">4b. Leveringen/diensten uit landen binnen de EU (omzet)</field>
-        <field name="tag_name">4b (omzet)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_rub_4"/>
-    </record>
-
-    <record id="tax_report_rub_btw_1" model="account.tax.report.line">
-        <field name="code">NLTAX_B1</field>
-        <field name="name">Rubriek 1: Prestaties binnenland (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-    </record>
-
-    <record id="tax_report_rub_btw_1a" model="account.tax.report.line">
-        <field name="name">1a. Leveringen/diensten belast met 21% (BTW)</field>
-        <field name="tag_name">1a (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_btw_1"/>
-    </record>
-
-    <record id="tax_report_rub_btw_1b" model="account.tax.report.line">
-        <field name="name">1b. Leveringen/diensten belast met laag tarief (BTW)</field>
-        <field name="tag_name">1b (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_rub_btw_1"/>
-    </record>
-
-    <record id="tax_report_rub_btw_1c" model="account.tax.report.line">
-        <field name="name">1c. Leveringen/diensten belast met overige tarieven behalve 0% (BTW)</field>
-        <field name="tag_name">1c (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_rub_btw_1"/>
-    </record>
-
-    <record id="tax_report_rub_btw_1d" model="account.tax.report.line">
-        <field name="name">1d. Privégebruik (BTW)</field>
-        <field name="tag_name">1d (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_rub_btw_1"/>
-    </record>
-
-    <record id="tax_report_rub_btw_1e" model="account.tax.report.line">
-        <field name="name">1e. Leveringen/diensten belast met 0% of niet bij u belast (BTW)</field>
-        <field name="tag_name">1e (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_rub_btw_1"/>
-    </record>
-
-    <record id="tax_report_rub_btw_2" model="account.tax.report.line">
-        <field name="name">Rubriek 2: Verleggingsregelingen binnenland (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="tax_report_rub_btw_2a" model="account.tax.report.line">
-        <field name="name">2a. Leveringen/diensten waarbij de heffing van Heffing van omzetbelasting naar u is verlegd (BTW)</field>
-        <field name="code">NLTAX_B2</field>
-        <field name="tag_name">2a (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_btw_2"/>
-    </record>
-
-    <record id="tax_report_rub_btw_4" model="account.tax.report.line">
-        <field name="name">Rubriek 4: Prestaties vanuit het buitenland aan u verricht (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-    </record>
-
-    <record id="tax_report_rub_btw_4a" model="account.tax.report.line">
-        <field name="name">4a. Leveringen/diensten uit landen buiten de EU (BTW)</field>
-        <field name="tag_name">4a (BTW)</field>
-        <field name="code">NLTAX_B4a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_btw_4"/>
-    </record>
-
-    <record id="tax_report_rub_btw_4b" model="account.tax.report.line">
-        <field name="name">4b. Leveringen/diensten uit landen binnen de EU (BTW)</field>
-        <field name="tag_name">4b (BTW)</field>
-        <field name="code">NLTAX_B4b</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_rub_btw_4"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5" model="account.tax.report.line">
-        <field name="name">Rubriek 5: Voorbelasting, kleineondernemersregeling en totaal (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5a" model="account.tax.report.line">
-        <field name="name">5a. Verschuldigde omzetbelasting (rubrieken 1a t/m 4b) (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-        <field name="formula">NLTAX_B1 + NLTAX_B2 + NLTAX_B4a + NLTAX_B4b</field>
-    </record>
-
-    <record id="tax_report_rub_btw_5b" model="account.tax.report.line">
-        <field name="code">NLTAX_B5b</field>
-        <field name="name">5b. Voorbelasting (BTW)</field>
-        <field name="tag_name">5b (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5c" model="account.tax.report.line">
-        <field name="code"></field>
-        <field name="name">5c. Subtotaal (rubriek 5a min 5b) (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">NLTAX_B1 + NLTAX_B2 + NLTAX_B4a + NLTAX_B4b - NLTAX_B5b</field>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5d" model="account.tax.report.line">
-        <field name="code">NLTAX_B5d</field>
-        <field name="name">5d. Vermindering volgens de kleineondernemersregeling (BTW)</field>
-        <field name="tag_name">5d. (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5e" model="account.tax.report.line">
-        <field name="code">NLTAX_B5e</field>
-        <field name="name">5e. Schatting vorige aangifte(n) (BTW)</field>
-        <field name="tag_name">5e. (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5f" model="account.tax.report.line">
-        <field name="code">NLTAX_B5f</field>
-        <field name="name">5f. Schatting deze aangifte (BTW)</field>
-        <field name="tag_name">5f. (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-    </record>
-
-    <record id="tax_report_rub_btw_5g" model="account.tax.report.line">
-        <field name="code">NLTAX_B5g</field>
-        <field name="name">5g. Totaal te betalen/terug te vragen (BTW)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="formula">NLTAX_B1 + NLTAX_B2 + NLTAX_B4a + NLTAX_B4b - NLTAX_B5b - NLTAX_B5d - NLTAX_B5e - NLTAX_B5f</field>
-        <field name="parent_id" ref="tax_report_rub_btw_5"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_no/data/account_tax_report_data.xml
+++ b/addons/l10n_no/data/account_tax_report_data.xml
@@ -1,291 +1,213 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.no"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_samlet_omsetning" model="account.tax.report.line">
+                <field name="name">A. Samlet omsetning, uttak og innførsel</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_1" model="account.tax.report.line">
+                        <field name="name">Post 1 Samlet omsetning og uttak utenfor merverdiavgiftsloven</field>
+                        <field name="tag_name">Post 1</field>
+                        <field name="code">NOTAX_01</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_2" model="account.tax.report.line">
+                        <field name="name">Post 2 Samlet omsetning og uttak innenfor merverdiavgiftloven og innførsel</field>
+                        <field name="formula">NOTAX_03+NOTAX_04+NOTAX_05+NOTAX_06+NOTAX_07+NOTAX_08</field>
+                        <field name="code">NOTAX_02</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_innenlands_omsetning" model="account.tax.report.line">
+                <field name="name">B. Innenlands omsetning og uttak</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_3" model="account.tax.report.line">
+                        <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 %</field>
+                        <field name="tag_name">Post 3 Base</field>
+                        <field name="code">NOTAX_03</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_3_tax" model="account.tax.report.line">
+                        <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 % Tax</field>
+                        <field name="tag_name">Post 3 Tax</field>
+                        <field name="code">NOTAX_03_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_4" model="account.tax.report.line">
+                        <field name="name">Post 4 Innenlands omsetning og uttak, og beregnet avgift 15 %</field>
+                        <field name="tag_name">Post 4 Base</field>
+                        <field name="code">NOTAX_04</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_4_tax" model="account.tax.report.line">
+                        <field name="name">Post 4 Innenlands omsetning og uttak, og beregnet avgift 15 % Tax</field>
+                        <field name="tag_name">Post 4 Tax</field>
+                        <field name="code">NOTAX_04_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_5" model="account.tax.report.line">
+                        <field name="name">Post 5 Innenlands omsetning og uttak, og beregnet avgift 12 %</field>
+                        <field name="tag_name">Post 5 Base</field>
+                        <field name="code">NOTAX_05</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_5_tax" model="account.tax.report.line">
+                        <field name="name">Post 5 Innenlands omsetning og uttak, og beregnet avgift 12 % Tax</field>
+                        <field name="tag_name">Post 5 Tax</field>
+                        <field name="code">NOTAX_05_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_6" model="account.tax.report.line">
+                        <field name="name">Post 6 Innenlands omsetning og uttak fritatt for merverdiavgift</field>
+                        <field name="tag_name">Post 6</field>
+                        <field name="code">NOTAX_06</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_7" model="account.tax.report.line">
+                        <field name="name">Post 7 Innenlands omsetning med omvendt avgiftsplikt</field>
+                        <field name="tag_name">Post 7</field>
+                        <field name="code">NOTAX_07</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_utforsel" model="account.tax.report.line">
+                <field name="name">C. Utførsel</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_8" model="account.tax.report.line">
+                        <field name="name">Post 8 Utførsel av varer og tjenester fritatt for merverdiavgift</field>
+                        <field name="tag_name">Post 8</field>
+                        <field name="code">NOTAX_08</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_innforsel_av_varer" model="account.tax.report.line">
+                <field name="name">D. Innførsel av varer</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_9" model="account.tax.report.line">
+                        <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 %</field>
+                        <field name="tag_name">Post 9 Base</field>
+                        <field name="code">NOTAX_09</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_9_tax" model="account.tax.report.line">
+                        <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 % Tax</field>
+                        <field name="tag_name">Post 9 Tax</field>
+                        <field name="code">NOTAX_09_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_10" model="account.tax.report.line">
+                        <field name="name">Post 10 Innførsel av varer, og beregnet avgift 15 %</field>
+                        <field name="tag_name">Post 10 Base</field>
+                        <field name="code">NOTAX_10</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_10_tax" model="account.tax.report.line">
+                        <field name="name">Post 10 Innførsel av varer, og beregnet avgift 15 % Tax</field>
+                        <field name="tag_name">Post 10 Tax</field>
+                        <field name="code">NOTAX_10_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_11" model="account.tax.report.line">
+                        <field name="name">Post 11 Innførsel av varer som det ikke skal beregnes merverdiavgift av</field>
+                        <field name="tag_name">Post 11</field>
+                        <field name="code">NOTAX_11</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_kjop_med_omvendt_avgiftsplikt" model="account.tax.report.line">
+                <field name="name">E. Kjøp med omvendt avgiftsplikt</field>
+                <field name="sequence" eval="5"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_12" model="account.tax.report.line">
+                        <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 %</field>
+                        <field name="tag_name">Post 12 Base</field>
+                        <field name="code">NOTAX_12</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_12_tax" model="account.tax.report.line">
+                        <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 % Tax</field>
+                        <field name="tag_name">Post 12 Tax</field>
+                        <field name="code">NOTAX_12_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_13" model="account.tax.report.line">
+                        <field name="name">Post 13 Innenlands kjøp av varer og tjenester, og beregnet avgift 25 %</field>
+                        <field name="tag_name">Post 13 Base</field>
+                        <field name="code">NOTAX_13</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_13_tax" model="account.tax.report.line">
+                        <field name="name">Post 13 Innenlands kjøp av varer og tjenester, og beregnet avgift 25 % Tax</field>
+                        <field name="tag_name">Post 13 Tax</field>
+                        <field name="code">NOTAX_13_1</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_fradragsberettigen_innenlands" model="account.tax.report.line">
+                <field name="name">F. Fradragsberettiget innenlands inngående avgift</field>
+                <field name="sequence" eval="6"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_14" model="account.tax.report.line">
+                        <field name="name">Post 14 Fradragsberettiget innenlands inngående avgift 25 %</field>
+                        <field name="tag_name">Post 14</field>
+                        <field name="code">NOTAX_14</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_15" model="account.tax.report.line">
+                        <field name="name">Post 15 Fradragsberettiget innenlands inngående avgift 15 %</field>
+                        <field name="tag_name">Post 15</field>
+                        <field name="code">NOTAX_15</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_16" model="account.tax.report.line">
+                        <field name="name">Post 16 Fradragsberettiget innenlands inngående avgift 12 %</field>
+                        <field name="tag_name">Post 16</field>
+                        <field name="code">NOTAX_16</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift" model="account.tax.report.line">
+                <field name="name">G. Fradragsberettiget innførselsmerverdiavgift</field>
+                <field name="sequence" eval="7"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_17" model="account.tax.report.line">
+                        <field name="name">Post 17 Fradragsberettiget innførselsmerverdiavgift 25 %</field>
+                        <field name="tag_name">Post 17</field>
+                        <field name="code">NOTAX_17</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                    <record id="account_tax_report_line_post_18" model="account.tax.report.line">
+                        <field name="name">Post 18 Fradragsberettiget innførselsmerverdiavgift 15 %</field>
+                        <field name="tag_name">Post 18</field>
+                        <field name="code">NOTAX_18</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_sum" model="account.tax.report.line">
+                <field name="name">H. Sum</field>
+                <field name="sequence" eval="8"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_post_19" model="account.tax.report.line">
+                        <field name="name">Post 19 Avgift å betale</field>
+                        <field name="formula">NOTAX_03_1+NOTAX_04_1+NOTAX_05_1+NOTAX_09_1+NOTAX_10_1+NOTAX_12_1+NOTAX_13_1-NOTAX_14-NOTAX_15-NOTAX_16-NOTAX_17-NOTAX_18</field>
+                        <field name="code">NOTAX_19</field>
+                        <field name="sequence" eval="0"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_line_samlet_omsetning" model="account.tax.report.line">
-        <field name="name">A. Samlet omsetning, uttak og innførsel</field>
-        <field name="sequence" eval="1"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_1" model="account.tax.report.line">
-        <field name="name">Post 1 Samlet omsetning og uttak utenfor merverdiavgiftsloven</field>
-        <field name="tag_name">Post 1</field>
-        <field name="code">NOTAX_01</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_samlet_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_2" model="account.tax.report.line">
-        <field name="name">Post 2 Samlet omsetning og uttak innenfor merverdiavgiftloven og innførsel</field>
-        <field name="formula">NOTAX_03+NOTAX_04+NOTAX_05+NOTAX_06+NOTAX_07+NOTAX_08</field>
-        <field name="code">NOTAX_02</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_samlet_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_innenlands_omsetning" model="account.tax.report.line">
-        <field name="name">B. Innenlands omsetning og uttak</field>
-        <field name="sequence" eval="2"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_3" model="account.tax.report.line">
-        <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 3 Base</field>
-        <field name="code">NOTAX_03</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_3_tax" model="account.tax.report.line">
-        <field name="name">Post 3 Innenlands omsetning og uttak, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 3 Tax</field>
-        <field name="code">NOTAX_03_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_4" model="account.tax.report.line">
-        <field name="name">Post 4 Innenlands omsetning og uttak, og beregnet avgift 15 %</field>
-        <field name="tag_name">Post 4 Base</field>
-        <field name="code">NOTAX_04</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_4_tax" model="account.tax.report.line">
-        <field name="name">Post 4 Innenlands omsetning og uttak, og beregnet avgift 15 % Tax</field>
-        <field name="tag_name">Post 4 Tax</field>
-        <field name="code">NOTAX_04_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_5" model="account.tax.report.line">
-        <field name="name">Post 5 Innenlands omsetning og uttak, og beregnet avgift 12 %</field>
-        <field name="tag_name">Post 5 Base</field>
-        <field name="code">NOTAX_05</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_5_tax" model="account.tax.report.line">
-        <field name="name">Post 5 Innenlands omsetning og uttak, og beregnet avgift 12 % Tax</field>
-        <field name="tag_name">Post 5 Tax</field>
-        <field name="code">NOTAX_05_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_6" model="account.tax.report.line">
-        <field name="name">Post 6 Innenlands omsetning og uttak fritatt for merverdiavgift</field>
-        <field name="tag_name">Post 6</field>
-        <field name="code">NOTAX_06</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_7" model="account.tax.report.line">
-        <field name="name">Post 7 Innenlands omsetning med omvendt avgiftsplikt</field>
-        <field name="tag_name">Post 7</field>
-        <field name="code">NOTAX_07</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innenlands_omsetning"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_utforsel" model="account.tax.report.line">
-        <field name="name">C. Utførsel</field>
-        <field name="sequence" eval="3"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_8" model="account.tax.report.line">
-        <field name="name">Post 8 Utførsel av varer og tjenester fritatt for merverdiavgift</field>
-        <field name="tag_name">Post 8</field>
-        <field name="code">NOTAX_08</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_utforsel"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_innforsel_av_varer" model="account.tax.report.line">
-        <field name="name">D. Innførsel av varer</field>
-        <field name="sequence" eval="4"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_9" model="account.tax.report.line">
-        <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 9 Base</field>
-        <field name="code">NOTAX_09</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_9_tax" model="account.tax.report.line">
-        <field name="name">Post 9 Innførsel av varer, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 9 Tax</field>
-        <field name="code">NOTAX_09_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_10" model="account.tax.report.line">
-        <field name="name">Post 10 Innførsel av varer, og beregnet avgift 15 %</field>
-        <field name="tag_name">Post 10 Base</field>
-        <field name="code">NOTAX_10</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_10_tax" model="account.tax.report.line">
-        <field name="name">Post 10 Innførsel av varer, og beregnet avgift 15 % Tax</field>
-        <field name="tag_name">Post 10 Tax</field>
-        <field name="code">NOTAX_10_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_11" model="account.tax.report.line">
-        <field name="name">Post 11 Innførsel av varer som det ikke skal beregnes merverdiavgift av</field>
-        <field name="tag_name">Post 11</field>
-        <field name="code">NOTAX_11</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_innforsel_av_varer"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_kjop_med_omvendt_avgiftsplikt" model="account.tax.report.line">
-        <field name="name">E. Kjøp med omvendt avgiftsplikt</field>
-        <field name="sequence" eval="5"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_12" model="account.tax.report.line">
-        <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 12 Base</field>
-        <field name="code">NOTAX_12</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_12_tax" model="account.tax.report.line">
-        <field name="name">Post 12 Tjenester kjøpt fra utlandet, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 12 Tax</field>
-        <field name="code">NOTAX_12_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_13" model="account.tax.report.line">
-        <field name="name">Post 13 Innenlands kjøp av varer og tjenester, og beregnet avgift 25 %</field>
-        <field name="tag_name">Post 13 Base</field>
-        <field name="code">NOTAX_13</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_13_tax" model="account.tax.report.line">
-        <field name="name">Post 13 Innenlands kjøp av varer og tjenester, og beregnet avgift 25 % Tax</field>
-        <field name="tag_name">Post 13 Tax</field>
-        <field name="code">NOTAX_13_1</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_kjop_med_omvendt_avgiftsplikt"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_fradragsberettigen_innenlands" model="account.tax.report.line">
-        <field name="name">F. Fradragsberettiget innenlands inngående avgift</field>
-        <field name="sequence" eval="6"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_14" model="account.tax.report.line">
-        <field name="name">Post 14 Fradragsberettiget innenlands inngående avgift 25 %</field>
-        <field name="tag_name">Post 14</field>
-        <field name="code">NOTAX_14</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettigen_innenlands"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_15" model="account.tax.report.line">
-        <field name="name">Post 15 Fradragsberettiget innenlands inngående avgift 15 %</field>
-        <field name="tag_name">Post 15</field>
-        <field name="code">NOTAX_15</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettigen_innenlands"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_16" model="account.tax.report.line">
-        <field name="name">Post 16 Fradragsberettiget innenlands inngående avgift 12 %</field>
-        <field name="tag_name">Post 16</field>
-        <field name="code">NOTAX_16</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettigen_innenlands"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift" model="account.tax.report.line">
-        <field name="name">G. Fradragsberettiget innførselsmerverdiavgift</field>
-        <field name="sequence" eval="7"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_17" model="account.tax.report.line">
-        <field name="name">Post 17 Fradragsberettiget innførselsmerverdiavgift 25 %</field>
-        <field name="tag_name">Post 17</field>
-        <field name="code">NOTAX_17</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_18" model="account.tax.report.line">
-        <field name="name">Post 18 Fradragsberettiget innførselsmerverdiavgift 15 %</field>
-        <field name="tag_name">Post 18</field>
-        <field name="code">NOTAX_18</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_fradragsberettiget_innforselsmerverdiavgift"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_sum" model="account.tax.report.line">
-        <field name="name">H. Sum</field>
-        <field name="sequence" eval="8"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_line_post_19" model="account.tax.report.line">
-        <field name="name">Post 19 Avgift å betale</field>
-        <field name="formula">NOTAX_03_1+NOTAX_04_1+NOTAX_05_1+NOTAX_09_1+NOTAX_10_1+NOTAX_12_1+NOTAX_13_1-NOTAX_14-NOTAX_15-NOTAX_16-NOTAX_17-NOTAX_18</field>
-        <field name="code">NOTAX_19</field>
-        <field name="sequence" eval="0"/>
-        <field name="parent_id" ref="account_tax_report_line_sum"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -1,112 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.nz"/>
+        <field name="root_line_ids">
+            <record id="tax_report_sale_and_income" model="account.tax.report.line">
+                <field name="name">Sales and Income</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_box5" model="account.tax.report.line">
+                        <field name="name">[BOX 5] Total sales and income for the period(including GST and zero-rated Supplies)</field>
+                        <field name="tag_name">BOX 5</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="code">NZBOX5</field>
+                    </record>
+                    <record id="tax_report_box6" model="account.tax.report.line">
+                        <field name="name">[BOX 6] Zero-rated supplies in Box 5</field>
+                        <field name="tag_name">BOX 6</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="code">NZBOX6</field>
+                    </record>
+                    <record id="tax_report_box7" model="account.tax.report.line">
+                        <field name="name">[BOX 7] The amount in Box 6 is subracted from Box 5</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="formula">NZBOX5 - NZBOX6</field>
+                    </record>
+                    <record id="tax_report_box8" model="account.tax.report.line">
+                        <field name="name">[BOX 8] Multiply the amount in Box 7 by 3 and then divide by 23</field>
+                        <field name="sequence" eval="4"/>
+                        <field name="formula">((NZBOX5 - NZBOX6) * 3)/23</field>
+                    </record>
+                    <record id="tax_report_box9" model="account.tax.report.line">
+                        <field name="name">[BOX 9] Enter any adjustments from your calculation sheet</field>
+                        <field name="tag_name">BOX 9</field>
+                        <field name="sequence" eval="5"/>
+                        <field name="code">NZBOX9</field>
+                        <field name="formula"/>
+                    </record>
+                    <record id="tax_report_box10" model="account.tax.report.line">
+                        <field name="name">[BOX 10] Total GST collected on sales and income</field>
+                        <field name="sequence" eval="6"/>
+                        <field name="formula">(((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_purchases_and_expenses" model="account.tax.report.line">
+                <field name="name">Purchases and Expenses</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_box11" model="account.tax.report.line">
+                        <field name="name">[BOX 11] Total purchases and expenses(including GST) for which tax invoicing requirements have been met</field>
+                        <field name="tag_name">BOX 11</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="code">NZBOX11</field>
+                    </record>
+                    <record id="tax_report_box12" model="account.tax.report.line">
+                        <field name="name">[BOX 12] Multiply BOX11 by 3 and then divide by 23</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="formula">(NZBOX11 * 3)/23</field>
+                    </record>
+                    <record id="tax_report_box13" model="account.tax.report.line">
+                        <field name="name">[BOX 13] Credit adjustments from your calculation sheet</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_box14" model="account.tax.report.line">
+                        <field name="name">[BOX 14] Total GST credit for purchases and expenses</field>
+                        <field name="sequence" eval="4"/>
+                        <field name="formula">((NZBOX11 * 3)/23)</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_box15" model="account.tax.report.line">
+                <field name="name">[BOX 15]  Difference between BOX10 and BOX14</field>
+                <field name="sequence" eval="3"/>
+                <field name="formula">((((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9) - ((NZBOX11 * 3)/23)</field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_sale_and_income" model="account.tax.report.line">
-        <field name="name">Sales and Income</field>
-        <field name="sequence" eval="1"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box5" model="account.tax.report.line">
-        <field name="name">[BOX 5] Total sales and income for the period(including GST and zero-rated Supplies)</field>
-        <field name="tag_name">BOX 5</field>
-        <field name="parent_id" ref="tax_report_sale_and_income"/>
-        <field name="sequence" eval="1"/>
-        <field name="code">NZBOX5</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box6" model="account.tax.report.line">
-        <field name="name">[BOX 6] Zero-rated supplies in Box 5</field>
-        <field name="tag_name">BOX 6</field>
-        <field name="parent_id" ref="tax_report_sale_and_income"/>
-        <field name="sequence" eval="2"/>
-        <field name="code">NZBOX6</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box7" model="account.tax.report.line">
-        <field name="name">[BOX 7] The amount in Box 6 is subracted from Box 5</field>
-        <field name="parent_id" ref="tax_report_sale_and_income"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">NZBOX5 - NZBOX6</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box8" model="account.tax.report.line">
-        <field name="name">[BOX 8] Multiply the amount in Box 7 by 3 and then divide by 23</field>
-        <field name="parent_id" ref="tax_report_sale_and_income"/>
-        <field name="sequence" eval="4"/>
-        <field name="formula">((NZBOX5 - NZBOX6) * 3)/23</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box9" model="account.tax.report.line">
-        <field name="name">[BOX 9] Enter any adjustments from your calculation sheet</field>
-        <field name="tag_name">BOX 9</field>
-        <field name="parent_id" ref="tax_report_sale_and_income"/>
-        <field name="sequence" eval="5"/>
-        <field name="code">NZBOX9</field>
-        <field name="formula"></field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box10" model="account.tax.report.line">
-        <field name="name">[BOX 10] Total GST collected on sales and income</field>
-        <field name="parent_id" ref="tax_report_sale_and_income"/>
-        <field name="sequence" eval="6"/>
-        <field name="formula">(((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_purchases_and_expenses" model="account.tax.report.line">
-        <field name="name">Purchases and Expenses</field>
-        <field name="sequence" eval="2"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box11" model="account.tax.report.line">
-        <field name="name">[BOX 11] Total purchases and expenses(including GST) for which tax invoicing requirements have been met</field>
-        <field name="tag_name">BOX 11</field>
-        <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
-        <field name="sequence" eval="1"/>
-        <field name="code">NZBOX11</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box12" model="account.tax.report.line">
-        <field name="name">[BOX 12] Multiply BOX11 by 3 and then divide by 23</field>
-        <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
-        <field name="sequence" eval="2"/>
-        <field name="formula">(NZBOX11 * 3)/23</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box13" model="account.tax.report.line">
-        <field name="name">[BOX 13] Credit adjustments from your calculation sheet</field>
-        <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
-        <field name="sequence" eval="3"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box14" model="account.tax.report.line">
-        <field name="name">[BOX 14] Total GST credit for purchases and expenses</field>
-        <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
-        <field name="sequence" eval="4"/>
-        <field name="formula">((NZBOX11 * 3)/23)</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="tax_report_box15" model="account.tax.report.line">
-        <field name="name">[BOX 15]  Difference between BOX10 and BOX14</field>
-        <field name="sequence" eval="3"/>
-        <field name="formula">((((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9) - ((NZBOX11 * 3)/23)</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_pl/data/account_tax_report_data.xml
+++ b/addons/l10n_pl/data/account_tax_report_data.xml
@@ -1,388 +1,274 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.pl"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_razem_c" model="account.tax.report.line">
+                <field name="name">Podstawa - Razem C</field>
+                <field name="sequence" eval="1"/>
+                <field name="formula">PLTAXC_01_10 + PLTAXC_02_11 + PLTAXC_03_13 + PLTAXC_04_15 + PLTAXC_05_17 + PLTAXC_06_19 + PLTAXC_07_21 + PLTAXC_08_22 + PLTAXC_09_23 + PLTAXC_10_25 + PLTAXC_11_27 + PLTAXC_12_31</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_kraj_zwolnione" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów/usług, kraj, zwolnione</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, zwolnione</field>
+                        <field name="code">PLTAXC_01_10</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_poza_kraj" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów/usług, poza kraj</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów/usług, poza kraj</field>
+                        <field name="code">PLTAXC_02_11</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_uslugi_art_100_1_4" model="account.tax.report.line">
+                                <field name="name">Podstawa - W tym usługi art 100.1.4</field>
+                                <field name="tag_name">Podstawa - W tym usługi art 100.1.4</field>
+                                <field name="code">PLTAXC_02a_12</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_uslugi_kraj_0" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 0%</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 0%</field>
+                        <field name="code">PLTAXC_03_13</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_towary_art_129" model="account.tax.report.line">
+                                <field name="name">Podstawa - W tym towary art 129</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_kraj_3_lub_5" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 3% lub 5%</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 3% lub 5%</field>
+                        <field name="code">PLTAXC_04_15</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="account_tax_report_line_kraj_7_lub_8" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 7% lub 8%</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 7% lub 8%</field>
+                        <field name="code">PLTAXC_05_17</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="account_tax_report_line_kraj_22_lub_23" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 22% lub 23%</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 22% lub 23%</field>
+                        <field name="code">PLTAXC_06_19</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="account_tax_report_line_dostawa_towarow" model="account.tax.report.line">
+                        <field name="name">Podstawa - Wew-wspól dostawa towarów</field>
+                        <field name="tag_name">Podstawa - Wew-wspól dostawa towarów</field>
+                        <field name="code">PLTAXC_07_21</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="account_tax_report_line_eksport_towarow" model="account.tax.report.line">
+                        <field name="name">Podstawa - Eksport towarów</field>
+                        <field name="tag_name">Podstawa - Eksport towarów</field>
+                        <field name="code">PLTAXC_08_22</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="account_tax_report_line_nabycie_towarow" model="account.tax.report.line">
+                        <field name="name">Podstawa - Wewn-wspól. nabycie towarów</field>
+                        <field name="tag_name">Podstawa - Wewn-wspól. nabycie towarów</field>
+                        <field name="code">PLTAXC_09_23</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="account_tax_report_line_art_33a" model="account.tax.report.line">
+                        <field name="name">Podstawa - Import towarów art. 33a</field>
+                        <field name="tag_name">Podstawa - Import towarów art. 33a</field>
+                        <field name="code">PLTAXC_10_25</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="account_tax_report_line_import_uslug" model="account.tax.report.line">
+                        <field name="name">Podstawa - Import usług</field>
+                        <field name="tag_name">Podstawa - Import usług</field>
+                        <field name="code">PLTAXC_11_27</field>
+                        <field name="sequence" eval="11"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_art_28b" model="account.tax.report.line">
+                                <field name="name">Podstawa - W tym nabycie wg art 28b</field>
+                                <field name="tag_name">Podstawa - W tym nabycie wg art 28b</field>
+                                <field name="code">PLTAXC_11a_29</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_podatnik_nabywca" model="account.tax.report.line">
+                        <field name="name">Podstawa - Dostawa towarów, podatnik nabywca</field>
+                        <field name="tag_name">Podstawa - Dostawa towarów, podatnik nabywca</field>
+                        <field name="code">PLTAXC_12_31</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_razem_d" model="account.tax.report.line">
+                <field name="name">Podstawa - Razem D</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_uslug_s_trwale" model="account.tax.report.line">
+                        <field name="name">Podstawa - Nabycie towarów i usług ś.trwałe</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_uslug_pozostalych" model="account.tax.report.line">
+                        <field name="name">Podstawa - Nabycie towarów i usług pozostałych</field>
+                        <field name="tag_name">Podstawa - Nabycie towarów i usług pozostałych</field>
+                        <field name="code">PLTAXD_02_41a</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_do_przeniesienia" model="account.tax.report.line">
+                <field name="name">Podatek - Do przeniesienia</field>
+                <field name="sequence" eval="3"/>
+                <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_nad_naleznym" model="account.tax.report.line">
+                        <field name="name">Podatek - Nadwyżka naliczonego nad należnym</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_do_US" model="account.tax.report.line">
+                                <field name="name">Podatek - Do wpłaty do US</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
+                                <field name="children_line_ids">
+                                    <record id="account_tax_report_line_kasy_rejestrujace" model="account.tax.report.line">
+                                        <field name="name">Podatek - Wydatek na kasy rejestrujące</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="account_tax_report_line_zaniechaniem_poboru" model="account.tax.report.line">
+                                        <field name="name">Podatek - Objęty zaniechaniem poboru</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="account_tax_report_line_podatek_razem_c" model="account.tax.report.line">
+                                        <field name="name">Podatek - Razem C</field>
+                                        <field name="sequence" eval="3"/>
+                                        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32</field>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_podatek_kraj_3_lub_5" model="account.tax.report.line">
+                                                <field name="name">Podatek - Dostawa towarów/usług, kraj, 3% lub 5%</field>
+                                                <field name="tag_name">Podatek - Dostawa towarów/usług, kraj, 3% lub 5%</field>
+                                                <field name="code">PLTAXC_04_16</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_kraj_7_lub_8" model="account.tax.report.line">
+                                                <field name="name">Podatek - Dostawa towarów/usług, kraj, 7% lub 8%</field>
+                                                <field name="tag_name">Podatek - Dostawa towarów/usług, kraj, 7% lub 8%</field>
+                                                <field name="code">PLTAXC_05_18</field>
+                                                <field name="sequence" eval="2"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_kraj_22_lub_23" model="account.tax.report.line">
+                                                <field name="name">Podatek - Dostawa towarów/usług, kraj, 22% lub 23%</field>
+                                                <field name="tag_name">Podatek - Dostawa towarów/usług, kraj, 22% lub 23%</field>
+                                                <field name="code">PLTAXC_06_20</field>
+                                                <field name="sequence" eval="3"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_nabycie_towarow" model="account.tax.report.line">
+                                                <field name="name">Podatek - Wewn-wspól. nabycie towarów</field>
+                                                <field name="tag_name">Podatek - Wewn-wspól. nabycie towarów</field>
+                                                <field name="code">PLTAXC_09_24</field>
+                                                <field name="sequence" eval="4"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_art_33a" model="account.tax.report.line">
+                                                <field name="name">Podatek - Import towarów art. 33a</field>
+                                                <field name="tag_name">Podatek - Import towarów art. 33a</field>
+                                                <field name="code">PLTAXC_10_26</field>
+                                                <field name="sequence" eval="5"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_import_uslug" model="account.tax.report.line">
+                                                <field name="name">Podatek - Import usług</field>
+                                                <field name="tag_name">Podatek - Import usług</field>
+                                                <field name="code">PLTAXC_11_28</field>
+                                                <field name="sequence" eval="6"/>
+                                                <field name="children_line_ids">
+                                                    <record id="account_tax_report_line_podatek_art_28b" model="account.tax.report.line">
+                                                        <field name="name">Podatek - W tym nabycie wg art 28b</field>
+                                                        <field name="tag_name">Podatek - W tym nabycie wg art 28b</field>
+                                                        <field name="code">PLTAXC_11a_30</field>
+                                                        <field name="sequence" eval="6"/>
+                                                    </record>
+                                                </field>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_podatnik_nabywca" model="account.tax.report.line">
+                                                <field name="name">Podatek - Dostawa towarów, podatnik nabywca</field>
+                                                <field name="tag_name">Podatek - Dostawa towarów, podatnik nabywca</field>
+                                                <field name="code">PLTAXC_12_32</field>
+                                                <field name="sequence" eval="7"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_art_14_5" model="account.tax.report.line">
+                                                <field name="name">Podatek - Ze spisu z natury art 14.5</field>
+                                                <field name="sequence" eval="8"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_transp_termin" model="account.tax.report.line">
+                                                <field name="name">Podatek - Wew.wspól. nabycie środk. transp. termin</field>
+                                                <field name="sequence" eval="9"/>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_podatek_razem_d" model="account.tax.report.line">
+                                        <field name="name">Podatek - Razem D</field>
+                                        <field name="sequence" eval="4"/>
+                                        <field name="children_line_ids">
+                                            <record id="account_tax_report_line_podatek_deklaracji" model="account.tax.report.line">
+                                                <field name="name">Podatek - Nadwyżka z poprzedniej deklaracji</field>
+                                                <field name="sequence" eval="1"/>
+                                            </record>
+                                            <record id="account_tax_report_line_pl_03_01_01_04_02" model="account.tax.report.line">
+                                                <field name="name">Podatek - Naliczony ze spisu z natury, art.113</field>
+                                                <field name="sequence" eval="2"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_s_trwale" model="account.tax.report.line">
+                                                <field name="name">Podatek - Nabycie towarów i usług ś.trwałe</field>
+                                                <field name="sequence" eval="3"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_uslug_pozostalych" model="account.tax.report.line">
+                                                <field name="name">Podatek - Nabycie towarów i usług pozostałych</field>
+                                                <field name="tag_name">Podatek - Nabycie towarów i usług pozostałych</field>
+                                                <field name="code">PLTAXD_02_42</field>
+                                                <field name="sequence" eval="4"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_s_trwalych" model="account.tax.report.line">
+                                                <field name="name">Podatek - Korekta naliczonego od nabycia ś.trwałych</field>
+                                                <field name="sequence" eval="5"/>
+                                            </record>
+                                            <record id="account_tax_report_line_podatek_pozostalych_nabyc" model="account.tax.report.line">
+                                                <field name="name">Podatek - Korekta naliczonego od pozostałych nabyć</field>
+                                                <field name="sequence" eval="6"/>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_podatek_okresie" model="account.tax.report.line">
+                                <field name="name">Podatek - Wydatek na kasy do zwrotu w tym okresie</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_podatek_do_zwrotu" model="account.tax.report.line">
+                        <field name="name">Podatek - Do zwrotu</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_do_zwrotu_25_dni" model="account.tax.report.line">
+                                <field name="name">Podatek - Do zwrotu 25 dni</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_do_zwrotu_60_dni" model="account.tax.report.line">
+                                <field name="name">Podatek - Do zwrotu 60 dni</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_do_zwrotu_180_dni" model="account.tax.report.line">
+                                <field name="name">Podatek - Do zwrotu 180 dni</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_line_razem_c" model="account.tax.report.line">
-        <field name="name">Podstawa - Razem C</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">PLTAXC_01_10 + PLTAXC_02_11 + PLTAXC_03_13 + PLTAXC_04_15 + PLTAXC_05_17 + PLTAXC_06_19 + PLTAXC_07_21 + PLTAXC_08_22 + PLTAXC_09_23 + PLTAXC_10_25 + PLTAXC_11_27 + PLTAXC_12_31</field>
-    </record>
-
-    <record id="account_tax_report_line_kraj_zwolnione" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów/usług, kraj, zwolnione</field>
-        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, zwolnione</field>
-        <field name="code">PLTAXC_01_10</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_poza_kraj" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów/usług, poza kraj</field>
-        <field name="tag_name">Podstawa - Dostawa towarów/usług, poza kraj</field>
-        <field name="code">PLTAXC_02_11</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_uslugi_art_100_1_4" model="account.tax.report.line">
-        <field name="name">Podstawa - W tym usługi art 100.1.4</field>
-        <field name="tag_name">Podstawa - W tym usługi art 100.1.4</field>
-        <field name="code">PLTAXC_02a_12</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_poza_kraj"/>
-    </record>
-
-    <record id="account_tax_report_line_uslugi_kraj_0" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 0%</field>
-        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 0%</field>
-        <field name="code">PLTAXC_03_13</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_towary_art_129" model="account.tax.report.line">
-        <field name="name">Podstawa - W tym towary art 129</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_uslugi_kraj_0"/>
-    </record>
-
-    <record id="account_tax_report_line_kraj_3_lub_5" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 3% lub 5%</field>
-        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 3% lub 5%</field>
-        <field name="code">PLTAXC_04_15</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_kraj_7_lub_8" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 7% lub 8%</field>
-        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 7% lub 8%</field>
-        <field name="code">PLTAXC_05_17</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_kraj_22_lub_23" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów/usług, kraj, 22% lub 23%</field>
-        <field name="tag_name">Podstawa - Dostawa towarów/usług, kraj, 22% lub 23%</field>
-        <field name="code">PLTAXC_06_19</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_dostawa_towarow" model="account.tax.report.line">
-        <field name="name">Podstawa - Wew-wspól dostawa towarów</field>
-        <field name="tag_name">Podstawa - Wew-wspól dostawa towarów</field>
-        <field name="code">PLTAXC_07_21</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_eksport_towarow" model="account.tax.report.line">
-        <field name="name">Podstawa - Eksport towarów</field>
-        <field name="tag_name">Podstawa - Eksport towarów</field>
-        <field name="code">PLTAXC_08_22</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_nabycie_towarow" model="account.tax.report.line">
-        <field name="name">Podstawa - Wewn-wspól. nabycie towarów</field>
-        <field name="tag_name">Podstawa - Wewn-wspól. nabycie towarów</field>
-        <field name="code">PLTAXC_09_23</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_art_33a" model="account.tax.report.line">
-        <field name="name">Podstawa - Import towarów art. 33a</field>
-        <field name="tag_name">Podstawa - Import towarów art. 33a</field>
-        <field name="code">PLTAXC_10_25</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_import_uslug" model="account.tax.report.line">
-        <field name="name">Podstawa - Import usług</field>
-        <field name="tag_name">Podstawa - Import usług</field>
-        <field name="code">PLTAXC_11_27</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_art_28b" model="account.tax.report.line">
-        <field name="name">Podstawa - W tym nabycie wg art 28b</field>
-        <field name="tag_name">Podstawa - W tym nabycie wg art 28b</field>
-        <field name="code">PLTAXC_11a_29</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_import_uslug"/>
-    </record>
-
-    <record id="account_tax_report_line_podatnik_nabywca" model="account.tax.report.line">
-        <field name="name">Podstawa - Dostawa towarów, podatnik nabywca</field>
-        <field name="tag_name">Podstawa - Dostawa towarów, podatnik nabywca</field>
-        <field name="code">PLTAXC_12_31</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_razem_d" model="account.tax.report.line">
-        <field name="name">Podstawa - Razem D</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_line_uslug_s_trwale" model="account.tax.report.line">
-        <field name="name">Podstawa - Nabycie towarów i usług ś.trwałe</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_uslug_pozostalych" model="account.tax.report.line">
-        <field name="name">Podstawa - Nabycie towarów i usług pozostałych</field>
-        <field name="tag_name">Podstawa - Nabycie towarów i usług pozostałych</field>
-        <field name="code">PLTAXD_02_41a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_do_przeniesienia" model="account.tax.report.line">
-        <field name="name">Podatek - Do przeniesienia</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
-    </record>
-
-    <record id="account_tax_report_line_nad_naleznym" model="account.tax.report.line">
-        <field name="name">Podatek - Nadwyżka naliczonego nad należnym</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
-        <field name="parent_id" ref="account_tax_report_line_do_przeniesienia"/>
-    </record>
-
-    <record id="account_tax_report_line_do_US" model="account.tax.report.line">
-        <field name="name">Podatek - Do wpłaty do US</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
-        <field name="parent_id" ref="account_tax_report_line_nad_naleznym"/>
-    </record>
-
-    <record id="account_tax_report_line_kasy_rejestrujace" model="account.tax.report.line">
-        <field name="name">Podatek - Wydatek na kasy rejestrujące</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_do_US"/>
-    </record>
-
-    <record id="account_tax_report_line_zaniechaniem_poboru" model="account.tax.report.line">
-        <field name="name">Podatek - Objęty zaniechaniem poboru</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_do_US"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_razem_c" model="account.tax.report.line">
-        <field name="name">Podatek - Razem C</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32</field>
-        <field name="parent_id" ref="account_tax_report_line_do_US"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_kraj_3_lub_5" model="account.tax.report.line">
-        <field name="name">Podatek - Dostawa towarów/usług, kraj, 3% lub 5%</field>
-        <field name="tag_name">Podatek - Dostawa towarów/usług, kraj, 3% lub 5%</field>
-        <field name="code">PLTAXC_04_16</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_kraj_7_lub_8" model="account.tax.report.line">
-        <field name="name">Podatek - Dostawa towarów/usług, kraj, 7% lub 8%</field>
-        <field name="tag_name">Podatek - Dostawa towarów/usług, kraj, 7% lub 8%</field>
-        <field name="code">PLTAXC_05_18</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_kraj_22_lub_23" model="account.tax.report.line">
-        <field name="name">Podatek - Dostawa towarów/usług, kraj, 22% lub 23%</field>
-        <field name="tag_name">Podatek - Dostawa towarów/usług, kraj, 22% lub 23%</field>
-        <field name="code">PLTAXC_06_20</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_nabycie_towarow" model="account.tax.report.line">
-        <field name="name">Podatek - Wewn-wspól. nabycie towarów</field>
-        <field name="tag_name">Podatek - Wewn-wspól. nabycie towarów</field>
-        <field name="code">PLTAXC_09_24</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_art_33a" model="account.tax.report.line">
-        <field name="name">Podatek - Import towarów art. 33a</field>
-        <field name="tag_name">Podatek - Import towarów art. 33a</field>
-        <field name="code">PLTAXC_10_26</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_import_uslug" model="account.tax.report.line">
-        <field name="name">Podatek - Import usług</field>
-        <field name="tag_name">Podatek - Import usług</field>
-        <field name="code">PLTAXC_11_28</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_art_28b" model="account.tax.report.line">
-        <field name="name">Podatek - W tym nabycie wg art 28b</field>
-        <field name="tag_name">Podatek - W tym nabycie wg art 28b</field>
-        <field name="code">PLTAXC_11a_30</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_import_uslug"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_podatnik_nabywca" model="account.tax.report.line">
-        <field name="name">Podatek - Dostawa towarów, podatnik nabywca</field>
-        <field name="tag_name">Podatek - Dostawa towarów, podatnik nabywca</field>
-        <field name="code">PLTAXC_12_32</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_art_14_5" model="account.tax.report.line">
-        <field name="name">Podatek - Ze spisu z natury art 14.5</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_transp_termin" model="account.tax.report.line">
-        <field name="name">Podatek - Wew.wspól. nabycie środk. transp. termin</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_c"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_razem_d" model="account.tax.report.line">
-        <field name="name">Podatek - Razem D</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_do_US"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_deklaracji" model="account.tax.report.line">
-        <field name="name">Podatek - Nadwyżka z poprzedniej deklaracji</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_pl_03_01_01_04_02" model="account.tax.report.line">
-        <field name="name">Podatek - Naliczony ze spisu z natury, art.113</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_s_trwale" model="account.tax.report.line">
-        <field name="name">Podatek - Nabycie towarów i usług ś.trwałe</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_uslug_pozostalych" model="account.tax.report.line">
-        <field name="name">Podatek - Nabycie towarów i usług pozostałych</field>
-        <field name="tag_name">Podatek - Nabycie towarów i usług pozostałych</field>
-        <field name="code">PLTAXD_02_42</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_s_trwalych" model="account.tax.report.line">
-        <field name="name">Podatek - Korekta naliczonego od nabycia ś.trwałych</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_pozostalych_nabyc" model="account.tax.report.line">
-        <field name="name">Podatek - Korekta naliczonego od pozostałych nabyć</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_razem_d"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_okresie" model="account.tax.report.line">
-        <field name="name">Podatek - Wydatek na kasy do zwrotu w tym okresie</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_nad_naleznym"/>
-    </record>
-
-    <record id="account_tax_report_line_podatek_do_zwrotu" model="account.tax.report.line">
-        <field name="name">Podatek - Do zwrotu</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_do_przeniesienia"/>
-    </record>
-
-    <record id="account_tax_report_line_do_zwrotu_25_dni" model="account.tax.report.line">
-        <field name="name">Podatek - Do zwrotu 25 dni</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_do_zwrotu"/>
-    </record>
-
-    <record id="account_tax_report_line_do_zwrotu_60_dni" model="account.tax.report.line">
-        <field name="name">Podatek - Do zwrotu 60 dni</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_do_zwrotu"/>
-    </record>
-
-    <record id="account_tax_report_line_do_zwrotu_180_dni" model="account.tax.report.line">
-        <field name="name">Podatek - Do zwrotu 180 dni</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_podatek_do_zwrotu"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_ro/data/account_tax_report_data.xml
+++ b/addons/l10n_ro/data/account_tax_report_data.xml
@@ -1,1017 +1,760 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Romanian Tax Report</field>
         <field name="country_id" ref="base.ro"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_ro_baza_intracom_eu" model="account.tax.report.line">
+                <field name="name">Baza COMERŢ INTRACOMUNITAR ŞI ÎN AFARA UE</field>
+                <field name="code">tax_ro_baza_intracom_eu</field>
+                <field name="sequence" eval="0"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_baza_rd1" model="account.tax.report.line">
+                        <field name="name">1 - BAZA - Livrări intracomunitare de bunuri, scutite conform art. 294 alin.(2) lit.a) şid) din Codul fiscal</field>
+                        <field name="tag_name">01 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd1</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd2" model="account.tax.report.line">
+                        <field name="name">2 - BAZA - Regularizări livrări intracomunitare scutite conform art. 294 alin.(2) lit.a) şi d) din Codul fiscal</field>
+                        <field name="tag_name">02 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd2</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd3" model="account.tax.report.line">
+                        <field name="name">3 - BAZA - Livrări de bunuri/prestări de servicii pentru care locul livrării/prestării este în afara României, precum şi livrări intracom. de bunuri, scut. conf. art. 294 alin.(2) lit.b) şi c) din CF, din care: </field>
+                        <field name="tag_name">03 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd3</field>
+                        <field name="sequence" eval="4"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd31" model="account.tax.report.line">
+                                <field name="name">3.1 - BAZA - Prestări de servicii intracomunitare care nu beneficiază de scutire in statul membru in care taxa este datorată</field>
+                                <field name="tag_name">03_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd31</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd4" model="account.tax.report.line">
+                        <field name="name">4 - BAZA - Regularizări privind prestările de servicii intracomunitare care nu beneficiază de scutire in statul membru in care taxa este datorată</field>
+                        <field name="tag_name">04 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd4</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd5" model="account.tax.report.line">
+                        <field name="name">5 - BAZA - Achizitii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă), din care:</field>
+                        <field name="tag_name">05 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd5</field>
+                        <field name="sequence" eval="7"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd51" model="account.tax.report.line">
+                                <field name="name">5.1 - BAZA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea intracom.</field>
+                                <field name="tag_name">05_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd51</field>
+                                <field name="sequence" eval="9"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd6" model="account.tax.report.line">
+                        <field name="name">6 - BAZA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA(taxare inversă)</field>
+                        <field name="tag_name">06 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd6</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd7" model="account.tax.report.line">
+                        <field name="name">7 - BAZA - Achizitii de bunuri, altele decat cele de la rd.5 şi 6 si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) din care:</field>
+                        <field name="tag_name">07 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd7</field>
+                        <field name="sequence" eval="13"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd71" model="account.tax.report.line">
+                                <field name="name">7.1 - BAZA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
+                                <field name="tag_name">07_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd71</field>
+                                <field name="sequence" eval="15"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd8" model="account.tax.report.line">
+                        <field name="name">8 - BAZA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
+                        <field name="tag_name">08 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd8</field>
+                        <field name="sequence" eval="17"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_tva_intracom_eu" model="account.tax.report.line">
+                <field name="name">TVA COMERŢ INTRACOMUNITAR ŞI ÎN AFARA UE</field>
+                <field name="code">tax_ro_tva_intracom_eu</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_tva_rd5" model="account.tax.report.line">
+                        <field name="name">5 - TVA - Achizitii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă), din care:</field>
+                        <field name="tag_name">05 - TVA</field>
+                        <field name="code">tax_ro_tva_rd5</field>
+                        <field name="sequence" eval="8"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd51" model="account.tax.report.line">
+                                <field name="name">5.1 - TVA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea intracom.</field>
+                                <field name="tag_name">05_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd51</field>
+                                <field name="sequence" eval="10"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd6" model="account.tax.report.line">
+                        <field name="name">6 - TVA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA(taxare inversă)</field>
+                        <field name="tag_name">06 - TVA</field>
+                        <field name="code">tax_ro_tva_rd6</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd7" model="account.tax.report.line">
+                        <field name="name">7 - TVA - Achizitii de bunuri, altele decat cele de la rd.5 şi 6 si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) din care:</field>
+                        <field name="tag_name">07 - TVA</field>
+                        <field name="code">tax_ro_tva_rd7</field>
+                        <field name="sequence" eval="14"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd71" model="account.tax.report.line">
+                                <field name="name">7.1 - TVA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
+                                <field name="tag_name">07_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd71</field>
+                                <field name="sequence" eval="16"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd8" model="account.tax.report.line">
+                        <field name="name">8 - TVA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
+                        <field name="tag_name">08 - TVA</field>
+                        <field name="code">tax_ro_tva_rd8</field>
+                        <field name="sequence" eval="18"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_baza_livrari" model="account.tax.report.line">
+                <field name="name">BAZA LIVRĂRI DE BUNURI/ PRESTĂRI DE SERVICII ÎN INTERIORUL ŢĂRII ŞI EXPORTURI</field>
+                <field name="code">tax_ro_baza_livrari</field>
+                <field name="sequence" eval="19"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_baza_rd9" model="account.tax.report.line">
+                        <field name="name">9 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
+                        <field name="tag_name">09 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd9</field>
+                        <field name="sequence" eval="21"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd91" model="account.tax.report.line">
+                                <field name="name">9.1 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
+                                <field name="tag_name">09_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd91</field>
+                                <field name="sequence" eval="23"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd92" model="account.tax.report.line">
+                                <field name="name">9.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
+                                <field name="code">tax_ro_baza_rd92</field>
+                                <field name="sequence" eval="25"/>
+                                <field name="formula">0.5 * tax_ro_baza_rd242</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd10" model="account.tax.report.line">
+                        <field name="name">10 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
+                        <field name="tag_name">10 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd10</field>
+                        <field name="sequence" eval="27"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd101" model="account.tax.report.line">
+                                <field name="name">10.1 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
+                                <field name="tag_name">10_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd101</field>
+                                <field name="sequence" eval="29"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd102" model="account.tax.report.line">
+                                <field name="name">10_2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
+                                <field name="code">tax_ro_baza_rd102</field>
+                                <field name="sequence" eval="31"/>
+                                <field name="formula">0.5 * tax_ro_baza_rd252</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd11" model="account.tax.report.line">
+                        <field name="name">11 - BAZA - Livrări de bunuri taxabile cu cota 5%</field>
+                        <field name="tag_name">11 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd11</field>
+                        <field name="sequence" eval="33"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd111" model="account.tax.report.line">
+                                <field name="name">11.1 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 5%</field>
+                                <field name="tag_name">11_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd111</field>
+                                <field name="sequence" eval="35"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd112" model="account.tax.report.line">
+                                <field name="name">11.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
+                                <field name="code">tax_ro_baza_rd112</field>
+                                <field name="sequence" eval="37"/>
+                                <field name="formula">0.5 * tax_ro_baza_rd262</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd12" model="account.tax.report.line">
+                        <field name="name">12 - BAZA - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
+                        <field name="tag_name">12 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd12</field>
+                        <field name="sequence" eval="39"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd121" model="account.tax.report.line">
+                                <field name="name">12.1 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 19%</field>
+                                <field name="tag_name">12_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd121</field>
+                                <field name="sequence" eval="41"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd122" model="account.tax.report.line">
+                                <field name="name">12.2 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 9%</field>
+                                <field name="tag_name">12_2 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd122</field>
+                                <field name="sequence" eval="43"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd123" model="account.tax.report.line">
+                                <field name="name">12.3 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 5%</field>
+                                <field name="tag_name">12_3 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd123</field>
+                                <field name="sequence" eval="45"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd13" model="account.tax.report.line">
+                        <field name="name">13 - BAZA - Livrări de bunuri şi prestări de servicii supuse masurilor de simplificare (taxare inversa)</field>
+                        <field name="tag_name">13 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd13</field>
+                        <field name="sequence" eval="47"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd14" model="account.tax.report.line">
+                        <field name="name">14 - BAZA - Livrări de bunuri şi prestări de servicii scutite cu drept de deducere, altele decat cele de la rd. 1-3</field>
+                        <field name="tag_name">14 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd14</field>
+                        <field name="sequence" eval="48"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd15" model="account.tax.report.line">
+                        <field name="name">15 - BAZA - Livrări de bunuri şi prestări de servicii scutite fără drept de deducere</field>
+                        <field name="tag_name">15 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd15</field>
+                        <field name="sequence" eval="49"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd16" model="account.tax.report.line">
+                        <field name="name">16 - BAZA - Regularizări taxă colectată</field>
+                        <field name="tag_name">16 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd16</field>
+                        <field name="sequence" eval="50"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd17" model="account.tax.report.line">
+                        <field name="name">17 - BAZA - Prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
+                        <field name="tag_name">17 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd17</field>
+                        <field name="sequence" eval="50"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd18" model="account.tax.report.line">
+                        <field name="name">18 - BAZA - Regularizări privind prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
+                        <field name="tag_name">18 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd18</field>
+                        <field name="sequence" eval="50"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_tva_livrari" model="account.tax.report.line">
+                <field name="name">TVA LIVRĂRI DE BUNURI/ PRESTĂRI DE SERVICII ÎN INTERIORUL ŢĂRII ŞI EXPORTURI</field>
+                <field name="code">tax_ro_tva_livrari</field>
+                <field name="sequence" eval="20"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_tva_rd9" model="account.tax.report.line">
+                        <field name="name">9 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
+                        <field name="tag_name">09 - TVA</field>
+                        <field name="code">tax_ro_tva_rd9</field>
+                        <field name="sequence" eval="22"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd91" model="account.tax.report.line">
+                                <field name="name">9.1 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
+                                <field name="tag_name">09_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd91</field>
+                                <field name="sequence" eval="24"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd92" model="account.tax.report.line">
+                                <field name="name">9.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
+                                <field name="tag_name">09_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd92</field>
+                                <field name="sequence" eval="26"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd10" model="account.tax.report.line">
+                        <field name="name">10 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
+                        <field name="tag_name">10 - TVA</field>
+                        <field name="code">tax_ro_tva_rd10</field>
+                        <field name="sequence" eval="28"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd101" model="account.tax.report.line">
+                                <field name="name">10.1 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
+                                <field name="tag_name">10_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd101</field>
+                                <field name="sequence" eval="30"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd102" model="account.tax.report.line">
+                                <field name="name">10.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
+                                <field name="tag_name">10_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd102</field>
+                                <field name="sequence" eval="32"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd11" model="account.tax.report.line">
+                        <field name="name">11 - TVA - Livrări de bunuri taxabile cu cota 5%</field>
+                        <field name="tag_name">11 - TVA</field>
+                        <field name="code">tax_ro_tva_rd11</field>
+                        <field name="sequence" eval="34"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd111" model="account.tax.report.line">
+                                <field name="name">11.1 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 5%</field>
+                                <field name="tag_name">11_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd111</field>
+                                <field name="sequence" eval="36"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd112" model="account.tax.report.line">
+                                <field name="name">11.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
+                                <field name="tag_name">11_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd112</field>
+                                <field name="sequence" eval="38"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd12" model="account.tax.report.line">
+                        <field name="name">12 - TVA - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
+                        <field name="tag_name">12 - TVA</field>
+                        <field name="code">tax_ro_tva_rd12</field>
+                        <field name="sequence" eval="40"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd121" model="account.tax.report.line">
+                                <field name="name">12.1 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 19%</field>
+                                <field name="tag_name">12_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd121</field>
+                                <field name="sequence" eval="42"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd122" model="account.tax.report.line">
+                                <field name="name">12.2 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 9%</field>
+                                <field name="tag_name">12_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd122</field>
+                                <field name="sequence" eval="44"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd123" model="account.tax.report.line">
+                                <field name="name">12.3 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 5%</field>
+                                <field name="tag_name">12_3 - TVA</field>
+                                <field name="code">tax_ro_tva_rd123</field>
+                                <field name="sequence" eval="46"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd16" model="account.tax.report.line">
+                        <field name="name">16 - TVA - Regularizări taxă colectată</field>
+                        <field name="tag_name">16 - TVA</field>
+                        <field name="code">tax_ro_tva_rd16</field>
+                        <field name="sequence" eval="51"/>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd17" model="account.tax.report.line">
+                        <field name="name">17 - TVA - Prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
+                        <field name="tag_name">17 - TVA</field>
+                        <field name="code">tax_ro_tva_rd17</field>
+                        <field name="sequence" eval="51"/>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd18" model="account.tax.report.line">
+                        <field name="name">18 - TVA - Regularizări privind prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
+                        <field name="tag_name">18 - TVA</field>
+                        <field name="code">tax_ro_tva_rd18</field>
+                        <field name="sequence" eval="51"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_baza_col" model="account.tax.report.line">
+                <field name="name">Baza Total Taxa COLECTATĂ</field>
+                <field name="code">total_tax_ro_baza_col</field>
+                <field name="sequence" eval="52"/>
+                <field name="formula">tax_ro_baza_intracom_eu + tax_ro_baza_livrari</field>
+            </record>
+            <record id="account_tax_report_ro_tva_col" model="account.tax.report.line">
+                <field name="name">TVA Total Taxa COLECTATĂ</field>
+                <field name="code">total_tax_ro_tva_col</field>
+                <field name="sequence" eval="53"/>
+                <field name="formula">tax_ro_tva_intracom_eu + tax_ro_tva_livrari</field>
+            </record>
+            <record id="account_tax_report_ro_baza_intracom_eu_achiz" model="account.tax.report.line">
+                <field name="name">BAZA ACHIZIŢII INTRACOMUNITARE DE BUNURI ŞI ALTE ACHIZIŢII DE BUNURI ŞI SERVICII IMPOZABILE ÎN ROMÂNIA</field>
+                <field name="code">tax_ro_baza_intracom_eu_a</field>
+                <field name="sequence" eval="54"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_baza_rd20" model="account.tax.report.line">
+                        <field name="name">20 - BAZA - Achiziţii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă) (rd.18=rd.5), din care:</field>
+                        <field name="tag_name">20 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd20</field>
+                        <field name="sequence" eval="56"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd201" model="account.tax.report.line">
+                                <field name="name">20.1 - BAZA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea (rd.18.1=rd.5.1)</field>
+                                <field name="tag_name">20_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd201</field>
+                                <field name="sequence" eval="58"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd21" model="account.tax.report.line">
+                        <field name="name">21 - BAZA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumparatorul este obligat la plata TVA (taxare inversa) (rd.19=rd.6)</field>
+                        <field name="tag_name">21 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd21</field>
+                        <field name="sequence" eval="60"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd22" model="account.tax.report.line">
+                        <field name="name">22 - BAZA - Achiziţii de bunuri, altele decat cele de la rd. 18 şi 19, si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.20=rd.7), din care:</field>
+                        <field name="tag_name">22 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd22</field>
+                        <field name="sequence" eval="62"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd221" model="account.tax.report.line">
+                                <field name="name">22.1 - BAZA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa) (rd.20.1=rd.7.1)</field>
+                                <field name="tag_name">22_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd221</field>
+                                <field name="sequence" eval="64"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd23" model="account.tax.report.line">
+                        <field name="name">23 - BAZA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.21=rd.8)</field>
+                        <field name="tag_name">23 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd23</field>
+                        <field name="sequence" eval="66"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_tva_intracom_eu_achiz" model="account.tax.report.line">
+                <field name="name">TVA ACHIZIŢII INTRACOMUNITARE DE BUNURI ŞI ALTE ACHIZIŢII DE BUNURI ŞI SERVICII IMPOZABILE ÎN ROMÂNIA</field>
+                <field name="code">tax_ro_tva_intracom_eu_a</field>
+                <field name="sequence" eval="55"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_tva_rd20" model="account.tax.report.line">
+                        <field name="name">20 - TVA - Achiziţii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă) (rd.18=rd.5), din care:</field>
+                        <field name="tag_name">20 - TVA</field>
+                        <field name="code">tax_ro_tva_rd20</field>
+                        <field name="sequence" eval="57"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd201" model="account.tax.report.line">
+                                <field name="name">20.1 - TVA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea (rd.18.1=rd.5.1)</field>
+                                <field name="tag_name">20_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd201</field>
+                                <field name="sequence" eval="59"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd21" model="account.tax.report.line">
+                        <field name="name">21 - TVA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumparatorul este obligat la plata TVA (taxare inversa) (rd.19=rd.6)</field>
+                        <field name="tag_name">21 - TVA</field>
+                        <field name="code">tax_ro_tva_rd21</field>
+                        <field name="sequence" eval="61"/>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd22" model="account.tax.report.line">
+                        <field name="name">22 - TVA - Achiziţii de bunuri, altele decat cele de la rd. 18 şi 19, si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.20=rd.7), din care:</field>
+                        <field name="tag_name">22 - TVA</field>
+                        <field name="code">tax_ro_tva_rd22</field>
+                        <field name="sequence" eval="63"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd221" model="account.tax.report.line">
+                                <field name="name">22.1 - TVA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa) (rd.20.1=rd.7.1)</field>
+                                <field name="tag_name">22_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd221</field>
+                                <field name="sequence" eval="65"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd23" model="account.tax.report.line">
+                        <field name="name">23 - TVA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.21=rd.8)</field>
+                        <field name="tag_name">23 - TVA</field>
+                        <field name="code">tax_ro_tva_rd23</field>
+                        <field name="sequence" eval="67"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_baza_achiz" model="account.tax.report.line">
+                <field name="name">BAZA ACHIZIŢII DE BUNURI/ SERVICII ÎN INTERIORUL ŢĂRII ŞI IMPORTURI, ACHIZIŢII INTRACOMUNITARE, SCUTITE SAU NEIMPOZABILE</field>
+                <field name="code">tax_ro_baza_achiz</field>
+                <field name="sequence" eval="68"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_baza_rd24" model="account.tax.report.line">
+                        <field name="name">24 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
+                        <field name="code">tax_ro_baza_rd24</field>
+                        <field name="tag_name" eval="None"/>
+                        <field name="sequence" eval="70"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd25" model="account.tax.report.line">
+                        <field name="name">25 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
+                        <field name="tag_name" eval="None"/>
+                        <field name="code">tax_ro_baza_rd25</field>
+                        <field name="sequence" eval="76"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd26" model="account.tax.report.line">
+                        <field name="name">26 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%</field>
+                        <field name="tag_name" eval="None"/>
+                        <field name="code">tax_ro_baza_rd26</field>
+                        <field name="sequence" eval="82"/>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd27" model="account.tax.report.line">
+                        <field name="name">27 - BAZA - Achiziţii de bunuri şi servicii supuse masurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversa),din care (rd.25=rd.12)</field>
+                        <field name="tag_name">27 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd27</field>
+                        <field name="sequence" eval="88"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd271" model="account.tax.report.line">
+                                <field name="name">27.1 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 19% (rd.25.1=rd.12.1)</field>
+                                <field name="tag_name">27_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd271</field>
+                                <field name="sequence" eval="90"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd272" model="account.tax.report.line">
+                                <field name="name">27.2 - BAZA - Achizitii de bunuri, taxabile cu cota 9% (rd.25.2=rd.12.2)</field>
+                                <field name="tag_name">27_2 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd272</field>
+                                <field name="sequence" eval="92"/>
+                            </record>
+                            <record id="account_tax_report_ro_baza_rd273" model="account.tax.report.line">
+                                <field name="name">27.3 - BAZA - Achizitii de bunuri, taxabile cu cota 5% (rd.25.3=rd.12.3)</field>
+                                <field name="tag_name">27_3 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd273</field>
+                                <field name="sequence" eval="94"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_baza_rd30" model="account.tax.report.line">
+                        <field name="name">30 - BAZA - Achiziţii de bunuri şi servicii scutite de taxă sau neimpozabile, din care:</field>
+                        <field name="tag_name">30 - BAZA</field>
+                        <field name="code">tax_ro_baza_rd30</field>
+                        <field name="sequence" eval="98"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_baza_rd301" model="account.tax.report.line">
+                                <field name="name">30.1 - BAZA - Achizitii de servicii intracomunitare scutite de taxa (nu se completeaza la metoda simplificata)</field>
+                                <field name="tag_name">30_1 - BAZA</field>
+                                <field name="code">tax_ro_baza_rd301</field>
+                                <field name="sequence" eval="99"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_tva_achiz" model="account.tax.report.line">
+                <field name="name">TVA ACHIZIŢII DE BUNURI/ SERVICII ÎN INTERIORUL ŢĂRII ŞI IMPORTURI, ACHIZIŢII INTRACOMUNITARE, SCUTITE SAU NEIMPOZABILE</field>
+                <field name="code">tax_ro_tva_achiz</field>
+                <field name="sequence" eval="69"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_ro_tva_rd24" model="account.tax.report.line">
+                        <field name="name">24 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
+                        <field name="code">tax_ro_tva_rd24</field>
+                        <field name="sequence" eval="71"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd241" model="account.tax.report.line">
+                                <field name="name">24.1 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
+                                <field name="tag_name">24_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd241</field>
+                                <field name="sequence" eval="73"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd242" model="account.tax.report.line">
+                                <field name="name">24.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile 50%</field>
+                                <field name="tag_name">24_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd242</field>
+                                <field name="sequence" eval="75"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd25" model="account.tax.report.line">
+                        <field name="name">25 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
+                        <field name="tag_name">25 - TVA</field>
+                        <field name="code">tax_ro_tva_rd25</field>
+                        <field name="sequence" eval="77"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd251" model="account.tax.report.line">
+                                <field name="name">25.1 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
+                                <field name="tag_name">25_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd251</field>
+                                <field name="sequence" eval="79"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd252" model="account.tax.report.line">
+                                <field name="name">25.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile 50%</field>
+                                <field name="tag_name">25_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd252</field>
+                                <field name="sequence" eval="81"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd26" model="account.tax.report.line">
+                        <field name="name">26 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
+                        <field name="code">tax_ro_tva_rd26</field>
+                        <field name="sequence" eval="83"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd261" model="account.tax.report.line">
+                                <field name="name">26.1 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
+                                <field name="tag_name">26_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd261</field>
+                                <field name="sequence" eval="85"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd262" model="account.tax.report.line">
+                                <field name="name">26.2 - TVA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile 50%</field>
+                                <field name="tag_name">26_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd262</field>
+                                <field name="sequence" eval="87"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd27" model="account.tax.report.line">
+                        <field name="name">27 - TVA - Achiziţii de bunuri şi servicii supuse masurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversa),din care (rd.25=rd.12)</field>
+                        <field name="tag_name">27 - TVA</field>
+                        <field name="code">tax_ro_tva_rd27</field>
+                        <field name="sequence" eval="89"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_ro_tva_rd271" model="account.tax.report.line">
+                                <field name="name">27.1 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 19% (rd.25.1=rd.12.1)</field>
+                                <field name="tag_name">27_1 - TVA</field>
+                                <field name="code">tax_ro_tva_rd271</field>
+                                <field name="sequence" eval="91"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd272" model="account.tax.report.line">
+                                <field name="name">27.2 - TVA - Achizitii de bunuri, taxabile cu cota 9% (rd.25.2=rd.12.2)</field>
+                                <field name="tag_name">27_2 - TVA</field>
+                                <field name="code">tax_ro_tva_rd272</field>
+                                <field name="sequence" eval="93"/>
+                            </record>
+                            <record id="account_tax_report_ro_tva_rd273" model="account.tax.report.line">
+                                <field name="name">27.3 - TVA - Achizitii de bunuri, taxabile cu cota 5% (rd.25.3=rd.12.3)</field>
+                                <field name="tag_name">27_3 - TVA</field>
+                                <field name="code">tax_ro_tva_rd273</field>
+                                <field name="sequence" eval="95"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd28" model="account.tax.report.line">
+                        <field name="name">28 - TVA - Compensația în cotă forfetară pentru achiziții de produse și servicii agricole de la furnizori care aplică regimul special pentru agricultori</field>
+                        <field name="tag_name">28 - TVA</field>
+                        <field name="code">tax_ro_tva_rd28</field>
+                        <field name="sequence" eval="96"/>
+                    </record>
+                    <record id="account_tax_report_ro_tva_rd29" model="account.tax.report.line">
+                        <field name="name">29 - TVA - Regularizări privind compensația în cotă forfetară</field>
+                        <field name="tag_name">29 - TVA</field>
+                        <field name="code">tax_ro_tva_rd29</field>
+                        <field name="sequence" eval="97"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_ro_baza_total_rd31" model="account.tax.report.line">
+                <field name="name">31 - BAZA - TOTAL TAXĂ DEDUCTIBILĂ ( sumă de la rd.20 până la rd.29, cu excepţia celor de la rd.20.1,22.1, 27.1, 27.2, 27.3)</field>
+                <field name="code">tax_ro_baza_total_rd31</field>
+                <field name="sequence" eval="100"/>
+                <field name="formula">tax_ro_baza_intracom_eu_a + tax_ro_baza_achiz</field>
+            </record>
+            <record id="account_tax_report_ro_tva_total_rd31" model="account.tax.report.line">
+                <field name="name">31 - TVA - TOTAL TAXĂ DEDUCTIBILĂ ( sumă de la rd.20 până la rd.29, cu excepţia celor de la rd.20.1,22.1, 27.1, 27.2, 27.3)</field>
+                <field name="code">tax_ro_tva_total_rd31</field>
+                <field name="sequence" eval="101"/>
+                <field name="formula">tax_ro_tva_intracom_eu_a + tax_ro_tva_achiz</field>
+            </record>
+            <record id="account_tax_report_ro_tva_rd32" model="account.tax.report.line">
+                <field name="name">32 - TVA - SUB-TOTAL TAXĂ DEDUSĂ CONFORM ART. 297 ŞI ART. 298 SAU ART. 300 ŞI ART. 298 (rd.30&lt;=rd.29)</field>
+                <field name="code">tax_ro_tva_rd32</field>
+                <field name="formula">tax_ro_tva_intracom_eu_a + tax_ro_tva_achiz</field>
+                <field name="sequence" eval="102"/>
+            </record>
+            <record id="account_tax_report_ro_tva_rd33" model="account.tax.report.line">
+                <field name="name">33 - TVA - TVA efectiv restituită cumpărătorilor straini, inclusiv comisionul unităţilor autorizate</field>
+                <field name="tag_name">33 - TVA</field>
+                <field name="code">tax_ro_tva_rd33</field>
+                <field name="sequence" eval="103"/>
+            </record>
+            <record id="account_tax_report_ro_baza_rd34" model="account.tax.report.line">
+                <field name="name">34 - BAZA - Regularizări taxă dedusă</field>
+                <field name="tag_name">34 - BAZA</field>
+                <field name="code">tax_ro_baza_rd34</field>
+                <field name="sequence" eval="104"/>
+            </record>
+            <record id="account_tax_report_ro_tva_rd34" model="account.tax.report.line">
+                <field name="name">34 - TVA - Regularizări taxă dedusă</field>
+                <field name="tag_name">34 - TVA</field>
+                <field name="code">tax_ro_tva_rd34</field>
+                <field name="sequence" eval="105"/>
+            </record>
+            <record id="account_tax_report_ro_tva_rd35" model="account.tax.report.line">
+                <field name="name">35 - TVA - Ajustări conform pro-rata / ajustări pentru bunurile de capital</field>
+                <field name="tag_name">35 - TVA</field>
+                <field name="code">tax_ro_tva_rd35</field>
+                <field name="sequence" eval="106"/>
+            </record>
+            <record id="account_tax_report_ro_tva_rd36" model="account.tax.report.line">
+                <field name="name">36 - TVA - TOTAL TAXA DEDUSA (rd.32+rd.33+rd.34+rd.35)</field>
+                <field name="code">tax_ro_tva_rd36</field>
+                <field name="sequence" eval="107"/>
+                <field name="formula">tax_ro_tva_intracom_eu_a + tax_ro_tva_achiz + tax_ro_tva_rd33 + tax_ro_tva_rd34 + tax_ro_tva_rd35</field>
+            </record>
+            <record id="account_tax_report_ro_tva_rd40" model="account.tax.report.line">
+                <field name="name">40 - TVA - Diferenţe de TVA de plată stabilite de organele de inspecţie fiscală prin decizie comunicată şi neachitate până la data depunerii decontului de  TVA </field>
+                <field name="tag_name">40 - TVA</field>
+                <field name="code">tax_ro_tva_rd40</field>
+                <field name="sequence" eval="110"/>
+            </record>
+            <record id="account_tax_report_ro_tva_rd43" model="account.tax.report.line">
+                <field name="name">43 - TVA - Diferenţe negative de TVA stabilite de organele de inspecţie fiscală prin decizie comunicată până la data depunerii decontului de TVA </field>
+                <field name="tag_name">43 - TVA</field>
+                <field name="code">tax_ro_tva_rd43</field>
+                <field name="sequence" eval="111"/>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_ro_baza_intracom_eu" model="account.tax.report.line">
-        <field name="name">Baza COMERŢ INTRACOMUNITAR ŞI ÎN AFARA UE</field>
-        <field name="code">tax_ro_baza_intracom_eu</field>
-        <field name="sequence" eval="0"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_intracom_eu" model="account.tax.report.line">
-        <field name="name">TVA COMERŢ INTRACOMUNITAR ŞI ÎN AFARA UE</field>
-        <field name="code">tax_ro_tva_intracom_eu</field>
-        <field name="sequence" eval="1"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd1" model="account.tax.report.line">
-        <field name="name">1 - BAZA - Livrări intracomunitare de bunuri, scutite conform art. 294 alin.(2) lit.a) şid) din Codul fiscal</field>
-        <field name="tag_name">01 - BAZA</field>
-        <field name="code">tax_ro_baza_rd1</field>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd2" model="account.tax.report.line">
-        <field name="name">2 - BAZA - Regularizări livrări intracomunitare scutite conform art. 294 alin.(2) lit.a) şi d) din Codul fiscal</field>
-        <field name="tag_name">02 - BAZA</field>
-        <field name="code">tax_ro_baza_rd2</field>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd3" model="account.tax.report.line">
-        <field name="name">3 - BAZA - Livrări de bunuri/prestări de servicii pentru care locul livrării/prestării este în afara României, precum şi livrări intracom. de bunuri, scut. conf. art. 294 alin.(2) lit.b) şi c) din CF, din care: </field>
-        <field name="tag_name">03 - BAZA</field>
-        <field name="code">tax_ro_baza_rd3</field>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd31" model="account.tax.report.line">
-        <field name="name">3.1 - BAZA - Prestări de servicii intracomunitare care nu beneficiază de scutire in statul membru in care taxa este datorată</field>
-        <field name="tag_name">03_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd31</field>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd3"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd4" model="account.tax.report.line">
-        <field name="name">4 - BAZA - Regularizări privind prestările de servicii intracomunitare care nu beneficiază de scutire in statul membru in care taxa este datorată</field>
-        <field name="tag_name">04 - BAZA</field>
-        <field name="code">tax_ro_baza_rd4</field>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd5" model="account.tax.report.line">
-        <field name="name">5 - BAZA - Achizitii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă), din care:</field>
-        <field name="tag_name">05 - BAZA</field>
-        <field name="code">tax_ro_baza_rd5</field>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd5" model="account.tax.report.line">
-        <field name="name">5 - TVA - Achizitii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă), din care:</field>
-        <field name="tag_name">05 - TVA</field>
-        <field name="code">tax_ro_tva_rd5</field>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd51" model="account.tax.report.line">
-        <field name="name">5.1 - BAZA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea intracom.</field>
-        <field name="tag_name">05_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd51</field>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd5"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd51" model="account.tax.report.line">
-        <field name="name">5.1 - TVA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea intracom.</field>
-        <field name="tag_name">05_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd51</field>
-        <field name="sequence" eval="10"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd5"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd6" model="account.tax.report.line">
-        <field name="name">6 - BAZA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA(taxare inversă)</field>
-        <field name="tag_name">06 - BAZA</field>
-        <field name="code">tax_ro_baza_rd6</field>
-        <field name="sequence" eval="11"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd6" model="account.tax.report.line">
-        <field name="name">6 - TVA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA(taxare inversă)</field>
-        <field name="tag_name">06 - TVA</field>
-        <field name="code">tax_ro_tva_rd6</field>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd7" model="account.tax.report.line">
-        <field name="name">7 - BAZA - Achizitii de bunuri, altele decat cele de la rd.5 şi 6 si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) din care:</field>
-        <field name="tag_name">07 - BAZA</field>
-        <field name="code">tax_ro_baza_rd7</field>
-        <field name="sequence" eval="13"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd7" model="account.tax.report.line">
-        <field name="name">7 - TVA - Achizitii de bunuri, altele decat cele de la rd.5 şi 6 si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) din care:</field>
-        <field name="tag_name">07 - TVA</field>
-        <field name="code">tax_ro_tva_rd7</field>
-        <field name="sequence" eval="14"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd71" model="account.tax.report.line">
-        <field name="name">7.1 - BAZA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
-        <field name="tag_name">07_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd71</field>
-        <field name="sequence" eval="15"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd7"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd71" model="account.tax.report.line">
-        <field name="name">7.1 - TVA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
-        <field name="tag_name">07_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd71</field>
-        <field name="sequence" eval="16"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd7"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd8" model="account.tax.report.line">
-        <field name="name">8 - BAZA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
-        <field name="tag_name">08 - BAZA</field>
-        <field name="code">tax_ro_baza_rd8</field>
-        <field name="sequence" eval="17"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd8" model="account.tax.report.line">
-        <field name="name">8 - TVA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa)</field>
-        <field name="tag_name">08 - TVA</field>
-        <field name="code">tax_ro_tva_rd8</field>
-        <field name="sequence" eval="18"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_livrari" model="account.tax.report.line">
-        <field name="name">BAZA LIVRĂRI DE BUNURI/ PRESTĂRI DE SERVICII ÎN INTERIORUL ŢĂRII ŞI EXPORTURI</field>
-        <field name="code">tax_ro_baza_livrari</field>
-        <field name="sequence" eval="19"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_livrari" model="account.tax.report.line">
-        <field name="name">TVA LIVRĂRI DE BUNURI/ PRESTĂRI DE SERVICII ÎN INTERIORUL ŢĂRII ŞI EXPORTURI</field>
-        <field name="code">tax_ro_tva_livrari</field>
-        <field name="sequence" eval="20"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd9" model="account.tax.report.line">
-        <field name="name">9 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
-        <field name="tag_name">09 - BAZA</field>
-        <field name="code">tax_ro_baza_rd9</field>
-        <field name="sequence" eval="21"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd9" model="account.tax.report.line">
-        <field name="name">9 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
-        <field name="tag_name">09 - TVA</field>
-        <field name="code">tax_ro_tva_rd9</field>
-        <field name="sequence" eval="22"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd91" model="account.tax.report.line">
-        <field name="name">9.1 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
-        <field name="tag_name">09_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd91</field>
-        <field name="sequence" eval="23"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd9"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd91" model="account.tax.report.line">
-        <field name="name">9.1 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 19%</field>
-        <field name="tag_name">09_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd91</field>
-        <field name="sequence" eval="24"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd9"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd92" model="account.tax.report.line">
-        <field name="name">9.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
-        <field name="code">tax_ro_baza_rd92</field>
-        <field name="sequence" eval="25"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd9"/>
-        <field name="formula">0.5 * tax_ro_baza_rd242</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd92" model="account.tax.report.line">
-        <field name="name">9.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 19%</field>
-        <field name="tag_name">09_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd92</field>
-        <field name="sequence" eval="26"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd9"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd10" model="account.tax.report.line">
-        <field name="name">10 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
-        <field name="tag_name">10 - BAZA</field>
-        <field name="code">tax_ro_baza_rd10</field>
-        <field name="sequence" eval="27"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd10" model="account.tax.report.line">
-        <field name="name">10 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
-        <field name="tag_name">10 - TVA</field>
-        <field name="code">tax_ro_tva_rd10</field>
-        <field name="sequence" eval="28"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd101" model="account.tax.report.line">
-        <field name="name">10.1 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
-        <field name="tag_name">10_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd101</field>
-        <field name="sequence" eval="29"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd10"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd101" model="account.tax.report.line">
-        <field name="name">10.1 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 9%</field>
-        <field name="tag_name">10_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd101</field>
-        <field name="sequence" eval="30"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd10"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd102" model="account.tax.report.line">
-        <field name="name">10_2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
-        <field name="code">tax_ro_baza_rd102</field>
-        <field name="sequence" eval="31"/>
-        <field name="formula">0.5 * tax_ro_baza_rd252</field>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd10"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd102" model="account.tax.report.line">
-        <field name="name">10.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 9%</field>
-        <field name="tag_name">10_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd102</field>
-        <field name="sequence" eval="32"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd10"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd11" model="account.tax.report.line">
-        <field name="name">11 - BAZA - Livrări de bunuri taxabile cu cota 5%</field>
-        <field name="tag_name">11 - BAZA</field>
-        <field name="code">tax_ro_baza_rd11</field>
-        <field name="sequence" eval="33"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd11" model="account.tax.report.line">
-        <field name="name">11 - TVA - Livrări de bunuri taxabile cu cota 5%</field>
-        <field name="tag_name">11 - TVA</field>
-        <field name="code">tax_ro_tva_rd11</field>
-        <field name="sequence" eval="34"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="account_tax_report_ro_baza_rd111" model="account.tax.report.line">
-        <field name="name">11.1 - BAZA - Livrări de bunuri şi prestări de servicii taxabile cu cota 5%</field>
-        <field name="tag_name">11_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd111</field>
-        <field name="sequence" eval="35"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd11"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd111" model="account.tax.report.line">
-        <field name="name">11.1 - TVA - Livrări de bunuri şi prestări de servicii taxabile cu cota 5%</field>
-        <field name="tag_name">11_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd111</field>
-        <field name="sequence" eval="36"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd11"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd112" model="account.tax.report.line">
-        <field name="name">11.2 - BAZA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
-        <field name="code">tax_ro_baza_rd112</field>
-        <field name="sequence" eval="37"/>
-        <field name="formula">0.5 * tax_ro_baza_rd262</field>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd11"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd112" model="account.tax.report.line">
-        <field name="name">11.2 - TVA - Achizitii de bunuri şi prestări de servicii nedeductibile 50% taxabile cu cota 5%</field>
-        <field name="tag_name">11_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd112</field>
-        <field name="sequence" eval="38"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd11"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd12" model="account.tax.report.line">
-        <field name="name">12 - BAZA - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
-        <field name="tag_name">12 - BAZA</field>
-        <field name="code">tax_ro_baza_rd12</field>
-        <field name="sequence" eval="39"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd12" model="account.tax.report.line">
-        <field name="name">12 - TVA - Achiziţii de bunuri şi servicii supuse măsurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversă) , din care:</field>
-        <field name="tag_name">12 - TVA</field>
-        <field name="code">tax_ro_tva_rd12</field>
-        <field name="sequence" eval="40"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd121" model="account.tax.report.line">
-        <field name="name">12.1 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 19%</field>
-        <field name="tag_name">12_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd121</field>
-        <field name="sequence" eval="41"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd12"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd121" model="account.tax.report.line">
-        <field name="name">12.1 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 19%</field>
-        <field name="tag_name">12_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd121</field>
-        <field name="sequence" eval="42"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd12"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd122" model="account.tax.report.line">
-        <field name="name">12.2 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 9%</field>
-        <field name="tag_name">12_2 - BAZA</field>
-        <field name="code">tax_ro_baza_rd122</field>
-        <field name="sequence" eval="43"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd12"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd122" model="account.tax.report.line">
-        <field name="name">12.2 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 9%</field>
-        <field name="tag_name">12_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd122</field>
-        <field name="sequence" eval="44"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd12"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd123" model="account.tax.report.line">
-        <field name="name">12.3 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 5%</field>
-        <field name="tag_name">12_3 - BAZA</field>
-        <field name="code">tax_ro_baza_rd123</field>
-        <field name="sequence" eval="45"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd12"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd123" model="account.tax.report.line">
-        <field name="name">12.3 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 5%</field>
-        <field name="tag_name">12_3 - TVA</field>
-        <field name="code">tax_ro_tva_rd123</field>
-        <field name="sequence" eval="46"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd12"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd13" model="account.tax.report.line">
-        <field name="name">13 - BAZA - Livrări de bunuri şi prestări de servicii supuse masurilor de simplificare (taxare inversa)</field>
-        <field name="tag_name">13 - BAZA</field>
-        <field name="code">tax_ro_baza_rd13</field>
-        <field name="sequence" eval="47"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd14" model="account.tax.report.line">
-        <field name="name">14 - BAZA - Livrări de bunuri şi prestări de servicii scutite cu drept de deducere, altele decat cele de la rd. 1-3</field>
-        <field name="tag_name">14 - BAZA</field>
-        <field name="code">tax_ro_baza_rd14</field>
-        <field name="sequence" eval="48"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd15" model="account.tax.report.line">
-        <field name="name">15 - BAZA - Livrări de bunuri şi prestări de servicii scutite fără drept de deducere</field>
-        <field name="tag_name">15 - BAZA</field>
-        <field name="code">tax_ro_baza_rd15</field>
-        <field name="sequence" eval="49"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd16" model="account.tax.report.line">
-        <field name="name">16 - BAZA - Regularizări taxă colectată</field>
-        <field name="tag_name">16 - BAZA</field>
-        <field name="code">tax_ro_baza_rd16</field>
-        <field name="sequence" eval="50"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd16" model="account.tax.report.line">
-        <field name="name">16 - TVA - Regularizări taxă colectată</field>
-        <field name="tag_name">16 - TVA</field>
-        <field name="code">tax_ro_tva_rd16</field>
-        <field name="sequence" eval="51"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd17" model="account.tax.report.line">
-        <field name="name">17 - BAZA - Prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
-        <field name="tag_name">17 - BAZA</field>
-        <field name="code">tax_ro_baza_rd17</field>
-        <field name="sequence" eval="50"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd17" model="account.tax.report.line">
-        <field name="name">17 - TVA - Prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
-        <field name="tag_name">17 - TVA</field>
-        <field name="code">tax_ro_tva_rd17</field>
-        <field name="sequence" eval="51"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd18" model="account.tax.report.line">
-        <field name="name">18 - BAZA - Regularizări privind prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
-        <field name="tag_name">18 - BAZA</field>
-        <field name="code">tax_ro_baza_rd18</field>
-        <field name="sequence" eval="50"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd18" model="account.tax.report.line">
-        <field name="name">18 - TVA - Regularizări privind prestări de servicii intracomunitare conform art.278 alin.(8) din Codul fiscal pentru care locul prestării este în România</field>
-        <field name="tag_name">18 - TVA</field>
-        <field name="code">tax_ro_tva_rd18</field>
-        <field name="sequence" eval="51"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_livrari"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_col" model="account.tax.report.line">
-        <field name="name">Baza Total Taxa COLECTATĂ</field>
-        <field name="code">total_tax_ro_baza_col</field>
-        <field name="sequence" eval="52"/>
-        <field name="formula">tax_ro_baza_intracom_eu + tax_ro_baza_livrari</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_col" model="account.tax.report.line">
-        <field name="name">TVA Total Taxa COLECTATĂ</field>
-        <field name="code">total_tax_ro_tva_col</field>
-        <field name="sequence" eval="53"/>
-        <field name="formula">tax_ro_tva_intracom_eu + tax_ro_tva_livrari</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_intracom_eu_achiz" model="account.tax.report.line">
-        <field name="name">BAZA ACHIZIŢII INTRACOMUNITARE DE BUNURI ŞI ALTE ACHIZIŢII DE BUNURI ŞI SERVICII IMPOZABILE ÎN ROMÂNIA</field>
-        <field name="code">tax_ro_baza_intracom_eu_a</field>
-        <field name="sequence" eval="54"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_intracom_eu_achiz" model="account.tax.report.line">
-        <field name="name">TVA ACHIZIŢII INTRACOMUNITARE DE BUNURI ŞI ALTE ACHIZIŢII DE BUNURI ŞI SERVICII IMPOZABILE ÎN ROMÂNIA</field>
-        <field name="code">tax_ro_tva_intracom_eu_a</field>
-        <field name="sequence" eval="55"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd20" model="account.tax.report.line">
-        <field name="name">20 - BAZA - Achiziţii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă) (rd.18=rd.5), din care:</field>
-        <field name="tag_name">20 - BAZA</field>
-        <field name="code">tax_ro_baza_rd20</field>
-        <field name="sequence" eval="56"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd20" model="account.tax.report.line">
-        <field name="name">20 - TVA - Achiziţii intracomunitare de bunuri pentru care cumpărătorul este obligat la plata TVA (taxare inversă) (rd.18=rd.5), din care:</field>
-        <field name="tag_name">20 - TVA</field>
-        <field name="code">tax_ro_tva_rd20</field>
-        <field name="sequence" eval="57"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd201" model="account.tax.report.line">
-        <field name="name">20.1 - BAZA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea (rd.18.1=rd.5.1)</field>
-        <field name="tag_name">20_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd201</field>
-        <field name="sequence" eval="58"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd20"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd201" model="account.tax.report.line">
-        <field name="name">20.1 - TVA - Achiziţii intracom. pentru care cumpărătorul este obligat la plata TVA (TI), iar furnizorul este înregistrat în scopuri de TVA în statul membru din care a avut loc livrarea (rd.18.1=rd.5.1)</field>
-        <field name="tag_name">20_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd201</field>
-        <field name="sequence" eval="59"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd20"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd21" model="account.tax.report.line">
-        <field name="name">21 - BAZA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumparatorul este obligat la plata TVA (taxare inversa) (rd.19=rd.6)</field>
-        <field name="tag_name">21 - BAZA</field>
-        <field name="code">tax_ro_baza_rd21</field>
-        <field name="sequence" eval="60"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd21" model="account.tax.report.line">
-        <field name="name">21 - TVA - Regularizări privind achiziţiile intracomunitare de bunuri pentru care cumparatorul este obligat la plata TVA (taxare inversa) (rd.19=rd.6)</field>
-        <field name="tag_name">21 - TVA</field>
-        <field name="code">tax_ro_tva_rd21</field>
-        <field name="sequence" eval="61"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd22" model="account.tax.report.line">
-        <field name="name">22 - BAZA - Achiziţii de bunuri, altele decat cele de la rd. 18 şi 19, si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.20=rd.7), din care:</field>
-        <field name="tag_name">22 - BAZA</field>
-        <field name="code">tax_ro_baza_rd22</field>
-        <field name="sequence" eval="62"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd22" model="account.tax.report.line">
-        <field name="name">22 - TVA - Achiziţii de bunuri, altele decat cele de la rd. 18 şi 19, si achizitii de servicii pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.20=rd.7), din care:</field>
-        <field name="tag_name">22 - TVA</field>
-        <field name="code">tax_ro_tva_rd22</field>
-        <field name="sequence" eval="63"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd221" model="account.tax.report.line">
-        <field name="name">22.1 - BAZA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa) (rd.20.1=rd.7.1)</field>
-        <field name="tag_name">22_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd221</field>
-        <field name="sequence" eval="64"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd22"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd221" model="account.tax.report.line">
-        <field name="name">22.1 - TVA - Achizitii de servicii intracomunitare pentru care beneficiarul este obligat la plata TVA (taxare inversa) (rd.20.1=rd.7.1)</field>
-        <field name="tag_name">22_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd221</field>
-        <field name="sequence" eval="65"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd22"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd23" model="account.tax.report.line">
-        <field name="name">23 - BAZA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.21=rd.8)</field>
-        <field name="tag_name">23 - BAZA</field>
-        <field name="code">tax_ro_baza_rd23</field>
-        <field name="sequence" eval="66"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd23" model="account.tax.report.line">
-        <field name="name">23 - TVA - Regularizari privind achizitii de servicii intracomunitare pentru care beneficiarul din Romania este obligat la plata TVA (taxare inversa) (rd.21=rd.8)</field>
-        <field name="tag_name">23 - TVA</field>
-        <field name="code">tax_ro_tva_rd23</field>
-        <field name="sequence" eval="67"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_intracom_eu_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_achiz" model="account.tax.report.line">
-        <field name="name">BAZA ACHIZIŢII DE BUNURI/ SERVICII ÎN INTERIORUL ŢĂRII ŞI IMPORTURI, ACHIZIŢII INTRACOMUNITARE, SCUTITE SAU NEIMPOZABILE</field>
-        <field name="code">tax_ro_baza_achiz</field>
-        <field name="sequence" eval="68"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_achiz" model="account.tax.report.line">
-        <field name="name">TVA ACHIZIŢII DE BUNURI/ SERVICII ÎN INTERIORUL ŢĂRII ŞI IMPORTURI, ACHIZIŢII INTRACOMUNITARE, SCUTITE SAU NEIMPOZABILE</field>
-        <field name="code">tax_ro_tva_achiz</field>
-        <field name="sequence" eval="69"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd24" model="account.tax.report.line">
-        <field name="name">24 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
-        <field name="code">tax_ro_baza_rd24</field>
-        <field name="tag_name" eval="None"/>
-        <field name="sequence" eval="70"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd24" model="account.tax.report.line">
-        <field name="name">24 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
-        <field name="code">tax_ro_tva_rd24</field>
-        <field name="sequence" eval="71"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd241" model="account.tax.report.line">
-        <field name="name">24.1 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
-        <field name="tag_name">24_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd241</field>
-        <field name="sequence" eval="72"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd24"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd241" model="account.tax.report.line">
-        <field name="name">24.1 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
-        <field name="tag_name">24_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd241</field>
-        <field name="sequence" eval="73"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd24"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd242" model="account.tax.report.line">
-        <field name="name">24.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile 50%</field>
-        <field name="tag_name">24_2 - BAZA</field>
-        <field name="code">tax_ro_baza_rd242</field>
-        <field name="sequence" eval="74"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd24"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd242" model="account.tax.report.line">
-        <field name="name">24.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile 50%</field>
-        <field name="tag_name">24_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd242</field>
-        <field name="sequence" eval="75"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd24"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
     <record id="account_tax_report_ro_baza_rd24" model="account.tax.report.line">
         <field name="formula">tax_ro_baza_rd241 + 0.5 * tax_ro_baza_rd242</field>
+        <field name="children_line_ids">
+            <record id="account_tax_report_ro_baza_rd241" model="account.tax.report.line">
+                <field name="name">24.1 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, altele decat cele de la rd.27</field>
+                <field name="tag_name">24_1 - BAZA</field>
+                <field name="code">tax_ro_baza_rd241</field>
+                <field name="sequence" eval="72"/>
+            </record>
+            <record id="account_tax_report_ro_baza_rd242" model="account.tax.report.line">
+                <field name="name">24.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 19%, nedeductibile 50%</field>
+                <field name="tag_name">24_2 - BAZA</field>
+                <field name="code">tax_ro_baza_rd242</field>
+                <field name="sequence" eval="74"/>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_ro_baza_rd25" model="account.tax.report.line">
-        <field name="name">25 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
-        <field name="tag_name" eval="None"/>
-        <field name="code">tax_ro_baza_rd25</field>
-        <field name="sequence" eval="76"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd25" model="account.tax.report.line">
-        <field name="name">25 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
-        <field name="tag_name">25 - TVA</field>
-        <field name="code">tax_ro_tva_rd25</field>
-        <field name="sequence" eval="77"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd251" model="account.tax.report.line">
-        <field name="name">25.1 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
-        <field name="tag_name">25_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd251</field>
-        <field name="sequence" eval="78"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd25"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd251" model="account.tax.report.line">
-        <field name="name">25.1 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
-        <field name="tag_name">25_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd251</field>
-        <field name="sequence" eval="79"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd25"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd252" model="account.tax.report.line">
-        <field name="name">25.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile 50%</field>
-        <field name="tag_name">25_2 - BAZA</field>
-        <field name="code">tax_ro_baza_rd252</field>
-        <field name="sequence" eval="80"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd25"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd252" model="account.tax.report.line">
-        <field name="name">25.2 - TVA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile 50%</field>
-        <field name="tag_name">25_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd252</field>
-        <field name="sequence" eval="81"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd25"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
     <record id="account_tax_report_ro_baza_rd25" model="account.tax.report.line">
         <field name="formula">tax_ro_baza_rd251 + 0.5 * tax_ro_baza_rd252</field>
+        <field name="children_line_ids">
+            <record id="account_tax_report_ro_baza_rd251" model="account.tax.report.line">
+                <field name="name">25.1 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%</field>
+                <field name="tag_name">25_1 - BAZA</field>
+                <field name="code">tax_ro_baza_rd251</field>
+                <field name="sequence" eval="78"/>
+            </record>
+            <record id="account_tax_report_ro_baza_rd252" model="account.tax.report.line">
+                <field name="name">25.2 - BAZA - Achiziţii de bunuri şi servicii taxabile cu cota de 9%, nedeductibile 50%</field>
+                <field name="tag_name">25_2 - BAZA</field>
+                <field name="code">tax_ro_baza_rd252</field>
+                <field name="sequence" eval="80"/>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_ro_baza_rd26" model="account.tax.report.line">
-        <field name="name">26 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%</field>
-        <field name="tag_name" eval="None"/>
-        <field name="code">tax_ro_baza_rd26</field>
-        <field name="sequence" eval="82"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd26" model="account.tax.report.line">
-        <field name="name">26 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
-        <field name="code">tax_ro_tva_rd26</field>
-        <field name="sequence" eval="83"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd261" model="account.tax.report.line">
-        <field name="name">26.1 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%</field>
-        <field name="tag_name">26_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd261</field>
-        <field name="sequence" eval="84"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd26"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd261" model="account.tax.report.line">
-        <field name="name">26.1 - TVA - Achiziţii de bunuri taxabile cu cota de 5%</field>
-        <field name="tag_name">26_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd261</field>
-        <field name="sequence" eval="85"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd26"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd262" model="account.tax.report.line">
-        <field name="name">26.2 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile 50%</field>
-        <field name="tag_name">26_2 - BAZA</field>
-        <field name="code">tax_ro_baza_rd262</field>
-        <field name="sequence" eval="86"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd26"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd262" model="account.tax.report.line">
-        <field name="name">26.2 - TVA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile 50%</field>
-        <field name="tag_name">26_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd262</field>
-        <field name="sequence" eval="87"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd26"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
     <record id="account_tax_report_ro_baza_rd26" model="account.tax.report.line">
         <field name="formula">tax_ro_baza_rd261 + 0.5 * tax_ro_baza_rd262</field>
+        <field name="children_line_ids">
+            <record id="account_tax_report_ro_baza_rd261" model="account.tax.report.line">
+                <field name="name">26.1 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%</field>
+                <field name="tag_name">26_1 - BAZA</field>
+                <field name="code">tax_ro_baza_rd261</field>
+                <field name="sequence" eval="84"/>
+            </record>
+            <record id="account_tax_report_ro_baza_rd262" model="account.tax.report.line">
+                <field name="name">26.2 - BAZA - Achiziţii de bunuri taxabile cu cota de 5%, nedeductibile 50%</field>
+                <field name="tag_name">26_2 - BAZA</field>
+                <field name="code">tax_ro_baza_rd262</field>
+                <field name="sequence" eval="86"/>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_ro_baza_rd27" model="account.tax.report.line">
-        <field name="name">27 - BAZA - Achiziţii de bunuri şi servicii supuse masurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversa),din care (rd.25=rd.12)</field>
-        <field name="tag_name">27 - BAZA</field>
-        <field name="code">tax_ro_baza_rd27</field>
-        <field name="sequence" eval="88"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd27" model="account.tax.report.line">
-        <field name="name">27 - TVA - Achiziţii de bunuri şi servicii supuse masurilor de simplificare pentru care beneficiarul este obligat la plata TVA (taxare inversa),din care (rd.25=rd.12)</field>
-        <field name="tag_name">27 - TVA</field>
-        <field name="code">tax_ro_tva_rd27</field>
-        <field name="sequence" eval="89"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd271" model="account.tax.report.line">
-        <field name="name">27.1 - BAZA - Achizitii de bunuri si servicii, taxabile cu cota 19% (rd.25.1=rd.12.1)</field>
-        <field name="tag_name">27_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd271</field>
-        <field name="sequence" eval="90"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd27"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd271" model="account.tax.report.line">
-        <field name="name">27.1 - TVA - Achizitii de bunuri si servicii, taxabile cu cota 19% (rd.25.1=rd.12.1)</field>
-        <field name="tag_name">27_1 - TVA</field>
-        <field name="code">tax_ro_tva_rd271</field>
-        <field name="sequence" eval="91"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd27"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd272" model="account.tax.report.line">
-        <field name="name">27.2 - BAZA - Achizitii de bunuri, taxabile cu cota 9% (rd.25.2=rd.12.2)</field>
-        <field name="tag_name">27_2 - BAZA</field>
-        <field name="code">tax_ro_baza_rd272</field>
-        <field name="sequence" eval="92"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd27"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd272" model="account.tax.report.line">
-        <field name="name">27.2 - TVA - Achizitii de bunuri, taxabile cu cota 9% (rd.25.2=rd.12.2)</field>
-        <field name="tag_name">27_2 - TVA</field>
-        <field name="code">tax_ro_tva_rd272</field>
-        <field name="sequence" eval="93"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd27"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd273" model="account.tax.report.line">
-        <field name="name">27.3 - BAZA - Achizitii de bunuri, taxabile cu cota 5% (rd.25.3=rd.12.3)</field>
-        <field name="tag_name">27_3 - BAZA</field>
-        <field name="code">tax_ro_baza_rd273</field>
-        <field name="sequence" eval="94"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd27"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd273" model="account.tax.report.line">
-        <field name="name">27.3 - TVA - Achizitii de bunuri, taxabile cu cota 5% (rd.25.3=rd.12.3)</field>
-        <field name="tag_name">27_3 - TVA</field>
-        <field name="code">tax_ro_tva_rd273</field>
-        <field name="sequence" eval="95"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_rd27"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd28" model="account.tax.report.line">
-        <field name="name">28 - TVA - Compensația în cotă forfetară pentru achiziții de produse și servicii agricole de la furnizori care aplică regimul special pentru agricultori</field>
-        <field name="tag_name">28 - TVA</field>
-        <field name="code">tax_ro_tva_rd28</field>
-        <field name="sequence" eval="96"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd29" model="account.tax.report.line">
-        <field name="name">29 - TVA - Regularizări privind compensația în cotă forfetară</field>
-        <field name="tag_name">29 - TVA</field>
-        <field name="code">tax_ro_tva_rd29</field>
-        <field name="sequence" eval="97"/>
-        <field name="parent_id" ref="account_tax_report_ro_tva_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd30" model="account.tax.report.line">
-        <field name="name">30 - BAZA - Achiziţii de bunuri şi servicii scutite de taxă sau neimpozabile, din care:</field>
-        <field name="tag_name">30 - BAZA</field>
-        <field name="code">tax_ro_baza_rd30</field>
-        <field name="sequence" eval="98"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_achiz"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd301" model="account.tax.report.line">
-        <field name="name">30.1 - BAZA - Achizitii de servicii intracomunitare scutite de taxa (nu se completeaza la metoda simplificata)</field>
-        <field name="tag_name">30_1 - BAZA</field>
-        <field name="code">tax_ro_baza_rd301</field>
-        <field name="sequence" eval="99"/>
-        <field name="parent_id" ref="account_tax_report_ro_baza_rd30"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_total_rd31" model="account.tax.report.line">
-        <field name="name">31 - BAZA - TOTAL TAXĂ DEDUCTIBILĂ ( sumă de la rd.20 până la rd.29, cu excepţia celor de la rd.20.1,22.1, 27.1, 27.2, 27.3)</field>
-        <field name="code">tax_ro_baza_total_rd31</field>
-        <field name="sequence" eval="100"/>
-        <field name="formula">tax_ro_baza_intracom_eu_a + tax_ro_baza_achiz</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_total_rd31" model="account.tax.report.line">
-        <field name="name">31 - TVA - TOTAL TAXĂ DEDUCTIBILĂ ( sumă de la rd.20 până la rd.29, cu excepţia celor de la rd.20.1,22.1, 27.1, 27.2, 27.3)</field>
-        <field name="code">tax_ro_tva_total_rd31</field>
-        <field name="sequence" eval="101"/>
-        <field name="formula">tax_ro_tva_intracom_eu_a + tax_ro_tva_achiz</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd32" model="account.tax.report.line">
-        <field name="name">32 - TVA - SUB-TOTAL TAXĂ DEDUSĂ CONFORM ART. 297 ŞI ART. 298 SAU ART. 300 ŞI ART. 298 (rd.30&lt;=rd.29)</field>
-        <field name="code">tax_ro_tva_rd32</field>
-        <field name="formula">tax_ro_tva_intracom_eu_a + tax_ro_tva_achiz</field>
-        <field name="sequence" eval="102"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd33" model="account.tax.report.line">
-        <field name="name">33 - TVA - TVA efectiv restituită cumpărătorilor straini, inclusiv comisionul unităţilor autorizate</field>
-        <field name="tag_name">33 - TVA</field>
-        <field name="code">tax_ro_tva_rd33</field>
-        <field name="sequence" eval="103"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_baza_rd34" model="account.tax.report.line">
-        <field name="name">34 - BAZA - Regularizări taxă dedusă</field>
-        <field name="tag_name">34 - BAZA</field>
-        <field name="code">tax_ro_baza_rd34</field>
-        <field name="sequence" eval="104"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd34" model="account.tax.report.line">
-        <field name="name">34 - TVA - Regularizări taxă dedusă</field>
-        <field name="tag_name">34 - TVA</field>
-        <field name="code">tax_ro_tva_rd34</field>
-        <field name="sequence" eval="105"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd35" model="account.tax.report.line">
-        <field name="name">35 - TVA - Ajustări conform pro-rata / ajustări pentru bunurile de capital</field>
-        <field name="tag_name">35 - TVA</field>
-        <field name="code">tax_ro_tva_rd35</field>
-        <field name="sequence" eval="106"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd36" model="account.tax.report.line">
-        <field name="name">36 - TVA - TOTAL TAXA DEDUSA (rd.32+rd.33+rd.34+rd.35)</field>
-        <field name="code">tax_ro_tva_rd36</field>
-        <field name="sequence" eval="107"/>
-        <field name="formula">tax_ro_tva_intracom_eu_a + tax_ro_tva_achiz + tax_ro_tva_rd33 + tax_ro_tva_rd34 + tax_ro_tva_rd35</field>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-    <record id="account_tax_report_ro_tva_rd40" model="account.tax.report.line">
-        <field name="name">40 - TVA - Diferenţe de TVA de plată stabilite de organele de inspecţie fiscală prin decizie comunicată şi neachitate până la data depunerii decontului de  TVA </field>
-        <field name="tag_name">40 - TVA</field>
-        <field name="code">tax_ro_tva_rd40</field>
-        <field name="sequence" eval="110"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-    <record id="account_tax_report_ro_tva_rd43" model="account.tax.report.line">
-        <field name="name">43 - TVA - Diferenţe negative de TVA stabilite de organele de inspecţie fiscală prin decizie comunicată până la data depunerii decontului de TVA </field>
-        <field name="tag_name">43 - TVA</field>
-        <field name="code">tax_ro_tva_rd43</field>
-        <field name="sequence" eval="111"/>
-        <field name="report_id" ref="tax_report"/>
-    </record>
-
-
-
 </odoo>

--- a/addons/l10n_sa/data/account_tax_report_data.xml
+++ b/addons/l10n_sa/data/account_tax_report_data.xml
@@ -1,483 +1,378 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <record id="tax_report_vat_filing" model="account.tax.report">
-            <field name="name">VAT Filing Report</field>
-            <field name="country_id" ref="base.sa"/>
-        </record>
-        <record id="tax_report_line_vat_all_sales_base" model="account.tax.report.line">
-            <field name="name">VAT on Sales and all other Outputs (Base)</field>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_standard_rated_15_base" model="account.tax.report.line">
-            <field name="name">1. Standard Rated 15% (Base)</field>
-            <field name="tag_name">1. Standard Rates 15% (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">STD_SALE_B</field>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_special_sales_to_locals_base" model="account.tax.report.line">
-            <field name="name">2. Special Sales to Locals (Base)</field>
-            <field name="tag_name">2. Special Sales to Locals (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">SPCL_SALE_B</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_local_sales_subject_to_0_base" model="account.tax.report.line">
-            <field name="name">3. Local Sales Subject to 0% (Base)</field>
-            <field name="tag_name">3. Local Sales Subject to 0% (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">ZERO_SALE_B</field>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_export_sales_base" model="account.tax.report.line">
-            <field name="name">4. Export Sales (Base)</field>
-            <field name="tag_name">4. Export Sales (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">EXP_SALE_B</field>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_exempt_sales_base" model="account.tax.report.line">
-            <field name="name">5. Exempt Sales (Base)</field>
-            <field name="tag_name">5. Exempt Sales (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">EXM_SALE_B</field>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_net_sales_base" model="account.tax.report.line">
-            <field name="name">6. Net Sales (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_SALE_B + SPCL_SALE_B + ZERO_SALE_B + EXP_SALE_B + EXM_SALE_B</field>
-            <field name="sequence" eval="6"/>
-        </record>
-        <record id="tax_report_line_vat_all_sales_tax" model="account.tax.report.line">
-            <field name="name">VAT on Sales and all other Outputs (Tax)</field>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_standard_rated_15_tax" model="account.tax.report.line">
-            <field name="name">1. Standard Rated 15% (Tax)</field>
-            <field name="tag_name">1. Standard Rates 15% (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">STD_SALE_T</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_special_sales_to_locals_tax" model="account.tax.report.line">
-            <field name="name">2. Special Sales to Locals (Tax)</field>
-            <field name="tag_name">2. Special Sales to Locals (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">SPCL_SALE_T</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_local_sales_subject_to_0_tax" model="account.tax.report.line">
-            <field name="name">3. Local Sales Subject to 0% (Tax)</field>
-            <field name="tag_name">3. Local Sales Subject to 0% (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">ZERO_SALE_T</field>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_export_sales_tax" model="account.tax.report.line">
-            <field name="name">4. Export Sales (Tax)</field>
-            <field name="tag_name">4. Export Sales (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">EXP_SALE_T</field>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_exempt_sales_tax" model="account.tax.report.line">
-            <field name="name">5. Exempt Sales (Tax)</field>
-            <field name="tag_name">5. Exempt Sales (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">EXM_SALE_T</field>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_net_sales_tax" model="account.tax.report.line">
-            <field name="name">6. Net Sales (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_sales_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_SALE_T + SPCL_SALE_T + ZERO_SALE_T + EXP_SALE_T + EXM_SALE_T</field>
-            <field name="sequence" eval="6"/>
-        </record>
-        <record id="tax_report_line_vat_all_expenses_base" model="account.tax.report.line">
-            <field name="name">VAT on Expenses and all other Inputs (Base)</field>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_standard_rated_15_purchases_base" model="account.tax.report.line">
-            <field name="name">7. Standard rated 15% Purchases (Base)</field>
-            <field name="tag_name">7. Standard rated 15% Purchases (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">STD_PUR_B</field>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_taxable_imports_15_paid_to_customs_base" model="account.tax.report.line">
-            <field name="name">8. Taxable Imports 15% Paid to Customs (Base)</field>
-            <field name="tag_name">8. Taxable Imports 15% Paid to Customs (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">CUST_PUR_B</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_imports_subject_tp_reverse_charge_mechanism_base" model="account.tax.report.line">
-            <field name="name">9. Imports subject to reverse charge mechanism (Base)</field>
-            <field name="tag_name">9. Imports subject to reverse charge mechanism (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">RCM_PUR_B</field>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_zero_rated_purchases_base" model="account.tax.report.line">
-            <field name="name">10. Zero Rated Purchases (Base)</field>
-            <field name="tag_name">10. Zero Rated Purchases (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">ZER_PUR_B</field>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_exempt_purchases_base" model="account.tax.report.line">
-            <field name="name">11. Exempt Purchases (Base)</field>
-            <field name="tag_name">11. Exempt Purchases (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">EXM_PUR_B</field>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_net_purchases_base" model="account.tax.report.line">
-            <field name="name">12. Net Purchases (Base)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_base"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_PUR_B + CUST_PUR_B + RCM_PUR_B + ZER_PUR_B + EXM_PUR_B</field>
-            <field name="sequence" eval="6"/>
-        </record>
-        <record id="tax_report_line_vat_all_expenses_tax" model="account.tax.report.line">
-            <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_standard_rated_15_purchases_tax" model="account.tax.report.line">
-            <field name="name">7. Standard rated 15% Purchases (Tax)</field>
-            <field name="tag_name">7. Standard rated 15% Purchases (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">STD_PUR_T</field>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_taxable_imports_15_paid_to_customs_tax" model="account.tax.report.line">
-            <field name="name">8. Taxable Imports 15% Paid to Customs (Tax)</field>
-            <field name="tag_name">8. Taxable Imports 15% Paid to Customs (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">CUST_PUR_T</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax" model="account.tax.report.line">
-            <field name="name">9. Imports subject to reverse charge mechanism (Tax)</field>
-            <field name="tag_name">9. Imports subject to reverse charge mechanism (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">RCM_PUR_T</field>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_zero_rated_purchases_tax" model="account.tax.report.line">
-            <field name="name">10. Zero Rated Purchases (Tax)</field>
-            <field name="tag_name">10. Zero Rated Purchases (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">ZER_PUR_T</field>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_exempt_purchases_tax" model="account.tax.report.line">
-            <field name="name">11. Exempt Purchases (Tax)</field>
-            <field name="tag_name">11. Exempt Purchases (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="code">EXM_PUR_T</field>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_net_purchases_tax" model="account.tax.report.line">
-            <field name="name">12. Net Purchases (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_vat_all_expenses_tax"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_PUR_T + CUST_PUR_T + RCM_PUR_T + ZER_PUR_T + EXM_PUR_T</field>
-            <field name="sequence" eval="6"/>
-        </record>
-        <record id="tax_report_line_net_vat_due" model="account.tax.report.line">
-            <field name="name">Net VAT Due</field>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_total_value_of_due_tax_for_the_period" model="account.tax.report.line">
-            <field name="name">Total value of due tax for the period</field>
-            <field name="parent_id" ref="tax_report_line_net_vat_due"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_SALE_T + SPCL_SALE_T + ZERO_SALE_T + EXP_SALE_T + EXM_SALE_T</field>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_total_value_of_recoverable_tax_for_the_period" model="account.tax.report.line">
-            <field name="name">Total value of recoverable tax for the period</field>
-            <field name="parent_id" ref="tax_report_line_net_vat_due"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_PUR_T + CUST_PUR_T + RCM_PUR_T + ZER_PUR_T + EXM_PUR_T</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_net_vat_due_or_reclaimed_for_the_period" model="account.tax.report.line">
-            <field name="name">Net VAT due (or reclaimed) for the period</field>
-            <field name="parent_id" ref="tax_report_line_net_vat_due"/>
-            <field name="report_id" ref="tax_report_vat_filing"/>
-            <field name="formula">STD_SALE_T + SPCL_SALE_T + ZERO_SALE_T + EXP_SALE_T + EXM_SALE_T - (STD_PUR_T + CUST_PUR_T + RCM_PUR_T + ZER_PUR_T + EXM_PUR_T)</field>
-            <field name="sequence" eval="3"/>
-        </record>
-
-
-        <!-- New report for Withholding Taxes-->
-
-
-        <record id="tax_report_withholding_tax" model="account.tax.report">
-            <field name="name">Withholding Tax Report</field>
-            <field name="country_id" ref="base.sa"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_on_purchased_services_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax on Purchased Services (Base)</field>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_rental_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Rental) (Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Rental) (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">RENTB</field>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_tickets_or_air_freight_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Tickets or Air Freight) (Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Tickets or Air Freight) (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">AIRB</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_tickets_or_sea_freight_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Tickets or Sea Freight)(Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Tickets or Sea Freight)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">SEAB</field>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_international_telecommunication_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (International Telecommunication)(Base)</field>
-            <field name="tag_name">Withholding Tax 5% (International Telecommunication)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">TELEB</field>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_distributed_profits_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Distributed Profits) (Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Distributed Profits) (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">DIVB</field>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_consulting_and_technical_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Consulting and Technical) (Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Consulting and Technical) (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">CONB</field>
-            <field name="sequence" eval="6"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_return_from_loans_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Return from Loans) (Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Return from Loans) (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">ROLB</field>
-            <field name="sequence" eval="7"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_insurance_and_reinsurance_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Base)</field>
-            <field name="tag_name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">INSB</field>
-            <field name="sequence" eval="8"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_royalties_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Royalties)(Base)</field>
-            <field name="tag_name">Withholding Tax 15% (Royalties)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">ROYB</field>
-            <field name="sequence" eval="9"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_paid_services_from_main_branch_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Paid Services from Main Branch)(Base)</field>
-            <field name="tag_name">Withholding Tax 15% (Paid Services from Main Branch)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">MAIB</field>
-            <field name="sequence" eval="10"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_paid_services_from_another_branch_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Paid Services from another branch)(Base)</field>
-            <field name="tag_name">Withholding Tax 15% (Paid Services from another branch)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">BRAB</field>
-            <field name="sequence" eval="11"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_others_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Others)(Base)</field>
-            <field name="tag_name">Withholding Tax 15% (Others)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">OTHB</field>
-            <field name="sequence" eval="12"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_20_managerial_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax 20% (Managerial)(Base)</field>
-            <field name="tag_name">Withholding Tax 20% (Managerial)(Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">MAGB</field>
-            <field name="sequence" eval="13"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_total_base" model="account.tax.report.line">
-            <field name="name">Withholding Tax Total (Base)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_base"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="formula">RENTB+AIRB+SEAB+TELEB+DIVB+CONB+ROLB+INSB+ROYB+MAIB+BRAB+OTHB+MAGB</field>
-            <field name="sequence" eval="14"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_on_purchased_services_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax on Purchased Services (Tax)</field>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_rental_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Rental) (Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Rental) (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">RENTT</field>
-            <field name="sequence" eval="1"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_tickets_or_air_freight_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Tickets or Air Freight) (Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Tickets or Air Freight) (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">AIRT</field>
-            <field name="sequence" eval="2"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Tickets or Sea Freight)(Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Tickets or Sea Freight)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">SEAT</field>
-            <field name="sequence" eval="3"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_international_telecommunication_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (International Telecommunication)(Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (International Telecommunication)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">TELET</field>
-            <field name="sequence" eval="4"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_distributed_profits_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Distributed Profits) (Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Distributed Profits) (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">DIVT</field>
-            <field name="sequence" eval="5"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_consulting_and_technical_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Consulting and Technical) (Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Consulting and Technical) (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">CONT</field>
-            <field name="sequence" eval="6"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_return_from_loans_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Return from Loans) (Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Return from Loans) (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">ROLT</field>
-            <field name="sequence" eval="7"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Tax)</field>
-            <field name="tag_name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">INST</field>
-            <field name="sequence" eval="8"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_royalties_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Royalties)(Tax)</field>
-            <field name="tag_name">Withholding Tax 15% (Royalties)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">ROYT</field>
-            <field name="sequence" eval="9"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Paid Services from Main Branch)(Tax)</field>
-            <field name="tag_name">Withholding Tax 15% (Paid Services from Main Branch)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">MAIT</field>
-            <field name="sequence" eval="10"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Paid Services from another branch)(Tax)</field>
-            <field name="tag_name">Withholding Tax 15% (Paid Services from another branch)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">BRAT</field>
-            <field name="sequence" eval="11"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_15_others_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 15% (Others)(Tax)</field>
-            <field name="tag_name">Withholding Tax 15% (Others)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">OTHT</field>
-            <field name="sequence" eval="12"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_20_managerial_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax 20% (Managerial)(Tax)</field>
-            <field name="tag_name">Withholding Tax 20% (Managerial)(Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="code">MAGT</field>
-            <field name="sequence" eval="13"/>
-        </record>
-        <record id="tax_report_line_withholding_tax_total_tax" model="account.tax.report.line">
-            <field name="name">Withholding Tax Total (Tax)</field>
-            <field name="parent_id" ref="tax_report_line_withholding_tax_on_purchased_services_tax"/>
-            <field name="report_id" ref="tax_report_withholding_tax"/>
-            <field name="formula">RENTT+AIRT+SEAT+TELET+DIVT+CONT+ROLT+INST+ROYT+MAIT+BRAT+OTHT+MAGT</field>
-            <field name="sequence" eval="14"/>
-        </record>
-    </data>
+    <record id="tax_report_vat_filing" model="account.tax.report">
+        <field name="name">VAT Filing Report</field>
+        <field name="country_id" ref="base.sa"/>
+        <field name="root_line_ids">
+            <record id="tax_report_line_vat_all_sales_base" model="account.tax.report.line">
+                <field name="name">VAT on Sales and all other Outputs (Base)</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_15_base" model="account.tax.report.line">
+                        <field name="name">1. Standard Rated 15% (Base)</field>
+                        <field name="tag_name">1. Standard Rates 15% (Base)</field>
+                        <field name="code">STD_SALE_B</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_special_sales_to_locals_base" model="account.tax.report.line">
+                        <field name="name">2. Special Sales to Locals (Base)</field>
+                        <field name="tag_name">2. Special Sales to Locals (Base)</field>
+                        <field name="code">SPCL_SALE_B</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_local_sales_subject_to_0_base" model="account.tax.report.line">
+                        <field name="name">3. Local Sales Subject to 0% (Base)</field>
+                        <field name="tag_name">3. Local Sales Subject to 0% (Base)</field>
+                        <field name="code">ZERO_SALE_B</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_export_sales_base" model="account.tax.report.line">
+                        <field name="name">4. Export Sales (Base)</field>
+                        <field name="tag_name">4. Export Sales (Base)</field>
+                        <field name="code">EXP_SALE_B</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_exempt_sales_base" model="account.tax.report.line">
+                        <field name="name">5. Exempt Sales (Base)</field>
+                        <field name="tag_name">5. Exempt Sales (Base)</field>
+                        <field name="code">EXM_SALE_B</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_net_sales_base" model="account.tax.report.line">
+                        <field name="name">6. Net Sales (Base)</field>
+                        <field name="formula">STD_SALE_B + SPCL_SALE_B + ZERO_SALE_B + EXP_SALE_B + EXM_SALE_B</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_vat_all_sales_tax" model="account.tax.report.line">
+                <field name="name">VAT on Sales and all other Outputs (Tax)</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_15_tax" model="account.tax.report.line">
+                        <field name="name">1. Standard Rated 15% (Tax)</field>
+                        <field name="tag_name">1. Standard Rates 15% (Tax)</field>
+                        <field name="code">STD_SALE_T</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_special_sales_to_locals_tax" model="account.tax.report.line">
+                        <field name="name">2. Special Sales to Locals (Tax)</field>
+                        <field name="tag_name">2. Special Sales to Locals (Tax)</field>
+                        <field name="code">SPCL_SALE_T</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_local_sales_subject_to_0_tax" model="account.tax.report.line">
+                        <field name="name">3. Local Sales Subject to 0% (Tax)</field>
+                        <field name="tag_name">3. Local Sales Subject to 0% (Tax)</field>
+                        <field name="code">ZERO_SALE_T</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_export_sales_tax" model="account.tax.report.line">
+                        <field name="name">4. Export Sales (Tax)</field>
+                        <field name="tag_name">4. Export Sales (Tax)</field>
+                        <field name="code">EXP_SALE_T</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_exempt_sales_tax" model="account.tax.report.line">
+                        <field name="name">5. Exempt Sales (Tax)</field>
+                        <field name="tag_name">5. Exempt Sales (Tax)</field>
+                        <field name="code">EXM_SALE_T</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_net_sales_tax" model="account.tax.report.line">
+                        <field name="name">6. Net Sales (Tax)</field>
+                        <field name="formula">STD_SALE_T + SPCL_SALE_T + ZERO_SALE_T + EXP_SALE_T + EXM_SALE_T</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_vat_all_expenses_base" model="account.tax.report.line">
+                <field name="name">VAT on Expenses and all other Inputs (Base)</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_15_purchases_base" model="account.tax.report.line">
+                        <field name="name">7. Standard rated 15% Purchases (Base)</field>
+                        <field name="tag_name">7. Standard rated 15% Purchases (Base)</field>
+                        <field name="code">STD_PUR_B</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_taxable_imports_15_paid_to_customs_base" model="account.tax.report.line">
+                        <field name="name">8. Taxable Imports 15% Paid to Customs (Base)</field>
+                        <field name="tag_name">8. Taxable Imports 15% Paid to Customs (Base)</field>
+                        <field name="code">CUST_PUR_B</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_imports_subject_tp_reverse_charge_mechanism_base" model="account.tax.report.line">
+                        <field name="name">9. Imports subject to reverse charge mechanism (Base)</field>
+                        <field name="tag_name">9. Imports subject to reverse charge mechanism (Base)</field>
+                        <field name="code">RCM_PUR_B</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_zero_rated_purchases_base" model="account.tax.report.line">
+                        <field name="name">10. Zero Rated Purchases (Base)</field>
+                        <field name="tag_name">10. Zero Rated Purchases (Base)</field>
+                        <field name="code">ZER_PUR_B</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_exempt_purchases_base" model="account.tax.report.line">
+                        <field name="name">11. Exempt Purchases (Base)</field>
+                        <field name="tag_name">11. Exempt Purchases (Base)</field>
+                        <field name="code">EXM_PUR_B</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_net_purchases_base" model="account.tax.report.line">
+                        <field name="name">12. Net Purchases (Base)</field>
+                        <field name="formula">STD_PUR_B + CUST_PUR_B + RCM_PUR_B + ZER_PUR_B + EXM_PUR_B</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_vat_all_expenses_tax" model="account.tax.report.line">
+                <field name="name">VAT on Expenses and all other Inputs (Tax)</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_standard_rated_15_purchases_tax" model="account.tax.report.line">
+                        <field name="name">7. Standard rated 15% Purchases (Tax)</field>
+                        <field name="tag_name">7. Standard rated 15% Purchases (Tax)</field>
+                        <field name="code">STD_PUR_T</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_taxable_imports_15_paid_to_customs_tax" model="account.tax.report.line">
+                        <field name="name">8. Taxable Imports 15% Paid to Customs (Tax)</field>
+                        <field name="tag_name">8. Taxable Imports 15% Paid to Customs (Tax)</field>
+                        <field name="code">CUST_PUR_T</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax" model="account.tax.report.line">
+                        <field name="name">9. Imports subject to reverse charge mechanism (Tax)</field>
+                        <field name="tag_name">9. Imports subject to reverse charge mechanism (Tax)</field>
+                        <field name="code">RCM_PUR_T</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_zero_rated_purchases_tax" model="account.tax.report.line">
+                        <field name="name">10. Zero Rated Purchases (Tax)</field>
+                        <field name="tag_name">10. Zero Rated Purchases (Tax)</field>
+                        <field name="code">ZER_PUR_T</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_exempt_purchases_tax" model="account.tax.report.line">
+                        <field name="name">11. Exempt Purchases (Tax)</field>
+                        <field name="tag_name">11. Exempt Purchases (Tax)</field>
+                        <field name="code">EXM_PUR_T</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_net_purchases_tax" model="account.tax.report.line">
+                        <field name="name">12. Net Purchases (Tax)</field>
+                        <field name="formula">STD_PUR_T + CUST_PUR_T + RCM_PUR_T + ZER_PUR_T + EXM_PUR_T</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_net_vat_due" model="account.tax.report.line">
+                <field name="name">Net VAT Due</field>
+                <field name="sequence" eval="5"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_total_value_of_due_tax_for_the_period" model="account.tax.report.line">
+                        <field name="name">Total value of due tax for the period</field>
+                        <field name="formula">STD_SALE_T + SPCL_SALE_T + ZERO_SALE_T + EXP_SALE_T + EXM_SALE_T</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_total_value_of_recoverable_tax_for_the_period" model="account.tax.report.line">
+                        <field name="name">Total value of recoverable tax for the period</field>
+                        <field name="formula">STD_PUR_T + CUST_PUR_T + RCM_PUR_T + ZER_PUR_T + EXM_PUR_T</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_net_vat_due_or_reclaimed_for_the_period" model="account.tax.report.line">
+                        <field name="name">Net VAT due (or reclaimed) for the period</field>
+                        <field name="formula">STD_SALE_T + SPCL_SALE_T + ZERO_SALE_T + EXP_SALE_T + EXM_SALE_T - (STD_PUR_T + CUST_PUR_T + RCM_PUR_T + ZER_PUR_T + EXM_PUR_T)</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+    <record id="tax_report_withholding_tax" model="account.tax.report">
+        <field name="name">Withholding Tax Report</field>
+        <field name="country_id" ref="base.sa"/>
+        <field name="root_line_ids">
+            <record id="tax_report_line_withholding_tax_on_purchased_services_base" model="account.tax.report.line">
+                <field name="name">Withholding Tax on Purchased Services (Base)</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_withholding_tax_5_rental_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Rental) (Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Rental) (Base)</field>
+                        <field name="code">RENTB</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_tickets_or_air_freight_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Tickets or Air Freight) (Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Tickets or Air Freight) (Base)</field>
+                        <field name="code">AIRB</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_tickets_or_sea_freight_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Tickets or Sea Freight)(Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Tickets or Sea Freight)(Base)</field>
+                        <field name="code">SEAB</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_international_telecommunication_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (International Telecommunication)(Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (International Telecommunication)(Base)</field>
+                        <field name="code">TELEB</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_distributed_profits_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Distributed Profits) (Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Distributed Profits) (Base)</field>
+                        <field name="code">DIVB</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_consulting_and_technical_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Consulting and Technical) (Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Consulting and Technical) (Base)</field>
+                        <field name="code">CONB</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_return_from_loans_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Return from Loans) (Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Return from Loans) (Base)</field>
+                        <field name="code">ROLB</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_insurance_and_reinsurance_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Base)</field>
+                        <field name="tag_name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Base)</field>
+                        <field name="code">INSB</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_royalties_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Royalties)(Base)</field>
+                        <field name="tag_name">Withholding Tax 15% (Royalties)(Base)</field>
+                        <field name="code">ROYB</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_paid_services_from_main_branch_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Paid Services from Main Branch)(Base)</field>
+                        <field name="tag_name">Withholding Tax 15% (Paid Services from Main Branch)(Base)</field>
+                        <field name="code">MAIB</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_paid_services_from_another_branch_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Paid Services from another branch)(Base)</field>
+                        <field name="tag_name">Withholding Tax 15% (Paid Services from another branch)(Base)</field>
+                        <field name="code">BRAB</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_others_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Others)(Base)</field>
+                        <field name="tag_name">Withholding Tax 15% (Others)(Base)</field>
+                        <field name="code">OTHB</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_20_managerial_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 20% (Managerial)(Base)</field>
+                        <field name="tag_name">Withholding Tax 20% (Managerial)(Base)</field>
+                        <field name="code">MAGB</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_total_base" model="account.tax.report.line">
+                        <field name="name">Withholding Tax Total (Base)</field>
+                        <field name="formula">RENTB+AIRB+SEAB+TELEB+DIVB+CONB+ROLB+INSB+ROYB+MAIB+BRAB+OTHB+MAGB</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_line_withholding_tax_on_purchased_services_tax" model="account.tax.report.line">
+                <field name="name">Withholding Tax on Purchased Services (Tax)</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_withholding_tax_5_rental_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Rental) (Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Rental) (Tax)</field>
+                        <field name="code">RENTT</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_tickets_or_air_freight_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Tickets or Air Freight) (Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Tickets or Air Freight) (Tax)</field>
+                        <field name="code">AIRT</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Tickets or Sea Freight)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Tickets or Sea Freight)(Tax)</field>
+                        <field name="code">SEAT</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_international_telecommunication_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (International Telecommunication)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (International Telecommunication)(Tax)</field>
+                        <field name="code">TELET</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_distributed_profits_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Distributed Profits) (Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Distributed Profits) (Tax)</field>
+                        <field name="code">DIVT</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_consulting_and_technical_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Consulting and Technical) (Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Consulting and Technical) (Tax)</field>
+                        <field name="code">CONT</field>
+                        <field name="sequence" eval="6"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_return_from_loans_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Return from Loans) (Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Return from Loans) (Tax)</field>
+                        <field name="code">ROLT</field>
+                        <field name="sequence" eval="7"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Tax)</field>
+                        <field name="tag_name">Withholding Tax 5% (Insurance &amp; Reinsurance) (Tax)</field>
+                        <field name="code">INST</field>
+                        <field name="sequence" eval="8"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_royalties_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Royalties)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 15% (Royalties)(Tax)</field>
+                        <field name="code">ROYT</field>
+                        <field name="sequence" eval="9"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Paid Services from Main Branch)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 15% (Paid Services from Main Branch)(Tax)</field>
+                        <field name="code">MAIT</field>
+                        <field name="sequence" eval="10"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Paid Services from another branch)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 15% (Paid Services from another branch)(Tax)</field>
+                        <field name="code">BRAT</field>
+                        <field name="sequence" eval="11"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_15_others_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 15% (Others)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 15% (Others)(Tax)</field>
+                        <field name="code">OTHT</field>
+                        <field name="sequence" eval="12"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_20_managerial_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax 20% (Managerial)(Tax)</field>
+                        <field name="tag_name">Withholding Tax 20% (Managerial)(Tax)</field>
+                        <field name="code">MAGT</field>
+                        <field name="sequence" eval="13"/>
+                    </record>
+                    <record id="tax_report_line_withholding_tax_total_tax" model="account.tax.report.line">
+                        <field name="name">Withholding Tax Total (Tax)</field>
+                        <field name="formula">RENTT+AIRT+SEAT+TELET+DIVT+CONT+ROLT+INST+ROYT+MAIT+BRAT+OTHT+MAGT</field>
+                        <field name="sequence" eval="14"/>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
 </odoo>

--- a/addons/l10n_se/data/account_tax_report_data.xml
+++ b/addons/l10n_se/data/account_tax_report_data.xml
@@ -1,365 +1,249 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-
-        <record id="tax_report" model="account.tax.report">
-            <field name="name">skatterapport</field>
-            <field name="country_id" ref="base.se"/>
-        </record>
-
-        <!-- -->
-        <!--A-->
-        <!-- -->
-        <record id="tax_report_title_sales" model="account.tax.report.line">
-            <field name="name">Block A – Momspliktig försäljning eller uttag exklusive moms</field>
-            <field name="code">se_a</field>
-            <field name="sequence">1</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_05" model="account.tax.report.line">
-            <field name="name">Fält 05 – Momspliktig försäljning som inte ingår i fält 06, 07 eller 08</field>
-            <field name="code">se_05</field>
-            <field name="tag_name">se_05</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_06" model="account.tax.report.line">
-            <field name="name">Fält 06 – Momspliktiga uttag</field>
-            <field name="code">se_06</field>
-            <field name="tag_name">se_06</field>
-            <field name="sequence">2</field>
-            <field name="parent_id" ref="tax_report_title_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_07" model="account.tax.report.line">
-            <field name="name">Fält 07 – Beskattningsunderlag vid vinstmarginalbeskattning</field>
-            <field name="code">se_07</field>
-            <field name="tag_name">se_07</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_08" model="account.tax.report.line">
-            <field name="name">Fält 08 – Hyresinkomster vid frivillig skattskyldighet</field>
-            <field name="code">se_08</field>
-            <field name="tag_name">se_08</field>
-            <field name="sequence">4</field>
-            <field name="parent_id" ref="tax_report_title_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--B-->
-        <!-- -->
-        <record id="tax_report_title_output_vat_sales" model="account.tax.report.line">
-            <field name="name">Block B – Utgående moms på försäljning eller uttag i fält 05–08</field>
-            <field name="code">se_b</field>
-            <field name="sequence">2</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_10" model="account.tax.report.line">
-            <field name="name">Fält 10 – Utgående moms 25 %</field>
-            <field name="code">se_10</field>
-            <field name="tag_name">se_10</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_11" model="account.tax.report.line">
-            <field name="name">Fält 11 – Utgående moms 12 %</field>
-            <field name="code">se_11</field>
-            <field name="tag_name">se_11</field>
-            <field name="sequence">2</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_12" model="account.tax.report.line">
-            <field name="name">Fält 12 – Utgående moms 6 %</field>
-            <field name="code">se_12</field>
-            <field name="tag_name">se_12</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--C-->
-        <!-- -->
-        <record id="tax_report_title_purchases" model="account.tax.report.line">
-            <field name="name">Block C – Momspliktiga inköp vid omvänd skattskyldighet</field>
-            <field name="code">se_c</field>
-            <field name="sequence">3</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_20" model="account.tax.report.line">
-            <field name="name">Fält 20 – Inköp av varor från annat EU-land</field>
-            <field name="code">se_20</field>
-            <field name="tag_name">se_20</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_21" model="account.tax.report.line">
-            <field name="name">Fält 21 – Inköp av tjänster från ett annat EU-land, enligt huvudregeln</field>
-            <field name="code">se_21</field>
-            <field name="tag_name">se_21</field>
-            <field name="sequence">2</field>
-            <field name="parent_id" ref="tax_report_title_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_22" model="account.tax.report.line">
-            <field name="name">Fält 22 – Inköp av tjänster från länder utanför EU</field>
-            <field name="code">se_22</field>
-            <field name="tag_name">se_22</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_23" model="account.tax.report.line">
-            <field name="name">Fält 23 – Inköp av varor i Sverige</field>
-            <field name="code">se_23</field>
-            <field name="tag_name">se_23</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_24" model="account.tax.report.line">
-            <field name="name">Fält 24 – Övriga inköp av tjänster</field>
-            <field name="code">se_24</field>
-            <field name="tag_name">se_24</field>
-            <field name="sequence">4</field>
-            <field name="parent_id" ref="tax_report_title_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--D-->
-        <!-- -->
-        <record id="tax_report_title_output_vat_purchases" model="account.tax.report.line">
-            <field name="name">Block D – Utgående moms på inköp i fält 20–24</field>
-            <field name="code">se_d</field>
-            <field name="sequence">4</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_30" model="account.tax.report.line">
-            <field name="name">Fält 30 – Utgående moms 25 %</field>
-            <field name="code">se_30</field>
-            <field name="tag_name">se_30</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_31" model="account.tax.report.line">
-            <field name="name">Fält 31 – Utgående moms 12 %</field>
-            <field name="code">se_31</field>
-            <field name="tag_name">se_31</field>
-            <field name="sequence">2</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_32" model="account.tax.report.line">
-            <field name="name">Fält 32 – Utgående moms 6 %</field>
-            <field name="code">se_32</field>
-            <field name="tag_name">se_32</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_purchases"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--H-->
-        <!-- -->
-        <record id="tax_report_title_imports" model="account.tax.report.line">
-            <field name="name">Block H - moms vid import</field>
-            <field name="code">se_h</field>
-            <field name="sequence">5</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_50" model="account.tax.report.line">
-            <field name="name">Fält 50 - Beskattningsunderlag vid import</field>
-            <field name="code">se_50</field>
-            <field name="tag_name">se_50</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_imports"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--I-->
-        <!-- -->
-        <record id="tax_report_title_output_vat_imports" model="account.tax.report.line">
-            <field name="name">Block I - Utgående moms på import i fält 50</field>
-            <field name="code">se_i</field>
-            <field name="sequence">6</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_60" model="account.tax.report.line">
-            <field name="name">Fält 60 – Utgående moms 25 %</field>
-            <field name="code">se_60</field>
-            <field name="tag_name">se_60</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_imports"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_61" model="account.tax.report.line">
-            <field name="name">Fält 61 – Utgående moms 12 %</field>
-            <field name="code">se_61</field>
-            <field name="tag_name">se_61</field>
-            <field name="sequence">2</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_imports"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_62" model="account.tax.report.line">
-            <field name="name">Fält 62 – Utgående moms 6 %</field>
-            <field name="code">se_62</field>
-            <field name="tag_name">se_62</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_output_vat_imports"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--E-->
-        <!-- -->
-        <record id="tax_report_title_exempt_sales" model="account.tax.report.line">
-            <field name="name">Block E – Försäljning m.m. som är undantagen från moms</field>
-            <field name="code">se_e</field>
-            <field name="sequence">7</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_35" model="account.tax.report.line">
-            <field name="name">Fält 35 – Försäljning av varor till ett annat EU-land</field>
-            <field name="code">se_35</field>
-            <field name="tag_name">se_35</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_36" model="account.tax.report.line">
-            <field name="name">Fält 36 – Försäljning av varor utanför EU</field>
-            <field name="code">se_36</field>
-            <field name="tag_name">se_36</field>
-            <field name="sequence">2</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_37" model="account.tax.report.line">
-            <field name="name">Fält 37 – Mellanmans inköp av varor vid trepartshandel</field>
-            <field name="code">se_37</field>
-            <field name="tag_name">se_37</field>
-            <field name="sequence">3</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_38" model="account.tax.report.line">
-            <field name="name">Fält 38 – Mellanmans försäljning av varor vid trepartshandel</field>
-            <field name="code">se_38</field>
-            <field name="tag_name">se_38</field>
-            <field name="sequence">4</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_39" model="account.tax.report.line">
-            <field name="name">Fält 39 – Försäljning av tjänster till en beskattningsbar person (näringsidkare) i ett
+    <record id="tax_report" model="account.tax.report">
+        <field name="name">skatterapport</field>
+        <field name="country_id" ref="base.se"/>
+        <field name="root_line_ids">
+            <record id="tax_report_title_sales" model="account.tax.report.line">
+                <field name="name">Block A – Momspliktig försäljning eller uttag exklusive moms</field>
+                <field name="code">se_a</field>
+                <field name="sequence">1</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_05" model="account.tax.report.line">
+                        <field name="name">Fält 05 – Momspliktig försäljning som inte ingår i fält 06, 07 eller 08</field>
+                        <field name="code">se_05</field>
+                        <field name="tag_name">se_05</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_06" model="account.tax.report.line">
+                        <field name="name">Fält 06 – Momspliktiga uttag</field>
+                        <field name="code">se_06</field>
+                        <field name="tag_name">se_06</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_07" model="account.tax.report.line">
+                        <field name="name">Fält 07 – Beskattningsunderlag vid vinstmarginalbeskattning</field>
+                        <field name="code">se_07</field>
+                        <field name="tag_name">se_07</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_line_08" model="account.tax.report.line">
+                        <field name="name">Fält 08 – Hyresinkomster vid frivillig skattskyldighet</field>
+                        <field name="code">se_08</field>
+                        <field name="tag_name">se_08</field>
+                        <field name="sequence">4</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_output_vat_sales" model="account.tax.report.line">
+                <field name="name">Block B – Utgående moms på försäljning eller uttag i fält 05–08</field>
+                <field name="code">se_b</field>
+                <field name="sequence">2</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_10" model="account.tax.report.line">
+                        <field name="name">Fält 10 – Utgående moms 25 %</field>
+                        <field name="code">se_10</field>
+                        <field name="tag_name">se_10</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_11" model="account.tax.report.line">
+                        <field name="name">Fält 11 – Utgående moms 12 %</field>
+                        <field name="code">se_11</field>
+                        <field name="tag_name">se_11</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_12" model="account.tax.report.line">
+                        <field name="name">Fält 12 – Utgående moms 6 %</field>
+                        <field name="code">se_12</field>
+                        <field name="tag_name">se_12</field>
+                        <field name="sequence">3</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_purchases" model="account.tax.report.line">
+                <field name="name">Block C – Momspliktiga inköp vid omvänd skattskyldighet</field>
+                <field name="code">se_c</field>
+                <field name="sequence">3</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_20" model="account.tax.report.line">
+                        <field name="name">Fält 20 – Inköp av varor från annat EU-land</field>
+                        <field name="code">se_20</field>
+                        <field name="tag_name">se_20</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_21" model="account.tax.report.line">
+                        <field name="name">Fält 21 – Inköp av tjänster från ett annat EU-land, enligt huvudregeln</field>
+                        <field name="code">se_21</field>
+                        <field name="tag_name">se_21</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_22" model="account.tax.report.line">
+                        <field name="name">Fält 22 – Inköp av tjänster från länder utanför EU</field>
+                        <field name="code">se_22</field>
+                        <field name="tag_name">se_22</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_line_23" model="account.tax.report.line">
+                        <field name="name">Fält 23 – Inköp av varor i Sverige</field>
+                        <field name="code">se_23</field>
+                        <field name="tag_name">se_23</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_line_24" model="account.tax.report.line">
+                        <field name="name">Fält 24 – Övriga inköp av tjänster</field>
+                        <field name="code">se_24</field>
+                        <field name="tag_name">se_24</field>
+                        <field name="sequence">4</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_output_vat_purchases" model="account.tax.report.line">
+                <field name="name">Block D – Utgående moms på inköp i fält 20–24</field>
+                <field name="code">se_d</field>
+                <field name="sequence">4</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_30" model="account.tax.report.line">
+                        <field name="name">Fält 30 – Utgående moms 25 %</field>
+                        <field name="code">se_30</field>
+                        <field name="tag_name">se_30</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_31" model="account.tax.report.line">
+                        <field name="name">Fält 31 – Utgående moms 12 %</field>
+                        <field name="code">se_31</field>
+                        <field name="tag_name">se_31</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_32" model="account.tax.report.line">
+                        <field name="name">Fält 32 – Utgående moms 6 %</field>
+                        <field name="code">se_32</field>
+                        <field name="tag_name">se_32</field>
+                        <field name="sequence">3</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_imports" model="account.tax.report.line">
+                <field name="name">Block H - moms vid import</field>
+                <field name="code">se_h</field>
+                <field name="sequence">5</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_50" model="account.tax.report.line">
+                        <field name="name">Fält 50 - Beskattningsunderlag vid import</field>
+                        <field name="code">se_50</field>
+                        <field name="tag_name">se_50</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_output_vat_imports" model="account.tax.report.line">
+                <field name="name">Block I - Utgående moms på import i fält 50</field>
+                <field name="code">se_i</field>
+                <field name="sequence">6</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_60" model="account.tax.report.line">
+                        <field name="name">Fält 60 – Utgående moms 25 %</field>
+                        <field name="code">se_60</field>
+                        <field name="tag_name">se_60</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_61" model="account.tax.report.line">
+                        <field name="name">Fält 61 – Utgående moms 12 %</field>
+                        <field name="code">se_61</field>
+                        <field name="tag_name">se_61</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_62" model="account.tax.report.line">
+                        <field name="name">Fält 62 – Utgående moms 6 %</field>
+                        <field name="code">se_62</field>
+                        <field name="tag_name">se_62</field>
+                        <field name="sequence">3</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_exempt_sales" model="account.tax.report.line">
+                <field name="name">Block E – Försäljning m.m. som är undantagen från moms</field>
+                <field name="code">se_e</field>
+                <field name="sequence">7</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_35" model="account.tax.report.line">
+                        <field name="name">Fält 35 – Försäljning av varor till ett annat EU-land</field>
+                        <field name="code">se_35</field>
+                        <field name="tag_name">se_35</field>
+                        <field name="sequence">1</field>
+                    </record>
+                    <record id="tax_report_line_36" model="account.tax.report.line">
+                        <field name="name">Fält 36 – Försäljning av varor utanför EU</field>
+                        <field name="code">se_36</field>
+                        <field name="tag_name">se_36</field>
+                        <field name="sequence">2</field>
+                    </record>
+                    <record id="tax_report_line_37" model="account.tax.report.line">
+                        <field name="name">Fält 37 – Mellanmans inköp av varor vid trepartshandel</field>
+                        <field name="code">se_37</field>
+                        <field name="tag_name">se_37</field>
+                        <field name="sequence">3</field>
+                    </record>
+                    <record id="tax_report_line_38" model="account.tax.report.line">
+                        <field name="name">Fält 38 – Mellanmans försäljning av varor vid trepartshandel</field>
+                        <field name="code">se_38</field>
+                        <field name="tag_name">se_38</field>
+                        <field name="sequence">4</field>
+                    </record>
+                    <record id="tax_report_line_39" model="account.tax.report.line">
+                        <field name="name">Fält 39 – Försäljning av tjänster till en beskattningsbar person (näringsidkare) i ett
                 annat EU-land, enligt huvudregeln
             </field>
-            <field name="code">se_39</field>
-            <field name="tag_name">se_39</field>
-            <field name="sequence">5</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_40" model="account.tax.report.line">
-            <field name="name">Fält 40 – Övrig försäljning av tjänster omsatta utanför Sverige</field>
-            <field name="code">se_40</field>
-            <field name="tag_name">se_40</field>
-            <field name="sequence">6</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_41" model="account.tax.report.line">
-            <field name="name">Fält 41 – Försäljning när köparen är skattskyldig i Sverige</field>
-            <field name="code">se_41</field>
-            <field name="tag_name">se_41</field>
-            <field name="sequence">7</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_42" model="account.tax.report.line">
-            <field name="name">Fält 42 – Övrig försäljning m.m.</field>
-            <field name="code">se_42</field>
-            <field name="tag_name">se_42</field>
-            <field name="sequence">8</field>
-            <field name="parent_id" ref="tax_report_title_exempt_sales"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--F-->
-        <!-- -->
-        <record id="tax_report_title_input_vat" model="account.tax.report.line">
-            <field name="name">Block F – Ingående moms</field>
-            <field name="code">se_f</field>
-            <field name="sequence">8</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_48" model="account.tax.report.line">
-            <field name="name">Fält 48 – Ingående moms att dra av</field>
-            <field name="code">se_48</field>
-            <field name="tag_name">se_48</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_input_vat"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <!-- -->
-        <!--G-->
-        <!-- -->
-        <record id="tax_report_title_vat_debt_credit" model="account.tax.report.line">
-            <field name="name">Block G – Moms att betala eller få tillbaka</field>
-            <field name="code">se_g</field>
-            <field name="formula">se_b+se_i+se_d+se_f</field>
-            <field name="sequence">9</field>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-        <record id="tax_report_line_49" model="account.tax.report.line">
-            <field name="name">Fält 49 – Moms att betala eller få tillbaka</field>
-            <field name="code">se_49</field>
-            <field name="formula">se_b+se_i+se_d+se_f</field>
-            <field name="sequence">1</field>
-            <field name="parent_id" ref="tax_report_title_vat_debt_credit"/>
-            <field name="report_id" ref="tax_report"/>
-        </record>
-
-    </data>
+                        <field name="code">se_39</field>
+                        <field name="tag_name">se_39</field>
+                        <field name="sequence">5</field>
+                    </record>
+                    <record id="tax_report_line_40" model="account.tax.report.line">
+                        <field name="name">Fält 40 – Övrig försäljning av tjänster omsatta utanför Sverige</field>
+                        <field name="code">se_40</field>
+                        <field name="tag_name">se_40</field>
+                        <field name="sequence">6</field>
+                    </record>
+                    <record id="tax_report_line_41" model="account.tax.report.line">
+                        <field name="name">Fält 41 – Försäljning när köparen är skattskyldig i Sverige</field>
+                        <field name="code">se_41</field>
+                        <field name="tag_name">se_41</field>
+                        <field name="sequence">7</field>
+                    </record>
+                    <record id="tax_report_line_42" model="account.tax.report.line">
+                        <field name="name">Fält 42 – Övrig försäljning m.m.</field>
+                        <field name="code">se_42</field>
+                        <field name="tag_name">se_42</field>
+                        <field name="sequence">8</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_input_vat" model="account.tax.report.line">
+                <field name="name">Block F – Ingående moms</field>
+                <field name="code">se_f</field>
+                <field name="sequence">8</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_48" model="account.tax.report.line">
+                        <field name="name">Fält 48 – Ingående moms att dra av</field>
+                        <field name="code">se_48</field>
+                        <field name="tag_name">se_48</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_title_vat_debt_credit" model="account.tax.report.line">
+                <field name="name">Block G – Moms att betala eller få tillbaka</field>
+                <field name="code">se_g</field>
+                <field name="formula">se_b+se_i+se_d+se_f</field>
+                <field name="sequence">9</field>
+                <field name="children_line_ids">
+                    <record id="tax_report_line_49" model="account.tax.report.line">
+                        <field name="name">Fält 49 – Moms att betala eller få tillbaka</field>
+                        <field name="code">se_49</field>
+                        <field name="formula">se_b+se_i+se_d+se_f</field>
+                        <field name="sequence">1</field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
 </odoo>

--- a/addons/l10n_sg/data/account_tax_report_data.xml
+++ b/addons/l10n_sg/data/account_tax_report_data.xml
@@ -1,123 +1,94 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.sg"/>
-    </record>
-
-    <record id="account_tax_report_line_supplies" model="account.tax.report.line">
-        <field name="name">Supplies</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_line_std_rated_supplies" model="account.tax.report.line">
-        <field name="name">Box 1 - Total value of standard-rated supplies</field>
-        <field name="tag_name">Box 1</field>
-        <field name="code">BOX1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref='account_tax_report_line_supplies'/>
-    </record>
-
-    <record id="account_tax_report_line_zero_rated_supplies" model="account.tax.report.line">
-        <field name="name">Box 2 - Total value of zero-rated supplies</field>
-        <field name="tag_name">Box 2</field>
-        <field name="code">BOX2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref='account_tax_report_line_supplies'/>
-    </record>
-
-    <record id="account_tax_report_line_exempt_supplies" model="account.tax.report.line">
-        <field name="name">Box 3 - Total value of exempt supplies</field>
-        <field name="tag_name">Box 3</field>
-        <field name="code">BOX3</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref='account_tax_report_line_supplies'/>
-    </record>
-
-    <record id="account_tax_report_line_total_supplies" model="account.tax.report.line">
-        <field name="name">Box 4 - Total value of (1) + (2) + (3)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="formula">BOX1 + BOX2 + BOX3</field>
-        <field name="parent_id" ref='account_tax_report_line_supplies'/>
-    </record>
-
-    <record id="account_tax_report_line_purchases" model="account.tax.report.line">
-        <field name="name">Purchases</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_line_total_taxable_purchases" model="account.tax.report.line">
-        <field name="name">Box 5 - Total value of taxable purchases</field>
-        <field name="tag_name">Box 5</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref='account_tax_report_line_purchases'/>
-    </record>
-
-    <record id="account_tax_report_line_taxes" model="account.tax.report.line">
-        <field name="name">Taxes</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="account_tax_report_line_output_tax_due" model="account.tax.report.line">
-        <field name="name">Box 6 - Output tax due</field>
-        <field name="tag_name">Box 6</field>
-        <field name="code">BOX6</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref='account_tax_report_line_taxes'/>
-    </record>
-
-    <record id="account_tax_report_line_inp_tax_refund_claim" model="account.tax.report.line">
-        <field name="name">Box 7 - Less : Input tax and refunds claimed</field>
-        <field name="tag_name">Box 7</field>
-        <field name="code">BOX7</field>
-        <field name="parent_id" ref='account_tax_report_line_taxes'/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_line_total_gst_paid_iras" model="account.tax.report.line">
-        <field name="name">Box 8 - Equals : Net GST to be paid to IRAS</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">BOX6 - BOX7</field>
-        <field name="parent_id" ref='account_tax_report_line_taxes'/>
-    </record>
-
-    <record id="account_tax_report_line_applicable" model="account.tax.report.line">
-        <field name="name">Applicable to Taxable Persons under Major Exported Scheme / Approved 3rd Party Logistics Company / Other Approved Schemes Only</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="account_tax_report_line_applicable_goods_imported_value" model="account.tax.report.line">
-        <field name="name">Box 9 - Total value of goods imported under this scheme</field>
-        <field name="tag_name">Box 9</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_applicable"/>
-    </record>
-
-    <record id="account_tax_report_line_revenues" model="account.tax.report.line">
-        <field name="name">Revenue</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-    </record>
-
-    <record id="account_tax_report_line_revenues_accounting_period" model="account.tax.report.line">
-        <field name="name">Box 13 - Revenue for the accounting period</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">net_profit</field>
-        <field name="parent_id" ref="account_tax_report_line_revenues"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_supplies" model="account.tax.report.line">
+                <field name="name">Supplies</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_std_rated_supplies" model="account.tax.report.line">
+                        <field name="name">Box 1 - Total value of standard-rated supplies</field>
+                        <field name="tag_name">Box 1</field>
+                        <field name="code">BOX1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_zero_rated_supplies" model="account.tax.report.line">
+                        <field name="name">Box 2 - Total value of zero-rated supplies</field>
+                        <field name="tag_name">Box 2</field>
+                        <field name="code">BOX2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_line_exempt_supplies" model="account.tax.report.line">
+                        <field name="name">Box 3 - Total value of exempt supplies</field>
+                        <field name="tag_name">Box 3</field>
+                        <field name="code">BOX3</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="account_tax_report_line_total_supplies" model="account.tax.report.line">
+                        <field name="name">Box 4 - Total value of (1) + (2) + (3)</field>
+                        <field name="sequence" eval="4"/>
+                        <field name="formula">BOX1 + BOX2 + BOX3</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_purchases" model="account.tax.report.line">
+                <field name="name">Purchases</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_total_taxable_purchases" model="account.tax.report.line">
+                        <field name="name">Box 5 - Total value of taxable purchases</field>
+                        <field name="tag_name">Box 5</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_taxes" model="account.tax.report.line">
+                <field name="name">Taxes</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_output_tax_due" model="account.tax.report.line">
+                        <field name="name">Box 6 - Output tax due</field>
+                        <field name="tag_name">Box 6</field>
+                        <field name="code">BOX6</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_inp_tax_refund_claim" model="account.tax.report.line">
+                        <field name="name">Box 7 - Less : Input tax and refunds claimed</field>
+                        <field name="tag_name">Box 7</field>
+                        <field name="code">BOX7</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_line_total_gst_paid_iras" model="account.tax.report.line">
+                        <field name="name">Box 8 - Equals : Net GST to be paid to IRAS</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="formula">BOX6 - BOX7</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_applicable" model="account.tax.report.line">
+                <field name="name">Applicable to Taxable Persons under Major Exported Scheme / Approved 3rd Party Logistics Company / Other Approved Schemes Only</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_applicable_goods_imported_value" model="account.tax.report.line">
+                        <field name="name">Box 9 - Total value of goods imported under this scheme</field>
+                        <field name="tag_name">Box 9</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_revenues" model="account.tax.report.line">
+                <field name="name">Revenue</field>
+                <field name="sequence" eval="6"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_revenues_accounting_period" model="account.tax.report.line">
+                        <field name="name">Box 13 - Revenue for the accounting period</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">net_profit</field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_si/data/account_tax_report_data.xml
+++ b/addons/l10n_si/data/account_tax_report_data.xml
@@ -1,203 +1,151 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.si"/>
+        <field name="root_line_ids">
+            <record id="tax_report_zo_dvd" model="account.tax.report.line">
+                <field name="name">Znesek osnov za DDV</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_zo_dvd_neo" model="account.tax.report.line">
+                        <field name="name">Neodbitni DDV</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_zo_dvd_neo_sdtopni" model="account.tax.report.line">
+                                <field name="name">Vstopni DDV</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_zo_dvd_neo_sdtopni_osno" model="account.tax.report.line">
+                                        <field name="name">Nabave po osnovni stopnji DDV</field>
+                                        <field name="tag_name">Nabave po osnovni stopnji DDV (Neodbitni)</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_zo_dvd_neo_sdtopni_zni" model="account.tax.report.line">
+                                        <field name="name">Nabave po znižani stopnji DDV</field>
+                                        <field name="tag_name">Nabave po znižani stopnji DDV (Neodbitni)</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_zo_dvd_odb" model="account.tax.report.line">
+                        <field name="name">Odbitni DDV</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_zo_dvd_odb_izstopni" model="account.tax.report.line">
+                                <field name="name">Izstopni DDV</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_zo_dvd_odb_izstopni_opr" model="account.tax.report.line">
+                                        <field name="name">Prodaja oproščena DDV</field>
+                                        <field name="tag_name">Prodaja oproščena DDV</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_zo_dvd_odb_izstopni_osn" model="account.tax.report.line">
+                                        <field name="name">Prodaja po osnovni stopnji DDV</field>
+                                        <field name="tag_name">Prodaja po osnovni stopnji DDV</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="tax_report_zo_dvd_odb_izstopni_zni" model="account.tax.report.line">
+                                        <field name="name">Prodaja po znižani stopnji DDV</field>
+                                        <field name="tag_name">Prodaja po znižani stopnji DDV</field>
+                                        <field name="sequence" eval="3"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_zo_dvd_odb_vstopni" model="account.tax.report.line">
+                                <field name="name">Vstopni DDV</field>
+                                <field name="sequence" eval="2"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_zo_dvd_odb_vstopni_opr" model="account.tax.report.line">
+                                        <field name="name">Nabave oproščene DDV</field>
+                                        <field name="tag_name">Nabave oproščene DDV</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_zo_dvd_odb_vstopni_osn" model="account.tax.report.line">
+                                        <field name="name">Nabave po osnovni stopnji DDV</field>
+                                        <field name="tag_name">Nabave po osnovni stopnji DDV (Vstopni)</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                    <record id="tax_report_zo_dvd_odb_vstopni_zni" model="account.tax.report.line">
+                                        <field name="name">Nabave po znižani stopnji DDV</field>
+                                        <field name="tag_name">Nabave po znižani stopnji DDV (Vstopni)</field>
+                                        <field name="sequence" eval="3"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_zn_dvd" model="account.tax.report.line">
+                <field name="name">Znesek DDV</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_zn_dvd_neo" model="account.tax.report.line">
+                        <field name="name">Neodbitni DDV</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_zn_dvd_neo_vstopni" model="account.tax.report.line">
+                                <field name="name">Vstopni DDV</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_zn_dvd_neo_vstopni_osnnovna" model="account.tax.report.line">
+                                        <field name="name">Neodbitni DDV – osnovna stopnja</field>
+                                        <field name="tag_name">Neodbitni DDV – osnovna stopnja</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_zn_dvd_neo_vstopni_zni" model="account.tax.report.line">
+                                        <field name="name">Neodbitni DDV – znižana stopnja</field>
+                                        <field name="tag_name">Neodbitni DDV – znižana stopnja</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_zn_dvd_odb" model="account.tax.report.line">
+                        <field name="name">Odbitni DDV</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="tax_report_zn_dvd_odb_izstopni" model="account.tax.report.line">
+                                <field name="name">Izstopni DDV</field>
+                                <field name="sequence" eval="1"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_zn_dvd_odb_izstopni_osn" model="account.tax.report.line">
+                                        <field name="name">Izstopni DDV - osnovna stopnja</field>
+                                        <field name="tag_name">Izstopni DDV - osnovna stopnja</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_zn_dvd_odb_izstopni_zni" model="account.tax.report.line">
+                                        <field name="tag_name">Izstopni DDV - znižana stopnja</field>
+                                        <field name="name">Izstopni DDV - znižana stopnja</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_zn_dvd_odb_vstopni" model="account.tax.report.line">
+                                <field name="name">Vstopni DDV</field>
+                                <field name="sequence" eval="2"/>
+                                <field name="children_line_ids">
+                                    <record id="tax_report_zn_dvd_odb_vstopni_osn" model="account.tax.report.line">
+                                        <field name="name">Vstopni DDV - osnovna stopnja</field>
+                                        <field name="tag_name">Vstopni DDV - osnovna stopnja</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="tax_report_zn_dvd_odb_vstopni_zni" model="account.tax.report.line">
+                                        <field name="name">Vstopni DDV - znižana stopnja</field>
+                                        <field name="tag_name">Vstopni DDV - znižana stopnja</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-	<record id="tax_report_zo_dvd" model="account.tax.report.line">
-        <field name="name">Znesek osnov za DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_neo" model="account.tax.report.line">
-        <field name="name">Neodbitni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zo_dvd"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_neo_sdtopni" model="account.tax.report.line">
-        <field name="name">Vstopni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_neo"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_neo_sdtopni_osno" model="account.tax.report.line">
-        <field name="name">Nabave po osnovni stopnji DDV</field>
-        <field name="tag_name">Nabave po osnovni stopnji DDV (Neodbitni)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_neo_sdtopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_neo_sdtopni_zni" model="account.tax.report.line">
-        <field name="name">Nabave po znižani stopnji DDV</field>
-        <field name="tag_name">Nabave po znižani stopnji DDV (Neodbitni)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_neo_sdtopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb" model="account.tax.report.line">
-        <field name="name">Odbitni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zo_dvd"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_izstopni" model="account.tax.report.line">
-        <field name="name">Izstopni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_izstopni_opr" model="account.tax.report.line">
-        <field name="name">Prodaja oproščena DDV</field>
-        <field name="tag_name">Prodaja oproščena DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb_izstopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_izstopni_osn" model="account.tax.report.line">
-        <field name="name">Prodaja po osnovni stopnji DDV</field>
-        <field name="tag_name">Prodaja po osnovni stopnji DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb_izstopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_izstopni_zni" model="account.tax.report.line">
-        <field name="name">Prodaja po znižani stopnji DDV</field>
-        <field name="tag_name">Prodaja po znižani stopnji DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb_izstopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_vstopni" model="account.tax.report.line">
-        <field name="name">Vstopni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_vstopni_opr" model="account.tax.report.line">
-        <field name="name">Nabave oproščene DDV</field>
-        <field name="tag_name">Nabave oproščene DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb_vstopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_vstopni_osn" model="account.tax.report.line">
-        <field name="name">Nabave po osnovni stopnji DDV</field>
-        <field name="tag_name">Nabave po osnovni stopnji DDV (Vstopni)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb_vstopni"/>
-    </record>
-
-    <record id="tax_report_zo_dvd_odb_vstopni_zni" model="account.tax.report.line">
-        <field name="name">Nabave po znižani stopnji DDV</field>
-        <field name="tag_name">Nabave po znižani stopnji DDV (Vstopni)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_zo_dvd_odb_vstopni"/>
-    </record>
-
-    <record id="tax_report_zn_dvd" model="account.tax.report.line">
-        <field name="name">Znesek DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_neo" model="account.tax.report.line">
-        <field name="name">Neodbitni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zn_dvd"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_neo_vstopni" model="account.tax.report.line">
-        <field name="name">Vstopni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_neo"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_neo_vstopni_osnnovna" model="account.tax.report.line">
-        <field name="name">Neodbitni DDV – osnovna stopnja</field>
-        <field name="tag_name">Neodbitni DDV – osnovna stopnja</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_neo_vstopni"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_neo_vstopni_zni" model="account.tax.report.line">
-        <field name="name">Neodbitni DDV – znižana stopnja</field>
-        <field name="tag_name">Neodbitni DDV – znižana stopnja</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_neo_vstopni"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb" model="account.tax.report.line">
-        <field name="name">Odbitni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zn_dvd"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb_izstopni" model="account.tax.report.line">
-        <field name="name">Izstopni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_odb"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb_izstopni_osn" model="account.tax.report.line">
-        <field name="name">Izstopni DDV - osnovna stopnja</field>
-        <field name="tag_name">Izstopni DDV - osnovna stopnja</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_odb_izstopni"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb_izstopni_zni" model="account.tax.report.line">
-        <field name="tag_name">Izstopni DDV - znižana stopnja</field>
-        <field name="name">Izstopni DDV - znižana stopnja</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_odb_izstopni"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb_vstopni" model="account.tax.report.line">
-        <field name="name">Vstopni DDV</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_odb"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb_vstopni_osn" model="account.tax.report.line">
-        <field name="name">Vstopni DDV - osnovna stopnja</field>
-        <field name="tag_name">Vstopni DDV - osnovna stopnja</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_odb_vstopni"/>
-    </record>
-
-    <record id="tax_report_zn_dvd_odb_vstopni_zni" model="account.tax.report.line">
-        <field name="name">Vstopni DDV - znižana stopnja</field>
-        <field name="tag_name">Vstopni DDV - znižana stopnja</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_zn_dvd_odb_vstopni"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_th/data/account_tax_report_data.xml
+++ b/addons/l10n_th/data/account_tax_report_data.xml
@@ -1,134 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.th"/>
+        <field name="root_line_ids">
+            <record id="tax_report_out_tax_title" model="account.tax.report.line">
+                <field name="name">Output Tax</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_out_tax_sale" model="account.tax.report.line">
+                        <field name="name">1. Sales amount</field>
+                        <field name="tag_name">1. Sales amount</field>
+                        <field name="code">OUTPUTTAX_SALEAMOUNT</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_out_tax_less_sales_0_rate" model="account.tax.report.line">
+                        <field name="name">2. Less sales subject to 0% tax rate </field>
+                        <field name="tag_name">2. Less sales subject to 0% tax rate </field>
+                        <field name="code">OUTPUTTAX_SALE_ZERO</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="tax_report_out_tax_less_exempted_sales" model="account.tax.report.line">
+                        <field name="name">3. Less exempted sales</field>
+                        <field name="tag_name">3. Less exempted sales</field>
+                        <field name="code">OUTPUTTAX_EXEMPTED</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                    <record id="tax_report_out_tax_taxable_sales_amount" model="account.tax.report.line">
+                        <field name="name">4. Taxable sales amount(1. -2. -3.)</field>
+                        <field name="sequence" eval="4"/>
+                        <field name="formula">OUTPUTTAX_SALEAMOUNT-(OUTPUTTAX_SALE_ZERO+OUTPUTTAX_EXEMPTED)</field>
+                    </record>
+                    <record id="tax_report_out_tax" model="account.tax.report.line">
+                        <field name="name">5. Output tax</field>
+                        <field name="tag_name">5. Output tax</field>
+                        <field name="code">OUTPUTTAX_TAX</field>
+                        <field name="sequence" eval="5"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_input_tax_title" model="account.tax.report.line">
+                <field name="name">Input Tax</field>
+                <field name="code">INPUTTAX</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_input_tax_purchase_from_out_tax" model="account.tax.report.line">
+                        <field name="name">6. Purchase amount that is entitled to deduction of input tax from output tax in tax computation</field>
+                        <field name="tag_name">6. Purchase amount that is entitled to deduction of input tax from output tax in tax computation</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_input_tax" model="account.tax.report.line">
+                        <field name="name">7. Input tax (according to invoice of purchase amount in 6.)</field>
+                        <field name="tag_name">7. Input tax (according to invoice of purchase amount in 6.)</field>
+                        <field name="code">INPUTTAX_TAX</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_vat" model="account.tax.report.line">
+                <field name="name">Value Added Tax</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_vat_payable" model="account.tax.report.line">
+                        <field name="name">8. Tax payable (5. minus 7. (if 5. is greater than 7.))</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">OUTPUTTAX_TAX - INPUTTAX_TAX if (OUTPUTTAX_TAX &gt; INPUTTAX_TAX) else 0</field>
+                    </record>
+                    <record id="tax_report_vat_excess" model="account.tax.report.line">
+                        <field name="name">9. Excess tax payable (7. minus 5. (if 5. is less than 7.))</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="formula">INPUTTAX_TAX - OUTPUTTAX_TAX if (INPUTTAX_TAX &gt; OUTPUTTAX_TAX) else 0</field>
+                    </record>
+                    <record id="tax_report_vat_payment_last_period" model="account.tax.report.line">
+                        <field name="name">10. Excess tax payment carried forward from last period</field>
+                        <field name="sequence" eval="3"/>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_report_net_vat" model="account.tax.report.line">
+                <field name="name">Net Tax</field>
+                <field name="sequence" eval="4"/>
+                <field name="children_line_ids">
+                    <record id="tax_report_net_vat_payable" model="account.tax.report.line">
+                        <field name="name">11. Net tax payable (if 8. is greater than 10.)</field>
+                        <field name="tag_name">11. Net tax payable (if 8. is greater than 10.)</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="tax_report_net_vat_excess" model="account.tax.report.line">
+                        <field name="name">12. Net excess tax payable ((if 10. is greater than 8.) or (9. plus 10.))</field>
+                        <field name="tag_name">12. Net excess tax payable ((if 10. is greater than 8.) or (9. plus 10.))</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="tax_report_out_tax_title" model="account.tax.report.line">
-        <field name="name">Output Tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="tax_report_out_tax_sale" model="account.tax.report.line">
-        <field name="name">1. Sales amount</field>
-        <field name="tag_name">1. Sales amount</field>
-        <field name="code">OUTPUTTAX_SALEAMOUNT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_out_tax_title"/>
-    </record>
-
-    <record id="tax_report_out_tax_less_sales_0_rate" model="account.tax.report.line">
-        <field name="name">2. Less sales subject to 0% tax rate </field>
-        <field name="tag_name">2. Less sales subject to 0% tax rate </field>
-        <field name="code">OUTPUTTAX_SALE_ZERO</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_out_tax_title"/>
-    </record>
-
-    <record id="tax_report_out_tax_less_exempted_sales" model="account.tax.report.line">
-        <field name="name">3. Less exempted sales</field>
-        <field name="tag_name">3. Less exempted sales</field>
-        <field name="code">OUTPUTTAX_EXEMPTED</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_out_tax_title"/>
-    </record>
-
-    <record id="tax_report_out_tax_taxable_sales_amount" model="account.tax.report.line">
-        <field name="name">4. Taxable sales amount(1. -2. -3.)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="tax_report_out_tax_title"/>
-        <field name="formula">OUTPUTTAX_SALEAMOUNT-(OUTPUTTAX_SALE_ZERO+OUTPUTTAX_EXEMPTED)</field>
-    </record>
-
-    <record id="tax_report_out_tax" model="account.tax.report.line">
-        <field name="name">5. Output tax</field>
-        <field name="tag_name">5. Output tax</field>
-        <field name="code">OUTPUTTAX_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref="tax_report_out_tax_title"/>
-    </record>
-
-    <record id="tax_report_input_tax_title" model="account.tax.report.line">
-        <field name="name">Input Tax</field>
-        <field name="code">INPUTTAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="tax_report_input_tax_purchase_from_out_tax" model="account.tax.report.line">
-        <field name="name">6. Purchase amount that is entitled to deduction of input tax from output tax in tax computation</field>
-        <field name="tag_name">6. Purchase amount that is entitled to deduction of input tax from output tax in tax computation</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_input_tax_title"/>
-    </record>
-
-    <record id="tax_report_input_tax" model="account.tax.report.line">
-        <field name="name">7. Input tax (according to invoice of purchase amount in 6.)</field>
-        <field name="tag_name">7. Input tax (according to invoice of purchase amount in 6.)</field>
-        <field name="code">INPUTTAX_TAX</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_input_tax_title"/>
-    </record>
-
-    <record id="tax_report_vat" model="account.tax.report.line">
-        <field name="name">Value Added Tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="tax_report_vat_payable" model="account.tax.report.line">
-        <field name="name">8. Tax payable (5. minus 7. (if 5. is greater than 7.))</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_vat"/>
-        <field name="formula">OUTPUTTAX_TAX - INPUTTAX_TAX if (OUTPUTTAX_TAX > INPUTTAX_TAX) else 0</field>
-    </record>
-
-    <record id="tax_report_vat_excess" model="account.tax.report.line">
-        <field name="name">9. Excess tax payable (7. minus 5. (if 5. is less than 7.))</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_vat"/>
-        <field name="formula">INPUTTAX_TAX - OUTPUTTAX_TAX if (INPUTTAX_TAX > OUTPUTTAX_TAX) else 0</field>
-    </record>
-
-    <record id="tax_report_vat_payment_last_period" model="account.tax.report.line">
-        <field name="name">10. Excess tax payment carried forward from last period</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="tax_report_vat"/>
-    </record>
-
-    <record id="tax_report_net_vat" model="account.tax.report.line">
-        <field name="name">Net Tax</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-    </record>
-
-    <record id="tax_report_net_vat_payable" model="account.tax.report.line">
-        <field name="name">11. Net tax payable (if 8. is greater than 10.)</field>
-        <field name="tag_name">11. Net tax payable (if 8. is greater than 10.)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="tax_report_net_vat"/>
-    </record>
-
-    <record id="tax_report_net_vat_excess" model="account.tax.report.line">
-        <field name="name">12. Net excess tax payable ((if 10. is greater than 8.) or (9. plus 10.))</field>
-        <field name="tag_name">12. Net excess tax payable ((if 10. is greater than 8.) or (9. plus 10.))</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="tax_report_net_vat"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_uk/data/account_tax_report_data.xml
+++ b/addons/l10n_uk/data/account_tax_report_data.xml
@@ -1,104 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.uk"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_vat_cal" model="account.tax.report.line">
+                <field name="name">VAT calculations</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_vat_box1" model="account.tax.report.line">
+                        <field name="name">[BOX 1] VAT due on sales and other outputs</field>
+                        <field name="tag_name">1</field>
+                        <field name="code">UKTAX_1</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_vat_box2" model="account.tax.report.line">
+                        <field name="name">[BOX 2] VAT due on acquisitions from EC</field>
+                        <field name="tag_name">2</field>
+                        <field name="code">UKTAX_2</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                    <record id="account_tax_report_line_vat_box3" model="account.tax.report.line">
+                        <field name="name">[BOX 3] Total VAT due (box 1 + box 2)</field>
+                        <field name="sequence" eval="3"/>
+                        <field name="formula">UKTAX_1 + UKTAX_2</field>
+                    </record>
+                    <record id="account_tax_report_line_vat_box4" model="account.tax.report.line">
+                        <field name="name">[BOX 4] VAT reclaimed on purchases and other inputs (including acquisitions from EC)</field>
+                        <field name="tag_name">4</field>
+                        <field name="code">UKTAX_4</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="account_tax_report_line_vat_box5" model="account.tax.report.line">
+                        <field name="name">[BOX 5] VAT to pay/reclaim</field>
+                        <field name="sequence" eval="5"/>
+                        <field name="formula">UKTAX_1 + UKTAX_2 - UKTAX_4</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_exd_vat" model="account.tax.report.line">
+                <field name="name">Sales and Purchases Excluding VAT</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_exd_vat_box6" model="account.tax.report.line">
+                        <field name="name">[BOX 6] Total value of sales and other outputs excluding VAT (including EC supplies)</field>
+                        <field name="tag_name">6</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_exd_vat_box7" model="account.tax.report.line">
+                        <field name="name">[BOX 7] Total value of purchases and inputs excluding VAT (including EC acquisitions)</field>
+                        <field name="tag_name">7</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_ec_exd_vat" model="account.tax.report.line">
+                <field name="name">EC Sales and Purchases excluding VAT</field>
+                <field name="sequence" eval="3"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_exd_vat_box8" model="account.tax.report.line">
+                        <field name="name">[BOX 8] Total value of EC sales excluding VAT</field>
+                        <field name="tag_name">8</field>
+                        <field name="code">UKTAX_8</field>
+                        <field name="sequence" eval="1"/>
+                    </record>
+                    <record id="account_tax_report_line_exd_vat_box9" model="account.tax.report.line">
+                        <field name="name">[BOX 9] Total value of EC purchases excluding VAT</field>
+                        <field name="tag_name">9</field>
+                        <field name="code">UKTAX_9</field>
+                        <field name="sequence" eval="2"/>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_line_vat_cal" model="account.tax.report.line">
-        <field name="name">VAT calculations</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_box1" model="account.tax.report.line">
-        <field name="name">[BOX 1] VAT due on sales and other outputs</field>
-        <field name="tag_name">1</field>
-        <field name="code">UKTAX_1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_vat_cal"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_box2" model="account.tax.report.line">
-        <field name="name">[BOX 2] VAT due on acquisitions from EC</field>
-        <field name="tag_name">2</field>
-        <field name="code">UKTAX_2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_vat_cal"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_box3" model="account.tax.report.line">
-        <field name="name">[BOX 3] Total VAT due (box 1 + box 2)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="formula">UKTAX_1 + UKTAX_2</field>
-        <field name="parent_id" ref="account_tax_report_line_vat_cal"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_box4" model="account.tax.report.line">
-        <field name="name">[BOX 4] VAT reclaimed on purchases and other inputs (including acquisitions from EC)</field>
-        <field name="tag_name">4</field>
-        <field name="code">UKTAX_4</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_line_vat_cal"/>
-    </record>
-
-    <record id="account_tax_report_line_vat_box5" model="account.tax.report.line">
-        <field name="name">[BOX 5] VAT to pay/reclaim</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="formula">UKTAX_1 + UKTAX_2 - UKTAX_4</field>
-        <field name="parent_id" ref="account_tax_report_line_vat_cal"/>
-    </record>
-
-    <record id="account_tax_report_line_exd_vat" model="account.tax.report.line">
-        <field name="name">Sales and Purchases Excluding VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_line_exd_vat_box6" model="account.tax.report.line">
-        <field name="name">[BOX 6] Total value of sales and other outputs excluding VAT (including EC supplies)</field>
-        <field name="tag_name">6</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_exd_vat"/>
-    </record>
-
-    <record id="account_tax_report_line_ec_exd_vat" model="account.tax.report.line">
-        <field name="name">EC Sales and Purchases excluding VAT</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-    </record>
-
-    <record id="account_tax_report_line_exd_vat_box7" model="account.tax.report.line">
-        <field name="name">[BOX 7] Total value of purchases and inputs excluding VAT (including EC acquisitions)</field>
-        <field name="tag_name">7</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_exd_vat"/>
-    </record>
-
-    <record id="account_tax_report_line_exd_vat_box8" model="account.tax.report.line">
-        <field name="name">[BOX 8] Total value of EC sales excluding VAT</field>
-        <field name="tag_name">8</field>
-        <field name="code">UKTAX_8</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_ec_exd_vat"/>
-    </record>
-
-    <record id="account_tax_report_line_exd_vat_box9" model="account.tax.report.line">
-        <field name="name">[BOX 9] Total value of EC purchases excluding VAT</field>
-        <field name="tag_name">9</field>
-        <field name="code">UKTAX_9</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_ec_exd_vat"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_uy/data/account_tax_report_data.xml
+++ b/addons/l10n_uy/data/account_tax_report_data.xml
@@ -1,189 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.uy"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_base_impb" model="account.tax.report.line">
+                <field name="name">Base Imponible</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_base_impb_cmprs" model="account.tax.report.line">
+                        <field name="name">Base Imponible Compras</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_base_impb_cmprs_22" model="account.tax.report.line">
+                                <field name="name">Base Compras 22%</field>
+                                <field name="tag_name">Base Compras 22%</field>
+                                <field name="code">UYTAX_010101</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_base_impb_cmprs_10" model="account.tax.report.line">
+                                <field name="name">Base Compras 10%</field>
+                                <field name="tag_name">Base Compras 10%</field>
+                                <field name="code">UYTAX_020101</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_base_impb_cmprs_0" model="account.tax.report.line">
+                                <field name="name">Base Compras 0%</field>
+                                <field name="tag_name">Base Compras 0%</field>
+                                <field name="code">UYTAX_030101</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="account_tax_report_impb_cmprs" model="account.tax.report.line">
+                                <field name="name">Base Imponible Compras</field>
+                                <field name="tag_name">Base Imponible Compras</field>
+                                <field name="code">UYTAX_040101</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_base_impb_vnts" model="account.tax.report.line">
+                        <field name="name">Base Imponible Ventas</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_base_impb_vnts_22" model="account.tax.report.line">
+                                <field name="name">Base Ventas 22%</field>
+                                <field name="tag_name">Base Ventas 22%</field>
+                                <field name="code">UYTAX_010201</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_base_impb_vnts_10" model="account.tax.report.line">
+                                <field name="name">Base Ventas 10%</field>
+                                <field name="tag_name">Base Ventas 10%</field>
+                                <field name="code">UYTAX_020201</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_base_impb_vnts_0" model="account.tax.report.line">
+                                <field name="name">Base Ventas 0%</field>
+                                <field name="tag_name">Base Ventas 0%</field>
+                                <field name="code">UYTAX_030201</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="account_tax_report_impb_vnts" model="account.tax.report.line">
+                                <field name="name">Base Imponible Ventas</field>
+                                <field name="tag_name">Base Imponible Ventas</field>
+                                <field name="code">UYTAX_040201</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_sldo_iva" model="account.tax.report.line">
+                <field name="name">Saldo de IVA</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_iva_cmprs_pagdo" model="account.tax.report.line">
+                        <field name="name">IVA Compras - pagado</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_iva_cmprs_22" model="account.tax.report.line">
+                                <field name="name">IVA Compras 22%</field>
+                                <field name="tag_name">IVA Compras 22%</field>
+                                <field name="code">UYTAX_010102</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_iva_cmprs_10" model="account.tax.report.line">
+                                <field name="name">IVA Compras 10%</field>
+                                <field name="tag_name">IVA Compras 10%</field>
+                                <field name="code">UYTAX_020102</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_cmprs_exnto_iva" model="account.tax.report.line">
+                                <field name="name">Compras Exento IVA</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_cmprs_pagdo" model="account.tax.report.line">
+                        <field name="name">IVA Compras - pagado</field>
+                        <field name="tag_name">IVA Compras - pagado</field>
+                        <field name="code">UYTAX_040102</field>
+                        <field name="sequence" eval="4"/>
+                    </record>
+                    <record id="account_tax_report_iva_vnts_prcbdo" model="account.tax.report.line">
+                        <field name="name">IVA Ventas - percibido</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_iva_vnts_22" model="account.tax.report.line">
+                                <field name="name">IVA Ventas 22%</field>
+                                <field name="tag_name">IVA Ventas 22%</field>
+                                <field name="code">UYTAX_010202</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_iva_vnts_10" model="account.tax.report.line">
+                                <field name="name">IVA Ventas 10%</field>
+                                <field name="tag_name">IVA Ventas 10%</field>
+                                <field name="code">UYTAX_020202</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_vnts_iva" model="account.tax.report.line">
+                                <field name="name">Ventas Exento IVA</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="account_tax_report_vnts_prcbdo" model="account.tax.report.line">
+                                <field name="name">IVA Ventas - percibido</field>
+                                <field name="tag_name">IVA Ventas - percibido</field>
+                                <field name="code">UYTAX_040202</field>
+                                <field name="sequence" eval="4"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="account_tax_report_base_impb" model="account.tax.report.line">
-        <field name="name">Base Imponible</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_cmprs" model="account.tax.report.line">
-        <field name="name">Base Imponible Compras</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_base_impb"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_cmprs_22" model="account.tax.report.line">
-        <field name="name">Base Compras 22%</field>
-        <field name="tag_name">Base Compras 22%</field>
-        <field name="code">UYTAX_010101</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_cmprs"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_cmprs_10" model="account.tax.report.line">
-        <field name="name">Base Compras 10%</field>
-        <field name="tag_name">Base Compras 10%</field>
-        <field name="code">UYTAX_020101</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_cmprs"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_cmprs_0" model="account.tax.report.line">
-        <field name="name">Base Compras 0%</field>
-        <field name="tag_name">Base Compras 0%</field>
-        <field name="code">UYTAX_030101</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_cmprs"/>
-    </record>
-
-    <record id="account_tax_report_impb_cmprs" model="account.tax.report.line">
-        <field name="name">Base Imponible Compras</field>
-        <field name="tag_name">Base Imponible Compras</field>
-        <field name="code">UYTAX_040101</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_cmprs"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_vnts" model="account.tax.report.line">
-        <field name="name">Base Imponible Ventas</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_base_impb"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_vnts_22" model="account.tax.report.line">
-        <field name="name">Base Ventas 22%</field>
-        <field name="tag_name">Base Ventas 22%</field>
-        <field name="code">UYTAX_010201</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_vnts"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_vnts_10" model="account.tax.report.line">
-        <field name="name">Base Ventas 10%</field>
-        <field name="tag_name">Base Ventas 10%</field>
-        <field name="code">UYTAX_020201</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_vnts"/>
-    </record>
-
-    <record id="account_tax_report_base_impb_vnts_0" model="account.tax.report.line">
-        <field name="name">Base Ventas 0%</field>
-        <field name="tag_name">Base Ventas 0%</field>
-        <field name="code">UYTAX_030201</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_vnts"/>
-    </record>
-
-    <record id="account_tax_report_impb_vnts" model="account.tax.report.line">
-        <field name="name">Base Imponible Ventas</field>
-        <field name="tag_name">Base Imponible Ventas</field>
-        <field name="code">UYTAX_040201</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_base_impb_vnts"/>
-    </record>
-
-    <record id="account_tax_report_sldo_iva" model="account.tax.report.line">
-        <field name="name">Saldo de IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_iva_cmprs_pagdo" model="account.tax.report.line">
-        <field name="name">IVA Compras - pagado</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_sldo_iva"/>
-    </record>
-
-    <record id="account_tax_report_iva_cmprs_22" model="account.tax.report.line">
-        <field name="name">IVA Compras 22%</field>
-        <field name="tag_name">IVA Compras 22%</field>
-        <field name="code">UYTAX_010102</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_iva_cmprs_pagdo"/>
-    </record>
-
-    <record id="account_tax_report_iva_cmprs_10" model="account.tax.report.line">
-        <field name="name">IVA Compras 10%</field>
-        <field name="tag_name">IVA Compras 10%</field>
-        <field name="code">UYTAX_020102</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_iva_cmprs_pagdo"/>
-    </record>
-
-    <record id="account_tax_report_cmprs_exnto_iva" model="account.tax.report.line">
-        <field name="name">Compras Exento IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_iva_cmprs_pagdo"/>
-    </record>
-
-    <record id="account_tax_report_cmprs_pagdo" model="account.tax.report.line">
-        <field name="name">IVA Compras - pagado</field>
-        <field name="tag_name">IVA Compras - pagado</field>
-        <field name="code">UYTAX_040102</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_sldo_iva"/>
-    </record>
-
-    <record id="account_tax_report_iva_vnts_prcbdo" model="account.tax.report.line">
-        <field name="name">IVA Ventas - percibido</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_sldo_iva"/>
-    </record>
-
-    <record id="account_tax_report_iva_vnts_22" model="account.tax.report.line">
-        <field name="name">IVA Ventas 22%</field>
-        <field name="tag_name">IVA Ventas 22%</field>
-        <field name="code">UYTAX_010202</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_iva_vnts_prcbdo"/>
-    </record>
-
-    <record id="account_tax_report_iva_vnts_10" model="account.tax.report.line">
-        <field name="name">IVA Ventas 10%</field>
-        <field name="tag_name">IVA Ventas 10%</field>
-        <field name="code">UYTAX_020202</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_iva_vnts_prcbdo"/>
-    </record>
-
-    <record id="account_tax_report_vnts_iva" model="account.tax.report.line">
-        <field name="name">Ventas Exento IVA</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_iva_vnts_prcbdo"/>
-    </record>
-
-    <record id="account_tax_report_vnts_prcbdo" model="account.tax.report.line">
-        <field name="name">IVA Ventas - percibido</field>
-        <field name="tag_name">IVA Ventas - percibido</field>
-        <field name="code">UYTAX_040202</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="4"/>
-        <field name="parent_id" ref="account_tax_report_iva_vnts_prcbdo"/>
-    </record>
-
 </odoo>

--- a/addons/l10n_vn/data/account_tax_report_data.xml
+++ b/addons/l10n_vn/data/account_tax_report_data.xml
@@ -1,144 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.vn"/>
-    </record>
-
-     <record id="account_tax_report_line_01_vn" model="account.tax.report.line">
-        <field name="name">Purchase of Goods and Services</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="account_tax_report_line_01_01_vn" model="account.tax.report.line">
-        <field name="name">VAT on purchase of goods and services</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_01_01_01_vn" model="account.tax.report.line">
-        <field name="name">VAT on purchase of goods and services 0%</field>
-        <field name="tag_name">VAT on purchase of goods and services 0%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_01_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_01_01_vn" model="account.tax.report.line">
-        <field name="name">VAT on purchase of goods and services 5%</field>
-        <field name="tag_name">VAT on purchase of goods and services 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_01_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_03_01_01_vn" model="account.tax.report.line">
-        <field name="name">VAT on purchase of goods and services 10%</field>
-        <field name="tag_name">VAT on purchase of goods and services 10%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_01_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_01_vn" model="account.tax.report.line">
-        <field name="name">Untaxed Purchase of Goods and Services</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_01_02_01_vn" model="account.tax.report.line">
-        <field name="name">Untaxed Purchase of Goods and Services taxed 0%</field>
-        <field name="tag_name">Untaxed Purchase of Goods and Services taxed 0%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_02_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_02_01_vn" model="account.tax.report.line">
-        <field name="name">Untaxed Purchase of Goods and Services taxed 5%</field>
-        <field name="tag_name">Untaxed Purchase of Goods and Services taxed 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_02_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_03_02_01_vn" model="account.tax.report.line">
-        <field name="name">Untaxed Purchase of Goods and Services taxed 10%</field>
-        <field name="tag_name">Untaxed Purchase of Goods and Services taxed 10%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_02_01_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_vn" model="account.tax.report.line">
-        <field name="name">Sales of Goods and Services</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-    </record>
-
-    <record id="account_tax_report_line_01_02_vn" model="account.tax.report.line">
-        <field name="name">VAT on sales of goods and services</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_01_01_02_vn" model="account.tax.report.line">
-        <field name="name">VAT on sales of goods and services 0%</field>
-        <field name="tag_name">VAT on sales of goods and services 0%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_01_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_01_02_vn" model="account.tax.report.line">
-        <field name="name">VAT on sales of goods and services 5%</field>
-        <field name="tag_name">VAT on sales of goods and services 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_01_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_03_01_02_vn" model="account.tax.report.line">
-        <field name="name">VAT on sales of goods and services 10%</field>
-        <field name="tag_name">VAT on sales of goods and services 10%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_01_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_02_vn" model="account.tax.report.line">
-        <field name="name">Untaxed Sales of Goods and Services</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_01_02_02_vn" model="account.tax.report.line">
-        <field name="name">Untaxed sales of goods and services taxed 0%</field>
-        <field name="tag_name">Untaxed sales of goods and services taxed 0%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_tax_report_line_02_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_02_02_02_vn" model="account.tax.report.line">
-        <field name="name">Untaxed sales of goods and services taxed 5%</field>
-        <field name="tag_name">Untaxed sales of goods and services taxed 5%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_tax_report_line_02_02_vn"/>
-    </record>
-
-    <record id="account_tax_report_line_03_02_02_vn" model="account.tax.report.line">
-        <field name="name">Untaxed sales of goods and services taxed 10%</field>
-        <field name="tag_name">Untaxed sales of goods and services taxed 10%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref="account_tax_report_line_02_02_vn"/>
+        <field name="root_line_ids">
+            <record id="account_tax_report_line_01_vn" model="account.tax.report.line">
+                <field name="name">Purchase of Goods and Services</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_01_01_vn" model="account.tax.report.line">
+                        <field name="name">VAT on purchase of goods and services</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_01_01_01_vn" model="account.tax.report.line">
+                                <field name="name">VAT on purchase of goods and services 0%</field>
+                                <field name="tag_name">VAT on purchase of goods and services 0%</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_02_01_01_vn" model="account.tax.report.line">
+                                <field name="name">VAT on purchase of goods and services 5%</field>
+                                <field name="tag_name">VAT on purchase of goods and services 5%</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_03_01_01_vn" model="account.tax.report.line">
+                                <field name="name">VAT on purchase of goods and services 10%</field>
+                                <field name="tag_name">VAT on purchase of goods and services 10%</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_02_01_vn" model="account.tax.report.line">
+                        <field name="name">Untaxed Purchase of Goods and Services</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_01_02_01_vn" model="account.tax.report.line">
+                                <field name="name">Untaxed Purchase of Goods and Services taxed 0%</field>
+                                <field name="tag_name">Untaxed Purchase of Goods and Services taxed 0%</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_02_02_01_vn" model="account.tax.report.line">
+                                <field name="name">Untaxed Purchase of Goods and Services taxed 5%</field>
+                                <field name="tag_name">Untaxed Purchase of Goods and Services taxed 5%</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_03_02_01_vn" model="account.tax.report.line">
+                                <field name="name">Untaxed Purchase of Goods and Services taxed 10%</field>
+                                <field name="tag_name">Untaxed Purchase of Goods and Services taxed 10%</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_02_vn" model="account.tax.report.line">
+                <field name="name">Sales of Goods and Services</field>
+                <field name="sequence" eval="2"/>
+                <field name="children_line_ids">
+                    <record id="account_tax_report_line_01_02_vn" model="account.tax.report.line">
+                        <field name="name">VAT on sales of goods and services</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_01_01_02_vn" model="account.tax.report.line">
+                                <field name="name">VAT on sales of goods and services 0%</field>
+                                <field name="tag_name">VAT on sales of goods and services 0%</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_02_01_02_vn" model="account.tax.report.line">
+                                <field name="name">VAT on sales of goods and services 5%</field>
+                                <field name="tag_name">VAT on sales of goods and services 5%</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_03_01_02_vn" model="account.tax.report.line">
+                                <field name="name">VAT on sales of goods and services 10%</field>
+                                <field name="tag_name">VAT on sales of goods and services 10%</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_02_02_vn" model="account.tax.report.line">
+                        <field name="name">Untaxed Sales of Goods and Services</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="children_line_ids">
+                            <record id="account_tax_report_line_01_02_02_vn" model="account.tax.report.line">
+                                <field name="name">Untaxed sales of goods and services taxed 0%</field>
+                                <field name="tag_name">Untaxed sales of goods and services taxed 0%</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="account_tax_report_line_02_02_02_vn" model="account.tax.report.line">
+                                <field name="name">Untaxed sales of goods and services taxed 5%</field>
+                                <field name="tag_name">Untaxed sales of goods and services taxed 5%</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="account_tax_report_line_03_02_02_vn" model="account.tax.report.line">
+                                <field name="name">Untaxed sales of goods and services taxed 10%</field>
+                                <field name="tag_name">Untaxed sales of goods and services taxed 10%</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
 </odoo>

--- a/addons/l10n_za/data/account_tax_report_data.xml
+++ b/addons/l10n_za/data/account_tax_report_data.xml
@@ -1,253 +1,180 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.za"/>
+        <field name="root_line_ids">
+            <record id="total_vat_payable" model="account.tax.report.line">
+                <field name="name">[20] VAT PAYABLE/REFUNDABLE (Total A - Total B)</field>
+                <field name="formula"> (VAT4 + VAT4A + (SEC6 * 60/100 + SEC7) + VAT11 + VAT12) - (VAT14 + VAT14A + VAT15 + VAT16 + VAT17 + VAT18)</field>
+                <field name="sequence" eval="1"/>
+                <field name="children_line_ids">
+                    <record id="total_output_tax" model="account.tax.report.line">
+                        <field name="name">[13] Total A: TOTAL OUTPUT TAX (4 + 4A + 9 + 11 + 12)</field>
+                        <field name="sequence" eval="1"/>
+                        <field name="formula">VAT4 + VAT4A + (SEC6 * 60/100 + SEC7) + VAT11 + VAT12</field>
+                        <field name="children_line_ids">
+                            <record id="standard_rate_exclude_capital_goods_service" model="account.tax.report.line">
+                                <field name="name">[1] Standard Rate (Excluding Capital goods and/or services and accomodation)</field>
+                                <field name="tag_name">[1] Standard Rate (Excluding Capital goods and/or services and accomodation)</field>
+                                <field name="code">VAT1</field>
+                                <field name="sequence" eval="1"/>
+                            </record>
+                            <record id="vat_on_standard_rate_exclude_capital_goods_service" model="account.tax.report.line">
+                                <field name="name">[4] x 15/ (100 + 15)</field>
+                                <field name="tag_name">[4] x 15/ (100 + 15)</field>
+                                <field name="code">VAT4</field>
+                                <field name="sequence" eval="2"/>
+                            </record>
+                            <record id="standard_rate_only_capital_goods_service" model="account.tax.report.line">
+                                <field name="name">[1A] Standard Rate (Only Capital goods and/or services)</field>
+                                <field name="tag_name">[1A] Standard Rate (Only Capital goods and/or services)</field>
+                                <field name="code">VAT1A</field>
+                                <field name="sequence" eval="3"/>
+                            </record>
+                            <record id="vat_on_standard_rate_only_capital_goods_service" model="account.tax.report.line">
+                                <field name="name">[4A] x 15/ (100 + 15)</field>
+                                <field name="tag_name">[4A] x 15/ (100 + 15)</field>
+                                <field name="code">VAT4A</field>
+                                <field name="sequence" eval="5"/>
+                            </record>
+                            <record id="zero_rate_exclude_goods_exported" model="account.tax.report.line">
+                                <field name="name">[2] Zero Rate (excluding goods exported)</field>
+                                <field name="tag_name">[2] Zero Rate (excluding goods exported)</field>
+                                <field name="code">VAT2</field>
+                                <field name="sequence" eval="6"/>
+                            </record>
+                            <record id="zero_rate_only_goods_exported" model="account.tax.report.line">
+                                <field name="name">[2A] Zero Rate (Only goods exported)</field>
+                                <field name="tag_name">[2A] Zero Rate (Only goods exported)</field>
+                                <field name="code">VAT2A</field>
+                                <field name="sequence" eval="7"/>
+                            </record>
+                            <record id="exempt_and_non_supplies" model="account.tax.report.line">
+                                <field name="name">[3] Exempt and Non supplies</field>
+                                <field name="tag_name">[3] Exempt and Non supplies</field>
+                                <field name="code">VAT3</field>
+                                <field name="sequence" eval="8"/>
+                            </record>
+                            <record id="accomodation_exceeding_28_days" model="account.tax.report.line">
+                                <field name="name">[5] Accomodation exceeding 28 days</field>
+                                <field name="tag_name">[5] Accomodation exceeding 28 days</field>
+                                <field name="code">VAT5</field>
+                                <field name="sequence" eval="9"/>
+                            </record>
+                            <record id="accomodation_exceeding_28_days_60_percent" model="account.tax.report.line">
+                                <field name="name">[6] x 60%</field>
+                                <field name="sequence" eval="11"/>
+                                <field name="formula"> VAT5 * 60 / 100</field>
+                            </record>
+                            <record id="accomodation_under_28_days" model="account.tax.report.line">
+                                <field name="name">[7] Accomodation under 28 days</field>
+                                <field name="tag_name">[7] Accomodation under 28 days</field>
+                                <field name="code">VAT7</field>
+                                <field name="sequence" eval="12"/>
+                            </record>
+                            <record id="accomodation_28_days" model="account.tax.report.line">
+                                <field name="name">[8] Total (6 + 7)</field>
+                                <field name="sequence" eval="14"/>
+                                <field name="formula">(VAT5 * 60 / 100) + VAT7</field>
+                            </record>
+                            <record id="vat_on_accomodation_28_days" model="account.tax.report.line">
+                                <field name="name">[9] x 15 / (100 ??) </field>
+                                <field name="sequence" eval="15"/>
+                                <field name="formula"> SEC6 * 60/100 + SEC7 </field>
+                                <field name="children_line_ids">
+                                    <record id="vat_on_accomodation_exceeding_28_days" model="account.tax.report.line">
+                                        <field name="name">VAT on Accomodation exceeding 28 days</field>
+                                        <field name="tag_name">VAT on Accomodation exceeding 28 days</field>
+                                        <field name="code">SEC6</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                    <record id="vat_on_accomodation_under_28_days" model="account.tax.report.line">
+                                        <field name="name">VAT on Accomodation under 28 days</field>
+                                        <field name="tag_name">VAT on Accomodation under 28 days</field>
+                                        <field name="code">SEC7</field>
+                                        <field name="sequence" eval="2"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="vat_plus_base_of_second_hand_goods_export" model="account.tax.report.line">
+                                <field name="name">[10] Change in use and export of second-hand goods</field>
+                                <field name="sequence" eval="17"/>
+                                <field name="formula"> VAT10a + VAT11</field>
+                                <field name="children_line_ids">
+                                    <record id="second_hand_goods_export" model="account.tax.report.line">
+                                        <field name="name">[10] Base Amount: Change in use and export of second-hand goods</field>
+                                        <field name="tag_name">[10] Change in use and export of second-hand goods</field>
+                                        <field name="code">VAT10a</field>
+                                        <field name="sequence" eval="1"/>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="vat_on_second_hand_goods_export" model="account.tax.report.line">
+                                <field name="name">[11] x 15 / (100 + 15)</field>
+                                <field name="tag_name">[11] x 15 / (100 + 15)</field>
+                                <field name="code">VAT11</field>
+                                <field name="sequence" eval="18"/>
+                            </record>
+                            <record id="other_imported_services" model="account.tax.report.line">
+                                <field name="name">[12] Other and imported services</field>
+                                <field name="tag_name">[12] Other and imported services</field>
+                                <field name="code">VAT12</field>
+                                <field name="sequence" eval="19"/>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="total_input_tax" model="account.tax.report.line">
+                        <field name="name">[19] Total B: TOTAL INPUT TAX (14 + 14A + 15 + 16 + 17 + 18)</field>
+                        <field name="sequence" eval="2"/>
+                        <field name="formula">VAT14 + VAT14A + VAT15 + VAT16 + VAT17 + VAT18</field>
+                        <field name="children_line_ids">
+                            <record id="capital_goods_services_supplied" model="account.tax.report.line">
+                                <field name="name">[14] Capital Goods and/or services supplied to you</field>
+                                <field name="tag_name">[14] Capital Goods and/or services supplied to you</field>
+                                <field name="code">VAT14</field>
+                                <field name="sequence" eval="21"/>
+                            </record>
+                            <record id="capital_goods_imported" model="account.tax.report.line">
+                                <field name="name">[14A] Capital Goods imported by you</field>
+                                <field name="tag_name">[14A] Capital Goods imported by you</field>
+                                <field name="code">VAT14A</field>
+                                <field name="sequence" eval="22"/>
+                            </record>
+                            <record id="other_goods_services_supplied" model="account.tax.report.line">
+                                <field name="name">[15] Other goods and/or services supplied to you (not Capital Goods)</field>
+                                <field name="tag_name">[15] Other goods and/or services supplied to you (not Capital Goods)</field>
+                                <field name="code">VAT15</field>
+                                <field name="sequence" eval="23"/>
+                            </record>
+                            <record id="other_goods_imported" model="account.tax.report.line">
+                                <field name="name">[15A] Other goods imported by you (not Capital Goods)</field>
+                                <field name="tag_name">[15A] Other goods imported by you (not Capital Goods)</field>
+                                <field name="code">VAT15A</field>
+                                <field name="sequence" eval="24"/>
+                            </record>
+                            <record id="change_in_use" model="account.tax.report.line">
+                                <field name="name">[16] Change in Use</field>
+                                <field name="tag_name">[16] Change in Use</field>
+                                <field name="code">VAT16</field>
+                                <field name="sequence" eval="25"/>
+                            </record>
+                            <record id="bad_debts" model="account.tax.report.line">
+                                <field name="name">[17] Bad Debts</field>
+                                <field name="tag_name">[17] Bad Debts</field>
+                                <field name="code">VAT17</field>
+                                <field name="sequence" eval="26"/>
+                            </record>
+                            <record id="others" model="account.tax.report.line">
+                                <field name="name">[18] Other</field>
+                                <field name="tag_name">[18] Other</field>
+                                <field name="code">VAT18</field>
+                                <field name="sequence" eval="27"/>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
     </record>
-
-    <record id="total_vat_payable" model="account.tax.report.line">
-        <field name="name">[20] VAT PAYABLE/REFUNDABLE (Total A - Total B)</field>
-        <field name="formula"> (VAT4 + VAT4A + (SEC6 * 60/100 + SEC7) + VAT11 + VAT12) - (VAT14 + VAT14A + VAT15 + VAT16 + VAT17 + VAT18)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-    </record>
-
-    <record id="total_output_tax" model="account.tax.report.line">
-        <field name="name">[13] Total A: TOTAL OUTPUT TAX (4 + 4A + 9 + 11 + 12)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="formula">VAT4 + VAT4A + (SEC6 * 60/100 + SEC7) + VAT11 + VAT12</field>
-        <field name="parent_id" ref='total_vat_payable'/>
-    </record>
-
-    <record id="total_input_tax" model="account.tax.report.line">
-        <field name="name">[19] Total B: TOTAL INPUT TAX (14 + 14A + 15 + 16 + 17 + 18)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="formula">VAT14 + VAT14A + VAT15 + VAT16 + VAT17 + VAT18</field>
-        <field name="parent_id" ref='total_vat_payable'/>
-    </record>
-
-    <record id="standard_rate_exclude_capital_goods_service" model="account.tax.report.line">
-        <field name="name">[1] Standard Rate (Excluding Capital goods and/or services and accomodation)</field>
-        <field name="tag_name">[1] Standard Rate (Excluding Capital goods and/or services and accomodation)</field>
-        <field name="code">VAT1</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="vat_on_standard_rate_exclude_capital_goods_service" model="account.tax.report.line">
-        <field name="name">[4] x 15/ (100 + 15)</field>
-        <field name="tag_name">[4] x 15/ (100 + 15)</field>
-        <field name="code">VAT4</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="standard_rate_only_capital_goods_service" model="account.tax.report.line">
-        <field name="name">[1A] Standard Rate (Only Capital goods and/or services)</field>
-        <field name="tag_name">[1A] Standard Rate (Only Capital goods and/or services)</field>
-        <field name="code">VAT1A</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="3"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="vat_on_standard_rate_only_capital_goods_service" model="account.tax.report.line">
-        <field name="name">[4A] x 15/ (100 + 15)</field>
-        <field name="tag_name">[4A] x 15/ (100 + 15)</field>
-        <field name="code">VAT4A</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="5"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="zero_rate_exclude_goods_exported" model="account.tax.report.line">
-        <field name="name">[2] Zero Rate (excluding goods exported)</field>
-        <field name="tag_name">[2] Zero Rate (excluding goods exported)</field>
-        <field name="code">VAT2</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="6"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="zero_rate_only_goods_exported" model="account.tax.report.line">
-        <field name="name">[2A] Zero Rate (Only goods exported)</field>
-        <field name="tag_name">[2A] Zero Rate (Only goods exported)</field>
-        <field name="code">VAT2A</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="7"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="exempt_and_non_supplies" model="account.tax.report.line">
-        <field name="name">[3] Exempt and Non supplies</field>
-        <field name="tag_name">[3] Exempt and Non supplies</field>
-        <field name="code">VAT3</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="8"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="accomodation_exceeding_28_days" model="account.tax.report.line">
-        <field name="name">[5] Accomodation exceeding 28 days</field>
-        <field name="tag_name">[5] Accomodation exceeding 28 days</field>
-        <field name="code">VAT5</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="9"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="accomodation_exceeding_28_days_60_percent" model="account.tax.report.line">
-        <field name="name">[6] x 60%</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="11"/>
-        <field name="formula"> VAT5 * 60 / 100</field>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="accomodation_under_28_days" model="account.tax.report.line">
-        <field name="name">[7] Accomodation under 28 days</field>
-        <field name="tag_name">[7] Accomodation under 28 days</field>
-        <field name="code">VAT7</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="12"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="accomodation_28_days" model="account.tax.report.line">
-        <field name="name">[8] Total (6 + 7)</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="14"/>
-        <field name="formula">(VAT5 * 60 / 100) + VAT7</field>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="vat_on_accomodation_28_days" model="account.tax.report.line">
-        <field name="name">[9] x 15 / (100 ??) </field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="15"/>
-        <field name="formula"> SEC6 * 60/100 + SEC7 </field>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="vat_on_accomodation_exceeding_28_days" model="account.tax.report.line">
-        <field name="name">VAT on Accomodation exceeding 28 days</field>
-        <field name="tag_name">VAT on Accomodation exceeding 28 days</field>
-        <field name="code">SEC6</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref='vat_on_accomodation_28_days'/>
-    </record>
-
-    <record id="vat_on_accomodation_under_28_days" model="account.tax.report.line">
-        <field name="name">VAT on Accomodation under 28 days</field>
-        <field name="tag_name">VAT on Accomodation under 28 days</field>
-        <field name="code">SEC7</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="2"/>
-        <field name="parent_id" ref='vat_on_accomodation_28_days'/>
-    </record>
-
-    <record id="vat_plus_base_of_second_hand_goods_export" model="account.tax.report.line">
-        <field name="name">[10] Change in use and export of second-hand goods</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="17"/>
-        <field name="formula"> VAT10a + VAT11</field>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="second_hand_goods_export" model="account.tax.report.line">
-        <field name="name">[10] Base Amount: Change in use and export of second-hand goods</field>
-        <field name="tag_name">[10] Change in use and export of second-hand goods</field>
-        <field name="code">VAT10a</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="1"/>
-        <field name="parent_id" ref='vat_plus_base_of_second_hand_goods_export'/>
-    </record>
-
-    <record id="vat_on_second_hand_goods_export" model="account.tax.report.line">
-        <field name="name">[11] x 15 / (100 + 15)</field>
-        <field name="tag_name">[11] x 15 / (100 + 15)</field>
-        <field name="code">VAT11</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="18"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="other_imported_services" model="account.tax.report.line">
-        <field name="name">[12] Other and imported services</field>
-        <field name="tag_name">[12] Other and imported services</field>
-        <field name="code">VAT12</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="19"/>
-        <field name="parent_id" ref='total_output_tax'/>
-    </record>
-
-    <record id="capital_goods_services_supplied" model="account.tax.report.line">
-        <field name="name">[14] Capital Goods and/or services supplied to you</field>
-        <field name="tag_name">[14] Capital Goods and/or services supplied to you</field>
-        <field name="code">VAT14</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="21"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
-    <record id="capital_goods_imported" model="account.tax.report.line">
-        <field name="name">[14A] Capital Goods imported by you</field>
-        <field name="tag_name">[14A] Capital Goods imported by you</field>
-        <field name="code">VAT14A</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="22"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
-    <record id="other_goods_services_supplied" model="account.tax.report.line">
-        <field name="name">[15] Other goods and/or services supplied to you (not Capital Goods)</field>
-        <field name="tag_name">[15] Other goods and/or services supplied to you (not Capital Goods)</field>
-        <field name="code">VAT15</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="23"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
-    <record id="other_goods_imported" model="account.tax.report.line">
-        <field name="name">[15A] Other goods imported by you (not Capital Goods)</field>
-        <field name="tag_name">[15A] Other goods imported by you (not Capital Goods)</field>
-        <field name="code">VAT15A</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="24"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
-    <record id="change_in_use" model="account.tax.report.line">
-        <field name="name">[16] Change in Use</field>
-        <field name="tag_name">[16] Change in Use</field>
-        <field name="code">VAT16</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="25"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
-    <record id="bad_debts" model="account.tax.report.line">
-        <field name="name">[17] Bad Debts</field>
-        <field name="tag_name">[17] Bad Debts</field>
-        <field name="code">VAT17</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="26"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
-    <record id="others" model="account.tax.report.line">
-        <field name="name">[18] Other</field>
-        <field name="tag_name">[18] Other</field>
-        <field name="code">VAT18</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence" eval="27"/>
-        <field name="parent_id" ref='total_input_tax'/>
-    </record>
-
 </odoo>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -160,6 +160,9 @@
                     <rng:empty/>
                 </rng:group>
                 <rng:text/>
+                <rng:zeroOrMore>
+                    <rng:ref name="record" />
+                </rng:zeroOrMore>
             </rng:choice>
         </rng:element>
     </rng:define>


### PR DESCRIPTION
Some data are formatted as a tree structure with a relation of parent.
We are adding meaning to the structure:

* This improves readability and allows to fold/unfold records in
  editors.
* This could be done before using `eval`, but this allows to have an
  xml_id for those records. It also allows to update the records without
  having to rewrite on the parent x2many field.

We also convert all the tax reports using this new way of declaring data.

Conversion script:
https://gist.github.com/william-andre/e8adf5173f95309c078805881f5d3220


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
