### PR TITLE
[FIX] web: Select the correct record when there is an html table in a line

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -852,7 +852,7 @@ ListRenderer.include({
      * @returns {string} record dataPoint id
      */
     _getRecordID: function (rowIndex) {
-        var $tr = this.$('table.o_list_table > tbody tr').eq(rowIndex);
+        var $tr = this.$('table.o_list_table > tbody > tr').eq(rowIndex);
         return $tr.data('id');
     },
     /**

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -9592,6 +9592,40 @@ QUnit.module('Views', {
 
         list.destroy();
     });
+
+    QUnit.test('selecting a row after another one containing a table within an html field should be the correct one', async function (assert) {
+        assert.expect(1);
+
+        this.data.foo.fields.html = {string: "HTML field", type: "html"}
+        this.data.foo.records[0].html = `
+            <table class="table table-bordered">
+                <tbody>
+                    <tr>
+                        <td><br></td>
+                        <td><br></td>
+                    </tr>
+                     <tr>
+                        <td><br></td>
+                        <td><br></td>
+                    </tr>
+                </tbody>
+            </table>`;
+
+        var list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: '<tree editable="top" multi_edit="1">' +
+                '<field name="html"/>' +
+                '</tree>',
+        });
+
+        await testUtils.dom.click(list.$('.o_data_cell:eq(1)'))
+        assert.ok($('table.o_list_table > tbody > tr:eq(1)')[0].classList.contains('o_selected_row'), "The second row should be selected")
+
+        list.destroy();
+    });
+
 });
 
 });


### PR DESCRIPTION
Steps to follow

  - Add an HTML field in the sales order line view
  - Create a sales order
  - Add a product
  - Add a table with multiple rows in the HTML widget
  - Add a new product
  -> The new product isn't selected

Cause of the issue

  The CSS selector used for finding the record to edit was taking all tr
  element into account

Solution

  Add the o_data_row to the selector

opw-2632817