### PR TITLE
[FIX] sale_coupon: allow to delete coupon programs

### DIFF
--- a/addons/sale_coupon/security/ir.model.access.csv
+++ b/addons/sale_coupon/security/ir.model.access.csv
@@ -2,10 +2,10 @@ id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 access_program_salesman,Coupon Program (Salesperson),coupon.model_coupon_program,sales_team.group_sale_salesman,1,0,0,0
 access_program_manager,Coupon Program (Manager),coupon.model_coupon_program,sales_team.group_sale_manager,1,1,1,1
 access_applicability_salesman,Coupon Rule (Salesperson),coupon.model_coupon_rule,sales_team.group_sale_salesman,1,0,0,0
-access_applicability_manager,Coupon Rule (Manager),coupon.model_coupon_rule,sales_team.group_sale_manager,1,1,1,0
+access_applicability_manager,Coupon Rule (Manager),coupon.model_coupon_rule,sales_team.group_sale_manager,1,1,1,1
 access_coupon_salesman,Coupon (Salesperson),coupon.model_coupon_coupon,sales_team.group_sale_salesman,1,1,0,0
 access_coupon_manager,Coupon (Manager),coupon.model_coupon_coupon,sales_team.group_sale_manager,1,1,1,0
 access_reward_salesman,Coupon Reward (Salesperson),coupon.model_coupon_reward,sales_team.group_sale_salesman,1,0,0,0
-access_reward_manager,Coupon Reward (Manager),coupon.model_coupon_reward,sales_team.group_sale_manager,1,1,1,0
+access_reward_manager,Coupon Reward (Manager),coupon.model_coupon_reward,sales_team.group_sale_manager,1,1,1,1
 access_sale_coupon_apply_code,Apply Coupon,model_sale_coupon_apply_code,sales_team.group_sale_salesman,1,1,1,0
 access_sale_coupon_generate,Coupon Generation,coupon.model_coupon_generate_wizard,sales_team.group_sale_salesman,1,1,1,0


### PR DESCRIPTION
Before this commit, No group was allowing to delete
coupon programs.

With this commit, We are allowing Sales / Administrator to delete
coupon programs.

Fixes #62211

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
