### PR TITLE
[IMP] calendar: removes the group-by availability preset filter

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -317,7 +317,6 @@
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                 <group expand="0" string="Group By">
                     <filter string="Responsible" name="responsible" domain="[]" context="{'group_by': 'user_id'}"/>
-                    <filter string="Availability" name="availability" domain="[]" context="{'group_by': 'show_as'}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
This commit will apply a minor change on the appointment module: It will remove the preset that allow the user to group the appointments by availability (in the backend).

task-2646322
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
