### PR TITLE
[IMP] product: Add helper methods to compute and set product variant fields

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -250,8 +250,10 @@ class ProductTemplate(models.Model):
         self._compute_template_field_from_variant_field('barcode')
 
     def _search_barcode(self, operator, value):
-        templates = self.with_context(active_test=False).search([('product_variant_ids.barcode', operator, value)])
-        return [('id', 'in', templates.ids)]
+        subquery = self.with_context(active_test=False)._search([
+            ('product_variant_ids.barcode', operator, value),
+        ])
+        return [('id', 'in', subquery)]
 
     def _set_barcode(self):
         self._set_product_variant_field('barcode')

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -226,8 +226,7 @@ class ProductTemplate(models.Model):
         self._set_product_variant_field('standard_price')
 
     def _search_standard_price(self, operator, value):
-        products = self.env['product.product'].search([('standard_price', operator, value)], limit=None)
-        return [('id', 'in', products.mapped('product_tmpl_id').ids)]
+        return [('product_variant_ids.standard_price', operator, value)]
 
     @api.depends('product_variant_ids.volume')
     def _compute_volume(self):


### PR DESCRIPTION
As a bonus:

* Use the `Query` returned by `_search` when searching on `barcode` (this uses a subquery to search, saves a db roundtrip).
* Simplify search by standard_price, should also save 1 query.


Optional to consider: Set `store=False` on `weight` and `volume`, replacing it with a `search='_search_*`



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
