### PR TITLE
[FIX] l10n_in: expected singleton error when posting multiple moves

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -105,7 +105,7 @@ class AccountMove(models.Model):
                     company_name=company_unit_partner.name,
                     company_id=company_unit_partner.id
                 ))
-            elif self.journal_id.type == 'purchase':
+            elif move.journal_id.type == 'purchase':
                 move.l10n_in_state_id = company_unit_partner.state_id
 
             shipping_partner = move._l10n_in_get_shipping_partner()
@@ -119,7 +119,7 @@ class AccountMove(models.Model):
                     partner_id=shipping_partner.id,
                     name=gst_treatment_name_mapping.get(move.l10n_in_gst_treatment)
                 ))
-            if self.journal_id.type == 'sale':
+            if move.journal_id.type == 'sale':
                 move.l10n_in_state_id = self._l10n_in_get_indian_state(shipping_partner)
                 if not move.l10n_in_state_id:
                     move.l10n_in_state_id = self._l10n_in_get_indian_state(move.partner_id)


### PR DESCRIPTION
```
ceback (most recent call last):
  File "/home/odoo/src/odoo/14.0/odoo/service/server.py", line 1199, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 474, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/14.0/odoo/modules/migration.py", line 180, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmpgxy7cwao/migrations/account/saas~13.4.1.1/end-09-payment-refactoring.py", line 618, in migrate
    util.iter_browse(env["account.move"].with_context(**ctx), ids, chunk_size=1024).action_post()
  File "/tmp/tmpgxy7cwao/migrations/util/orm.py", line 169, in caller
    return [getattr(chnk, attr)(*args, **kwargs) for chnk in chain(it, self._end())]
  File "/tmp/tmpgxy7cwao/migrations/util/orm.py", line 169, in <listcomp>
    return [getattr(chnk, attr)(*args, **kwargs) for chnk in chain(it, self._end())]
  File "/home/odoo/src/odoo/14.0/addons/sale/models/account_move.py", line 14, in action_post
    res = super(AccountMove, self).action_post()
  File "/home/odoo/src/odoo/14.0/addons/account/models/account_move.py", line 2649, in action_post
    self._post(soft=False)
  File "/home/odoo/src/odoo/14.0/addons/sale/models/account_invoice.py", line 81, in _post
    posted = super()._post(soft)
  File "/home/odoo/src/odoo/14.0/addons/purchase_stock/models/account_invoice.py", line 188, in _post
    return super()._post(soft)
  File "/home/odoo/src/odoo/14.0/addons/l10n_in/models/account_invoice.py", line 108, in _post
    elif self.journal_id.type == 'purchase':
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 963, in __get__
    record.ensure_one()
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 4993, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.journal(4, 3, 59, 99, 18, 11, 8, 77, 10, 72, 21, 66, 92, 88, 74)
```

upg-30689