### PR TITLE
[FIX] l10n_cl: relax the condition for registering entries in purchase journal

### DIFF
--- a/addons/l10n_cl/i18n/es.po
+++ b/addons/l10n_cl/i18n/es.po
@@ -642,16 +642,6 @@ msgstr ""
 "importación"
 
 #. module: l10n_cl
-#: code:addons/l10n_cl/models/account_move.py:0
-#, python-format
-msgid ""
-"This supplier should be defined as foreigner tax payer type and the country "
-"should be different from Chile to register purchases."
-msgstr ""
-"Este proveedor debería ser definido como tipo de contribuyente “Extranjero” "
-"y el país debería ser diferente de Chile para registrar compras."
-
-#. module: l10n_cl
 #: model_terms:ir.ui.view,arch_db:l10n_cl.view_complete_invoice_refund_tree
 msgid "Total"
 msgstr "Total"

--- a/addons/l10n_cl/i18n/l10n_cl.pot
+++ b/addons/l10n_cl/i18n/l10n_cl.pot
@@ -613,14 +613,6 @@ msgid ""
 msgstr ""
 
 #. module: l10n_cl
-#: code:addons/l10n_cl/models/account_move.py:0
-#, python-format
-msgid ""
-"This supplier should be defined as foreigner tax payer type and the country "
-"should be different from Chile to register purchases."
-msgstr ""
-
-#. module: l10n_cl
 #: model_terms:ir.ui.view,arch_db:l10n_cl.view_complete_invoice_refund_tree
 msgid "Total"
 msgstr ""

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -43,7 +43,6 @@ class AccountMove(models.Model):
             domain += [('code', 'in', [])]
         return domain
 
-
     def _check_document_types_post(self):
         for rec in self.filtered(
                 lambda r: r.company_id.country_id.code == "CL" and
@@ -85,10 +84,6 @@ class AccountMove(models.Model):
                 if tax_payer_type == '4' or country_id.code != "CL":
                     raise ValidationError(_('You need a journal without the use of documents for foreign '
                                             'suppliers'))
-            if rec.journal_id.type == 'purchase' and not rec.journal_id.l10n_latam_use_documents:
-                if tax_payer_type != '4':
-                    raise ValidationError(_('This supplier should be defined as foreigner tax payer type and '
-                                            'the country should be different from Chile to register purchases.'))
 
     @api.onchange('journal_id')
     def _l10n_cl_onchange_journal(self):


### PR DESCRIPTION
Before this PR:
If expense app is used, it is not possible to register expenses in purchase journal

Current behavior before PR:
This is allowed




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
