### PR TITLE
[FIX] project: send created tasks to following portal user

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1293,6 +1293,8 @@ class Task(models.Model):
         task = super(Task, self.with_context(create_context)).message_new(msg, custom_values=defaults)
         email_list = task.email_split(msg)
         partner_ids = [p.id for p in self.env['mail.thread']._mail_find_partner_from_emails(email_list, records=task, force_create=False) if p]
+        customer_ids = [p.id for p in self.env['mail.thread']._mail_find_partner_from_emails(tools.email_split(defaults['email_from']), records=task) if p]
+        partner_ids += customer_ids
         task.message_subscribe(partner_ids)
         return task
 


### PR DESCRIPTION
How to reproduce the problem:
- Go to General Settings
- Check Custom Email Servers and create an Alias Domain
- Go to the Project app
- Create a new project and put an alias email for it
- In another (private) window), create a new portal user
- Send an email from that user's address to the created project's mail

A task is created, and the portal user is set as a follower.
BUT the portal user doesn't receive the task in his "Documents".

Cause of the problem : only the recipients of the mail are correctly
subscribed to the followers list, not the sender (which skips a step).

This commit adds the sender in the process of subscribing followers to a task.

opw-2619370