### PR TITLE
[FIX] mail: avoid exception when creating channel

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -577,6 +577,9 @@ class Channel(models.Model):
                 self._action_unfollow(p)
         return super(Channel, self)._message_receive_bounce(email, partner)
 
+    def _message_compute_author(self, author_id=None, email_from=None, raise_exception=False):
+        return super()._message_compute_author(author_id=author_id, email_from=email_from, raise_exception=False);
+
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, message_type='notification', **kwargs):
         self.filtered(lambda channel: channel.is_chat).mapped('channel_last_seen_partner_ids').sudo().write({

--- a/addons/test_mail/tests/test_ui.py
+++ b/addons/test_mail/tests/test_ui.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo import Command
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -8,3 +9,13 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_01_mail_tour(self):
         self.start_tour("/web", 'mail_tour', login="admin")
+
+    def test_02_mail_create_channel_no_mail_tour(self):
+        self.env['res.users'].create({
+            'email': '', # User should be able to create a channel even if no email is defined
+            'groups_id': [Command.set([self.ref('base.group_user')])],
+            'name': 'Test User',
+            'login': 'testuser',
+            'password': 'testuser',
+        })
+        self.start_tour("/web", 'mail_tour', login='testuser')


### PR DESCRIPTION
When a user without an email partner try to create a channel, an exception is
raised because he has no email.
This exception should not happen when creating a new channel.

task-2641660