### PR TITLE
[IMP] Display description_done field

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -83,6 +83,9 @@
                         <page string="Description" name="description">
                             <field name="description" nolabel="1"></field>
                         </page>
+                        <page string="End Message" name="description_done">
+                            <field name="description_done" nolabel="1"></field>
+                        </page>
                         <page string="Options" name="options">
                             <group name="options">
                                 <group string="Questions" name="questions">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add (back) the edition of description_done field on surveys

Current behavior before PR:
description_done field is not displayed on backend and therefore user cannot fill it.

Desired behavior after PR is merged:
description_done field is displayed to / editable by user

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
