### PR TITLE
[FIX] l10n_ar: fix l10n_ar_currency_rate

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -177,11 +177,10 @@ class AccountMove(models.Model):
         for rec in ar_invoices:
             rec.l10n_ar_afip_responsibility_type_id = rec.commercial_partner_id.l10n_ar_afip_responsibility_type_id.id
             if rec.company_id.currency_id == rec.currency_id:
-                l10n_ar_currency_rate = 1.0
-            else:
-                l10n_ar_currency_rate = rec.currency_id._convert(
+                rec.l10n_ar_currency_rate = 1.0
+            elif not rec.l10n_ar_currency_rate:
+                rec.l10n_ar_currency_rate = rec.currency_id._convert(
                     1.0, rec.company_id.currency_id, rec.company_id, rec.invoice_date or fields.Date.today(), round=False)
-            rec.l10n_ar_currency_rate = l10n_ar_currency_rate
 
         # We make validations here and not with a constraint because we want validation before sending electronic
         # data on l10n_ar_edi


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If an invoice is posted, sended back to draft and the rate was change on res.currency, we preserve the value already existing on l10n_ar_currency_rate

Current behavior before PR:
l10n_ar_currency_rate is changed on an already posted invoie

Desired behavior after PR is merged:
l10n_ar_currency_rate should not be changed


Video showing before: https://drive.google.com/file/d/1IPk8XrB_DJUJHRmPZg2RrsqOFImBJsQw/view

Video showing after: https://drive.google.com/file/d/1WP2f3xXMqtXYjkKLUwWWBHxURKYMR7bA/view


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
