### PR TITLE
[FIX] website: fix main menu navbar disappearing

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -35,8 +35,8 @@ weSnippetEditor.SnippetsMenu.include({
     /**
      * @override
      */
-    start() {
-        this._super(...arguments);
+    async start() {
+        await this._super(...arguments);
         this.$currentAnimatedText = $();
 
         this.__onSelectionChange = ev => {


### PR DESCRIPTION
Before this commit, the "purple" main menu navbar disappeared before
the editor was loaded (after clicking on the "Edit" button).

task-2652381

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
