### PR TITLE
[FIX] website, website_blog: keep resize_class upon cover change

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
 import logging
 
 
@@ -9,6 +8,7 @@ from odoo import api, fields, models, _
 from odoo.http import request
 from odoo.osv import expression
 from odoo.exceptions import AccessError
+from odoo.tools.json import scriptsafe as json_scriptsafe
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ class WebsiteCoverPropertiesMixin(models.AbstractModel):
     _name = 'website.cover_properties.mixin'
     _description = 'Cover Properties Website Mixin'
 
-    cover_properties = fields.Text('Cover Properties', default=lambda s: json.dumps(s._default_cover_properties()))
+    cover_properties = fields.Text('Cover Properties', default=lambda s: json_scriptsafe.dumps(s._default_cover_properties()))
 
     def _default_cover_properties(self):
         return {
@@ -111,6 +111,29 @@ class WebsiteCoverPropertiesMixin(models.AbstractModel):
             "opacity": "0.2",
             "resize_class": "o_half_screen_height",
         }
+
+    def write(self, vals):
+        if 'cover_properties' not in vals:
+            return super().write(vals)
+
+        cover_properties = json_scriptsafe.loads(vals['cover_properties'])
+        resize_classes = cover_properties.get('resize_class', '').split()
+        classes = ['o_half_screen_height', 'o_full_screen_height', 'cover_auto']
+        if not set(resize_classes).isdisjoint(classes):
+            # Updating cover properties and the given 'resize_class' set is
+            # valid, normal write.
+            return super().write(vals)
+
+        # If we do not receive a valid resize_class via the cover_properties, we
+        # keep the original one (prevents updates on list displays from
+        # destroying resize_class).
+        copy_vals = dict(vals)
+        for item in self:
+            old_cover_properties = json_scriptsafe.loads(item.cover_properties)
+            cover_properties['resize_class'] = old_cover_properties.get('resize_class', classes[0])
+            copy_vals['cover_properties'] = json_scriptsafe.dumps(cover_properties)
+            super(WebsiteCoverPropertiesMixin, item).write(copy_vals)
+        return True
 
 
 class WebsiteMultiMixin(models.AbstractModel):

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -3,10 +3,10 @@
 
 from datetime import datetime
 import random
-import json
 
 from odoo import api, models, fields, _
 from odoo.addons.http_routing.models.ir_http import slug
+from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.translate import html_translate
 from odoo.tools import html2plaintext
 
@@ -211,7 +211,7 @@ class BlogPost(models.Model):
             if (published_in_vals and 'published_date' not in vals and
                     (not post.published_date or post.published_date <= fields.Datetime.now())):
                 copy_vals['published_date'] = vals[list(published_in_vals)[0]] and fields.Datetime.now() or False
-            result &= super(BlogPost, self).write(copy_vals)
+            result &= super(BlogPost, post).write(copy_vals)
         self._check_for_publication(vals)
         return result
 
@@ -263,7 +263,7 @@ class BlogPost(models.Model):
         res['default_opengraph']['article:modified_time'] = self.write_date
         res['default_opengraph']['article:tag'] = self.tag_ids.mapped('name')
         # background-image might contain single quotes eg `url('/my/url')`
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = json.loads(self.cover_properties).get('background-image', 'none')[4:-1].strip("'")
+        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = json_scriptsafe.loads(self.cover_properties).get('background-image', 'none')[4:-1].strip("'")
         res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
         res['default_meta_description'] = self.subtitle
         return res


### PR DESCRIPTION
Before this commit when covers were edited from their list view (e.g.
changing their background color from the blog posts list or from the
events list), the resize class was lost.

After this commit the resize class is kept from its previously saved
value if it is not a parameter during edition.

Related to task-2359250

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
