### PR TITLE
[fix] project: task's gantt view popover assignee show users ids

### DIFF
--- a/addons/web_tour/static/src/scss/tip.scss
+++ b/addons/web_tour/static/src/scss/tip.scss
@@ -130,6 +130,7 @@ $o-tip-size-delay-in: $o-tip-duration-in - $o-tip-size-duration-in;
 
         // Force style so that it does not depend on where the tooltip is attached
         line-height: $line-height-base;
+        font-size: $font-size-base;
         font-family: $font-family-sans-serif;
         font-weight: normal;
 

--- a/addons/web_tour/static/src/scss/tip.scss
+++ b/addons/web_tour/static/src/scss/tip.scss
@@ -130,7 +130,6 @@ $o-tip-size-delay-in: $o-tip-duration-in - $o-tip-size-duration-in;
 
         // Force style so that it does not depend on where the tooltip is attached
         line-height: $line-height-base;
-        font-size: $font-size-base;
         font-family: $font-family-sans-serif;
         font-weight: normal;
 


### PR DESCRIPTION
purpose of this task is to display  assignee's names in  task's gantt view
popover instead of  ids.

id-2647037

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
