### PR TITLE
[FIX] account_analytic_default_purchase: Default analytic on PO

### DIFF
--- a/addons/account_analytic_default_purchase/models/purchase_order_line.py
+++ b/addons/account_analytic_default_purchase/models/purchase_order_line.py
@@ -7,15 +7,31 @@ from odoo import api, fields, models
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    @api.onchange('product_id', 'date_order')
-    def _onchange_product_id_date(self):
-        default_analytic_account = self.env['account.analytic.default'].sudo().account_get(
-            product_id=self.product_id.id,
-            partner_id=self.order_id.partner_id.id,
-            user_id=self.env.uid,
-            date=self.date_order,
-            company_id=self.company_id.id,
-        )
-        if default_analytic_account:
-            self.account_analytic_id = default_analytic_account.analytic_id.id
-            self.analytic_tag_ids = [(6, 0, default_analytic_account.analytic_tag_ids.ids)]
+    account_analytic_id = fields.Many2one(compute='_compute_analytic_id', store=True, readonly=False)
+    analytic_tag_ids = fields.Many2many(compute='_compute_tag_ids', store=True, readonly=False)
+
+    @api.depends('product_id', 'date_order')
+    def _compute_analytic_id(self):
+        for rec in self:
+            if not rec.account_analytic_id:
+                default_analytic_account = rec.env['account.analytic.default'].sudo().account_get(
+                    product_id=rec.product_id.id,
+                    partner_id=rec.order_id.partner_id.id,
+                    user_id=rec.env.uid,
+                    date=rec.date_order,
+                    company_id=rec.company_id.id,
+                )
+                rec.account_analytic_id = default_analytic_account.analytic_id
+
+    @api.depends('product_id', 'date_order')
+    def _compute_tag_ids(self):
+        for rec in self:
+            if not rec.analytic_tag_ids:
+                default_analytic_account = rec.env['account.analytic.default'].sudo().account_get(
+                    product_id=rec.product_id.id,
+                    partner_id=rec.order_id.partner_id.id,
+                    user_id=rec.env.uid,
+                    date=rec.date_order,
+                    company_id=rec.company_id.id,
+                )
+                rec.analytic_tag_ids = default_analytic_account.analytic_tag_ids


### PR DESCRIPTION
Steps to reproduce the bug:

- Enable analytic accounting and analytic tags
- Create a new analytic default to specify a product. Add an account and some tags
- Create a new SO that triggers a replenishment rule for a PO

The created PO does not have any analytic accounts or tags attached to it.

Inspired from 14.0

opw:2585348