### PR TITLE
[FIX] maintenance: display maintenance action on only form view

### DIFF
--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -269,6 +269,7 @@
         <field name="name">Maintenance Requests</field>
         <field name="res_model">maintenance.request</field>
         <field name="binding_model_id" ref="maintenance.model_maintenance_equipment"/>
+        <field name="binding_view_types">form</field>
         <field name="view_mode">kanban,tree,form,pivot,graph,calendar</field>
         <field name="context">{
             'default_equipment_id': active_id,


### PR DESCRIPTION
Before this commit,
Maintenance Requests action was displayed on list view as well which
doesn't makes sense as it will always use `active_id` only.

With this commit,
we are displaying `Maintenance Requests` action on form view only.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
