### PR TITLE
[IMP] website - add an option for automatic redirection to custom domain

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -463,6 +463,9 @@ class IrHttp(models.AbstractModel):
         if request.is_frontend:
             cls._add_dispatch_parameters(func)
 
+            if getattr(request, "domain_redirect", None):
+                return request.domain_redirect
+
             path = request.httprequest.path.split('/')
             default_lg_id = cls._get_default_lang()
             if request.routing_iteration == 1:

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -16,6 +16,9 @@ class ResConfigSettings(models.TransientModel):
 
     website_id = fields.Many2one('website', string="website",
                                  default=_default_website, ondelete='cascade')
+
+    website_fallback_id = fields.Many2one("website", string="Fallback Website", config_parameter="website.fallback_id",
+                                          help="Visitors of your website will be redirected to this website or its specified domain if any.")
     website_name = fields.Char('Website Name', related='website_id.name', readonly=False)
     website_domain = fields.Char('Website Domain', related='website_id.domain', readonly=False)
     website_country_group_ids = fields.Many2many(related='website_id.country_group_ids', readonly=False)

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -24,6 +24,17 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-xs-12 col-md-6 o_setting_box" id="website_fallback_setting">
+                                <div class="o_setting_right_pane">
+                                    <label for="website_fallback_id"/>
+                                    <div class="text-muted">
+                                        Redirect visitors automatically towards the selected website.
+                                    </div>
+                                    <div class="mt8">
+                                        <field name="website_fallback_id" options="{'no_open': True, 'no_create': True}"/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h2>Website <button name="action_website_create_new" type="object" string="New" class="ml-2 btn btn-link" icon="fa-plus" groups="!website.group_multi_website"/></h2>
                         <div class="row mt16 o_settings_container" id="website_settings_placeholder" attrs="{'invisible': [('website_id', '!=', False)]}">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Currently, search engines index a SAAS-hosted website twice
(once for the actual domain, and once for the .odoo.com domain)
which is something that should be preventable.

**Desired behavior after PR is merged:**
A new option allows for the selection of a default fallback website.
That website needs to have a domain configured, and any requests
made towards Odoo websites as a public user will redirect to the
same page on the configured domain of the fallback website.

For example, we have a company named my_company and a 
Website 1 and Website 2 exist, Website 2 is set as the default
fallback website and has https://my-domain.com configured as
its domain. Visiting https://my_company.odoo.com/abc?def as a
public user, we are redirected to https://my-domain.com/abc?def.

In order to access https://my_company.odoo.com/ and any of its
pages, we need to be logged in.  So the /web/login page can be
used and redirection will never happen for that one specifically.

task-2418904