### PR TITLE
[FIX] mail: correct inaccurate doc comment

### DIFF
--- a/addons/mail/static/src/models/welcome_view/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view/welcome_view.js
@@ -144,8 +144,8 @@ function factory(dependencies) {
         /**
          * Determines whether the 'joinButton' is disabled.
          * 
-         * Shall be disabled when 'pendingGuestName' is an empty string or when
-         * the current user is not a guest.
+         * Shall be disabled when 'pendingGuestName' is an empty string while
+         * the current user is a guest.
          */
         isJoinButtonDisabled: attr({
             compute: '_computeIsJoinButtonDisabled'


### PR DESCRIPTION
This commit will correct an inaccurate comment introduced with
odoo/odoo#76951. The comment states that the 'joinButton' shall be
disabled when the current user is NOT a guest, which is not true:
'joinButton' can only be disabled if the current user is a guest.
