### PR TITLE
[FIX] web_editor: correctly init "open in new window" link option

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -58,6 +58,7 @@ const Link = Widget.extend({
             range.selectNodeContents(link);
             this.data.range = range;
             this.$link = $(link);
+            this.linkEl = link;
         } else {
             const selection = editable && editable.ownerDocument.getSelection();
             this.data.range = selection && selection.rangeCount && selection.getRangeAt(0);
@@ -65,6 +66,7 @@ const Link = Widget.extend({
 
         if (this.data.range) {
             this.$link = this.$link || $(OdooEditorLib.getInSelection(this.editable.ownerDocument, 'a'));
+            this.linkEl = this.$link[0];
             this.data.iniClassName = this.$link.attr('class') || '';
             this.colorCombinationClass = false;
             let $node = this.$link;
@@ -85,6 +87,10 @@ const Link = Widget.extend({
             this.data.url = this.$link.attr('href') || '';
         } else {
             this.data.content = this.data.content ? this.data.content.replace(/[ \t\r\n]+/g, ' ') : '';
+        }
+
+        if (this.linkEl) {
+            this.data.isNewWindow = this.data.isNewWindow || this.linkEl.target === '_blank';
         }
 
         const allBtnClassSuffixes = /(^|\s+)btn(-[a-z0-9_-]*)?/gi;

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -577,7 +577,7 @@
             </we-select>
         </we-row>
         <we-row  t-if="!widget.isButton &amp;&amp; !widget.options.forceNewWindow">
-            <we-button class="o_we_user_value_widget o_we_checkbox_wrapper">
+            <we-button t-attf-class="o_we_user_value_widget o_we_checkbox_wrapper #{widget.data.isNewWindow ? 'active' : ''}">
                 <we-title class="o_long_title">⌙ Open in new window</we-title>
                     <div class="o_switch">
                         <we-checkbox name="is_new_window" t-att-checked="widget.data.isNewWindow ? 'checked' : undefined"/>


### PR DESCRIPTION
The "Open in new window" checkbox was always initialized as false, even
if the link would open in a new window - both in the link tools and
dialog.

task-2172311




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
