### PR TITLE
[MERGE] website_slides(_survey/_forum): improve standard and reporting views

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -174,9 +174,10 @@
                 <field name="active" invisible="1"/>
                 <field name="certification" invisible="1"/>
                 <field name="title"/>
+                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="answer_duration_avg" widget="float_time"/>
                 <field name="answer_count"/>
                 <field name="answer_done_count"/>
-                <field name="answer_duration_avg"/>
                 <field name="success_count"/>
                 <field name="success_ratio"/>
                 <field name="answer_score_avg"/>

--- a/addons/website_forum/views/forum.xml
+++ b/addons/website_forum/views/forum.xml
@@ -32,10 +32,10 @@
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="website_id" groups="website.group_multi_website"/>
-                    <field name="total_posts"/>
-                    <field name="total_views"/>
-                    <field name="total_answers"/>
-                    <field name="total_favorites"/>
+                    <field name="total_posts" sum="Total Posts"/>
+                    <field name="total_views" sum="Total Views"/>
+                    <field name="total_answers" optional="hide"/>
+                    <field name="total_favorites" optional="hide"/>
                     <field name="active" invisible="1"/>
                 </tree>
             </field>
@@ -187,11 +187,13 @@
                     <field name="name"/>
                     <field name="active" invisible="1"/>
                     <field name="forum_id"/>
-                    <field name="views" sum="Total Views"/>
-                    <field name="child_count" sum="Total Answers"/>
-                    <field name="favourite_count" sum="Total Favorites"/>
-                    <field name="website_id" groups="website.group_multi_website"/>
-                    <field name="state"/>
+                    <field name="views" string="# Views" sum="Total Views"/>
+                    <field name="child_count" string="# Answers" sum="Total Answers"/>
+                    <field name="state" widget="badge"
+                        decoration-success="state == 'active'"
+                        decoration-danger="state == 'close'"
+                        decoration-warning="state not in ('active', 'close')"/>
+                    <field name="website_id" groups="website.group_multi_website" optional="hide"/>
                 </tree>
             </field>
         </record>

--- a/addons/website_sale_slides/views/slide_channel_views.xml
+++ b/addons/website_sale_slides/views/slide_channel_views.xml
@@ -23,6 +23,18 @@
         </field>
     </record>
 
+    <record id="slide_channel_view_tree_report" model="ir.ui.view">
+        <field name="name">slide.channel.view.tree.report.inherit.sale_slides</field>
+        <field name="model">slide.channel</field>
+        <field name="inherit_id" ref="website_slides.slide_channel_view_tree_report"/>
+        <field name="arch" type="xml">
+            <field name="members_done_count" position="after">
+                <field name="currency_id" invisible="1"/>
+                <field name="product_sale_revenues" string="Total Revenues" sum="Total Revenues" widget="monetary"/>
+            </field>
+        </field>
+    </record>
+
     <record id="slide_channel_view_kanban" model="ir.ui.view">
         <field name="name">slide.channel.view.kanban.inherit.sale</field>
         <field name="model">slide.channel</field>

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -160,7 +160,7 @@ class Slide(models.Model):
     html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True, sanitize_attributes=False, sanitize_form=False)
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
-    date_published = fields.Datetime('Publish Date', readonly=True, tracking=1)
+    date_published = fields.Datetime('Publish Date', readonly=True, tracking=False)
     likes = fields.Integer('Likes', compute='_compute_user_info', store=True, compute_sudo=False)
     dislikes = fields.Integer('Dislikes', compute='_compute_user_info', store=True, compute_sudo=False)
     user_vote = fields.Integer('User vote', compute='_compute_user_info', compute_sudo=False)
@@ -183,6 +183,8 @@ class Slide(models.Model):
     nbr_webpage = fields.Integer("Number of Webpages", compute='_compute_slides_statistics', store=True)
     nbr_quiz = fields.Integer("Number of Quizs", compute="_compute_slides_statistics", store=True)
     total_slides = fields.Integer(compute='_compute_slides_statistics', store=True)
