### PR TITLE
[FIX] website: avoid error when no template installed for dynamic snippet

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -58,7 +58,7 @@ const dynamicSnippetOptions = options.Class.extend({
         await this._super(...arguments);
         const template = this._getCurrentTemplate();
         const groupingMessage = this.el.querySelector('.o_grouping_message');
-        groupingMessage.classList.toggle('d-none', !!template.numOfEl && !!template.numOfElSm);
+        groupingMessage.classList.toggle('d-none', template && !!template.numOfEl && !!template.numOfElSm);
     },
 
     //--------------------------------------------------------------------------
@@ -85,15 +85,18 @@ const dynamicSnippetOptions = options.Class.extend({
         }
 
         if (widgetName === 'number_of_elements_opt') {
-            return !this._getCurrentTemplate().numOfEl;
+            const template = this._getCurrentTemplate();
+            return template && !template.numOfEl;
         }
 
         if (widgetName === 'number_of_elements_small_devices_opt') {
-            return !this._getCurrentTemplate().numOfElSm;
+            const template = this._getCurrentTemplate();
+            return template && !template.numOfElSm;
         }
 
         if (widgetName === 'number_of_records_opt') {
-            return !this._getCurrentTemplate().numOfElFetch;
+            const template = this._getCurrentTemplate();
+            return template && !template.numOfElFetch;
         }
 
         return this._super.apply(this, arguments);


### PR DESCRIPTION
Since [1] if neither website_blog nor website_sale was installed, upon
selecting a dynamic snippet, an error was raised.
It therefore prevented deleting the unusable snippet.

After this commit the error is avoided by coping with the fact that it
is possible that no template is installed.

[1] https://github.com/odoo/odoo/commit/ef531afe39f9a586f4eac381651aa32eaec8b098

Related to #75662

task-2651978

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
