### PR TITLE
[FIX] website, web_editor: fix deadlock on snippet column removal

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3781,7 +3781,7 @@ const SnippetOptionWidget = Widget.extend({
      * @param {UserValueWidget} widget - the widget which triggered the option change
      * @returns {Promise}
      */
-    _select: async function (previewMode, widget) {
+    _select: async function (previewMode, widget, inMutex = false) {
         let $applyTo = null;
 
         if (previewMode === true) {
@@ -3803,7 +3803,7 @@ const SnippetOptionWidget = Widget.extend({
                 });
                 await Promise.all(proms);
             } else {
-                await this[methodName](previewMode, widgetValue, params);
+                await this[methodName](previewMode, widgetValue, params, inMutex);
             }
         }
 
@@ -3939,7 +3939,8 @@ const SnippetOptionWidget = Widget.extend({
         if (shouldRecordUndo) {
             this.options.wysiwyg.odooEditor.unbreakableStepUnactive();
         }
-        this.trigger_up('snippet_edition_request', {exec: async () => {
+        // TROUBLES START HERE
+        this.trigger_up('snippet_edition_request', {exec: async (inMutex = true) => {
             // If some previous snippet edition in the mutex removed the target from
             // the DOM, the widget can be destroyed, in that case the edition request
             // is now useless and can be discarded.
@@ -3974,7 +3975,7 @@ const SnippetOptionWidget = Widget.extend({
             }
 
             // Call widget option methods and update $target
-            await this._select(previewMode, widget);
+            await this._select(previewMode, widget, inMutex);
 
             // If it is not preview mode, the user selected the option for good
             // (so record the action)

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1649,7 +1649,7 @@ options.registry.layout_column = options.Class.extend({
      *
      * @see this.selectClass for parameters
      */
-    selectCount: async function (previewMode, widgetValue, params) {
+    selectCount: async function (previewMode, widgetValue, params, inMutex=false) {
         const previousNbColumns = this.$('> .row').children().length;
         let $row = this.$('> .row');
         if (!$row.length) {
@@ -1657,7 +1657,7 @@ options.registry.layout_column = options.Class.extend({
         }
 
         const nbColumns = parseInt(widgetValue);
-        await this._updateColumnCount($row, (nbColumns || 1) - $row.children().length);
+        await this._updateColumnCount($row, (nbColumns || 1) - $row.children().length, inMutex);
         // Yield UI thread to wait for event to bubble before activate_snippet is called.
         // In this case this lets the select handle the click event before we switch snippet.
         // TODO: make this more generic in activate_snippet event handler.
@@ -1691,7 +1691,7 @@ options.registry.layout_column = options.Class.extend({
      * @param {jQuery} $row - the row in which to update the columns
      * @param {integer} count - positif to add, negative to remove
      */
-    _updateColumnCount: async function ($row, count) {
+    _updateColumnCount: async function ($row, count, inMutex=false) {
         if (!count) {
             return;
         }
@@ -1707,7 +1707,7 @@ options.registry.layout_column = options.Class.extend({
             var self = this;
             for (const el of $row.children().slice(count)) {
                 await new Promise(resolve => {
-                    self.trigger_up('remove_snippet', {$snippet: $(el), onSuccess: resolve, shouldRecordUndo: false});
+                    self.trigger_up('remove_snippet', {$snippet: $(el), onSuccess: resolve, shouldRecordUndo: false, inMutex: inMutex});
                 });
             }
         }


### PR DESCRIPTION
This is not yet a fix. The current purpose of this commit is to show
from where the problem comes from

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
