### PR TITLE
[IMP] l10n_vn: Change external ID for avoid confusion

### DIFF
--- a/addons/l10n_vn/data/account.account.template.csv
+++ b/addons/l10n_vn/data/account.account.template.csv
@@ -184,7 +184,7 @@
 "chart6427","Outside services",6427,"account.data_account_type_expenses","vn_template","False"
 "chart6428","Other expenses",6428,"account.data_account_type_expenses","vn_template","False"
 "chart711","Other Income",711,"account.data_account_type_other_income","vn_template","False"
-"chart8111","Other Expenses",811,"account.data_account_type_expenses","vn_template","False"
+"chart811","Other Expenses",811,"account.data_account_type_expenses","vn_template","False"
 "chart8211","Current tax expense",8211,"account.data_account_type_expenses","vn_template","False"
 "chart8212","Deferred tax expense",8212,"account.data_account_type_expenses","vn_template","False"
 "chart911","Income Summary",911,"account.data_unaffected_earnings","vn_template","False"

--- a/addons/l10n_vn/i18n_extra/l10n_vn.pot
+++ b/addons/l10n_vn/i18n_extra/l10n_vn.pot
@@ -631,8 +631,8 @@ msgid "Ordinary shares with voting rights"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.account,name:l10n_vn.1_chart8111
-#: model:account.account.template,name:l10n_vn.chart8111
+#: model:account.account,name:l10n_vn.1_chart811
+#: model:account.account.template,name:l10n_vn.chart811
 msgid "Other Expenses"
 msgstr ""
 

--- a/addons/l10n_vn/i18n_extra/vi_VN.po
+++ b/addons/l10n_vn/i18n_extra/vi_VN.po
@@ -632,8 +632,8 @@ msgid "Ordinary shares with voting rights"
 msgstr "Cổ phiếu phổ thông có quyền biểu quyết"
 
 #. module: l10n_vn
-#: model:account.account,name:l10n_vn.1_chart8111
-#: model:account.account.template,name:l10n_vn.chart8111
+#: model:account.account,name:l10n_vn.1_chart811
+#: model:account.account.template,name:l10n_vn.chart811
 msgid "Other Expenses"
 msgstr "Chi phí bằng tiền khác"
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Because of this id `chart8111` for `account 811`, I was perplexed. I created access to this id `chart811` for find `account 811` out of habit, but I couldn't find it.

Desired behavior after PR is merged:
To make code easier, I believe it is not difficult to alter this external id.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
