### PR TITLE
[IMP] hr_holidays: allow users to cancel Time Off

### DIFF
--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -41,6 +41,7 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
         'views/hr_leave_accrual_views.xml',
         'views/mail_activity_views.xml',
 
+        'wizard/hr_holidays_cancel_leave_views.xml',
         'wizard/hr_holidays_summary_employees_views.xml',
         'wizard/hr_departure_wizard_views.xml',
 

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -107,6 +107,7 @@ class HolidaysRequest(models.Model):
             new_values['request_unit_custom'] = True
         return new_values
 
+    active = fields.Boolean(default=True)
     # description
     name = fields.Char('Description', compute='_compute_description', inverse='_inverse_description', search='_search_description', compute_sudo=False)
     private_name = fields.Char('Time Off Description', groups='hr_holidays.group_hr_holidays_user')
@@ -140,7 +141,7 @@ class HolidaysRequest(models.Model):
         states={'cancel': [('readonly', True)], 'refuse': [('readonly', True)], 'validate1': [('readonly', True)], 'validate': [('readonly', True)]},
         tracking=True)
     employee_company_id = fields.Many2one(related='employee_id.company_id', readonly=True, store=True)
-    active_employee = fields.Boolean(related='employee_id.active', readonly=True)
+    active_employee = fields.Boolean(related='employee_id.active', string='Employee Active', readonly=True)
     tz_mismatch = fields.Boolean(compute='_compute_tz_mismatch')
     tz = fields.Selection(_tz_get, compute='_compute_tz')
     department_id = fields.Many2one(
@@ -198,6 +199,7 @@ class HolidaysRequest(models.Model):
         help='This area is automatically filled by the user who validate the time off with second level (If time off type need second validation)')
     can_reset = fields.Boolean('Can reset', compute='_compute_can_reset')
     can_approve = fields.Boolean('Can Approve', compute='_compute_can_approve')
+    can_cancel = fields.Boolean('Can Cancel', compute='_compute_can_cancel')
 
     attachment_ids = fields.One2many('ir.attachment', 'res_id', string="Attachments")
     # To display in form view
@@ -615,6 +617,13 @@ class HolidaysRequest(models.Model):
             else:
                 holiday.can_approve = True
 
+    @api.depends_context('uid')
+    @api.depends('state', 'employee_id')
+    def _compute_can_cancel(self):
+        today = fields.Datetime.today()
+        for leave in self:
+            leave.can_cancel = leave.id and leave.employee_id.user_id == self.env.user and leave.state == 'validate' and leave.date_from and leave.date_from > today
+
     @api.depends('state')
     def _compute_is_hatched(self):
         for holiday in self:
@@ -883,8 +892,10 @@ class HolidaysRequest(models.Model):
         return holidays
 
     def write(self, values):
-        is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
+        if 'active' in values and not values['active'] and not self.env.context.get('from_cancel_wizard'):
+            raise UserError(_("You can't manually archive a time off."))
 
+        is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
         if not is_officer:
             if any(hol.date_from.date() < fields.Date.today() and hol.employee_id.leave_manager_id != self.env.user for hol in self):
                 raise UserError(_('You must have manager rights to modify/validate a time off that already begun'))
@@ -1030,6 +1041,21 @@ class HolidaysRequest(models.Model):
             'employee_ids': employee,
             'state': 'validate',
         } for employee in employees if work_days_data[employee.id]['days']]
+
+    def action_cancel(self):
+        self.ensure_one()
+
+        return {
+            'name': _('Cancel Time Off'),
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'res_model': 'hr.holidays.cancel.leave',
+            'view_mode': 'form',
+            'views': [[False, 'form']],
+            'context': {
+                'default_leave_id': self.id,
+            }
+        }
 
     def action_draft(self):
         if any(holiday.state not in ['confirm', 'refuse'] for holiday in self):

--- a/addons/hr_holidays/security/ir.model.access.csv
+++ b/addons/hr_holidays/security/ir.model.access.csv
@@ -21,3 +21,4 @@ access_hr_leave_accrual_plan_user,hr.leave.accrual.plan.user,model_hr_leave_accr
 access_hr_leave_accrual_level_user,hr.leave.accrual.level.user,model_hr_leave_accrual_level,hr_holidays.group_hr_holidays_user,1,0,0,0
 access_hr_leave_accrual_plan_manager,hr.leave.accrual.plan.manager,model_hr_leave_accrual_plan,hr_holidays.group_hr_holidays_manager,1,1,1,1
 access_hr_leave_accrual_level_manager,hr.leave.accrual.level.manager,model_hr_leave_accrual_level,hr_holidays.group_hr_holidays_manager,1,1,1,1
