### PR TITLE
[REF] stock*,purchase,mrp: used groupby of odoo

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1668,12 +1668,6 @@ class MrpProduction(models.Model):
 
     def _log_downside_manufactured_quantity(self, moves_modification, cancel=False):
 
-        def _keys_in_sorted(move):
-            """ sort by picking and the responsible for the product the
-            move.
-            """
-            return (move.picking_id.id, move.product_id.responsible_id.id)
-
         def _keys_in_groupby(move):
             """ group by picking and the responsible for the product the
             move.
@@ -1689,7 +1683,7 @@ class MrpProduction(models.Model):
             }
             return self.env.ref('mrp.exception_on_mo')._render(values=values)
 
-        documents = self.env['stock.picking']._log_activity_get_documents(moves_modification, 'move_dest_ids', 'DOWN', _keys_in_sorted, _keys_in_groupby)
+        documents = self.env['stock.picking']._log_activity_get_documents(moves_modification, 'move_dest_ids', 'DOWN', _keys_in_groupby)
         documents = self.env['stock.picking']._less_quantities_than_expected_add_documents(moves_modification, documents)
         self.env['stock.picking']._log_activity(_render_note_exception_quantity_mo, documents)
 

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -2,9 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
-from itertools import groupby
 
 from odoo import api, fields, models
+from odoo.tools import groupby
 from odoo.tools.float_utils import float_round, float_is_zero
 
 
@@ -257,7 +257,7 @@ class ProductProduct(models.Model):
         self.ensure_one()
         if not product_template_attribute_value_ids:
             return True
-        for _, iter_ptav in groupby(product_template_attribute_value_ids.sorted('attribute_line_id'), lambda ptav: ptav.attribute_line_id):
+        for _, iter_ptav in groupby(product_template_attribute_value_ids, lambda ptav: ptav.attribute_line_id):
             if not any(ptav in self.product_template_attribute_value_ids for ptav in iter_ptav):
                 return False
         return True

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -399,12 +399,6 @@ class StockMove(models.Model):
         res['cost_share'] = sum(self.mapped('cost_share'))
         return res
 
-    @api.model
-    def _prepare_merge_move_sort_method(self, move):
-        keys_sorted = super()._prepare_merge_move_sort_method(move)
-        keys_sorted += [move.created_production_id.id, move.cost_share]
-        return keys_sorted
-
     def _compute_kit_quantities(self, product_id, kit_qty, kit_bom, filters):
         """ Computes the quantity delivered or received when a kit is sold or purchased.
         A ratio 'qty_processed/qty_needed' is computed for each component, and the lowest one is kept

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -63,17 +63,11 @@ class StockPicking(models.Model):
     def _less_quantities_than_expected_add_documents(self, moves, documents):
         documents = super(StockPicking, self)._less_quantities_than_expected_add_documents(moves, documents)
 
-        def _keys_in_sorted(move):
-            """ sort by picking and the responsible for the product the
-            move.
-            """
-            return (move.raw_material_production_id.id, move.product_id.responsible_id.id)
-
         def _keys_in_groupby(move):
             """ group by picking and the responsible for the product the
             move.
             """
             return (move.raw_material_production_id, move.product_id.responsible_id)
 
-        production_documents = self._log_activity_get_documents(moves, 'move_dest_ids', 'DOWN', _keys_in_sorted, _keys_in_groupby)
+        production_documents = self._log_activity_get_documents(moves, 'move_dest_ids', 'DOWN', _keys_in_groupby)
         return {**documents, **production_documents}

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -2,8 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
-from functools import partial
-from itertools import groupby
 import json
 
 from markupsafe import escape, Markup
@@ -12,10 +10,9 @@ from werkzeug.urls import url_encode
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, formatLang, get_lang, groupby
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.tools.misc import formatLang, get_lang
 
 
 class PurchaseOrder(models.Model):

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -151,12 +151,6 @@ class PurchaseOrder(models.Model):
 
     def _log_decrease_ordered_quantity(self, purchase_order_lines_quantities):
 
