### PR TITLE
[FIX] event_booth_sale: change the default product type of 'Event Booth'

### DIFF
--- a/addons/event_booth_sale/data/product_data.xml
+++ b/addons/event_booth_sale/data/product_data.xml
@@ -8,7 +8,7 @@
         <field name="description_sale" eval="False"/>
         <field name="categ_id" ref="event_sale.product_category_events"/>
         <field name="invoice_policy">order</field>
-        <field name="detailed_type">service</field>
+        <field name="detailed_type">event_booth</field>
     </record>
 
 </data></odoo>


### PR DESCRIPTION
PURPOSE

The default product type of 'Event Booth' product should be 'Event Booth'.
The purpose of this commit is to set the default product type as 'Event Booth'.

SPECIFICATIONS

Right now, when we only have the event installed and activate 
the Booth Management, The 'Event Booth' product has a Service type.

This fixes the default product type.

This is the goal of this commit.

LINKS

PR #76796
Task-2648950
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr