### PR TITLE
[14.0][FIX] Fix to_url() method on ModelsConverter to properly deal w…

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -66,7 +66,7 @@ class ModelsConverter(werkzeug.routing.BaseConverter):
         return env[self.model].browse(int(v) for v in value.split(','))
 
     def to_url(self, value):
-        return ",".join(value.ids)
+        return ",".join([str(v) for v in value.ids])
 
 
 class SignedIntConverter(werkzeug.routing.NumberConverter):


### PR DESCRIPTION
…ith a RecordSet converting the id in string to satisfy the string join()

Description of the issue/feature this PR addresses:

Odoo support recordset on http.route() controller by specifing the ``<models("model.name"):model_ids>`` with the indicated URL, but once we use the feature we end up on getting a crash like this:

```
2021-09-22 08:15:42,068 550900 INFO v14.0-HREG-Test1 werkzeug: 127.0.0.1 - - [22/Sep/2021 08:15:42] "GET /nt_product_export/download/23,15 HTTP/1.1" 500 - 17 0.009 4.825
2021-09-22 08:15:42,074 550900 ERROR v14.0-HREG-Test1 werkzeug: Error on request:
Traceback (most recent call last):
  File "/OtherData/Projects/odoo-14/odoo/addons/http_routing/models/ir_http.py", line 537, in _postprocess_args
    _, path = rule.build(arguments)
  File "/home/roberto/.virtualenvs/odoo-14/lib/python3.8/site-packages/werkzeug/routing.py", line 975, in build
    return self._build_unknown(**values)
  File "<werkzeug routing>", line 1, in <builder:'/product_export/download/<models("product.template"):product_ids>'>
    
  File "/OtherData/Projects/odoo-14/odoo/odoo/addons/base/models/ir_http.py", line 69, in to_url
    return ",".join(value.ids)
Exception
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/roberto/.virtualenvs/odoo-14/lib/python3.8/site-packages/werkzeug/serving.py", line 306, in run_wsgi
    execute(self.server.app)
  File "/home/roberto/.virtualenvs/odoo-14/lib/python3.8/site-packages/werkzeug/serving.py", line 294, in execute
    application_iter = app(environ, start_response)
  File "/OtherData/Projects/odoo-14/odoo/odoo/service/server.py", line 441, in app
    return self.app(e, s)
  File "/OtherData/Projects/odoo-14/odoo/odoo/service/wsgi_server.py", line 113, in application
    return application_unproxied(environ, start_response)
  File "/OtherData/Projects/odoo-14/odoo/odoo/service/wsgi_server.py", line 88, in application_unproxied
    result = odoo.http.root(environ, start_response)
  File "/OtherData/Projects/odoo-14/odoo/odoo/http.py", line 1306, in __call__
    return self.dispatch(environ, start_response)
  File "/OtherData/Projects/odoo-14/odoo/odoo/http.py", line 1272, in __call__
    return self.app(environ, start_wrapped)
  File "/home/roberto/.virtualenvs/odoo-14/lib/python3.8/site-packages/werkzeug/middleware/shared_data.py", line 220, in __call__
    return self.app(environ, start_response)
  File "/OtherData/Projects/odoo-14/odoo/odoo/http.py", line 1479, in dispatch
    result = ir_http._dispatch()
  File "/OtherData/Projects/odoo-14/odoo/addons/auth_signup/models/ir_http.py", line 19, in _dispatch
    return super(Http, cls)._dispatch()
  File "/OtherData/Projects/odoo-14/odoo/addons/web_editor/models/ir_http.py", line 21, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/OtherData/Projects/odoo-14/odoo/addons/utm/models/ir_http.py", line 29, in _dispatch
    response = super(IrHttp, cls)._dispatch()
  File "/OtherData/Projects/odoo-14/odoo/addons/http_routing/models/ir_http.py", line 508, in _dispatch
    result = super(IrHttp, cls)._dispatch()
  File "/OtherData/Projects/odoo-14/odoo/odoo/addons/base/models/ir_http.py", line 230, in _dispatch
    processing = cls._postprocess_args(arguments, rule)
  File "/OtherData/Projects/odoo-14/odoo/addons/http_routing/models/ir_http.py", line 542, in _postprocess_args
    return cls._handle_exception(e)
  File "/OtherData/Projects/odoo-14/odoo/addons/utm/models/ir_http.py", line 34, in _handle_exception
    response = super(IrHttp, cls)._handle_exception(exc)
  File "/OtherData/Projects/odoo-14/odoo/addons/http_routing/models/ir_http.py", line 598, in _handle_exception
    return super(IrHttp, cls)._handle_exception(exception)
  File "/OtherData/Projects/odoo-14/odoo/odoo/addons/base/models/ir_http.py", line 209, in _handle_exception
    return request._handle_exception(exception)
  File "/OtherData/Projects/odoo-14/odoo/odoo/http.py", line 745, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/OtherData/Projects/odoo-14/odoo/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: sequence item 0: expected str instance, int found - - -
```
The method ``to_url`` at https://github.com/odoo/odoo/blob/ad0d9e25077b9173441923d3fc5b09309833b8e5/odoo/addons/base/models/ir_http.py#L68-L69 shows pretty easily what is happening, a RecordSet is received and the ``join()`` cannot concatenate the list of id because the ``join()`` cannot deal with integers hence the TypeError above. Below a quick demostration.

```
PyDev console: starting.

Python 3.8.12 (default, Aug 30 2021, 00:00:00) 
[GCC 11.2.1 20210728 (Red Hat 11.2.1-1)] on linux
>>> ','.join([1,2,3,4])
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: sequence item 0: expected str instance, int found
```

Current behavior before PR:

Odoo crashes when using the ``<models()...`` in a ``route()`` in a controller

Desired behavior after PR is merged:

Fix the issue an make the ``<models()...`` working in a ``route()``


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
