### PR TITLE
[FIX] web: scrolling: take html to scroll in mobile

### DIFF
--- a/addons/web/static/src/core/utils/scrolling.js
+++ b/addons/web/static/src/core/utils/scrolling.js
@@ -34,6 +34,24 @@ export function scrollTo(element, scrollable = null) {
     }
 }
 
+/*
+ * Returns the main scrollable element relevant in a context of an action.
+ * In desktop, the relevant element is the .o_content of the action.
+ * In mobile, it is the html node itself, provided no other children is scrollable
+ *   Most of the times in mobile, we don't want to scroll individual elements, so every bit
+ *   of code should enforce that html is the scrollable element.
+ *
+ * @param {Component} The action component.
+ * @return {Element}
+ */
+function getScrollableElement(component) {
+    if (component.env.isSmall) {
+        return document.firstElementChild; // aka html node;
+    } else {
+        return component.el.querySelector(".o_action_manager .o_content");
+    }
+}
+
 /**
  * Retrieves the current top and left scroll position. By default, the scrolling
  * area is the '.o_content' main div. In mobile, it is the body.
@@ -42,12 +60,7 @@ export function scrollTo(element, scrollable = null) {
  *   area.
  */
 export function getScrollPosition(component) {
-    let scrollingEl;
-    if (component.env.isSmall) {
-        scrollingEl = document.body;
-    } else {
-        scrollingEl = component.el.querySelector(".o_action_manager .o_content");
-    }
+    const scrollingEl = getScrollableElement(component);
     return {
         left: scrollingEl ? scrollingEl.scrollLeft : 0,
         top: scrollingEl ? scrollingEl.scrollTop : 0,
@@ -65,12 +78,7 @@ export function getScrollPosition(component) {
  * @param {number} [offset.top=0]
  */
 export function setScrollPosition(component, offset) {
-    let scrollingEl;
-    if (component.env.isSmall) {
-        scrollingEl = document.body;
-    } else {
-        scrollingEl = component.el.querySelector(".o_action_manager .o_content");
-    }
+    const scrollingEl = getScrollableElement(component);
     if (scrollingEl) {
         scrollingEl.scrollLeft = offset.left || 0;
         scrollingEl.scrollTop = offset.top || 0;


### PR DESCRIPTION
Before this commit the scroll position in mobile mode were not kept.
This was because the reference element on which we get the scroll coordinates
was the body, instead of the html node.

After this commit, the scroll is saved and reused correctly as the reference
node is the html node

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
