### PR TITLE
[FIX] website_blog, website_sale: don't show frontend filter in backend

### DIFF
--- a/addons/website_blog/data/blog_snippet_template_data.xml
+++ b/addons/website_blog/data/blog_snippet_template_data.xml
@@ -8,6 +8,7 @@
             <field name="user_id" eval="False" />
             <field name="domain">[('post_date', '&lt;=', context_today())]</field>
             <field name="sort">['post_date desc']</field>
+            <field name="action_id" ref="website.action_website"/>
         </record>
         <record id="dynamic_snippet_most_viewed_blog_post_filter" model="ir.filters">
             <field name="name">Most Viewed Blog Posts</field>
@@ -15,6 +16,7 @@
             <field name="user_id" eval="False" />
             <field name="domain">[('post_date', '&lt;=', context_today()), ('visits', '!=', False)]</field>
             <field name="sort">['visits desc']</field>
+            <field name="action_id" ref="website.action_website"/>
         </record>
         <!-- Dynamic Filter -->
         <record id="dynamic_filter_latest_blog_posts" model="website.snippet.filter">

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -66,6 +66,7 @@
             <field name="domain">[('website_published', '=', True)]</field>
             <field name="context">{'display_default_code': False}</field>
             <field name="sort">['create_date desc']</field>
+            <field name="action_id" ref="website.action_website"/>
         </record>
         <!-- Action Server for Dynamic Filter -->
         <record id="dynamic_snippet_latest_sold_products_action" model="ir.actions.server">


### PR DESCRIPTION
We use ir.filters for dynamic snippet filter.
But domain is not exactly the same syntax.

e.g. time.strftime() vs context_today()

So we add a fake action_id to avoid to display these filters on each action
of this model.

task-2654131

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
