### PR TITLE
[FIX] web_editor: split list on enter in empty li

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/enter.js
@@ -101,11 +101,11 @@ HTMLHeadingElement.prototype.oEnter = function () {
  */
 HTMLQuoteElement.prototype.oEnter = HTMLHeadingElement.prototype.oEnter;
 /**
- * Specific behavior for list items: deletion and unindentation in some cases.
+ * Specific behavior for list items: deletion and unindentation when empty.
  */
 HTMLLIElement.prototype.oEnter = function () {
-    // If not last list item or not empty last item, regular block split
-    if (this.nextElementSibling || this.textContent) {
+    // If not empty list item, regular block split
+    if (this.textContent) {
         const node = HTMLElement.prototype.oEnter.call(this, ...arguments);
         if (node.classList.contains('o_checked')) {
             toggleClass(node, 'o_checked');


### PR DESCRIPTION
Previously, it only exited the list on enter in the last li if it was empty. Now it exists the list on enter in any empty li, not merely the last.

This matches the behavior of GDocs and CKEditor.