### PR TITLE
[FIX] mail: Error when sending email for updating vendor date confirm

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -958,9 +958,10 @@ class MailActivityMixin(models.AbstractModel):
                 'date_deadline': date_deadline,
                 'res_model_id': model_id,
                 'res_id': record.id,
-                'user_id': act_values.get('user_id') or activity_type.default_user_id.id or self.env.uid
             }
             create_vals.update(act_values)
+            if not create_vals.get('user_id'):
+                create_vals['user_id'] = activity_type.default_user_id.id or self.env.uid
             activities |= self.env['mail.activity'].create(create_vals)
         return activities
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a PO
- Remove the Purchase representative
- Send a reminder to confirm the order date
- Open the reminder email and click on No, Upate date
- Choose a date

Bug:

An access error was raised because a user_id is required to create a mail.activity

PS: When passing user_id=False to function activity_schedule, user_id=False was kept when creating the mail.activity

opw:2638140