### PR TITLE
[FIX] purchase : Account analytic default changed by user is reset in invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1815,6 +1815,8 @@ class AccountMove(models.Model):
         self.ensure_one()
 
         for line in self.line_ids:
+            analytic_account = line.analytic_account_id
+
             # Do something only on invoice lines.
             if line.exclude_from_invoice_tab:
                 continue
@@ -1839,7 +1841,8 @@ class AccountMove(models.Model):
             line.date = self.date
             line.recompute_tax_line = True
             line.currency_id = self.currency_id
-
+            if analytic_account:
+                line.analytic_account_id = analytic_account
 
         self.line_ids._onchange_price_subtotal()
         self._recompute_dynamic_lines(recompute_all_taxes=True)


### PR DESCRIPTION


Reproduce :
1. Add a default analytical rule: if Coin Gourmand partner then Administrative analytical account
2. Create a PO at the Coin Gourmand supplier, add a product, and select the Internal analytical account.
3. Bill for this product.

Result :
Internal analytical account has disappeared from the invoice line. It has been replaced by Administrative.

Fix :
Recompute the right analytic account in the invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
