### PR TITLE
[FIX] hr_holidays: round the number of days of a time off

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_model.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_model.js
@@ -2,10 +2,18 @@
 
 import CalendarModel from "web.CalendarModel";
 
-
 export const TimeOffCalendarModel = CalendarModel.extend({
     _getFilterDomain: function() {
         const company_domain = [['user_id.company_id', 'in', this.data.context.allowed_company_ids]];
         return this._super().concat(company_domain);
+    },
+
+    calendarEventToRecord(event) {
+        const data = this._super(...arguments);
+        if (event.allDay) {
+            data.date_from = data.date_from.utc().startOf('day');
+            data.date_to = data.date_to.utc().endOf('day');
+        }
+        return data;
     },
 });

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -18,6 +18,7 @@ class TestHrHolidaysCommon(common.TransactionCase):
 
         cls.user_hrmanager = mail_new_test_user(cls.env, login='bastien', groups='base.group_user,hr_holidays.group_hr_holidays_manager')
         cls.user_hrmanager_id = cls.user_hrmanager.id
+        cls.user_hrmanager.tz = 'Europe/Brussels'
 
         cls.user_employee = mail_new_test_user(cls.env, login='david', groups='base.group_user')
         cls.user_employee_id = cls.user_employee.id

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -323,7 +323,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=250, admin=865):  # 249 community
+        with self.assertQueryCount(__system__=353, admin=865):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -316,11 +316,6 @@
                                     <label for="request_unit_hours" attrs="{
                                         'invisible': [('leave_type_request_unit', '!=', 'hour')]
                                     }"/>
-
-                                    <field name="request_unit_custom" invisible="1" attrs="{
-                                        'readonly': [('state', 'not in', ('draft', 'confirm'))],
-                                    }" class="ml-5"/>
-                                    <label for="request_unit_custom" invisible="1"/>
                                 </div>
                                 <div class="o_row o_row_readonly">
                                     <label for="request_hour_from" string="From"


### PR DESCRIPTION
When the user is set in another timezone than the context timezone, the first or last work interval retrieved to calculate the number of days between two dates is starting later or ending earlier depending on the user timezone.
The number of days displayed between two dates is therefore not an integer.
e.g.
A time off taken between 08/06/2021 and 10/06/2021 (timezone in the context is Europe/Brussels) will give:
- Number of days: 3 days if the user is in Europe/Brussels
- Number of days: 2.69 if the user is in Asia/Calcutta (first work interval starting later)
- Number of days: 2.5 if the user is in US/Pacific (last work interval ending earlier)

task-2646655

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
