### PR TITLE
[FIX] mrp: gather SM generated by unbuild order

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -190,8 +190,10 @@ class MrpUnbuild(models.Model):
             if unbuild.mo_id:
                 finished_moves = unbuild.mo_id.move_finished_ids.filtered(lambda move: move.state == 'done')
                 factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.product_qty, unbuild.product_uom_id)
-                for finished_move in finished_moves:
-                    moves += unbuild._generate_move_from_existing_move(finished_move, factor, finished_move.location_dest_id, finished_move.location_id)
+                for product in finished_moves.product_id:
+                    product_moves = finished_moves.filtered(lambda m: m.product_id == product)
+                    qty = sum(product_moves.mapped('product_uom_qty'))
+                    moves += unbuild._generate_move_from_existing_move_with_qty(product_moves[0], factor * qty, product_moves[0].location_dest_id, product_moves[0].location_id)
             else:
                 factor = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id) / unbuild.bom_id.product_qty
                 moves += unbuild._generate_move_from_bom_line(self.product_id, self.product_uom_id, unbuild.product_qty)
@@ -206,8 +208,10 @@ class MrpUnbuild(models.Model):
             if unbuild.mo_id:
                 raw_moves = unbuild.mo_id.move_raw_ids.filtered(lambda move: move.state == 'done')
                 factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.product_qty, unbuild.product_uom_id)
-                for raw_move in raw_moves:
-                    moves += unbuild._generate_move_from_existing_move(raw_move, factor, raw_move.location_dest_id, self.location_dest_id)
+                for product in raw_moves.product_id:
+                    product_moves = raw_moves.filtered(lambda m: m.product_id == product)
+                    qty = sum(product_moves.mapped('product_uom_qty'))
+                    moves += unbuild._generate_move_from_existing_move_with_qty(product_moves[0], factor * qty, product_moves[0].location_dest_id, self.location_dest_id)
             else:
                 factor = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id) / unbuild.bom_id.product_qty
                 boms, lines = unbuild.bom_id.explode(unbuild.product_id, factor, picking_type=unbuild.bom_id.picking_type_id)
@@ -216,11 +220,14 @@ class MrpUnbuild(models.Model):
         return moves
 
     def _generate_move_from_existing_move(self, move, factor, location_id, location_dest_id):
+        return self._generate_move_from_existing_move_with_qty(move, move.product_uom_qty * factor, location_id, location_dest_id)
+
+    def _generate_move_from_existing_move_with_qty(self, move, qty, location_id, location_dest_id):
         return self.env['stock.move'].create({
             'name': self.name,
             'date': self.create_date,
             'product_id': move.product_id.id,
-            'product_uom_qty': move.product_uom_qty * factor,
+            'product_uom_qty': qty,
             'product_uom': move.product_uom.id,
             'procure_method': 'make_to_stock',
             'location_dest_id': location_dest_id.id,

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -604,3 +604,34 @@ class TestUnbuild(TestMrpCommon):
         self.assertEqual(StockQuant._get_available_quantity(finshed_product, self.stock_location), 0, 'Table should not be available in stock')
         self.assertEqual(StockQuant._get_available_quantity(component1, self.stock_location), 1, 'Table head should be available in stock as the picking is transferred')
         self.assertEqual(StockQuant._get_available_quantity(component2, self.stock_location), 1, 'Table stand should be available in stock as the picking is transferred')
+
+    def test_unbuild_an_updated_mo(self):
+        """ Suppose the user has a MO with qty = 1. On Produce step, he increases the quantity to 3.
+        Then the user unbuilds one product"""
+        mo, bom, p_final, p1, p2 = self.generate_mo(qty_final=1, qty_base_1=1, qty_base_2=1)
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 3)
+        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 3)
+        mo.action_assign()
+
+        produce_form = Form(self.env['mrp.product.produce'].with_context({
+            'active_id': mo.id,
+            'active_ids': [mo.id],
+        }))
+        produce_form.qty_producing = 3
+        produce_wizard = produce_form.save()
+        produce_wizard.do_produce()
+
+        mo.button_mark_done()
+
+        ub_form = Form(self.env['mrp.unbuild'])
+        ub_form.mo_id = mo
+        self.assertEqual(ub_form.product_qty, 3)
+        ub_form.product_qty = 1
+        ub = ub_form.save()
+        ub.action_unbuild()
+
+        for p, qty in [(p1, 1), (p2, 1), (p_final, 2)]:
+            self.assertEqual(p.qty_available, qty, 'Inorrect qty for product %s' % p.name)
+            ub_sm = self.env['stock.move'].search([('product_id', '=', p.id), ('name', 'like', 'UB%')])
+            self.assertEqual(len(ub_sm), 1, 'Incorrect nb of SM for product %s' % p.name)
+            self.assertEqual(ub_sm.product_uom_qty, 1, 'Incorrect qty for prodcut %s' % p.name)

--- a/addons/mrp/wizard/mrp_product_produce.py
+++ b/addons/mrp/wizard/mrp_product_produce.py
@@ -148,6 +148,9 @@ class MrpProductProduce(models.TransientModel):
             quantity = wizard.qty_producing
             if float_compare(quantity, 0, precision_rounding=self.product_uom_id.rounding) <= 0:
                 raise UserError(_("The production order for '%s' has no quantity specified.") % self.product_id.display_name)
+            quantity = wizard.product_uom_id._compute_quantity(quantity, wizard.production_id.product_uom_id)
+            if float_compare(quantity, wizard.production_id.product_qty, precision_rounding=self.product_uom_id.rounding) > 0:
+                wizard.production_id.write({'product_qty': quantity})
         self._update_finished_move()
         self._update_moves()
         self.production_id.filtered(lambda mo: mo.state == 'confirmed').write({


### PR DESCRIPTION
In some cases, when unbuilding a product with a specific MO, the default
quantity won't be correct and there will be several SM for the same
products

To reproduce the issue:
1. Create two storable components P_compo, P_finished
2. Update P_compo's quantity to 3
3. Create a BOM for P_finished:
    - Components: 1 x P_compo
4. Create a MO for 1 x P_finished
5. Mark as TODO, Check Availability
6. Produce: in the Produce wizard, increase the quantity to 3 and Save
7. Mark as Done
8. Create an Unbuild Order:
    - Manufacturing Order: MO
    - Error: the Quantity field should become 3 (but let the quantity
equal to 1)
9. Unbuild
10. Open the product moves related to P_finished

Error: There are two SM with the Unbuild Order as reference and the
total quantity is 3, it should be 1

OPW-2450041