### PR TITLE
[FIX] mail: add missing notifition when leaving a channel

### DIFF
--- a/addons/mail/models/mail_channel_partner.py
+++ b/addons/mail/models/mail_channel_partner.py
@@ -66,7 +66,7 @@ class ChannelPartner(models.Model):
         return super(ChannelPartner, self).write(vals)
 
     def unlink(self):
-        self.sudo().rtc_session_ids.unlink()
+        self.sudo().rtc_session_ids._disconnect()
         return super().unlink()
 
     @api.model

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -822,6 +822,9 @@ function factory(dependencies) {
                 }
             }
             this.mailRtc && this.mailRtc.filterCallees(this.rtcSessions);
+            if (this.mailRtc && !this.mailRtc.currentRtcSession) {
+                this.endCall();
+            }
         }
 
         /**


### PR DESCRIPTION
This will close the RTC session when a user leave a channel with a RTC session
open.

task-2646095