### PR TITLE
Fix debug manager crash within modal

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -73,7 +73,13 @@ export function editSearchView({ accessRights, component, env }) {
     let { searchViewId } = component.props.info || {}; // fallback is there for legacy
     if ("viewParams" in component.props) {
         //legacy
-        searchViewId = component.props.viewParams.action.controlPanelFieldsView.view_id;
+        if (component.props.viewParams.withControlPanel && component.props.viewParams.action.controlPanelFieldsView) {
+            searchViewId = component.props.viewParams.action.controlPanelFieldsView.view_id;
+        }
+    }
+    // allow to edit 'ControlPanelView' only if there is a controlPanel and it's searchView
+    if (!searchViewId) {
+        return null;
     }
     const description = env._t("Edit ControlPanelView");
     return {


### PR DESCRIPTION
After recent debug manager refactoring, while trying to open debug manager
within a modal, we face a traceback (when the legacy view does not have
search view / control panel).

This PR fixes the issues by checking whether or not the control panel
and search view is available before binding the callback.

TaskID-2648765