### PR TITLE
[FIX] website: hide control panel elements in themes kanban view

### DIFF
--- a/addons/website/static/src/js/theme_preview_kanban.js
+++ b/addons/website/static/src/js/theme_preview_kanban.js
@@ -24,13 +24,15 @@ var ThemePreviewKanbanController = KanbanController.extend(ThemePreviewControlle
             href: '/',
             innerHTML: '<i class="fa fa-close"></i>',
         });
-        const smallBreadcumb = Object.assign(document.createElement('small'), {
-            className: 'mx-2 text-muted',
-            innerHTML: _lt("Don't worry, you can switch later."),
-        });
+        if (!this.initialState.context.module) { // not coming from res.config.settings
+            const smallBreadcumb = Object.assign(document.createElement('small'), {
+                className: 'mx-2 text-muted',
+                innerHTML: _lt("Don't worry, you can switch later."),
+            });
+            this._controlPanelWrapper.el.querySelector('.o_cp_top li').appendChild(smallBreadcumb);
+            this._controlPanelWrapper.el.querySelector('.o_cp_top').appendChild(websiteLink);
+        }
         this._controlPanelWrapper.el.querySelector('.o_cp_top .breadcrumb li.active').classList.add('text-black-75');
-        this._controlPanelWrapper.el.querySelector('.o_cp_top').appendChild(websiteLink);
-        this._controlPanelWrapper.el.querySelector('.o_cp_top li').appendChild(smallBreadcumb);
     },
     /**
      * Called when user click on any button in kanban view.

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -40,7 +40,7 @@
                         <div class="row mt16 o_settings_container" id="website_settings" attrs="{'invisible': [('website_id', '=', False)]}">
                             <div class="col-12 o_setting_box" id="website_action_setting" style="margin-left: 30px; margin-bottom: 16px;">
                                 <button name="website_go_to" type="object" string="Go to Website" class="btn btn-primary" icon="fa-globe"/>
-                                <button name="install_theme_on_current_website" type="object" string="Pick a Theme" class="ml-2 btn btn-primary" icon="fa-paint-brush"/>
+                                <button name="install_theme_on_current_website" type="object" string="Pick a Theme" class="ml-2 btn btn-secondary" icon="fa-paint-brush"/>
                                 <button name="%(website.action_website_add_features)d" type="action" string="Add features" class="ml-2 btn btn-secondary" icon="fa-plus"/>
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="domain_setting">


### PR DESCRIPTION
The message 'Don't worry, you can switch later' is displayed in the
breadcrumb of the theme kanban view. When we reach this kanban view
from the website settings we want to hide this message.

task-2610896

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
