### PR TITLE
[FIX] website_crm_partner_assign: display valid partners on forward t…

### DIFF
--- a/addons/website_crm_partner_assign/wizard/crm_forward_to_partner_view.xml
+++ b/addons/website_crm_partner_assign/wizard/crm_forward_to_partner_view.xml
@@ -10,7 +10,8 @@
                     </group>
                     <group>
                         <group>
-                            <field name="partner_id" attrs="{'invisible': [('forward_type', 'in', ['assigned',False])], 'required': [('forward_type', '=', 'single')]}"  />
+                            <field name="partner_id" attrs="{'invisible': [('forward_type', 'in', ['assigned',False])], 'required': [('forward_type', '=', 'single')]}"
+                                   domain="[('grade_id','!=',False)]" />
                         </group>
                         <group>
                         </group>


### PR DESCRIPTION
…o partner

Steps:
Lead --> Assigned Partner --->Send Email

Issue: 
It will open Wizard which is displaying all Partners while
it should display partner with valid `grade_id`.

Fix:
Now we are displaying partner having `grade_id`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
