### PR TITLE
[FIX] account: remove upgrade_boolean from community module

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -419,7 +419,7 @@
                         <div class="row mt16 o_settings_container" id="print_vendor_checks_setting_container">
                             <div class="col-12 col-lg-6 o_setting_box" id="print_checks" groups="account.group_account_user">
                                 <div class="o_setting_left_pane">
-                                    <field name="module_account_check_printing" widget="upgrade_boolean"/>
+                                    <field name="module_account_check_printing"/>
                                 </div>
                                 <div class="o_setting_right_pane">
                                     <label string="Checks" for="module_account_check_printing"/>


### PR DESCRIPTION
Module `account_check_printing` exist on community edition so
It doesn't makes sense to apply `upgrade_boolean` widget on that.

However, It is necessary to have supported modules installed to
use Check Layout.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
