### PR TITLE
[FIX] website: dynamic snippet, use lxml.html to process rendered view

### DIFF
--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -5,8 +5,7 @@ from collections import OrderedDict
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError, MissingError
 from odoo.osv import expression
-from odoo.tools import html_escape as escape
-from lxml import etree as ET
+from lxml import etree, html
 import logging
 from random import randint
 
@@ -77,7 +76,7 @@ class WebsiteSnippetFilter(models.Model):
             records=records,
             is_sample=is_sample,
         ))
-        return [ET.tostring(el, encoding='unicode') for el in ET.fromstring('<root>%s</root>' % str(content)).getchildren()]
+        return [etree.tostring(el, encoding='unicode') for el in html.fromstring('<root>%s</root>' % str(content)).getchildren()]
 
     def _prepare_values(self, limit=None, search_domain=None):
         """Gets the data and returns it the right format for render."""


### PR DESCRIPTION
t-field of a Text field, will use nl2br function that replace \n to <br>.
So it is html that we need to parse.

Add one return line in your sale description, and the rendering will fail
with an error opening and ending missmatch for br...

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