+access_hr_holidays_cancel_leave,access_hr_holidays_cancel_leave,hr_holidays.model_hr_holidays_cancel_leave,base.group_user,1,1,1,1

--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
@@ -58,20 +58,50 @@ export const TimeOffCalendarController = CalendarController.extend({
         const timeoffData = event.target.state.data.find((timeOff) => timeOff.id === eventId);
         // Take the record associated to the timeoffData and read its state to hide or not the Delete button
         const timeoffState = timeoffData && timeoffData.record.state;
-        if(timeoffState && !['validate', 'refuse'].includes(timeoffState)) {
+        const canCancel = timeoffData && timeoffData.record.can_cancel;
+        if(canCancel || timeoffState && !['validate', 'refuse'].includes(timeoffState)) {
             options.deletable = true;
             options.removeButtonText = _t("Delete");
-            options.on_remove = () => {
-                Dialog.confirm(self, _t("Are you sure you want to delete this record ?"), {
-                    confirm_callback: () => {
-                        self.model.deleteRecords(self._getEventId(event), self.modelName).then(() => {
-                            self.reload();
-                        });
-                    }
-                });
-            };
+            options.on_remove = () => this._deleteLeave(timeoffData.record);
         }
         return options;
+    },
+
+    _onDeleteRecord(ev) {
+        this._deleteLeave(ev.data.event.record);
+    },
+
+    _deleteLeave(timeoff) {
+        const canCancel = timeoff.can_cancel;
+        if (canCancel) {
+            const context = Object.assign({}, this.context, {
+                default_leave_id: timeoff.id,
+            });
+            const cancel_dialog = new dialogs.FormViewDialog(this, {
+                title: _t('Delete Confirmation'),
+                res_model: 'hr.holidays.cancel.leave',
+                context: context,
+            });
+            cancel_dialog.on('execute_action', this, (ev) => {
+                const action_name = ev.data.action_data.name || ev.data.action_data.special;
+                const event_data = _.clone(ev.data);
+                if (action_name === 'action_cancel_leave') {
+                    ev.stopPropagation();
+                    this.trigger_up('execute_action', event_data);
+                    setTimeout(() => this.reload(), 300);
+                    cancel_dialog.close();
+                }
+            });
+            cancel_dialog.open();
+        } else {
+            Dialog.confirm(this, _t("Are you sure you want to delete this record ?"), {
+                confirm_callback: () => {
+                    this.model.deleteRecords(timeoff.id, this.modelName).then(() => {
+                        this.reload();
+                    });
+                }
+            });
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_popover.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_popover.js
@@ -9,7 +9,7 @@ export const TimeOffCalendarPopover = CalendarPopover.extend({
     init(parent, eventInfo) {
         this._super(...arguments);
         const state = this.event.extendedProps.record.state;
-        this.canDelete = state && !['validate', 'refuse'].includes(state);
+        this.canDelete = this.event.extendedProps.record.can_cancel || state && !['validate', 'refuse'].includes(state);
         this.canEdit = state !== undefined;
         this.displayFields = [];
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -59,6 +59,8 @@
                     domain="[('holiday_status_id.active', '=', True)]" help="Active Time Off"/>
                 <filter name="archive" string="Archived Time Off"
                     domain="[('holiday_status_id.active', '=', False)]" help="Archived Time Off"/>
+                <separator/>
+                <filter name="archived_leaves" string="Deleted Time Off" domain="[('active', '=', False)]" />
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                     domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
                     help="Show all records which has next action date is before today"/>
@@ -196,19 +198,23 @@
         <field name="priority">32</field>
         <field name="arch" type="xml">
             <form string="Time Off Request">
+            <field name="active" invisible="1"/>
             <field name="can_reset" invisible="1"/>
             <field name="can_approve" invisible="1"/>
+            <field name="can_cancel" invisible="1"/>
             <field name="holiday_allocation_id" invisible="1" force_save="1"/>
             <header>
-                <button string="Confirm" name="action_confirm" states="draft" type="object" class="oe_highlight"/>
-                <button string="Approve" name="action_approve" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('can_approve', '=', False), ('state', '!=', 'confirm')]}"/>
+                <button string="Confirm" name="action_confirm" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('active', '=', False)]}"/>
+                <button string="Approve" name="action_approve" type="object" class="oe_highlight" attrs="{'invisible': ['|', '|', ('active', '=', False), ('can_approve', '=', False), ('state', '!=', 'confirm')]}"/>
                 <button string="Validate" name="action_validate" states="validate1" type="object" groups="hr_holidays.group_hr_holidays_manager" class="oe_highlight"/>
-                <button string="Refuse" name="action_refuse" type="object" attrs="{'invisible': ['|', ('can_approve', '=', False), ('state', 'not in', ('confirm','validate1','validate'))]}"/>
+                <button string="Refuse" name="action_refuse" type="object" attrs="{'invisible': ['|', '|', ('active', '=', False), ('can_approve', '=', False), ('state', 'not in', ('confirm','validate1','validate'))]}"/>
+                <button string="Cancel" name="action_cancel" type="object" attrs="{'invisible': ['|', ('active', '=', False), ('can_cancel', '=', False)]}" />
                 <button string="Mark as Draft" name="action_draft" type="object"
                         attrs="{'invisible': ['|', ('can_reset', '=', False), ('state', 'not in', ['confirm', 'refuse'])]}"/>
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate"/>
             </header>
             <sheet>
+                <widget name="web_ribbon" title="Canceled" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <div class="alert alert-info" role="alert" attrs="{'invisible': ['|', ('request_unit_hours', '=', False), '|', ('tz_mismatch', '=', False), ('holiday_type', '=', 'category')]}">
                     <span attrs="{'invisible': [('holiday_type', '!=', 'employee')]}">
                         The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone
@@ -380,6 +386,7 @@
                 <field name="state" invisible="1"/>
                 <field name="is_hatched" invisible="1" />
                 <field name="is_striked" invisible="1"/>
+                <field name="can_cancel" invisible="1"/>
             </calendar>
         </field>
     </record>
@@ -394,6 +401,7 @@
                 <field name="state" invisible="1"/>
                 <field name="is_hatched" invisible="1" />
                 <field name="is_striked" invisible="1"/>
+                <field name="can_cancel" invisible="1"/>
             </calendar>
         </field>
     </record>

--- a/addons/hr_holidays/wizard/__init__.py
+++ b/addons/hr_holidays/wizard/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import hr_holidays_cancel_leave
 from . import hr_holidays_summary_employees
 from . import hr_departure_wizard

--- a/addons/hr_holidays/wizard/hr_holidays_cancel_leave.py
+++ b/addons/hr_holidays/wizard/hr_holidays_cancel_leave.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class HrHolidaysCancelLeave(models.TransientModel):
+    _name = 'hr.holidays.cancel.leave'
+    _description = 'Cancel Leave Wizard'
+
+    leave_id = fields.Many2one('hr.leave', required=True)
+    reason = fields.Text(required=True)
+
+    def action_cancel_leave(self):
+        self.ensure_one()
+
+        if not self.leave_id.can_cancel:
+            raise ValidationError(_('This time off cannot be canceled.'))
+
+        self.leave_id.message_post(
+            body=_('The time off has been canceled: %s', self.reason)
+        )
+
+        leave_sudo = self.leave_id.sudo()
+        leave_sudo.with_context(from_cancel_wizard=True).active = False
+        leave_sudo._remove_resource_leave()
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': _("Your time off has been canceled."),
+                'next': {'type': 'ir.actions.act_window_close'},
+            }
+        }

--- a/addons/hr_holidays/wizard/hr_holidays_cancel_leave_views.xml
+++ b/addons/hr_holidays/wizard/hr_holidays_cancel_leave_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_holidays_cancel_leave_form" model="ir.ui.view">
+        <field name="model">hr.holidays.cancel.leave</field>
+        <field name="arch" type="xml">
+            <form string="Cancel Time Off">
+                <group>
+                    <field name="leave_id" invisible="1" />
+                    <field name="reason" placeholder="Provide a reason for cancellation of an approved time off" />
+                </group>
+                <footer>
+                    <button name="action_cancel_leave" type="object" string="Delete Time Off" />
+                    <button special="cancel" string="Discard" close="1" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -215,3 +215,13 @@ class HrLeave(models.Model):
             contract_calendar = contracts[:1].resource_calendar_id if contracts else None
             return contract_calendar or self.employee_id.resource_calendar_id or self.env.company.resource_calendar_id
         return super()._get_calendar()
+
+    def _compute_can_cancel(self):
+        super()._compute_can_cancel()
+
+        cancellable_leaves = self.filtered('can_cancel')
+        work_entries = self.env['hr.work.entry'].sudo().search([('leave_id', 'in', cancellable_leaves.ids)])
+        leave_ids = work_entries.mapped('leave_id').ids
+
+        for leave in cancellable_leaves:
+            leave.can_cancel = leave.id not in leave_ids


### PR DESCRIPTION
A user without Time Off rights is now allowed to cancel their own
validated time off when:
    - It's not yet started;
    - No work-entries has been generated for it yet.

The time off is archived and the days taken reallocated.

TaskID: 2643713
Related: odoo/upgrade#2843

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
