### PR TITLE
[FIX] project: align the div to the right in the activity view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1211,11 +1211,15 @@
                 <activity string="Project Tasks" js_class="project_activity">
                     <field name="user_ids"/>
                     <templates>
-                        <div t-name="activity-box">
+                        <div class="justify-content-between" t-name="activity-box">
                             <field name="user_ids" widget="many2many_avatar_user"/>
-                            <div>
-                                <field name="name" display="full"/>
-                                <field name="project_id" muted="1" display="full" invisible="context.get('default_project_id', False)"/>
+                            <div class="text-right">
+                                <span t-att-title="record.name.value">
+                                    <field name="name" display="full"/>
+                                </span>
+                                <span t-att-title="record.project_id.value">
+                                    <field name="project_id" muted="1" display="full" invisible="context.get('default_project_id', False)"/>
+                                </span>
                             </div>
                         </div>
                     </templates>


### PR DESCRIPTION
The purpose of this commit is to display the project name and task
to the right of the div in the activity view.

before this commit, the project name and task displays next to
the many2many_tags div in the activity view.

TaskID-2646204