-        def _keys_in_sorted(move):
-            """ sort by picking and the responsible for the product the
-            move.
-            """
-            return (move.picking_id.id, move.product_id.responsible_id.id)
-
         def _keys_in_groupby(move):
             """ group by picking and the responsible for the product the
             move.
@@ -175,7 +169,7 @@ class PurchaseOrder(models.Model):
             }
             return self.env.ref('purchase_stock.exception_on_po')._render(values=values)
 
-        documents = self.env['stock.picking']._log_activity_get_documents(purchase_order_lines_quantities, 'move_ids', 'DOWN', _keys_in_sorted, _keys_in_groupby)
+        documents = self.env['stock.picking']._log_activity_get_documents(purchase_order_lines_quantities, 'move_ids', 'DOWN', _keys_in_groupby)
         filtered_documents = {}
         for (parent, responsible), rendering_context in documents.items():
             if parent._name == 'stock.picking':

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -26,13 +26,6 @@ class StockMove(models.Model):
         distinct_fields += ['purchase_line_id', 'created_purchase_line_id']
         return distinct_fields
 
-    @api.model
-    def _prepare_merge_move_sort_method(self, move):
-        move.ensure_one()
-        keys_sorted = super(StockMove, self)._prepare_merge_move_sort_method(move)
-        keys_sorted += [move.purchase_line_id.id, move.created_purchase_line_id.id]
-        return keys_sorted
-
     def _get_price_unit(self):
         """ Returns the unit price for the move"""
         self.ensure_one()

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -21,13 +21,6 @@ class StockMove(models.Model):
         distinct_fields.append('sale_line_id')
         return distinct_fields
 
-    @api.model
-    def _prepare_merge_move_sort_method(self, move):
-        move.ensure_one()
-        keys_sorted = super(StockMove, self)._prepare_merge_move_sort_method(move)
-        keys_sorted.append(move.sale_line_id.id)
-        return keys_sorted
-
     def _get_related_invoices(self):
         """ Overridden from stock_account to return the customer invoices
         related to this stock move.
@@ -116,10 +109,6 @@ class StockPicking(models.Model):
         new and old quantity as value. eg: {move_1 : (4, 5)}
         """
 
-        def _keys_in_sorted(sale_line):
-            """ sort by order_id and the sale_person on the order """
-            return (sale_line.order_id.id, sale_line.order_id.user_id.id)
-
         def _keys_in_groupby(sale_line):
             """ group by order_id and the sale_person on the order """
             return (sale_line.order_id, sale_line.order_id.user_id)
@@ -144,7 +133,7 @@ class StockPicking(models.Model):
             }
             return self.env.ref('sale_stock.exception_on_picking')._render(values=values)
 
-        documents = self._log_activity_get_documents(moves, 'sale_line_id', 'DOWN', _keys_in_sorted, _keys_in_groupby)
+        documents = self._log_activity_get_documents(moves, 'sale_line_id', 'DOWN', _keys_in_groupby)
         self._log_activity(_render_note_exception_quantity, documents)
 
         return super(StockPicking, self)._log_less_quantities_than_expected(moves)

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -5,7 +5,6 @@ import logging
 from collections import defaultdict
 from datetime import datetime, time
 from dateutil import relativedelta
-from itertools import groupby
 from psycopg2 import OperationalError
 
 from odoo import SUPERUSER_ID, _, api, fields, models, registry

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -14,10 +14,6 @@ class StockRule(models.Model):
         """
         return procurement.values.get('sale_line_id'), super(StockRule, self)._get_procurements_to_merge_groupby(procurement)
 
-    @api.model
-    def _get_procurements_to_merge_sorted(self, procurement):
-        return procurement.values.get('sale_line_id'), super(StockRule, self)._get_procurements_to_merge_sorted(procurement)
-
 
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"


### PR DESCRIPTION
Instead of using sort + groupby of itertools (which group only
consecutive), use only the groupby of odoo.tools which
decrease the complexity of the code and avoid unmatched keys
between sort keys and groupby keys

task-2648449
