### PR TITLE
[FIX] hr_holidays: show Time Off Analysis action only in debug

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_type_report.xml
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.xml
@@ -33,7 +33,7 @@
         <field name="model_id" ref="hr_holidays.model_hr_leave_employee_type_report"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
         <field name="state">code</field>
-        <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
+        <field name="groups_id" eval="[(4, ref('base.group_no_one'))]"/>
         <field name="code">
             action = model.action_time_off_analysis()
         </field>


### PR DESCRIPTION
The Time Off Analysis action should only be available in debug mode.

TaskID: 2653912

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
