### PR TITLE
[IMP] stock: `inventory_quantity_set` own compute

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -109,7 +109,7 @@ class StockQuant(models.Model):
     inventory_date = fields.Date(
         'Scheduled Date', compute='_compute_inventory_date', store=True, readonly=False,
         help="Next date the On Hand Quantity should be counted.")
-    inventory_quantity_set = fields.Boolean()  # Only used for UI purposes in the Inventory Adjustment page
+    inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False)
     is_outdated = fields.Boolean('Quantity has been moved since last count', compute='_compute_is_outdated')
     user_id = fields.Many2one(
         'res.users', 'Assigned To', help="User assigned to do product count.")
@@ -129,8 +129,11 @@ class StockQuant(models.Model):
     @api.depends('inventory_quantity')
     def _compute_inventory_diff_quantity(self):
         for quant in self:
-            quant.inventory_quantity_set = True
             quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity
+
+    @api.depends('inventory_quantity')
+    def _compute_inventory_quantity_set(self):
+        self.inventory_quantity_set = True
 
     @api.depends('inventory_quantity', 'quantity', 'product_id')
     def _compute_is_outdated(self):

--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -305,12 +305,22 @@ class TestInventory(TransactionCase):
             'location_id': self.stock_location.id,
             'inventory_quantity': 42,
         })
-        # Generate new inventory, its line must have a theoretical
-        # quantity of 42 and a counted quantity to 0.
+        # Applies the change, the quant must have a quantity of 42 and a inventory quantity to 0.
         inventory_quant.action_apply_inventory()
         self.assertEqual(len(inventory_quant), 1)
         self.assertEqual(inventory_quant.inventory_quantity, 0)
         self.assertEqual(inventory_quant.quantity, 42)
+
+        # Checks we can write on `inventory_quantity_set` even if we write on
+        # `inventory_quantity` at the same time.
+        self.assertEqual(inventory_quant.inventory_quantity_set, False)
+        inventory_quant.write({'inventory_quantity': 5})
+        self.assertEqual(inventory_quant.inventory_quantity_set, True)
+        inventory_quant.write({
+            'inventory_quantity': 12,
+            'inventory_quantity_set': False,
+        })
+        self.assertEqual(inventory_quant.inventory_quantity_set, False)
 
     def test_inventory_outdate_1(self):
         """ Checks that applying an inventory adjustment that is outdated due to


### PR DESCRIPTION
Sets the `inventory_quantity_set` as an editable field (not readonly) and creates its own compute to avoid to override it each time the `inventory_quantity` is modify and we set the `inventory_quantity_set` aside (before this commit, this field new value was always overrided by the `inventory_diff_quantity` compute).
This is useful when we want to write on the quants from the Barcode App as we can write on `inventory_quantity` and `inventory_quantity_set` at the same time.

task-2632818