### PR TITLE
[FIX] portal: preserve newlines from share note

### DIFF
--- a/addons/portal/data/portal_data.xml
+++ b/addons/portal/data/portal_data.xml
@@ -101,7 +101,7 @@
                 <br/>
                 <a t-attf-href="#{share_link}" style="background-color: #875A7B; padding: 10px; text-decoration: none; color: #fff; border-radius: 5px; font-size: 12px;"><strong>Open </strong><strong t-esc="record.display_name"/></a><br/>
                 <br/>
-                <p t-if="note" t-esc="note"/>
+                <p t-if="note" style="white-space: pre-wrap;" t-esc="note"/>
             </div>
         </template>
     </data>


### PR DESCRIPTION
Before this patch, if you wrote newlines or more than a single whitespace character while sharing any document, in the note, those'd get collapsed in the final email.

@Tecnativa TT31901 @tde-banana-odoo 

Same as https://github.com/odoo/odoo/pull/76577 but for v13, because as explained in https://github.com/odoo/odoo/pull/76577#issuecomment-920834650 it was a valid patch.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
