### PR TITLE
[IMP] hr_recruitment: improve applicant creation through calendar

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -31,7 +31,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
             if applicants and wizard.send_mail:
                 wizard.applicant_without_email = "%s\n%s" % (
                     _("The email will not be sent to the following applicant(s) as they don't have email address."),
-                    "\n".join([i.partner_name for i in applicants])
+                    "\n".join([i.partner_name or i.name for i in applicants])
                 )
             else:
                 wizard.applicant_without_email = False


### PR DESCRIPTION
Previously when creating an applicant through the calendar application,
no activity would be created making the newly created record not show up
in the calendar because it depends on the activities linked to the
record.
A calendar event will now be created upon creation through the calendar
view in order for the applicant to be displayed directly.

TaskId-2641495