### PR TITLE
[FIX] point_of_sale: cogs entries wrong currency conversion

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -553,11 +553,11 @@ class PosSession(models.Model):
                     exp_key = move.product_id._get_product_accounts()['expense']
                     out_key = move.product_id.categ_id.property_stock_account_output_categ_id
                     amount = -sum(move.stock_valuation_layer_ids.mapped('value'))
-                    stock_expense[exp_key] = self._update_amounts(stock_expense[exp_key], {'amount': amount}, move.picking_id.date)
+                    stock_expense[exp_key] = self._update_amounts(stock_expense[exp_key], {'amount': amount}, move.picking_id.date, force_company_currency=True)
                     if move.location_id.usage == 'customer':
-                        stock_return[out_key] = self._update_amounts(stock_return[out_key], {'amount': amount}, move.picking_id.date)
+                        stock_return[out_key] = self._update_amounts(stock_return[out_key], {'amount': amount}, move.picking_id.date, force_company_currency=True)
                     else:
-                        stock_output[out_key] = self._update_amounts(stock_output[out_key], {'amount': amount}, move.picking_id.date)
+                        stock_output[out_key] = self._update_amounts(stock_output[out_key], {'amount': amount}, move.picking_id.date, force_company_currency=True)
         MoveLine = self.env['account.move.line'].with_context(check_move_validity=False)
 
         data.update({


### PR DESCRIPTION
1) Have Accounting and POS.
2) Activate multi-currencies (EUR and USD available).
3) Main currency should be USD, set a rate to EUR (i.e. 0.5).
4) Activate automated inventory valuation [CATEG].
5) Create storable product [TEST]:
  - Storable, Category [CATEG]
  - with public price $10 and cost $1
  - available in POS
  - no taxes needed
6) Have a POS in EUR (Pricelists, Journal, Payment methods +
their journal in EUR).
7) Sell [TEST] (it costs ($10/2) = 5EUR)
8) Close the session and post entries.

Result: in the journal Items, some of the COGS entries (110300
Stock Interim (Delivered) and 600000 Expenses) are multiplied by
the ratio between $ and EUR. This occur because the system attempts to
convert an amount which has been created in company currency.

opw-2613739

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
