### PR TITLE
[FIX] mail: avoid unwanted scroll bar jump with mulitline message

### DIFF
--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -115,7 +115,7 @@ QUnit.test('message list desc order', async function (assert) {
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => createThreadViewComponent(threadViewer.threadView, undefined, { isFixedSize: true }),
+        func: () => createThreadViewComponent(threadViewer.threadView, {}, { isFixedSize: true }),
         message: "should wait until channel 100 loaded initial messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -213,7 +213,7 @@ QUnit.test('message list asc order', async function (assert) {
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => createThreadViewComponent(threadViewer.threadView, undefined, { isFixedSize: true }),
+        func: () => createThreadViewComponent(threadViewer.threadView, {}, { isFixedSize: true }),
         message: "should wait until channel 100 loaded initial messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -847,7 +847,7 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
         eventName: 'o-component-message-list-scrolled',
         func: () => createThreadViewComponent(
             threadViewer.threadView,
-            undefined,
+            {},
             { isFixedSize: true },
         ),
         message: "should wait until channel 20 scrolled initially",
@@ -914,13 +914,14 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
     const threadViewer = this.messaging.models['mail.thread_viewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
+        order: 'asc',
         thread: link(thread),
     });
     await this.afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () => createThreadViewComponent(
             threadViewer.threadView,
-            undefined,
+            {},
             { isFixedSize: true },
         ),
         message: "should wait until channel 20 scrolled initially",
@@ -1723,7 +1724,7 @@ QUnit.test('[technical] message list with a full page of empty messages should s
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
         func: () => {
-            createThreadViewComponent(threadViewer.threadView, undefined, { isFixedSize: true });
+            createThreadViewComponent(threadViewer.threadView, {}, { isFixedSize: true });
         },
         message: "should wait until thread becomes loaded with messages",
         predicate: ({ hint, threadViewer }) => {

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -146,6 +146,55 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {boolean}
+         */
+        _computeHasAutoScrollOnMessageReceived() {
+            return this.isAtEnd;
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtBottom() {
+            return (
+                this.scrollTop >= this.scrollHeight - this.clientHeight - 30
+            );
+        }
+
+        /***
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtEnd() {
+            if (this.order === 'asc') {
+                return this.isAtBottom;
+            }
+            return this.isAtTop;
+        }
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtStart() {
+            if (this.order === 'asc') {
+                return this.isAtTop;
+            }
+            return this.isAtBottom;
+        }
+
+
+        /**
+         * @private
+         * @returns {boolean}
+         */
+        _computeIsAtTop() {
+            return this.scrollTop <= 30;
+        }
+
+        /**
+         * @private
          * @returns {string[]}
          */
         _computeTextInputSendShortcuts() {
@@ -352,6 +401,7 @@ function factory(dependencies) {
             inverse: 'threadView',
             isCausal: true,
         }),
+        clientHeight: attr(),
         /**
          * List of component hints. Hints contain information that help
          * components make UI/UX decisions based on their UI state.
@@ -409,6 +459,36 @@ function factory(dependencies) {
             related: 'threadViewer.hasTopbar',
         }),
         /**
+         * States whether the message list scroll position is at the bottom
+         * of the message list.
+         */
+        isAtBottom: attr({
+            compute: '_computeIsAtBottom',
+        }),
+        /**
+         * States whether the message list scroll position is at the end of
+         * the message list. Depending of the message list order, this could be
+         * the top or the bottom.
+         */
+        isAtEnd: attr({
+            compute: '_computeIsAtEnd',
+        }),
+        /**
+         * States whether the message list scroll position is at the start
+         * of the message list. Depending of the message list order, this could
+         * be the top or the bottom.
+         */
+        isAtStart: attr({
+            compute: '_computeIsAtStart',
+        }),
+        /**
+         * States whether the message list scroll position is at the top of
+         * the message list.
+         */
+        isAtTop: attr({
+            compute: '_computeIsAtTop',
+        }),
+        /**
          * States whether `this.threadCache` is currently loading messages.
          *
          * This field is related to `this.threadCache.isLoading` but with a
@@ -446,7 +526,7 @@ function factory(dependencies) {
          * hint `message-received`.
          */
         hasAutoScrollOnMessageReceived: attr({
-            default: true,
+            compute: '_computeHasAutoScrollOnMessageReceived',
         }),
         /**
          * Last message in the context of the currently displayed thread cache.
@@ -490,6 +570,8 @@ function factory(dependencies) {
             isCausal: true,
             readonly: true,
         }),
+        scrollHeight: attr(),
+        scrollTop: attr(),
         /**
          * Determines the keyboard shortcuts that are available to send a message
          * from the composer of this thread viewer.


### PR DESCRIPTION
Before this commit, when the what window composer was multi line, the message
list scroll bar jumped over the content.
This PR prevent this jump by listening to resize event and restore the chat
window scroll position if needed.

task-2377824