### PR TITLE
[FIX] base_vat: only use VIES service for company VAT numbers

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -154,7 +154,8 @@ class ResPartner(models.Model):
             if not partner.vat:
                 continue
 
-            if company.vat_check_vies and partner.commercial_partner_id.country_id in eu_countries:
+            is_eu_country = partner.commercial_partner_id.country_id in eu_countries
+            if company.vat_check_vies and is_eu_country and partner.company_type == "company":
                 # force full VIES online check
                 check_func = self.vies_vat_check
             else:


### PR DESCRIPTION
Some countries, such as Portugal, persons also have VAT-like tax
numbers, that can be used in invoices, just like company VAT numbers
can.

However, the VIES service does not work for these person VAT numbers,
only for companies.

This fix ensures that VIES validation is only used for companies.
