### PR TITLE
[FIX] stock: avoid write on move when create return line

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -13,7 +13,7 @@ class ReturnPickingLine(models.TransientModel):
 
     product_id = fields.Many2one('product.product', string="Product", required=True, domain="[('id', '=', product_id)]")
     quantity = fields.Float("Quantity", digits='Product Unit of Measure', required=True)
-    uom_id = fields.Many2one('uom.uom', string='Unit of Measure', related='move_id.product_uom', readonly=False)
+    uom_id = fields.Many2one('uom.uom', string='Unit of Measure', related='move_id.product_uom', readonly=True)
     wizard_id = fields.Many2one('stock.return.picking', string="Wizard")
     move_id = fields.Many2one('stock.move', "Move")
 


### PR DESCRIPTION
When creating a wizard `stock.return.picking` and call
`_onchange_picking_id`, the creation of return picking line will perform
a write on move linked with the return line, due to `uom_id` being set
as related with `readonly=False`

Description of the issue/feature this PR addresses:

Take the following code as example

```
return_wizard = self.env["stock.return.picking"].with_context(active_id=id, active_ids=ids).create({"picking_id": id})
return_wizard._onchange_picking_id()
```

Prior to this point, there isn't an issue raise when execute `_onchange_picking_id` on the wizard, but it does now, telling you that you cannot update uom on a done move. The reason is, while setting return lines on line 69, it will `write` to move reference in `move_id` since we have `uom_id` set as related to `move_id.uom_id` and `readonly=False`.

In the same source code for return picking, we have `_prepare_stock_return_picking_line_vals_from_move` returning `move_id` and `uom_id` during the creation of wizard, so I think it's safe to remove the definition of related model on `uom_id`

```
68     if self.picking_id: 
69       --> self.product_return_moves = product_return_moves  
70           self.move_dest_exists = move_dest_exists
```

The alternative solution to what I proposed, is to set `readonly=True`, and then refactor  `_prepare_stock_return_picking_line_vals_from_move` to not return `uom_id`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
