### PR TITLE
[FIX] stock: correct condition for StockMove's field "show_details_visible"

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -219,16 +219,18 @@ class StockMove(models.Model):
         multi_locations_enabled = self.user_has_groups('stock.group_stock_multi_locations')
         consignment_enabled = self.user_has_groups('stock.group_tracking_owner')
 
-        show_details_visible = multi_locations_enabled or has_package
-
         for move in self:
             if not move.product_id:
                 move.show_details_visible = False
             elif len(move.move_line_ids) > 1:
                 move.show_details_visible = True
             else:
+                has_childlocation = bool(move.location_id.child_ids | move.location_dest_id.child_ids)
+                # If Multi Location is not enabled, do not show details even if children locations exist
+                # IF Multi Location is enabled, do not show details if there are no children locations
+                show_because_location = has_childlocation and multi_locations_enabled
                 move.show_details_visible = (((consignment_enabled and move.picking_id.picking_type_id.code != 'incoming') or
-                                             show_details_visible or move.has_tracking != 'none') and
+                                             show_because_location or has_package or move.has_tracking != 'none') and
                                              move._show_details_in_draft() and
                                              move.picking_id.picking_type_id.show_operations is False)
 


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

This PR fixes/improve the conditions used to define the Stock Moves boolean `show_details_visible`.
This boolean is used to display (or not) the button used to fill the Stock Moves lines _when it is necessary._
It is [also used to define the `quantity_done_editable` boolean](https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_move.py#L261) which is used to allow the user to fill a Stock Move's done quantity directly instead of opening the StockMoveLine's wizard, _when it is not necessary_.

# Current behavior before PR:

Currently `show_details_visible` is **always True** if the user is part of the "Manage Multiple Stock Locations" group, which is not a _necessary_ condition to force the user to realize a movement through the StockMoveLines instead of through the StockMove directly.

In fact, **the user do not need to use the StockMoveLines if neither the origin nor the destination location of a StockMove have children.**

# Desired behavior after PR is merged:

This PR introduce this check on the origin and destination location's children to allow the user to realize a StockMove without going through the StockMoveLines details.

## Typical use case :

When a user has many warehouses but do not have children locations on each of these warehouses main locations. The "Multi Location" group will be enabled but the user won't need the details of the StockMoveLines.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
