### PR TITLE
[FIX] web_editor: add link to image option is missing

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -2,6 +2,7 @@ odoo.define('mass_mailing.snippets.options', function (require) {
 "use strict";
 
 var options = require('web_editor.snippets.options');
+var ImageLinkTools = require('wysiwyg.widgets.ImageLinkTools');
 
 // Snippet option for resizing  image and column width inline like excel
 options.registry.mass_mailing_sizing_x = options.Class.extend({
@@ -137,6 +138,22 @@ options.registry.BackgroundImage = options.registry.BackgroundImage.extend({
             }
         }
     }
+});
+
+// Adding compatibility for Image tools.
+ImageLinkTools.include({
+    destroy: function () {
+        this.$link.removeClass('oe_edited_link');
+        const $contents = this.$link.contents();
+        if (!this.$link.attr('href')) {
+            $contents.unwrap();
+        }
+        this.$button.removeClass('active');
+        this.options.wysiwyg.odooEditor.observerActive();
+        this.applyLinkToDom(this._getData());
+        this.options.wysiwyg.odooEditor.historyStep();
+        this._super(...arguments);
+    },
 });
 
 });

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1281,7 +1281,7 @@ var SnippetsMenu = Widget.extend({
             this.updateCurrentSnippetEditorOverlay();
         }, 50);
         this.$window.on('resize.snippets_menu', debouncedCoverUpdate);
-        this.$window.on('content_changed.snippets_menu', debouncedCoverUpdate);
+        // this.$window.on('content_changed.snippets_menu', debouncedCoverUpdate);
 
         // On keydown add a class on the active overlay to hide it and show it
         // again when the mouse moves

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_link_tools.js
@@ -1,0 +1,24 @@
+odoo.define('wysiwyg.widgets.ImageLinkTools', function (require) {
+'use strict';
+
+const LinkTools = require('wysiwyg.widgets.LinkTools');
+
+/**
+ * Allows to customize Image link content and style.
+ */
+const ImageLinkTools = LinkTools.extend({
+    template: 'wysiwyg.widgets.imageLinkTools',
+    /**
+     * @override
+     * Explicitly override becuase setCursor will keep focus on Image and
+     * when you click next time on Image will consider as a click on Anchor tag
+     * leads to open Text tools instead of Image tools.
+     */
+    destroy: function () {
+        this._super(...arguments);
+        $('.oe_edited_link').removeClass('oe_edited_link');
+    },
+});
+
+return ImageLinkTools;
+});

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -85,6 +85,7 @@ const Link = Widget.extend({
             this.data.content = encodedText;
             this.data.images = images;
             this.data.url = this.$link.attr('href') || '';
+            this.data.isNewWindow = this.$link[0] && this.$link[0].getAttribute("target");
         } else {
             this.data.content = this.data.content ? this.data.content.replace(/[ \t\r\n]+/g, ' ') : '';
         }
@@ -128,6 +129,11 @@ const Link = Widget.extend({
             var match = /mailto:(.+)/.exec(this.data.url);
             this.$('input[name="url"]').val(match ? match[1] : this.data.url);
             this._onURLInput();
+        }
+        if (this.data.isNewWindow) {
+            if (document.getElementsByName("is_new_window").length) {
+                document.getElementsByName("is_new_window")[0].closest('.o_we_checkbox_wrapper').classList.toggle('active');
+            }
         }
 
         this._updateOptionsUI();

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/widgets.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/widgets.js
@@ -6,6 +6,7 @@ var AltDialog = require('wysiwyg.widgets.AltDialog');
 var MediaDialog = require('wysiwyg.widgets.MediaDialog');
 var LinkDialog = require('wysiwyg.widgets.LinkDialog');
 var LinkTools = require('wysiwyg.widgets.LinkTools');
+var ImageLinkTools = require('wysiwyg.widgets.ImageLinkTools');
 var ImageCropWidget = require('wysiwyg.widgets.ImageCropWidget');
 const LinkPopoverWidget = require('@web_editor/js/wysiwyg/widgets/link_popover_widget')[Symbol.for("default")];
 const {ColorpickerDialog} = require('web.Colorpicker');
@@ -18,6 +19,7 @@ return {
     MediaDialog: MediaDialog,
     LinkDialog: LinkDialog,
     LinkTools: LinkTools,
+    ImageLinkTools: ImageLinkTools,
     ImageCropWidget: ImageCropWidget,
     LinkPopoverWidget: LinkPopoverWidget,
     ColorpickerDialog: ColorpickerDialog,

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -585,6 +585,32 @@
             </we-button>
         </we-row>
     </we-customizeblock-option>
+    <we-customizeblock-option t-name="wysiwyg.widgets.imageLinkTools">
+        <we-row t-attf-class="{{widget.needLabel ? '' : 'd-none'}}">
+            <we-title>⌙ Link Label</we-title>
+            <we-input class="o_we_user_value_widget">
+                <div>
+                    <input name="label" id="o_link_dialog_label_input" t-att-value="widget.data.content" type="text"/>
+                </div>
+            </we-input>
+        </we-row>
+        <we-row id="url_row">
+            <we-input class="o_we_user_value_widget w-100">
+                <div class="o_url_input w-100">
+                    <input name="url" id="o_link_dialog_url_input" type="text" placeholder="Your URL"/>
+                </div>
+            </we-input>
+        </we-row>
+
+        <we-row t-if="!widget.options.forceNewWindow">
+            <we-button class="o_we_user_value_widget o_we_checkbox_wrapper">
+                <we-title class="o_long_title w-75">⌙ Open in new window</we-title>
+                    <div class="o_switch w-25">
+                        <we-checkbox name="is_new_window" t-att-checked="widget.data.isNewWindow ? 'checked' : undefined"/>
+                    </div>
+            </we-button>
+        </we-row>
+    </we-customizeblock-option>
 
     <!-- ImageCropWidget controls (allows to crop images on the page) -->
     <div t-name="wysiwyg.widgets.crop" class="o_we_crop_widget" contenteditable="false">

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -426,6 +426,11 @@
             <we-button data-select-style="50%" title="Resize Half">50%</we-button>
             <we-button data-select-style="100%" title="Resize Full">100%</we-button>
         </we-button-group>
+
+        <we-row string="Link" class="o_we_full_row">
+            <we-button data-create-link="true" data-no-preview="true" title="Insert or edit link" class="create-link"><i class="fa fa-link"></i></we-button>
+            <we-button data-unlink="true" data-no-preview="true" title="Remove link" class="unlink"><i class="fa fa-unlink"></i></we-button>
+        </we-row>
     </div>
 
     <div data-selector="span.fa, i.fa, img">


### PR DESCRIPTION
**PURPOSE**
After moving image tools to snippet option, the link to image option
was missing.

**SPEC** 
we are adding the link option to add the link on the image.
The link might be the external website link or any internal pages links with
target new tab option.
    
task-2612931


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
