### PR TITLE
[FIX] attachment_indexation: AttributeError __enter__

### DIFF
--- a/addons/attachment_indexation/models/ir_attachment.py
+++ b/addons/attachment_indexation/models/ir_attachment.py
@@ -108,7 +108,8 @@ class IrAttachment(models.Model):
             f = io.BytesIO(bin_data)
             try:
                 resource_manager = PDFResourceManager()
-                with io.StringIO() as content, TextConverter(resource_manager, content) as device:
+                with io.StringIO() as content:
+                    device = TextConverter(resource_manager, content)
                     logging.getLogger("pdfminer").setLevel(logging.CRITICAL)
                     interpreter = PDFPageInterpreter(resource_manager, device)
 


### PR DESCRIPTION
TextConverter cannot be used with `with` statement



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
