### PR TITLE
[FIX] web: export empty relational field in xlsx as empty string

### DIFF
--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -266,7 +266,7 @@ class TestGroupedExport(XlsxCreatorCase):
             ['    export.integer:4 (1)' ,''],
             ['10'                       ,'export.integer:4'],
             ['    Undefined (1)'        ,''],
-            ['10'                       ,'False'],
+            ['10'                       ,''],
         ])
 
     def test_nested_records(self):

--- a/odoo/addons/test_impex/tests/test_export.py
+++ b/odoo/addons/test_impex/tests/test_export.py
@@ -323,7 +323,7 @@ class test_m2o(CreatorCase):
     def test_empty(self):
         self.assertEqual(
             self.export(False),
-            [[False]])
+            [['']])
 
     def test_basic(self):
         """ Exported value is the name_get of the related object
@@ -384,7 +384,7 @@ class test_o2m(CreatorCase):
     def test_empty(self):
         self.assertEqual(
             self.export(False),
-            [[False]])
+            [['']])
 
     def test_single(self):
         self.assertEqual(
@@ -499,16 +499,16 @@ class test_o2m_multiple(CreatorCase):
     def test_empty(self):
         self.assertEqual(
             self.export(child1=False, child2=False),
-            [[False, False]])
+            [['', '']])
 
     def test_single_per_side(self):
         self.assertEqual(
             self.export(child1=False, child2=[(0, False, {'value': 42})]),
-            [[False, u'export.one2many.child.2:42']])
+            [['', u'export.one2many.child.2:42']])
 
         self.assertEqual(
             self.export(child1=[(0, False, {'value': 43})], child2=False),
-            [[u'export.one2many.child.1:43', False]])
+            [[u'export.one2many.child.1:43', '']])
 
         self.assertEqual(
             self.export(child1=[(0, False, {'value': 43})],
@@ -520,12 +520,12 @@ class test_o2m_multiple(CreatorCase):
         self.assertEqual(
             self.export(child1=False, child2=[(0, False, {'value': 42})],
                         fields=fields),
-            [[36, False, 42]])
+            [[36, '', 42]])
 
         self.assertEqual(
             self.export(child1=[(0, False, {'value': 43})], child2=False,
                         fields=fields),
-            [[36, 43, False]])
+            [[36, 43, '']])
 
         self.assertEqual(
             self.export(child1=[(0, False, {'value': 43})],
@@ -546,7 +546,7 @@ class test_o2m_multiple(CreatorCase):
         self.assertEqual(
             self.export(child1=child1, child2=False, fields=fields),
             [
-                [36, 4, False],
+                [36, 4, ''],
                 ['', 42, ''],
                 ['', 36, ''],
                 ['', 4, ''],
@@ -555,7 +555,7 @@ class test_o2m_multiple(CreatorCase):
         self.assertEqual(
             self.export(child1=False, child2=child2, fields=fields),
             [
-                [36, False, 8],
+                [36, '', 8],
                 ['', '', 12],
                 ['', '', 8],
                 ['', '', 55],
@@ -595,7 +595,7 @@ class test_m2m(CreatorCase):
     def test_empty(self):
         self.assertEqual(
             self.export(False),
-            [[False]])
+            [['']])
 
     def test_single(self):
         self.assertEqual(

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -876,7 +876,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                         # a comma-separated list of xids in a single cell
                         if import_compatible and field.type == 'many2many' and len(path) > 1 and path[1] == 'id':
                             xml_ids = [xid for _, xid in value.__ensure_xml_id()]
-                            current[i] = ','.join(xml_ids) or False
+                            current[i] = ','.join(xml_ids)
                             continue
 
                         # recursively export the fields that follow name; use
@@ -892,7 +892,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                             # append the other lines at the end
                             lines += lines2[1:]
                         else:
-                            current[i] = False
+                            current[i] = ''
 
         # if any xid should be exported, only do so at toplevel
         if _is_toplevel_call and any(f[-1] == 'id' for f in fields):


### PR DESCRIPTION
**Steps to follow**

  - Go to the contact app for example
  - Export some records with a relational field in the import-compatible xlsx format
  - Reimport the downloaded file
  - Odoo can't find matching records with a name False

**Cause of the issue**

  xlsxwriter will write a boolean false value for empty relations

**Solution**

  If a field is relational, write an empty string instead

opw-2643705