### PR TITLE
[FIX] mail: make field error_msg computed

### DIFF
--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -35,8 +35,8 @@ class MailTemplatePreview(models.TransientModel):
     resource_ref = fields.Reference(string='Record', selection='_selection_target_model')
     lang = fields.Selection(_selection_languages, string='Template Preview Language')
     no_record = fields.Boolean('No Record', compute='_compute_no_record')
-    error_msg = fields.Char('Error Message', readonly=True)
     # Fields same than the mail.template model, computed with resource_ref and lang
+    error_msg = fields.Char('Error Message', compute='_compute_mail_template_fields')
     subject = fields.Char('Subject', compute='_compute_mail_template_fields')
     email_from = fields.Char('From', compute='_compute_mail_template_fields', help="Sender address")
     email_to = fields.Char('To', compute='_compute_mail_template_fields',


### PR DESCRIPTION
Field `error_msg` is meant to be computed based to display
error message.

Before this commit, 'Error Message' was not displayed on wizard
when email template is failed to generate Preview.

Fixes #75104

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
