### PR TITLE
[FIX] hr_work_entry_contract: fix traceback

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -159,13 +159,19 @@ class HrContract(models.Model):
         for contract in self:
             # If we generate work_entries which exceeds date_start or date_stop, we change boundaries on contract
             if contract_vals:
-                date_stop_max = max([x['date_stop'] for x in contract_vals if x['contract_id'] == contract.id])
-                if date_stop_max > contract.date_generated_to:
-                    contract.date_generated_to = date_stop_max
+                #Handle empty work entries for certain contracts, could happen on an attendance based contract
+                #NOTE: this does not handle date_stop or date_start not being present in vals
+                dates_stop = [x['date_stop'] for x in contract_vals if x['contract_id'] == contract.id]
+                if dates_stop:
+                    date_stop_max = max(dates_stop)
+                    if date_stop_max > contract.date_generated_to:
+                        contract.date_generated_to = date_stop_max
 
-                date_start_min = min([x['date_start'] for x in contract_vals if x['contract_id'] == contract.id])
-                if date_start_min < contract.date_generated_from:
-                    contract.date_generated_from = date_start_min
+                dates_start = [x['date_start'] for x in contract_vals if x['contract_id'] == contract.id]
+                if dates_start:
+                    date_start_min = min(dates_start)
+                    if date_start_min < contract.date_generated_from:
+                        contract.date_generated_from = date_start_min
 
         return contract_vals
 


### PR DESCRIPTION
Fixes a traceback when generating work entries.
How to reproduce:
- Create a contract with a working schedule with 0 attendances
- Set the contract as running
- Make sure you have another contract for another employee running on
  the same period, this one must have attendances
- Go to the work entries views, this should generate working entries for
  the viewable dates
- If the work entries were already generated, go to a month where they
  are not generated yet, you should have the traceback

Task ID: 2654797
