### PR TITLE
[FIX] hr_org_chart: remove res_id from the widget's action

### DIFF
--- a/addons/hr_org_chart/i18n/hr_org_chart.pot
+++ b/addons/hr_org_chart/i18n/hr_org_chart.pot
@@ -93,9 +93,23 @@ msgid "Redirect"
 msgstr ""
 
 #. module: hr_org_chart
+#. openerp-web
+#: code:addons/hr_org_chart/static/src/xml/hr_org_chart.xml:108
+#, python-format
+msgid "See All"
+msgstr ""
+
+#. module: hr_org_chart
 #: model:ir.model.fields,field_description:hr_org_chart.field_hr_employee__subordinate_ids
 #: model:ir.model.fields,field_description:hr_org_chart.field_hr_employee_public__subordinate_ids
 msgid "Subordinates"
+msgstr ""
+
+#. module: hr_org_chart
+#. openerp-web
+#: code:addons/hr_org_chart/static/src/js/hr_org_chart.js:181
+#, python-format
+msgid "Team"
 msgstr ""
 
 #. module: hr_org_chart

--- a/addons/hr_org_chart/static/src/js/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/js/hr_org_chart.js
@@ -178,10 +178,15 @@ var FieldOrgChart = AbstractField.extend({
                     args: [employee_id],
                 }).then(function(action) {
                     action = _.extend(action, {
+                        'name': _t('Team'),
                         'view_mode': 'kanban,list,form',
                         'views':  [[false, 'kanban'], [false, 'list'], [false, 'form']],
                         'domain': domain,
+                        'context': {
+                            'default_parent_id': employee_id,
+                        }
                     });
+                    delete action['res_id'];
                     return self.do_action(action); 
                 });
             });

--- a/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
@@ -105,7 +105,7 @@
                     <a href="#"
                         t-att-data-employee-id="self.id"
                         t-att-data-employee-name="self.name"
-                        class="o_org_chart_show_more text-center o_employee_sub_redirect">&#8230;</a>
+                        class="o_org_chart_show_more text-center o_employee_sub_redirect">See All</a>
                 </div>
             </div>
         </t>


### PR DESCRIPTION
On the employee view there is a possibility to open a list of all the
employees managed by the current employee however the action contains
the key 'res_id' which makes both create and open action invalid. (the
manager is opened either way instead of the right action)

The action now also has a proper name instead of displaying `unnamed`,
aswell as containing the context necessary to default the manager as
expected. and the triple dots displayed when there are too many
employees has been replaced with `See All`.

TaskId-2648133