### PR TITLE
[FIX] sale_stock_margin: Traceback after reset to quotation avco kit SO

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -51,6 +51,8 @@ class ProductProduct(models.Model):
         bom_lines = {line: data for line, data in bom_lines}
         value = 0
         for move in stock_moves:
+            if move.state == 'cancel':
+                continue
             bom_line = move.bom_line_id
             if bom_line:
                 bom_line_data = bom_lines[bom_line]


### PR DESCRIPTION
Issue: With margin enabled and avco for stock valuation, after
confirming a SO with a product variant which is a bom kit,
when we try to change the variant, there is a traceback

Steps to reproduce :
1) Install Stock, Accounting, MRP, Sale,
2) Enable Margins in settings

3) Configure a Product Category with costing method AVCO
4) Configure a Product with 2 variants and that product category
5) [Important: KIT] Create 2 BoM, one for each variant and set those
BoM to KIT
6) Create a SO for that product and one variant
7) Confirm the SO, cancel it, and set to quotation
8) Edit the SO and change the variant, save
-> Traceback

Side-Note:
 This issue is due to the fact that we iterate over the stock_moves to
 find the quantity of the BoM, but that stock_move correspond to
 confirming at step 7, when we change the variant at step 8, the stock
 move has not changed, so still contains the previous bom_line_id with
 the quantity, but this doesn't reflect with the new state of the SO
 which is for a different variant.

 For me since the stock move is canceled, it should be taken into
 consideration when computing the average price but I might be wrong,
 it's up to the reviewer to decide if it makes sense

opw-2639093

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
