### PR TITLE
[FIX] account: typo - active to activate fix

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -276,7 +276,7 @@
                                 <div class="o_setting_right_pane" name="show_sale_receipts_right_pane">
                                     <label for="group_show_sale_receipts"/>
                                     <div class="text-muted">
-                                        Active to create sale receipt
+                                        Activate to create sale receipt
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Fix typo under sale receipt in res_config_settings_views.
Active to create sale receipt ---to---> Activate to create sale receipt

task: 2643691