### PR TITLE
[FIX] web_editor: prevent editing document in iframe with cross-origi…

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -327,6 +327,11 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                         return;
                     }
                     var cwindow = self.$iframe[0].contentWindow;
+                    try {
+                        cwindow.document;
+                    } catch (e) {
+                        return;
+                    }
                     cwindow.document
                         .open("text/html", "replace")
                         .write(


### PR DESCRIPTION
…n access issue

- Go to Email Marketing
- Create a new mailing with template having social media links
- Save
- Click on one of the social links
An error is triggered:
"Error: Blocked a frame with origin xxx from accessing a cross-origin frame."

The traceback occurs because we try to change the content of something we
don't have access to, as these sites prevent display in an iframe.

opw-2599540



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
