### PR TITLE
[FIX] web: fix calendar quick create removing everything

### DIFF
--- a/addons/web/static/src/legacy/xml/web_calendar.xml
+++ b/addons/web/static/src/legacy/xml/web_calendar.xml
@@ -12,7 +12,7 @@
     </div>
 
     <t t-name="calendar-box">
-        <div t-att-style="typeof color === 'string' ? ('background-color:' + color) + ';' : ''" t-attf-class="#{record.is_highlighted ? 'o_event_hightlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} #{record.is_hatched ? 'o_calendar_hatched o_calendar_hatched_' + (typeof color === 'number' ? color : 1): ''} #{record.is_striked ? 'o_calendar_striked o_calendar_striked_' + (typeof color === 'number' ? color : 1): ''}">
+        <div t-att-style="typeof color === 'string' ? ('background-color:' + color) + ';' : ''" t-attf-class="o_event #{record.is_highlighted ? 'o_event_hightlight' : ''} #{typeof color === 'number' ? _.str.sprintf('o_calendar_color_%s', color) : 'o_calendar_color_1'} #{record.is_hatched ? 'o_calendar_hatched o_calendar_hatched_' + (typeof color === 'number' ? color : 1): ''} #{record.is_striked ? 'o_calendar_striked o_calendar_striked_' + (typeof color === 'number' ? color : 1): ''}">
             <span t-if="showTime" class="fc-time"/>
             <div class="o_event_title" t-esc="record.display_name"/>
             <div t-if="showLocation and record.location" t-esc="record.location"/>


### PR DESCRIPTION
When an event is currently being inspected by the user, i.e. the popover
is displayed and the user clicks somewhere else on the calendar, we do
not wish to open the quick create menu, only close the popover.
However the code that handled that case was not adapted to the regular
calendar view, only the one from the calendar app and would remove all
data currently displayed.

This commit fixes that issue.

TaskId-2652219