### PR TITLE
[IMP] crm, web: forecast filter

### DIFF
--- a/addons/crm/static/src/js/forecast/forecast_model_extension.js
+++ b/addons/crm/static/src/js/forecast/forecast_model_extension.js
@@ -1,12 +1,11 @@
 /** @odoo-module */
 import ActionModel from 'web.ActionModel';
+import { Domain } from "@web/core/domain";
 
 /**
  * This file contains the logic behind a special "Forecast" filter.
- * Any such filter should set the context key {forecast_filter: 1}
- * Another context key must also be set for the view using this model extension:
- * {forecast_field: "date_field_name"}, which represents the date/time field on which
- * the forecast should be applied
+ * Any such filter should set the context key {forecast_field: "date_field_name"}
+ * which represents the date/time field on which the forecast should be applied
  *
  * The main purpose is to be able to modify the domain depending on the groupby granularity
  * when the field is a `date/time` field and is the `forecast_field`. The domain should filter
@@ -35,69 +34,50 @@ class ForecastModelExtension extends ActionModel.Extension {
     }
 
     /**
-     * @override
-     */
-    prepareState() {
-        super.prepareState(...arguments);
-        Object.assign(this.state, {
-            forecastField: null,  // {string} forecast_field from the context (name)
-            forecastFilter: null,  // {boolean} if the "Forecast" filter is active
-            forecastStart: null,  // {string} limiting bound of the filter (if active)
-                                  // -> starting date before which records are filtered out
-        });
-    }
-
-    /**
-     * The state needs to be recomputed each time the parent model initiates a load action.
-     *
-     * @override
-     * @returns {Promise}
-     */
-    callLoad() {
-        // this is bad to do this always: if a state has been received and the view is loaded the
-        // first time, the state won't be used! to fix!
-        this._computeState();
-        return super.callLoad(...arguments);
-    }
-
-    /**
      * Adds a domain constraint to only get records from the start of the period containing "now",
-     * only if the "Forecast" filter is active
+     * only if a "Forecast" filter is active
      *
      * @returns {Array[]}
      */
     getDomain() {
-        return !this.state.forecastFilter ? null :
-            ['|', [this.state.forecastField, '=', false],
-             [this.state.forecastField, '>=', this.state.forecastStart]
+        const filters = this.config.get('filters').flat();
+        const forecastFilters = filters.filter(f => f.isActive && f.context && f.context.forecast_field);
+        if (!forecastFilters.length) {
+            return null;
+        }
+        const addNextFilterDomain = (domain, filter) => {
+            const forecastField = filter.context.forecast_field;
+            const forecastStart = this._getForecastStart(forecastField);
+            const filterDomain = ['|', [forecastField, '=', false],
+                [forecastField, '>=', forecastStart]
             ];
+            return (!domain) ? filterDomain : Domain.and([domain, filterDomain]).ast.value;
+        };
+        return forecastFilters.reduce(addNextFilterDomain, null);
     }
 
     /**
-     * The state is mostly dependent on 2 context keys :
-     * forecast_field -> is a prerequisite for this extension to work
-     * forecast_filter -> a filter which applies this context key should be present and active in
-     * order to get the modified domain
+     * The forecastStart date/time is mostly dependent on a context key in the filter:
+     * forecast_field -> a custom filter with this context key in its own context should be present
+     * and active in order to get the modified domain
+     *
+     * And is also dependent on whether forecast_field is one of the groupby fields:
      * If the forecast_field is present in the groupby, the related granularity is used
      * If no granularity is specified, or if there is no groupby, the default is "month"
      * If there is a groupby, but not the forecast_field, "day" is used (the filter will get data
      * from 00:00:00 today, browser time)
      *
      * @private
+     * @param {string} forecastField name of the date/time field related to the forecast
+     * @returns {string}
      */
-    _computeState() {
-        this.prepareState();
-        if (!this.config.context.forecast_field) { return; }
-        this.state.forecastField = this.config.context.forecast_field;
-        const format = DATE_FORMAT[this.config.fields[this.state.forecastField].type];
-        const filters = this.config.get('filters').flat();
-        this.state.forecastFilter = !!filters.filter(f => f.isActive && f.context &&
-            f.context.forecast_filter).length;
+    _getForecastStart(forecastField) {
+        const type = this.config.fields[forecastField].type;
         const groupBy = this.config.get('groupBy').flat();
-        const forecastGroupBys = groupBy.filter(gb => gb.includes(this.state.forecastField));
+        const firstForecastGroupBy = groupBy.find(gb => gb.includes(forecastField));
         let granularity = "month";
-        if (forecastGroupBys.length > 0) {
-            [this.state.forecastField, granularity] = [...forecastGroupBys[0].split(":"), granularity];
+        if (firstForecastGroupBy) {
+            granularity = firstForecastGroupBy.split(":")[1] || "month";
         } else if (groupBy.length) {
             // there is a groupBy, but it is not the forecast_field
             granularity = "day";
@@ -105,10 +85,11 @@ class ForecastModelExtension extends ActionModel.Extension {
         let startMoment = moment().startOf(granularity);
         // The server needs a date/time in UTC, but to avoid a day shift in case
         // of date, we only need to consider it for datetime fields
-        if (this.config.fields[this.state.forecastField].type === "datetime") {
+        if (this.config.fields[forecastField].type === "datetime") {
             startMoment = moment.utc(startMoment);
         }
-        this.state.forecastStart = startMoment.format(format);
+        const format = DATE_FORMAT[type];
+        return startMoment.format(format);
     }
 }
 

--- a/addons/crm/static/src/js/forecast/forecast_views.js
+++ b/addons/crm/static/src/js/forecast/forecast_views.js
@@ -14,7 +14,7 @@ import viewRegistry from 'web.view_registry';
  * Graph view to be used for a Forecast @see ForecastSearchModel
  * requires:
  * - context key `forecast_field` on a date/datetime field
- * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ * - special filter "Forecast" (which must set the `forecast_field:"date_field_name"` context key)
  */
 class ForecastGraphView extends GraphView {}
 ForecastGraphView.SearchModel = ForecastSearchModel;
@@ -28,7 +28,7 @@ registry.category("views").add("forecast_graph", ForecastGraphView);
  * @see ForecastKanbanColumnQuickCreate
  * requires:
  * - context key `forecast_field` on a date/datetime field
- * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ * - special filter "Forecast" (which must set the `forecast_field:"date_field_name"` context key)
  */
 const ForecastKanbanView = KanbanView.extend({
     config: _.extend({}, KanbanView.prototype.config, {
@@ -51,7 +51,7 @@ viewRegistry.add('forecast_kanban', ForecastKanbanView);
  * List view to be used for a Forecast @see ForecastModelExtension
  * requires:
  * - context key `forecast_field` on a date/datetime field
- * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ * - special filter "Forecast" (which must set the `forecast_field:"date_field_name"` context key)
  */
 const ForecastListView = ListView.extend({
     /**
@@ -69,7 +69,7 @@ viewRegistry.add('forecast_list', ForecastListView);
  * Pivot view to be used for a Forecast @see ForecastSearchModel
  * requires:
  * - context key `forecast_field` on a date/datetime field
- * - special filter "Forecast" (which must set the `forecast_filter:1` context key)
+ * - special filter "Forecast" (which must set the `forecast_field:"date_field_name"` context key)
  */
 class ForecastPivotView extends PivotView {}
 ForecastPivotView.SearchModel = ForecastSearchModel;

--- a/addons/crm/static/tests/forecast_kanban_tests.js
+++ b/addons/crm/static/tests/forecast_kanban_tests.js
@@ -19,7 +19,8 @@ QUnit.module('Crm Forecast Model Extension', {
             archs: {
                 "crm.lead,false,search": `
                     <search>
-                        <filter name="forecast" string="Forecast" context="{'forecast_filter':1}"/>
+                        <filter name="forecast_date_deadline" string="Forecast Date Deadline" context="{'forecast_field':'date_deadline'}"/>
+                        <filter name="forecast_date_closed" string="Forecast Date Closed" context="{'forecast_field':'date_closed'}"/>
                         <filter name='groupby_date_deadline' context="{'group_by':'date_deadline'}"/>
                         <filter name='groupby_date_closed' context="{'group_by':'date_closed'}"/>
                     </search>`
@@ -44,15 +45,6 @@ QUnit.module('Crm Forecast Model Extension', {
             services: { 'fillTemporalService': FillTemporalService },
             model: 'crm.lead',
             View: ForecastKanbanView,
-            viewOptions: {
-                context: {
-                    search_default_forecast: true,
-                    search_default_groupby_date_deadline: true,
-                    forecast_field: 'date_deadline',
-                },
-            },
-            groupBy: ['date_deadline'],
-            
         };
         this.unPatchDate = testUtils.mock.patchDate(2021, 1, 10, 0, 0, 0);
     },
@@ -61,11 +53,18 @@ QUnit.module('Crm Forecast Model Extension', {
     },
 
 }, function () {
-    QUnit.test("filter out every records before the start of the current month with forecast_filter for a date field", async function (assert) {
-        // the filter is used by the forecast model extension, and applies the forecast_filter context key,
-        // which adds a domain constraint on the field marked in the other context key forecast_field
+    QUnit.test("filter out every records before the start of the current month with a forecast filter for a date field", async function (assert) {
+        // the filter is used by the forecast model extension, and applies the forecast_field context key,
+        // which adds a domain constraint on the specified field.
         assert.expect(7);
 
+        this.testKanbanView.viewOptions = {
+            context: {
+                search_default_forecast_date_deadline: true,
+                search_default_groupby_date_deadline: true,
+            }
+        };
+        this.testKanbanView.groupBy = ['date_deadline'];
         const kanban = await testUtils.createView(this.testKanbanView);
 
         // the filter is active
@@ -76,7 +75,7 @@ QUnit.module('Crm Forecast Model Extension', {
                         "2nd column March should contain 2 records");
 
         // remove the filter
-        await testUtils.dom.click($('.o_searchview_facet:contains("Forecast") .o_facet_remove'));
+        await testUtils.dom.click($('.o_searchview_facet:contains("Forecast Date Deadline") .o_facet_remove'));
 
         assert.containsN(kanban, '.o_kanban_group', 3, "There should be 3 columns");
         assert.containsN(kanban, '.o_kanban_group:nth-child(1) .o_kanban_record', 2,
@@ -88,14 +87,15 @@ QUnit.module('Crm Forecast Model Extension', {
         kanban.destroy();
     });
 
-    QUnit.test("filter out every records before the start of the current month with forecast_filter for a datetime field", async function (assert) {
+    QUnit.test("filter out every records before the start of the current month with a forecast filter for a datetime field", async function (assert) {
         // same tests as for the date field
         assert.expect(7);
 
-        this.testKanbanView.viewOptions.context = {
-            search_default_forecast: true,
-            search_default_groupby_date_closed: true,
-            forecast_field: 'date_closed',
+        this.testKanbanView.viewOptions = {
+            context: {
+                search_default_forecast_date_closed: true,
+                search_default_groupby_date_closed: true,
+            }
         };
         this.testKanbanView.groupBy = ['date_closed'];
         const kanban = await testUtils.createView(this.testKanbanView);
@@ -108,7 +108,7 @@ QUnit.module('Crm Forecast Model Extension', {
                         "2nd column March should contain 2 records");
 
         // remove the filter
-        await testUtils.dom.click($('.o_searchview_facet:contains("Forecast") .o_facet_remove'));
+        await testUtils.dom.click($('.o_searchview_facet:contains("Forecast Date Closed") .o_facet_remove'));
 
         assert.containsN(kanban, '.o_kanban_group', 3, "There should be 3 columns");
         assert.containsN(kanban, '.o_kanban_group:nth-child(1) .o_kanban_record', 2,
@@ -141,7 +141,7 @@ QUnit.module('Crm Fill Temporal Service', {
             archs: {
                 "crm.lead,false,search": `
                     <search>
-                        <filter name="forecast" string="Forecast" context="{'forecast_filter':1}"/>
+                        <filter name="forecast" string="Forecast" context="{'forecast_field':'date_deadline'}"/>
                         <filter name='groupby_date_deadline' context="{'group_by':'date_deadline'}"/>
                     </search>`
             },
@@ -228,7 +228,7 @@ QUnit.module('Crm Fill Temporal Service', {
         ];
         this.testKanbanView.groupBy = ['date_deadline:year'];
         this.testKanbanView.archs["crm.lead,false,search"] = 
-            this.testKanbanView.archs["crm.lead,false,search"].replace("'date_deadline'", "'date_deadline:year'");
+            this.testKanbanView.archs["crm.lead,false,search"].replace("'group_by':'date_deadline'", "'group_by':'date_deadline:year'");
         this.testKanbanView.mockRPC = function (route, args) {
             if (route === '/web/dataset/call_kw/crm.lead/web_read_group') {
                 assert.deepEqual(args.kwargs.context.fill_temporal, {

--- a/addons/crm/static/tests/forecast_view_tests.js
+++ b/addons/crm/static/tests/forecast_view_tests.js
@@ -57,7 +57,7 @@ QUnit.module("Views", (hooks) => {
                 "foo,false,graph": `<graph js_class="forecast_graph"/>`,
                 "foo,false,search": `
                     <search>
-                        <filter name="forecast_filter" string="Forecast Filter" context="{ 'forecast_filter': 1 }"/>
+                        <filter name="forecast_filter" string="Forecast Filter" context="{ 'forecast_field': 'date_field' }"/>
                         <filter name="group_by_bar" string="Bar" context="{ 'group_by': 'bar' }"/>
                         <filter name="group_by_date_field" string="Date Field" context="{ 'group_by': 'date_field' }"/>
                     </search>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1004,7 +1004,7 @@
             <field name="priority">32</field>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='assigned_to_me']" position="before">
-                    <filter name="forecast" string="Upcoming Closings" context="{'forecast_filter':1}"/>
+                    <filter name="forecast" string="Upcoming Closings" context="{'forecast_field':'date_deadline'}"/>
                     <separator/>
                 </xpath>
                 <xpath expr="//filter[@name='date_deadline']" position="replace"/>


### PR DESCRIPTION
The forecast filter is a feature that allows to generate a date domain from
values extracted from the current groupby fields.

The purpose of this change is twofold:
  - remove the dependency on the context of the action:
    - the context key forecast_field should be instead directly defined in the
      context of the filter and will be sufficient in itself for the filter to
      work as intended.
    - we no longer require an additional context key (forecast_filter)
  - remove the fields added to the state of the model_extension (old version)
    and the search_model (new version)
    - the only useful information was the forecastStart, and it should be
      computed each time the modified domain is requested, therefore it is
      not really correct to store it as a state property (no need to
      import/export, ...).

REM: the context key forecast_field may still be required in the action context
  as it is used by the fillTemporalService and the forecast views, but is not
  required there if only the filter feature is needed.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
