### PR TITLE
[FIX] stock_picking_batch: wrong widget

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -272,7 +272,7 @@
                             ('picking_type_id', '=', picking_type_id),
                             ('picking_type_id', '=', False),
                     ]"
-                    widget="many2onebutton"
+                    widget="many2one"
                     context="{'default_picking_type_id': picking_type_id}"/>
             </xpath>
         </field>


### PR DESCRIPTION
The widget many2onebutton doesn't exist anymore. As the web client
fallbacked on the default many2one widget. The behavior was the intended
one but with a warning in the logs. This commit uses the proper widget
to avoid the unintentional warning

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
