### PR TITLE
[FIX] web: fix Edit ControlPanelView

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -73,7 +73,13 @@ export function editSearchView({ accessRights, component, env }) {
     let { searchViewId } = component.props.info || {}; // fallback is there for legacy
     if ("viewParams" in component.props) {
         //legacy
+        if (!component.props.viewParams.action.controlPanelFieldsView) {
+            return null;
+        }
         searchViewId = component.props.viewParams.action.controlPanelFieldsView.view_id;
+    }
+    if (searchViewId === undefined) {
+        return null;
     }
     const description = env._t("Edit ControlPanelView");
     return {

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -424,4 +424,29 @@ QUnit.module("DebugMenu", (hooks) => {
             "293"
         );
     });
+
+    QUnit.test(
+        "cannot edit the control panel of a form view contained in a dialog without control panel.",
+        async (assert) => {
+            const mockRPC = async (route, args) => {
+                if (args.method === "check_access_rights") {
+                    return Promise.resolve(true);
+                }
+            };
+            prepareRegistriesWithCleanup();
+
+            patchWithCleanup(odoo, {
+                debug: true,
+            });
+            registry.category("debug").category("view").add("editSearchViewItem", editSearchView);
+
+            const serverData = getActionManagerServerData();
+
+            const webClient = await createWebClient({ serverData, mockRPC });
+            // opens a form view in a dialog without a control panel.
+            await doAction(webClient, 5);
+            await click(webClient.el.querySelector(".o_dialog .o_debug_manager button"));
+            assert.containsNone(webClient, ".o_debug_manager .o_dropdown_item");
+        }
+    );
 });


### PR DESCRIPTION
The debug item "Edit ControlPanelView" is only available if there is
a control panel in the current view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
