### PR TITLE
[FIX] website_slides: Don't set completion_time for encrypt/corrupt PDF 

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -352,6 +352,10 @@ class Slide(models.Model):
             data = base64.b64decode(self.datas)
             if data.startswith(b'%PDF-'):
                 pdf = PyPDF2.PdfFileReader(io.BytesIO(data), overwriteWarnings=False, strict=False)
+                try:
+                    pdf.getNumPages()
+                except PyPDF2.utils.PdfReadError:
+                    return
                 self.completion_time = (5 * len(pdf.pages)) / 60
 
     @api.depends('name', 'channel_id.website_id.domain')


### PR DESCRIPTION
Steps to reproduce:

  - Install eLearning module
  - Go to eLearning, open course Basics of Gardening and edit it
  - Click on `How to Grow and Harvest The Best Strawberries | Basics`
  - Upload an encrypted PDF as Attachement

Issue:

  Traceback is raised :
  utils.PdfReadError("File has not been decrypted")

Cause:

  When trying to calculate `completion_time` to read pages, we try to
  get the number of pages of the pdf but an error will be raised if the
  pdf is encrypted.

Solution:

  If not possible to get number of pages, we dont set/update the
  completion_time.

opw-2612529