### PR TITLE
[FIX] account: disable aml creation from kanban

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -91,7 +91,7 @@
             <field name="name">account.move.line.kanban</field>
             <field name="model">account.move.line</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile">
+                <kanban class="o_kanban_mobile" create="false">
                     <field name="date_maturity"/>
                     <field name="move_id"/>
                     <field name="name"/>


### PR DESCRIPTION
Steps:
- Go to Journal Items
- Switch to Kanban View
- Click on create

Issue:
- Traeback due to unknow currency

Fix:
Journal Items are not created individually so we have disabled
`Create` button in Kanban view.

Fixes: odoo#76543

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
