### PR TITLE
[FIX] website: properly handle "100% height" snippet when in popups

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -915,7 +915,12 @@ registry.FullScreenHeight = publicWidget.Widget.extend({
      * @override
      */
     start() {
-        if (this.$el.outerHeight() > this._computeIdealHeight()) {
+        this.inModal = !!this.el.closest('.modal');
+
+        // TODO maybe review the way the public widgets work for non-visible-at-
+        // load snippets -> probably better to not do anything for them and
+        // start the widgets only once they become visible..?
+        if (this.$el.is(':not(:visible)') || this.$el.outerHeight() > this._computeIdealHeight()) {
             // Only initialize if taller than the ideal height as some extra css
             // rules may alter the full-screen-height class behavior in some
             // cases (blog...).
@@ -949,6 +954,10 @@ registry.FullScreenHeight = publicWidget.Widget.extend({
      */
     _computeIdealHeight() {
         const windowHeight = $(window).outerHeight();
+        if (this.inModal) {
+            return (windowHeight - $('#wrapwrap').position().top);
+        }
+
         // Doing it that way allows to considerer fixed headers, hidden headers,
         // connected users, ...
         const firstContentEl = $('#wrapwrap > main > :first-child')[0]; // first child to consider the padding-top of main


### PR DESCRIPTION
Before this commit, when a "100% height" snippet was set in a popup
snippet, it was still computed to take full-screen height minus the size
of the navbar.

Now, it will properly be full-height.
