### PR TITLE
[FIX] sale_coupon: Prommotional program applied on canceled SO

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -329,10 +329,11 @@ class SaleOrder(models.Model):
             # We should only apply a little part of the checks in _check_promo_code...
             error_status = program._check_promo_code(order, False)
             if not error_status.get('error'):
-                if program.promo_applicability == 'on_next_order':
-                    order.state != 'cancel' and order._create_reward_coupon(program)
-                elif program.discount_line_product_id.id not in self.order_line.mapped('product_id').ids:
-                    self.write({'order_line': [(0, False, value) for value in self._get_reward_line_values(program)]})
+                if order.state != 'cancel':
+                    if program.promo_applicability == 'on_next_order':
+                        order._create_reward_coupon(program)
+                    elif program.discount_line_product_id.id not in self.order_line.mapped('product_id').ids:
+                        self.write({'order_line': [(0, False, value) for value in self._get_reward_line_values(program)]})
                 order.no_code_promo_program_ids |= program
 
     def _update_existing_reward_lines(self):


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a promotional program P with 'Fixed amount' discount of $50 and 'Automatically applied' on current order
- Create SO and cancel it

Bug:

P was applied on the canceled SO

opw:2579344