### PR TITLE
add dynamic placeholder on field

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -279,7 +279,17 @@ var InputField = DebouncedField.extend({
         this.$input = $input || $("<input/>");
         this.$input.addClass('o_input');
 
-        var inputAttrs = { placeholder: this.attrs.placeholder || "" };
+        let placeholder = this.attrs.placeholder || "";
+        const placeholderField = this.attrs['placeholder_field'];
+        if (placeholderField) {
+            const placeholderValue = placeholderField && this.record.data[placeholderField];
+            const formatOptions = {
+                escape: true,
+            };
+            const field = this.record.fields[placeholderField];
+            placeholder = field_utils.format[field.type](placeholderValue, field, formatOptions);
+        }
+        let inputAttrs = { placeholder: placeholder };
         var inputVal;
         if (this.nodeOptions.isPassword) {
             inputAttrs = _.extend(inputAttrs, { type: 'password', autocomplete: this.attrs.autocomplete || 'new-password' });

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -282,12 +282,9 @@ var InputField = DebouncedField.extend({
         let placeholder = this.attrs.placeholder || "";
         const placeholderField = this.attrs['placeholder_field'];
         if (placeholderField) {
-            const placeholderValue = placeholderField && this.record.data[placeholderField];
-            const formatOptions = {
-                escape: true,
-            };
+            const placeholderValue = this.record.data[placeholderField];
             const field = this.record.fields[placeholderField];
-            placeholder = field_utils.format[field.type](placeholderValue, field, formatOptions);
+            placeholder = placeholderValue && field_utils.format[field.type](placeholderValue, field, { escape: true }) || placeholder;
         }
         let inputAttrs = { placeholder: placeholder };
         var inputVal;

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -257,11 +257,11 @@ var FieldMany2One = AbstractField.extend({
     _bindAutoComplete: function () {
         var self = this;
         // avoid ignoring autocomplete="off" by obfuscating placeholder, see #30439
-        // if ($.browser.chrome && this.$input.attr('placeholder')) {
-        //     this.$input.attr('placeholder', function (index, val) {
-        //         return val.split('').join('\ufeff');
-        //     });
-        // }
+        if ($.browser.chrome && this.$input.attr('placeholder')) {
+            this.$input.attr('placeholder', function (index, val) {
+                return val.split('').join('\ufeff');
+            });
+        }
         this.$input.autocomplete({
             source: function (req, resp) {
                 self.suggestions = [];

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -22,6 +22,7 @@ var Dialog = require('web.Dialog');
 var dialogs = require('web.view_dialogs');
 var dom = require('web.dom');
 const Domain = require('web.Domain');
+const field_utils = require('web.field_utils');
 var KanbanRecord = require('web.KanbanRecord');
 var KanbanRenderer = require('web.KanbanRenderer');
 var ListRenderer = require('web.ListRenderer');
@@ -119,6 +120,13 @@ var FieldMany2One = AbstractField.extend({
         });
         this.noOpen = 'noOpen' in options ? options.noOpen : this.nodeOptions.no_open;
         this.m2o_value = this._formatValue(this.value);
+        this.placeholder = this.attrs.placeholder;
+        const placeholderField = this.attrs['placeholder_field'];
+        if (placeholderField) {
+            const placeholderValue = this.record.data[placeholderField];
+            const field = this.record.fields[placeholderField];
+            this.placeholder = placeholderValue && field_utils.format[field.type](placeholderValue, field, { escape: true }) || this.placeholder;
+        }
         // 'recordParams' is a dict of params used when calling functions
         // 'getDomain' and 'getContext' on this.record
         this.recordParams = {fieldName: this.name, viewType: this.viewType};
@@ -249,11 +257,11 @@ var FieldMany2One = AbstractField.extend({
     _bindAutoComplete: function () {
         var self = this;
         // avoid ignoring autocomplete="off" by obfuscating placeholder, see #30439
-        if ($.browser.chrome && this.$input.attr('placeholder')) {
-            this.$input.attr('placeholder', function (index, val) {
-                return val.split('').join('\ufeff');
-            });
-        }
+        // if ($.browser.chrome && this.$input.attr('placeholder')) {
+        //     this.$input.attr('placeholder', function (index, val) {
+        //         return val.split('').join('\ufeff');
+        //     });
+        // }
         this.$input.autocomplete({
             source: function (req, resp) {
                 self.suggestions = [];

--- a/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
@@ -476,7 +476,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
         if (node.attrs.style) {
             $el.attr('style', node.attrs.style);
         }
-        if (node.attrs.placeholder) {
+        if (node.attrs.placeholder && node.tag !== 'field') {
             $el.attr('placeholder', node.attrs.placeholder);
         }
     },

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -1032,7 +1032,7 @@
                     t-att-barcode_events="widget.nodeOptions.barcode_events"
                     t-att-tabindex="widget.attrs.tabindex"
                     t-att-autofocus="widget.attrs.autofocus"
-                    t-att-placeholder="widget.attrs.placeholder"
+                    t-att-placeholder="widget.placeholder"
                     t-att-id="widget.idForLabel"/>
                 <a role="button" class="o_dropdown_button" draggable="false"/>
             </div>

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -378,7 +378,7 @@ QUnit.module('Views', {
         form.destroy();
     });
 
-    QUnit.only('placeholder_field attribute on field', async function (assert) {
+    QUnit.test('placeholder_field attribute on field', async function (assert) {
         assert.expect(4);
 
         const form = await createView({
@@ -401,22 +401,21 @@ QUnit.module('Views', {
                     default_state: 'ab',
                 },
             },
-            debug: true,
         });
-
-        await testUtils.nextTick();
 
         // placeholder_field has more precedence if field give in placeholder_field has value
         assert.containsOnce(form, 'input[name="display_name"][placeholder="Allu Arjun"]');
         // placeholder value is set to default if  placeholder_field has no value
         assert.containsOnce(form, 'input[name="foo"][placeholder="Thalapathy Vijay"]');
-        const trululuInput = form.$('div[name="trululu"] .o_input[placeholder="xphone"]');
-        debugger;
-        assert.strictEqual(trululuInput.attr('placeholder'), "xphone",
+        const trululuInput = form.$('div[name="trululu"] .o_input');
+        // Remove BOM characters added by commit: 6ff7d4b0f551f95c0941c5dd0571c4c7f780d8fc
+        let placeholder = trululuInput[0].getAttribute('placeholder').replace(/[\u200B-\u200D\uFEFF]/g, '');
+        assert.strictEqual(placeholder, "xphone",
             "should have trululu input with xphone placeholder");
 
         const timmyInput = form.$('div[name="timmy"] .o_input');
-        assert.strictEqual(timmyInput.attr('placeholder'), "AB",
+        placeholder = timmyInput[0].getAttribute('placeholder').replace(/[\u200B-\u200D\uFEFF]/g, '');
+        assert.strictEqual(placeholder, "AB",
             "should have trululu input with AB placeholder");
 
         form.destroy();

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -378,6 +378,50 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.only('placeholder_field attribute on field', async function (assert) {
+        assert.expect(4);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:
+                `<form string="Partners">
+                    <field name="display_name" placeholder="Ravi Teja" placeholder_field="foo"/>
+                    <field name="foo" placeholder="Thalapathy Vijay" placeholder_field="display_name"/>
+                    <field name="product_id" invisible="1"/>
+                    <field name="state" invisible="1"/>
+                    <field name="trululu" placeholder_field="product_id"/>
+                    <field name="timmy" widget="many2many_tags" placeholder_field="state"/>
+                </form>`,
+            viewOptions: {
+                context: {
+                    default_foo: "Allu Arjun",
+                    default_product_id: 37,
+                    default_state: 'ab',
+                },
+            },
+            debug: true,
+        });
+
+        await testUtils.nextTick();
+
+        // placeholder_field has more precedence if field give in placeholder_field has value
+        assert.containsOnce(form, 'input[name="display_name"][placeholder="Allu Arjun"]');
+        // placeholder value is set to default if  placeholder_field has no value
+        assert.containsOnce(form, 'input[name="foo"][placeholder="Thalapathy Vijay"]');
+        const trululuInput = form.$('div[name="trululu"] .o_input[placeholder="xphone"]');
+        debugger;
+        assert.strictEqual(trululuInput.attr('placeholder'), "xphone",
+            "should have trululu input with xphone placeholder");
+
+        const timmyInput = form.$('div[name="timmy"] .o_input');
+        assert.strictEqual(timmyInput.attr('placeholder'), "AB",
+            "should have trululu input with AB placeholder");
+
+        form.destroy();
+    });
+
     QUnit.test('decoration works on widgets', async function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
PURPOSE

Allow to define placeholders dynamically in input fields (i.e. char, text, many2xxx, etc.).

SPECIFICATION
The idea in short:
    New placeholder_field attribute on input widgets to set the display_name of another field as placeholder.

Add a new "placeholder_field" attribute on the following input widgets:
    many2one
    many2many
    char
    text

This attribute takes another field of the current view as parameter.
The display_name of the field set in the "placeholder_field" attribute is used as placeholder.
Attribut "placeholder_field" has precedence over the standard "placeholder" attribute.

If placeholder_field="my_other_field" is defined on field X, the placeholder of field X is the current display_name of "my_other_field".

The use case that motivated this feature:
    On account.payment, there is a non-required outstanding_account_id many2one field to account.account.
    If this field is not set when the payment is confirmed, it is set to the default account defined in the default_outstanding_account_id field.
    So, by setting the display_name of the default_outstanding_account_id field as the placeholder of the outstanding_account_id field, we let the user know which fallback value will be set if no account is defined.

TASK 2643714
