### PR TITLE
[FIX] product_expiry, stock: issue with lots

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -33,4 +33,4 @@ class StockMoveLine(models.Model):
 
     def _assign_production_lot(self, lot):
         super()._assign_production_lot(lot)
-        self.lot_id._update_date_values(self.expiration_date)
+        self.lot_id._update_date_values(self[0].expiration_date)

--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -9,7 +9,8 @@ from odoo import api, fields, models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    expiration_date = fields.Datetime(string='Expiration Date', compute='_compute_expiration_date', store=True,
+    expiration_date = fields.Datetime(
+        string='Expiration Date', compute='_compute_expiration_date', store=True,
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
 
@@ -18,7 +19,8 @@ class StockMoveLine(models.Model):
         for move_line in self:
             if move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date:
-                    move_line.expiration_date = fields.Datetime.today() + datetime.timedelta(days=move_line.product_id.expiration_time)
+                    if not move_line.expiration_date:
+                        move_line.expiration_date = fields.Datetime.today() + datetime.timedelta(days=move_line.product_id.expiration_time)
                 else:
                     move_line.expiration_date = False
 
@@ -30,6 +32,16 @@ class StockMoveLine(models.Model):
             self.expiration_date = self.lot_id.expiration_date
         else:
             self.expiration_date = False
+
+    @api.onchange('product_id', 'product_uom_id')
+    def _onchange_product_id(self):
+        res = super()._onchange_product_id()
+        if self.picking_type_use_create_lots:
+            if self.product_id.use_expiration_date:
+                self.expiration_date = fields.Datetime.today() + datetime.timedelta(days=self.product_id.expiration_time)
+            else:
+                self.expiration_date = False
+        return res
 
     def _assign_production_lot(self, lot):
         super()._assign_production_lot(lot)

--- a/addons/product_expiry/tests/test_stock_production_lot.py
+++ b/addons/product_expiry/tests/test_stock_production_lot.py
@@ -293,12 +293,12 @@ class TestStockProductionLot(TestStockCommon):
         receipt.action_confirm()
 
         # Defines a date during the receipt.
-        move = receipt.move_ids_without_package[0]
-        line = move.move_line_ids[0]
-        self.assertEqual(move.use_expiration_date, True)
-        line.lot_name = 'Apple Box #2'
-        line.expiration_date = expiration_date
-        line.qty_done = 4
+        move_form = Form(receipt.move_ids_without_package, view="stock.view_stock_move_operations")
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'Apple Box #2'
+            line.expiration_date = expiration_date
+            line.qty_done = 4
+        move = move_form.save()
 
         receipt._action_done()
         # Get back the lot created when the picking was done...

--- a/addons/stock/tests/test_generate_serial_numbers.py
+++ b/addons/stock/tests/test_generate_serial_numbers.py
@@ -295,6 +295,7 @@ class StockGenerate(SavepointCase):
             self.assertEqual(move_line.qty_done, 1)
             # The location dest must be now the one from the putaway.
             self.assertEqual(move_line.location_dest_id.id, shelf_location.id)
+
     def test_set_multiple_lot_name_01(self):
         """ Sets five SN in one time in stock move view form, then checks move
         has five new move lines with the right `lot_name`.

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -9,7 +9,6 @@ from odoo.exceptions import UserError
 from odoo.tests import Form
 from odoo.tools import float_is_zero, float_compare
 
-from odoo.tests.common import Form
 
 class TestPickShip(TestStockCommon):
     def create_pick_ship(self):

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.exceptions import ValidationError
 from odoo.tests import Form
 from odoo.tools import mute_logger, float_round
-from odoo.exceptions import UserError
 from odoo import fields
+
 
 class TestStockFlow(TestStockCommon):
     def setUp(cls):
@@ -15,12 +16,12 @@ class TestStockFlow(TestStockCommon):
             'name': 'My Company (Chicago)-demo',
             'email': 'chicago@yourcompany.com',
             'company_id': False,
-            })
+        })
         cls.company = cls.env['res.company'].create({
             'currency_id': cls.env.ref('base.USD').id,
             'partner_id': cls.partner_company2.id,
             'name': 'My Company (Chicago)-demo',
-            })
+        })
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     def test_00_picking_create_and_transfer_quantity(self):
@@ -105,7 +106,7 @@ class TestStockFlow(TestStockCommon):
             'location_dest_id': self.stock_location,
             'move_id': move_c.id,
             'lot_id': lot2_productC.id,
-            })
+        })
         self.StockPackObj.create({
             'product_id': self.productD.id,
             'qty_done': 2,
@@ -113,11 +114,11 @@ class TestStockFlow(TestStockCommon):
             'location_id': self.supplier_location,
             'location_dest_id': self.stock_location,
             'move_id': move_d.id
-            })
+        })
 
         # Check incoming shipment total quantity of pack operation
         total_qty = sum(self.StockPackObj.search([('move_id', 'in', picking_in.move_lines.ids)]).mapped('qty_done'))
-        self.assertEqual(total_qty, 23,  'Wrong quantity in pack operation')
+        self.assertEqual(total_qty, 23, 'Wrong quantity in pack operation')
 
         # Transfer Incoming Shipment.
         picking_in._action_done()
@@ -1976,3 +1977,118 @@ class TestStockFlow(TestStockCommon):
         picking = f.save()
 
         self.assertEqual(f.state, 'confirmed')
+
+    def test_validate_multiple_pickings_with_same_lot_names(self):
+        """ Checks only one lot is created when the same lot name is used in
+        different pickings and those pickings are validated together.
+        """
+        # Creates two tracked products (one by lots and one by SN).
+        product_lot = self.env['product.product'].create({
+            'name': 'Tracked by lot',
+            'type': 'product',
+            'tracking': 'lot',
+        })
+        product_serial = self.env['product.product'].create({
+            'name': 'Tracked by SN',
+            'type': 'product',
+            'tracking': 'serial',
+        })
+        # Creates two receipts using some lot names in common.
+        picking_type = self.env['stock.picking.type'].browse(self.picking_type_in)
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = picking_type
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = product_lot
+            move.product_uom_qty = 8
+        receipt_1 = picking_form.save()
+        receipt_1.action_confirm()
+
+        move_form = Form(receipt_1.move_lines, view="stock.view_stock_move_operations")
+        with move_form.move_line_ids.edit(0) as line:
+            line.lot_name = 'lot-001'
+            line.qty_done = 3
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'lot-002'
+            line.qty_done = 3
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'lot-003'
+            line.qty_done = 2
+        move = move_form.save()
+
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = picking_type
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = product_lot
+            move.product_uom_qty = 8
+        receipt_2 = picking_form.save()
+        receipt_2.action_confirm()
+
+        move_form = Form(receipt_2.move_lines, view="stock.view_stock_move_operations")
+        with move_form.move_line_ids.edit(0) as line:
+            line.lot_name = 'lot-003'
+            line.qty_done = 2
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'lot-004'
+            line.qty_done = 4
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'lot-001'
+            line.qty_done = 1
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'lot-005'
+            line.qty_done = 1
+        move = move_form.save()
+
+        # Validates the two receipts and checks the move lines' lot.
+        (receipt_1 | receipt_2).button_validate()
+        lots = self.env['stock.production.lot'].search([('product_id', '=', product_lot.id)])
+        self.assertEqual(len(lots), 5)
+        lot1, lot2, lot3, lot4, lot5 = lots
+        self.assertEqual(lot1.name, 'lot-001')
+        self.assertEqual(lot2.name, 'lot-002')
+        self.assertEqual(lot3.name, 'lot-003')
+        self.assertEqual(lot4.name, 'lot-004')
+        self.assertEqual(lot5.name, 'lot-005')
+        self.assertEqual(receipt_1.move_line_ids[0].lot_id.id, lot1.id)
+        self.assertEqual(receipt_1.move_line_ids[1].lot_id.id, lot2.id)
+        self.assertEqual(receipt_1.move_line_ids[2].lot_id.id, lot3.id)
+        self.assertEqual(receipt_2.move_line_ids[0].lot_id.id, lot3.id)
+        self.assertEqual(receipt_2.move_line_ids[1].lot_id.id, lot4.id)
+        self.assertEqual(receipt_2.move_line_ids[2].lot_id.id, lot1.id)
+        self.assertEqual(receipt_2.move_line_ids[3].lot_id.id, lot5.id)
+
+        # Checks also it still raise an error when it tries to create multiple time
+        # the same serial numbers (same scenario but with SN instead of lots).
+        picking_type = self.env['stock.picking.type'].browse(self.picking_type_in)
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = picking_type
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = product_serial
+            move.product_uom_qty = 2
+        receipt_1 = picking_form.save()
+        receipt_1.action_confirm()
+
+        move_form = Form(receipt_1.move_lines, view="stock.view_stock_move_operations")
+        with move_form.move_line_ids.edit(0) as line:
+            line.lot_name = 'sn-001'
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'sn-002'
+        move = move_form.save()
+
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = picking_type
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = product_serial
+            move.product_uom_qty = 2
+        receipt_2 = picking_form.save()
+        receipt_2.action_confirm()
+
+        move_form = Form(receipt_2.move_lines, view="stock.view_stock_move_operations")
+        with move_form.move_line_ids.edit(0) as line:
+            line.lot_name = 'sn-002'
+        with move_form.move_line_ids.new() as line:
+            line.lot_name = 'sn-001'
+        move = move_form.save()
+
+        # Validates the two receipts => It should raise an error as there is duplicate SN.
+        with self.assertRaises(ValidationError):
+            (receipt_1 | receipt_2).button_validate()


### PR DESCRIPTION
**[FIX] stock: avoid attempt to create the same lot**
> How to reproduce:
>   - Create a product tracked by lot;
>   - Create two receipts for this product;
>   - Use the same lot name in the two receipts;
>   - Try to validate the two receipts in the same time
>     => `ValidationError` will trigger in the `_check_unique_lot` constrain of the production lot.
> 
> task-2646107

**[FIX] product_expiry: lot expiration_date**
> This commit adresses to two issues:
> 
> Since 0c83542, the move line's `expiration_date` set by the user is always overrided at the creation of the move which means the user has to modify it after the move was created.
> 
> To fix that, the compute doesn't override the `expiration_date` if there is already one set.
> Therefore, the onchange on the product who was removed is re-added to force to recompute the `expiration_date` if the move line's product is changed and it has already an `expiration_date` set.