### PR TITLE
[FIX] web_editor: better field html sizing

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -113,7 +113,7 @@
                         </group>
                         </page>
                     </notebook>
-                    <field name="note" placeholder="Legal Notes..."/>
+                    <field name="note" options="{'autoresize': false}" placeholder="Legal Notes..."/>
                     </sheet>
                 </form>
             </field>

--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -48,7 +48,7 @@
                                 </div>
                                 <field name="subject" placeholder="Subject..." attrs="{'required': [('is_email', '=', True), ('composition_mode', '=', 'comment')]}"/>
                             </group>
-                            <field name="body" style="border:none;" options="{'style-inline': true}"/>
+                            <field name="body" style="border:none;" options="{'style-inline': true, 'autoresize': false}" />
                         </div>
                         <group>
                             <group attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -163,7 +163,7 @@
                                 </group>
                             </group>
                             <label for="description"/>
-                            <field name="description"/>
+                            <field name="description" options="{'autoresize': false}"/>
                         </page>
                         <page name="page_options" string="Options">
                             <group>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -254,7 +254,7 @@
 
                         <notebook>
                             <page string="Internal Notes" name="internal_notes">
-                                <field name="description" placeholder="Add a description..."/>
+                                <field name="description" options="{'autoresize': false}" placeholder="Add a description..."/>
                             </page>
                             <page name="extra" string="Extra Info" attrs="{'invisible': [('type', '=', 'opportunity')]}">
                                 <group>

--- a/addons/hr/views/hr_plan_views.xml
+++ b/addons/hr/views/hr_plan_views.xml
@@ -76,7 +76,7 @@
                             <field name="summary"/>
                             <field name="responsible"/>
                             <field name="responsible_id" attrs="{'invisible': [('responsible', '!=', 'other')]}"/>
-                            <field name="note"/>
+                            <field name="note" options="{'autoresize': false}"/>
                         </group>
                     </sheet>
                 </form>

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -242,7 +242,7 @@
                             <label for="note" class="font-weight-bold" />
                         </div>
                         <div class="col-10">
-                            <field name="note" nolabel="1" placeholder="Information, allergens, ..." />
+                            <field name="note" options="{'autoresize': false}" nolabel="1" placeholder="Information, allergens, ..." />
                         </div>
                     </div>
                 </div>

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -76,7 +76,7 @@
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <label for="description"/>
-                        <field name='description'/>
+                        <field name="description" options="{'autoresize': false}"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/mail/views/ir_actions_server_views.xml
+++ b/addons/mail/views/ir_actions_server_views.xml
@@ -35,7 +35,7 @@
                                 }"/>
                             </group>
                         </group>
-                        <field name="activity_note" placeholder="Log a note..."/>
+                        <field name="activity_note" options="{'autoresize': false}" placeholder="Log a note..."/>
                     </page>
                 </xpath>
                 <xpath expr="//field[@name='link_field_id']" position="after">

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -126,7 +126,7 @@
                             <field name="user_id"/>
                         </group>
                     </group>
-                    <field name="note" placeholder="Log a note..."/>
+                    <field name="note" options="{'autoresize': false}" placeholder="Log a note..."/>
                     <footer>
                         <field name="id" invisible="1"/>
                         <button id="mail_activity_schedule" string="Schedule" name="action_close_dialog" type="object" class="btn-primary"

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -49,7 +49,7 @@
                         </group>
                         <notebook>
                             <page string="Body" name="body">
-                                <field name="body" options="{'style-inline': true}"/>
+                                <field name="body" options="{'style-inline': true, 'autoresize': false}"/>
                             </page>
                             <page string="Gateway" name="gateway">
                                 <group>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -69,7 +69,7 @@
                                     'required':[('reply_to_mode', '!=', 'update'), ('composition_mode', '=', 'mass_mail')]}"/>
                     </group>
                     <field name="can_edit_body" invisible="1"/>
-                    <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                    <field name="body" options="{'style-inline': true, 'autoresize': false}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                     <group col="4">
                         <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                         <field name="template_id" options="{'no_create': True}"

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -365,7 +365,7 @@
                     </group>
                     <notebook>
                         <page string="Description" name="description">
