### PR TITLE
[FIX] hr_holidays: propagate context from Time Off dashboard

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -188,7 +188,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
                 return self._rpc({
                     model: 'hr.leave.type',
                     method: 'get_days_all_request',
-                    context: self.context,
+                    context: self.state.context,
                 });
             }).then(function (result) {
                 self.$el.parent().find('.o_calendar_mini').hide();


### PR DESCRIPTION
The context was not propagated hence it was not showing the allocations
of the current companies.

TaskID: 2652888

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
