### PR TITLE
[FIX] account: display valid activity list

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -125,7 +125,7 @@
                                         <field name="invoice_reference_model" attrs="{'invisible': [('invoice_reference_type', '=', 'none')]}"/>
                                     </group>
                                     <group string="Follow Customer Payments" attrs="{'invisible': [('type', '!=', 'sale')]}">
-                                        <field name="sale_activity_type_id"/>
+                                        <field name="sale_activity_type_id" domain="['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'account.move')]"/>
                                         <field name="sale_activity_user_id" attrs="{'invisible': [('sale_activity_type_id', '=', False)]}"/>
                                         <field name="sale_activity_note" placeholder="e.g. Give a phone call, check with others , ..."  attrs="{'invisible': [('sale_activity_type_id', '=', False)]}"/>
                                     </group>


### PR DESCRIPTION
Before this commit, It was displaying all activity types regardless of Model,
which may lead to inconsistency as the activity might have different model.

With this commit, we are displaying activities having model not set or
'account.move'.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
