### PR TITLE
web_editor: fix several problems within custom button colors

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -317,6 +317,19 @@ function _isColorGradient(value) {
     // FIXME duplicated in odoo-editor/utils.js
     return value && value.includes('-gradient(');
 }
+/**
+ * Returns the class of the element that matches the specified prefix.
+ *
+ * @private
+ * @param {Element} el element from which to recover the color class
+ * @param {string[]} colorNames
+ * @param {string} prefix prefix of the color class to recover
+ * @returns {string} color class matching the prefix or an empty string
+ */
+function _getColorClass(el, colorNames, prefix) {
+    const prefixedColorNames = _computeColorClasses(colorNames, prefix);
+    return el.classList.value.split(' ').filter(cl => prefixedColorNames.includes(cl)).join(' ');
+}
 
 return {
     CSS_SHORTHANDS: CSS_SHORTHANDS,
@@ -335,5 +348,6 @@ return {
     getBgImageURL: _getBgImageURL,
     backgroundImageCssToParts: _backgroundImageCssToParts,
     backgroundImagePartsToCss: _backgroundImagePartsToCss,
+    getColorClass: _getColorClass,
 };
 });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -5,6 +5,7 @@ const core = require('web.core');
 const OdooEditorLib = require('@web_editor/../lib/odoo-editor/src/OdooEditor');
 const wysiwygUtils = require('@web_editor/js/wysiwyg/wysiwyg_utils');
 const Widget = require('web.Widget');
+const {isColorGradient} = require('web_editor.utils');
 
 const getDeepRange = OdooEditorLib.getDeepRange;
 const getInSelection = OdooEditorLib.getInSelection;
@@ -93,9 +94,11 @@ const Link = Widget.extend({
             this.data.isNewWindow = this.data.isNewWindow || this.linkEl.target === '_blank';
         }
 
+        const allBtnColorPrefixes = /(^|\s+)(bg|text|border)(-[a-z0-9_-]*)?/gi;
         const allBtnClassSuffixes = /(^|\s+)btn(-[a-z0-9_-]*)?/gi;
         const allBtnShapes = /\s*(rounded-circle|flat)\s*/gi;
         this.data.className = this.data.iniClassName
+            .replace(allBtnColorPrefixes, ' ')
             .replace(allBtnClassSuffixes, ' ')
             .replace(allBtnShapes, ' ');
         // 'o_submit' class will force anchor to be handled as a button in linkdialog.
@@ -131,7 +134,6 @@ const Link = Widget.extend({
         }
 
         this._updateOptionsUI();
-        this._adaptPreview();
 
         if (!this.options.noFocusUrl) {
             // ensure the focus in the first input of the link modal
@@ -160,9 +162,16 @@ const Link = Widget.extend({
         if (!data.classes.includes('btn') && this.data.iniClassName.includes("btn-link")) {
             data.classes += " btn btn-link";
         }
-        if (!['btn-custom', 'btn-outline-custom', 'btn-fill-custom'].some(className =>
+        if (['btn-custom', 'btn-outline-custom', 'btn-fill-custom'].some(className =>
             data.classes.includes(className)
         )) {
+            this.$link.css('color', data.classes.includes(data.customTextColor) ? '' : data.customTextColor);
+            this.$link.css('background-color', data.classes.includes(data.customFill) || isColorGradient(data.customFill) ? '' : data.customFill);
+            this.$link.css('background-image', isColorGradient(data.customFill) ? data.customFill : '');
+            this.$link.css('border-width', data.customBorderWidth);
+            this.$link.css('border-style', data.customBorderStyle);
+            this.$link.css('border-color', data.customBorder);
+        } else {
             this.$link.css('color', '');
             this.$link.css('background-color', '');
             this.$link.css('background-image', '');
@@ -289,6 +298,7 @@ const Link = Widget.extend({
         const customBorder = this._getLinkCustomBorder();
         const customBorderWidth = this._getLinkCustomBorderWidth();
         const customBorderStyle = this._getLinkCustomBorderStyle();
+        const customClasses = this._getLinkCustomClasses();
         const size = this._getLinkSize();
         const shape = this._getLinkShape();
         const shapes = shape ? shape.split(',') : [];
@@ -296,6 +306,7 @@ const Link = Widget.extend({
         const shapeClasses = shapes.slice(style ? 1 : 0).join(' ');
         const classes = (this.data.className || '') +
             (type ? (` btn btn-${style}${type}`) : '') +
+            (type === 'custom' ? customClasses : '') +
             (type && shapeClasses ? (` ${shapeClasses}`) : '') +
             (type && size ? (' btn-' + size) : '');
         var isNewWindow = this._isNewWindow(url);
@@ -410,6 +421,14 @@ const Link = Widget.extend({
      * @returns {string}
      */
     _getLinkCustomFill: function () {},
+    /**
+     * Returns the custom text, fill and border color classes for custom type.
+     *
+     * @abstract
+     * @private
+     * @returns {string}
+     */
+    _getLinkCustomClasses: function () {},
     /**
      * Abstract method: return true if the link should open in a new window.
      *

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -258,6 +258,17 @@ const LinkTools = Link.extend({
         this.colorpickers[cssProperty] = colorpicker;
         colorpicker.appendTo($(ev.target).closest('.dropdown').find('.dropdown-menu'));
         colorpicker.on('custom_color_picked color_picked color_hover color_leave', this, (ev) => {
+            // Reset color styles in link content to make sure new color is not hidden.
+            // Only done when applied to avoid losing state during preview.
+            if (['custom_color_picked', 'color_picked'].includes(ev.name)) {
+                const selection = window.getSelection();
+                const range = document.createRange();
+                range.selectNodeContents(this.$link[0]);
+                selection.removeAllRanges();
+                selection.addRange(range);
+                this.options.wysiwyg.odooEditor.execCommand('applyColor', '', 'color');
+                this.options.wysiwyg.odooEditor.execCommand('applyColor', '', 'backgroundColor');
+            }
             let color = ev.data.color;
             let gradientColor = '';
             if (cssProperty === 'background-color') {


### PR DESCRIPTION
Before this commit if button text had styles, they would override the
color set by customizing the button.
Also, colors from classes could not be used.

After this commit button text styles are removed when applying custom
button colors.
Colors are now also applied when selected from classes colors.

task-2653874

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
