### PR TITLE
[FIX] web: fix error stack undefined

### DIFF
--- a/addons/web/static/src/core/errors/error_utils.js
+++ b/addons/web/static/src/core/errors/error_utils.js
@@ -29,7 +29,7 @@ export function formatTraceback(error) {
         //     _onOpenFormView@http://localhost:8069/web/content/425-baf33f1/web.assets.js:1064:30
         //     ...
         traceback = `${errorName}: ${error.message}\n${error.stack}`.replace(/\n/g, "\n    ");
-    } else {
+    } else if (error.stack) {
         // Chromium stack starts with the error's name but the name is "Error" by default
         // so we replace it to have the error type name
         traceback = error.stack.replace(/^[^:]*/g, errorName);


### PR DESCRIPTION
In javascript, Error.stack is not standard so it could be undefined on
some browsers.

This commit fixes possible crashes when we perform some operations
on error.stack.