### PR TITLE
[FIX] orm: fix flush context unawareness

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -379,13 +379,14 @@ def call_kw(model, name, args, kwargs):
     """ Invoke the given method ``name`` on the recordset ``model``. """
     method = getattr(type(model), name)
     api = getattr(method, '_api', None)
+    context = kwargs.get('context')
     if api == 'model':
         result = _call_kw_model(method, model, args, kwargs)
     elif api == 'model_create':
         result = _call_kw_model_create(method, model, args, kwargs)
     else:
         result = _call_kw_multi(method, model, args, kwargs)
-    model.flush()
+    model.with_context(context or {}).flush()
     return result
 
 


### PR DESCRIPTION
Prior to this commit, the context wasn't yield to flush method causing
unconsistencies during recompute (i.e. the values in the context was the
default ones and not the ones from the kwargs).

This commits makes sure the flush is context-aware.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
