### PR TITLE
[FIX] website: properly handle removing the active item of a carousel

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -253,7 +253,8 @@ var SnippetEditor = Widget.extend({
         function isEmptyAndRemovable($el, editor) {
             editor = editor || $el.data('snippet-editor');
             return $el.children().length === 0 && $el.text().trim() === ''
-                && !$el.hasClass('oe_structure') && (!editor || editor.isTargetParentEditable);
+                && !$el.hasClass('oe_structure') && !$el.parent().hasClass('carousel-item')
+                && (!editor || editor.isTargetParentEditable);
         }
     },
     /**

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -1,0 +1,32 @@
+odoo.define("website.tour.carousel_content_removal", function (require) {
+"use strict";
+
+var tour = require("web_tour.tour");
+var base = require("web_editor.base");
+
+tour.register("carousel_content_removal", {
+    url: "/",
+    wait_for: base.ready(),
+}, [{
+    trigger: "a[data-action=edit]",
+    content: "Click the Edit button.",
+    extra_trigger: ".homepage",
+}, {
+    trigger: "#snippet_structure .oe_snippet:has(span:contains('Carousel')) .oe_snippet_thumbnail",
+    content: "Drag the Carousel block and drop it in your page.",
+    run: "drag_and_drop #wrap",
+},
+{
+    trigger: ".carousel .carousel-item.active .carousel-content",
+    content: "Select the active carousel item.",
+}, {
+    trigger: ".oe_snippet_remove:last",
+    content: "Remove the active carousel item.",
+},
+{
+    trigger: ".carousel .carousel-item.active .container:not(:has(*))",
+    content: "Check for a carousel slide with an empty container tag",
+    run: function () {},
+}]);
+
+});

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -152,3 +152,6 @@ class TestUi(odoo.tests.HttpCase):
             </t>
         """
         self.start_tour("/", "public_user_editor", login=None)
+
+    def test_07_carousel_snippet_content_removal(self):
+        self.start_tour("/", "carousel_content_removal", login='admin')

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -19,6 +19,7 @@
 
 <template id="assets_tests" name="Website Assets Tests" inherit_id="web.assets_tests">
     <xpath expr="." position="inside">
+        <script type="text/javascript" src="/website/static/tests/tours/carousel_content_removal.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/reset_password.js"></script>
         <script type="text/javascript" src="/website/static/tests/tours/rte.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/html_editor.js"/>


### PR DESCRIPTION
A bug currently makes the carousel snippet collapse/disappear when its active contents are removed. This happens because after the removal, the carousel no longer has an active item.

The solution simply consists of activating another item in the carousel or possibly removing the carousel entirely when the last item is being removed.

task-2506165