### PR TITLE
[FIX] maintenance: use context_today instead of today

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -351,7 +351,7 @@ class MaintenanceRequest(models.Model):
         if vals.get('owner_user_id') or vals.get('user_id'):
             self._add_followers()
         if 'stage_id' in vals:
-            self.filtered(lambda m: m.stage_id.done).write({'close_date': fields.Date.today()})
+            self.filtered(lambda m: m.stage_id.done).write({'close_date': fields.Date.context_today(self)})
             self.activity_feedback(['maintenance.mail_act_maintenance_request'])
         if vals.get('user_id') or vals.get('schedule_date'):
             self.activity_update()


### PR DESCRIPTION
`fields.Date.today` doesn't give date based on TZ which might be wrong
in some cases as it doesn't respect TZ.

With this commit, we are using `fields.Date.context_today` for `close_date` field.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
