### PR TITLE
[FIX] hr_holidays: fix wrong context for absent action

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
+from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 from odoo.tools.float_utils import float_round
@@ -133,11 +134,16 @@ class HrEmployeeBase(models.AbstractModel):
                 employee.show_leaves = False
 
     def _search_absent_employee(self, operator, value):
+        # This search is only used for the 'Absent Today' filter however
+        # this only returns employees that are absent right now.
+        today_date = datetime.datetime.utcnow().date()
+        today_start = fields.Datetime.to_string(today_date)
+        today_end = fields.Datetime.to_string(today_date + relativedelta(hours=23, minutes=59, seconds=59))
         holidays = self.env['hr.leave'].sudo().search([
             ('employee_id', '!=', False),
             ('state', 'not in', ['cancel', 'refuse']),
-            ('date_from', '<=', datetime.datetime.utcnow()),
-            ('date_to', '>=', datetime.datetime.utcnow())
+            ('date_from', '<=', today_end),
+            ('date_to', '>=', today_start),
         ])
         return [('id', 'in', holidays.mapped('employee_id').ids)]
 

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -7,7 +7,7 @@
        <field name="view_mode">kanban,tree,form</field>
        <field name="context">{
            'search_default_is_absent': 1,
-           'search_default_department_id': [active_id],
+           'searchpanel_default_department_id': active_id,
            'default_department_id': active_id}
        </field>
        <field name="search_view_id" ref="hr.view_employee_filter"/>


### PR DESCRIPTION
Since odoo/odoo#35700 department_id is not a searchable field in the
employee search view as it has been added in the searchpanel. Since
then, the view from department > absence has been broken since it was
not filtering on the department anymore.
This commit fixes that behaviour by defaulting to the department in the
searchpanel instead.

TaskId-2648380
