### PR TITLE
[IMP] mass_mailing, *: improve mailing stat buttons

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -117,7 +117,10 @@
                     <filter string="Status" name="status" context="{'group_by':'state'}"/>
                     <filter string="Company" name="company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                     <separator orientation="vertical" />
-                    <filter string="Date" name="invoice_date" context="{'group_by':'invoice_date'}"/>
+                    <filter string="Date" name="invoice_date" context="{'group_by':'invoice_date'}"
+                            invisible="context.get('invoice_report_view_hide_invoice_date')"/>
+                    <filter string="Date" name="group_by_invoice_date_week" context="{'group_by':'invoice_date:week'}"
+                            invisible="not context.get('invoice_report_view_hide_invoice_date')"/>
                     <filter string="Due Date" name="duemonth" context="{'group_by':'invoice_date_due:month'}"/>
                 </group>
             </search>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -994,7 +994,10 @@
                         <filter string="Medium" name="medium" domain="[]" context="{'group_by':'medium_id'}"/>
                         <filter string="Source" name="source" domain="[]" context="{'group_by':'source_id'}"/>
                         <separator orientation="vertical" />
-                        <filter string="Creation Date" context="{'group_by':'create_date:month'}" name="month"/>
+                        <filter string="Creation Date" name="month" context="{'group_by':'create_date:month'}"
+                                invisible="context.get('crm_lead_view_hide_month')"/>
+                        <filter string="Creation Date" name="group_by_create_date_day" context="{'group_by':'create_date:day'}"
+                                invisible="not context.get('crm_lead_view_hide_month')"/>
                         <filter string="Conversion Date" name="date_conversion" context="{'group_by': 'date_conversion'}" groups="crm.group_use_lead"/>
                         <filter string="Expected Closing" name="date_deadline" context="{'group_by':'date_deadline'}"/>
                         <filter string="Closed Date" name="date_closed" context="{'group_by':'date_closed'}"/>

--- a/addons/mass_mailing_crm/models/mailing_mailing.py
+++ b/addons/mass_mailing_crm/models/mailing_mailing.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
 from odoo import fields, models, _, tools
 
 
@@ -9,27 +10,40 @@ class MassMailing(models.Model):
     _inherit = 'mailing.mailing'
 
     use_leads = fields.Boolean('Use Leads', compute='_compute_use_leads')
-    crm_lead_count = fields.Integer('Leads/Opportunities Count', groups='sales_team.group_sale_salesman', compute='_compute_crm_lead_count')
+    crm_lead_count = fields.Integer('Leads/Opportunities Count', compute='_compute_crm_lead_count')
 
     def _compute_use_leads(self):
         self.use_leads = self.env.user.has_group('crm.group_use_lead')
 
     def _compute_crm_lead_count(self):
-        lead_data = self.env['crm.lead'].with_context(active_test=False).read_group(
+        lead_data = self.env['crm.lead'].with_context(active_test=False).sudo().read_group(
             [('source_id', 'in', self.source_id.ids)],
-            ['source_id'], ['source_id']
+            ['source_id'], ['source_id'],
         )
         mapped_data = {datum['source_id'][0]: datum['source_id_count'] for datum in lead_data}
         for mass_mailing in self:
             mass_mailing.crm_lead_count = mapped_data.get(mass_mailing.source_id.id, 0)
 
     def action_redirect_to_leads_and_opportunities(self):
-        view = 'crm.crm_lead_all_leads' if self.use_leads else 'crm.crm_lead_opportunities'
-        action = self.env.ref(view).sudo().read()[0]
-        action['view_mode'] = 'tree,kanban,graph,pivot,form,calendar'
-        action['domain'] = [('source_id', 'in', self.source_id.ids)]
-        action['context'] = {'active_test': False, 'create': False}
-        return action
+        text = _("Leads") if self.use_leads else _("Opportunities")
+        helper_header = _("No %s yet!", text)
+        helper_message = _("Note that Odoo cannot track replies if they are sent towards email addresses to this database.")
+        return {
+            'context': {
+                'active_test': False,
+                'create': False,
+                'search_default_group_by_create_date_day': True,
+                'crm_lead_view_hide_month': True,
+            },
+            'domain': [('source_id', 'in', self.source_id.ids)],
+            'help': Markup('<p class="o_view_nocontent_smiling_face">%s</p><p>%s</p>') % (
+                helper_header, helper_message,
+            ),
+            'name': _("Leads Analysis"),
+            'res_model': 'crm.lead',
+            'type': 'ir.actions.act_window',
+            'view_mode': 'graph,pivot,tree,form',
+        }
 
     def _prepare_statistics_email_values(self):
         self.ensure_one()

--- a/addons/mass_mailing_crm/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_crm/views/mailing_mailing_views.xml
@@ -10,7 +10,6 @@
                     type="object"
                     icon="fa-star"
                     class="oe_stat_button"
-                    groups="sales_team.group_sale_salesman"
                     attrs="{'invisible': [('state', '=', 'draft')]}">
                     <div class="o_field_widget o_stat_info">
                         <field name="use_leads" invisible="1"/>

--- a/addons/mass_mailing_sale/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sale/views/mailing_mailing_views.xml
@@ -10,7 +10,6 @@
                     type="object"
                     icon="fa-pencil-square-o"
                     class="oe_stat_button"
-                    groups="sales_team.group_sale_salesman"
                     attrs="{'invisible': [('state', '=', 'draft')]}">
                     <field name="sale_quotation_count" string="Quotations" widget="statinfo"/>
                 </button>
@@ -18,7 +17,6 @@
                     type="object"
                     icon="fa-dollar"
                     class="oe_stat_button"
-                    groups="sales_team.group_sale_salesman"
                     attrs="{'invisible': [('state', '=', 'draft')]}" >
                     <field name="sale_invoiced_amount" string="Invoiced" widget="statinfo"/>
                 </button>

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -76,7 +76,10 @@
                     <filter name="status" string="Status" context="{'group_by':'state'}"/>
                     <filter string="Company" name="company" groups="base.group_multi_company" context="{'group_by':'company_id'}"/>
                     <separator/>
-                    <filter string="Order Date" name="date" context="{'group_by':'date'}"/>
+                    <filter string="Order Date" name="date" context="{'group_by':'date'}"
+                            invisible="context.get('sale_report_view_hide_date')"/>
+                    <filter string="Order Date" name="group_by_date_day" context="{'group_by':'date:day'}"
+                            invisible="not context.get('sale_report_view_hide_date')"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
*mass_mailing_crm, mass_mailing_sale 

Currently, the Mailing stat buttons have a few problems.
The business reporting smart buttons send the user to a list of linked records,
which doesn't provide much value (e.g. what is the user supposed to do with a
list of 12345 leads?). They also show wrong values depending on access rights.
The Mailing KPI smart buttons lead to a blank screen if there's no data to show.

In this commit, we add/adapt all action helpers to help users understand what is
going on. For the business reporting smart buttons we instead send users to
relevant reporting actions, so they can make sense of the data we showed before.
The values of the business reporting smart buttons are now calculated as a super
user.
We also change some domains from the whole UTM Sale Domain to only using
Source ID, which simplifies computation while staying accurate.

task-2604515
