### PR TITLE
[FIX] purchase_stock: bill status correctly set w/ backorder

### DIFF
--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -5,7 +5,7 @@ from odoo.tests import tagged
 from odoo.tests.common import Form
 
 
-@tagged('post_install', '-at_install')
+@tagged('post_install', '-at_install', 'guva')
 class TestPurchaseToInvoice(AccountTestInvoicingCommon):
 
     @classmethod


### PR DESCRIPTION
Steps to reproduce:

- Go to purchase and create a PO with a product
  (quantity more than 1)
- Confirm the order and receive a part of the
  command, then create a backorder
- create a vendor bill for the quantity received

Issue:

The billing status of the PO is set to
'Fully Billed' instead' of 'Waiting Bills'

Solution:

By checking the state of the move_ids, we're
able to check if there are still remaining
products to receive

Also add a test to check the flow

opw-2627674

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
