### PR TITLE
Debug manager icon in modal

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -5,7 +5,7 @@
         <Dropdown class="o_debug_manager"
           beforeOpen="getElements"
           position="'bottom-end'"
-          tag="'li'"
+          tag="props.tag or 'li'"
           togglerClass="'btn btn-link'">
             <t t-set-slot="toggler">
                 <span class="fa fa-bug"/>

--- a/addons/web/static/src/webclient/actions/action_dialog.xml
+++ b/addons/web/static/src/webclient/actions/action_dialog.xml
@@ -3,7 +3,7 @@
 
   <t t-name="web.ActionDialog" t-inherit="web.Dialog" t-inherit-mode="primary" owl="1">
     <xpath expr="//header/h4[contains(concat(' ',normalize-space(@class),' '),' modal-title ')]" position="before">
-      <DebugMenu t-if="env.debug" />
+      <DebugMenu t-if="env.debug" tag="'div'" />
     </xpath>
     <xpath expr="//main[@class='modal-body']" position="attributes">
       <attribute name="t-att-class">


### PR DESCRIPTION
Spotted in Master but please check prior versions as well.

How to reproduce:
    Go into debug mode
    Open a modal

Current behavior:
    An extra character is displayed before the bug icon
    From what I see, this is because the buttons are inside a list?
    <li class="o_dropdown o_debug_manager">

TASK 2652867


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
