### PR TITLE
[FIX] mail: keyboard shouldn't pop on WebRTC call on mobile devices

### DIFF
--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -160,7 +160,7 @@ export class Composer extends Component {
      */
     _onClickAddAttachment() {
         this._fileUploaderRef.comp.openBrowserFileUploader();
-        if (!this.env.device.isMobile) {
+        if (!this.messaging.device.isMobileDevice) {
             this.composerView.update({ doFocus: true });
         }
     }
@@ -248,7 +248,7 @@ export class Composer extends Component {
         ev.stopPropagation();
         this._textInputRef.comp.saveStateInStore();
         this.composerView.insertIntoTextInput(ev.detail.unicode);
-        if (!this.env.device.isMobile) {
+        if (!this.messaging.device.isMobileDevice) {
             this.composerView.update({ doFocus: true });
         }
     }

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -36,7 +36,7 @@ function factory(dependencies) {
             if (notifyServer === undefined) {
                 notifyServer = !this.messaging.device.isMobile;
             }
-            if (this.env.device.isMobile && !this.messaging.discuss.isOpen) {
+            if (this.messaging.device.isMobile && !this.messaging.discuss.isOpen) {
                 // If we are in mobile and discuss is not open, it means the
                 // chat window was opened from the messaging menu. In that
                 // case it should be re-opened to simulate it was always
@@ -105,14 +105,14 @@ function factory(dependencies) {
 
         /**
          * Makes this chat window active, which consists of making it visible,
-         * unfolding it, and focusing it.
+         * unfolding it, and focusing it if the user isn't on a mobile device.
          *
          * @param {Object} [options]
          */
         makeActive(options) {
             this.makeVisible();
             this.unfold(options);
-            if ((options && options.focus !== undefined) ? options.focus : true) {
+            if ((options && options.focus !== undefined) ? options.focus : !this.messaging.device.isMobileDevice) {
                 this.focus();
             }
         }

--- a/addons/mail/static/src/models/device/device.js
+++ b/addons/mail/static/src/models/device/device.js
@@ -50,7 +50,7 @@ function factory(dependencies) {
                 globalWindowInnerHeight: this.env.browser.innerHeight,
                 globalWindowInnerWidth: this.env.browser.innerWidth,
                 isMobile: this.env.device.isMobile,
-                isMobileDevice: this.env.device.isMobileDevice,
+                isMobileDevice: this.messaging.device.isMobileDevice,
                 sizeClass: this.env.device.size_class,
             });
         }

--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -207,13 +207,13 @@ function factory(dependencies) {
          *
          * @param {mail.thread} thread
          * @param {Object} [param1={}]
-         * @param {Boolean} [param1.focus=true]
+         * @param {Boolean} [param1.focus]
          */
-        async openThread(thread, { focus = true } = {}) {
+        async openThread(thread, { focus } = {}) {
             this.update({
                 thread: link(thread),
             });
-            if (focus) {
+            if (focus !== undefined ? focus : !this.messaging.device.isMobileDevice) {
                 this.focus();
             }
             if (!this.isOpen) {

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -994,9 +994,9 @@ function factory(dependencies) {
          *
          * @param {Object} [param0]
          * @param {boolean} [param0.expanded=false]
-         * @param {boolean} [param0.focus=true]
+         * @param {boolean} [param0.focus]
          */
-        async open({ expanded = false, focus = true } = {}) {
+        async open({ expanded = false, focus } = {}) {
             const discuss = this.messaging.discuss;
             // check if thread must be opened in form view
             if (!['mail.box', 'mail.channel'].includes(this.model)) {
@@ -1018,7 +1018,9 @@ function factory(dependencies) {
                 (!device.isMobile && (discuss.isOpen || expanded)) ||
                 this.model === 'mail.box'
             ) {
-                return discuss.openThread(this, { focus });
+                return discuss.openThread(this, {
+                    focus: focus !== undefined ? focus : !this.messaging.device.isMobileDevice,
+                });
             }
             // thread must be opened in chat window
             return this.messaging.chatWindowManager.openThread(this, {


### PR DESCRIPTION
Steps to reproduce:

1. Log on odoo with a user A on mobile device
2. Log on odoo with a user B on desktop
3. User B call user A
4. User A answer the call and the keyboard popup on the screen => BUG

To avoid this behavior, we disable the input focus on mobile device when
 the user answer a call.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