+    is_published = fields.Boolean(tracking=1)
+    website_published = fields.Boolean(tracking=False)
 
     _sql_constraints = [
         ('exclusion_html_content_and_url', "CHECK(html_content IS NULL OR url IS NULL)", "A slide is either filled with a document url or HTML content. Not both.")

--- a/addons/website_slides/views/res_config_settings_views.xml
+++ b/addons/website_slides/views/res_config_settings_views.xml
@@ -43,6 +43,19 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="o_setting_box" id="website_slides_install_sale_slides">
+                                <div class="o_setting_left_pane">
+                                    <field name="module_website_sale_slides"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="module_website_sale_slides" string="Paid Courses"/>
+                                    <div class="text-muted">
+                                        Sell access to your courses on your website and track revenues.
+                                    </div>
+                                </div>
+                            </div>
+                        </group>
+                        <group>
                             <div class="o_setting_box" id="website_slides_install_mass_mailing_slides">
                                 <div class="o_setting_left_pane">
                                     <field name="module_mass_mailing_slides"/>
@@ -54,8 +67,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </group>
-                        <group>
                             <div class="o_setting_box mr-auto" id="website_slide_install_website_slides_forum">
                                 <div class="o_setting_left_pane">
                                     <field name="module_website_slides_forum"/>
@@ -64,17 +75,6 @@
                                     <label for="module_website_slides_forum"/>
                                     <div class="text-muted mr-auto">
                                         Create a community and let Attendees answer each others' questions.
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="o_setting_box" id="website_slides_install_sale_slides">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_website_sale_slides"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_website_sale_slides" string="Paid Courses"/>
-                                    <div class="text-muted">
-                                        Sell access to your courses on your website and track revenues.
                                     </div>
                                 </div>
                             </div>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -103,6 +103,7 @@
                                         <field name="enroll" widget="radio" options="{'horizontal': true}"/>
                                         <field name="upload_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
                                         <field name="enroll_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
+                                        <field name="enroll_msg" attrs="{'invisible': [('enroll', '!=', 'invite')]}"/>
                                     </group>
                                 </group>
                                 <group>
@@ -124,10 +125,6 @@
                                                domain="[('channel_id', '=', active_id), ('is_category', '=', False)]"/>
                                     </group>
                                 </group>
-                                <div attrs="{'invisible': [('enroll', '!=', 'invite')]}">
-                                    <label for="enroll_msg"/>
-                                    <field name="enroll_msg" colspan="4" nolabel="1"/>
-                                </div>
                             </page>
                             <page string="Karma" name="karma_rules">
                                 <group>
@@ -158,14 +155,14 @@
             <field name="name">slide.channel.view.tree</field>
             <field name="model">slide.channel</field>
             <field name="arch" type="xml">
-                <tree string="Courses" sample="1">
+                <tree string="Courses" sample="1" multi_edit="1">
                     <field name="sequence" widget="handle"/>
-                    <field name="name"/>
-                    <field name="channel_type"/>
-                    <field name="visibility"/>
-                    <field name="enroll" widget="badge" decoration-success="enroll == 'public'" decoration-info="enroll == 'invite'" decoration-warning="enroll == 'payment'"/>
+                    <field name="name" readonly="1"/>
                     <field name="user_id" widget="many2one_avatar_user"/>
                     <field name="website_id" groups="website.group_multi_website"/>
+                    <field name="channel_type" string="Course Type"/>
+                    <field name="visibility"/>
+                    <field name="enroll" widget="badge" decoration-success="enroll == 'public'" decoration-info="enroll == 'invite'" decoration-warning="enroll == 'payment'"/>
                     <field name="active" invisible="1"/>
                 </tree>
             </field>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -175,11 +175,12 @@
             <field name="arch" type="xml">
                 <tree string="Courses" create="false" default_order="total_views desc" sample="1">
                     <field name="name"/>
-                    <field name="total_views"/>
-                    <field name="total_time" widget="float_time" />
-                    <field name="members_count"/>
-                    <field name="total_votes"/>
-                    <field name="rating_avg_stars" string="Average Rating"/>
+                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="total_views" string="# Views"/>
+                    <field name="rating_avg_stars" string="Average Review"/>
+                    <field name="total_time" string="Total Duration" widget="float_time" sum="Total Duration"/>
+                    <field name="members_count" string="# Attendees" sum="Total Attendees"/>
+                    <field name="members_done_count" string="# Completed" sum="Total Completed"/>
                 </tree>
             </field>
         </record>
@@ -191,6 +192,7 @@
                 <search string="Courses">
                     <field name="name" string="Course"/>
                     <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
+                    <filter string="Published" name="filter_published" domain="[('is_published', '=', True)]"/>
                 </search>
             </field>
         </record>
@@ -347,6 +349,7 @@
             <field name="res_model">slide.channel</field>
             <field name="view_mode">tree,graph,pivot,form</field>
             <field name="view_id" ref="slide_channel_view_tree_report"/>
+            <field name="context">{"search_default_filter_published":1}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     <strong>Create a course</strong>
@@ -357,5 +360,31 @@
                 </p>
             </field>
         </record>
+
+        <record id="slide_channel_action_report_view_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="1"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="slide_channel_view_tree_report"/>
+            <field name="act_window_id" ref="slide_channel_action_report"/>
+        </record>
+        <record id="slide_channel_action_report_view_graph" model="ir.actions.act_window.view">
+            <field name="sequence" eval="2"/>
+            <field name="view_mode">graph</field>
+            <field name="view_id" ref="slide_channel_view_graph"/>
+            <field name="act_window_id" ref="slide_channel_action_report"/>
+        </record>
+        <record id="slide_channel_action_report_view_pivot" model="ir.actions.act_window.view">
+            <field name="sequence" eval="3"/>
+            <field name="view_mode">pivot</field>
+            <field name="view_id" ref="slide_channel_view_pivot"/>
+            <field name="act_window_id" ref="slide_channel_action_report"/>
+        </record>
+        <record id="slide_channel_action_report_view_form" model="ir.actions.act_window.view">
+            <field name="sequence" eval="4"/>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_slide_channel_form"/>
+            <field name="act_window_id" ref="slide_channel_action_report"/>
+        </record>
+
     </data>
 </odoo>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -273,18 +273,14 @@
             <field name="name">slide.slide.tree</field>
             <field name="model">slide.slide</field>
             <field name="arch" type="xml">
-                <tree string="Contents" sample="1">
-                    <field name="name"/>
-                    <field name="website_id" groups="website.group_multi_website"/>
-                    <field name="active" invisible="1"/>
-                    <field name="slide_type"/>
-                    <field name="channel_id"/>
-                    <field name="category_id"/>
-                    <field name="date_published"/>
-                    <field name="slide_views"/>
-                    <field name="public_views"/>
-                    <field name="total_views"/>
-                    <field name="completion_time"/>
+                <tree string="Contents" sample="1" multi_edit="1">
+                    <field name="name" readonly="1"/>
+                    <field name="channel_id" readonly="1"/>
+                    <field name="category_id" readonly="1" optional="hide"/>
+                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="is_published"/>
+                    <field name="date_published" readonly="1"/>
+                    <field name="completion_time" sum="Total" readonly="1" widget="float_time"/>
                 </tree>
             </field>
         </record>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -285,6 +285,24 @@
             </field>
         </record>
 
+        <record id="slide_slide_view_tree_report" model="ir.ui.view">
+            <field name="name">slide.slide.view.tree.report</field>
+            <field name="model">slide.slide</field>
+            <field name="priority" eval="20"/>
+            <field name="arch" type="xml">
+                <tree string="Contents" sample="1">
+                    <field name="name"/>
+                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="channel_id"/>
+                    <field name="category_id" optional="hide"/>
+                    <field name="date_published"/>
+                    <field name="total_views" string="# Views" sum="Total Views"/>
+                    <field name="questions_count" string="# Questions" sum="Total Questions"/>
+                    <field name="completion_time" sum="Total Duration" widget="float_time"/>
+                </tree>
+            </field>
+        </record>
+
         <record id="view_slide_slide_search" model="ir.ui.view">
             <field name="name">slide.slide.filter</field>
             <field name="model">slide.slide</field>
@@ -355,7 +373,8 @@
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">slide.slide</field>
             <field name="view_mode">graph,tree,form,pivot</field>
-            <field name="view_id" ref="slide_slide_view_graph"/>
+            <field name="context">{"search_default_published": 1}</field>
+            <field name="domain">[('is_category', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No data yet!
@@ -363,6 +382,31 @@
                     Create new content for your eLearning
                 </p>
             </field>
+        </record>
+
+        <record id="slide_slide_action_report_view_graph" model="ir.actions.act_window.view">
+            <field name="sequence" eval="0"/>
+            <field name="view_mode">graph</field>
+            <field name="view_id" ref="slide_slide_view_graph"/>
+            <field name="act_window_id" ref="slide_slide_action_report"/>
+        </record>
+        <record id="slide_slide_action_report_view_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="1"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="slide_slide_view_tree_report"/>
+            <field name="act_window_id" ref="slide_slide_action_report"/>
+        </record>
+        <record id="slide_slide_action_report_view_form" model="ir.actions.act_window.view">
+            <field name="sequence" eval="2"/>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_slide_slide_form"/>
+            <field name="act_window_id" ref="slide_slide_action_report"/>
+        </record>
+        <record id="slide_slide_action_report_view_pivot" model="ir.actions.act_window.view">
+            <field name="sequence" eval="3"/>
+            <field name="view_mode">pivot</field>
+            <field name="view_id" ref="slide_slide_view_pivot"/>
+            <field name="act_window_id" ref="slide_slide_action_report"/>
         </record>
     </data>
 </odoo>

--- a/addons/website_slides_forum/data/slide_channel_demo.xml
+++ b/addons/website_slides_forum/data/slide_channel_demo.xml
@@ -25,13 +25,14 @@
         <field name="create_date" eval="DateTime.now() - relativedelta(days=31)"/>
     </record>
     <record id="forum_post_O_0_answer_0" model="forum.post">
+        <field name="name">Re: What is the best fertilizer for tulips ?</field>
         <field name="forum_id" ref="forum_forum_demo_channel_0"/>
         <field name="content" type="html"><p>You can use loam for tulips.</p></field>
         <field name="parent_id" ref="forum_post_O_0"/>
     </record>
 
     <record id="forum_post_2_0" model="forum.post">
-        <field name="name">Heigth of my tree...</field>
+        <field name="name">Height of my tree...</field>
         <field name="forum_id" ref="forum_forum_demo_channel_2"/>
         <field name="views">1</field>
         <field name="create_uid" ref="base.user_demo"/>

--- a/addons/website_slides_forum/views/forum_views.xml
+++ b/addons/website_slides_forum/views/forum_views.xml
@@ -22,11 +22,26 @@
         </field>
     </record>
 
+    <record id="forum_forum_view_tree_slides" model="ir.ui.view">
+        <field name="name">forum.forum.view.tree.slides</field>
+        <field name="model">forum.forum</field>
+        <field name="mode">primary</field>
+        <field name="priority" eval="20"/>
+        <field name="inherit_id" ref="website_forum.view_forum_forum_list"/>
+        <field name="arch" type="xml">
+            <field name="website_id" position="after">
+                <field name="slide_channel_id"/>
+                <field name="visibility"/>
+            </field>
+        </field>
+    </record>
+
     <record id="forum_forum_action_channel" model="ir.actions.act_window">
         <field name="name">Forums</field>
         <field name="res_model">forum.forum</field>
         <field name="view_mode">tree,form</field>
         <field name="domain">[('slide_channel_ids', '!=', 'False')]</field>
+        <field name="view_id" ref="forum_forum_view_tree_slides"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a Forum

--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="survey_view_tree_slides" model="ir.ui.view">
+        <field name="name">survey.view.tree.slides</field>
+        <field name="model">survey.survey</field>
+        <field name="inherit_id" ref="survey.survey_tree"/>
+        <field name="mode">primary</field>
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <field name="title" position="attributes">
+                <attribute name="string">Certification Title</attribute>
+            </field>
+            <field name="answer_count" position="replace"/>
+            <field name="success_ratio" position="attributes">
+                <attribute name="string">Success Ratio (%)</attribute>
+            </field>
+            <field name="answer_score_avg" position="attributes">
+                <attribute name="string">Avg Score (%)</attribute>
+            </field>
+            <button name="certification" position="replace"/>
+        </field>
+    </record>
+
     <record id="survey_survey_inherit_view_search" model="ir.ui.view">
         <field name="name">survey.survey.search.inherit.website_slides</field>
         <field name="model">survey.survey</field>
@@ -7,24 +28,6 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr='//filter[@name="certification"]' position="replace"/>
-        </field>
-    </record>
-
-    <record id="survey_survey_action_slides" model="ir.actions.act_window">
-        <field name="name">Certifications</field>
-        <field name="res_model">survey.survey</field>
-        <field name="view_mode">kanban,tree,pivot,graph,form</field>
-        <field name="domain">[('certification', '=', True)]</field>
-        <field name="search_view_id" ref="survey_survey_inherit_view_search"/>
-        <field name="context">{'default_certification': True, 'default_scoring_type': 'scoring_with_answers'}</field>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                Create a Certification
-            </p>
-            <p>
-                Assess the level of understanding of your attendees
-                <br/>and send them a document if they pass the test.
-            </p>
         </field>
     </record>
 
@@ -45,4 +48,40 @@
             </xpath>
         </field>
     </record>
+
+    <record id="survey_survey_action_slides" model="ir.actions.act_window">
+        <field name="name">Certifications</field>
+        <field name="res_model">survey.survey</field>
+        <field name="view_mode">kanban,tree,pivot,graph,form</field>
+        <field name="domain">[('certification', '=', True)]</field>
+        <field name="search_view_id" ref="survey_survey_inherit_view_search"/>
+        <field name="context">{'default_certification': True, 'default_scoring_type': 'scoring_with_answers'}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a Certification
+            </p>
+            <p>
+                Assess the level of understanding of your attendees
+                <br/>and send them a document if they pass the test.
+            </p>
+        </field>
+    </record>
+    <record id="survey_survey_action_slides_view_kanban" model="ir.actions.act_window.view">
+         <field name="sequence" eval="0"/>
+         <field name="view_mode">kanban</field>
+         <field name="view_id" ref="survey.survey_kanban"/>
+         <field name="act_window_id" ref="survey_survey_action_slides"/>
+     </record>
+     <record id="survey_survey_action_slides_view_tree" model="ir.actions.act_window.view">
+         <field name="sequence" eval="1"/>
+         <field name="view_mode">tree</field>
+         <field name="view_id" ref="survey_view_tree_slides"/>
+         <field name="act_window_id" ref="survey_survey_action_slides"/>
+     </record>
+     <record id="survey_survey_action_slides_view_form" model="ir.actions.act_window.view">
+         <field name="sequence" eval="4"/>
+         <field name="view_mode">form</field>
+         <field name="view_id" ref="survey.survey_form"/>
+         <field name="act_window_id" ref="survey_survey_action_slides"/>
+     </record>
 </odoo>


### PR DESCRIPTION
PURPOSE

Improve eLearning list views and settings UI. Better split standard views from
reporting views.

SPECIFICATIONS

- Lighten the "operational" list views which should not be cluttered with a ton of KPIs.
    Keep those for the reporting views (which in turn need to display some data).
- Reorder settings options for a better cleanup.

See sub commits for more details about the changes.

Task-2607467
