### PR TITLE
[REF] web: dropdown: factorise positioning

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -66,24 +66,6 @@ export class Dropdown extends Component {
         // Set up key navigation -----------------------------------------------
         useDropdownNavigation();
 
-        // Set up toggler and positioning --------------------------------------
-        /** @type {string} **/
-        let position =
-            this.props.position || (this.hasParentDropdown ? "right-start" : "bottom-start");
-        if (localization.direction === "rtl") {
-            let [direction, variant = "middle"] = position.split("-");
-            if (["bottom", "top"].includes(direction)) {
-                variant = variant === "start" ? "end" : "start";
-            } else {
-                direction = direction === "left" ? "right" : "left";
-            }
-            position = [direction, variant].join("-");
-        }
-        const positioningOptions = {
-            popper: "menuRef",
-            position,
-            directionFlipOrder: { right: "rl", bottom: "bt", top: "tb", left: "lr" },
-        };
         if (this.props.toggler === "parent") {
             // Add parent click listener to handle toggling
             useEffect(
@@ -102,13 +84,37 @@ export class Dropdown extends Component {
                 },
                 () => []
             );
+        }
+
+        // Setup positioning only when in desktop
+        if (!this.env.isSmall) {
+            /** @type {string} **/
+            let position =
+                this.props.position || (this.hasParentDropdown ? "right-start" : "bottom-start");
+            if (localization.direction === "rtl") {
+                let [direction, variant = "middle"] = position.split("-");
+                if (["bottom", "top"].includes(direction)) {
+                    variant = variant === "start" ? "end" : "start";
+                } else {
+                    direction = direction === "left" ? "right" : "left";
+                }
+                position = [direction, variant].join("-");
+            }
+
+            const positioningOptions = {
+                popper: "menuRef",
+                position,
+                directionFlipOrder: { right: "rl", bottom: "bt", top: "tb", left: "lr" },
+            };
 
             // Position menu relatively to parent element
-            usePosition(() => this.el.parentElement, positioningOptions);
-        } else {
-            // Position menu relatively to inner toggler
-            const togglerRef = useRef("togglerRef");
-            usePosition(() => togglerRef.el, positioningOptions);
+            if (this.props.toggler === "parent") {
+                usePosition(() => this.el.parentElement, positioningOptions);
+            } else {
+                // Position menu relatively to inner toggler
+                const togglerRef = useRef("togglerRef");
+                usePosition(() => togglerRef.el, positioningOptions);
+            }
         }
     }
 


### PR DESCRIPTION
Before this commit, the positioning of the dropdown (which is powered as a poppover)
was executed all the time by the constructor.

This commit factorizes that operation, both for clarity and for extensivity sakes.
In particular, in pivot in mobile, we may not want to be placed as a popper, since we need
the overflow anyway.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