-                            <field name="note"/>
+                            <field name="note" options="{'autoresize': false}"/>
                         </page>
                         <page string="Product Information" name="product_information">
                             <group>

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -333,6 +333,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
     _getWysiwygOptions: function () {
         const options = this._super.apply(this, arguments);
         options.resizable = false;
+        options.autoresize = false;
         if (!this._wysiwygSnippetsActive) {
             delete options.snippets;
         }

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -101,7 +101,7 @@
                                     <field name="worksheet_type" widget="radio"/>
                                     <field name="worksheet" help="Upload your PDF file." widget="pdf_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'pdf')], 'required':  [('worksheet_type', '=', 'pdf')]}"/>
                                     <field name="worksheet_google_slide" placeholder="Google Slide Link" widget="embed_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'google_slide')], 'required': [('worksheet_type', '=', 'google_slide')]}"/>
-                                    <field name="note" attrs="{'invisible':  [('worksheet_type', '!=', 'text')]}"/>
+                                    <field name="note" options="{'autoresize': false}" attrs="{'invisible':  [('worksheet_type', '!=', 'text')]}"/>
                                 </group>
                             </page>
                         </notebook>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -220,7 +220,7 @@
                     <field name="worksheet_type" invisible="1"/>
                     <field name="worksheet" widget="pdf_viewer" attrs="{'invisible': [('worksheet_type', '!=', 'pdf')]}"/>
                     <field name="worksheet_google_slide" widget="embed_viewer" attrs="{'invisible': [('worksheet_type', '!=', 'google_slide')]}"/>
-                    <field name="operation_note" attrs="{'invisible': [('worksheet_type', '!=', 'text')]}"/>
+                    <field name="operation_note" options="{'autoresize': false}" attrs="{'invisible': [('worksheet_type', '!=', 'text')]}"/>
                 </page>
                 </notebook>
             </sheet>

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -170,7 +170,7 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <field name="description" type="html" options="{'collaborative': true, 'autoresize': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
                             <field name="child_ids" context="{'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': [(6, 0, [uid])], 'default_parent_id': id, 'default_partner_id': partner_id}">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -860,7 +860,7 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <field name="description" type="html" options="{'collaborative': true, 'autoresize': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
                             <field name="child_ids" context="{'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': user_ids, 'default_parent_id': id, 'default_partner_id': partner_id}">

--- a/addons/survey/views/gamification_badge_views.xml
+++ b/addons/survey/views/gamification_badge_views.xml
@@ -16,7 +16,7 @@
                         </h1>
                     </div>
                     <group>
-                        <field name="description" nolabel="1" placeholder="e.g. No one can solve challenges like you do"/>
+                        <field name="description" nolabel="1" options="{'autoresize': false}" placeholder="e.g. No one can solve challenges like you do"/>
                     </group>
                     <group string="Rewards for challenges">
                         <field name="level"/>

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -45,7 +45,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" options="{'autoresize': false, 'style-inline': true, 'height': 380}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -654,6 +654,12 @@ $o-form-label-margin-right: 0px;
 
         .tab-content > .tab-pane {
             padding: $o-horizontal-padding 0;
+            > .oe_form_field_html {
+                padding: 20px 20px 0;
+            }
+            .note-editable {
+                border: 0;
+            }
         }
     }
 

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -204,10 +204,12 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                 noVideos: 'noVideos' in this.nodeOptions ? this.nodeOptions.noVideos : true,
             },
             linkForceNewWindow: true,
-
+            autoresize: 'autoresize' in this.nodeOptions ? this.nodeOptions.autoresize : true,
             tabsize: 0,
-            height: this.nodeOptions.height || 110,
-            resizable: 'resizable' in this.nodeOptions ? this.nodeOptions.resizable : true,
+            height: this.nodeOptions.height,
+            minHeight: this.nodeOptions.minHeight,
+            maxHeight: this.nodeOptions.maxHeight,
+            resizable: 'resizable' in this.nodeOptions ? this.nodeOptions.resizable : false,
             editorPlugins: [QWebPlugin],
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -437,7 +437,7 @@ const Wysiwyg = Widget.extend({
                     }
                 }
             },
-        }
+        };
         return editorCollaborationOptions;
     },
     /**
@@ -475,6 +475,14 @@ const Wysiwyg = Widget.extend({
     renderElement: function () {
         this.$editable = this.options.editable || $('<div class="note-editable">');
 
+        if (this.options.autoresize) {
+            this.$editable.addClass("auto-resize");
+            this.$editable.css("min-height", this.options.minHeight || 10);
+            this.$editable.css("max-height", this.options.maxHeight || 340);
+        } else {
+            this.$editable.css("min-height", this.options.minHeight || 100);
+            this.$editable.css("max-height", this.options.maxHeight || 450);
+        }
         if (this.options.resizable && !device.isMobile) {
             const $wrapper = $('<div class="o_wysiwyg_wrapper odoo-editor">');
             $wrapper.append(this.$editable);

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -708,6 +708,16 @@ img::selection {
     color: black;
     height: 100%;
     padding: 5px 10px;
+    &.auto-resize {
+        border-top:0;
+        border-right:0;
+        border-left:0;
+        padding: 3px 0 5px;
+    }
+}
+.oe_bordered_editor .note-editable.auto-resize {
+    border: $o-we-border-width solid $o-we-fg-light;
+    padding: 5px 10px;
 }
 
 .o_we_no_pointer_events {

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -86,7 +86,7 @@
                                 </group>
                             </page>
                             <page name="description" string="Description">
-                                <field name="description" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
+                                <field name="description" options="{'autoresize': false}" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
                             </page>
                             <page string="Additional Resources" name="external_links" >
                                 <group string="External Links">

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -19,7 +19,7 @@
                             <field name="subject" placeholder="Subject..."/>
                         </group>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" options="{'style-inline': true}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
+                        <field name="body" options="{'style-inline': true, 'autoresize': false}" attrs="{'readonly': [('can_edit_body', '=', False)]}" force_save="1"/>
                         <group>
                             <group>
                                 <field name="attachment_ids" widget="many2many_binary"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -321,7 +321,7 @@
                                             </group>
                                         </group>
                                         <group>
-                                            <field name="comment" placeholder="Internal notes..."/>
+                                            <field name="comment" options="{'autoresize': false}" placeholder="Internal notes..."/>
                                         </group>
                                         <field name="lang" invisible="True"/>
                                         <field name="user_id" invisible="True"/>
@@ -344,7 +344,7 @@
                             </group>
                         </page>
                         <page name='internal_notes' string="Internal Notes">
-                            <field name="comment" options="{'height': 70}" placeholder="Internal note..."/>
+                            <field name="comment" options="{'autoresize': false}" placeholder="Internal note..."/>
                         </page>
                     </notebook>
                 </sheet>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -119,7 +119,7 @@
                                 </tree>
                             </field>
                         </page><page string="Notes" name="notes">
-                            <field name="comment"/>
+                            <field name="comment" options="{'autoresize': false}"/>
                         </page>
                     </notebook>
                   </sheet>


### PR DESCRIPTION
Allow wysiwyg field html to blend better in odoo view,
Remove the default resizer by a auto size field html.

task-2637488

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
